### PR TITLE
requirements

### DIFF
--- a/Resources/Prototypes/Roles/requirement_overrides.yml
+++ b/Resources/Prototypes/Roles/requirement_overrides.yml
@@ -4,41 +4,52 @@
     Captain:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 720 # 12 mins
+      time: 10800 # 3 hours
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 720 # 12 mins
+      time: 10800 # 3 hours
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 720 # 12 mins
+      time: 10800 # 3 hours
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 720 # 12 min
+      time: 18000 # 5 hours
+    - !type:OverallPlaytimeRequirement
+      time: 36000 # 10 hours
     HeadOfSecurity:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 720 # 12 mins
+      time: 10800 # 3 hours
+    - !type:OverallPlaytimeRequirement
+      time: 18000 # 5 hours
     ChiefEngineer:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 720 # 12 mins
+      time: 10800 # 3 hours
     ResearchDirector:
     - !type:DepartmentTimeRequirement
       department: Science
-      time: 720 # 12 mins
+      time: 10800 # 3 hours
     ChiefMedicalOfficer:
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 720 # 12 mins
+      time: 10800 # 3 hours
     HeadOfPersonnel:
     - !type:DepartmentTimeRequirement
       department: Civilian
-      time: 720 # 12 mins
+      time: 10800 # 3 hours
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 10800 # 3 hours
+    - !type:DepartmentTimeRequirement
+      department: Command
+      time: 18000 # 5 hours
+    - !type:OverallPlaytimeRequirement
+      time: 25200 # 7 hours
     Quartermaster:
     - !type:DepartmentTimeRequirement
       department: Cargo
-      time: 720 # 12 mins
-
+      time: 10800 # 3 hours
     SalvageSpecialist:
     - !type:OverallPlaytimeRequirement
       time: 0
@@ -109,12 +120,10 @@
 
     Detective:
     - !type:OverallPlaytimeRequirement
-      time: 720    
+      time: 3600    
     SecurityOfficer:
     - !type:OverallPlaytimeRequirement
-      time: 720    
+      time: 3600    
     Warden:
     - !type:OverallPlaytimeRequirement
-      time: 720
-
-        
+      time: 3600


### PR DESCRIPTION
This pull request includes changes to the `Resources/Prototypes/Roles/requirement_overrides.yml` file to update the time requirements for various roles. The most important changes involve increasing the time requirements for department-specific and overall playtime.

Increased time requirements for department-specific roles:

* Updated `Captain` role's department time requirements from 720 seconds (12 mins) to 3600 seconds (60 mins) for Engineering, Medical, Security, and Command departments.
* Updated `HeadOfSecurity` role's department time requirement from 720 seconds (12 mins) to 3600 seconds (60 mins) for Security department.
* Updated `ChiefEngineer` role's department time requirement from 720 seconds (12 mins) to 3600 seconds (60 mins) for Engineering department.
* Updated `ResearchDirector` role's department time requirement from 720 seconds (12 mins) to 3600 seconds (60 mins) for Science department.
* Updated `ChiefMedicalOfficer` role's department time requirement from 720 seconds (12 mins) to 3600 seconds (60 mins) for Medical department.
* Updated `HeadOfPersonnel` role's department time requirement from 720 seconds (12 mins) to 3600 seconds (60 mins) for Civilian department.
* Updated `Quartermaster` role's department time requirement from 720 seconds (12 mins) to 3600 seconds (60 mins) for Cargo department.

Increased overall playtime requirements:

* Updated `Detective` role's overall playtime requirement from 720 seconds (12 mins) to 3600 seconds (60 mins).
* Updated `SecurityOfficer` role's overall playtime requirement from 720 seconds (12 mins) to 3600 seconds (60 mins).
* Updated `Warden` role's overall playtime requirement from 720 seconds (12 mins) to 3600 seconds