### PR TITLE
Update limb attachment logic and correct surgery sprites

### DIFF
--- a/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
@@ -174,9 +174,8 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
             {
                 case BodyPartType.Arm: //todo move to systems
                     if (limb.Children.Keys.Count == 0)
-                    {
                         _body.TryCreatePartSlot(limbId, limb.Symmetry == BodyPartSymmetry.Left ? "left hand" : "right hand", BodyPartType.Hand, out var slotId);
-                    }
+
                     foreach (var slotId in limb.Children.Keys)
                     {
                         if (slotId is null) continue;
@@ -195,6 +194,9 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
                     _hands.AddHand(body, BodySystem.GetPartSlotContainerId(slot), limb.Symmetry == BodyPartSymmetry.Left ? HandLocation.Left : HandLocation.Right);
                     break;
                 case BodyPartType.Leg:
+                    if (limb.Children.Keys.Count == 0)
+                        _body.TryCreatePartSlot(limbId, limb.Symmetry == BodyPartSymmetry.Left ? "left foot" : "right foot", BodyPartType.Foot, out var slotId);
+                    break;
                 case BodyPartType.Foot:
                     break;
             }

--- a/Resources/Prototypes/_StarLight/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_StarLight/Surgery/surgeries.yml
@@ -43,7 +43,7 @@
     parts: 
     - Torso
   - type: Sprite
-    sprite: Mobs/Species/Human/parts.rsi
+    sprite: Mobs/Species/Skeleton/parts.rsi
     state: torso_m
     
 - type: entity
@@ -61,7 +61,7 @@
     parts:
     - Torso
   - type: Sprite
-    sprite: Mobs/Species/Skeleton/parts.rsi
+    sprite: Mobs/Species/Human/parts.rsi
     state: torso_m
 
 - type: entity


### PR DESCRIPTION
Updated `OnStepAttachLimbComplete` in `SurgerySystem.Steps.cs` to handle limb attachment for arms and legs more effectively. For arms, the code now iterates over `limb.Children.Keys` to process each child slot. For legs, a new part slot is created if there are no children.

Corrected sprite paths in `surgeries.yml`:
- Changed sprite for `SurgeryStepPriseOpenBones` to `Mobs/Species/Skeleton/parts.rsi`.
- Changed sprite for `SurgeryStepRetractAbdominalWalls` to `Mobs/Species/Human/parts.rsi`.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
