### PR TITLE
Change salary and time requirements for sec department

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 54000 # 15 hours
+      time: 72000 # 20 hrs
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -4,9 +4,9 @@
   description: job-description-detective
   playTimeTracker: JobDetective
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 72000 # 20 hrs
+    - !type:RoleTimeRequirement
+      role: JobSecurityOfficer
+      time: 36000 # 10 hrs
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -6,15 +6,8 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobWarden
-      time: 10800 #3 hrs
-    - !type:RoleTimeRequirement
-      role: JobSecurityOfficer
-      time: 36000 #10 hrs
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 108000 # 30 hrs
-    - !type:OverallPlaytimeRequirement
-      time: 144000 #40 hrs
+      time: 28800 # 8 hrs
+
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -5,10 +5,10 @@
   playTimeTracker: JobSecurityCadet
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 36000 #10 hrs
+      time: 108000 # 30 hrs
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 54000 #15 hrs
+      time: 54000 # 15 hrs
       inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -7,6 +7,9 @@
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
       time: 72000 # 20 hrs
+    - !type:RoleTimeRequirement
+      role: JobDetective
+      time: 3600 # 1 hr
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 36000 #10 hrs
+      time: 72000 # 20 hrs
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/requirement_overrides.yml
+++ b/Resources/Prototypes/Roles/requirement_overrides.yml
@@ -53,20 +53,9 @@
     - !type:OverallPlaytimeRequirement
       time: 25200 # 7 hours
     HeadOfSecurity:
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 10800 # 3 hours
-    - !type:DepartmentTimeRequirement
-      department: Command
-      time: 3600 # 1 hour in Command
-    - !type:OverallPlaytimeRequirement
-      time: 18000 # 5 hours
     - !type:RoleTimeRequirement
       role: JobWarden
-      time: 10800 # 3 hours as Warden
-    - !type:RoleTimeRequirement
-      role: JobSecurityOfficer
-      time: 7200 # 2 hours as Security Officer
+      time: 28800 # 8 hrs
     ChiefEngineer:
     - !type:DepartmentTimeRequirement
       department: Engineering
@@ -143,30 +132,34 @@
       role: JobStationEngineer
       time: 3600 # 1 hour as Station Engineer
     Warden:
-    - !type:OverallPlaytimeRequirement
-      time: 7200 # 2 hours
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 108000 # 30 hrs
+    - !type:RoleTimeRequirement
+      role: JobSecurityOfficer
+      time: 72000 # 20 hrs
+    - !type:RoleTimeRequirement
+      role: JobDetective
+      time: 3600 # 1 hr
     SecurityCadet:
     - !type:OverallPlaytimeRequirement
-      time: 1800 # 30 minutes overall playtime
+      time: 108000 # 30 hrs
     - !type:DepartmentTimeRequirement
       department: Security
       time: 54000 # 15 hrs
-      inverted: true 
+      inverted: true # stop playing intern if you're good at security!
     SecurityOfficer:
-    - !type:OverallPlaytimeRequirement
-      time: 3600 # 1 hour overall playtime
-    - !type:RoleTimeRequirement
-      role: JobSecurityCadet
-      time: 3600 # 1 hour as Security Cadet
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 #10 hrs
     Detective:
-    - !type:OverallPlaytimeRequirement
-      time: 5400 # 1 hour 30 minutes
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 3600 # 1 hour as Security Officer
+      time: 36000 # 10 hrs
+    Brigmedic:
+    - !type:RoleTimeRequirement
+      role: JobSecurityOfficer
+      time: 36000 # 10 hrs
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 28800 # 8 hrs
     StationAi:
     - !type:OverallPlaytimeRequirement
       time: 0

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
@@ -4,12 +4,12 @@
   description: job-description-brigmedic
   playTimeTracker: JobBrigmedic
   requirements:
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 72000 #20 hrs
-  - !type:DepartmentTimeRequirement
-    department: Medical
-    time: 54000 #15 hrs
+    - !type:RoleTimeRequirement
+      role: JobSecurityOfficer
+      time: 36000 # 10 hrs
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 28800 # 8 hrs
   startingGear: BrigmedicGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/_StarLight/Roles/salaries.yml
+++ b/Resources/Prototypes/_StarLight/Roles/salaries.yml
@@ -18,11 +18,11 @@
     StationEngineer: 55
     TechnicalAssistant: 23
 
-    Warden: 80
+    Warden: 90
     Detective: 80
+    Brigmedic: 70
     SecurityOfficer: 50
     SecurityCadet: 23
-    Brigmedic: 68
 
     StationAi: 155
     Borg: 85

--- a/Resources/Prototypes/_StarLight/Roles/salaries.yml
+++ b/Resources/Prototypes/_StarLight/Roles/salaries.yml
@@ -21,7 +21,7 @@
     Warden: 90
     Detective: 80
     Brigmedic: 70
-    SecurityOfficer: 50
+    SecurityOfficer: 55
     SecurityCadet: 23
 
     StationAi: 155


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Description
Change salary and time requirements for sec department

I am tired of people entering sec department after only 10 hours of being in ss14. They don't know basics mechanics, let alone space law. 

## Details
- 30 hours overall playtime to start playing security
- 10 hours of cadet to start playing as officer
- 10 hours as officer to start playing as detective/brigmedic (+8 hours in med for brigmedic)
- 20 hours as officer and 1 hour as a detective to start playing as warden (warden is literally the most stressful role on the station, also wouldnt wanna see warden/hos who doesnt even know that forensic scanner exists.)
- 8 hours as warden to start playing as HoS (HoS sometimes has to substitute warden, and he is part of command)

I know this seems like 1984 but it will improve experience for both sides -players with low playtime wont get early in sec, and they wont be called shitters for doing something stupid (they will do something stupid)

-------------------------

Salary changes:
- Warden: 90
- Detective: 80
- Brigmedic: 70
- SecurityOfficer: 55
- SecurityCadet: 23

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Miracula
- tweak: Changed salary and time requirements for sec department

