### PR TITLE
Fix accentless trait not working at vulpkanins

### DIFF
--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -12,6 +12,7 @@
     - type: OwOAccent
     - type: LizardAccent
     - type: MothAccent
+    - type: GrowlingAccent
     - type: ReplacementAccent
       accent: dwarf
 


### PR DESCRIPTION
fixes #125

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Miracula
- fix: Accentless trait now works at vulpkanins
