### PR TITLE
Security ExtendedEmergencyTank w/ Captain

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -77,13 +77,13 @@
   parent: BoxCardboard
   id: BoxSurvivalSecurity
   name: survival box
-  description: It's a box with basic internals inside.
+  description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
   suffix: Security
   components:
   - type: StorageFill
     contents:
     - id: ClothingMaskGasSecurity
-    - id: EmergencyOxygenTankFilled
+    - id: ExtendedEmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick
@@ -101,7 +101,7 @@
   - type: StorageFill
     contents:
     - id: ClothingMaskGasSecurity
-    - id: EmergencyNitrogenTankFilled
+    - id: ExtendedEmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -7,7 +7,7 @@
   - CaptainJumpsuit
   - CaptainBackpack
   - CaptainOuterClothing
-  - Survival
+  - SurvivalExtended
   - Trinkets
   - GroupSpeciesBreathTool
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

A lot of security prefers using pocket tanks, so that they can store their weapon or mini jetpack at their suit slot.

Captain also gets an extended because he's the first beneficiary in the budget.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Security has an unwanted strain in the inventory management with their breathables.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

![image](https://github.com/user-attachments/assets/249f49be-6adb-445f-8d44-194d3d11f91d)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: aedler
- tweak: Security gets extended emergency tanks in their survival box.
- tweak: Captain gets an extended emergency survival box.

