### PR TITLE
Readds HoS shotgun recharge

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -767,5 +767,8 @@
     stealGroup: WeaponEnergyShotgun
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Battery
-    maxCharge: 800
-    startingCharge: 800
+    maxCharge: 500
+    startingCharge: 500
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 10


### PR DESCRIPTION
## Short description
Gives the HoS's shotgun auto recharge again.
this both reduces to totall number of shots from 8 to 5, but makes it recharge 1 shot every 10 seconds
(this is close but technically 8 seconds slower than the original recharge)

## Why we need to add this
the intention is to give the shotgun the ability to have somewhat sustained use in combat senarios without the need of recharging it every, what feels like, 5 seconds

## Media (Video/Screenshots)


https://github.com/user-attachments/assets/38d6651b-598d-44e4-8ac3-8aa99303ae6e


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Clone0401
- tweak: HoS's energy shotgun max shot capacity changed from 8 to 5.
- tweak: HoS's energy shotgun now recharges at a rate of 1 shot per 10 seconds.
