### PR TITLE
Temporarily removes syndicate expeditions from salvage

### DIFF
--- a/Resources/Prototypes/_StarLight/Procedural/add to salvage_difficulties to re-enable syndies.txt
+++ b/Resources/Prototypes/_StarLight/Procedural/add to salvage_difficulties to re-enable syndies.txt
@@ -1,8 +1,0 @@
-- type: salvageDifficulty
-  id: Impossible
-  lootPrototype: "SalvageLootImpossible"
-  lootBudget: 675
-  mobBudget: 463
-  modifierBudget: 1
-  color: "#DE3A3A96"
-  recommendedPlayers: 6

--- a/Resources/Prototypes/_StarLight/Procedural/add to salvage_difficulties to re-enable syndies.txt
+++ b/Resources/Prototypes/_StarLight/Procedural/add to salvage_difficulties to re-enable syndies.txt
@@ -1,0 +1,8 @@
+- type: salvageDifficulty
+  id: Impossible
+  lootPrototype: "SalvageLootImpossible"
+  lootBudget: 675
+  mobBudget: 463
+  modifierBudget: 1
+  color: "#DE3A3A96"
+  recommendedPlayers: 6

--- a/Resources/Prototypes/_StarLight/Procedural/salvage_difficulties.yml
+++ b/Resources/Prototypes/_StarLight/Procedural/salvage_difficulties.yml
@@ -34,12 +34,3 @@
   modifierBudget: 1
   color: "#EFB34196"
   recommendedPlayers: 4
-
-- type: salvageDifficulty
-  id: Impossible
-  lootPrototype: "SalvageLootImpossible"
-  lootBudget: 675
-  mobBudget: 463
-  modifierBudget: 1
-  color: "#DE3A3A96"
-  recommendedPlayers: 6

--- a/Resources/Prototypes/_StarLight/Procedural/salvage_difficulties.yml
+++ b/Resources/Prototypes/_StarLight/Procedural/salvage_difficulties.yml
@@ -34,3 +34,12 @@
   modifierBudget: 1
   color: "#EFB34196"
   recommendedPlayers: 4
+
+  #- type: salvageDifficulty
+  #id: Impossible
+  #lootPrototype: "SalvageLootImpossible"
+  #lootBudget: 675
+  #mobBudget: 463
+  #modifierBudget: 1
+  #color: "#DE3A3A96"
+  #recommendedPlayers: 6


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
title

## Why we need to add this
Salvage syndicate expeditions just cause a lot of issues at the moment (powergaming, bug abuse, validhunting, self antag, open play), and this is just a temporary removal until a proper solution is added

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![image](https://github.com/user-attachments/assets/1691a217-8b4e-49f1-a354-326d72136573)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->:cl: PubliclyExecutedPig
- remove: Temporarily removed syndicate expeditions from salvage
