### PR TITLE
Adds Abductor Guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/Antagonist/Abductors.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Abductors.xml
@@ -1,3 +1,39 @@
 <Document>
+  # Abductors
 
+  <Box>
+    [color=#999999][italic]" ..."[/italic][/color]
+  </Box>
+  Abductors are an alien society set on cataloging and experimenting on the sectors personnel.
+  Its important to note: Abductors, unlike most antagonists are [color=red]NOT set on killing people[/color] and are rather purely interested in completing their experiments.
+
+  Abductors do not possess the ability to speak and therefore communicate through more... mime-like methods.
+
+  ##Abduction
+  Abductors begin on their ship somewhere near the station. Using the [color=#a149bf]"Human Observation Console"[/color] you can seek out victims who are alone and [color=lightblue]warp[/color] near them to begin abduction.
+
+  The wonderprod is the primary tool of an Abductor. It has four modes you will use for abduction:
+  - [color=yellow]{Stun}[/color] Stuns the victim for roughly 5 seconds.
+  - [color=pink]{Restrain}[/color] binds the victims hands in weak cables.
+  - [color=blue]{Sleep}[/color] Induces a sleep-like state in the victim.
+  - [color=red]{Harm}[/color] Burns the target, dealing damage. [bold]ONLY USE IF YOU MUST.[/bold]
+
+  Once a target is immobilized you can use the [italic]gizmo[/italic] to implant them with a nano tracker, return to your ship using the [color=lightblue]return action[/color], then use the gizmo on your [color=#a149bf]Abductor Console[/color].
+
+  ##Experimentation
+  Once you have linked the most recent nano tracker to the console, select [bold]{ATTRACT}[/bold] to warp your victim to your ship.
+  
+  Now that you have your victim aboard, its recommended you:
+  - Buckle them to your surgical table.
+  - Change out their cuffs for a higher grade of handcuffs provided on the ship.
+  - Remove any of their belongings that could damage you or the secrecy of the experiment.
+  - Use your vast surgical knowledge to replace their heart with a gland.
+  - Optionally: Give them back their primitive technology.
+
+  Finally, drag the victim whom you have completed your experiment on into the [color=#a149bf]Experimentator[/color] to confirm the results of the experiment on the [color=#a149bf]Abductor Console[/color] and send them back where you found them.
+
+  ##Getting rid of an Abductor
+  Like [textlink="Changelings" link="Changelings"], Abductors are not protected by [textlink="space law" link="SpaceLaw"] and are able to be executed freely.
+
+  Also, an abductor's ship is a physical object in the world, anyone with access to a space-faring ship such as [textlink="salvage" link="Salvage"] can bump into them in space and dismantle their ship.
 </Document>

--- a/Resources/ServerInfo/Guidebook/Antagonist/Antagonists.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Antagonists.xml
@@ -15,4 +15,7 @@
   - [textlink="Space Ninjas" link="SpaceNinja"], masters of espionage and sabotage with special gear.
   - [textlink="Thieves" link="Thieves"] driven by kleptomania, determined to get their fix using their special gloves.
   - [textlink="Various non-humanoid creatures" link="MinorAntagonists"] that generally attack anything that moves.
+  - [textlink="Abductors" link="Abductors"], an advanced alien society set on kidnapping station personnel for their own experiments.
+  - [textlink="Vampires" link="Vampires"] who gain strength and powers by drinking the blood of the crew.
+  - [textlink="Changelings" link="Changelings"], a bodyswapping alien creature who is never what they say they are.
 </Document>


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds the Abductors nonexistent guidebook page and adds new antagonists to Antagonists page.

## Why we need to add this
fixes [issue #58](https://github.com/ss14Starlight/space-station-14/issues/58#issue-2665415345)

## Media (Video/Screenshots)
![Screenshot 2024-12-28 143410](https://github.com/user-attachments/assets/daa9d59f-c95f-4904-94d6-84469093e61e)
![Screenshot 2024-12-28 143338](https://github.com/user-attachments/assets/aaf1f68c-61c4-4922-abaa-776f963f98a1)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: landosaur
- add: Added Abductor guidebook entry.
- tweak: Antagonists guidebook page now includes new antagonists.
