### PR TITLE
add defib module to base mediborg

### DIFF
--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -152,6 +152,7 @@
 
   defaultModules:
   - BorgModuleTreatment
+  - BorgModuleDefibrillator
 
   radioChannels:
   - Science


### PR DESCRIPTION
## Short description
gives the base mediborg the defib module

## Why we need to add this
cyborgs should probably have all the tools that the normal jobs get at the start of the round, or atleast similar tools.
which in this case would be a defiberlator

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/b7c5ce46-920c-43b8-8876-bf7b431b762d


## Checks
- [ X] I do not require assistance to complete the PR.
- [ X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ i think they are] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Clone0401
  - tweak: Mediborgs now start with a defib
