### PR TITLE
 Rebalance for ~unrobusts~ terror spiders.

### DIFF
--- a/Content.Shared/_Starlight/Antags/TerrorSpider/StealthOnWebSystem.cs
+++ b/Content.Shared/_Starlight/Antags/TerrorSpider/StealthOnWebSystem.cs
@@ -1,9 +1,12 @@
 ﻿using Content.Shared._Starlight.Antags.TerrorSpider;
 using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Events;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Spider;
+using Content.Shared.Stealth;
 using Content.Shared.Stealth.Components;
+using Content.Shared.Verbs;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Timing;
 
@@ -12,10 +15,25 @@ namespace Content.Shared.Starlight.Antags.TerrorSpider;
 public sealed class StealthOnWebSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedStealthSystem _stealth = default!;
     public override void Initialize()
     {
         SubscribeLocalEvent<StealthOnWebComponent, StartCollideEvent>(OnEntityEnter);
         SubscribeLocalEvent<StealthOnWebComponent, EndCollideEvent>(OnEntityExit);
+        SubscribeLocalEvent<StealthOnWebComponent, StaminaMeleeHitEvent>(OnHit);
+
+    }
+
+    private void OnHit(Entity<StealthOnWebComponent> ent, ref StaminaMeleeHitEvent args)
+    {
+        if (!TryComp<StealthComponent>(ent.Owner, out var stealth))
+        {
+            args.Multiplier *= 0.1f;
+            return;
+        }
+
+        var t = (_stealth.GetVisibility(ent.Owner) - stealth.MinVisibility) / (stealth.MaxVisibility - stealth.MinVisibility);
+        args.Multiplier *= Math.Clamp(1 - t, 0.1f, 1f);
     }
 
     private void OnEntityExit(Entity<StealthOnWebComponent> ent, ref EndCollideEvent args)
@@ -37,7 +55,5 @@ public sealed class StealthOnWebSystem : EntitySystem
         ent.Comp.Collisions++;
         EnsureComp<StealthComponent>(ent.Owner);
         EnsureComp<StealthOnMoveComponent>(ent.Owner);
-        var staminaOnHit = EnsureComp<StaminaDamageOnHitComponent>(ent.Owner);
-        staminaOnHit.Damage = 200;
     }
 }

--- a/Resources/Prototypes/_StarLight/Actions/spiders.yml
+++ b/Resources/Prototypes/_StarLight/Actions/spiders.yml
@@ -64,7 +64,7 @@
     renewCharges: true
     charges: 1
     maxCharges: 3
-    useDelay: 150
+    useDelay: 120
     icon:
       sprite: _Starlight/Interface/Actions/actions_spider.rsi
       state: egg

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -3,3 +3,11 @@
   coefficients:
     Cold: 0.5
     Heat: 1.5
+
+- type: damageModifierSet
+  id: TerrorSpider
+  coefficients:
+    Blunt: 0.4 
+    Slash: 1.1
+    Piercing: 0.9
+    Heat: 1.6

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/terror_spiders.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/terror_spiders.yml
@@ -11,13 +11,6 @@
     - map: ["enum.DamageStateVisualLayers.Base", "movement"]
       state: alive
       sprite: _Starlight/Mobs/Animals/Spiders/terror_red.rsi
-#  - type: SpriteMovement
-#    movementLayers:
-#      movement:
-#        state: tarantula-moving
-#    noMovementLayers:
-#      movement:
-#        state: tarantula
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -45,6 +38,9 @@
   - type: CombatMode
   - type: Body
     prototype: AnimalHemocyanin
+  - type: Damageable
+    damageContainer: Biological
+    damageModifierSet: TerrorSpider
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -138,18 +134,18 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      160: Dead
+      140: Dead
   - type: PassiveDamage 
     allowedStates:
     - Alive
-    damageCap: 159
+    damageCap: 139
     damage:
       types:
-        Poison: -1
+        Poison: -0.8
       groups:
-        Brute: -1
-        Burn: -1
-        Airloss: -2
+        Brute: -0.8
+        Burn: -0.8
+        Airloss: -1.5
   - type: MeleeWeapon
     altDisarm: false
     angle: 0
@@ -158,7 +154,7 @@
       path: /Audio/Effects/bite.ogg
     damage:
       types:
-        Piercing: 23
+        Piercing: 21
         Structural: 20
   - type: MovementSpeedModifier
     baseWalkSpeed : 3.00
@@ -177,21 +173,23 @@
       sprite: _Starlight/Mobs/Animals/Spiders/terror_gray2.rsi
   - type: VentCrawler
   - type: StealthOnWeb
+  - type: StaminaDamageOnHit
+    damage: 100
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Dead
+      80: Dead
   - type: PassiveDamage 
     allowedStates:
     - Alive
-    damageCap: 99
+    damageCap: 79
     damage:
       types:
-        Poison: -1
+        Poison: -0.5
       groups:
-        Brute: -1
-        Burn: -1
-        Airloss: -2
+        Brute: -0.5
+        Burn: -0.5
+        Airloss: -1.5
   - type: MeleeWeapon
     altDisarm: false
     angle: 0
@@ -209,7 +207,7 @@
       path: /Audio/Items/crowbar.ogg
   - type: MovementSpeedModifier
     baseWalkSpeed : 3.00
-    baseSprintSpeed : 5.00
+    baseSprintSpeed : 5
     
 - type: entity
   name: terror green
@@ -226,18 +224,18 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Dead
+      80: Dead
   - type: PassiveDamage 
     allowedStates:
     - Alive
-    damageCap: 99
+    damageCap: 79
     damage:
       types:
-        Poison: -1
+        Poison: -0.5
       groups:
-        Brute: -1
-        Burn: -1
-        Airloss: -2
+        Brute: -0.5
+        Burn: -0.5
+        Airloss: -1.5
   - type: MeleeWeapon
     altDisarm: false
     angle: 0
@@ -248,7 +246,7 @@
       types:
         Piercing: 11
   - type: MeleeChemicalInjector
-    transferAmount: 3.75
+    transferAmount: 2.75
     solution: melee
   - type: Prying
     pryPowered: false
@@ -258,7 +256,7 @@
       path: /Audio/Items/crowbar.ogg
   - type: MovementSpeedModifier
     baseWalkSpeed : 3.00
-    baseSprintSpeed : 6.00
+    baseSprintSpeed : 4.75
   - type: ActionGrant
     actions:
     - ActionEggInjection
@@ -278,7 +276,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      180: Dead
+      160: Dead
   - type: PassiveDamage 
     allowedStates:
     - Alive
@@ -289,7 +287,7 @@
       groups:
         Brute: -1
         Burn: -1
-        Airloss: -3
+        Airloss: -2
   - type: MeleeWeapon
     altDisarm: false
     angle: 0
@@ -300,7 +298,7 @@
       types:
         Piercing: 15
   - type: MeleeChemicalInjector
-    transferAmount: 7.75
+    transferAmount: 3.75
     solution: melee
   - type: Prying
     pryPowered: true
@@ -310,7 +308,7 @@
       path: /Audio/Items/crowbar.ogg
   - type: MovementSpeedModifier
     baseWalkSpeed : 3.00
-    baseSprintSpeed : 4.00
+    baseSprintSpeed : 3.75
   - type: TerrorPrincess
   - type: ActionGrant
     actions:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ ] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: STARLIGHT TEAM
- fix: The ambush attack of the gray spider from invisibility now deals less stamina damage, and the damage directly depends on the level of transparency.
- tweak: Reduced health, regeneration, damage, and speed.
- tweak: The egg-laying cooldown has been reduced by 30 seconds, from 2.5 minutes to 2 minutes.
- tweak: Damage modifiers have been adjusted: brute damage now deals only 40% damage, while heat damage deals 160%.
