### PR TITLE
Roboticist access tweak

### DIFF
--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Science/roboticist.yml
@@ -16,7 +16,6 @@
   access:
     - Research
     - Maintenance
-    - Engineering
 
 - type: startingGear
   id: RoboticistGear


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removing engineering access from Roboticist

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The Roboticist has no logical reason to have engineering access. All the tools/materials and machines needed to build and maintain borgs are available in their departement. 
Inspired by https://discord.com/channels/1272545509562777621/1324020103502762064

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Neccer
- tweak: Removed roboticists engineering access.


