### PR TITLE
Add Pirate Shuttle Event

### DIFF
--- a/Resources/Prototypes/_StarLight/Shuttles/shuttles.yml
+++ b/Resources/Prototypes/_StarLight/Shuttles/shuttles.yml
@@ -1,4 +1,0 @@
-- type: preloadedGrid
-  id: LancePirates
-  path: /Maps/_starlight/Shuttles/LancePirates.yml
-  copies: 1

--- a/Resources/Prototypes/_StarLight/Shuttles/shuttles.yml
+++ b/Resources/Prototypes/_StarLight/Shuttles/shuttles.yml
@@ -1,0 +1,4 @@
+- type: preloadedGrid
+  id: LancePirates
+  path: /Maps/_Starlight/Shuttles/LancePirates.yml
+  copies: 1

--- a/Resources/Prototypes/_StarLight/Shuttles/shuttles.yml
+++ b/Resources/Prototypes/_StarLight/Shuttles/shuttles.yml
@@ -1,0 +1,4 @@
+- type: preloadedGrid
+  id: LancePirates
+  path: /Maps/_starlight/Shuttles/LancePirates.yml
+  copies: 1


### PR DESCRIPTION
## Short description
Adds an Event 'LancePirates' to the shuttles prototypes to (hopefully) enable Admins to spawn the Shuttle. Is not included in any random event pools etc at the moment.

## Why we need to add this
Spawning for the Lance shuttle

## Media (Video/Screenshots)
NA

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added event to spawn the new Pirate Shuttle for Admins