### PR TITLE
Fix AI actions when reinserted to AI core

### DIFF
--- a/Content.Shared/Actions/ActionContainerSystem.cs
+++ b/Content.Shared/Actions/ActionContainerSystem.cs
@@ -239,13 +239,16 @@ public sealed class ActionContainerSystem : EntitySystem
         comp ??= EnsureComp<ActionsContainerComponent>(uid);
 
         if (!TryComp<MetaDataComponent>(actionId, out var actionData))
-            return false;
-        if (!TryPrototype(actionId, out var actionProto, actionData))
-            return false;
-
-        if (HasAction(uid, actionProto.ID))
         {
-            Log.Debug($"Tried to insert action {ToPrettyString(actionId)} into {ToPrettyString(uid)}. Failed due to duplicate actions.");
+            Log.Debug(
+                $"Tried to insert action {ToPrettyString(actionId)} into {ToPrettyString(uid)}. Failed due to lack of MetaDataComponent.");
+            return false;
+        }
+
+        if (!TryPrototype(actionId, out var actionProto, actionData))
+        {
+            Log.Debug(
+                $"Tried to insert action {ToPrettyString(actionId)} into {ToPrettyString(uid)}. Failed, could not retrieve prototype.");
             return false;
         }
 


### PR DESCRIPTION
Don't fail to insert an action to a container if it exists in the container.

The comment to the function even says "If the action is already in some container it will first remove it."

- Fixes AI actions when removed and added to the core via intellicard

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

## Why we need to add this

bug fix

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- fix: AI Actions when reinserted in core
