### PR TITLE
Adds Core to the map pool

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
@@ -4,6 +4,7 @@
   - StarlightBagel
   - StarlightBox
   - StarlightCog
+  - StarlightCore
   - StarlightFland
   - Hotel
   - Lobster


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Title
## Why we need to add this
I'm not sure what the story with core is, but I noticed it was already starlightified, and its a pretty nice station
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
--> :cl: PubliclyExecutedPig
- add: Added Core to the map pool
