### PR TITLE
Lowered Rates for antagonist

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -20,7 +20,7 @@
     - junk
     - meteorhell
   name: kessler-syndrome-title
-  showInVote: true # 🌟Starlight🌟
+  showInVote: false # 🌟Starlight🌟
   minPlayers: 10
   description: kessler-syndrome-description
   rules:
@@ -240,7 +240,7 @@
   name: zombieteors-title
   description: zombieteors-description
   minPlayers: 50 # 🌟Starlight🌟
-  showInVote: true # 🌟Starlight🌟
+  showInVote: false # 🌟Starlight🌟
   rules:
   - Zombie
   - BasicStationEventScheduler
@@ -257,7 +257,7 @@
   - vampires
   name: vampire-gamemode-title
   description: vampire-gamemode-description
-  showInVote: true # 🌟Starlight🌟
+  showInVote: false # 🌟Starlight🌟
   minPlayers: 50 # 🌟Starlight🌟
   rules:
   - Vampire
@@ -275,6 +275,7 @@
   name: changeling-gamemode-title
   description: changeling-gamemode-description
   showInVote: false
+  minPlayers: 50 # 🌟Starlight🌟
   rules:
     - Changeling
     - SubGamemodesRule

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,26 +1,25 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.20
+    Nukeops: 0.10
     Traitor: 0.60
     Zombie: 0.05
-    Changeling: 0.20
-    Zombieteors: 0.01
-    Survival: 0.10
-    KesslerSyndrome: 0.01
-    Revolutionary: 0.05
-    Vampire: 0.15
+    Changeling: 0.15
+    Survival: 0.05
+    Revolutionary: 0.10
+    Vampire: 0.20
+    Greenshift: 0.30
+    Extended: 0.15
 
 - type: weightedRandom
   id: SecretLP
   weights:
     Nukeops: 0.05
-    Traitor: 0.80
-    Zombie: 0.01
-    Changeling: 0.10
-    Zombieteors: 0.01
-    Survival: 0.10
-    KesslerSyndrome: 0.05
-    Revolutionary: 0.10
-    Vampire: 0.20
+    Traitor: 0.30
+    Zombie: 0.05
+    Survival: 0.05
+    Revolutionary: 0.05
+    Vampire: 0.15
     Extended: 0.20
+    Greenshift: 0.25
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Lowered the antagonist rates

## Why / Balance
seen nukies back to back so i decided hey why not reduce the chance of nukies to happen and a bunch of antags, so i lowered most antag rates and removed kessedler or whatever its called as its such a LRP gamemode for engineering department same for zombmeitors, I also removed Changling from SecretsLP as changling should not be happening during Lowpop for various reasons

## Technical details
Just changed weigh configs and added when clings should be shown (50 pop +)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**


- remove: zombieteors
- remove: KesslerSyndrome
- tweak: Changed the secret weighs
- removed: changeling from low pop