### PR TITLE
Add new security SOP with the text of grapegifter

### DIFF
--- a/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
@@ -64,6 +64,13 @@ guide-entry-sl-vote-of-no-confidence = Vote of No Confidence
 guide-entry-sl-money-accounts-and-space-credits = Money Accounts and Space Credits
 
 guide-entry-sl-security-sop-intro = Security
+guide-entry-sl-security-sop-cadet = Cadet
+guide-entry-sl-security-sop-securityofficer = Security Officer
+guide-entry-sl-security-sop-detective = Detective
+guide-entry-sl-security-sop-brigmedic = Brigmedic
+guide-entry-sl-security-sop-warden = Warden
+guide-entry-sl-security-sop-headofsecurity = Head of Security
+guide-entry-sl-security-sop-prisonertreatment = Prisoner Treatment
 
 guide-entry-sl-legal-sop-intro = Legal
 

--- a/Resources/Prototypes/_StarLight/Guidebook/sop.yml
+++ b/Resources/Prototypes/_StarLight/Guidebook/sop.yml
@@ -233,7 +233,56 @@
   name: guide-entry-sl-security-sop-intro
   text: "/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/security-sop-intro.xml"
   priority: 3
+  children:
+  - security-sop-cadet
+  - security-sop-securityofficer
+  - security-sop-detective
+  - security-sop-brigmedic
+  - security-sop-warden
+  - security-sop-headofsecurity
+  - security-sop-prisonertreatment
 
+- type: guideEntry
+  id: security-sop-cadet
+  name: guide-entry-sl-security-sop-cadet
+  text: "/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Cadet.xml"
+  priority: 4
+
+- type: guideEntry
+  id: security-sop-securityofficer
+  name: guide-entry-sl-security-sop-securityofficer
+  text: "/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/SecurityOfficer.xml"
+  priority: 4
+
+- type: guideEntry
+  id: security-sop-detective
+  name: guide-entry-sl-security-sop-detective
+  text: "/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Detective.xml"
+  priority: 4
+
+- type: guideEntry
+  id: security-sop-brigmedic
+  name: guide-entry-sl-security-sop-brigmedic
+  text: "/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Brigmedic.xml"
+  priority: 4
+
+- type: guideEntry
+  id: security-sop-warden
+  name: guide-entry-sl-security-sop-warden
+  text: "/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Warden.xml"
+  priority: 4
+
+- type: guideEntry
+  id: security-sop-headofsecurity
+  name: guide-entry-sl-security-sop-headofsecurity
+  text: "/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/HeadOfSecurity.xml"
+  priority: 4
+
+- type: guideEntry
+  id: security-sop-prisonertreatment
+  name: guide-entry-sl-security-sop-prisonertreatment
+  text: "/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/PrisonerTreatment.xml"
+  priority: 4
 
 
 - type: guideEntry

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Brigmedic.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Brigmedic.xml
@@ -1,0 +1,36 @@
+<Document>
+    # Brigmedic
+
+        <GuideEntityEmbed Entity="ToyFigurineSecurity" Caption="Brigmedic"/>
+
+    1 . Standard Code Green equipment is:
+
+
+    <Box>    
+        <GuideEntityEmbed Entity="MedkitAdvancedFilled"/>
+        <GuideEntityEmbed Entity="DefibrillatorBrigmedical"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="WeaponDisabler"/>
+        <GuideEntityEmbed Entity="Stunbaton"/>
+        <GuideEntityEmbed Entity="HoloprojectorSecurity"/>
+        <GuideEntityEmbed Entity="FlashlightSeclite"/>
+        <GuideEntityEmbed Entity="RadioHandheldSecurity"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="CombatKnife"/>
+        in
+        <GuideEntityEmbed Entity="ClothingShoesBootsJack"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="Handcuffs"/>
+        or
+        <GuideEntityEmbed Entity="Zipties"/>
+    </Box>
+
+    2. Brigmedics may not perform Security Officer duties unless Security is severely understaffed, or a crime has occurred in their sight.
+
+    3. Brigmedics must prioritize the health and safety of Security Officers and Prisoners over all other priorities.
+
+    4. Brigmedics putting themselves in excessive danger, and by extension the entire department, are to be considered negligent in their duties.
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Brigmedic.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Brigmedic.xml
@@ -9,6 +9,7 @@
     <Box>    
         <GuideEntityEmbed Entity="MedkitAdvancedFilled"/>
         <GuideEntityEmbed Entity="DefibrillatorBrigmedical"/>
+        <GuideEntityEmbed Entity="HandheldBrigmedicCrewMonitor"/>
     </Box>
     <Box>
         <GuideEntityEmbed Entity="WeaponDisabler"/>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Cadet.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Cadet.xml
@@ -1,0 +1,32 @@
+<Document>
+    # Cadet
+
+     <GuideEntityEmbed Entity="ToyFigurineSecurity" Caption="Cadet"/>
+
+    1 . Standard Code Green equipment is:
+
+    <Box>
+        <GuideEntityEmbed Entity="WeaponDisabler"/>
+
+        <GuideEntityEmbed Entity="Stunbaton"/>
+        <GuideEntityEmbed Entity="CombatKnife"/>
+
+        <GuideEntityEmbed Entity="HoloprojectorSecurity"/>
+        <GuideEntityEmbed Entity="FlashlightSeclite"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="GrenadeFlashBang"/>
+        or
+        <GuideEntityEmbed Entity="TearGasGrenade"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="Handcuffs"/>
+        or
+        <GuideEntityEmbed Entity="Zipties"/>
+    </Box>
+
+    2. Cadets are to assign themselves to a Security Officer if one is not assigned to them.
+
+    3. Cadets may only use lethal equipment on Code Red.
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Detective.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Detective.xml
@@ -1,0 +1,38 @@
+<Document>
+    # Detective
+
+    <GuideEntityEmbed Entity="ToyFigurineDetective" Caption="Detective"/>
+
+    1 . Standard Code Green equipment is:
+
+    <Box>
+        <GuideEntityEmbed Entity="WeaponRevolverInspector"/>
+        <GuideEntityEmbed Entity="ClothingHandsGlovesForensic"/>
+        <GuideEntityEmbed Entity="ForensicScanner"/>
+        <GuideEntityEmbed Entity="ForensicPad"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="RadioHandheldSecurity"/>
+        <GuideEntityEmbed Entity="Stunbaton"/>
+        <GuideEntityEmbed Entity="HoloprojectorSecurity"/>
+        <GuideEntityEmbed Entity="FlashlightSeclite"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="CombatKnife"/>
+        in
+        <GuideEntityEmbed Entity="ClothingShoesBootsJack"/>
+    </Box>
+
+    <Box>
+    
+    </Box>
+
+    2. The Detective is permitted to patrol with a Security Officer on all alert levels, but should focus on collecting of evidence and investigations at all times.
+
+    3. When acting as a Security Officer, the Detective must follow all Security Officer guidelines listed above.
+
+    4. The Detective is permitted to wear non-security uniforms for undercover investigations, with approval from the Head of Security. The Detective's Security ID should be on their person at all times, however.
+
+    5. The Detective is permitted to interrogate detained suspects, however any detainment must be subtracted from their overall arrest time.
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/HeadOfSecurity.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/HeadOfSecurity.xml
@@ -8,7 +8,7 @@
     <Box>
         <GuideEntityEmbed Entity="WeaponSubMachineGunWt550"/>
         or
-        <GuideEntityEmbed Entity="WeaponLaserCannon"/>
+        <GuideEntityEmbed Entity="WeaponEnergyShotgun"/>
     </Box>
 
 

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/HeadOfSecurity.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/HeadOfSecurity.xml
@@ -1,0 +1,47 @@
+<Document>
+    # Head of Security
+
+     <GuideEntityEmbed Entity="ToyFigurineHeadOfSecurity" Caption="Head of Security"/>
+
+    1 . Standard Code Green equipment is:
+
+    <Box>
+        <GuideEntityEmbed Entity="WeaponSubMachineGunWt550"/>
+        or
+        <GuideEntityEmbed Entity="WeaponLaserCannon"/>
+    </Box>
+
+
+    <Box>
+        <GuideEntityEmbed Entity="Stunbaton"/>
+        <GuideEntityEmbed Entity="HoloprojectorSecurity"/>
+        <GuideEntityEmbed Entity="FlashlightSeclite"/>
+        <GuideEntityEmbed Entity="RadioHandheldSecurity"/>
+
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="CombatKnife"/>
+        in
+        <GuideEntityEmbed Entity="ClothingShoesBootsJack"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="GrenadeFlashBang"/>
+        or
+        <GuideEntityEmbed Entity="TearGasGrenade"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="Handcuffs"/>
+        or
+        <GuideEntityEmbed Entity="Zipties"/>
+    </Box>
+
+    2. When patrolling, the Head of Security must follow all Security Officer protocols as above.
+
+    3. The Head of Security may overrule any sentence that is not assigned by an official NT Magistrate, but not for prisoners who have already had their sentences read to them.
+
+    4. The Head of Security may not utilize the armory for their own personal benefit.
+
+    5. The Head of Security must follow the Warden procedures for distributing any armory equipment, portable flashers, or portable barriers.
+
+    6. If a Code Red is called, the Head of Security must state the reason for the Code Red. The Captain may perform this duty instead, with permission from the Head of Security.
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/PrisonerTreatment.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/PrisonerTreatment.xml
@@ -1,0 +1,19 @@
+<Document>
+    # Prisoner Treatment
+
+    1. Prisoners must be read their list of crimes before the warden before sentencing can commence. Any time spent in confinement must be subtracted from the total time of their sentence.
+
+    2. Arrested prisoners are to be searched upon entry to Security. IDs and PDAs are to be removed from prisoners while in confinement. Prisoners are to be provided/allowed their own radio communications equipment.
+
+    Prisoner Searches include:
+        - Pockets
+        - PDA Slots
+        - Bags
+        - Coats/Overwear
+    
+    3. Prisoners placed into confinement are to be unrestrained. Prisoners who become combative or pose a flight risk may be restrained at the Warden's discretion.
+
+    4. Prisoners who receive perma/execution sentences may request a trial for their crimes, as decided by a jury of 12 of their peers. This may be waived in the face of imminent station destruction.
+
+    5. A paper copy of an arrest report should be created and then given to the prisoner after detainment, unless station threats are imminent. 
+</Document> 

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/SecurityOfficer.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/SecurityOfficer.xml
@@ -1,0 +1,37 @@
+<Document>
+    # Security Officer
+
+     <GuideEntityEmbed Entity="ToyFigurineSecurity" Caption="Security Officer"/>
+    
+    1 . Standard Code Green equipment is:
+
+    <Box>
+        <GuideEntityEmbed Entity="WeaponDisabler"/>
+
+        <GuideEntityEmbed Entity="Stunbaton"/>
+        <GuideEntityEmbed Entity="HoloprojectorSecurity"/>
+        <GuideEntityEmbed Entity="FlashlightSeclite"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="CombatKnife"/>
+        in
+        <GuideEntityEmbed Entity="ClothingShoesBootsJack"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="GrenadeFlashBang"/>
+        or
+        <GuideEntityEmbed Entity="TearGasGrenade"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="Handcuffs"/>
+        or
+        <GuideEntityEmbed Entity="Zipties"/>
+    </Box>
+
+    
+    2. Security Officers are to patrol the station unless an active threat has been recognized.
+    
+    3. Security Officers are permitted to assign sentences up to 15 minutes, but should inform the Warden of the accusation and sentencing if timing exceeds 10 mintues. Sentences over 15 minutes must be approved by the warden or Head of Security.
+    
+    4. It is advised on Code Blue or above that Security Officers patrol the station in pairs.
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Warden.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/Warden.xml
@@ -1,0 +1,40 @@
+<Document>
+    # Warden
+
+    <GuideEntityEmbed Entity="ToyFigurineWarden" Caption="Warden"/>
+
+    1 . Standard Code Green equipment is:
+
+        <Box>
+        <GuideEntityEmbed Entity="WeaponPistolMk58"/>
+        <GuideEntityEmbed Entity="Stunbaton"/>
+        <GuideEntityEmbed Entity="HoloprojectorSecurity"/>
+        <GuideEntityEmbed Entity="FlashlightSeclite"/>
+        <GuideEntityEmbed Entity="RadioHandheldSecurity"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="CombatKnife"/>
+        in
+        <GuideEntityEmbed Entity="ClothingShoesBootsJack"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="GrenadeFlashBang"/>
+        or
+        <GuideEntityEmbed Entity="TearGasGrenade"/>
+    </Box>
+    <Box>
+        <GuideEntityEmbed Entity="Handcuffs"/>
+        or
+        <GuideEntityEmbed Entity="Zipties"/>
+    </Box>
+
+    2. The Warden may not perform normal Security Officer duties, or arrests, if sufficient numbers of Security Officers are active. This is waived on Code Red or above.
+
+    3. The Warden may choose to hand out lethal weapons on Code Blue with a permit, or Code Red or above.
+
+    4. The Warden may choose to hand out body armor on Code Blue or above.
+
+    4. Uncooperative prisoners, or those deemed to be a flight risk may be cuffed, straightjacketed, or have an electropack placed on them.
+
+    5. Portable flashers and Barriers may be deployed on Code Blue or above.
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/security-sop-intro.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/security-sop-intro.xml
@@ -1,6 +1,26 @@
 <Document>
 # Securtiy SOP
 
-This SOP dictates the behavior of the station's security department. All crew members should review this SOP to ensure space law is being interpreted correctly. (WIP at the moment, Grapegifter will make and upload soonish) 
+These procedures apply to all security members, unless otherwise stated in their specific SOP.
+
+1. Armory weapons shall not be taken outside the brig on Code Green. Lethal sidearms are allowed on all alert levels (mk58, WT550, revolvers, etc.) and are not considered Armory Weapons.
+
+2. Armory weapons will be issued on a permit basis on Code Blue, and are allowed to all Security Personnel on Code Red. Disabler SMGs are not considered armory weapons.
+
+3. Weapons must remain holstered unless in active pursuit or on Code Red.
+
+4. Security personnel are required to state the reason for an arrest before any action may be taken against a suspect. This does not apply on Code Red, or if a suspect flees when approached.
+
+5. Security personnel must bring suspects to the brig uncuffed. This does not apply on Code Red, or if a suspect has already fled or become uncooperative.
+
+6. Security personnel may not request entry to a department, unless in pursuit of a suspect, or on Code Blue or Code Red.
+
+8. Searches may be conducted randomly on Codes Red and Blue, and on Green with an applicable warrant. Crew refusing searches on Blue/Red may be detained.
+
+9. All Security personnel must wear at least one piece of an official Security uniform at all times. Official Security uniforms are any uniforms that are found in any security locker, or Security vendor.
+
+10. Security personnel should refrain from wearing hardsuits or magboots unless an imminent threat or massive station damage is present.
+
+11. Security personnel may forcefully relocate crew members to their departments on Codes Red, Violet, Yellow, or Gamma.
 
 </Document> 


### PR DESCRIPTION
## Short description
Update Guidebooks ingame with the content from the wiki
https://ss14-starlight.wiki/Security_SOP
After discussion with Grapegifter on Discord, he wanted to have his Wiki changes inside the game.
My account name is Guntram

## Why we need to add this
Better Documentation for newbs

## Media (Video/Screenshots)

![Screenshot_2025-03-06_14-43-43](https://github.com/user-attachments/assets/bba95f56-6b64-4605-aa16-93d93173775d)

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- add: Security SOP in the Guidebook

