### PR TITLE
delink TTS voice selection from sex selection

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -471,15 +471,13 @@ namespace Content.Client.Lobby.UI
             for (var i = 0; i < _voices.Count; i++)
             {
                 var voice = _voices[i];
-                if (Profile.Sex != Sex.Unsexed && Profile.Sex != voice.Sex)
-                    continue;
 
-                VoiceButton.AddItem(Loc.GetString(voice.Name), i);
+                VoiceButton.AddItem($"[{voice.Sex}] {Loc.GetString(voice.Name)}", i);
             }
 
             if (string.IsNullOrEmpty(Profile.Voice))
             {
-                var available = _voices.Where(x => Profile.Sex == Sex.Unsexed || x.Sex == Profile.Sex).ToArray();
+                var available = _voices.ToArray();
                 if (available.Length > 0)
                 {
                     var index = new Random().Next(0, available.Length);


### PR DESCRIPTION
## Short description
This de links the voice selection dropdown from being related to your current characters sex selection. This just makes sense to change as voice training is a thing, and having a specific voice pitch is not guaranteed based on your sex. This also adds the assumed sex of the voice to the selection for clarity purposes

if there is a way to localize the sex selection let me know, but I couldn't find a function for it in my searching. I am willing to fix this error though if I am pointed in the right direction for what to reference

## Why we need to add this
Overall diversity and just common sense

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/7e92c507-8ede-4b85-8336-e2ac0623c9b2)

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Happyrobot33
- tweak: Changed voice selection to allow all voices no matter your characters sex
- add: Added the assumed sex of a voice to the voice dropdown