### PR TITLE
Add new cargo SOP from the wiki (grapegifter)

### DIFF
--- a/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
@@ -79,6 +79,16 @@ guide-entry-sl-engineering-sop-intro = Engineering
 guide-entry-sl-medical-sop-intro = Medical
 
 guide-entry-sl-cargo-sop-intro = Cargo
+guide-entry-sl-cargo-sop-cargotechnician = Cargo Technician
+guide-entry-sl-cargo-sop-miningspecialist = Mining Specialist
+guide-entry-sl-cargo-sop-salvagespecialist = SalvageSpecialist
+guide-entry-sl-cargo-sop-quartermaster = Quartermaster (QM)
+guide-entry-sl-cargo-sop-handlingorders = Handling Orders
+guide-entry-sl-cargo-sop-handlingorders-engineering = Engineering Orders
+guide-entry-sl-cargo-sop-handlingorders-security = Security Orders
+guide-entry-sl-cargo-sop-handlingorders-science = Science Orders
+guide-entry-sl-cargo-sop-handlingorders-medical = Medical Orders
+guide-entry-sl-cargo-sop-handlingorders-service = Service Orders
 
 guide-entry-sl-science-sop-intro = Science
 

--- a/Resources/Prototypes/_StarLight/Guidebook/sop.yml
+++ b/Resources/Prototypes/_StarLight/Guidebook/sop.yml
@@ -314,6 +314,78 @@
   name: guide-entry-sl-cargo-sop-intro
   text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/cargo-sop-intro.xml"
   priority: 7
+  children:
+    - cargo-sop-cargotechnician
+    - cargo-sop-miningspecialist
+    - cargo-sop-salvagespecialist
+    - cargo-sop-quartermaster
+    - cargo-sop-handlingorders
+
+- type: guideEntry
+  id: cargo-sop-cargotechnician
+  name: guide-entry-sl-cargo-sop-cargotechnician
+  text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/CargoTechnician.xml"
+  priority: 1
+
+- type: guideEntry
+  id: cargo-sop-miningspecialist
+  name: guide-entry-sl-cargo-sop-miningspecialist
+  text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/MiningSpecialist.xml"
+  priority: 2
+
+- type: guideEntry
+  id: cargo-sop-salvagespecialist
+  name: guide-entry-sl-cargo-sop-salvagespecialist
+  text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/SalvageSpecialist.xml"
+  priority: 3
+
+- type: guideEntry
+  id: cargo-sop-quartermaster
+  name: guide-entry-sl-cargo-sop-quartermaster
+  text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/Quartermaster.xml"
+  priority: 4
+
+- type: guideEntry
+  id: cargo-sop-handlingorders
+  name: guide-entry-sl-cargo-sop-handlingorders
+  text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/HandlingOrders.xml"
+  priority: 5
+  children:
+    - cargo-sop-handlingorders-engineering
+    - cargo-sop-handlingorders-security
+    - cargo-sop-handlingorders-science
+    - cargo-sop-handlingorders-medical
+    - cargo-sop-handlingorders-service
+
+- type: guideEntry
+  id: cargo-sop-handlingorders-engineering
+  name: guide-entry-sl-cargo-sop-handlingorders-engineering
+  text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/EngineeringOrders.xml"
+  priority: 1
+
+- type: guideEntry
+  id: cargo-sop-handlingorders-security
+  name: guide-entry-sl-cargo-sop-handlingorders-security
+  text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/SecurityOrders.xml"
+  priority: 2
+
+- type: guideEntry
+  id: cargo-sop-handlingorders-science
+  name: guide-entry-sl-cargo-sop-handlingorders-science
+  text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/ScienceOrders.xml"
+  priority: 3
+
+- type: guideEntry
+  id: cargo-sop-handlingorders-medical
+  name: guide-entry-sl-cargo-sop-handlingorders-medical
+  text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/MedicalOrders.xml"
+  priority: 4
+
+- type: guideEntry
+  id: cargo-sop-handlingorders-service
+  name: guide-entry-sl-cargo-sop-handlingorders-service
+  text: "/ServerInfo/Guidebook/StarlightSOP/CargoSOP/ServiceOrders.xml"
+  priority: 5
 
 
 

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/CargoTechnician.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/CargoTechnician.xml
@@ -1,0 +1,17 @@
+<Document>
+
+    # Cargo Technician
+
+    <GuideEntityEmbed Entity="ToyFigurineCargoTech" Caption="Cargo Technician"/>
+
+    1. Technicians report directly to the quartermaster.
+
+    2. Technicians are responsible for handling of orders, and retrieval from the ATS once an order is approved. Orders must not be delayed to being on station more than 10 minutes after approval. must not be delayed more than 10 minutes. Delays longer than this, without sufficient cause, can be considered negligence or incompetence.
+
+    3. Crates that are part of an order should not be opened. Instead their label should be checked for questions about their contents and the requestor.
+
+    4. Secure crates should not be opened by force. An exception is made if ordered to do so by the head of the relevant department or captain during an emergency.
+
+    5. Issues with policy or employment should be directed to the quartermaster or head of personnel. Any mention of "Cargonia" will be met with contract termination. 
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/EngineeringOrders.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/EngineeringOrders.xml
@@ -1,0 +1,26 @@
+<Document>
+
+    # Engineering Orders
+
+    Basic Materials
+    <Box>
+        <GuideEntityEmbed Entity="SheetSteel"/>
+        <GuideEntityEmbed Entity="SheetGlass"/>
+        <GuideEntityEmbed Entity="SheetPlastic"/>
+        <GuideEntityEmbed Entity="SheetPlasteel"/> 
+    </Box>
+
+    Cables
+    <Box>
+        <GuideEntityEmbed Entity="CableApcStack"/> 
+        <GuideEntityEmbed Entity="CableMVStack"/> 
+        <GuideEntityEmbed Entity="CableHVStack"/> 
+    </Box>
+
+    Other
+    <Box>
+        <GuideEntityEmbed Entity="VendingMachineRestockEngineering"/> 
+        <GuideEntityEmbed Entity="AmeJar"/> 
+    </Box>
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/HandlingOrders.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/HandlingOrders.xml
@@ -1,0 +1,46 @@
+<Document>
+
+    # Handling Orders
+
+    Orders are to be taken and handled as they come in. Orders out of the ordinary or not on the pre-approved list for a department are to be vetted with Item Request Forms.
+
+    1. Only Cargo Technicians and the Quartermaster shall place orders. Non-Cargo crew members should never touch the cargo computer.
+
+    2. On Codes Red, Violet, or Gamma, item request forms shall not be required for any orders for Security, and Medical respectively.
+
+    3. Orders are not required to be delivered to their recipients. However, the mailing system or normal deliveries may take place on Code Green or Blue.
+
+    4. Item Request Forms are to be filled out should the requestor's department not match the pre-approved item list.
+
+    5. Passengers must fill out an Item Request Form for any request.
+
+    6. To be valid the order request form must must state:
+
+        - Time of request.
+        - Name and title of requestor.
+        - Quantity of items and reason for request.
+        - Any special statements or considerations.
+        - Stamp from the requestor's head if the order is large or contains potential contraband.
+
+    7. All orders should have 3 copies.
+
+        - One copy is to be stored for future review if needed, such as a Security review.
+        - One copy is to be placed for the Quartermaster's review.
+        - One copy is to be returned for the requestor for proof of their order.
+
+    The order may then be entered fully into the cargo request computer. The entered request should include all relevant information that was provided, including reason for the order, as well as requestor. The request SHOULD NOT be approved. Technicians may not approve requests unless it is an emergency.
+
+    8. Upon receipt of 5 or more requests, or after 15 minutes, all current requests should be brought to the Quartermaster for review and approval. Alternatively, the Quartermaster may use their digiboard, and a cargo technician may approve the paperwork with the relevant stamp.
+
+    7. Once an order has arrived, the order slip that came with the order should be posted outside of Cargo for the requestor's use.
+
+    8. In order to receive their order, the requestor must bring their original request form and present it to the cargo technician or Quartermaster.
+
+    9. Non-cargo personnel may not use the cargo ordering computer.
+
+    10. Orders for the basic materials (glass, steel, plastic, cloth) may be placed by cargo personnel for the Cargo department if the material is below a limit of 180 between all lathes and loose resources.
+    Pre-Approved Materials List
+
+    This pre-approved materials list does not mean that you must order the item, rather it means that the Item Request Form may be omitted. Consideration to the station's needs and Cargo's budget still applies.
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/MedicalOrders.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/MedicalOrders.xml
@@ -1,0 +1,23 @@
+<Document>
+
+    # Medical Orders
+
+    Basic Materials only for printer/lathes
+    <Box>
+        <GuideEntityEmbed Entity="SheetSteel"/>
+        <GuideEntityEmbed Entity="SheetGlass"/>
+        <GuideEntityEmbed Entity="SheetPlastic"/>
+        <GuideEntityEmbed Entity="MaterialCloth1"/> 
+    </Box>
+
+    Chemicals
+    <Box>
+        <GuideEntityEmbed Entity="CrateVendingMachineRestockMedicalFilled"/> 
+        <GuideEntityEmbed Entity="CrateChemistryD"/> 
+        <GuideEntityEmbed Entity="CrateChemistryP"/> 
+        <GuideEntityEmbed Entity="CrateChemistryS"/> 
+    </Box>
+
+</Document>
+
+

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/MiningSpecialist.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/MiningSpecialist.xml
@@ -1,0 +1,15 @@
+<Document>
+
+# Mining Specialist
+
+<GuideEntityEmbed Entity="ToyFigurineSalvage" Caption="Mining Specialist"/>
+
+1. You report directly to the Quartermaster and are considered equal with others in the department.
+
+2. Mining Specialists must deliver one ore bag full of ore each before performing any other duties.
+
+3. Mining Specialists may not go on combat oriented expeditions.
+
+4. Mining Specialists are expected to act according to the Salvage Specialist and Cargo Technician subsections when away from and on the station respectively. 
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/Quartermaster.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/Quartermaster.xml
@@ -1,0 +1,17 @@
+<Document>
+
+# Quartermaster (QM)
+
+<GuideEntityEmbed Entity="ToyFigurineQuartermaster" Caption="Quartermaster (QM)"/>
+
+1. The Quartermaster is responsible for making sure that every batch of orders approved arrives on station within 15 minutes of approval.
+
+2. It is the Quartermaster's ultimate responsibility to make sure all forms are correct and in order. In case of dire emergencies such as imminent warhead detonation, paperwork may be filled out at a later date.
+
+3. The Quartermaster may not order security equipment without the express permission of the Head of security or the captain. In dire emergencies, paperwork may be filed at a later date.
+
+4. The Quartermaster may authorize non-standard orders, however any misuse of materials or crimes committed involving these orders will also implicate the Quartermaster.
+
+5. The Quartermaster may not go on salvage expeditions. 
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/SalvageSpecialist.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/SalvageSpecialist.xml
@@ -1,0 +1,21 @@
+<Document>
+
+# Salvage Specialist
+
+<GuideEntityEmbed Entity="ToyFigurineSalvage" Caption="Salvage Specialist"/>
+
+1. You report directly to the quartermaster, and should communicate with the QM before and after each expedition with a verbal status report. After every 3 expeditions, a formal paper report must be submitted to the Quartermaster for evaluation, included shall be:
+
+    Any contraband found
+    Any salvage materials found
+    Any damage to the ship/crew
+
+2. Dangerous expeditions may only be undertook with the express permission of the quartermaster. Going on unauthorized expeditions is grounds for demotion.
+
+4. Contraband found while on an expedition may not be used. Exceptions for imminent loss of life or grievous bodily harm are accepted.
+
+5. Upon arrival to the station, all contraband must be delivered to the Security department immediately.
+
+6. Salvage Specialists are to follow the guidelines for Cargo Technicians when on station. 
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/ScienceOrders.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/ScienceOrders.xml
@@ -1,0 +1,21 @@
+<Document>
+
+# Science Orders
+
+Basic Materials only for printer/lathes
+<Box>
+    <GuideEntityEmbed Entity="SheetSteel"/>
+    <GuideEntityEmbed Entity="SheetGlass"/>
+    <GuideEntityEmbed Entity="SheetPlastic"/>
+    <GuideEntityEmbed Entity="SheetPlasteel"/> 
+</Box>
+
+Other
+<Box>
+    <GuideEntityEmbed Entity="SheetPlasma"/> 
+    <GuideEntityEmbed Entity="SimpleXenoArtifact"/> 
+    <GuideEntityEmbed Entity="CrateVendingMachineRestockRoboticsFilled"/> 
+</Box>
+
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/SecurityOrders.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/SecurityOrders.xml
@@ -1,0 +1,20 @@
+<Document>
+
+# Security Orders
+
+Basic Materials only for printer/lathes
+<Box>
+    <GuideEntityEmbed Entity="SheetSteel"/>
+    <GuideEntityEmbed Entity="SheetGlass"/>
+    <GuideEntityEmbed Entity="SheetPlastic"/>
+</Box>
+
+Refill Crates
+<Box>
+    <GuideEntityEmbed Entity="CrateSecurityTrackingMindshieldImplants"/>
+    <GuideEntityEmbed Entity="CrateVendingMachineRestockSecTechFilled"/>
+</Box>
+
+</Document>
+
+

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/ServiceOrders.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/ServiceOrders.xml
@@ -1,0 +1,29 @@
+<Document>
+
+# Service Orders
+
+Bartender
+<Box>
+    <GuideEntityEmbed Entity="CrateFoodBarSupply"/>
+</Box>
+
+Botanist
+<Box>
+    <GuideEntityEmbed Entity="VendingMachineRestockSeeds"/>
+</Box>
+
+Janitor
+<Box>
+    <GuideEntityEmbed Entity="JanitorialTrolley"/>
+    <GuideEntityEmbed Entity="CrateServiceJanitorialSupplies"/>
+</Box>
+
+Clown/Mime
+<Box>
+    Any and all orders require QM and HoP stamps for approval
+</Box>
+
+
+</Document>
+
+

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/cargo-sop-intro.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/CargoSOP/cargo-sop-intro.xml
@@ -1,7 +1,7 @@
 <Document>
-# Cargo SOP
 
-This SOP is to assist the station's cargo and salvage team, and give them guidelines on how to best supply the station with materials. (WIP at the moment, Grapegifter will make and upload soonish) 
+    # Cargo SOP
 
+    This SOP is to assist the station's cargo and salvage team, and give them guidelines on how to best supply the station with materials.
 
 </Document> 


### PR DESCRIPTION
## Short description
Same as https://github.com/ss14Starlight/space-station-14/pull/365 but for Cargo

Update Guidebooks ingame with the content from the wiki
https://ss14-starlight.wiki/Cargo_SOP
After discussion with Grapegifter on Discord, he wanted to have his Wiki changes inside the game.
My account name is Guntram

## Why we need to add this
Better Documentation for newbs

## Media (Video/Screenshots)
![Screenshot_2025-03-06_21-31-09](https://github.com/user-attachments/assets/9e64f1ef-c4f2-45d8-8eb3-9be7900cec69)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: B1773rm4n
- add: Cargo SOP in the Guidebook
