### PR TITLE
Add defaults for server URLs as they haven't been set and won't likel…

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.Infolinks.cs
+++ b/Content.Shared/CCVar/CCVars.Game.Infolinks.cs
@@ -8,7 +8,7 @@ public sealed partial class CCVars
     ///     Link to Discord server to show in the launcher.
     /// </summary>
     public static readonly CVarDef<string> InfoLinksDiscord =
-        CVarDef.Create("infolinks.discord", "", CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("infolinks.discord", "https://discord.gg/HyDhPwAmUq", CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
     ///     Link to website to show in the launcher.
@@ -20,19 +20,19 @@ public sealed partial class CCVars
     ///     Link to GitHub page to show in the launcher.
     /// </summary>
     public static readonly CVarDef<string> InfoLinksGithub =
-        CVarDef.Create("infolinks.github", "", CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("infolinks.github", "https://github.com/ss14Starlight/space-station-14/", CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
     ///     Link to website to show in the launcher.
     /// </summary>
     public static readonly CVarDef<string> InfoLinksWebsite =
-        CVarDef.Create("infolinks.website", "", CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("infolinks.website", "https://ss14-starlight.online/", CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
     ///     Link to wiki to show in the launcher.
     /// </summary>
     public static readonly CVarDef<string> InfoLinksWiki =
-        CVarDef.Create("infolinks.wiki", "", CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("infolinks.wiki", "https://ss14-starlight.wiki/", CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
     ///     Link to Patreon. Not shown in the launcher currently.
@@ -44,7 +44,7 @@ public sealed partial class CCVars
     ///     Link to the bug report form.
     /// </summary>
     public static readonly CVarDef<string> InfoLinksBugReport =
-        CVarDef.Create("infolinks.bug_report", "", CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("infolinks.bug_report", "https://github.com/ss14Starlight/space-station-14/issues", CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
     ///     Link to site handling ban appeals. Shown in ban disconnect messages.


### PR DESCRIPTION
## Short description
I added default variables for the server. Seemingly they were supposed to be set up on the respective server hardware but some of them haven't been set up there. I consider it correct to set them as default variables as they are unlikely to change so often. And I'm pretty sure if a local environment will be set, it will overwrite the default anyway.

It mostly boils down to preference where this change should happen

## Why we need to add this
As requested in discord:
https://discord.com/channels/1272545509562777621/1347753334047641720

Aleph (M. Mothman)OP
>It's not easy to find the wiki for players that actually need to find it. You have to scroll up the announcements channel or have it linked by someone else, which is not ideal at all. I propose a links channel for server-relevant links to be posted, along with adding a link to the wiki in the server browser, like in the image attached.

>Needless to say, these changes will result in the wiki being significantly more accessible for every player, both new and old. 


## Media (Video/Screenshots)
![Screenshot_2025-03-08_11-45-49](https://github.com/user-attachments/assets/2952a1fc-8937-4d09-940f-0559fc59dee2)
![Screenshot_2025-03-08_11-45-37](https://github.com/user-attachments/assets/2aa74a77-85f9-4e6e-bf16-1923499465fb)

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- fix: Missing URLs to the wiki and website which made the button not show up

