### PR TITLE
Implement searchbox for the Player Manifest search at Round End

### DIFF
--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -107,8 +107,10 @@ namespace Content.Client.RoundEnd
                 Orientation = LayoutOrientation.Vertical
             };
 
-            // Starlight-edit: Search filter Box
-            // Starlight-edit: This adds the filter input box. Skip this part if you only want to know how the list gets populated.
+            // <summary>
+            // Starlight-start: Search filter Box
+            // This adds the filter input box. Skip this part if you only want to know how the list gets populated.
+            // </summary>
             var searchContainer = new BoxContainer
             {
                 Orientation = LayoutOrientation.Horizontal,
@@ -137,7 +139,7 @@ namespace Content.Client.RoundEnd
             searchContainer.AddChild(searchInput);
 
             playerManifestTab.AddChild(searchContainer);
-            // Starlight-edit: End of search box
+            // End of search box
 
             populatePlayManifestList(playerInfoContainer, playersInfo);
 
@@ -206,28 +208,30 @@ namespace Content.Client.RoundEnd
 
         private void OnSearchTextChanged(LineEdit.LineEditEventArgs searchTerm, BoxContainer playerInfoContainer, RoundEndMessageEvent.RoundEndPlayerInfo[] playersInfo)
         {
-            // Starlight-edit: Empty the result box when we star typing            
+            // Empty the result box when we star typing            
             playerInfoContainer.RemoveAllChildren();
 
             string newText = searchTerm.Text;
             if (string.IsNullOrWhiteSpace(newText))
             {
-                // Starlight-edit: If search is empty, show all text and all players
+                // If search is empty, show all text and all players
                 populatePlayManifestList(playerInfoContainer, playersInfo);
                 return;
             }
 
-            // Starlight-edit: Filter the player list based on search term
-            // Starlight-edit: Searches: Player OOC Name, Player IC Name, and Player Role
+            // Filter the player list based on search term
+            // Searches: Player OOC Name, Player IC Name, and Player Role
             var filteredPlayersInfo = playersInfo.Where(player =>
                 player.PlayerOOCName.ToLowerInvariant().Contains(newText.ToLowerInvariant()) ||
                 (player.PlayerICName != null && player.PlayerICName.ToLowerInvariant().Contains(newText.ToLowerInvariant())) ||
                 Loc.GetString(player.Role).ToLowerInvariant().Contains(newText.ToLowerInvariant())
             ).ToArray();
 
-            // Starlight-edit: Populate the player list with filtered results
+            // Populate the player list with filtered results
             populatePlayManifestList(playerInfoContainer, filteredPlayersInfo);
         }
+        
+        // Starlight-end
     }
 
 }

--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -107,8 +107,8 @@ namespace Content.Client.RoundEnd
                 Orientation = LayoutOrientation.Vertical
             };
 
-            // Search filter Box
-            // This adds the filter input box. Skip this part if you only want to know how the list gets populated.
+            // Starlight-edit: Search filter Box
+            // Starlight-edit: This adds the filter input box. Skip this part if you only want to know how the list gets populated.
             var searchContainer = new BoxContainer
             {
                 Orientation = LayoutOrientation.Horizontal,
@@ -137,7 +137,7 @@ namespace Content.Client.RoundEnd
             searchContainer.AddChild(searchInput);
 
             playerManifestTab.AddChild(searchContainer);
-            // End of search box
+            // Starlight-edit: End of search box
 
             populatePlayManifestList(playerInfoContainer, playersInfo);
 
@@ -206,26 +206,26 @@ namespace Content.Client.RoundEnd
 
         private void OnSearchTextChanged(LineEdit.LineEditEventArgs searchTerm, BoxContainer playerInfoContainer, RoundEndMessageEvent.RoundEndPlayerInfo[] playersInfo)
         {
-            // Empty the result box when we star typing            
+            // Starlight-edit: Empty the result box when we star typing            
             playerInfoContainer.RemoveAllChildren();
 
             string newText = searchTerm.Text;
             if (string.IsNullOrWhiteSpace(newText))
             {
-                // If search is empty, show all text and all players
+                // Starlight-edit: If search is empty, show all text and all players
                 populatePlayManifestList(playerInfoContainer, playersInfo);
                 return;
             }
 
-            // Filter the player list based on search term
-            // Searches: Player OOC Name, Player IC Name, and Player Role
+            // Starlight-edit: Filter the player list based on search term
+            // Starlight-edit: Searches: Player OOC Name, Player IC Name, and Player Role
             var filteredPlayersInfo = playersInfo.Where(player =>
                 player.PlayerOOCName.ToLowerInvariant().Contains(newText.ToLowerInvariant()) ||
                 (player.PlayerICName != null && player.PlayerICName.ToLowerInvariant().Contains(newText.ToLowerInvariant())) ||
                 Loc.GetString(player.Role).ToLowerInvariant().Contains(newText.ToLowerInvariant())
             ).ToArray();
 
-            // Populate the player list with filtered results
+            // Starlight-edit: Populate the player list with filtered results
             populatePlayManifestList(playerInfoContainer, filteredPlayersInfo);
         }
     }

--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -107,6 +107,48 @@ namespace Content.Client.RoundEnd
                 Orientation = LayoutOrientation.Vertical
             };
 
+            // Search filter Box
+            // This adds the filter input box. Skip this part if you only want to know how the list gets populated.
+            var searchContainer = new BoxContainer
+            {
+                Orientation = LayoutOrientation.Horizontal,
+                Margin = new Thickness(10, 10, 10, 5),
+                VerticalExpand = false,
+                HorizontalExpand = true
+            };
+
+            var searchLabel = new Label
+            {
+                Text = Loc.GetString("round-end-summary-window-search-label"),
+                MinSize = new Vector2(80, 0),
+                VerticalAlignment = VAlignment.Center
+            };
+
+            var searchInput = new LineEdit
+            {
+                PlaceHolder = Loc.GetString("round-end-summary-window-search-placeholder"),
+                HorizontalExpand = true,
+                MinHeight = 30
+            };
+
+            searchInput.OnTextChanged += (args) => OnSearchTextChanged(args, playerInfoContainer, playersInfo);
+
+            searchContainer.AddChild(searchLabel);
+            searchContainer.AddChild(searchInput);
+
+            playerManifestTab.AddChild(searchContainer);
+            // End of search box
+
+            populatePlayManifestList(playerInfoContainer, playersInfo);
+
+            playerInfoContainerScrollbox.AddChild(playerInfoContainer);
+            playerManifestTab.AddChild(playerInfoContainerScrollbox);
+
+            return playerManifestTab;
+        }
+
+        private void populatePlayManifestList(BoxContainer playerInfoContainer, RoundEndMessageEvent.RoundEndPlayerInfo[] playersInfo)
+        {
             //Put observers at the bottom of the list. Put antags on top.
             var sortedPlayersInfo = playersInfo.OrderBy(p => p.Observer).ThenBy(p => !p.Antag);
 
@@ -127,12 +169,12 @@ namespace Content.Client.RoundEnd
                 if (playerInfo.PlayerNetEntity != null)
                 {
                     hBox.AddChild(new SpriteView(playerInfo.PlayerNetEntity.Value, _entityManager)
-                        {
-                            OverrideDirection = Direction.South,
-                            VerticalAlignment = VAlignment.Center,
-                            SetSize = new Vector2(32, 32),
-                            VerticalExpand = true,
-                        });
+                    {
+                        OverrideDirection = Direction.South,
+                        VerticalAlignment = VAlignment.Center,
+                        SetSize = new Vector2(32, 32),
+                        VerticalExpand = true,
+                    });
                 }
 
                 if (playerInfo.PlayerICName != null)
@@ -160,11 +202,31 @@ namespace Content.Client.RoundEnd
                 hBox.AddChild(playerInfoText);
                 playerInfoContainer.AddChild(hBox);
             }
+        }
 
-            playerInfoContainerScrollbox.AddChild(playerInfoContainer);
-            playerManifestTab.AddChild(playerInfoContainerScrollbox);
+        private void OnSearchTextChanged(LineEdit.LineEditEventArgs searchTerm, BoxContainer playerInfoContainer, RoundEndMessageEvent.RoundEndPlayerInfo[] playersInfo)
+        {
+            // Empty the result box when we star typing            
+            playerInfoContainer.RemoveAllChildren();
 
-            return playerManifestTab;
+            string newText = searchTerm.Text;
+            if (string.IsNullOrWhiteSpace(newText))
+            {
+                // If search is empty, show all text and all players
+                populatePlayManifestList(playerInfoContainer, playersInfo);
+                return;
+            }
+
+            // Filter the player list based on search term
+            // Searches: Player OOC Name, Player IC Name, and Player Role
+            var filteredPlayersInfo = playersInfo.Where(player =>
+                player.PlayerOOCName.ToLowerInvariant().Contains(newText.ToLowerInvariant()) ||
+                (player.PlayerICName != null && player.PlayerICName.ToLowerInvariant().Contains(newText.ToLowerInvariant())) ||
+                Loc.GetString(player.Role).ToLowerInvariant().Contains(newText.ToLowerInvariant())
+            ).ToArray();
+
+            // Populate the player list with filtered results
+            populatePlayManifestList(playerInfoContainer, filteredPlayersInfo);
         }
     }
 

--- a/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-summary-window.ftl
@@ -6,3 +6,5 @@ round-end-summary-window-gamemode-name-label = The game mode was [color=white]{$
 round-end-summary-window-duration-label = It lasted for [color=yellow]{$hours} hours, {$minutes} minutes, and {$seconds} seconds.
 round-end-summary-window-player-info-if-observer-text = [color=gray]{$playerOOCName}[/color] was [color=lightblue]{$playerICName}[/color], an observer.
 round-end-summary-window-player-info-if-not-observer-text = [color=gray]{$playerOOCName}[/color] was [color={$icNameColor}]{$playerICName}[/color] playing role of [color=orange]{$playerRole}[/color].
+round-end-summary-window-search-label = Search:
+round-end-summary-window-search-placeholder = Filter by player...


### PR DESCRIPTION
## Short description
Add filter box for round end player overview

Requirement first stated by me on Discord, see:
https://discord.com/channels/1272545509562777621/1348169989454168134/1348169989454168134

## Why we need to add this
Pure convenience to filter names without any downsides

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/12a56ccb-3de1-4671-ac1e-795424306689

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: B1773rm4n
- add: Implement searchbox for the Player Manifest search at Round End
