### PR TITLE
Allow credits to be used as spesos

### DIFF
--- a/Resources/Locale/en-US/_Starlight/economy/atm-ui.ftl
+++ b/Resources/Locale/en-US/_Starlight/economy/atm-ui.ftl
@@ -5,7 +5,8 @@ economy-atm-ui-balance = Balance: {$balance} cr.
 
 economy-atm-ui-deposit = To make a deposit, insert money into the ATM,
                         but remember that cash withdrawal has a 0% fee,
-                        while cash deposit incurs a 10% fee.
+                        while cash deposit incurs a 10% fee. Credits
+                        can be used as a 1:1 replacement for Spesos.
 
 economy-chat-salary-message = Salary credited, {$amount} cr., sender: {$sender}.
 economy-chat-salary-wrapped-message = [bold]Salary credited, [color=green]{$amount}[/color][/bold] cr., sender: [bold][color={$senderColor}]{$sender}[/color][/bold].

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/credits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/credits.yml
@@ -12,6 +12,7 @@
   description: You gotta have real money.
   components:
   - type: NTCash
+  - type: Cash
   - type: Item
     shape:
     - 0,0,1,0

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/credits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/credits.yml
@@ -9,7 +9,7 @@
   parent: BaseItem
   id: NTCredit
   name: credit
-  description: You gotta have real money.
+  description: You gotta have real money. Can be used in place of Spesos, at a 1:1 conversion rate.
   components:
   - type: NTCash
   - type: Cash


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This makes it so ATM Credits can also be used as Spesos in the cargo console.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I changed this as it gives a more relevant purpose to the Credits, and also allows people to pay out of pocket themselves for Cargo to order specific things they may want. You could already do this before by taking the Credits to the ATS and selling them there, so this is just a quicker method to accomplish this goal

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/74c69070-d13b-4b53-a1c3-930a1ebac5b6



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- tweak: Made ATM Credits able to be treated as direct Spesos in things like the Cargo Order Terminal
-->

:cl: Happyrobot33
- tweak: Made ATM Credits able to be treated as direct Spesos in things like the Cargo Order Terminal
