### PR TITLE
Fixes arm breaking bug

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Shields/cyberlimb.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Shields/cyberlimb.yml
@@ -82,24 +82,24 @@
             - !type:PlaySoundBehavior
               sound:
                 collection: GlassBreak
-            - !type:SpawnEntitiesBehavior
-              spawn:
-                BrokenEnergyShieldCyber:
-                  min: 1
-                  max: 1
+            #- !type:SpawnEntitiesBehavior - Breaks arm. Who'da thunk?
+              #spawn:
+                #BrokenEnergyShieldCyber:
+                  #min: 1
+                  #max: 1
     - type: StaticPrice
       price: 350
 
-- type: entity
-  name: broken bulwark
-  parent: BaseItem
-  id: BrokenEnergyShieldCyber
-  description: Too damaged to effectively protect. Time to get a new one!
-  components:
-    - type: Sprite
-      sprite: Objects/Weapons/Melee/e_shield.rsi
-      state: eshield-icon
-    - type: Item
-      sprite: Objects/Weapons/Melee/e_shield.rsi
-      size: Small
-      heldPrefix: eshield
+#- type: entity
+  #name: broken bulwark
+  #parent: BaseItem
+  #id: BrokenEnergyShieldCyber
+  #description: Too damaged to effectively protect. Time to get a new one!
+  #components:
+    #- type: Sprite
+      #sprite: Objects/Weapons/Melee/e_shield.rsi
+      #state: eshield-icon
+    #- type: Item
+      #sprite: Objects/Weapons/Melee/e_shield.rsi
+      #size: Small
+      #heldPrefix: eshield


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes the bug made by the bulwark shield dropping a broken variant once destroyed.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
When the shield gets destroyed in the arm, it drops a broken variant "broken bulwark" which completely breaks the arm. All this does is turn off the code that does that, which fixes the bug.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- fix: Fixed Bulwark arm breaking when shield is destroyed.