### PR TITLE
supermatter from the ATS

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_engineering.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: SuppermatterSpawnGrenadePurchase
+  icon:
+    sprite: _Starlight/Objects/Specific/supermatter.rsi
+    state: supermatter
+  product: CrateSupermatterSpawnGrenade
+  cost: 8000
+  category: cargoproduct-category-name-engineering
+  group: market

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/engineering.yml
@@ -1,0 +1,9 @@
+- type: entity
+  id: CrateSupermatterSpawnGrenade
+  parent: CrateEngineeringSecure
+  name: supermatter calling crate
+  description: A crate containing a single supermatter calling grenade. used to replace or get a Supermatter when it is missing.
+  components:
+    - type: StorageFill
+      contents:
+        - id: SupermatterSpawnGrenade

--- a/Resources/Prototypes/_StarLight/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_StarLight/Objects/Weapons/Throwable/grenades.yml
@@ -1,0 +1,13 @@
+- type: entity
+  parent: [ BaseEngineeringContraband, SmokeGrenade ]
+  id: SupermatterSpawnGrenade
+  name: supermatter calling grenade
+  description: A grenade that has NanoTransen send a Supermatter Crystal to the location. DO NOT USE UNLESS CHAMBER PREPARED
+  components:
+    - type: Sprite
+      sprite: Objects/Weapons/Grenades/metalfoam.rsi
+    - type: SmokeOnTrigger
+      duration: 10
+      spreadAmount: 13
+    - type: SpawnOnTrigger
+      proto: SupermatterCrystal


### PR DESCRIPTION
## Short description
adds a way to replace and get the suppermatter via cargo.

## Why we need to add this
cargo can allready replace the singulo/tesla/TEG but cannot replace the supermatter. this brings parity in that aspect

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/3ca6542f-1c8b-4531-8f37-4aa0b4af8f79)
![image](https://github.com/user-attachments/assets/f3e56e42-13c8-48ac-9817-fe952264640f)
![image](https://github.com/user-attachments/assets/86ecf1a0-ab14-463a-a86b-0292eb4b8816)
![image](https://github.com/user-attachments/assets/c77f9b2a-4dd2-423d-bfd0-67ff84c75ae4)
![image](https://github.com/user-attachments/assets/edcdd408-8ec1-4f1d-8058-4d417544e7b3)
![image](https://github.com/user-attachments/assets/41cc6bfe-505d-438a-95f7-095a7c5e4b00)


## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- add: supermatter can now be bought at cargo for 8,000 spesos

