### PR TITLE
EMERGENCY FIX FOR AMMO BUNDLE

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -83,6 +83,7 @@
     contents:
       - id: WeaponLightMachineGunL6
       - id: MagazineBoxLightRifleSP
+      - id: MagazineLightRifleBoxSP
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle
@@ -128,7 +129,7 @@
         amount: 4
       - id: MagazineShotgun
         amount: 4
-      - id: WeaponLightMachineGunL6
+      - id: MagazineLightRifleBoxSP
         amount: 3
       - id: MagazineBoxLightRifleSP
         amount: 1


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
I got the names mixed up and accidentally gave the ammo bundle 3 LMGS instead of 3 LMG MAGAZINES
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I am SO sorry.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- fix: Fixed Ammo Bundle giving THREE LMGS. It now gives 3 LMG MAGS.