### PR TITLE
Fix backwards salvage magnet on Manor

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Manor.yml
+++ b/Resources/Maps/_Starlight/Stations/Manor.yml
@@ -165370,7 +165370,6 @@ entities:
   - uid: 24768
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -36.5,-23.5
       parent: 2
 - proto: SawElectric


### PR DESCRIPTION
- Turns magnet around
- One line change
- No other map YAML touched

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
The salvage magnet is turned around to point out towards open space instead of the Manor station insides.

## Why we need to add this
You use the magnet and the salvage appears on the opposite side of the station, far away from you, and confuses new salvs and anyone new to the map.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/8cd3311f-909f-49b9-b979-be8b8e3ef127)

## Checks
- [?] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Az Builds
- tweak: Manor station salvage magnet points at space now.