### PR TITLE
Dominater/Hybrid Buff

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -35,16 +35,16 @@
     zeroVisible: true
   - type: HitscanBatteryAmmoProvider
     proto: DisablerBolt
-    fireCost: 100
+    fireCost: 50
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: DisablerBolt
-      fireCost: 100
+      fireCost: 50
       visualState: disable
       magState: disable
       heldPrefix: disable4
     - proto: TaserBolt
-      fireCost: 250
+      fireCost: 125
       visualState: stun
       magState: stun
       heldPrefix: stun4
@@ -179,14 +179,14 @@
     access: [["Security"]]
   - type: HitscanBatteryAmmoProvider
     proto: DisablerBolt
-    fireCost: 100
+    fireCost: 50
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: DisablerBolt
-      fireCost: 100
+      fireCost: 50
       magState: disable
     - proto: TaserBolt
-      fireCost: 250
+      fireCost: 125
       magState: stun
       conditions:
       - !type:AlertLevelCondition
@@ -197,7 +197,7 @@
         - red
         - gamma
     - proto: LaserBolt
-      fireCost: 100
+      fireCost: 50
       magState: lethal
       conditions:
       - !type:AlertLevelCondition

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -44,7 +44,7 @@
       magState: disable
       heldPrefix: disable4
     - proto: TaserBolt
-      fireCost: 125
+      fireCost: 166
       visualState: stun
       magState: stun
       heldPrefix: stun4
@@ -186,7 +186,7 @@
       fireCost: 50
       magState: disable
     - proto: TaserBolt
-      fireCost: 125
+      fireCost: 166
       magState: stun
       conditions:
       - !type:AlertLevelCondition
@@ -197,7 +197,7 @@
         - red
         - gamma
     - proto: LaserBolt
-      fireCost: 50
+      fireCost: 66.6
       magState: lethal
       conditions:
       - !type:AlertLevelCondition


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Making dominator's and Hybrid taser's modes match the new disabler buff introduced.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
With the new disabler buffs (disabler having 20) it effectively made any other security sidearm, that being the dominator and hybrid taser, functionally useless as they had 10 less than the disabler, making people just toss their dominator or taser for a disabler instead.

This follows the formula of "x2 increase" so disabler and lethal mode have 20 shots (also making the dominator a slightly better lethal sidearm, still will NEVER be as good as the MK.) , and tase has 8--which should give it some use finally as the original 4 shot mode was never used ever since the taser nerfs (syndie armor having stun resist, taser mode not having insta-down) since you would have to burn all the charge in your dominator or hybrid taser to take down ONE guy, and that was IF you hit every shot, for something that would drop their gun but they could just as easily pick it back up and shoot you with.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![yrjsyrk](https://github.com/user-attachments/assets/fdad5bc1-b037-4d23-90a3-30835709aa0a)
![uoi;guo](https://github.com/user-attachments/assets/793217a2-2192-4e02-9270-fafb456ba816)
![ui;lugoi;](https://github.com/user-attachments/assets/ef9519ac-3c31-457a-a602-3cba82aab09f)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- tweak: Buffed dominator/hybrid's capacity to match the new 20-shot disabler