### PR TITLE
Fix glowing resomi and cyclorites

### DIFF
--- a/Content.Client/_Starlight/Overlay/Cyclorites/CycloritesVisionSystem.cs
+++ b/Content.Client/_Starlight/Overlay/Cyclorites/CycloritesVisionSystem.cs
@@ -38,6 +38,8 @@ public sealed class CycloritesVisionSystem : EntitySystem
 
     private void OnFlashImmunityChanged(Entity<CycloritesVisionComponent> ent, ref FlashImmunityChangedEvent args)
     {
+        if (_player.LocalEntity != ent.Owner) return;
+
         if (args.IsImmune)
         {
             ent.Comp.blockedByFlashImmunity = true;

--- a/Content.Client/_Starlight/Overlay/Cyclorites/CycloritesVisionSystem.cs
+++ b/Content.Client/_Starlight/Overlay/Cyclorites/CycloritesVisionSystem.cs
@@ -38,7 +38,7 @@ public sealed class CycloritesVisionSystem : EntitySystem
 
     private void OnFlashImmunityChanged(Entity<CycloritesVisionComponent> ent, ref FlashImmunityChangedEvent args)
     {
-        if (_player.LocalEntity != ent.Owner) return;
+        if (_player.LocalSession?.AttachedEntity != ent.Owner) return;
 
         if (args.IsImmune)
         {

--- a/Content.Client/_Starlight/Overlay/Night/NightVisionSystem.cs
+++ b/Content.Client/_Starlight/Overlay/Night/NightVisionSystem.cs
@@ -39,6 +39,8 @@ public sealed class NightVisionSystem : EntitySystem
 
     private void OnFlashImmunityChanged(Entity<NightVisionComponent> ent, ref FlashImmunityChangedEvent args)
     {
+        if (_player.LocalEntity != ent.Owner) return;
+
         if (args.IsImmune)
         {
             if (ent.Comp.Effect != null)

--- a/Content.Client/_Starlight/Overlay/Night/NightVisionSystem.cs
+++ b/Content.Client/_Starlight/Overlay/Night/NightVisionSystem.cs
@@ -39,7 +39,7 @@ public sealed class NightVisionSystem : EntitySystem
 
     private void OnFlashImmunityChanged(Entity<NightVisionComponent> ent, ref FlashImmunityChangedEvent args)
     {
-        if (_player.LocalEntity != ent.Owner) return;
+        if (_player.LocalSession?.AttachedEntity != ent.Owner) return;
 
         if (args.IsImmune)
         {

--- a/Content.Client/_Starlight/Overlay/Thermal/ThermalVisionSystem.cs
+++ b/Content.Client/_Starlight/Overlay/Thermal/ThermalVisionSystem.cs
@@ -41,6 +41,8 @@ public sealed class ThermalVisionSystem : SharedThermalVisionSystem
 
     private void OnFlashImmunityChanged(Entity<ThermalVisionComponent> ent, ref FlashImmunityChangedEvent args)
     {
+        if (_player.LocalEntity != ent.Owner) return;
+
         if (args.IsImmune)
         {
             ent.Comp.blockedByFlashImmunity = true;

--- a/Content.Client/_Starlight/Overlay/Thermal/ThermalVisionSystem.cs
+++ b/Content.Client/_Starlight/Overlay/Thermal/ThermalVisionSystem.cs
@@ -41,7 +41,7 @@ public sealed class ThermalVisionSystem : SharedThermalVisionSystem
 
     private void OnFlashImmunityChanged(Entity<ThermalVisionComponent> ent, ref FlashImmunityChangedEvent args)
     {
-        if (_player.LocalEntity != ent.Owner) return;
+        if (_player.LocalSession?.AttachedEntity != ent.Owner) return;
 
         if (args.IsImmune)
         {


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Hotfix, resomi and cyclorite and bees were glowing for other people not just the person currently controlling them

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Its broken lol

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed Resomi, Cyclorites and Bees appearing to glow to other players and not just the local player controlling them.