### PR TITLE
Re add this file as it not existing breaks the toggle for thermal vision

### DIFF
--- a/Content.Server/_Starlight/Overlay/Thermal/ThermalVisionSystem.cs
+++ b/Content.Server/_Starlight/Overlay/Thermal/ThermalVisionSystem.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Content.Server.Flash.Components;
+using Content.Server.Flash;
+using Content.Shared.Eye.Blinding.Components;
+
+namespace Content.Server._Starlight.Overlay.Thermal;
+public sealed class ThermalVisionSystem : SharedThermalVisionSystem
+{
+}


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Hotfixes the toggle for thermal vision being removed. I thought this file wasn't important, and seemingly it was even though it appears to do nothing when you just look at the file. It not existing lead to the action never being added to your bar to toggle thermal vision on and off

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
its broken, this fixes it

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed the ability to toggle thermal vision on and off.