### PR TITLE
Swap NT lockers to filled variants

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Hotel.yml
+++ b/Resources/Maps/_Starlight/Stations/Hotel.yml
@@ -103695,7 +103695,7 @@ entities:
     - type: Transform
       pos: -16.5,-26.5
       parent: 2
-- proto: LockerRepresentative
+- proto: LockerRepresentativeFilled
   entities:
   - uid: 1060
     components:

--- a/Resources/Maps/_Starlight/Stations/Lobster.yml
+++ b/Resources/Maps/_Starlight/Stations/Lobster.yml
@@ -98558,7 +98558,7 @@ entities:
     - type: Transform
       pos: 10.5,22.5
       parent: 2
-- proto: LockerRepresentative
+- proto: LockerRepresentativeFilled
   entities:
   - uid: 6535
     components:

--- a/Resources/Maps/_Starlight/Stations/Manor.yml
+++ b/Resources/Maps/_Starlight/Stations/Manor.yml
@@ -152868,7 +152868,7 @@ entities:
     - type: Transform
       pos: -26.5,-9.5
       parent: 2
-- proto: LockerRepresentative
+- proto: LockerRepresentativeFilled
   entities:
   - uid: 1666
     components:

--- a/Resources/Maps/_Starlight/Stations/Reach.yml
+++ b/Resources/Maps/_Starlight/Stations/Reach.yml
@@ -12621,7 +12621,7 @@ entities:
     - type: Transform
       pos: 12.5,-2.5
       parent: 2
-- proto: LockerRepresentative
+- proto: LockerRepresentativeFilled
   entities:
   - uid: 2560
     components:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Changes all the maps with the NT rep locker to use the filled variant instead

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Now that the filled variant exists, all maps should be updated to have them

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Filled NT Rep Locker on Cog, Hotel, Lobster, Manor and Reach.