### PR TITLE
Fix boxcutter item in backpacks

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/boxcutter.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/boxcutter.yml
@@ -7,6 +7,9 @@
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Melee/boxcutter.rsi
     state: boxcutter
+  - type: Item
+    sprite: _Starlight/Objects/Weapons/Melee/boxcutter.rsi
+    storedSprite:
   - type: ItemSwitch
     state: sheathed
     states:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes the box cutter visuals in the backpack to not be the combat knife

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Its broken lol

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Before 
![image](https://github.com/user-attachments/assets/6b4cea9a-59d8-4e01-990d-8adcbc4cfb65)

After
![image](https://github.com/user-attachments/assets/e97cb3a5-cb3a-43e6-8310-95b74e677dc1)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed Boxcutter sprite when in a inventory.