### PR TITLE
Clarifys the essence costs to unlock things

### DIFF
--- a/Resources/Locale/en-US/vampires/vampires.ftl
+++ b/Resources/Locale/en-US/vampires/vampires.ftl
@@ -53,48 +53,44 @@ vampire-mutation-none-info = Nothing selected
 
 vampire-mutation-hemomancer-info = 
     Hemomancer
-    
     Focuses on blood magic and manipulating the blood around him.
-    
     Abilities:
-    
-    - Screech
     - Blood Steal
+      - Requires 200 Essence to be usable
+    - Screech
+      - Requires 300 Essence to be usable
 
 vampire-mutation-umbrae-info = 
     Shadow
-    
     Focuses on darkness, stealth, mobility.
-    
     Abilities:
-    
     - Glare
+      - Requires 200 Essence to be usable
     - Cloak of Darkness
+      - Requires 300 Essence to be usable
     
 vampire-mutation-gargantua-info = 
     Gargantua
-    
     Focuses on melee damage and resilience.
-    
     Abilities:
-    
     - Unholy Strength
+      - Requires 200 Essence to be usable
     - Supernatural Strength
+      - Requires 300 Essence to be usable
 
 vampire-mutation-bestia-info = 
     Bestia
-    
     Focuses on turning and collecting trophies.
-    
     Abilities:
-    
     - Bat Form
+      - Requires 200 Essence to be usable
     - Mouse Form
+      - Requires 300 Essence to be usable
     
 ## Objectives
 
 objective-condition-drain-title = Drain { $count } blood.
-objective-condition-drain-description = I must drink { $count } of blood. It is necessary for my survival and further evolution.
+objective-condition-drain-description = I must drink { $count } blood. It is necessary for my survival and further evolution.
 ent-VampireSurviveObjective = Survive
     .desc = I have to survive, whatever it takes.
 ent-VampireEscapeObjective = Fly off the station alive and free.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This just clarifys the essence costs needed for different abilities to be usable. The ENTIRE vampire antag needs to be ground up rewritten as its utter shitcode, but this should clear up some confusion atleast

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
People think the antag is broken because its not at all obvious the abilities arent available in the action bar immediately

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Clarified the essence costs for the vampires ability in the evolution menu.