### PR TITLE
Shotgun Ammo Rebalancing

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -631,7 +631,7 @@
   parent: BulletTrace
   damage:
     types:
-      Piercing: 28
+      Piercing: 40
   pierceChance: 0.08
   bullet:
     sprite:
@@ -655,7 +655,8 @@
   parent: BulletTrace
   damage:
     types:
-      Piercing: 5
+      Piercing: 6
+  armorPenetration: -1
   pierceChance: 0.03
   count: 12
   spread: 15
@@ -670,7 +671,8 @@
   damage:
     types:
       Blunt: 2
-      Heat: 3
+      Heat: 4
+  armorPenetration: -1
   pierceChance: 0.02
   igniteOnCollision: true
   count: 12
@@ -701,6 +703,7 @@
     types:
       Piercing: 2
       Slash: 2
+  armorPenetration: -1
   pierceChance: 0
   count: 14
   spread: 45


### PR DESCRIPTION
## Short description

This PR buffs normal slugs by increasing their damage quite significantly. Also buffs the common pellet rounds against unarmored targets and vastly nerfs it against armored targets.

## Why we need to add this

It bothers me that Buckshot does quite well against armor (no modifier or penalty), and is merely "OK" against unarmored targets, whilst slugs are completely useless and never used. This is obviously not realistic and works against the expectations of how these weapons would perform, and is in stark contrast to our ap/fmj/sp/hp for other ballistics.

Those with shotguns will now have to resort to slugs if they are forced to fight an armored opponent, with buckshot doing nothing to anything on the level of a nukie hardsuit (just like HP rounds).

The numbers here are just a suggestion.

## Media (Video/Screenshots)

A screenshot proving I ran a simple test on my local server for the changes, testing damages of buckshot and slugs against armored and unarmored targets.

![40 Pierce](https://github.com/user-attachments/assets/0d038850-41d2-45ad-9728-5b662115bd1d)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: ddsaw
- tweak: Shotgun slug damage: 28->40
- tweak: Shotgun pellet damage(normal and incendiary) 5->6
- tweak: Shotgun pellet Armorpen 0->-1(very bad against armored targets)

