### PR TITLE
Changeling mindshield

### DIFF
--- a/Content.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -21,6 +21,8 @@ using Content.Shared.Damage.Components;
 using Content.Server.Radio.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Flash.Components;
+using Content.Shared.Mindshield.Components;
+using Content.Shared.Mindshield.FakeMindShield;
 
 namespace Content.Server.Changeling;
 
@@ -63,6 +65,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         SubscribeLocalEvent<ChangelingComponent, ActionLesserFormEvent>(OnLesserForm);
         SubscribeLocalEvent<ChangelingComponent, ActionSpacesuitEvent>(OnSpacesuit);
         SubscribeLocalEvent<ChangelingComponent, ActionHivemindAccessEvent>(OnHivemindAccess);
+        SubscribeLocalEvent<ChangelingComponent, FakeMindShieldToggleEvent>(OnFakeMindShieldToggle);
     }
 
     #region Basic Abilities
@@ -642,5 +645,10 @@ public sealed partial class ChangelingSystem : EntitySystem
         _popup.PopupEntity(Loc.GetString("changeling-hivemind-start"), uid, uid);
     }
 
+
+    public void OnFakeMindShieldToggle(EntityUid uid, ChangelingComponent comp, FakeMindShieldToggleEvent toggleEvent)
+    {
+        EnsureComp<FakeMindShieldComponent>(uid);
+    }
     #endregion
 }

--- a/Content.Shared/Mindshield/FakeMindShield/SharedFakeMindShieldImplantSystem.cs
+++ b/Content.Shared/Mindshield/FakeMindShield/SharedFakeMindShieldImplantSystem.cs
@@ -28,7 +28,6 @@ public sealed class SharedFakeMindShieldImplantSystem : EntitySystem
 
         if (!TryComp<FakeMindShieldComponent>(ent, out var comp))
             return;
-        _actionsSystem.SetToggled(ev.Action, !comp.IsEnabled); // Set it to what the Mindshield component WILL be after this
         RaiseLocalEvent(ent, ev); //this reraises the action event to support an eventual future Changeling Antag which will also be using this component for it's "mindshield" ability
     }
     private void ImplantCheck(EntityUid uid, FakeMindShieldImplantComponent component ,ref ImplantImplantedEvent ev)

--- a/Content.Shared/Mindshield/FakeMindShield/SharedFakeMindshieldSystem.cs
+++ b/Content.Shared/Mindshield/FakeMindShield/SharedFakeMindshieldSystem.cs
@@ -5,6 +5,8 @@ namespace Content.Shared.Mindshield.FakeMindShield;
 
 public sealed class SharedFakeMindShieldSystem : EntitySystem
 {
+    [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+    
     public override void Initialize()
     {
         base.Initialize();
@@ -13,6 +15,7 @@ public sealed class SharedFakeMindShieldSystem : EntitySystem
 
     private void OnToggleMindshield(EntityUid uid, FakeMindShieldComponent comp, FakeMindShieldToggleEvent toggleEvent)
     {
+        _actionsSystem.SetToggled(toggleEvent.Action, !comp.IsEnabled); // Set it to what the Mindshield component WILL be after this
         comp.IsEnabled = !comp.IsEnabled;
         Dirty(uid, comp);
     }

--- a/Content.Shared/Store/ListingPrototype.cs
+++ b/Content.Shared/Store/ListingPrototype.cs
@@ -203,7 +203,7 @@ public partial class ListingData : IEquatable<ListingData>
     /// </summary>
     [DataField]
     public bool DisableRefund = false;
-    
+
     public bool Equals(ListingData? listing)
     {
         if (listing == null)

--- a/Content.Shared/Store/ListingPrototype.cs
+++ b/Content.Shared/Store/ListingPrototype.cs
@@ -203,7 +203,7 @@ public partial class ListingData : IEquatable<ListingData>
     /// </summary>
     [DataField]
     public bool DisableRefund = false;
-
+    
     public bool Equals(ListingData? listing)
     {
         if (listing == null)

--- a/Resources/Locale/en-US/store/changeling-catalog.ftl
+++ b/Resources/Locale/en-US/store/changeling-catalog.ftl
@@ -132,3 +132,9 @@ evolutionmenu-utility-hivemindaccess-name = Hivemind Access
 evolutionmenu-utility-hivemindaccess-desc =
     Tunes our chemical receptors for hivemind communication, allowing us to recognize and communicate with other changelings who have also evolved this ability.
     Default radio key is +h
+
+evolutionmenu-utility-fakemindshield-name = Fake MindShield
+evolutionmenu-utility-fakemindshield-desc = 
+    Modifies a small portion of greymatter to be able to mimic MindShield signals, allowing you to trick specific devices.
+    May need a few toggle attempts to get the right frequency.
+    Cost 0 chemicals.

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -344,7 +344,7 @@
 - type: entity
   id: FakeMindShieldToggleAction
   name: '[color=green]Toggle Fake Mindshield[/color]'
-  description: Turn the Fake Mindshield implant's transmission on/off
+  description: Turn the Fake Mindshield's transmission on/off
   components:
   - type: InstantAction
     icon: { sprite: Interface/Actions/actions_fakemindshield.rsi, state: icon }

--- a/Resources/Prototypes/Catalog/changeling_catalog.yml
+++ b/Resources/Prototypes/Catalog/changeling_catalog.yml
@@ -343,7 +343,7 @@
 - type: listing
   id: EvolutionMenuUtilityFakeMindshield
   name: evolutionmenu-utility-fakemindshield-name
-  description: evolutionmenu-usility-fakemindshield-desc
+  description: evolutionmenu-utility-fakemindshield-desc
   productAction: FakeMindShieldToggleAction
   cost:
     EvolutionPoint: 2

--- a/Resources/Prototypes/Catalog/changeling_catalog.yml
+++ b/Resources/Prototypes/Catalog/changeling_catalog.yml
@@ -346,7 +346,7 @@
   description: evolutionmenu-utility-fakemindshield-desc
   productAction: FakeMindShieldToggleAction
   cost:
-    EvolutionPoint: 2
+    EvolutionPoint: 4
   categories:
     - ChangelingAbilityUtility
   conditions:

--- a/Resources/Prototypes/Catalog/changeling_catalog.yml
+++ b/Resources/Prototypes/Catalog/changeling_catalog.yml
@@ -339,3 +339,16 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
+
+- type: listing
+  id: EvolutionMenuUtilityFakeMindshield
+  name: evolutionmenu-utility-fakemindshield-name
+  description: evolutionmenu-usility-fakemindshield-desc
+  productAction: FakeMindShieldToggleAction
+  cost:
+    EvolutionPoint: 2
+  categories:
+    - ChangelingAbilityUtility
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1


### PR DESCRIPTION
## Short description
gave changelings a fake mindshield

## Why we need to add this
it is what the fake MindShield was made for. and also now command and sec can trust NO ONE when changelings are around. as lings can now impersonate command and sec properly.
also the line about "may need to toggle it mutiple times" is about how it uses ensure comp on the first call to make sure the fake MindShield component exists. as I could not think of any better way to do it within my (limited) knowledge

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/260810d6-e595-4d08-be3d-a5503efb81e8)
(after removing the captains mindshield component)
![image](https://github.com/user-attachments/assets/60ddc0aa-23e3-4f83-ab2d-91d83f001a57)
![image](https://github.com/user-attachments/assets/52a206e8-3b2a-4b76-935c-51782c869cbc)



## Checks
I have also checked that my tweaks to the implant and component allow the syndicate implant to keep working.

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: Changelings can now get a fake mindshield for 2 evolution points.
