### PR TITLE
Add supersynth to trinkets menu for staff, extra roles, 

### DIFF
--- a/Content.Shared/_Starlight/Preferences/Loadouts/Effects/AnyFlagLoadoutEffect.cs
+++ b/Content.Shared/_Starlight/Preferences/Loadouts/Effects/AnyFlagLoadoutEffect.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Utility;
 namespace Content.Shared.Preferences.Loadouts.Effects;
 
 /// <summary>
-/// Uses a <see cref="LoadoutEffectGroupPrototype"/> prototype as a singular effect that can be re-used.
+/// Takes a list of PlayerFlags and checks if the player has any of them. 
 /// </summary>
 public sealed partial class AnyFlagLoadoutEffect : LoadoutEffect
 {

--- a/Content.Shared/_Starlight/Preferences/Loadouts/Effects/AnyFlagLoadoutEffect.cs
+++ b/Content.Shared/_Starlight/Preferences/Loadouts/Effects/AnyFlagLoadoutEffect.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Content.Shared.Starlight;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Preferences.Loadouts.Effects;
+
+/// <summary>
+/// Uses a <see cref="LoadoutEffectGroupPrototype"/> prototype as a singular effect that can be re-used.
+/// </summary>
+public sealed partial class AnyFlagLoadoutEffect : LoadoutEffect
+{
+    [DataField(required: true)]
+    public List<PlayerFlags> Flags = [];
+    
+    public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, ICommonSession? session,
+        IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = new FormattedMessage();
+        if (session is not null && IoCManager.Resolve<ISharedPlayersRoleManager>().HasAnyPlayerFlags(session, Flags))
+            return true;
+
+        reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
+            "any-role-required",
+            ("roles", string.Join(", ", Flags.Select(Enum.GetName)))));
+        return false;
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
@@ -128,7 +128,7 @@
   - type: Sprite
     sprite: Objects/Fun/Instruments/reversecymbal.rsi
     state: icon
-
+    
 - type: entity
   parent: BaseHandheldInstrument
   id: SuperSynthesizerInstrument
@@ -138,7 +138,7 @@
   - type: Instrument
     allowPercussion: true
     allowProgramChange: true
-    respectMidiLimits: false
+    respectMidiLimits: true
   - type: Sprite
     sprite: Objects/Fun/Instruments/h_synthesizer.rsi
     state: supersynth
@@ -146,3 +146,10 @@
     heldPrefix: super
     size: Normal
     sprite: Objects/Fun/Instruments/h_synthesizer.rsi
+
+- type: entity
+  parent: SuperSynthesizerInstrument
+  id: SuperSynthesizerInstrumentAdmeme
+  components:
+  - type: Instrument
+    respectMidiLimits: false

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -49,6 +49,7 @@
   - TowelColorSilver
   - TowelColorWhite
   - TowelColorYellow
+  - SuperSynthesizerInstrument # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: Glasses

--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
@@ -1,0 +1,25 @@
+#The Synth
+# Timers
+- type: loadoutEffectGroup
+  id: SuperSynthTimerAndWhitelist
+  effects:
+    - !type:AnyFlagLoadoutEffect
+      flags:
+        - Staff
+        - Mentor
+        - ExtRoles
+        - Retiree
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:RoleTimeRequirement
+        role: JobMusician
+        time: 36000 # 1 hour of being the biggest nerd on the station
+
+- type: loadout
+  id: SuperSynthesizerInstrument
+  effects:
+    - !type:GroupLoadoutEffect
+      proto: SuperSynthTimerAndWhitelist
+  storage:
+    back:
+      - SuperSynthesizerInstrument

--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
@@ -13,7 +13,7 @@
       requirement:
         !type:RoleTimeRequirement
         role: JobMusician
-        time: 36000 # 1 hour of being the biggest nerd on the station
+        time: 72000 # 20 hours of being the biggest musician on the station
 
 - type: loadout
   id: SuperSynthesizerInstrument

--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
@@ -3,12 +3,6 @@
 - type: loadoutEffectGroup
   id: SuperSynthTimerAndWhitelist
   effects:
-    - !type:AnyFlagLoadoutEffect
-      flags:
-        - Staff
-        - Mentor
-        - ExtRoles
-        - Retiree
     - !type:JobRequirementLoadoutEffect
       requirement:
         !type:RoleTimeRequirement


### PR DESCRIPTION
## Short description
Killer wanted supersynth. heres the supersynth

## Why we need to add this
allows trusted people to get supersynths as they are cool and play really good songs.
also adds the work for locking other loadout options behind discord roles.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/de4db56f-1c83-4638-9780-ab6640da2da5)

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: Musician can now get a sypersynth as as a trinket loadout option. after 10 hours of musician gameplay. (With Midi Limit)

