### PR TITLE
Resomi and Felionoid gun rebalance (Knockback!)

### DIFF
--- a/Content.Client/_Starlight/Knockback/KnockbackSystem.cs
+++ b/Content.Client/_Starlight/Knockback/KnockbackSystem.cs
@@ -1,0 +1,12 @@
+using System.Numerics;
+using Content.Shared.Starlight.Knockback;
+using Content.Shared.Tag;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Client.Starlight.Knockback;
+public sealed partial class KnockbackSystem : SharedKnockbackSystem
+{
+}

--- a/Content.Server/_Starlight/Knockback/KnockbackSystem.cs
+++ b/Content.Server/_Starlight/Knockback/KnockbackSystem.cs
@@ -1,0 +1,12 @@
+using System.Numerics;
+using Content.Shared.Starlight.Knockback;
+using Content.Shared.Tag;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Server._Starlight.Knockback;
+public sealed partial class KnockbackSystem : SharedKnockbackSystem
+{
+}

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -391,6 +391,9 @@ public abstract partial class SharedGunSystem : EntitySystem
             return;
         }
 
+        var NonEmptyGunShotEvent = new OnNonEmptyGunShotEvent(user, ev.Ammo);
+        RaiseLocalEvent(gunUid, ref NonEmptyGunShotEvent);
+
         // Handle burstfire
         if (gun.SelectedMode == SelectiveFire.Burst)
         {
@@ -679,6 +682,9 @@ public record struct AttemptShootEvent(EntityUid User, string? Message, bool Can
 /// <param name="User">The user that fired this gun.</param>
 [ByRefEvent]
 public record struct GunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootable Shootable)> Ammo);
+
+[ByRefEvent]
+public record struct OnNonEmptyGunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootable Shootable)> Ammo);
 
 public enum EffectLayers : byte
 {

--- a/Content.Shared/_Starlight/Knockback/KnockbackByUserTagComponent.cs
+++ b/Content.Shared/_Starlight/Knockback/KnockbackByUserTagComponent.cs
@@ -14,4 +14,6 @@ public sealed partial class KnockbackByUserTagComponent : Component
 
     [DataField, AutoNetworkedField]
     public float Knockback = 0;
+    [DataField, AutoNetworkedField]
+    public float StaminaMultiplier = 10;
 }

--- a/Content.Shared/_Starlight/Knockback/KnockbackByUserTagComponent.cs
+++ b/Content.Shared/_Starlight/Knockback/KnockbackByUserTagComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Tag;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Starlight.Knockback;
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class KnockbackByUserTagComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public List<ProtoId<TagPrototype>> Contains = [];
+
+    [DataField, AutoNetworkedField]
+    public List<ProtoId<TagPrototype>> DoestContain = [];
+
+    [DataField, AutoNetworkedField]
+    public float Knockback = 0;
+}

--- a/Content.Shared/_Starlight/Knockback/KnockbackByUserTagComponent.cs
+++ b/Content.Shared/_Starlight/Knockback/KnockbackByUserTagComponent.cs
@@ -1,19 +1,24 @@
 using Content.Shared.Tag;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Starlight.Knockback;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class KnockbackByUserTagComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public List<ProtoId<TagPrototype>> Contains = [];
+    public Dictionary<ProtoId<TagPrototype>, KnockbackData> DoestContain = new();
+}
 
-    [DataField, AutoNetworkedField]
-    public List<ProtoId<TagPrototype>> DoestContain = [];
+[DataDefinition]
+[Serializable, NetSerializable]
+public sealed partial class KnockbackData
+{
+    public KnockbackData() { }
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float Knockback = 0;
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float StaminaMultiplier = 10;
 }

--- a/Content.Shared/_Starlight/Knockback/SharedKnockbackSystem.cs
+++ b/Content.Shared/_Starlight/Knockback/SharedKnockbackSystem.cs
@@ -1,0 +1,114 @@
+using System.Numerics;
+using Content.Shared._Starlight.Weapon.Components;
+using Content.Shared.Inventory;
+using Content.Shared.Popups;
+using Content.Shared.Slippery;
+using Content.Shared.Tag;
+using Content.Shared.Throwing;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+using Microsoft.Extensions.ObjectPool;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Shared.Starlight.Knockback;
+public abstract partial class SharedKnockbackSystem : EntitySystem
+{
+    [Dependency] private readonly TagSystem _tagSystem = default!;
+    [Dependency] private readonly SharedGunSystem _gunSystem = default!;
+    [Dependency] private readonly ILogManager _log = default!;
+    [Dependency] protected readonly SharedTransformSystem _transformSystem = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ThrowingSystem _throwing = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<KnockbackByUserTagComponent, OnNonEmptyGunShotEvent>(OnGunShot);
+    }
+
+    private void OnGunShot(Entity<KnockbackByUserTagComponent> ent, ref OnNonEmptyGunShotEvent args)
+    {
+        //make sure the ammo is shootable
+        foreach (var ammo in args.Ammo)
+        {
+            if (TryComp<HitScanCartridgeAmmoComponent>(ammo.Uid, out var hitscanCartridge))
+            {
+                //check if its spent
+                if (hitscanCartridge.Spent)
+                {
+                    return;
+                }
+            }
+
+            if (TryComp<CartridgeAmmoComponent>(ammo.Uid, out var cartridge))
+            {
+                //check if its spent
+                if (cartridge.Spent)
+                {
+                    return;
+                }
+            }
+        }
+
+        //check for tags
+        if (!_tagSystem.HasAllTags(args.User, ent.Comp.Contains) || _tagSystem.HasAnyTag(args.User, ent.Comp.DoestContain))
+        {
+            //get the gun component
+            if (TryComp<GunComponent>(ent, out var gunComponent))
+            {
+                var toCoordinates = gunComponent.ShootCoordinates;
+                
+                if (toCoordinates == null)
+                    return;
+
+                float knockback = ent.Comp.Knockback;
+                //If we have no slips, cut the knockback in half
+                if (CheckForNoSlips(args.User))
+                {
+                    knockback *= 0.5f;
+                }
+
+                if (knockback <= 0.0f)
+                    return;
+
+                //make a clone, not a reference
+                Vector2 modifiedCoords = toCoordinates.Value.Position;
+                //flip the direction
+                modifiedCoords = -modifiedCoords;
+                //normalize them
+                modifiedCoords = Vector2.Normalize(modifiedCoords);
+                //multiply by the knockback value
+                modifiedCoords *= knockback;
+                //set the new coordinates
+                var flippedDirection = new EntityCoordinates(args.User, modifiedCoords);
+
+                _throwing.TryThrow(args.User, flippedDirection, knockback * 5, args.User, 0, doSpin: false, compensateFriction: true);
+            }
+        }
+    }
+
+    private bool CheckForNoSlips(EntityUid uid)
+    {
+        if (EntityManager.TryGetComponent(uid, out NoSlipComponent? flashImmunityComponent))
+        {
+            return true;
+        }
+
+        if (TryComp<InventoryComponent>(uid, out var inventoryComp))
+        {
+            //get all worn items
+            var slots = _inventory.GetSlotEnumerator((uid, inventoryComp), SlotFlags.WITHOUT_POCKET);
+            while (slots.MoveNext(out var slot))
+            {
+                if (slot.ContainedEntity != null && EntityManager.TryGetComponent(slot.ContainedEntity, out NoSlipComponent? wornNoSlipComponent))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/Content.Shared/_Starlight/Knockback/SharedKnockbackSystem.cs
+++ b/Content.Shared/_Starlight/Knockback/SharedKnockbackSystem.cs
@@ -70,13 +70,17 @@ public abstract partial class SharedKnockbackSystem : EntitySystem
                     knockback *= 0.5f;
                 }
 
-                if (knockback <= 0.0f)
+                if (knockback == 0.0f)
                     return;
 
                 //make a clone, not a reference
                 Vector2 modifiedCoords = toCoordinates.Value.Position;
                 //flip the direction
-                modifiedCoords = -modifiedCoords;
+                if(knockback > 0)
+                    modifiedCoords = -modifiedCoords;
+                
+                //absolute knockback now
+                knockback = Math.Abs(knockback);
                 //normalize them
                 modifiedCoords = Vector2.Normalize(modifiedCoords);
                 //multiply by the knockback value

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -8,9 +8,12 @@
   - type: RestrictByUserTag
     doestContain:
     - Abductor
-    - Resomi
     messages:
     - abductor-gun-restricted-1
+  - type: KnockbackByUserTag
+    doestContain:
+    - Resomi
+    knockback: 0.01
   - type: Sprite
   - type: Item
     size: Ginormous

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -14,6 +14,7 @@
     doestContain:
     - Resomi
     knockback: 0.01
+    staminaMultiplier: 100
   - type: Sprite
   - type: Item
     size: Ginormous

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -12,9 +12,9 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
-    - Resomi
-    knockback: 0.01
-    staminaMultiplier: 100
+      Resomi:
+        knockback: 0.01
+        staminaMultiplier: 100
   - type: Sprite
   - type: Item
     size: Ginormous

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -8,9 +8,12 @@
   - type: RestrictByUserTag
     doestContain:
     - Abductor
-    - Resomi
     messages:
     - abductor-gun-restricted-1
+  - type: KnockbackByUserTag
+    doestContain:
+    - Resomi
+    knockback: 0.02
   - type: Sprite
   - type: Item
     size: Huge

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -14,6 +14,7 @@
     doestContain:
     - Resomi
     knockback: 0.02
+    staminaMultiplier: 100
   - type: Sprite
   - type: Item
     size: Huge

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -12,9 +12,9 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
-    - Resomi
-    knockback: 0.02
-    staminaMultiplier: 100
+      Resomi:
+        knockback: 0.02
+        staminaMultiplier: 100
   - type: Sprite
   - type: Item
     size: Huge

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -14,6 +14,7 @@
     doestContain:
     - Resomi
     knockback: 10
+    staminaMultiplier: 8
   - type: Sprite
   - type: Clothing
     sprite: Objects/Weapons/Guns/Launchers/china_lake.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -64,10 +64,14 @@
 
 - type: entity
   name: RPG-7
-  parent: [ BaseWeaponLauncher, BaseMajorContraband ]
+  parent: [ BaseWeaponLauncher, BaseMajorContraband]
   id: WeaponLauncherRocket
   description: A modified ancient rocket-propelled grenade launcher.
   components:
+  - type: KnockbackByUserTag
+    doestContain:
+    - Resomi
+    knockback: -5
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/rocket.rsi
     layers:
@@ -97,10 +101,14 @@
 
 - type: entity
   name: multiple rocket launcher
-  parent: BaseWeaponLauncher
+  parent: [BaseWeaponLauncher]
   id: WeaponLauncherMultipleRocket
   description: A modified ancient rocket-propelled grenade launcher.
   components:
+  - type: KnockbackByUserTag
+    doestContain:
+    - Resomi
+    knockback: -5
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/rocket.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -8,9 +8,12 @@
   - type: RestrictByUserTag
     doestContain:
     - Abductor
-    - Resomi
     messages:
     - abductor-gun-restricted-1
+  - type: KnockbackByUserTag
+    doestContain:
+    - Resomi
+    knockback: 10
   - type: Sprite
   - type: Clothing
     sprite: Objects/Weapons/Guns/Launchers/china_lake.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -12,9 +12,12 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
-    - Resomi
-    knockback: 10
-    staminaMultiplier: 8
+      Resomi:
+        knockback: 10
+        staminaMultiplier: 8
+      Felionoid:
+        knockback: 5 #half of what resomi take
+        staminaMultiplier: 8
   - type: Sprite
   - type: Clothing
     sprite: Objects/Weapons/Guns/Launchers/china_lake.rsi
@@ -71,8 +74,10 @@
   components:
   - type: KnockbackByUserTag
     doestContain:
-    - Resomi
-    knockback: -5
+      Resomi:
+        knockback: -5
+      Felionoid:
+        knockback: -2.5 #half of what resomi take
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/rocket.rsi
     layers:
@@ -108,8 +113,12 @@
   components:
   - type: KnockbackByUserTag
     doestContain:
-    - Resomi
-    knockback: -5
+      Resomi:
+        knockback: 10
+        staminaMultiplier: 8
+      Felionoid:
+        knockback: 5 #half of what resomi take
+        staminaMultiplier: 8
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/rocket.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: BaseWeaponRifle
-  parent: [BaseItem, BaseGunWieldable]
+  parent: [ BaseItem, BaseGunWieldable ]
   id: BaseWeaponRifle
   description: A rooty tooty point and shooty.
   abstract: true
@@ -8,9 +8,12 @@
   - type: RestrictByUserTag
     doestContain:
     - Abductor
-    - Resomi
     messages:
     - abductor-gun-restricted-1
+  - type: KnockbackByUserTag
+    doestContain:
+    - Resomi
+    knockback: 0.1
   - type: Sprite
   - type: Item
     size: Huge
@@ -25,7 +28,7 @@
     fireRate: 5
     selectedMode: FullAuto
     availableModes:
-      - FullAuto
+    - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/batrifle.ogg
   - type: ChamberMagazineAmmoProvider
@@ -41,7 +44,7 @@
         priority: 2
         whitelist:
           tags:
-            - MagazineLightRifle
+          - MagazineLightRifle
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
@@ -49,27 +52,27 @@
         priority: 1
         whitelist:
           tags:
-            - CartridgeLightRifle
+          - CartridgeLightRifle
   - type: ContainerContainer
     containers:
-      gun_magazine: !type:ContainerSlot
-      gun_chamber: !type:ContainerSlot
+      gun_magazine: !type:ContainerSlot ""
+      gun_chamber: !type:ContainerSlot ""
   - type: StaticPrice
     price: 500
 
 - type: entity
   name: AKMS
-  parent: [BaseWeaponRifle, BaseSecurityContraband]
+  parent: [ BaseWeaponRifle, BaseSecurityContraband ]
   id: WeaponRifleAk
   description: An iconic weapon of war. Uses .30 rifle ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/ak.rsi
     layers:
-      - state: base
-        map: ["enum.GunVisualLayers.Base"]
-      - state: mag-0
-        map: ["enum.GunVisualLayers.Mag"]
+    - state: base
+      map: [ "enum.GunVisualLayers.Base" ]
+    - state: mag-0
+      map: [ "enum.GunVisualLayers.Mag" ]
   - type: Gun
     fireRate: 5
     soundGunshot:
@@ -87,7 +90,7 @@
         priority: 2
         whitelist:
           tags:
-            - MagazineLightRifle
+          - MagazineLightRifle
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
@@ -95,11 +98,11 @@
         priority: 1
         whitelist:
           tags:
-            - CartridgeLightRifle
+          - CartridgeLightRifle
   - type: ContainerContainer
     containers:
-      gun_magazine: !type:ContainerSlot
-      gun_chamber: !type:ContainerSlot
+      gun_magazine: !type:ContainerSlot ""
+      gun_chamber: !type:ContainerSlot ""
   - type: MagazineVisuals
     magState: mag
     steps: 1
@@ -108,17 +111,17 @@
 
 - type: entity
   name: M-90gl
-  parent: [BaseWeaponRifle, BaseSyndicateContraband]
+  parent: [ BaseWeaponRifle, BaseSyndicateContraband ]
   id: WeaponRifleM90GrenadeLauncher
   description: An older bullpup carbine model, with an attached underbarrel grenade launcher. Uses .20 rifle ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/carbine.rsi
     layers:
-      - state: base
-        map: ["enum.GunVisualLayers.Base"]
-      - state: mag-0
-        map: ["enum.GunVisualLayers.Mag"]
+    - state: base
+      map: [ "enum.GunVisualLayers.Base" ]
+    - state: mag-0
+      map: [ "enum.GunVisualLayers.Mag" ]
   - type: Clothing
     sprite: Objects/Weapons/Guns/Rifles/carbine.rsi
   - type: ItemSlots
@@ -131,7 +134,7 @@
         priority: 2
         whitelist:
           tags:
-            - MagazineRifle
+          - MagazineRifle
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
@@ -139,11 +142,11 @@
         priority: 1
         whitelist:
           tags:
-            - CartridgeRifle
+          - CartridgeRifle
   - type: ContainerContainer
     containers:
-      gun_magazine: !type:ContainerSlot
-      gun_chamber: !type:ContainerSlot
+      gun_magazine: !type:ContainerSlot ""
+      gun_chamber: !type:ContainerSlot ""
   - type: MagazineVisuals
     magState: mag
     steps: 1
@@ -152,17 +155,17 @@
 
 - type: entity
   name: Lecter
-  parent: [BaseWeaponRifle, BaseSecurityContraband]
+  parent: [ BaseWeaponRifle, BaseSecurityContraband ]
   id: WeaponRifleLecter
   description: A high end military grade assault rifle. Uses .20 rifle ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
     layers:
-      - state: base
-        map: ["enum.GunVisualLayers.Base"]
-      - state: mag-0
-        map: ["enum.GunVisualLayers.Mag"]
+    - state: base
+      map: [ "enum.GunVisualLayers.Base" ]
+    - state: mag-0
+      map: [ "enum.GunVisualLayers.Mag" ]
   - type: Clothing
     sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
   - type: Gun
@@ -178,7 +181,7 @@
         priority: 2
         whitelist:
           tags:
-            - MagazineRifle
+          - MagazineRifle
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
@@ -186,11 +189,11 @@
         priority: 1
         whitelist:
           tags:
-            - CartridgeRifle
+          - CartridgeRifle
   - type: ContainerContainer
     containers:
-      gun_magazine: !type:ContainerSlot
-      gun_chamber: !type:ContainerSlot
+      gun_magazine: !type:ContainerSlot ""
+      gun_chamber: !type:ContainerSlot ""
   - type: MagazineVisuals
     magState: mag
     steps: 1
@@ -199,10 +202,14 @@
 
 - type: entity
   name: Foam Force Astro Ace
-  parent: [BaseWeaponShotgun, BaseGunWieldable]
+  parent: [ BaseWeaponShotgun, BaseGunWieldable ]
   id: WeaponRifleFoam
   description: A premium foam rifle of the highest quality. Its plastic feels rugged, and its mechanisms sturdy.
   components:
+  - type: KnockbackByUserTag
+    doestContain:
+    - Resomi
+    knockback: 0
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/foam_rifle.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -12,8 +12,8 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
-    - Resomi
-    knockback: 0.1
+      Resomi:
+        knockback: 0.1
   - type: Sprite
   - type: Item
     size: Huge
@@ -208,8 +208,8 @@
   components:
   - type: KnockbackByUserTag
     doestContain:
-    - Resomi
-    knockback: 0
+      Resomi:
+        knockback: 0
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/foam_rifle.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -8,9 +8,12 @@
   - type: RestrictByUserTag
     doestContain:
     - Abductor
-    - Resomi
     messages:
     - abductor-gun-restricted-1
+  - type: KnockbackByUserTag
+    doestContain:
+    - Resomi
+    knockback: 1
   - type: Sprite
     layers:
     - state: icon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -12,9 +12,12 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
-    - Resomi
-    knockback: 3
-    staminaMultiplier: 20
+      Resomi:
+        knockback: 3
+        staminaMultiplier: 20
+      Felionoid:
+        knockback: 1.5 #half of what resomi take
+        staminaMultiplier: 20
   - type: Sprite
     layers:
     - state: icon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -13,7 +13,8 @@
   - type: KnockbackByUserTag
     doestContain:
     - Resomi
-    knockback: 1
+    knockback: 3
+    staminaMultiplier: 20
   - type: Sprite
     layers:
     - state: icon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -8,9 +8,12 @@
   - type: RestrictByUserTag
     doestContain:
     - Abductor
-    - Resomi
     messages:
     - abductor-gun-restricted-1
+  - type: KnockbackByUserTag
+    doestContain:
+    - Resomi
+    knockback: 4
   - type: Sprite
     layers:
     - state: base
@@ -50,6 +53,10 @@
   id: WeaponSniperMosin
   description: A weapon for hunting, or endless trench warfare. Uses .30 rifle ammo.
   components:
+  - type: KnockbackByUserTag
+    doestContain:
+    - Resomi
+    knockback: 2
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -14,6 +14,7 @@
     doestContain:
     - Resomi
     knockback: 4
+    staminaMultiplier: 15
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -12,9 +12,12 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
-    - Resomi
-    knockback: 4
-    staminaMultiplier: 15
+      Resomi:
+        knockback: 4
+        staminaMultiplier: 15
+      Felionoid:
+        knockback: 2 #half of what resomi take
+        staminaMultiplier: 15
   - type: Sprite
     layers:
     - state: base
@@ -56,8 +59,10 @@
   components:
   - type: KnockbackByUserTag
     doestContain:
-    - Resomi
-    knockback: 2
+      Resomi:
+        knockback: 2
+      Felionoid:
+        knockback: 1 #half of what resomi take
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
 

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -122,9 +122,6 @@
       fallbackRoles: [ Nukeops, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsCommander
       startingGear: SyndicateCommanderGearFull
-      blacklist:
-        tags:
-          - Resomi
       roleLoadout:
       - RoleSurvivalNukie
       components:
@@ -142,9 +139,6 @@
       fallbackRoles: [ Nukeops, NukeopsCommander ]
       spawnerPrototype: SpawnPointNukeopsMedic
       startingGear: SyndicateOperativeMedicFull
-      blacklist:
-        tags:
-          - Resomi
       roleLoadout:
       - RoleSurvivalNukie
       components:
@@ -164,9 +158,6 @@
       max: 3
       playerRatio: 10
       startingGear: SyndicateOperativeGearFull
-      blacklist:
-        tags:
-          - Resomi
       roleLoadout:
       - RoleSurvivalNukie
       components:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -122,6 +122,9 @@
       fallbackRoles: [ Nukeops, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsCommander
       startingGear: SyndicateCommanderGearFull
+      blacklist:
+        tags:
+          - Resomi
       roleLoadout:
       - RoleSurvivalNukie
       components:
@@ -139,6 +142,9 @@
       fallbackRoles: [ Nukeops, NukeopsCommander ]
       spawnerPrototype: SpawnPointNukeopsMedic
       startingGear: SyndicateOperativeMedicFull
+      blacklist:
+        tags:
+          - Resomi
       roleLoadout:
       - RoleSurvivalNukie
       components:
@@ -158,6 +164,9 @@
       max: 3
       playerRatio: 10
       startingGear: SyndicateOperativeGearFull
+      blacklist:
+        tags:
+          - Resomi
       roleLoadout:
       - RoleSurvivalNukie
       components:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
@@ -67,6 +67,13 @@
         showInChat: true
   - type: Sprite 
     scale: 0.8, 0.8
+  - type: Tag
+    tags:
+    - CanPilot
+    - FootstepSound
+    - DoorBumpOpener
+    - AnomalyHost
+    - Felionoid
   - type: Fixtures
     fixtures: 
       fix1:

--- a/Resources/Prototypes/_StarLight/tags.yml
+++ b/Resources/Prototypes/_StarLight/tags.yml
@@ -77,3 +77,6 @@
 
 - type: Tag
   id: ClownKudzu
+
+- type: Tag
+  id: Felionoid

--- a/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
@@ -32,45 +32,11 @@
   Resomi are able to slash at others with their claws.
   These attacks deal [color=red]5[/color] points of Slash damage with a hit rate that is the same as humans fists attack.
   
-  ## Weapon Restrictions
-  Resomi have a few restrictions on what weapons they can hold due to their hands being too small.
-  [color=yellow]Due to these restrictions, the Syndicate has opted to not use Resomi for Nuclear Operatives at this time.[/color]
-  These are all the current weapons they cannot use.
-  <Box>
-    <GuideEntityEmbed Entity="WeaponMinigun"/>
-    <GuideEntityEmbed Entity="WeaponLauncherChinaLake"/>
-    <GuideEntityEmbed Entity="WeaponLauncherRocket"/>
-    <GuideEntityEmbed Entity="WeaponLauncherPirateCannon"/>
-    <GuideEntityEmbed Entity="WeaponLauncherAdmemeMeteorLarge"/>
-  </Box>
-  <Box>
-    <GuideEntityEmbed Entity="WeaponLauncherAdmemeImmovableRodSlow"/>
-    <GuideEntityEmbed Entity="WeaponLightMachineGunL6"/>
-    <GuideEntityEmbed Entity="WeaponSniperMosin"/>
-    <GuideEntityEmbed Entity="WeaponSniperHristov"/>
-    <GuideEntityEmbed Entity="Musket"/>
-  </Box>
-  <Box>
-    <GuideEntityEmbed Entity="WeaponPistolFlintlock"/>
-    <GuideEntityEmbed Entity="WeaponShotgunBulldog"/>
-    <GuideEntityEmbed Entity="WeaponShotgunDoubleBarreled"/>
-    <GuideEntityEmbed Entity="WeaponShotgunEnforcer"/>
-  </Box>
-  <Box>
-    <GuideEntityEmbed Entity="WeaponShotgunKammerer"/>
-    <GuideEntityEmbed Entity="WeaponShotgunSawn"/>
-    <GuideEntityEmbed Entity="WeaponShotgunHandmade"/>
-    <GuideEntityEmbed Entity="WeaponShotgunBlunderbuss"/>
-  </Box>
-  <Box>
-    <GuideEntityEmbed Entity="WeaponShotgunImprovised"/>
-    <GuideEntityEmbed Entity="WeaponRifleAk"/>
-    <GuideEntityEmbed Entity="WeaponRifleM90GrenadeLauncher"/>
-    <GuideEntityEmbed Entity="WeaponRifleLecter"/>
-  </Box>
-  <Box>
-    <GuideEntityEmbed Entity="WeaponRifleFoam"/>
-  </Box>
+  ## Weapon Knockback
+  Resomi have a few downsides to using large caliber weapons, and as such take so much knockback from them that they get pushed around.
+  In general, the weapons that will give you knockback are [color=yellow]Rifles, Sniper Rifles, Shotguns, LMGs, HMGs, and Grenade Launchers.[/color]
+  Look out especially on Rocket launchers, as since they are recoil-less, you will actually get [color=red]pulled forward with the rocket[/color] for a short distance.
+  The safest weapons to use that will give you no knockback are [color=green]Pistols and SMGs[/color]
 
   ## Jumping
   Resomi are able to jump, allowing them to move around station hallways quickly, and to jump ahead of others in a chase.

--- a/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
@@ -34,6 +34,7 @@
   
   ## Weapon Knockback
   Resomi have a few downsides to using large caliber weapons, and as such take so much knockback from them that they get pushed around.
+  Resomi also will receive [color=yellow]Stun Damage[/color] from large caliber weapons for each shot.
   In general, the weapons that will give you knockback are [color=yellow]Rifles, Sniper Rifles, Shotguns, LMGs, HMGs, and Grenade Launchers.[/color]
   Look out especially on Rocket launchers, as since they are recoil-less, you will actually get [color=red]pulled forward with the rocket[/color] for a short distance.
   The safest weapons to use that will give you no knockback are [color=green]Pistols and SMGs[/color]

--- a/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
@@ -37,7 +37,8 @@
   Resomi also will receive [color=yellow]Stun Damage[/color] from large caliber weapons for each shot.
   In general, the weapons that will give you knockback are [color=yellow]Rifles, Sniper Rifles, Shotguns, LMGs, HMGs, and Grenade Launchers.[/color]
   Look out especially on Rocket launchers, as since they are recoil-less, you will actually get [color=red]pulled forward with the rocket[/color] for a short distance.
-  The safest weapons to use that will give you no knockback are [color=green]Pistols and SMGs[/color]
+  The safest weapons to use that will give you no knockback are [color=green]Pistols and SMGs[/color].
+  No slips can help mitigate some of the knockback from firing weapons, but not all of it!
 
   ## Jumping
   Resomi are able to jump, allowing them to move around station hallways quickly, and to jump ahead of others in a chase.

--- a/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
@@ -33,7 +33,7 @@
   These attacks deal [color=red]5[/color] points of Slash damage with a hit rate that is the same as humans fists attack.
   
   ## Weapon Knockback
-  Resomi have a few downsides to using large caliber weapons, and as such take so much knockback from them that they get pushed around.
+  Resomi are very lightweight, and as such take so much knockback from large caliber weapons that they get pushed around.
   Resomi also will receive [color=yellow]Stun Damage[/color] from large caliber weapons for each shot.
   In general, the weapons that will give you knockback are [color=yellow]Rifles, Sniper Rifles, Shotguns, LMGs, HMGs, and Grenade Launchers.[/color]
   Look out especially on Rocket launchers, as since they are recoil-less, you will actually get [color=red]pulled forward with the rocket[/color] for a short distance.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This is a inherent rebalance of Resomi as a species when it comes to weapons. Instead of being limited to just up to a SMG, now resomi can use all weapons, however the ones that they couldn't use in the past now give them varying levels of knockback, and stun damage for each shot. Alongside this, a new component has been added to facilitate this knockback, and (hopefully!) all weapon prototypes have been updated that need this component. Alongside this, Resomi are now eligible to be round start nukies again from this PR.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This is needed as currently its just not fun game design to restrict roughly half of the weapon base just because balance. This is a more fun way of doing it, that allows resomi to still use these weapons but still have a slight debuff in the form of the knockback and eventual stun if they don't take a break from shooting.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
General weapon overview

https://github.com/user-attachments/assets/31541ab3-4d90-4317-99d6-e9c0e0b9ce7a

No slips half your knockback

https://github.com/user-attachments/assets/73ac72d8-1594-49a7-8aca-04d57c047527

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- add: Added Knockback and self-stun damage to large weapons for Resomi and Felionoids only.
- tweak: Resomi can now use large weapons.