### PR TITLE
Implement simple emote cooldown system

### DIFF
--- a/Content.Shared/Emoting/EmoteSystem.cs
+++ b/Content.Shared/Emoting/EmoteSystem.cs
@@ -1,7 +1,10 @@
-﻿namespace Content.Shared.Emoting;
+﻿using Robust.Shared.Timing;
+
+namespace Content.Shared.Emoting;
 
 public sealed class EmoteSystem : EntitySystem
 {
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -26,5 +29,18 @@ public sealed class EmoteSystem : EntitySystem
     {
         if (!TryComp(args.Uid, out EmotingComponent? emote) || !emote.Enabled)
             args.Cancel();
+
+        if (emote == null)
+            return;
+        
+        //check if they are on cooldown
+        if (_gameTiming.CurTime > emote.LastEmoteTime + emote.EmoteCooldown)
+        {
+            emote.LastEmoteTime = _gameTiming.CurTime;
+        }
+        else
+        {
+            args.Cancel();
+        }
     }
 }

--- a/Content.Shared/Emoting/EmoteSystem.cs
+++ b/Content.Shared/Emoting/EmoteSystem.cs
@@ -4,7 +4,7 @@ namespace Content.Shared.Emoting;
 
 public sealed class EmoteSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!; //Starlight-edit
     public override void Initialize()
     {
         base.Initialize();
@@ -29,7 +29,8 @@ public sealed class EmoteSystem : EntitySystem
     {
         if (!TryComp(args.Uid, out EmotingComponent? emote) || !emote.Enabled)
             args.Cancel();
-
+        
+        //Starlight-start
         if (emote == null)
             return;
         
@@ -42,5 +43,6 @@ public sealed class EmoteSystem : EntitySystem
         {
             args.Cancel();
         }
+        //Starlight-end
     }
 }

--- a/Content.Shared/Emoting/EmotingComponent.cs
+++ b/Content.Shared/Emoting/EmotingComponent.cs
@@ -12,9 +12,9 @@ public sealed partial class EmotingComponent : Component
     //track the last time they emoted
     [DataField, AutoNetworkedField]
     [Access(typeof(EmoteSystem), Friend = AccessPermissions.ReadWrite, Other = AccessPermissions.Read)]
-    public TimeSpan LastEmoteTime = TimeSpan.Zero;
+    public TimeSpan LastEmoteTime = TimeSpan.Zero; //Starlight-edit
 
     [DataField, AutoNetworkedField]
     [Access(typeof(EmoteSystem), Friend = AccessPermissions.ReadWrite, Other = AccessPermissions.Read)]
-    public TimeSpan EmoteCooldown = TimeSpan.FromSeconds(0.5f);
+    public TimeSpan EmoteCooldown = TimeSpan.FromSeconds(0.5f); //Starlight-edit
 }

--- a/Content.Shared/Emoting/EmotingComponent.cs
+++ b/Content.Shared/Emoting/EmotingComponent.cs
@@ -8,4 +8,13 @@ public sealed partial class EmotingComponent : Component
     [DataField, AutoNetworkedField]
     [Access(typeof(EmoteSystem), Friend = AccessPermissions.ReadWrite, Other = AccessPermissions.Read)]
     public bool Enabled = true;
+
+    //track the last time they emoted
+    [DataField, AutoNetworkedField]
+    [Access(typeof(EmoteSystem), Friend = AccessPermissions.ReadWrite, Other = AccessPermissions.Read)]
+    public TimeSpan LastEmoteTime = TimeSpan.Zero;
+
+    [DataField, AutoNetworkedField]
+    [Access(typeof(EmoteSystem), Friend = AccessPermissions.ReadWrite, Other = AccessPermissions.Read)]
+    public TimeSpan EmoteCooldown = TimeSpan.FromSeconds(0.5f);
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a emote cooldown of 0.5 seconds. This is to remove some annoyingness of felinoids, although the time maybe should still be raised.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Felinoids spamming emotes is the worst. This fixes some of it.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
This video is of me spamming the key as fast as I can

https://github.com/user-attachments/assets/17cde966-d254-4dc7-86cd-b0fe8995241e


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- add: Added cooldown of 0.5 seconds to all Emotes.