### PR TITLE
move emote cooldown system to vocal system instead

### DIFF
--- a/Content.Shared/Emoting/EmoteSystem.cs
+++ b/Content.Shared/Emoting/EmoteSystem.cs
@@ -4,7 +4,6 @@ namespace Content.Shared.Emoting;
 
 public sealed class EmoteSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _gameTiming = default!; //Starlight-edit
     public override void Initialize()
     {
         base.Initialize();
@@ -29,20 +28,5 @@ public sealed class EmoteSystem : EntitySystem
     {
         if (!TryComp(args.Uid, out EmotingComponent? emote) || !emote.Enabled)
             args.Cancel();
-        
-        //Starlight-start
-        if (emote == null)
-            return;
-        
-        //check if they are on cooldown
-        if (_gameTiming.CurTime > emote.LastEmoteTime + emote.EmoteCooldown)
-        {
-            emote.LastEmoteTime = _gameTiming.CurTime;
-        }
-        else
-        {
-            args.Cancel();
-        }
-        //Starlight-end
     }
 }

--- a/Content.Shared/Emoting/EmotingComponent.cs
+++ b/Content.Shared/Emoting/EmotingComponent.cs
@@ -8,13 +8,4 @@ public sealed partial class EmotingComponent : Component
     [DataField, AutoNetworkedField]
     [Access(typeof(EmoteSystem), Friend = AccessPermissions.ReadWrite, Other = AccessPermissions.Read)]
     public bool Enabled = true;
-
-    //track the last time they emoted
-    [DataField, AutoNetworkedField]
-    [Access(typeof(EmoteSystem), Friend = AccessPermissions.ReadWrite, Other = AccessPermissions.Read)]
-    public TimeSpan LastEmoteTime = TimeSpan.Zero; //Starlight-edit
-
-    [DataField, AutoNetworkedField]
-    [Access(typeof(EmoteSystem), Friend = AccessPermissions.ReadWrite, Other = AccessPermissions.Read)]
-    public TimeSpan EmoteCooldown = TimeSpan.FromSeconds(0.5f); //Starlight-edit
 }

--- a/Content.Shared/Speech/Components/VocalComponent.cs
+++ b/Content.Shared/Speech/Components/VocalComponent.cs
@@ -54,7 +54,6 @@ public sealed partial class VocalComponent : Component
     //starlight start
     [ViewVariables]
     [AutoNetworkedField]
-    [NonSerialized]
     //have to use string as for some reason emote prototypes are not serializable even though im telling it not to serialize
     public Dictionary<string, TimeSpan> LastEmoteTime = new Dictionary<string, TimeSpan>();
 

--- a/Content.Shared/Speech/Components/VocalComponent.cs
+++ b/Content.Shared/Speech/Components/VocalComponent.cs
@@ -50,4 +50,17 @@ public sealed partial class VocalComponent : Component
     [ViewVariables]
     [AutoNetworkedField]
     public EmoteSoundsPrototype? EmoteSounds = null;
+
+    //starlight start
+    [ViewVariables]
+    [AutoNetworkedField]
+    [NonSerialized]
+    //have to use string as for some reason emote prototypes are not serializable even though im telling it not to serialize
+    public Dictionary<string, TimeSpan> LastEmoteTime = new Dictionary<string, TimeSpan>();
+
+    [ViewVariables]
+    [AutoNetworkedField]
+    [DataField]
+    public TimeSpan EmoteCooldown = TimeSpan.FromSeconds(0.5f);
+    //starlight end
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Its broken. Right now, people basically cant emote. the REASON they cant emote, is for WHATEVER REASON, when you emote using the `me yawns` command in the console, it triggers one emote event. when you do it via chat or radial however, it triggers two events right in a row, and only the second event plays the audio, and thus gets cancelled. So ofcourse, since I was testing about spam, I didn't catch this as I was using a bind.

I moved it to the vocal component, so now the only thing that gets cancelled at all is the audio, the text always sends. Additionally, since there is now context about what emote we are playing, I store the cooldown on a per emote level in a dictionary, because why not.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This fixes emotes on the server for normal people lol.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed Emote cooldown system for regular uses like radial and chat.