### PR TITLE
Un-Nerf Tranquilizer rounds

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -177,10 +177,10 @@
     solutions:
       ammo:
         reagents:
-        - ReagentId: ChloralHydrate
-          Quantity: 7
+        - ReagentId: Nocturine #Starlight
+          Quantity: 5
   - type: SolutionTransfer
-    maxTransferAmount: 7
+    maxTransferAmount: 5
 
 - type: entity
   id: ShellShotgunImprovised


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Revert the Tranquilizer rounds nerf
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Due to the chloral hydrate nerf, tranq rounds (which require special materials to make) also got nerfed into uselessness as it no longer put anything to sleep despite that being the entire purpose of the rounds. This reverts that, by making the shells use nocturine instead of chloral hydrate.

2 shots drops a person into sleepy time. 

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- tweak: Changed Tranq rounds to use Noct to enforce sleepytimes.
