### PR TITLE
Fixed Chainsword bug where it couldn't break glass and other objects.

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cyberlimb.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cyberlimb.yml
@@ -31,7 +31,7 @@
       types:
         Slash: 5
         Heat: 5
-        Structural: 10
+        Structural: 15
   - type: MeleeWeapon
     angle: 0
     wideAnimationRotation: -135


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Increasing structural damage of chainsword to fix bug caused by it being too low, has been changed to 15.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
As it turns out structural damage at 10 does not do enough damage to actually break windows, grilles and lockers.

Which led to odd situations where someone with an energy chainsword could not break glass, lockers or other things it should be able to destroy.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- fix: Fixed bug with chainsword that prevented it from breaking windows, lockers and other structures.