### PR TITLE
add clown anomaly into anomaly pool

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/anomaly.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/anomaly.yml
@@ -14,7 +14,7 @@
     - AnomalyPyroclastic
     - AnomalyGravity
     - AnomalyElectricity
-    - AnomalyFlesh
+    - RandomFleshAnomalySpawner # Starlight edit, don't dilute the pool with a flesh anomaly variant
     - AnomalyBluespace
     - AnomalyIce
     - RandomRockAnomalySpawner

--- a/Resources/Prototypes/_StarLight/Entities/Markers/Spawners/Random/anomaly.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Markers/Spawners/Random/anomaly.yml
@@ -1,0 +1,16 @@
+﻿- type: entity
+  id: RandomFleshAnomalySpawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Structures/Specific/anomaly.rsi
+          state: anom5
+    - type: RandomSpawner
+      prototypes:
+      - AnomalyFlesh
+      rarePrototypes:
+      - AnomalyClown
+      rareChance: 0.20 # 1 in 5 chance of spawning clown instead of flesh
+      offset: 0.15


### PR DESCRIPTION
## Short description

Add previously added clown anomaly to the general pool.

Since it is a variant of the flesh anomaly, I implemented it such that it does not dilute the general anomaly pool.

Instead, it is spawned with a 20% chance instead of the flesh anomaly if the flesh anomaly is chosen.

## Why we need to add this

It's fun, interesting, and seems balanced

## Media (Video/Screenshots)

See #431 

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Quantumcross
- add: Funny anomalies are showing up on station 🤡 

