### PR TITLE
add the ability to reset admin testing room

### DIFF
--- a/Content.Server/_Starlight/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/_Starlight/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -1,0 +1,66 @@
+using Content.Server.Administration.Systems;
+using Content.Shared.Administration;
+using Content.Shared.Administration.Managers;
+using Content.Shared.Database;
+using Content.Shared.Verbs;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+using static Content.Server.Administration.Systems.AdminVerbSystem;
+
+namespace Content.Server.Starlight.Administration.Systems;
+public sealed partial class AdminVerbSystem : EntitySystem
+{
+    [Dependency] private readonly AdminTestArenaSystem _adminTestArenaSystem = default!;
+    [Dependency] private readonly ISharedAdminManager _adminManager = default!;
+    [Dependency] private readonly IEntityManager _entities = default!;
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddVerbs);
+    }
+    private void AddVerbs(GetVerbsEvent<Verb> args)
+    {
+        if (!EntityManager.TryGetComponent(args.User, out ActorComponent? actor))
+            return;
+
+        var player = actor.PlayerSession;
+
+        if (!_adminManager.HasAdminFlag(player, AdminFlags.Admin))
+            return;
+
+        if (_adminManager.HasAdminFlag(player, AdminFlags.Admin))
+        {
+            Verb sendToTestArena = new()
+            {
+                Text = "Reset test arena",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/refresh.svg.192dpi.png")),
+
+                Act = () =>
+                {
+                    //we technically load the map here, but it doesnt matter, this is safer since the behaviour of this function is garunteed
+                    //and reimplementing it would be stupid and unsafe
+                    var data = _adminTestArenaSystem.AssertArenaLoaded(player);
+
+                    var _mapManager = _entities.System<SharedMapSystem>();
+
+                    //we need to get the actual map ID, so first get the transform
+                    if (!_entities.TryGetComponent(data.Map, out TransformComponent? transform))
+                        return;
+                    
+                    //then get the map ID from the transform
+                    MapId mapId = transform.MapID;
+
+                    //call remove map on it
+                    _mapManager.DeleteMap(mapId);
+                    //_transformSystem.SetCoordinates(args.Target, new EntityCoordinates(data.gridUid ?? data.mapUid, Vector2.One));
+                },
+                Impact = LogImpact.Medium,
+                Message = Loc.GetString("admin-trick-reset-test-arena-description"),
+                Priority = (int)TricksVerbPriorities.SendToTestArena,
+            };
+            args.Verbs.Add(sendToTestArena);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Starlight/administration/smites.ftl
+++ b/Resources/Locale/en-US/_Starlight/administration/smites.ftl
@@ -1,0 +1,1 @@
+admin-trick-reset-test-arena-description = Resets your test arena. Any players attached to entities will be sent to map 1 as ghosts.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds the ability to reset the admin testing area by deleting and re loading the map

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Testing ANYTHING explosive fucks up the admin area annoyingly. This fixes that by allowing you to reset it to a clean state after your done. Especially pertinent on beta where rounds last hours.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/1883ff9c-31f9-470e-b89e-ad53828287de

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- add: Added ability to reset admin testing rooms.