### PR TITLE
Rebalances the Riot SMG

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -43,7 +43,11 @@
     minAngle: -19
     maxAngle: -16
   - type: Gun
-    fireRate: 10
+    fireRate: 13
+    selectedMode: Burst
+    shotsPerBurst: 5
+    availableModes:
+      - Burst
     soundGunshot:
       path: /Audio/_Starlight/Weapons/Guns/Gunshots/1sp_91.ogg
   - type: MagazineVisuals


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Alters the SP-91 Riot SMG to be a burst only gun
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Right now, the RIOT SMG is a certified nukie killer, completely melting anything in like 3 seconds if you put an FMJ mag into it. It is clearly the strongest gun by far, surpassing the C-20r, a nukie gun, which is ridiculous for a gun which the crew gets two of roundstart. This change simply makes it a bit easier to retreat from whilst still keeping it lethal
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/e3341b4f-eeff-469e-a455-a0db24ef69a1

i forgot to record myself spam click shooting it, but the burst cooldown is like half a second, which is the standard thing
## Checks     
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.-->

:cl: PubliclyExecutedPig
- tweak: Altered the SP-91 Riot SMG, its now a burst gun, and slightly less lethal. Antagonists rejoice!

