### PR TITLE
Add ability to unlimit shuttle limitations

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleMapControl.xaml.cs
@@ -271,7 +271,7 @@ public sealed partial class ShuttleMapControl : BaseShuttleControl
                 gridRelativePos = gridRelativePos with { Y = -gridRelativePos.Y };
                 var gridUiPos = ScalePosition(gridRelativePos);
 
-                var range = _shuttles.GetFTLRange(gridUid);
+                var range = _shuttles.GetFTLRange(_shuttleEntity.Value);
                 range *= MinimapScale;
                 handle.DrawCircle(gridUiPos, range, Color.Gold, filled: false);
             }

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -8,6 +8,7 @@ using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Spawners.Components;
 using Content.Server.Station.Components;
+using Content.Shared.Shuttles.Components; //Starlight-edit
 using Content.Shared.CCVar;
 using Content.Shared.Roles;
 using Robust.Shared.Configuration;

--- a/Content.IntegrationTests/Tests/ShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/ShuttleTest.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Server.Shuttles.Components;
+using Content.Shared.Shuttles.Components; //Starlight-edit
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;

--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -1,68 +1,72 @@
-using System.Numerics;
+//Commented out, component moved to shared instead of just server. Starlight modification
 
-namespace Content.Server.Shuttles.Components
-{
-    [RegisterComponent]
-    public sealed partial class ShuttleComponent : Component
-    {
-        [ViewVariables]
-        public bool Enabled = true;
 
-        [ViewVariables]
-        public Vector2[] CenterOfThrust = new Vector2[4];
 
-        /// <summary>
-        /// Thrust gets multiplied by this value if it's for braking.
-        /// </summary>
-        public const float BrakeCoefficient = 1.5f;
+// using System.Numerics;
 
-        /// <summary>
-        /// Maximum velocity assuming unupgraded, tier 1 thrusters
-        /// </summary>
-        [ViewVariables(VVAccess.ReadWrite)]
-        public float BaseMaxLinearVelocity = 20f;
+// namespace Content.Server.Shuttles.Components
+// {
+//     [RegisterComponent]
+//     public sealed partial class ShuttleComponent : Component
+//     {
+//         [ViewVariables]
+//         public bool Enabled = true;
 
-        public const float MaxAngularVelocity = 4f;
+//         [ViewVariables]
+//         public Vector2[] CenterOfThrust = new Vector2[4];
 
-        /// <summary>
-        /// The cached thrust available for each cardinal direction
-        /// </summary>
-        [ViewVariables]
-        public readonly float[] LinearThrust = new float[4];
+//         /// <summary>
+//         /// Thrust gets multiplied by this value if it's for braking.
+//         /// </summary>
+//         public const float BrakeCoefficient = 1.5f;
 
-        /// <summary>
-        /// The thrusters contributing to each direction for impulse.
-        /// </summary>
-        // No touchy
-        public readonly List<EntityUid>[] LinearThrusters = new List<EntityUid>[]
-        {
-            new(),
-            new(),
-            new(),
-            new(),
-        };
+//         /// <summary>
+//         /// Maximum velocity assuming unupgraded, tier 1 thrusters
+//         /// </summary>
+//         [ViewVariables(VVAccess.ReadWrite)]
+//         public float BaseMaxLinearVelocity = 20f;
 
-        /// <summary>
-        /// The thrusters contributing to the angular impulse of the shuttle.
-        /// </summary>
-        public readonly List<EntityUid> AngularThrusters = new();
+//         public const float MaxAngularVelocity = 4f;
 
-        [ViewVariables]
-        public float AngularThrust = 0f;
+//         /// <summary>
+//         /// The cached thrust available for each cardinal direction
+//         /// </summary>
+//         [ViewVariables]
+//         public readonly float[] LinearThrust = new float[4];
 
-        /// <summary>
-        /// A bitmask of all the directions we are considered thrusting.
-        /// </summary>
-        [ViewVariables]
-        public DirectionFlag ThrustDirections = DirectionFlag.None;
+//         /// <summary>
+//         /// The thrusters contributing to each direction for impulse.
+//         /// </summary>
+//         // No touchy
+//         public readonly List<EntityUid>[] LinearThrusters = new List<EntityUid>[]
+//         {
+//             new(),
+//             new(),
+//             new(),
+//             new(),
+//         };
 
-        /// <summary>
-        /// Damping applied to the shuttle's physics component when not in FTL.
-        /// </summary>
-        [DataField("linearDamping"), ViewVariables(VVAccess.ReadWrite)]
-        public float LinearDamping = 0.05f;
+//         /// <summary>
+//         /// The thrusters contributing to the angular impulse of the shuttle.
+//         /// </summary>
+//         public readonly List<EntityUid> AngularThrusters = new();
 
-        [DataField("angularDamping"), ViewVariables(VVAccess.ReadWrite)]
-        public float AngularDamping = 0.05f;
-    }
-}
+//         [ViewVariables]
+//         public float AngularThrust = 0f;
+
+//         /// <summary>
+//         /// A bitmask of all the directions we are considered thrusting.
+//         /// </summary>
+//         [ViewVariables]
+//         public DirectionFlag ThrustDirections = DirectionFlag.None;
+
+//         /// <summary>
+//         /// Damping applied to the shuttle's physics component when not in FTL.
+//         /// </summary>
+//         [DataField("linearDamping"), ViewVariables(VVAccess.ReadWrite)]
+//         public float LinearDamping = 0.05f;
+
+//         [DataField("angularDamping"), ViewVariables(VVAccess.ReadWrite)]
+//         public float AngularDamping = 0.05f;
+//     }
+// }

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -15,6 +15,7 @@ using Content.Shared.UserInterface;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Timer = Robust.Shared.Timing.Timer;
+using Content.Shared.Shuttles.Components; //starlight
 
 namespace Content.Server.Shuttles.Systems;
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -236,7 +236,7 @@ public sealed partial class ShuttleSystem
         {
 
             // Too large to FTL
-            if (FTLMassLimit > 0 &&  shuttlePhysics.Mass > FTLMassLimit)
+            if (FTLMassLimit > 0 &&  shuttlePhysics.Mass > FTLMassLimit && TryComp<ShuttleComponent>(shuttleUid, out var shuttleComp) && shuttleComp.FTLMassLimits)
             {
                 reason = Loc.GetString("shuttle-console-mass");
                 return false;

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Player;
+using Content.Shared.Shuttles.Components; //starlight
 
 namespace Content.Server.Shuttles.Systems;
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.GameTicking;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Salvage;
 using Content.Shared.Shuttles.Systems;
+using Content.Shared.Shuttles.Components; //starlight
 using Content.Shared.Throwing;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;

--- a/Content.Server/Shuttles/Systems/StationAnchorSystem.cs
+++ b/Content.Server/Shuttles/Systems/StationAnchorSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Power.EntitySystems;
 using Content.Server.Shuttles.Components;
 using Content.Shared.Construction.Components;
 using Content.Shared.Popups;
+using Content.Shared.Shuttles.Components; //starlight
 
 namespace Content.Server.Shuttles.Systems;
 

--- a/Content.Shared/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Shared/Shuttles/Components/ShuttleComponent.cs
@@ -1,0 +1,78 @@
+using Content.Shared.Shuttles.Systems;
+using Robust.Shared.GameStates;
+using System.Numerics;
+
+namespace Content.Shared.Shuttles.Components
+{
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+    public sealed partial class ShuttleComponent : Component
+    {
+        [ViewVariables, AutoNetworkedField]
+        public bool Enabled = true;
+
+        [ViewVariables, AutoNetworkedField]
+        public Vector2[] CenterOfThrust = new Vector2[4];
+
+        /// <summary>
+        /// Thrust gets multiplied by this value if it's for braking.
+        /// </summary>
+        public const float BrakeCoefficient = 1.5f;
+
+        /// <summary>
+        /// Maximum velocity assuming unupgraded, tier 1 thrusters
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+        public float BaseMaxLinearVelocity = 20f;
+
+        public const float MaxAngularVelocity = 4f;
+
+        /// <summary>
+        /// The cached thrust available for each cardinal direction
+        /// </summary>
+        [ViewVariables]
+        public readonly float[] LinearThrust = new float[4];
+
+        /// <summary>
+        /// The thrusters contributing to each direction for impulse.
+        /// </summary>
+        // No touchy
+        public readonly List<EntityUid>[] LinearThrusters = new List<EntityUid>[]
+        {
+            new(),
+            new(),
+            new(),
+            new(),
+        };
+
+        /// <summary>
+        /// The thrusters contributing to the angular impulse of the shuttle.
+        /// </summary>
+        public readonly List<EntityUid> AngularThrusters = new();
+
+        [ViewVariables]
+        public float AngularThrust = 0f;
+
+        /// <summary>
+        /// A bitmask of all the directions we are considered thrusting.
+        /// </summary>
+        [ViewVariables]
+        public DirectionFlag ThrustDirections = DirectionFlag.None;
+
+        /// <summary>
+        /// Damping applied to the shuttle's physics component when not in FTL.
+        /// </summary>
+        [DataField("linearDamping"), ViewVariables(VVAccess.ReadWrite)]
+        public float LinearDamping = 0.05f;
+
+        [DataField("angularDamping"), ViewVariables(VVAccess.ReadWrite)]
+        public float AngularDamping = 0.05f;
+
+        //Starlight
+        [DataField, AutoNetworkedField]
+        public float FTLRange = 256f;
+
+        [DataField, AutoNetworkedField]
+        public bool FTLMassLimits = true;
+        //end starlight
+    }
+}

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -19,7 +19,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem XformSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
-    public const float FTLRange = 256f;
+    //public const float FTLRange = 256f; //starlight removed
     public const float FTLBufferRange = 8f;
 
     private EntityQuery<MapGridComponent> _gridQuery;
@@ -155,7 +155,15 @@ public abstract partial class SharedShuttleSystem : EntitySystem
         return HasComp<MapComponent>(coordinates.EntityId);
     }
 
-    public float GetFTLRange(EntityUid shuttleUid) => FTLRange;
+    public float GetFTLRange(EntityUid shuttleUid)
+    {
+        Logger.Info($"GetFTLRange({shuttleUid})");
+        if(!TryComp<ShuttleComponent>(shuttleUid, out var shuttle))
+            return 0f;
+        
+        Logger.Info($"GetFTLRange({shuttleUid}) = {shuttle.FTLRange}");
+        return shuttle.FTLRange;
+    }
 
     public float GetFTLBufferRange(EntityUid shuttleUid, MapGridComponent? grid = null)
     {
@@ -189,7 +197,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
         var targetPosition = mapCoordinates.Position;
 
         // Check range even if it's cross-map.
-        if ((targetPosition - ourPos).Length() > FTLRange)
+        if ((targetPosition - ourPos).Length() > GetFTLRange(shuttleUid)) //starlight modification
         {
             return false;
         }

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -2,12 +2,14 @@ using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Shuttles.BUIStates;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.UI.MapObjects;
+using Content.Shared.Starlight.CCVar; //Starlight-edit
 using Content.Shared.Whitelist;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Configuration; //Starlight-edit
 
 namespace Content.Shared.Shuttles.Systems;
 
@@ -18,6 +20,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     [Dependency] protected readonly SharedMapSystem Maps = default!;
     [Dependency] protected readonly SharedTransformSystem XformSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
     //public const float FTLRange = 256f; //starlight removed
     public const float FTLBufferRange = 8f;
@@ -155,15 +158,22 @@ public abstract partial class SharedShuttleSystem : EntitySystem
         return HasComp<MapComponent>(coordinates.EntityId);
     }
 
+    // Starlight-edit start
     public float GetFTLRange(EntityUid shuttleUid)
     {
         Logger.Info($"GetFTLRange({shuttleUid})");
         if(!TryComp<ShuttleComponent>(shuttleUid, out var shuttle))
             return 0f;
         
+        var serverShuttleLimit = _configurationManager.GetCVar(StarlightCCVars.AdmemeShuttleLimit);
+        
+        if (serverShuttleLimit != null && shuttle.FTLRange > serverShuttleLimit)
+            return serverShuttleLimit;
+        
         Logger.Info($"GetFTLRange({shuttleUid}) = {shuttle.FTLRange}");
         return shuttle.FTLRange;
     }
+    // Starlight-edit end
 
     public float GetFTLBufferRange(EntityUid shuttleUid, MapGridComponent? grid = null)
     {

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
@@ -14,4 +14,10 @@ public sealed partial class StarlightCCVars
     /// </summary>
     public static readonly CVarDef<bool> CryoTeleportation =
         CVarDef.Create("game.cryo_teleportation", true, CVar.SERVERONLY);
+        
+    /// <summary>
+    /// Sends afk players to cryo.
+    /// </summary>
+    public static readonly CVarDef<float> AdmemeShuttleLimit =
+        CVarDef.Create("game.admeme_shuttle_limit", 1000f, CVar.SERVERONLY);
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds the ability to unlimit shuttles constraints. Both allows changing the FTL distance, but also disabling the mass limit entirely as a admin

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This is useful for admeme ships that can easily exceed the mass limit that's currently in place

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Added way for admins to unlimit shuttle range and mass for FTL.