### PR TITLE
Adds an admeme only CBURN Shuttle

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/CBURN.yml
+++ b/Resources/Maps/_Starlight/Shuttles/CBURN.yml
@@ -1,0 +1,8060 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  12: Space
+  3: FloorDark
+  5: FloorDarkMono
+  13: FloorDarkPavement
+  7: FloorDarkPavementVertical
+  10: FloorHullReinforced
+  4: FloorMining
+  0: FloorOldConcrete
+  8: FloorOldConcreteMono
+  11: FloorRGlass
+  6: FloorReinforced
+  1: FloorWood
+  14: FloorWoodTile
+  9: Lattice
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: CBURN 'Flea' RQ-5634
+    - type: Transform
+      pos: -0.53125,-0.484375
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAABAAAAAAAAgAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABgAAAAAAAwAAAAAABgAAAAAAAwAAAAAABgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABgAAAAAAAwAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAAAwAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAAgAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAAAgAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABgAAAAAAAQAAAAAAAQAAAAAABgAAAAAAAgAAAAAAAgAAAAAACQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAAAgAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAgAAAAAAAgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAABgAAAAAACQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAADgAAAAAABgAAAAAACQAAAAAAAgAAAAAABgAAAAAAAgAAAAAAAgAAAAAACgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAADgAAAAAADgAAAAAAAQAAAAAAAQAAAAAADgAAAAAADgAAAAAABgAAAAAACQAAAAAAAgAAAAAACgAAAAAAAgAAAAAAAgAAAAAACgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABgAAAAAACQAAAAAAAgAAAAAACgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAACwAAAAAAAwAAAAAACwAAAAAAAwAAAAAACwAAAAAAAwAAAAAABgAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAACQAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: DAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAADAAAAAAABgAAAAAACAAAAAAACAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAADAAAAAAABgAAAAAACAAAAAAACAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAADAAAAAAABgAAAAAACAAAAAAACAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAACQAAAAAADAAAAAAACQAAAAAACQAAAAAADAAAAAAABgAAAAAACAAAAAAACAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAABgAAAAAABgAAAAAAAAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAACQAAAAAADAAAAAAACQAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAACAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAACAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAABgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAACgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAgAAAAAAAgAAAAAACgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAgAAAAAAAgAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: DAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAgAAAAAAAgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAABQAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAABQAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAABQAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAABQAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAABQAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAACAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAACAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAACQAAAAAADAAAAAAACQAAAAAADAAAAAAACQAAAAAAAgAAAAAAAgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAABgAAAAAABgAAAAAAAAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAACQAAAAAADAAAAAAACQAAAAAACQAAAAAADAAAAAAABgAAAAAACAAAAAAACAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: DAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAACQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAACQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABwAAAAAABwAAAAAABwAAAAAAAgAAAAAAAwAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAAAwAAAAAAAgAAAAAACQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABQAAAAAABQAAAAAABQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAACQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABgAAAAAAAgAAAAAAAgAAAAAACQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABQAAAAAAAwAAAAAAAwAAAAAABQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAACQAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABQAAAAAAAwAAAAAAAwAAAAAABQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAACQAAAAAABgAAAAAABQAAAAAABgAAAAAAAgAAAAAABQAAAAAABQAAAAAAAgAAAAAAAgAAAAAABgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAABgAAAAAAAgAAAAAAAgAAAAAACQAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAABgAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAgAAAAAABgAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABgAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABgAAAAAAAwAAAAAABgAAAAAAAwAAAAAABgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAwAAAAAABAAAAAAAAgAAAAAAAwAAAAAA
+          version: 6
+        1,0:
+          ind: 1,0
+          tiles: AwAAAAAADQAAAAAABgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAwAAAAAADQAAAAAABgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAwAAAAAADQAAAAAABgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAwAAAAAAAgAAAAAAAgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAwAAAAAABwAAAAAABwAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAwAAAAAAAgAAAAAABgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAwAAAAAABwAAAAAABwAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAABgAAAAAABgAAAAAAAgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAA
+          version: 6
+        1,-1:
+          ind: 1,-1
+          tiles: DAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAABgAAAAAABgAAAAAAAgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAwAAAAAABwAAAAAABwAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAwAAAAAAAgAAAAAABgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAwAAAAAABwAAAAAABwAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAAAwAAAAAAAgAAAAAAAgAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAA
+          version: 6
+        0,1:
+          ind: 0,1
+          tiles: CQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAACQAAAAAAAgAAAAAABgAAAAAABgAAAAAABgAAAAAAAgAAAAAABgAAAAAABgAAAAAABgAAAAAAAgAAAAAACQAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAA
+          version: 6
+        -1,1:
+          ind: -1,1
+          tiles: DAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAACQAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAADAAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      fTLMassLimits: False
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteCornerNe
+          decals:
+            114: 13,-7
+            122: 9,-12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNe
+          decals:
+            152: 5,11
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteCornerNw
+          decals:
+            113: 8,-7
+            139: 11,-12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNw
+          decals:
+            148: -1,11
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteCornerSe
+          decals:
+            104: 11,-10
+            111: 13,-8
+            124: 9,-13
+            140: 13,-13
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSe
+          decals:
+            150: 5,9
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteCornerSw
+          decals:
+            103: 9,-10
+            110: 8,-8
+            123: 7,-13
+            138: 11,-13
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSw
+          decals:
+            149: -1,9
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteEndN
+          decals:
+            121: 7,-10
+            134: 13,-10
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteInnerNe
+          decals:
+            125: 7,-12
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteInnerNw
+          decals:
+            133: 13,-12
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteInnerSe
+          decals:
+            108: 11,-8
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteInnerSw
+          decals:
+            109: 9,-8
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteLineE
+          decals:
+            106: 11,-9
+            129: 7,-11
+            136: 13,-11
+            137: 13,-12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineE
+          decals:
+            151: 5,10
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteLineN
+          decals:
+            115: 9,-7
+            116: 10,-7
+            117: 11,-7
+            118: 12,-7
+            130: 8,-12
+            132: 12,-12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineN
+          decals:
+            145: 2,11
+            146: 1,11
+            147: 0,11
+            158: 4,11
+            159: 3,11
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteLineS
+          decals:
+            105: 10,-10
+            112: 12,-8
+            126: 8,-13
+            141: 12,-13
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineS
+          decals:
+            153: 0,9
+            154: 1,9
+            155: 2,9
+            156: 3,9
+            157: 4,9
+        - node:
+            color: '#43990996'
+            id: BrickTileWhiteLineW
+          decals:
+            107: 9,-9
+            127: 7,-11
+            128: 7,-12
+            135: 13,-11
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineW
+          decals:
+            160: -1,10
+        - node:
+            color: '#334E6DC8'
+            id: HalfTileOverlayGreyscale
+          decals:
+            86: 8,15
+            87: 9,15
+            88: 10,15
+            89: 11,15
+            90: 12,15
+        - node:
+            color: '#334E6DC8'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            96: 12,13
+            97: 11,13
+            98: 10,13
+            99: 9,13
+            100: 8,13
+        - node:
+            color: '#334E6DC8'
+            id: HalfTileOverlayGreyscale270
+          decals:
+            85: 7,14
+        - node:
+            color: '#DE3A3A96'
+            id: HalfTileOverlayGreyscale270
+          decals:
+            62: 0,-11
+            63: 0,-10
+            64: 0,-9
+            65: 0,-8
+            66: 0,-7
+        - node:
+            color: '#334E6DC8'
+            id: HalfTileOverlayGreyscale90
+          decals:
+            95: 13,14
+        - node:
+            color: '#DE3A3A96'
+            id: HalfTileOverlayGreyscale90
+          decals:
+            59: 2,-9
+            60: 2,-8
+            61: 2,-7
+            79: 2,-10
+            80: 2,-11
+        - node:
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            161: 13,2
+        - node:
+            color: '#DE3A3A96'
+            id: QuarterTileOverlayGreyscale270
+          decals:
+            72: 1,-7
+            73: 1,-8
+            74: 1,-9
+            75: 1,-10
+            82: 1,-11
+        - node:
+            color: '#DE3A3A96'
+            id: QuarterTileOverlayGreyscale90
+          decals:
+            68: 1,-10
+            69: 1,-9
+            70: 1,-8
+            71: 1,-7
+            81: 1,-11
+        - node:
+            color: '#334E6DC8'
+            id: ThreeQuarterTileOverlayGreyscale
+          decals:
+            83: 7,15
+        - node:
+            color: '#334E6DC8'
+            id: ThreeQuarterTileOverlayGreyscale180
+          decals:
+            93: 13,13
+        - node:
+            color: '#334E6DC8'
+            id: ThreeQuarterTileOverlayGreyscale270
+          decals:
+            92: 7,13
+        - node:
+            color: '#334E6DC8'
+            id: ThreeQuarterTileOverlayGreyscale90
+          decals:
+            94: 13,15
+        - node:
+            color: '#DE3A3AFF'
+            id: WarnCornerNE
+          decals:
+            35: 5,-7
+        - node:
+            color: '#DE3A3AFF'
+            id: WarnCornerNW
+          decals:
+            36: 4,-7
+        - node:
+            color: '#DE3A3AFF'
+            id: WarnCornerSE
+          decals:
+            37: 5,-8
+        - node:
+            color: '#DE3A3AFF'
+            id: WarnCornerSW
+          decals:
+            38: 4,-8
+        - node:
+            color: '#52B4E996'
+            id: WarnCornerSmallGreyscaleNE
+          decals:
+            17: 8,0
+        - node:
+            color: '#52B4E996'
+            id: WarnCornerSmallGreyscaleNW
+          decals:
+            16: 12,0
+        - node:
+            color: '#52B4E996'
+            id: WarnCornerSmallGreyscaleSE
+          decals:
+            15: 8,2
+        - node:
+            color: '#52B4E996'
+            id: WarnCornerSmallGreyscaleSW
+          decals:
+            18: 12,2
+        - node:
+            color: '#43990996'
+            id: WarnFullGreyscale
+          decals:
+            101: 8,-10
+            102: 12,-10
+            119: 9,-6
+            120: 11,-6
+        - node:
+            color: '#DE3A3AFF'
+            id: WarnLineE
+          decals:
+            39: -1,-7
+            40: -1,-8
+            41: -1,-9
+            42: -1,-10
+            43: -1,-11
+        - node:
+            color: '#52B4E996'
+            id: WarnLineGreyscaleE
+          decals:
+            0: 12,-1
+            1: 12,0
+            2: 12,1
+            3: 12,2
+            4: 12,3
+            14: 8,1
+        - node:
+            color: '#52B4E996'
+            id: WarnLineGreyscaleN
+          decals:
+            19: 9,0
+            20: 10,0
+            21: 11,0
+        - node:
+            color: '#52B4E996'
+            id: WarnLineGreyscaleS
+          decals:
+            10: 9,2
+            11: 10,2
+            12: 11,2
+        - node:
+            color: '#52B4E996'
+            id: WarnLineGreyscaleW
+          decals:
+            5: 8,-1
+            6: 8,0
+            7: 8,1
+            8: 8,2
+            9: 8,3
+            13: 12,1
+        - node:
+            color: '#DE3A3AFF'
+            id: WarnLineN
+          decals:
+            44: 3,-10
+            45: 4,-10
+            46: 5,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerNe
+          decals:
+            22: 3,-2
+            23: 2,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            24: 2,3
+            25: 3,4
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerNe
+          decals:
+            26: 2,-2
+            27: 1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinInnerSe
+          decals:
+            28: 2,4
+            29: 1,3
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            30: 1,0
+            31: 1,1
+            32: 1,1
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          0,-1:
+            0: 65535
+          -1,0:
+            0: 52428
+          0,1:
+            0: 65535
+          -1,1:
+            0: 34824
+            1: 32
+          0,2:
+            0: 65520
+          -1,2:
+            0: 34944
+            1: 4368
+          0,3:
+            0: 680
+          -1,3:
+            0: 2176
+            1: 17
+          0,4:
+            1: 15
+          1,0:
+            0: 48059
+          1,1:
+            0: 49075
+          1,2:
+            0: 30579
+          1,3:
+            0: 34995
+          1,-1:
+            0: 46015
+          1,4:
+            1: 3
+          2,0:
+            0: 65535
+          2,1:
+            0: 65530
+          2,2:
+            0: 65530
+          2,3:
+            0: 65535
+          2,-1:
+            0: 64255
+          3,0:
+            0: 48059
+          3,1:
+            0: 16312
+          3,2:
+            0: 13104
+            1: 34952
+          3,3:
+            0: 13107
+            1: 34952
+          3,-1:
+            0: 47295
+          4,0:
+            0: 4915
+          4,1:
+            0: 1815
+          3,4:
+            1: 8
+          -3,0:
+            1: 34952
+          -3,-1:
+            1: 32768
+          -2,0:
+            1: 54340
+          -2,1:
+            1: 10937
+          -2,-1:
+            1: 55738
+          -2,2:
+            1: 8
+          -1,-1:
+            0: 51208
+            1: 32
+          -1,4:
+            1: 8
+          -2,-2:
+            1: 10240
+          -1,-3:
+            1: 4368
+            0: 34944
+          -1,-2:
+            1: 17
+            0: 32904
+          -1,-4:
+            1: 2048
+          0,-4:
+            1: 3840
+          0,-3:
+            0: 32752
+          0,-2:
+            0: 62071
+          1,-4:
+            1: 768
+            0: 32768
+          1,-3:
+            0: 3000
+          1,-2:
+            0: 45943
+          2,-4:
+            0: 45056
+          2,-3:
+            0: 61195
+          2,-2:
+            0: 65279
+          3,-4:
+            0: 12288
+            1: 34816
+          3,-3:
+            0: 803
+            1: 34952
+          3,-2:
+            0: 12339
+            1: 2184
+          4,-1:
+            0: 5911
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirlockCentralCommandGlassLocked
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+- proto: AirlockCommandGlass
+  entities:
+  - uid: 570
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,8.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 1
+- proto: AirlockEngineeringGlass
+  entities:
+  - uid: 351
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+  - uid: 352
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 561
+    components:
+    - type: Transform
+      pos: 14.5,-3.5
+      parent: 1
+  - uid: 563
+    components:
+    - type: Transform
+      pos: 14.5,6.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 542
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-1.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-3.5
+      parent: 1
+  - uid: 565
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,4.5
+      parent: 1
+  - uid: 566
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,6.5
+      parent: 1
+- proto: AirlockMedicalGlass
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+- proto: AirlockSecurityGlass
+  entities:
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+- proto: AirlockVirologyGlass
+  entities:
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 11.5,-5.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 12.5,-9.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 1
+    - type: AccessReader
+      access:
+      - - CentralCommand
+- proto: AlwaysPoweredLightExterior
+  entities:
+  - uid: 595
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 999
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 1
+- proto: AmmoTechFab
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 505
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 667
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 734
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-8.5
+      parent: 1
+  - uid: 752
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,2.5
+      parent: 1
+  - uid: 753
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,0.5
+      parent: 1
+  - uid: 827
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-8.5
+      parent: 1
+  - uid: 846
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,7.5
+      parent: 1
+  - uid: 874
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-4.5
+      parent: 1
+  - uid: 1020
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,12.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 814
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-1.5
+      parent: 1
+  - uid: 815
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-3.5
+      parent: 1
+  - uid: 816
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,4.5
+      parent: 1
+  - uid: 817
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,6.5
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,1.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,0.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-12.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-11.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-12.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-11.5
+      parent: 1
+- proto: BiomassReclaimer
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 13.5,3.5
+      parent: 1
+- proto: BoxShotgunIncendiary
+  entities:
+  - uid: 1063
+    components:
+    - type: Transform
+      pos: 11.419496,12.481311
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 508
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 510
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 511
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 513
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 514
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 522
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 668
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 669
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 670
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 671
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 672
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 673
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 674
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 675
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 676
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 677
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 678
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 679
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 680
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 681
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 682
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 683
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 684
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 685
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 686
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 687
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 688
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 689
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 690
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 691
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 692
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 693
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 694
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 695
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 696
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 697
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 698
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 699
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 700
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 701
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 702
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 703
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 704
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 705
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 706
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 707
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 708
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 709
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 710
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 711
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 712
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 713
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 731
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 1
+  - uid: 732
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 735
+    components:
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 1
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 737
+    components:
+    - type: Transform
+      pos: 5.5,-10.5
+      parent: 1
+  - uid: 738
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 739
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 740
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 741
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 742
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 743
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 744
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 745
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+  - uid: 746
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 747
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 748
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 749
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 751
+    components:
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 1
+  - uid: 774
+    components:
+    - type: Transform
+      pos: 14.5,2.5
+      parent: 1
+  - uid: 775
+    components:
+    - type: Transform
+      pos: 13.5,2.5
+      parent: 1
+  - uid: 776
+    components:
+    - type: Transform
+      pos: 12.5,2.5
+      parent: 1
+  - uid: 777
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 778
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 779
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 780
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 781
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 1
+  - uid: 782
+    components:
+    - type: Transform
+      pos: 12.5,0.5
+      parent: 1
+  - uid: 783
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 1
+  - uid: 784
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 785
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 786
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 787
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 788
+    components:
+    - type: Transform
+      pos: 11.5,-0.5
+      parent: 1
+  - uid: 789
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+  - uid: 790
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+  - uid: 791
+    components:
+    - type: Transform
+      pos: 14.5,0.5
+      parent: 1
+  - uid: 792
+    components:
+    - type: Transform
+      pos: 15.5,0.5
+      parent: 1
+  - uid: 793
+    components:
+    - type: Transform
+      pos: 16.5,0.5
+      parent: 1
+  - uid: 794
+    components:
+    - type: Transform
+      pos: 17.5,0.5
+      parent: 1
+  - uid: 795
+    components:
+    - type: Transform
+      pos: 16.5,1.5
+      parent: 1
+  - uid: 796
+    components:
+    - type: Transform
+      pos: 16.5,2.5
+      parent: 1
+  - uid: 797
+    components:
+    - type: Transform
+      pos: 16.5,3.5
+      parent: 1
+  - uid: 798
+    components:
+    - type: Transform
+      pos: 16.5,4.5
+      parent: 1
+  - uid: 799
+    components:
+    - type: Transform
+      pos: 16.5,5.5
+      parent: 1
+  - uid: 800
+    components:
+    - type: Transform
+      pos: 16.5,6.5
+      parent: 1
+  - uid: 802
+    components:
+    - type: Transform
+      pos: 16.5,-0.5
+      parent: 1
+  - uid: 803
+    components:
+    - type: Transform
+      pos: 16.5,-1.5
+      parent: 1
+  - uid: 804
+    components:
+    - type: Transform
+      pos: 16.5,-2.5
+      parent: 1
+  - uid: 805
+    components:
+    - type: Transform
+      pos: 16.5,-3.5
+      parent: 1
+  - uid: 847
+    components:
+    - type: Transform
+      pos: 14.5,7.5
+      parent: 1
+  - uid: 848
+    components:
+    - type: Transform
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 849
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 1
+  - uid: 850
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 1
+  - uid: 851
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 852
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 853
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 854
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 855
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 856
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 1
+  - uid: 857
+    components:
+    - type: Transform
+      pos: 12.5,6.5
+      parent: 1
+  - uid: 858
+    components:
+    - type: Transform
+      pos: 12.5,5.5
+      parent: 1
+  - uid: 859
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 860
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 861
+    components:
+    - type: Transform
+      pos: 14.5,-4.5
+      parent: 1
+  - uid: 862
+    components:
+    - type: Transform
+      pos: 13.5,-4.5
+      parent: 1
+  - uid: 863
+    components:
+    - type: Transform
+      pos: 12.5,-4.5
+      parent: 1
+  - uid: 864
+    components:
+    - type: Transform
+      pos: 11.5,-4.5
+      parent: 1
+  - uid: 865
+    components:
+    - type: Transform
+      pos: 10.5,-4.5
+      parent: 1
+  - uid: 866
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 867
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 868
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 869
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 870
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 871
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 872
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 1
+  - uid: 873
+    components:
+    - type: Transform
+      pos: 12.5,-2.5
+      parent: 1
+  - uid: 875
+    components:
+    - type: Transform
+      pos: 13.5,-8.5
+      parent: 1
+  - uid: 876
+    components:
+    - type: Transform
+      pos: 13.5,-7.5
+      parent: 1
+  - uid: 877
+    components:
+    - type: Transform
+      pos: 13.5,-6.5
+      parent: 1
+  - uid: 878
+    components:
+    - type: Transform
+      pos: 12.5,-7.5
+      parent: 1
+  - uid: 879
+    components:
+    - type: Transform
+      pos: 11.5,-7.5
+      parent: 1
+  - uid: 880
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 1
+  - uid: 881
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 1
+  - uid: 882
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 1
+  - uid: 883
+    components:
+    - type: Transform
+      pos: 13.5,-9.5
+      parent: 1
+  - uid: 884
+    components:
+    - type: Transform
+      pos: 13.5,-10.5
+      parent: 1
+  - uid: 885
+    components:
+    - type: Transform
+      pos: 13.5,-11.5
+      parent: 1
+  - uid: 886
+    components:
+    - type: Transform
+      pos: 12.5,-11.5
+      parent: 1
+  - uid: 887
+    components:
+    - type: Transform
+      pos: 12.5,-12.5
+      parent: 1
+  - uid: 888
+    components:
+    - type: Transform
+      pos: 9.5,-8.5
+      parent: 1
+  - uid: 889
+    components:
+    - type: Transform
+      pos: 9.5,-9.5
+      parent: 1
+  - uid: 890
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 1
+  - uid: 891
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 1
+  - uid: 892
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 1
+  - uid: 893
+    components:
+    - type: Transform
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 894
+    components:
+    - type: Transform
+      pos: 8.5,-11.5
+      parent: 1
+  - uid: 895
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 1
+  - uid: 896
+    components:
+    - type: Transform
+      pos: 12.5,-9.5
+      parent: 1
+  - uid: 897
+    components:
+    - type: Transform
+      pos: 11.5,-9.5
+      parent: 1
+  - uid: 898
+    components:
+    - type: Transform
+      pos: 15.5,-5.5
+      parent: 1
+  - uid: 899
+    components:
+    - type: Transform
+      pos: 15.5,-8.5
+      parent: 1
+  - uid: 900
+    components:
+    - type: Transform
+      pos: 15.5,-7.5
+      parent: 1
+  - uid: 901
+    components:
+    - type: Transform
+      pos: 15.5,-6.5
+      parent: 1
+  - uid: 902
+    components:
+    - type: Transform
+      pos: 15.5,-9.5
+      parent: 1
+  - uid: 903
+    components:
+    - type: Transform
+      pos: 15.5,-10.5
+      parent: 1
+  - uid: 904
+    components:
+    - type: Transform
+      pos: 15.5,-11.5
+      parent: 1
+  - uid: 905
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 906
+    components:
+    - type: Transform
+      pos: 3.5,-12.5
+      parent: 1
+  - uid: 907
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1
+  - uid: 908
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 909
+    components:
+    - type: Transform
+      pos: 1.5,-13.5
+      parent: 1
+  - uid: 910
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 1
+  - uid: 911
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 912
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 913
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 914
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 915
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 916
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 917
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 918
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 919
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 920
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 921
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 922
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 923
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 924
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 925
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 926
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 927
+    components:
+    - type: Transform
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 928
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 929
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 930
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 931
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 932
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 933
+    components:
+    - type: Transform
+      pos: 14.5,8.5
+      parent: 1
+  - uid: 934
+    components:
+    - type: Transform
+      pos: 15.5,8.5
+      parent: 1
+  - uid: 935
+    components:
+    - type: Transform
+      pos: 15.5,9.5
+      parent: 1
+  - uid: 936
+    components:
+    - type: Transform
+      pos: 15.5,10.5
+      parent: 1
+  - uid: 937
+    components:
+    - type: Transform
+      pos: 15.5,11.5
+      parent: 1
+  - uid: 938
+    components:
+    - type: Transform
+      pos: 15.5,12.5
+      parent: 1
+  - uid: 939
+    components:
+    - type: Transform
+      pos: 15.5,13.5
+      parent: 1
+  - uid: 940
+    components:
+    - type: Transform
+      pos: 15.5,14.5
+      parent: 1
+  - uid: 941
+    components:
+    - type: Transform
+      pos: 14.5,-5.5
+      parent: 1
+  - uid: 1029
+    components:
+    - type: Transform
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 1030
+    components:
+    - type: Transform
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 1031
+    components:
+    - type: Transform
+      pos: 8.5,13.5
+      parent: 1
+  - uid: 1032
+    components:
+    - type: Transform
+      pos: 9.5,13.5
+      parent: 1
+  - uid: 1033
+    components:
+    - type: Transform
+      pos: 10.5,13.5
+      parent: 1
+  - uid: 1034
+    components:
+    - type: Transform
+      pos: 11.5,13.5
+      parent: 1
+  - uid: 1035
+    components:
+    - type: Transform
+      pos: 12.5,13.5
+      parent: 1
+  - uid: 1036
+    components:
+    - type: Transform
+      pos: 13.5,13.5
+      parent: 1
+  - uid: 1037
+    components:
+    - type: Transform
+      pos: 12.5,14.5
+      parent: 1
+  - uid: 1038
+    components:
+    - type: Transform
+      pos: 10.5,14.5
+      parent: 1
+  - uid: 1039
+    components:
+    - type: Transform
+      pos: 8.5,14.5
+      parent: 1
+  - uid: 1040
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 1
+  - uid: 1041
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 1042
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 1043
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+  - uid: 1044
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 1
+  - uid: 1045
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 1
+  - uid: 1046
+    components:
+    - type: Transform
+      pos: 12.5,9.5
+      parent: 1
+  - uid: 1047
+    components:
+    - type: Transform
+      pos: 13.5,9.5
+      parent: 1
+  - uid: 1048
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 1
+  - uid: 1049
+    components:
+    - type: Transform
+      pos: 10.5,11.5
+      parent: 1
+  - uid: 1050
+    components:
+    - type: Transform
+      pos: 11.5,11.5
+      parent: 1
+  - uid: 1051
+    components:
+    - type: Transform
+      pos: 12.5,11.5
+      parent: 1
+  - uid: 1052
+    components:
+    - type: Transform
+      pos: 13.5,11.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 452
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 501
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 660
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 661
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 664
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 666
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 714
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 715
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 716
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 717
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 718
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 719
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 720
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 721
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 722
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 723
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 724
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 725
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 726
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 727
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 728
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 729
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 730
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 733
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 1
+  - uid: 754
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 755
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 756
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 757
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 758
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 1
+  - uid: 759
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+  - uid: 760
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 761
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 1
+  - uid: 762
+    components:
+    - type: Transform
+      pos: 12.5,6.5
+      parent: 1
+  - uid: 763
+    components:
+    - type: Transform
+      pos: 13.5,6.5
+      parent: 1
+  - uid: 764
+    components:
+    - type: Transform
+      pos: 14.5,6.5
+      parent: 1
+  - uid: 765
+    components:
+    - type: Transform
+      pos: 15.5,6.5
+      parent: 1
+  - uid: 766
+    components:
+    - type: Transform
+      pos: 15.5,5.5
+      parent: 1
+  - uid: 767
+    components:
+    - type: Transform
+      pos: 15.5,4.5
+      parent: 1
+  - uid: 768
+    components:
+    - type: Transform
+      pos: 15.5,3.5
+      parent: 1
+  - uid: 769
+    components:
+    - type: Transform
+      pos: 15.5,2.5
+      parent: 1
+  - uid: 770
+    components:
+    - type: Transform
+      pos: 14.5,2.5
+      parent: 1
+  - uid: 771
+    components:
+    - type: Transform
+      pos: 15.5,1.5
+      parent: 1
+  - uid: 772
+    components:
+    - type: Transform
+      pos: 15.5,0.5
+      parent: 1
+  - uid: 773
+    components:
+    - type: Transform
+      pos: 14.5,0.5
+      parent: 1
+  - uid: 828
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 829
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 830
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 831
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 832
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 833
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 834
+    components:
+    - type: Transform
+      pos: 11.5,-3.5
+      parent: 1
+  - uid: 835
+    components:
+    - type: Transform
+      pos: 11.5,-4.5
+      parent: 1
+  - uid: 836
+    components:
+    - type: Transform
+      pos: 11.5,-5.5
+      parent: 1
+  - uid: 837
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 1
+  - uid: 838
+    components:
+    - type: Transform
+      pos: 11.5,-7.5
+      parent: 1
+  - uid: 839
+    components:
+    - type: Transform
+      pos: 12.5,-7.5
+      parent: 1
+  - uid: 840
+    components:
+    - type: Transform
+      pos: 13.5,-7.5
+      parent: 1
+  - uid: 841
+    components:
+    - type: Transform
+      pos: 13.5,-8.5
+      parent: 1
+  - uid: 842
+    components:
+    - type: Transform
+      pos: 12.5,-4.5
+      parent: 1
+  - uid: 843
+    components:
+    - type: Transform
+      pos: 13.5,-4.5
+      parent: 1
+  - uid: 844
+    components:
+    - type: Transform
+      pos: 14.5,-4.5
+      parent: 1
+  - uid: 845
+    components:
+    - type: Transform
+      pos: 14.5,7.5
+      parent: 1
+  - uid: 1021
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 1022
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 1023
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+  - uid: 1024
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 1025
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 1
+  - uid: 1026
+    components:
+    - type: Transform
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 1027
+    components:
+    - type: Transform
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 1028
+    components:
+    - type: Transform
+      pos: 7.5,12.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 461
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,11.5
+      parent: 1
+- proto: CarpetBlack
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+- proto: CarpetBlue
+  entities:
+  - uid: 1214
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 1215
+    components:
+    - type: Transform
+      pos: 10.5,10.5
+      parent: 1
+  - uid: 1216
+    components:
+    - type: Transform
+      pos: 11.5,10.5
+      parent: 1
+  - uid: 1217
+    components:
+    - type: Transform
+      pos: 12.5,10.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,11.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 596
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 649
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 942
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 943
+    components:
+    - type: Transform
+      pos: 15.5,15.5
+      parent: 1
+  - uid: 944
+    components:
+    - type: Transform
+      pos: 15.5,14.5
+      parent: 1
+  - uid: 945
+    components:
+    - type: Transform
+      pos: 15.5,13.5
+      parent: 1
+  - uid: 946
+    components:
+    - type: Transform
+      pos: 15.5,12.5
+      parent: 1
+  - uid: 947
+    components:
+    - type: Transform
+      pos: 15.5,11.5
+      parent: 1
+  - uid: 948
+    components:
+    - type: Transform
+      pos: 15.5,10.5
+      parent: 1
+  - uid: 949
+    components:
+    - type: Transform
+      pos: 15.5,9.5
+      parent: 1
+  - uid: 950
+    components:
+    - type: Transform
+      pos: 15.5,8.5
+      parent: 1
+  - uid: 951
+    components:
+    - type: Transform
+      pos: 15.5,-5.5
+      parent: 1
+  - uid: 952
+    components:
+    - type: Transform
+      pos: 15.5,-6.5
+      parent: 1
+  - uid: 953
+    components:
+    - type: Transform
+      pos: 15.5,-7.5
+      parent: 1
+  - uid: 954
+    components:
+    - type: Transform
+      pos: 15.5,-8.5
+      parent: 1
+  - uid: 955
+    components:
+    - type: Transform
+      pos: 15.5,-9.5
+      parent: 1
+  - uid: 956
+    components:
+    - type: Transform
+      pos: 15.5,-10.5
+      parent: 1
+  - uid: 957
+    components:
+    - type: Transform
+      pos: 15.5,-11.5
+      parent: 1
+  - uid: 958
+    components:
+    - type: Transform
+      pos: 15.5,-12.5
+      parent: 1
+  - uid: 959
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 960
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 961
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 962
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 963
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 964
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 965
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 966
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 967
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 968
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 969
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 970
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 971
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 1
+  - uid: 972
+    components:
+    - type: Transform
+      pos: 1.5,-13.5
+      parent: 1
+  - uid: 973
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 974
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1
+  - uid: 975
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1
+- proto: CentcommComputerComms
+  entities:
+  - uid: 622
+    components:
+    - type: Transform
+      pos: 8.5,15.5
+      parent: 1
+- proto: Chair
+  entities:
+  - uid: 806
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-0.5
+      parent: 1
+  - uid: 807
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,0.5
+      parent: 1
+  - uid: 808
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,1.5
+      parent: 1
+  - uid: 809
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,2.5
+      parent: 1
+  - uid: 810
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,3.5
+      parent: 1
+  - uid: 811
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,0.5
+      parent: 1
+  - uid: 812
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,1.5
+      parent: 1
+  - uid: 813
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,2.5
+      parent: 1
+- proto: ChairOfficeLight
+  entities:
+  - uid: 632
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,14.5
+      parent: 1
+  - uid: 633
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,14.5
+      parent: 1
+  - uid: 634
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,14.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,11.5
+      parent: 1
+  - uid: 616
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,11.5
+      parent: 1
+  - uid: 1140
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,9.5
+      parent: 1
+  - uid: 1141
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,10.5
+      parent: 1
+  - uid: 1142
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 1143
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,10.5
+      parent: 1
+- proto: ChairWood
+  entities:
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: ChemDispenser
+  entities:
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 1
+- proto: ChemMaster
+  entities:
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 1
+- proto: CloningPod
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+- proto: ClothingBackpackWaterTank
+  entities:
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 10.511066,-9.422283
+      parent: 1
+- proto: ClothingBeltSecurityFilled
+  entities:
+  - uid: 1061
+    components:
+    - type: Transform
+      pos: 10.480806,12.570823
+      parent: 1
+  - uid: 1062
+    components:
+    - type: Transform
+      pos: 10.543306,12.445823
+      parent: 1
+- proto: ClothingMaskGasERT
+  entities:
+  - uid: 218
+    components:
+    - type: Transform
+      parent: 217
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 224
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 228
+    components:
+    - type: Transform
+      parent: 227
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingOuterHardsuitCBURN
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      parent: 217
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 226
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 231
+    components:
+    - type: Transform
+      parent: 227
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ComputerCloningConsole
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+- proto: ComputerId
+  entities:
+  - uid: 625
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,14.5
+      parent: 1
+- proto: ComputerIFF
+  entities:
+  - uid: 624
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,13.5
+      parent: 1
+- proto: ComputerRadar
+  entities:
+  - uid: 618
+    components:
+    - type: Transform
+      pos: 12.5,15.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 623
+    components:
+    - type: Transform
+      pos: 10.5,15.5
+      parent: 1
+- proto: Crematorium
+  entities:
+  - uid: 1139
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,2.5
+      parent: 1
+- proto: DebugGenerator
+  entities:
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+- proto: DiseaseDiagnoser
+  entities:
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 13.5,-7.5
+      parent: 1
+- proto: FirelockGlass
+  entities:
+  - uid: 279
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-5.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 976
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 978
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 979
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 980
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 981
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 982
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 983
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 984
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 985
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 1
+  - uid: 986
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 1
+  - uid: 988
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 1
+  - uid: 989
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 990
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 991
+    components:
+    - type: Transform
+      pos: 11.5,-5.5
+      parent: 1
+  - uid: 992
+    components:
+    - type: Transform
+      pos: 12.5,-9.5
+      parent: 1
+  - uid: 993
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 1
+  - uid: 994
+    components:
+    - type: Transform
+      pos: 14.5,-3.5
+      parent: 1
+  - uid: 995
+    components:
+    - type: Transform
+      pos: 14.5,6.5
+      parent: 1
+- proto: FloorDrain
+  entities:
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 13.5,3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: GasMinerNitrogen
+  entities:
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+- proto: GasMinerOxygen
+  entities:
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+- proto: GasMixerFlipped
+  entities:
+  - uid: 475
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 441
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+- proto: GasPipeBend
+  entities:
+  - uid: 445
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 482
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 987
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1079
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1083
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1118
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1125
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 1070
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1109
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1169
+    components:
+    - type: Transform
+      pos: 11.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1172
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 443
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 446
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 477
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 478
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 479
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 480
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 481
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1065
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1066
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1071
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1072
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1073
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1074
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1075
+    components:
+    - type: Transform
+      pos: 9.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1076
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1077
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1078
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1081
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1082
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1085
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1086
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1087
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1088
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1089
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1093
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1094
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1095
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1096
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1097
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1098
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1099
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-0.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1101
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1105
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1106
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1107
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1108
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1110
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1111
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1113
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1115
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1116
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1117
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1119
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1121
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1122
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1127
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1128
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1129
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1130
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1132
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1136
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1137
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1138
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1144
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1145
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1146
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1151
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1152
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1153
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1154
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1155
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1156
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1157
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1158
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1159
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1162
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1163
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1164
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1165
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1166
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1167
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1168
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1170
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1171
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1173
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1175
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1177
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1180
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,0.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1181
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-0.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1186
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1192
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1194
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1195
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1199
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1200
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1202
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1203
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1207
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1208
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1209
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1210
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1211
+    components:
+    - type: Transform
+      pos: 11.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1212
+    components:
+    - type: Transform
+      pos: 11.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 476
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1067
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1069
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1102
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1104
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1123
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1147
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1150
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1191
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasVentPump
+  entities:
+  - uid: 483
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1068
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1080
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1084
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1091
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1092
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1103
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1112
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1133
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1134
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 554
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1161
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1178
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1179
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1190
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1197
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1198
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1205
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1213
+    components:
+    - type: Transform
+      pos: 11.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 393
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 12.5,-1.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-5.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 9.5,-10.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-8.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-8.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 11.5,-10.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 12.5,-10.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      pos: 18.5,1.5
+      parent: 1
+  - uid: 538
+    components:
+    - type: Transform
+      pos: 16.5,7.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 18.5,2.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: Transform
+      pos: 14.5,5.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      pos: 14.5,-2.5
+      parent: 1
+  - uid: 567
+    components:
+    - type: Transform
+      pos: 18.5,0.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: Transform
+      pos: 18.5,5.5
+      parent: 1
+  - uid: 569
+    components:
+    - type: Transform
+      pos: 18.5,-2.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      pos: 7.5,16.5
+      parent: 1
+  - uid: 582
+    components:
+    - type: Transform
+      pos: 9.5,16.5
+      parent: 1
+  - uid: 583
+    components:
+    - type: Transform
+      pos: 8.5,16.5
+      parent: 1
+  - uid: 584
+    components:
+    - type: Transform
+      pos: 11.5,16.5
+      parent: 1
+  - uid: 585
+    components:
+    - type: Transform
+      pos: 12.5,16.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      pos: 13.5,16.5
+      parent: 1
+  - uid: 597
+    components:
+    - type: Transform
+      pos: 17.5,7.5
+      parent: 1
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 15.5,7.5
+      parent: 1
+  - uid: 599
+    components:
+    - type: Transform
+      pos: 15.5,-4.5
+      parent: 1
+  - uid: 600
+    components:
+    - type: Transform
+      pos: 16.5,-4.5
+      parent: 1
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 17.5,-4.5
+      parent: 1
+  - uid: 602
+    components:
+    - type: Transform
+      pos: 14.5,10.5
+      parent: 1
+  - uid: 603
+    components:
+    - type: Transform
+      pos: 14.5,11.5
+      parent: 1
+  - uid: 604
+    components:
+    - type: Transform
+      pos: 14.5,12.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      pos: 14.5,13.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      pos: 14.5,14.5
+      parent: 1
+  - uid: 659
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-2.5
+      parent: 1
+  - uid: 823
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,5.5
+      parent: 1
+  - uid: 1090
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,8.5
+      parent: 1
+- proto: GunSafeLaserCarbine
+  entities:
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+- proto: GunSafeRifleLecter
+  entities:
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+- proto: GunSafeShotgunKammerer
+  entities:
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 392
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 648
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,11.5
+      parent: 1
+  - uid: 655
+    components:
+    - type: Transform
+      pos: 15.5,-8.5
+      parent: 1
+- proto: HighSecCentralCommandLocked
+  entities:
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 1
+- proto: HolopadBluespace
+  entities:
+  - uid: 353
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+- proto: Lamp
+  entities:
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 2.5280437,2.6702652
+      parent: 1
+- proto: MaterialBiomass
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 13.388358,-0.5105796
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 13.513358,-0.3855796
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 13.591483,-0.5105796
+      parent: 1
+- proto: MedicalBed
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 13.5,1.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 13.5,0.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 11.5,-11.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 11.5,-12.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      pos: 9.5,-11.5
+      parent: 1
+- proto: MedicalScanner
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 1
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 7.4200745,0.65613663
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 7.5763245,0.49988663
+      parent: 1
+  - uid: 1060
+    components:
+    - type: Transform
+      pos: 11.496431,15.586448
+      parent: 1
+- proto: MicrophoneInstrument
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 2.5592937,1.2015151
+      parent: 1
+    missingComponents:
+    - Item
+    - Pullable
+- proto: Morgue
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 1
+- proto: NitrogenTankFilled
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      parent: 217
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 223
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 230
+    components:
+    - type: Transform
+      parent: 227
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: OxygenTankFilled
+  entities:
+  - uid: 219
+    components:
+    - type: Transform
+      parent: 217
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 225
+    components:
+    - type: Transform
+      parent: 222
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 229
+    components:
+    - type: Transform
+      parent: 227
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: PillAmbuzol
+  entities:
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 10.339191,-8.500408
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 10.323566,-8.281658
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 10.698566,-8.516033
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 10.667316,-8.281658
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 10.651691,-8.406658
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      pos: 10.417316,-8.406658
+      parent: 1
+- proto: PillAmbuzolPlus
+  entities:
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 7.3670826,-4.1900277
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 7.6639576,-4.1900277
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      pos: 7.3983326,-4.3150277
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      pos: 7.6952076,-4.3150277
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 7.3983326,-4.4556527
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: 7.7108326,-4.4556527
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 7.3983326,-4.5962777
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 7.7264576,-4.6119027
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-9.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-4.5
+      parent: 1
+- proto: PlasmaWindoorSecureCentralCommandLocked
+  entities:
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 819
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-1.5
+      parent: 1
+  - uid: 822
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-3.5
+      parent: 1
+  - uid: 825
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,4.5
+      parent: 1
+  - uid: 826
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,6.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 1057
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,15.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 996
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 997
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 998
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 1000
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 1001
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-10.5
+      parent: 1
+  - uid: 1002
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-10.5
+      parent: 1
+  - uid: 1003
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 1004
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 1005
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-11.5
+      parent: 1
+  - uid: 1006
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-7.5
+      parent: 1
+  - uid: 1007
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-7.5
+      parent: 1
+  - uid: 1008
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-4.5
+      parent: 1
+  - uid: 1009
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 1010
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 1011
+    components:
+    - type: Transform
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 1012
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-0.5
+      parent: 1
+  - uid: 1013
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 1014
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 1015
+    components:
+    - type: Transform
+      pos: 13.5,3.5
+      parent: 1
+  - uid: 1016
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-0.5
+      parent: 1
+  - uid: 1017
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,3.5
+      parent: 1
+  - uid: 1018
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,4.5
+      parent: 1
+  - uid: 1019
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-1.5
+      parent: 1
+  - uid: 1053
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,9.5
+      parent: 1
+  - uid: 1054
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,15.5
+      parent: 1
+  - uid: 1055
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,15.5
+      parent: 1
+  - uid: 1056
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,9.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-0.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 1
+- proto: Railing
+  entities:
+  - uid: 57
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-0.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,3.5
+      parent: 1
+- proto: RailingCorner
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+- proto: RailingCornerSmall
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,2.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,0.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-8.5
+      parent: 1
+- proto: SheetPlastic
+  entities:
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 6.59089,-6.5272465
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: 6.59089,-6.5272465
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 6.59089,-6.5272465
+      parent: 1
+- proto: SheetSteel
+  entities:
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 6.419015,-6.3553715
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 6.419015,-6.3553715
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 6.419015,-6.3553715
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 15.5,7.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,4.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-1.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-5.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-8.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-8.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 11.5,-10.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 12.5,-10.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 9.5,-10.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      pos: 18.5,0.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: 18.5,-2.5
+      parent: 1
+  - uid: 537
+    components:
+    - type: Transform
+      pos: 18.5,5.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      pos: 18.5,2.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      pos: 18.5,1.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      pos: 15.5,-4.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      pos: 16.5,-4.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      pos: 17.5,-4.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 553
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,8.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 14.5,5.5
+      parent: 1
+  - uid: 564
+    components:
+    - type: Transform
+      pos: 14.5,-2.5
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 14.5,14.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 14.5,13.5
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 14.5,12.5
+      parent: 1
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 14.5,11.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 14.5,10.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      pos: 13.5,16.5
+      parent: 1
+  - uid: 590
+    components:
+    - type: Transform
+      pos: 12.5,16.5
+      parent: 1
+  - uid: 591
+    components:
+    - type: Transform
+      pos: 11.5,16.5
+      parent: 1
+  - uid: 592
+    components:
+    - type: Transform
+      pos: 9.5,16.5
+      parent: 1
+  - uid: 593
+    components:
+    - type: Transform
+      pos: 8.5,16.5
+      parent: 1
+  - uid: 594
+    components:
+    - type: Transform
+      pos: 7.5,16.5
+      parent: 1
+  - uid: 801
+    components:
+    - type: Transform
+      pos: 17.5,7.5
+      parent: 1
+  - uid: 820
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,5.5
+      parent: 1
+  - uid: 821
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-2.5
+      parent: 1
+  - uid: 824
+    components:
+    - type: Transform
+      pos: 16.5,7.5
+      parent: 1
+- proto: SignArmory
+  entities:
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+- proto: SignBridge
+  entities:
+  - uid: 626
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,8.5
+      parent: 1
+- proto: SignCloning
+  entities:
+  - uid: 627
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-1.5
+      parent: 1
+  - uid: 628
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,4.5
+      parent: 1
+  - uid: 629
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 630
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 1
+- proto: SignNanotrasen1
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+- proto: SignNanotrasen2
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+- proto: SignNanotrasen3
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+- proto: SignNanotrasen4
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+- proto: SignNanotrasen5
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 1
+- proto: SignVirology
+  entities:
+  - uid: 631
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-5.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 1
+- proto: StairWood
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 612
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,12.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,12.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 495
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+- proto: SuitStorageBase
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 218
+          - 219
+          - 220
+          - 221
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 223
+          - 224
+          - 225
+          - 226
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 228
+          - 229
+          - 230
+          - 231
+- proto: Table
+  entities:
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      pos: 10.5,12.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      pos: 11.5,12.5
+      parent: 1
+  - uid: 617
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,15.5
+      parent: 1
+  - uid: 619
+    components:
+    - type: Transform
+      pos: 9.5,15.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      pos: 11.5,15.5
+      parent: 1
+  - uid: 621
+    components:
+    - type: Transform
+      pos: 13.5,15.5
+      parent: 1
+- proto: TableReinforcedGlass
+  entities:
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 1
+- proto: TableWood
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 422
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 539
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,9.5
+      parent: 1
+  - uid: 635
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 636
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 637
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 638
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 639
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 640
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 641
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 642
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-13.5
+      parent: 1
+  - uid: 643
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-13.5
+      parent: 1
+  - uid: 644
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 645
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-13.5
+      parent: 1
+  - uid: 646
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 647
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,10.5
+      parent: 1
+  - uid: 650
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,13.5
+      parent: 1
+  - uid: 651
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,14.5
+      parent: 1
+  - uid: 652
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-11.5
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-10.5
+      parent: 1
+  - uid: 654
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,12.5
+      parent: 1
+  - uid: 656
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-7.5
+      parent: 1
+  - uid: 657
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-6.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-9.5
+      parent: 1
+- proto: ToiletDirtyWater
+  entities:
+  - uid: 346
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-12.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-12.5
+      parent: 1
+- proto: TurboItemRecharger
+  entities:
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 1058
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,15.5
+      parent: 1
+- proto: UraniumWindoorSecureCentralCommandLocked
+  entities:
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 1
+- proto: Vaccinator
+  entities:
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 13.5,-6.5
+      parent: 1
+- proto: VendingMachineChemicals
+  entities:
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 14.5,-1.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 14.5,4.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 13.5,4.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 13.5,-1.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 14.5,-0.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 14.5,3.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 14.5,2.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 14.5,1.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 14.5,0.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 6.5,-9.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 3.5,-12.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-13.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-13.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-13.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-13.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-13.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-13.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-13.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-13.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-13.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-12.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-8.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-8.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-9.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-10.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-11.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-12.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-5.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-5.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-6.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-7.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 5.5,15.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,15.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,14.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,12.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      pos: 7.5,12.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,11.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      pos: 2.5,15.5
+      parent: 1
+  - uid: 384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,15.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-11.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 419
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 421
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,13.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-0.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-4.5
+      parent: 1
+  - uid: 533
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,3.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,7.5
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,3.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,7.5
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-4.5
+      parent: 1
+  - uid: 555
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,8.5
+      parent: 1
+  - uid: 556
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,8.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,8.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 14.5,9.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      pos: 14.5,15.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      pos: 14.5,16.5
+      parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      pos: 10.5,16.5
+      parent: 1
+  - uid: 588
+    components:
+    - type: Transform
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 818
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-0.5
+      parent: 1
+  - uid: 977
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+- proto: WallSolid
+  entities:
+  - uid: 530
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-0.5
+      parent: 1
+- proto: WardrobeMixedFilled
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+- proto: WarningN2
+  entities:
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+- proto: WarningO2
+  entities:
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 1064
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+    - type: WarpPoint
+      location: CBURN Shuttle
+- proto: WeaponLaserGun
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5406275,-7.470862
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.33750248,-7.486487
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.7437525,-7.423987
+      parent: 1
+- proto: WeaponPDW9
+  entities:
+  - uid: 1059
+    components:
+    - type: Transform
+      pos: 9.496431,15.602073
+      parent: 1
+- proto: WeaponShotgunRiot
+  entities:
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -0.5419791,-8.266237
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -0.5107291,-8.344362
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -0.46385407,-8.484987
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -0.43260407,-8.625612
+      parent: 1
+- proto: WeaponSprayNozzle
+  entities:
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 10.526691,-8.812908
+      parent: 1
+- proto: WindoorSecurePlasma
+  entities:
+  - uid: 357
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+- proto: WindoorSecureUranium
+  entities:
+  - uid: 326
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-5.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 607
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,12.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,12.5
+      parent: 1
+...

--- a/Resources/Prototypes/_StarLight/GameRules/events.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/events.yml
@@ -112,6 +112,15 @@
   - type: LoadMapRule
     gridPath: /Maps/_Starlight/Shuttles/DSshuttle.yml
 
+      #Pig's ERT Shuttle
+- type: entity
+  parent: BaseGameRule
+  id: CBURNShuttleSpawn
+  components:
+  - type: RuleGrids
+  - type: LoadMapRule
+    gridPath: /Maps/_Starlight/Shuttles/CBURN.yml
+
 # Karma's Quantum Ark Shuttles
 - type: entity
   parent: BaseGameRule


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a CBURN Shuttle that can only be spawned by admins with 'addgamerule CBURNShuttleSpawn'
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
So that CBURN doesnt need to use the ERT Shuttle
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![image](https://github.com/user-attachments/assets/9db3f4b8-79b3-42bb-84f5-ee3475164dbb)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.-->

:cl: PubliclyExecutedPig
- add: Added an admin-only CBURN Shuttle

