### PR TITLE
Elkridge Station - Bug fix

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Elkridge.yml
+++ b/Resources/Maps/_Starlight/Stations/Elkridge.yml
@@ -46796,7 +46796,7 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: ClothingHeadsetGrey
+- proto: ClothingHeadsetAssistant
   entities:
   - uid: 16721
     components:


### PR DESCRIPTION
## Short description
Brought to my attention that with the new assistant changelog changing most of all passenger titles and names. Elkridge suddenly has began to flip out all of the sudden. This is the patch for a simple wrong name prototype in the files of elkridge.

## Why we need to add this
If people would like to play it more. I'd suggest merging this. 

## Media (Video/Screenshots)


## Checks

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: ScorchFollower
- fix: Bug fix on Elkridge Station.

