### PR TITLE
We have IPCs at home (makes borgis round start)

### DIFF
--- a/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
+++ b/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
@@ -55,7 +55,12 @@ public sealed partial class BorgMenu : FancyWindow
             NameIdentifierLabel.Text = nameIdentifierComponent.FullIdentifier;
 
             var fullName = _entity.GetComponent<MetaDataComponent>(Entity).EntityName;
-            var name = fullName.Substring(0, fullName.Length - nameIdentifierComponent.FullIdentifier.Length - 1);
+            #region Starlight
+            var name = fullName.EndsWith(nameIdentifierComponent.FullIdentifier)
+                ? fullName.Substring(0, fullName.Length - nameIdentifierComponent.FullIdentifier.Length - 1) //old behaviour
+                : fullName; // our full name does not contain the Name Identifer so we use the full name.
+            #endregion Starlight
+            
             NameLineEdit.Text = name;
         }
         else

--- a/Resources/Locale/en-US/species/species.ftl
+++ b/Resources/Locale/en-US/species/species.ftl
@@ -11,6 +11,7 @@ species-name-skeleton = Skeleton
 species-name-vox = Vox
 species-name-resomi = Resomi
 species-name-gingerbread = delicious baked good
+species-name-borgi = Borgi
 
 ## Misc species things
 

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borgi_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borgi_chassis.yml
@@ -189,6 +189,7 @@
   - type: Emoting
   - type: GuideHelp
     guides:
+    - Borgi
     - Cyborgs
   # Borgis by-and-large can't wear space suits so this helps mitigate that trouble somewhat where needed
   - type: Barotrauma

--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -15,6 +15,7 @@
   - Cyclorite
   - Vulpkanin
   - Resomi
+  - Borgi
 
 - type: guideEntry
   id: Arachnid
@@ -75,3 +76,8 @@
   id: Resomi
   name: species-name-resomi
   text: "/ServerInfo/Guidebook/Mobs/Resomi.xml"
+
+- type: guideEntry
+  id: Borgi
+  name: species-name-borgi
+  text: "/ServerInfo/Guidebook/Mobs/Borgi.xml"

--- a/Resources/Prototypes/Species/borgi.yml
+++ b/Resources/Prototypes/Species/borgi.yml
@@ -1,0 +1,50 @@
+- type: species
+  id: Borgi
+  name: species-name-borgi
+  roundStart: true
+  prototype: SmartBorgiVulnerable
+  sprites: MobSmartCorgiSprites
+  defaultSkinTone: "#385878"
+  markingLimits: MobArachnidMarkingLimits
+  dollPrototype: MobSmartCorgiDummy
+  skinColoration: Hues
+  maleFirstNames: NamesBorgi
+  femaleFirstNames: NamesBorgi
+  lastNames: NamesBorgi
+  naming: First
+  sexes:
+    - Unsexed
+
+- type: speciesBaseSprites
+  id: MobSmartCorgiSprites
+  sprites:
+    Chest: TorsoAdmemeCorgi
+
+- type: entity
+  parent: BaseSpeciesDummy
+  id: MobSmartCorgiDummy
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: HumanoidAppearance
+      species: Borgi
+    - type: Inventory
+      speciesId: dog
+      templateId: smartpetborgi
+
+- type: humanoidBaseSprite
+  id: TorsoAdmemeCorgi
+  baseSprite:
+    sprite: Mobs/Pets/corgi.rsi
+    state: corgi
+    
+- type: humanoidBaseSprite
+  id: TorsoAdmemeCorgiMale
+  baseSprite:
+    sprite: Mobs/Pets/corgi.rsi
+    state: corgi
+
+- type: humanoidBaseSprite
+  id: TorsoAdmemeCorgiFemale
+  baseSprite:
+    sprite: Mobs/Pets/corgi.rsi
+    state: corgi

--- a/Resources/Prototypes/Species/borgi.yml
+++ b/Resources/Prototypes/Species/borgi.yml
@@ -4,13 +4,11 @@
   roundStart: true
   prototype: SmartBorgiVulnerable
   sprites: MobSmartCorgiSprites
-  defaultSkinTone: "#385878"
-  markingLimits: MobArachnidMarkingLimits
+  defaultSkinTone: "#ffffff"
+  markingLimits: MobArachnidMarkingLimits # without this the game just gives up. why arachnid? why not?
   dollPrototype: MobSmartCorgiDummy
-  skinColoration: Hues
+  skinColoration: HumanToned
   maleFirstNames: NamesBorgi
-  femaleFirstNames: NamesBorgi
-  lastNames: NamesBorgi
   naming: First
   sexes:
     - Unsexed

--- a/Resources/ServerInfo/Guidebook/Mobs/Borgi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Borgi.xml
@@ -11,5 +11,5 @@
   
   Unlike Cyborgs however they require food, water, and atmos (also preferablly love), Cannot be healed by a welder, and only have binary radio built in requiring a headset for other radios.
   
-  also ontop of being partially borg like they cant wear alot of clothing garments. neck, glasses, [color=red]bags, belts[color]
+  also ontop of being partially borg like they cant wear alot of clothing garments including. neckties, glasses, [color=red]bags, and belts[color]
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Borgi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Borgi.xml
@@ -7,8 +7,9 @@
 
   Borgis were made by the loving hand of god. and are a mix of silicon and cute flesh.
   
-  Like a [textlink="Generic Cyborg" link="Cyborgs"]they can install modules, use binary radio, talk while crit, and have a battery.
+  Like a [textlink="Generic Cyborg" link="Cyborgs"] they can install modules, use binary radio, talk while crit, and have a battery.
   
   Unlike Cyborgs however they require food, water, and atmos (also preferablly love), Cannot be healed by a welder, and only have binary radio built in requiring a headset for other radios.
   
+  also ontop of being partially borg like they cant wear alot of clothing garments. neck, glasses, [color=red]bags, belts[color]
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Borgi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Borgi.xml
@@ -1,0 +1,15 @@
+<Document>
+  # Borgis
+
+  <Box>
+    <GuideEntityEmbed Entity="MobSmartCorgiDummy" Caption=""/>
+  </Box>
+
+  Borgis were made by the loving hand of god. and are a mix of silicon and cute flesh.
+  
+  Like a [textlink="Generic Cyborg" link="Cyborgs"]they can install modules and have a battery.
+  
+  
+  Unlike Cyborgs however they require food,water, and atmos (also preferablly love). And cannot be healed by a welder.
+  
+</Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Borgi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Borgi.xml
@@ -7,9 +7,8 @@
 
   Borgis were made by the loving hand of god. and are a mix of silicon and cute flesh.
   
-  Like a [textlink="Generic Cyborg" link="Cyborgs"]they can install modules and have a battery.
+  Like a [textlink="Generic Cyborg" link="Cyborgs"]they can install modules, use binary radio, talk while crit, and have a battery.
   
-  
-  Unlike Cyborgs however they require food,water, and atmos (also preferablly love). And cannot be healed by a welder.
+  Unlike Cyborgs however they require food, water, and atmos (also preferablly love), Cannot be healed by a welder, and only have binary radio built in requiring a headset for other radios.
   
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -8,6 +8,7 @@
   <GuideEntityEmbed Entity="MobDiona" Caption="Diona"/>
   <GuideEntityEmbed Entity="MobDwarf" Caption="Dwarf"/>
   <GuideEntityEmbed Entity="MobHuman" Caption="Human"/>
+  <GuideEntityEmbed Entity="MobSmartCorgiDummy" Caption="Borgi"/>
   <GuideEntityEmbed Entity="MobMoth" Caption="Moth Person"/>
   </Box>
   <Box>
@@ -18,7 +19,6 @@
   <GuideEntityEmbed Entity="MobFelionoid" Caption="Felionoid"/>
   <GuideEntityEmbed Entity="MobVulpkanin" Caption="Vulpkanin"/>
   <GuideEntityEmbed Entity="MobResomi" Caption="Resomi"/>
-  <GuideEntityEmbed Entity="MobSmartCorgiDummy" Caption="Borgi"/>
   </Box>
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -18,6 +18,7 @@
   <GuideEntityEmbed Entity="MobFelionoid" Caption="Felionoid"/>
   <GuideEntityEmbed Entity="MobVulpkanin" Caption="Vulpkanin"/>
   <GuideEntityEmbed Entity="MobResomi" Caption="Resomi"/>
+  <GuideEntityEmbed Entity="MobSmartCorgiDummy" Caption="Borgi"/>
   </Box>
 
 </Document>


### PR DESCRIPTION
## Short description
made borgis a round-start species. have not tested antag rolling as borgis yet.

## Why we need to add this
I want command borgis it would be VERY funny. (and also "we have IPCs at home")

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/ce10027b-921d-4449-8271-5fb6efee143e)



## Checks


- [ ] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add:Borgis are a round-start species now

