### PR TITLE
move grav gland to new proto, nerf the gland

### DIFF
--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Organs.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Organs.cs
@@ -80,7 +80,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
                 if (_time.CurTime - victim.LastActivation < TimeSpan.FromSeconds(60))
                     return;
                 victim.LastActivation = _time.CurTime;
-                var gravity = SpawnAttachedTo("AdminInstantEffectGravityWell", Transform(uid).Coordinates);
+                var gravity = SpawnAttachedTo("AbductorGravityGlandGravityWell", Transform(uid).Coordinates);
                 _xformSys.SetParent(gravity, uid);
                 break;
             case AbductorOrganType.Egg:

--- a/Resources/Prototypes/_StarLight/Entities/Effects/abductor_glands.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Effects/abductor_glands.yml
@@ -1,0 +1,38 @@
+- type: entity
+  id: GlandEffectBase
+  abstract: true
+  name: Abductor Gland Effect
+  components:
+  - type: Sprite
+    sprite: /Textures/Objects/Fun/goldbikehorn.rsi
+    visible: false
+    state: icon
+  - type: TriggerOnSpawn
+  - type: TimedDespawn #controls how long the effect lasts. Can be overriden by gland
+    lifetime: 5
+
+- type: entity
+  id: AbductorGravityGlandGravityWell
+  suffix: Gravity
+  parent: GlandEffectBase
+  components: 
+  - type: SoundOnTrigger
+    removeOnTrigger: true
+    sound:
+      path: /Audio/Effects/Grenades/Supermatter/supermatter_start.ogg
+      volume: 5
+  - type: AmbientSound
+    enabled: true
+    volume: -5
+    range: 14
+    sound:
+      path: /Audio/Effects/Grenades/Supermatter/supermatter_loop.ogg
+  - type: GravityWell
+    maxRange: 3
+    minRange: 0.25
+    baseRadialAcceleration: 1
+    baseTangentialAcceleration: 1
+    gravPulsePeriod: 0.01
+  - type: SingularityDistortion
+    intensity: 10
+    falloffPower: 1.5


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This PR nerfs the grav gland significantly, primarily to tackle the issue of it sending entities and players into walls and outside the station

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This is needed as currently, the grav gland is essentially a death sentence to anyone near the person with it, as they will either get trapped into a wall, or get completely flung outside the station. This change makes the gland bearable and manageable, and prevents physics from completely breaking

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/d27217fc-79a5-43bd-8e4f-2c834762d4fc

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Reworked abductor grav gland to not be horrible.