### PR TITLE
Add bluespaced locker variants of custom jobs

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/representatives.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/representatives.yml
@@ -19,6 +19,15 @@
       - id: BoxFolderClipboardFilled
       - id: PrinterDocFlatpack
       - id: FaxMachineFlatpack
+  
+- type: entity
+  id: LockerRepresentativeFilledBluespaced
+  suffix: Filled, Bluespaced
+  parent: LockerRepresentativeFilled
+  components:
+  - type: TriggerOnSpawn
+  - type: SpawnOnTrigger
+    proto: EffectFlashBluespace
 
 - type: entity
   id: LockerBSOFilled
@@ -42,3 +51,12 @@
       - id: ClothingNeckCloakBsoElite
       - id: ClothingNeckCloakBsoElite
       - id: RadioHandheldSecurity
+
+- type: entity
+  id: LockerBSOFilledBluespaced
+  suffix: Filled, Bluespaced
+  parent: LockerBSOFilled
+  components:
+  - type: TriggerOnSpawn
+  - type: SpawnOnTrigger
+    proto: EffectFlashBluespace

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/suit_storage.yml
@@ -11,3 +11,12 @@
         - id: ClothingShoesBootsMagBSO
   - type: AccessReader
     access: [["BlueShield"]]
+  
+- type: entity
+  id: SuitStorageBlueShieldBluespaced
+  suffix: BlueShield, Bluespaced
+  parent: SuitStorageBlueShield
+  components:
+  - type: TriggerOnSpawn
+  - type: SpawnOnTrigger
+    proto: EffectFlashBluespace


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds bluespaced in variants of the BSO locker, suit storage and representative locker

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Useful for when maps don't have these lockers and we want the in character effect to happen of bluespace

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/3628859a-efb8-49ed-a087-b7040c5be25d


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- add: Added variants of lockers to allow bluespacing them to the station.