### PR TITLE
add a way to disable the que on the radio for TTS

### DIFF
--- a/Content.Client/Options/UI/Tabs/AudioTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AudioTab.xaml
@@ -26,6 +26,7 @@
                     StyleClasses="LabelKeyText"/>
                 <!--🌟Starlight🌟-->
                 <CheckBox Name="TtsClientCheckBox" Text="{Loc 'ui-options-tts-enabled'}" />
+                <CheckBox Name="TtsRadioQueueCheckBox" Text="{Loc 'ui-options-tts-radio-queue-enabled'}" />
                 
                 <ui:OptionSlider Name="SliderTts" Title="{Loc 'ui-options-tts-volume'}" />
                 <ui:OptionSlider Name="SliderTtsRadio" Title="{Loc 'ui-options-tts-radio-volume'}" />

--- a/Content.Client/Options/UI/Tabs/AudioTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AudioTab.xaml.cs
@@ -82,6 +82,7 @@ public sealed partial class AudioTab : Control
         Control.AddOptionCheckBox(CCVars.AdminSoundsEnabled, AdminSoundsCheckBox);
         Control.AddOptionCheckBox(CCVars.BwoinkSoundEnabled, BwoinkSoundCheckBox);
         Control.AddOptionCheckBox(StarlightCCVars.TTSClientEnabled, TtsClientCheckBox);
+        Control.AddOptionCheckBox(StarlightCCVars.TTSRadioQueueEnabled, TtsRadioQueueCheckBox);
 
         Control.Initialize();
     }

--- a/Content.Client/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Client/_Starlight/TextToSpeech/TTSSystem.cs
@@ -29,6 +29,7 @@ public sealed class TextToSpeechSystem : EntitySystem
     private float _volume;
     private float _radioVolume;
     private float _volumeAnnounce;
+    private bool _ttsQueueEnabled;
 
     public override void Initialize()
     {
@@ -36,6 +37,7 @@ public sealed class TextToSpeechSystem : EntitySystem
         _cfg.OnValueChanged(StarlightCCVars.TTSVolume, OnTtsVolumeChanged, true);
         _cfg.OnValueChanged(StarlightCCVars.TTSAnnounceVolume, OnTtsAnnounceVolumeChanged, true);
         _cfg.OnValueChanged(StarlightCCVars.TTSRadioVolume, OnTtsRadioVolumeChanged, true);
+        _cfg.OnValueChanged(StarlightCCVars.TTSRadioQueueEnabled, OnTtsRadioQueueChanged, true);
         _cfg.OnValueChanged(StarlightCCVars.TTSClientEnabled, OnTtsClientOptionChanged, true);
         SubscribeNetworkEvent<PlayTTSEvent>(OnPlayTTS);
         SubscribeNetworkEvent<AnnounceTtsEvent>(OnAnnounceTTSPlay);
@@ -47,6 +49,7 @@ public sealed class TextToSpeechSystem : EntitySystem
         _cfg.UnsubValueChanged(StarlightCCVars.TTSVolume, OnTtsVolumeChanged);
         _cfg.UnsubValueChanged(StarlightCCVars.TTSAnnounceVolume, OnTtsAnnounceVolumeChanged);
         _cfg.UnsubValueChanged(StarlightCCVars.TTSRadioVolume, OnTtsRadioVolumeChanged);
+        _cfg.UnsubValueChanged(StarlightCCVars.TTSRadioQueueEnabled, OnTtsRadioQueueChanged);
         _cfg.UnsubValueChanged(StarlightCCVars.TTSClientEnabled, OnTtsClientOptionChanged);
         _contentRoot.Dispose();
     }
@@ -59,6 +62,9 @@ public sealed class TextToSpeechSystem : EntitySystem
 
     private void OnTtsRadioVolumeChanged(float volume)
         => _radioVolume = volume;
+    
+    private void OnTtsRadioQueueChanged(bool enabled)
+        => _ttsQueueEnabled = enabled;
 
     private void OnTtsAnnounceVolumeChanged(float volume)
         => _volumeAnnounce = volume;
@@ -86,7 +92,7 @@ public sealed class TextToSpeechSystem : EntitySystem
     {
         var volume = ev.IsRadio ? _radioVolume : _volume;
 
-        if (ev.IsRadio)
+        if (ev.IsRadio && _ttsQueueEnabled)
             _ttsQueue.Enqueue((ev.Data, null));
         else
         {

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.TTS.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.TTS.cs
@@ -41,6 +41,9 @@ public sealed partial class StarlightCCVars
 
     public static readonly CVarDef<float> TTSRadioVolume =
         CVarDef.Create("tts.radio_volume", 0.50f, CVar.CLIENTONLY | CVar.ARCHIVE);
+    
+    public static readonly CVarDef<bool> TTSRadioQueueEnabled =
+        CVarDef.Create("tts.radio_queue_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     public static readonly CVarDef<float> TTSAnnounceVolume =
         CVarDef.Create("tts.announce_volume", 0.50f, CVar.CLIENTONLY | CVar.ARCHIVE);

--- a/Resources/Locale/en-US/_Starlight/ui-options/ui-options-tts.ftl
+++ b/Resources/Locale/en-US/_Starlight/ui-options/ui-options-tts.ftl
@@ -6,3 +6,4 @@ ui-options-tts-radio-volume = Radio Volume:
 ui-options-tts-announce-volume = Announcement Volume:
 
 ui-options-tts-enabled = Text-To-Speech Enabled
+ui-options-tts-radio-queue-enabled = Queue Radio TTS


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a toggle to disable the queue that is automatically incured on specifically TTS over radio channels

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
With the pop count on alfa, the radio can get SIGNIFICANTLY behind late in a shift, to the point that the TTS isn't useful anymore. This setting allows users to get TTS messages as fast as they possibly can play them, to combat this problem

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/0f12cb04-fd4b-49c9-955d-368872b1a381


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- add: Added ability to turn off the TTS queue on radio messages.