### PR TITLE
hotfix removing items with stripping and nesting

### DIFF
--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -74,14 +74,14 @@ namespace Content.Shared.Strip.Components
 
     //starlight start
     [ByRefEvent]
-    public sealed class StripInsertAttemptEvent(Entity<HandsComponent?> user,
+    public sealed class StripAttemptEvent(Entity<HandsComponent?> user,
         EntityUid target,
-        EntityUid held,
+        EntityUid item,
         string slot) : CancellableEntityEventArgs
         {
         public Entity<HandsComponent?> User = user;
         public EntityUid Target = target;
-        public EntityUid Held = held;
+        public EntityUid Item = item;
         public string Slot = slot;
         }
     //starlight end

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -182,7 +182,7 @@ public abstract class SharedStrippableSystem : EntitySystem
         }
 
         //starlight start
-        var ev = new StripInsertAttemptEvent(user, target, held, slot);
+        var ev = new StripAttemptEvent(user, target, held, slot);
         RaiseLocalEvent(target, ref ev, true);
 
         if (ev.Cancelled)
@@ -282,6 +282,16 @@ public abstract class SharedStrippableSystem : EntitySystem
             _popupSystem.PopupCursor(Loc.GetString(reason));
             return false;
         }
+
+        //starlight start
+        var ev = new StripAttemptEvent(user, target, item, slot);
+        RaiseLocalEvent(target, ref ev, true);
+
+        if (ev.Cancelled)
+        {
+            return false;
+        }
+        //starlight end
 
         return true;
     }
@@ -392,7 +402,7 @@ public abstract class SharedStrippableSystem : EntitySystem
         }
 
         //starlight start
-        var ev = new StripInsertAttemptEvent(user, target, held, handName);
+        var ev = new StripAttemptEvent(user, target, held, handName);
         RaiseLocalEvent(target, ref ev, true);
 
         if (ev.Cancelled)
@@ -503,6 +513,16 @@ public abstract class SharedStrippableSystem : EntitySystem
             _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-drop-message", ("owner", Identity.Entity(target, EntityManager))));
             return false;
         }
+
+        //starlight start
+        var ev = new StripAttemptEvent(user, target, item, handName);
+        RaiseLocalEvent(target, ref ev, true);
+
+        if (ev.Cancelled)
+        {
+            return false;
+        }
+        //starlight end
 
         return true;
     }

--- a/Content.Shared/_Starlight/Restrict/SharedRestrictNestingItemSystem.cs
+++ b/Content.Shared/_Starlight/Restrict/SharedRestrictNestingItemSystem.cs
@@ -36,7 +36,7 @@ public abstract partial class SharedRestrictNestingItemSystem : EntitySystem
         SubscribeLocalEvent<RestrictNestingItemComponent, GetVerbsEvent<InteractionVerb>>(AddPickupVerb);
         SubscribeLocalEvent<RestrictNestingItemComponent, RestrictNestingItemPickupDoAfterEvent>(FinishPickup);
         SubscribeLocalEvent<RestrictNestingItemComponent, DoAfterAttemptEvent<RestrictNestingItemPickupDoAfterEvent>>(DuringPickup);
-        SubscribeLocalEvent<RestrictNestingItemComponent, StripInsertAttemptEvent>(StripInsertAttempt);
+        SubscribeLocalEvent<RestrictNestingItemComponent, StripAttemptEvent>(StripAttempt);
     }
 
     private void AddPickupVerb(Entity<RestrictNestingItemComponent> ent, ref GetVerbsEvent<InteractionVerb> args)
@@ -72,13 +72,14 @@ public abstract partial class SharedRestrictNestingItemSystem : EntitySystem
         return true;
     }
 
-    private void StripInsertAttempt(Entity<RestrictNestingItemComponent> ent, ref StripInsertAttemptEvent args)
+    private void StripAttempt(Entity<RestrictNestingItemComponent> ent, ref StripAttemptEvent args)
     {
         //if we are already in a container
-        if(_containerSystem.TryGetContainingContainer((args.Target, null, null), out var container))
+        if(_containerSystem.TryGetContainingContainer((args.Target, null, null), out var container) || 
+           _containerSystem.TryGetContainingContainer((args.User, null, null), out var container2))
         {
             //check if the thing we are trying to insert is a nesting item
-            if (RecursivelyCheckForNesting(args.Held, initialItem: false))
+            if (RecursivelyCheckForNesting(args.Item, initialItem: false))
             {
                 //if it is, cancel the insert
                 args.Cancel();


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Cant believe it gets merged and I instantly think of a workaround. guhh. at least I caught it to make a hotfix for it

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
You can currently strip away duffelbags into you hands that have resomi in them, even if you are carried currently. This fixes that

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
No CL as this is intended as a hotfix to the previously merged PR