### PR TITLE
fix borgi/smart corgi name datasets.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borgi_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borgi_chassis.yml
@@ -223,7 +223,7 @@
   components:
   - type: RandomMetadata
     nameSegments:
-    - NamesСorgi
+    - NamesCorgi
   # Custom inventory template
   - type: Inventory
     speciesId: dog
@@ -357,7 +357,7 @@
     subverted: true
   - type: RandomMetadata
     nameSegments:
-    - NamesSyndieBorgi
+    - NamesSyndiBorgi
   - type: ActionGrant
     actions:
     - ActionViewLaws
@@ -412,7 +412,7 @@
     subverted: true
   - type: RandomMetadata
     nameSegments:
-    - NamesSyndieBorgi
+    - NamesSyndiBorgi
   - type: ActionGrant
     actions:
     - ActionViewLaws
@@ -473,7 +473,7 @@
     subverted: true
   - type: RandomMetadata
     nameSegments:
-    - NamesSyndieBorgi
+    - NamesSyndiBorgi
   - type: ActionGrant
     actions:
     - ActionViewLaws


### PR DESCRIPTION

## Short description
somehow NamesCorgi was wrong? re-typing it fixed it and there is a diff???? and `NamesSyndieBorgi` -> `NamesSyndiBorgi` to allign with the dataset proto

## Why we need to add this
fixes them not having names

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/131ba77e-26f3-4ac0-9256-5c17d952d910)
![image](https://github.com/user-attachments/assets/d0de9f05-4a42-4956-8044-b7c07ea428a6)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora and sparlight
- fix: Fixed Smart Corgis and SyndiBorgis not having propper names.

