### PR TITLE
Fix boxcutter in various ways

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/boxcutter.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/boxcutter.yml
@@ -25,6 +25,13 @@
           damage:
             types:
               Blunt: 1
+        - type: DamageOtherOnHit #this just clears out the comp to not have any damage when thrown
+          damage:
+            types:
+              Blunt: 0
+        - type: EmbeddableProjectile #here to disable embedding. Ideally this comp wouldnt be here at all, but due to limits, we have to have it. Instead the values are set as such that it basically should never embed normally
+          minimumSpeed: 100000 #require CRAZY speed to embed ever. This seems to actually be bugged and non functional?
+          embedOnThrow: false
 
       unsheathed: !type:ItemSwitchState
         verb: sheathe
@@ -38,9 +45,18 @@
           damage:
             types:
               Slash: 8
+        - type: DamageOtherOnHit
+          damage:
+            types:
+              Slash: 6
+        - type: EmbeddableProjectile
+          sound: /Audio/Weapons/star_hit.ogg
+          offset: -0.15,0.0
   - type: Tool
     qualities:
       - Screwing
     speedModifier: 0.5
     useSound:
       collection: Screwdriver
+  - type: ThrowingAngle
+    angle: 180


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes some more bugs with the boxcutter weapon.

- Throw angle is correct now, it will throw completely blade first
- Damage on hit when thrown now is correct, 0 when sheathed, 6 when extended
- Will not embed into things when sheathed

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugs lel

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/bbf83de1-b523-43c7-a3dc-5fe1f93dcd77


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed Boxcutter throw damage.
- fix: Fixed Boxcutter embedding when sheathed.
- fix: Fixed Boxcutter sprite angle when thrown