### PR TITLE
add flash immunity vision exceptions for antag items

### DIFF
--- a/Content.Client/_Starlight/Overlay/FlashImmunitySystem.cs
+++ b/Content.Client/_Starlight/Overlay/FlashImmunitySystem.cs
@@ -79,7 +79,8 @@ public sealed class FlashImmunitySystem : EntitySystem
     {
         if (EntityManager.TryGetComponent(uid, out FlashImmunityComponent? flashImmunityComponent))
         {
-            return true;
+            if (flashImmunityComponent.AffectsVision)
+                return true;
         }
 
         if (TryComp<InventoryComponent>(uid, out var inventoryComp))
@@ -90,7 +91,8 @@ public sealed class FlashImmunitySystem : EntitySystem
             {
                 if (slot.ContainedEntity != null && EntityManager.TryGetComponent(slot.ContainedEntity, out FlashImmunityComponent? wornFlashImmunityComponent))
                 {
-                    return true;
+                    if (wornFlashImmunityComponent.AffectsVision)
+                        return true;
                 }
             }
         }

--- a/Content.Client/_Starlight/Overlay/FlashImmunitySystem.cs
+++ b/Content.Client/_Starlight/Overlay/FlashImmunitySystem.cs
@@ -79,7 +79,7 @@ public sealed class FlashImmunitySystem : EntitySystem
     {
         if (EntityManager.TryGetComponent(uid, out FlashImmunityComponent? flashImmunityComponent))
         {
-            if (flashImmunityComponent.AffectsVision)
+            if (flashImmunityComponent.BlocksSpecialVision)
                 return true;
         }
 
@@ -91,7 +91,7 @@ public sealed class FlashImmunitySystem : EntitySystem
             {
                 if (slot.ContainedEntity != null && EntityManager.TryGetComponent(slot.ContainedEntity, out FlashImmunityComponent? wornFlashImmunityComponent))
                 {
-                    if (wornFlashImmunityComponent.AffectsVision)
+                    if (wornFlashImmunityComponent.BlocksSpecialVision)
                         return true;
                 }
             }

--- a/Content.Shared/Flash/Components/FlashImmunityComponent.cs
+++ b/Content.Shared/Flash/Components/FlashImmunityComponent.cs
@@ -1,13 +1,25 @@
+using Robust.Shared.GameStates;
+
 namespace Content.Shared.Flash.Components;
 
 /// <summary>
 ///     Makes the entity immune to being flashed.
 ///     When given to clothes in the "head", "eyes" or "mask" slot it protects the wearer.
 /// </summary>
-[RegisterComponent, Access(typeof(SharedFlashSystem))]
+[RegisterComponent, Access(typeof(SharedFlashSystem)), NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class FlashImmunityComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("enabled")]
     public bool Enabled { get; set; } = true;
+
+    //starlight
+    /// <summary>
+    /// If true, will affect night vision, thermal vision, and cyclorite vision.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [AutoNetworkedField]
+    [DataField]
+    public bool AffectsVision { get; set; } = true;
+    //starlight end
 }

--- a/Content.Shared/Flash/Components/FlashImmunityComponent.cs
+++ b/Content.Shared/Flash/Components/FlashImmunityComponent.cs
@@ -20,6 +20,6 @@ public sealed partial class FlashImmunityComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
     [DataField]
-    public bool AffectsVision { get; set; } = true;
+    public bool BlocksSpecialVision { get; set; } = true;
     //starlight end
 }

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -265,4 +265,4 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/ninjavisor.rsi
   - type: FlashImmunity
-    affectsVision: false
+    blocksSpecialVision: false

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -265,3 +265,4 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/ninjavisor.rsi
   - type: FlashImmunity
+    affectsVision: false

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -53,7 +53,7 @@
   - type: Clothing
     sprite: Clothing/Mask/gassyndicate.rsi
   - type: FlashImmunity
-    affectsVision: false
+    blocksSpecialVision: false
   - type: EyeProtection
   - type: Pierceable
     level: Metal

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -53,6 +53,7 @@
   - type: Clothing
     sprite: Clothing/Mask/gassyndicate.rsi
   - type: FlashImmunity
+    affectsVision: false
   - type: EyeProtection
   - type: Pierceable
     level: Metal


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a immunity to disabling special vision on specific items that are associated with nukies and ninja

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
it wasn't very intuitive that you had to swap these antag spawn items out for something else if you wanted the advantages of your species.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Nukie gas masks and Ninja visors will no longer block special vision effects.