### PR TITLE
allow resomi to roundstart as nukies

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -132,9 +132,6 @@
       fallbackRoles: [ Nukeops, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsCommander
       startingGear: SyndicateCommanderGearFull
-      blacklist:
-        tags:
-          - Resomi
       roleLoadout:
       - RoleSurvivalNukie
       components:
@@ -152,9 +149,6 @@
       fallbackRoles: [ Nukeops, NukeopsCommander ]
       spawnerPrototype: SpawnPointNukeopsMedic
       startingGear: SyndicateOperativeMedicFull
-      blacklist:
-        tags:
-          - Resomi
       roleLoadout:
       - RoleSurvivalNukie
       components:
@@ -174,9 +168,6 @@
       max: 3
       playerRatio: 10
       startingGear: SyndicateOperativeGearFull
-      blacklist:
-        tags:
-          - Resomi
       roleLoadout:
       - RoleSurvivalNukie
       components:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes resomi from the blacklist of roundstarting as nukies

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Resomi of all species are probably the weakest but can still hold their own, they should be allowed especially now that they can use larger guns

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Allowed Resomi to roundstart as nukies.