### PR TITLE
Changes super synth name to use suffix instead

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_percussion.yml
@@ -157,7 +157,8 @@
 - type: entity
   parent: SuperSynthesizerInstrument
   id: SuperSynthesizerInstrumentAdmeme
-  name: super synthesizer (Admeme)
+  name: super synthesizer
+  suffix: Admeme
   components:
   - type: Instrument
     respectMidiLimits: false


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Pretty much what it says. Changes admeme variant to use the suffix system instead of it just being called admeme

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
fix
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- fix: Admeme synth now uses [suffix] instead of (name)