### PR TITLE
Raise emote cooldown

### DIFF
--- a/Content.Shared/Speech/Components/VocalComponent.cs
+++ b/Content.Shared/Speech/Components/VocalComponent.cs
@@ -52,14 +52,13 @@ public sealed partial class VocalComponent : Component
     public EmoteSoundsPrototype? EmoteSounds = null;
 
     //starlight start
-    [ViewVariables]
+    [ViewVariables(VVAccess.ReadOnly)]
     [AutoNetworkedField]
     //have to use string as for some reason emote prototypes are not serializable even though im telling it not to serialize
     public Dictionary<string, TimeSpan> LastEmoteTime = new Dictionary<string, TimeSpan>();
 
-    [ViewVariables]
     [AutoNetworkedField]
     [DataField]
-    public TimeSpan EmoteCooldown = TimeSpan.FromSeconds(0.5f);
+    public TimeSpan EmoteCooldown = TimeSpan.FromSeconds(1.5f);
     //starlight end
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Raises emote cooldown and fixes visibility of cooldown

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Felionoids still abusing emotes. This time might be too high, hard to tell without testing

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Raise emote cooldown to 1.5s