### PR TITLE
Make collective mind/Syndicate radio channel more readable

### DIFF
--- a/Resources/Prototypes/_StarLight/CollectiveMinds/collective_mind.yml
+++ b/Resources/Prototypes/_StarLight/CollectiveMinds/collective_mind.yml
@@ -2,7 +2,7 @@
   id: Dionas
   name: collective-mind-dioneas
   keycode: 'd'
-  color: "#0f6b1e"
+  color: "#15912a"
   requiredTags: 
   - Diona
 
@@ -10,7 +10,7 @@
   id: Arachnids
   name: collective-mind-arachnids
   keycode: 'a'
-  color: "#706d0d"
+  color: "#cec816"
   requiredTags: 
   - Arachnid
   
@@ -44,7 +44,7 @@
   id: Spider
   name: collective-mind-spider
   keycode: 's'
-  color: "#3f2f20"
+  color: "#8f6741"
   requiredComponents:
   - Spider
   

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -67,7 +67,7 @@
   name: chat-radio-syndicate
   keycode: 't'
   frequency: 1213
-  color: "#9d2f2f"
+  color: "#802424"
   longRange: true
 
 - type: radioChannel

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -67,7 +67,7 @@
   name: chat-radio-syndicate
   keycode: 't'
   frequency: 1213
-  color: "#8f4a4b"
+  color: "#9d2f2f"
   longRange: true
 
 - type: radioChannel

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -67,7 +67,7 @@
   name: chat-radio-syndicate
   keycode: 't'
   frequency: 1213
-  color: "#802424"
+  color: "#b52424"
   longRange: true
 
 - type: radioChannel


### PR DESCRIPTION
## Short description
alot of the text of hiveminds are really hard to read, such as spider and dionae, you can bearly read them.

## Why we need to add this
https://discord.com/channels/1272545509562777621/1364456047263088753

## Media (Video/Screenshots)
![изображение_2025-04-24_164924786](https://github.com/user-attachments/assets/a31b9153-0353-4d96-83b4-25541a3a10a6)
![изображение_2025-04-24_164939225](https://github.com/user-attachments/assets/ad0f8579-f97f-4c01-8980-a66f123eb4f9)
![изображение_2025-04-24_164946065](https://github.com/user-attachments/assets/f39b51dc-2162-484f-b720-1b59483de732)
![изображение_2025-04-24_164956281](https://github.com/user-attachments/assets/907860ba-8c62-426a-8824-5e484acd7b3e)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [✅] I do not require assistance to complete the PR.
- [✅] Before posting/requesting review of a PR, I have verified that the changes work.
- [✅] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [✅] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: CringeCursed
- tweak: make some of collective minds and syndicate radio channel more readable