### PR TITLE
make diona slow but steady

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -192,10 +192,14 @@
 - type: damageModifierSet
   id: Diona
   coefficients:
-    Blunt: 0.7
-    Slash: 0.8
-    Heat: 1.5
+    Blunt: 0.5 # punching a tree is not wise.
+    Slash: 2.0 # an strong hit with an axe hurts like hell 
+    Heat: 2.0 # they also have increased fire stacks. basicly cancels out firesuit.
     Shock: 1.2
+  flatReductions:
+    Blunt: 5 # same as wood.
+    Slash: 5 # (12-5)*2 = 14 so combat knife do a bit more damage then before, fire axes do ~50 per hit to a diona.
+    Piercing: 5 # now you can play darts with a diona without killing them. about a 20% reduction from most powerful guns.
 
 - type: damageModifierSet
   id: Moth # Slightly worse at everything but cold

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -25,6 +25,13 @@
   - type: Body
     prototype: Diona
     requiredLegs: 2
+  - type: MovementSpeedModifier
+    baseWalkSpeed : 2.0
+    baseSprintSpeed : 3.5
+  - type: PressureProtection
+    highPressureMultiplier: 0.5
+    lowPressureModifier: 100
+  - type: NoSlip
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Diona
@@ -86,7 +93,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.35
-        density: 300 #weighs more than humans because wood
+        density: 600 #weighs more than humans because wood
         restitution: 0.0
         mask:
           - MobMask

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -28,6 +28,21 @@
   - type: MovementSpeedModifier
     baseWalkSpeed : 2.0
     baseSprintSpeed : 3.5
+    # the wood damage modifier set doubles the damage taken from fire + slash
+    # and keeps getting shot take same amout
+    # also takes structual damage
+    # blunt at half normal. punching a tree is pointless.
+    # double the total health so shooting a diona with a gun is the same as shooting a human
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      200: Critical
+      300: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      70: 0.7
+      100: 0.5
+      150: 0.1 # magdumping a diona will inmobilize them
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureModifier: 100

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -28,11 +28,6 @@
   - type: MovementSpeedModifier
     baseWalkSpeed : 2.0
     baseSprintSpeed : 3.5
-    # the wood damage modifier set doubles the damage taken from fire + slash
-    # and keeps getting shot take same amout
-    # also takes structual damage
-    # blunt at half normal. punching a tree is pointless.
-    # double the total health so shooting a diona with a gun is the same as shooting a human
   - type: MobThresholds
     thresholds:
       0: Alive


### PR DESCRIPTION
a 20% movement debuff but study footing and no barotrauma damage from vacuum. are not space proof, will still freeze, slow down, and die. but takes a bit longer now and makes more sense for a tree.

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

## Why we need to add this
Massive tree people that have roots instead falling over doesn't make much sense.
Wood does not take barotrauma damage same way as skin does.
Diona are by far the weakest race in a fight. You can RR instantly with plant killer. They have no way to avoid slipping and die to 2 shots of caps laser.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- tweak: diona are slow again, but have steady footing
- tweak: diona have some preasure resistance