### PR TITLE
speed walk felionoid

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
@@ -5,8 +5,8 @@
   components:
   - type: Absorbable
   - type: MovementSpeedModifier
-    speciesSprintSpeedModifier: 1.25
-    speciesWalkSpeedModifier: 1.00
+    speciesSprintSpeedModifier: 1.00
+    speciesWalkSpeedModifier: 1.25
   - type: Speech
     speechVerb: Felionoid
     allowedEmotes: ['Mew', 'Hisses', 'Meow', 'Growl', 'Purr', 'Trill']


### PR DESCRIPTION
they now can walk fast and run normal.
25% movement speed buff is insane.

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
slow down

## Why we need to add this
balance

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/a69d2341-4126-4826-a3e5-f3e265d03526)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- fix: felionoid now walk fast not run fast
