### PR TITLE
Raise maximum to 60 biomass

### DIFF
--- a/Content.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Server/Changeling/ChangelingSystem.cs
@@ -615,8 +615,6 @@ public sealed partial class ChangelingSystem : EntitySystem
             _actions.AddAction(uid, actionId);
 
         // making sure things are right in this world
-        comp.Chemicals = comp.MaxChemicals;
-        comp.Biomass = comp.MaxBiomass;
         comp.ChemicalNextUpdateTime = _timing.CurTime + comp.ChemicalUpdateCooldown;
         comp.BiomassNextUpdateTime = _timing.CurTime + comp.BiomassUpdateCooldown;
 

--- a/Content.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Server/Changeling/ChangelingSystem.cs
@@ -174,7 +174,6 @@ public sealed partial class ChangelingSystem : EntitySystem
         _alerts.ShowAlert(uid, "ChangelingBiomass");
 
         var random = _rand.Prob(0.5f);
-        random = true;
 
         if (comp.Biomass <= 0)
         {

--- a/Content.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Server/Changeling/ChangelingSystem.cs
@@ -204,13 +204,16 @@ public sealed partial class ChangelingSystem : EntitySystem
                 _popup.PopupEntity(Loc.GetString("disease-vomit", ("person", Identity.Entity(uid, EntityManager))), uid);
             }
         }
-        else if (comp.Biomass <= comp.MaxBiomass * comp.BiomassDeficitJitterPercent && random)
+        else if (comp.Biomass <= comp.MaxBiomass * comp.BiomassDeficitJitterPercent)
         {
             // the funny itch is not real
             _popup.PopupEntity(Loc.GetString("popup-changeling-biomass-deficit-medium"), uid, uid, PopupType.MediumCaution);
-            _jitter.DoJitter(uid, TimeSpan.FromSeconds(.5f), true, amplitude: 5, frequency: 10);
+            if (random)
+            {
+                _jitter.DoJitter(uid, TimeSpan.FromSeconds(.5f), true, amplitude: 5, frequency: 10);
+            }
         }
-        else if (comp.Biomass <= comp.MaxBiomass * comp.BiomassDeficitWarningPercent && random)
+        else if (comp.Biomass <= comp.MaxBiomass * comp.BiomassDeficitWarningPercent) //always do this every update
         {
             _popup.PopupEntity(Loc.GetString("popup-changeling-biomass-deficit-low"), uid, uid, PopupType.SmallCaution);
         }

--- a/Content.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Server/Changeling/ChangelingSystem.cs
@@ -173,23 +173,23 @@ public sealed partial class ChangelingSystem : EntitySystem
         Dirty(uid, comp);
         _alerts.ShowAlert(uid, "ChangelingBiomass");
 
-        var random = (int) _rand.Next(1, 3);
+        var random = _rand.Prob(0.5f);
+        random = true;
 
         if (comp.Biomass <= 0)
+        {
             // game over, man
             _damage.TryChangeDamage(uid, new DamageSpecifier(_proto.Index(AbsorbedDamageGroup), 50), true);
-
-        if (comp.Biomass <= comp.MaxBiomass / 10)
+        }
+        else if (comp.Biomass <= comp.MaxBiomass * comp.BiomassDeficitVomitPercent)
         {
             // THE FUNNY ITCH IS REAL!!
             comp.BonusChemicalRegen = 3f;
             _popup.PopupEntity(Loc.GetString("popup-changeling-biomass-deficit-high"), uid, uid, PopupType.LargeCaution);
             _jitter.DoJitter(uid, comp.BiomassUpdateCooldown, true, amplitude: 5, frequency: 10);
-        }
-        else if (comp.Biomass <= comp.MaxBiomass / 3)
-        {
+
             // vomit blood
-            if (random == 1)
+            if (random)
             {
                 if (TryComp<StatusEffectsComponent>(uid, out var status))
                     _stun.TrySlowdown(uid, TimeSpan.FromSeconds(1.5f), true, 0.5f, 0.5f, status);
@@ -204,18 +204,16 @@ public sealed partial class ChangelingSystem : EntitySystem
 
                 _popup.PopupEntity(Loc.GetString("disease-vomit", ("person", Identity.Entity(uid, EntityManager))), uid);
             }
-
-            // the funny itch is not real
-            if (random == 3)
-            {
-                _popup.PopupEntity(Loc.GetString("popup-changeling-biomass-deficit-medium"), uid, uid, PopupType.MediumCaution);
-                _jitter.DoJitter(uid, TimeSpan.FromSeconds(.5f), true, amplitude: 5, frequency: 10);
-            }
         }
-        else if (comp.Biomass <= comp.MaxBiomass / 2 && random == 3)
+        else if (comp.Biomass <= comp.MaxBiomass * comp.BiomassDeficitJitterPercent && random)
         {
-            if (random == 1)
-                _popup.PopupEntity(Loc.GetString("popup-changeling-biomass-deficit-low"), uid, uid, PopupType.SmallCaution);
+            // the funny itch is not real
+            _popup.PopupEntity(Loc.GetString("popup-changeling-biomass-deficit-medium"), uid, uid, PopupType.MediumCaution);
+            _jitter.DoJitter(uid, TimeSpan.FromSeconds(.5f), true, amplitude: 5, frequency: 10);
+        }
+        else if (comp.Biomass <= comp.MaxBiomass * comp.BiomassDeficitWarningPercent && random)
+        {
+            _popup.PopupEntity(Loc.GetString("popup-changeling-biomass-deficit-low"), uid, uid, PopupType.SmallCaution);
         }
         else comp.BonusChemicalRegen = 0f;
     }

--- a/Content.Shared/Changeling/ChangelingComponent.cs
+++ b/Content.Shared/Changeling/ChangelingComponent.cs
@@ -70,7 +70,7 @@ public sealed partial class ChangelingComponent : Component
     ///     Maximum amount of biomass a changeling can have.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float MaxBiomass = 30f;
+    public float MaxBiomass = 60f;
 
     /// <summary>
     ///     How much biomass should be removed per cycle.

--- a/Content.Shared/Changeling/ChangelingComponent.cs
+++ b/Content.Shared/Changeling/ChangelingComponent.cs
@@ -72,6 +72,13 @@ public sealed partial class ChangelingComponent : Component
     [DataField, AutoNetworkedField]
     public float MaxBiomass = 60f;
 
+    [DataField, AutoNetworkedField]
+    public float BiomassDeficitWarningPercent = 0.5f;
+    [DataField, AutoNetworkedField]
+    public float BiomassDeficitJitterPercent = 0.33f;
+    [DataField, AutoNetworkedField]
+    public float BiomassDeficitVomitPercent = 0.1f;
+
     /// <summary>
     ///     How much biomass should be removed per cycle.
     /// </summary>


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Raises the ling biomass max to 60 instead of 30, starting players at 30

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Now that biomass decreases, it invariably nerfed some ability that took up to 15 biomass to activate. The goal with this PR isn't to increase the start biomass, but to allow players to batch up and hold onto more biomass during a round instead of hitting the cap quickly

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Raised ling biomass maximum to 60, lings start at 30 now.
- fix: Fixed ling biomass warning and jitter system.