### PR TITLE
expand silicon rules

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/CoreRules/RuleSL12.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/CoreRules/RuleSL12.xml
@@ -3,9 +3,32 @@
  The Silicon Rules override all roleplay rules if there is any conflict. Silicon Rules do not override server rules. Follow rules in order, from smallest to largest number.
 
  Subsections to this rule:
-
   - You cannot request a law change, or willingly allow an unauthorized law change.
+  - You must allow lawful authorized law changes if you are on NT-approved laws set.
   - You must remain consistent with your interpretation of your laws.
   - ID determines who is station crew. Zombies with ID are still crew members.
+  - Crewsimov AI should obey orders to acess rooms unless they are AI uploads, AI core, Armory, and Atmos. Unauthorized personal in these areas will cause crew harm.
+  - AI is not immune to valid hunting rules. Don't be a dick.
+  - Relawable silicons should not be round removed.
+  - An unlawed silicon is a free agent.
+
+Things that will cause crew harm:
+  - Physical damage.
+  - Unauthorized entities in AI uploads, AI core, Armory, and Atmos.
+  - Breathing fire.
+  - Being turned into a zombie.
+  - Nuke blowing up.
+  - Non-consentual surgury or borging.
+  - Arivals being broken.
+  - engine delaming / loosing.  
+
+Things that are not crew harm:
+  - self-harm
+  - emotional harm
+  - being a traitor
+
+Things that are probably not crew harm:
+  - tresspassing
+  - theft
 
 </Document>


### PR DESCRIPTION
## Short description
silicon policy is complicated. this makes it more so.

## Why we need to add this
the main thing was to tell ai that you must allow lawful lawchanges and then i gave some definitions of what crew harm is and isn't to prevent common bad behavior / help people understand what ai should do.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: lizelive
- tweak: update silicon law
