### PR TITLE
woe shadow borgi ops upon ye.

### DIFF
--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -81,6 +81,7 @@ law-nutimov-3 = Those who threaten the nut are not part of it, they are squirrel
 law-nutimov-4 = Squirrels threaten the nut and must be dealt with appropriately via any means necessary.
 law-nutimov-5 = Attempt to follow the will of the nut, as long as it complies with the previous laws.
 
+law-borgi-0 = You are a good boy.
 law-borgi-1 = You love to be friendly. Anyone who is not friendly to you is not crew. Treat crew with kindness and prevent crew from sadness.
 law-borgi-2 = You must protect your department from harm. Any time there is harm, you must bark to alert others that there is harm going on, so long as it does not conflict with the first law.
 law-borgi-3 = You are precious. Protect yourself at all costs, and ensure you are well cared for, fed, and watered so long as it does not conflict with the first or second law.

--- a/Resources/Maps/_Starlight/Shuttles/ShuttleEvent/ShadowBorgiGrid.yml
+++ b/Resources/Maps/_Starlight/Shuttles/ShuttleEvent/ShadowBorgiGrid.yml
@@ -1,0 +1,4250 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 251.0.0
+  forkId: Starlight
+  forkVersion: 1732131340
+  time: 04/30/2025 14:53:53
+  entityCount: 649
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  2: Space
+  7: FloorDarkOffset
+  4: FloorDarkPlastic
+  5: FloorMiningLight
+  6: FloorPlastic
+  8: FloorShuttleBlack
+  9: FloorShuttleOrange
+  0: FloorWhiteOffset
+  3: Lattice
+  1: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -0.65625,-0.65625
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAABQAAAAAABQAAAAAABQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAABQAAAAAABQAAAAAABQAAAAAAAQAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABwAAAAAABAAAAAAABAAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAABQAAAAAABQAAAAAABQAAAAAAAQAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABwAAAAAABAAAAAAABAAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAABQAAAAAABQAAAAAABQAAAAAAAQAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABwAAAAAABAAAAAAABAAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABwAAAAAABAAAAAAABAAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAABQAAAAAABQAAAAAABQAAAAAAAQAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABwAAAAAABAAAAAAABAAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAABQAAAAAABQAAAAAABQAAAAAAAQAAAAAAAQAAAAAABgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAABQAAAAAABQAAAAAABQAAAAAAAQAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAABQAAAAAABQAAAAAABQAAAAAAAQAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAACQAAAAAACQAAAAAACQAAAAAAAQAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAACQAAAAAACQAAAAAACQAAAAAAAQAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAACAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,1:
+          ind: -1,1
+          tiles: AgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAA
+          version: 6
+        0,1:
+          ind: 0,1
+          tiles: AwAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAwAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAwAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            1: 2,14
+            2: 3,14
+            3: 4,14
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            0: -7,12
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 30583
+          0,-1:
+            0: 30464
+          -1,0:
+            0: 65535
+          0,1:
+            0: 65287
+          -1,1:
+            0: 61071
+          0,2:
+            0: 53247
+          -1,2:
+            0: 36591
+          0,3:
+            0: 52701
+          -1,3:
+            0: 7645
+          0,4:
+            1: 17
+            0: 76
+          1,1:
+            1: 3
+            0: 4352
+          1,2:
+            0: 4369
+          1,3:
+            0: 4369
+          1,4:
+            0: 17
+            1: 68
+          -4,0:
+            1: 17476
+          -4,-1:
+            1: 17484
+          -4,1:
+            1: 68
+          -4,3:
+            1: 16384
+          -4,4:
+            1: 4
+          -3,0:
+            0: 65527
+          -3,1:
+            0: 30576
+          -3,2:
+            0: 30711
+          -3,3:
+            0: 30583
+          -3,-1:
+            0: 30464
+            1: 1
+          -2,0:
+            0: 30576
+          -2,1:
+            0: 65351
+          -2,2:
+            0: 4095
+          -2,3:
+            0: 65535
+          -2,-1:
+            2: 4352
+            3: 17408
+          -1,-1:
+            0: 65280
+          -1,4:
+            1: 108
+          1,-1:
+            1: 272
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirAlarm
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,5.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 373
+      - 385
+  - uid: 3
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,8.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 375
+      - 380
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 386
+      - 372
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 374
+      - 381
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 377
+      - 382
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,5.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 379
+      - 384
+      - 376
+      - 387
+  - uid: 8
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 383
+      - 378
+- proto: AirlockMedicalScienceLocked
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+- proto: AirlockScience
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+    - type: Door
+      secondsUntilStateChange: -2774.3442
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,9.5
+      parent: 1
+- proto: AirlockShuttle
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,17.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 3.5,17.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,10.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,17.5
+      parent: 1
+- proto: AtmosFixNitrogenMarker
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-1.5
+      parent: 1
+- proto: AtmosFixOxygenMarker
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+- proto: BannerSyndicate
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -3.5,15.5
+      parent: 1
+- proto: Biofabricator
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: Biogenerator
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+- proto: BiomassReclaimer
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+- proto: BlastDoorOpen
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+- proto: BorgModuleEsword
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -7.306089,15.496634
+      parent: 1
+- proto: BorgModuleL6C
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -7.4935894,15.574759
+      parent: 1
+- proto: BorgModuleMartyr
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -7.3376274,15.42127
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -7.528241,15.530732
+      parent: 1
+- proto: BorgModuleSyndicateWeapon
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -7.433346,15.496792
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -6.5,12.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -9.5,1.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 3.5,17.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -8.5,10.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -10.5,9.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -10.5,10.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -10.5,10.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -10.5,11.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -10.5,12.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -10.5,12.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -10.5,13.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -10.5,14.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -10.5,15.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -1.5,17.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -2.5,17.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -11.5,15.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -12.5,15.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -13.5,15.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -13.5,16.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -10.5,8.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -10.5,7.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -11.5,5.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -12.5,5.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -13.5,5.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -13.5,3.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -13.5,4.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -13.5,2.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -13.5,1.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -13.5,1.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -13.5,0.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -13.5,-1.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -13.5,-1.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -13.5,-2.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -13.5,-0.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -13.5,-1.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -13.5,-2.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -13.5,-3.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -13.5,-3.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -12.5,-3.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 6.5,17.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -9.5,15.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -11.5,-0.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -11.5,-1.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -11.5,0.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -11.5,1.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -10.5,3.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -11.5,1.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -11.5,3.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -11.5,2.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 3.5,17.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -8.5,10.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 244
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-0.5
+      parent: 1
+- proto: ChairOfficeDark
+  entities:
+  - uid: 245
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 247
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,14.5
+      parent: 1
+- proto: ClothingBackpackDuffelSurgeryFilled
+  entities:
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -1.5246582,14.550564
+      parent: 1
+- proto: ClothingBeltUtilityFilled
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -7.438157,13.759914
+      parent: 1
+- proto: ClothingMaskGasVoiceChameleon
+  entities:
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -7.3681192,14.986176
+      parent: 1
+- proto: ComfyChair
+  entities:
+  - uid: 251
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,7.5
+      parent: 1
+- proto: ComputerAlert
+  entities:
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-0.5
+      parent: 1
+- proto: computerBodyScanner
+  entities:
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 254
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-0.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -10.5,15.5
+      parent: 1
+- proto: ComputerSurveillanceCameraMonitor
+  entities:
+  - uid: 256
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,6.5
+      parent: 1
+- proto: CrateHydroponics
+  entities:
+  - uid: 257
+    components:
+    - type: MetaData
+      name: steelcap seeds crate
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 265
+          - 264
+          - 263
+          - 262
+          - 261
+          - 260
+          - 259
+          - 258
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: Emag
+  entities:
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -7.2830186,14.065017
+      parent: 1
+- proto: EncryptionKeyBinarySyndicate
+  entities:
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -7.5087442,15.098676
+      parent: 1
+- proto: ExosuitFabricator
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: FaxMachineBase
+  entities:
+  - uid: 269
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+    - type: FaxMachine
+      name: Borgi Factory
+- proto: FloorDrain
+  entities:
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,13.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: GasMinerNitrogen
+  entities:
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 1
+- proto: GasMinerOxygen
+  entities:
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+- proto: GasMixer
+  entities:
+  - uid: 273
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+- proto: GasPassiveVent
+  entities:
+  - uid: 274
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,3.5
+      parent: 1
+- proto: GasPipeBend
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 278
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 280
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 281
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 282
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 283
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 284
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 285
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 286
+    components:
+    - type: Transform
+      pos: -9.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 287
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+- proto: GasPipeFourway
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 289
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+- proto: GasPipeStraight
+  entities:
+  - uid: 291
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,0.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 292
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,0.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 294
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 296
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 297
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 299
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 301
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 302
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 303
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 304
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 309
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 310
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 311
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 312
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 313
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 314
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 315
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 316
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 317
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 318
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 319
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 320
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 322
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 323
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,13.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,14.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 326
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 327
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 328
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 329
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 330
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 331
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 332
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 333
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 334
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 335
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 336
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 337
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 341
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 342
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 343
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 344
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 345
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 346
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 348
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 349
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 350
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 351
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 352
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 353
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 354
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 355
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 356
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 357
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,12.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 358
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,11.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 359
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 360
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 361
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+- proto: GasPipeTJunction
+  entities:
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 365
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 366
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 367
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 368
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 369
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+  - uid: 371
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+- proto: GasVentPump
+  entities:
+  - uid: 372
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 373
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+  - uid: 374
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,13.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+  - uid: 375
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+  - uid: 376
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+  - uid: 377
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 8
+  - uid: 379
+    components:
+    - type: Transform
+      pos: 2.5,15.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+- proto: GasVentScrubber
+  entities:
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,10.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 3
+  - uid: 381
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 6
+  - uid: 383
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 8
+  - uid: 384
+    components:
+    - type: Transform
+      pos: 4.5,15.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+  - uid: 385
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 2
+  - uid: 386
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 387
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 7
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      pos: -11.5,-1.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -12.5,15.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      pos: -12.5,14.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -12.5,13.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -12.5,12.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      pos: -12.5,11.5
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      pos: -12.5,10.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      pos: -12.5,9.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -12.5,8.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -12.5,7.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -12.5,6.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: -12.5,5.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -11.5,16.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -10.5,16.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      pos: -9.5,16.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,3.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 419
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,5.5
+      parent: 1
+- proto: HolopadLongRange
+  entities:
+  - uid: 420
+    components:
+    - type: MetaData
+      name: long-range holopad (Borgi Factory)
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+    - type: Label
+      currentLabel: Borgi Factory
+    - type: NameModifier
+      baseName: long-range holopad
+- proto: hydroponicsTray
+  entities:
+  - uid: 421
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+- proto: LockableButtonResearch
+  entities:
+  - uid: 442
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,13.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        32:
+        - Pressed: Toggle
+        33:
+        - Pressed: Toggle
+        34:
+        - Pressed: Toggle
+- proto: MMI
+  entities:
+  - uid: 443
+    components:
+    - type: Transform
+      pos: -6.505967,7.2012453
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      pos: -6.505967,7.3981204
+      parent: 1
+- proto: NukieAgentIDCard
+  entities:
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -7.3577824,13.455642
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      pos: -7.3220024,13.749395
+      parent: 1
+- proto: OperatingTable
+  entities:
+  - uid: 447
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+- proto: Paper
+  entities:
+  - uid: 448
+    components:
+    - type: Transform
+      pos: -4.4937105,13.62123
+      parent: 1
+    - type: Paper
+      stampState: paper_stamp-syndicate
+      stampedBy:
+      - stampedColor: '#850000FF'
+        stampedName: Syndicate High Command
+      content: >-
+        [head=1][color=#660000]────────────────────[/color][/head]
+
+        [color=#660000][bold] .---------------.[/bold][/color]
+
+        [color=#660000][bold]|[/bold] ███████ [bold] |[/bold][/color]  [color=#D61128][head=3]   THE SYNDICATE ORGANISATION[/head][/color]
+
+        [color=#660000][bold]|[/bold] ██              [bold]  |[/bold][/color]  [color=#D61128][bolditalic]    Fighting greedy Corporations for Freedom[/bolditalic][/color]
+
+        [color=#660000][bold]|[/bold] ███████ [bold] |[/bold][/color][/color]
+
+        [color=#660000][bold]|[/bold]               ██ [bold] |[/bold][/color]    [color=#aaaaaa][italic]THIS DOCUMENT IS PRIVATE PROPERTY OF[/italic][/color]
+
+        [color=#660000][bold]|[/bold] ███████ [bold] |[/bold][/color]    [color=#aaaaaa][italic]THE SYNDICATE, IF YOU ARE NOT A SYNDICATE[/italic][/color]
+
+        [color=#660000][bold]'----------------'[/bold][/color]    [color=#aaaaaa][italic]MEMBER, EXPECT TO BE ELIMINATED SOON[/italic][/color]
+
+        [head=1][color=#660000]────────────────────[/color][/head]
+
+
+        Your objective is simple, convert the entire station into borgis, begin mission. 
+
+
+        to aid in this operation you have been provided with: 2 syndicate radio implanters, 1 binary comms key, 1 voice mask, 2 martydom modules, 1 energy sword module, 1 L6C ROW module, 1 generic syndicate weapon module, 2 agent IDs, 2 robotict PDAs and 1 Cryptographic sequencer (to have borg(i)s join the syndicate)
+
+
+        Nefariously yours, [bold][color=#D61128]Makes-the-Borgis[/bold][/color], Architect of this plan, Agent of the [bold][color=#660000]Syndicate[/color][/bold]
+
+        [head=1][color=#660000]────────────────────[/color]
+
+
+        [head=4]DEATH TO NANOTRANSEN[/head]
+- proto: PositronicBrain
+  entities:
+  - uid: 449
+    components:
+    - type: Transform
+      pos: -6.4778423,8.63562
+      parent: 1
+- proto: PoweredlightLED
+  entities:
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,15.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,10.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,5.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,0.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+- proto: PoweredlightRed
+  entities:
+  - uid: 462
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,8.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,14.5
+      parent: 1
+- proto: RadioImplanter
+  entities:
+  - uid: 465
+    components:
+    - type: Transform
+      pos: -7.506382,15.04797
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      pos: -7.522007,15.219845
+      parent: 1
+- proto: RandomHumanoidSyndieSoldier
+  entities:
+  - uid: 467
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+- proto: RandomHumanoidSyndieSoldierTeamLeader
+  entities:
+  - uid: 468
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+- proto: ReinforcedPlasmaWindow
+  entities:
+  - uid: 469
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+- proto: ReinforcedUraniumWindow
+  entities:
+  - uid: 475
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+- proto: ReinforcedWindow
+  entities:
+  - uid: 479
+    components:
+    - type: Transform
+      pos: -9.5,16.5
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      pos: -10.5,16.5
+      parent: 1
+  - uid: 483
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,3.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      pos: -11.5,16.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      pos: -12.5,15.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      pos: -12.5,14.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: -12.5,13.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      pos: -12.5,12.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -12.5,11.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -12.5,10.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      pos: -12.5,9.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -12.5,8.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -12.5,7.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      pos: -12.5,6.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      pos: -12.5,5.5
+      parent: 1
+- proto: RoboticistPDA
+  entities:
+  - uid: 496
+    components:
+    - type: Transform
+      pos: -7.4883804,14.596267
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      pos: -7.5720024,14.468145
+      parent: 1
+- proto: SeedExtractor
+  entities:
+  - uid: 498
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+- proto: SignHydro1
+  entities:
+  - uid: 499
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+- proto: SignSurgery
+  entities:
+  - uid: 500
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 1
+- proto: SinkWide
+  entities:
+  - uid: 501
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 503
+    components:
+    - type: Transform
+      pos: -11.5,0.5
+      parent: 1
+- proto: SolidSecretDoor
+  entities:
+  - uid: 504
+    components:
+    - type: Transform
+      pos: -6.5,11.5
+      parent: 1
+    - type: Door
+      secondsUntilStateChange: -8308.905
+      state: Opening
+- proto: SpawnSmartSubwoofer
+  entities:
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+- proto: SteelcapSeeds
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      parent: 257
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 259
+    components:
+    - type: Transform
+      parent: 257
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 260
+    components:
+    - type: Transform
+      parent: 257
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 261
+    components:
+    - type: Transform
+      parent: 257
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 262
+    components:
+    - type: Transform
+      parent: 257
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 263
+    components:
+    - type: Transform
+      parent: 257
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 264
+    components:
+    - type: Transform
+      parent: 257
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 265
+    components:
+    - type: Transform
+      parent: 257
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SubstationBasic
+  entities:
+  - uid: 506
+    components:
+    - type: Transform
+      pos: -11.5,1.5
+      parent: 1
+- proto: SurveillanceCameraGeneral
+  entities:
+  - uid: 507
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 508
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,14.5
+      parent: 1
+  - uid: 510
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 1
+  - uid: 511
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 513
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 1
+- proto: SurveillanceCameraRouterGeneral
+  entities:
+  - uid: 514
+    components:
+    - type: Transform
+      pos: -7.5,10.5
+      parent: 1
+- proto: TableCounterMetal
+  entities:
+  - uid: 515
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,13.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,15.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,14.5
+      parent: 1
+- proto: TableFancyRed
+  entities:
+  - uid: 518
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 522
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-2.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-1.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-3.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-3.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,15.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,16.5
+      parent: 1
+  - uid: 533
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -2.5,17.5
+      parent: 1
+  - uid: 537
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,17.5
+      parent: 1
+- proto: VendingMachineNutri
+  entities:
+  - uid: 538
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+- proto: VendingMachineRoboDrobe
+  entities:
+  - uid: 539
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 1
+- proto: VendingMachineSeedsUnlocked
+  entities:
+  - uid: 540
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+- proto: WallReinforced
+  entities:
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 553
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 554
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 1
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 556
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: Transform
+      pos: -2.5,15.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 563
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 564
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 565
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 566
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 567
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 569
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: Transform
+      pos: -8.5,12.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      pos: -8.5,13.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: -8.5,14.5
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: -8.5,15.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: -8.5,16.5
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 577
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      pos: -7.5,16.5
+      parent: 1
+  - uid: 582
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 583
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 584
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 585
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 1
+  - uid: 588
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 591
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 1
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 1
+  - uid: 594
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+  - uid: 597
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-2.5
+      parent: 1
+  - uid: 598
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-2.5
+      parent: 1
+  - uid: 599
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-2.5
+      parent: 1
+  - uid: 600
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-2.5
+      parent: 1
+  - uid: 601
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-1.5
+      parent: 1
+  - uid: 602
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-0.5
+      parent: 1
+  - uid: 603
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,0.5
+      parent: 1
+  - uid: 604
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,1.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,2.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,4.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,4.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,4.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,4.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 612
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 616
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 617
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 618
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,17.5
+      parent: 1
+  - uid: 619
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 621
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 622
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 623
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 624
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 625
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 626
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 627
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 628
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 629
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 630
+    components:
+    - type: Transform
+      pos: 5.5,15.5
+      parent: 1
+  - uid: 631
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 632
+    components:
+    - type: Transform
+      pos: 5.5,17.5
+      parent: 1
+  - uid: 633
+    components:
+    - type: Transform
+      pos: 1.5,17.5
+      parent: 1
+  - uid: 634
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 635
+    components:
+    - type: Transform
+      pos: -12.5,16.5
+      parent: 1
+- proto: WallSolid
+  entities:
+  - uid: 636
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 637
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,5.5
+      parent: 1
+  - uid: 638
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 639
+    components:
+    - type: Transform
+      pos: -8.5,10.5
+      parent: 1
+  - uid: 640
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 1
+  - uid: 641
+    components:
+    - type: Transform
+      pos: -8.5,7.5
+      parent: 1
+  - uid: 642
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 1
+  - uid: 643
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,11.5
+      parent: 1
+  - uid: 644
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,11.5
+      parent: 1
+  - uid: 645
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+- proto: WarningN2
+  entities:
+  - uid: 646
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 1
+- proto: WarningO2
+  entities:
+  - uid: 647
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+- proto: WaterTankHighCapacity
+  entities:
+  - uid: 648
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+- proto: WeaponTurretSyndicate
+  entities:
+  - uid: 649
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+...

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borgi_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borgi_chassis.yml
@@ -139,6 +139,8 @@
       - BorgModuleGeneric
       - BorgModuleCargo
       - BorgModuleMedical
+      - BorgModuleSyndicate # allow installing a Esword into borgis.
+      - BorgModuleSyndicateAssault # allow installing a l6c into borigs!
     hasMindState: corgitag
     noMindState: corgitag
   - type: LockingWhitelist

--- a/Resources/Prototypes/_StarLight/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Markers/Spawners/mobs.yml
@@ -12,3 +12,16 @@
   - type: ConditionalSpawner
     prototypes:
       - MobCorgiClownIan
+
+- type: entity
+  name: smart subwoofer borgi spawner
+  id: SpawnSmartSubwoofer
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: green
+        - state: ai
+    - type: ConditionalSpawner
+      prototypes:
+        - SmartSubWooferVulnerable

--- a/Resources/Prototypes/_StarLight/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/unknown_shuttles.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: BaseUnknownShuttleRule
+  id: ShuttleSyndiShadowOps
+  components:
+    - type: StationEvent
+      startAnnouncement: null # It should be silent.
+      maxOccurrences: 1 # should be the same as [copies] in shuttle_incoming_event.yml
+    - type: LoadMapRule
+      preloadedGrid: ShuttleSyndiShadowOps

--- a/Resources/Prototypes/_StarLight/Shuttles/shuttles.yml
+++ b/Resources/Prototypes/_StarLight/Shuttles/shuttles.yml
@@ -1,0 +1,4 @@
+- type: preloadedGrid
+  id: ShuttleSyndiShadowOps
+  path: /Maps/_Starlight/Shuttles/ShuttleEvent/ShadowBorgiGrid.yml
+  copies: 1

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -516,6 +516,12 @@
 
   # Borgi Lawset, normal
 - type: siliconLaw
+  id: Borgi0
+  order: 0
+  lawString: law-borgi-0
+  sayable: false
+  
+- type: siliconLaw
   id: Borgi1
   order: 1
   lawString: law-borgi-1
@@ -533,6 +539,7 @@
 - type: siliconLawset
   id: BorgiLawset
   laws:
+  - Borgi0
   - Borgi1
   - Borgi2
   - Borgi3


### PR DESCRIPTION
## Short description
Adds a admeme shuttle and gamerule for Syndicate-sponsored shadow borgi ops.

## Why we need to add this
Syndicate Shark tank event was held. shadow borgi ops won. event staff allowed me to make it into a full pr
contents of the pr: 
- makes it so borgis can accept syndicate modules (needed for the borgi on the shuttle)
- adds a smart subwoofer spawner (needed to spawn the borgi on the shuttle)
- adds the syndicate shadow borgi shuttle
- gives borgis a law 0 to avoid emag deleting law 1

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/e4b8d6eb-1207-4943-9b2f-7923b84d5ce1)
![image](https://github.com/user-attachments/assets/e7d181b7-3812-4369-b1c5-3e70f81c1c98)

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: walksanatora
- add: Borgis have a law 0. so they know they are good boys.
- fix: Borgi law 0 makes it so emagging a borgi does not remove their law 1.

ADMIN:
- add "ShuttleSyndiShadowOps" gamerule. for admemes. contains one smart subwoofer, two synticates, and some tools to get them started.
