### PR TITLE
peaceful round end exceptions

### DIFF
--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -1,35 +1,65 @@
 using Content.Server.GameTicking;
+using Content.Shared.Chemistry.Components;
 using Content.Shared.Starlight.CCVar;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Movement.Components;
 using Content.Shared.Mech.Components;
-using Robust.Server.Player;
 using Robust.Shared.Configuration;
+using Content.Shared.GameTicking;
+using Content.Shared.Starlight;
 
 namespace Content.Server.Starlight.GameTicking;
 
 public sealed class PeacefulRoundEndSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly ISharedPlayersRoleManager _sharedPlayersRoleManager = default!;
     private bool _isEnabled = false;
-
+    private bool _roundedEnded = false;
+    private readonly List<PlayerFlags> _bypassFlags =
+    [
+        PlayerFlags.Mentor,
+        PlayerFlags.Staff,
+        PlayerFlags.ExtRoles
+    ]; // I would love to make this a CVar. but it is just not in the cards.
+    
+    
     public override void Initialize()
     {
         base.Initialize();
         _cfg.OnValueChanged(StarlightCCVars.PeacefulRoundEnd, v => _isEnabled = v, true);
         SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnded);
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnSpawnComplete);
+        SubscribeLocalEvent<GotRehydratedEvent>(OnRehydrateEvent);
+    }
+    
+    private void SpreadPeace(EntityUid target)
+    {
+        if (!_isEnabled || !_roundedEnded) return;
+        if (_sharedPlayersRoleManager.HasAnyPlayerFlags(target, _bypassFlags)) return;
+        EnsureComp<PacifiedComponent>(target);
+    }
+    
+    private void OnSpawnComplete(PlayerSpawnCompleteEvent ev)
+    {
+        SpreadPeace(ev.Mob);
+    }
+
+    private void OnRehydrateEvent(ref GotRehydratedEvent ev)
+    {
+        SpreadPeace(ev.Target);
     }
 
     private void OnRoundEnded(RoundEndTextAppendEvent ev)
     {
-        if (!_isEnabled) return;
+        _roundedEnded = true;
         foreach (var mob in EntityQuery<MobMoverComponent>())
         {
-            EnsureComp<PacifiedComponent>(mob.Owner);
+            SpreadPeace(mob.Owner);   
         }
         foreach (var mob in EntityQuery<MechComponent>())
         {
-            EnsureComp<PacifiedComponent>(mob.Owner);
+            SpreadPeace(mob.Owner);
         }
     }
 }

--- a/Content.Shared/Chemistry/EntitySystems/RehydratableSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/RehydratableSystem.cs
@@ -51,7 +51,7 @@ public sealed class RehydratableSystem : EntitySystem
 
         _xform.AttachToGridOrMap(target);
         var ev = new GotRehydratedEvent(target);
-        RaiseLocalEvent(uid, ref ev);
+        RaiseLocalEvent(uid, ref ev, true); // Starlight: made it broadcast so EoR creatures can be pacified
 
         // prevent double hydration while queued
         RemComp<RehydratableComponent>(uid);


### PR DESCRIPTION
## Short description
A tweaks of #566 that makes it so it doesn't for loop over every ent, and also adds exceptions for staff/mentors/extra roles (designated "trusted flags"

## Why we need to add this
A poll was held and EOR pacifism was to be removed. it was not followed through. this is a middle ground that allows "trusted" people to be able to defend themselves or roleplay "harmful" actions (you are telling me I *cant* throw a foam sword cause it could hurt people?)

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/6539b9b4-f248-41b2-99a8-6c4daf9eacc5)

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: lizelive
- fix: spawning after round gives pacified
- fix: rehydrating animal cubes applies pacifism

:cl: walksanatora
- tweak: people who are staff, extra roles, or mentors now are exempt from end of round pacifism

