### PR TITLE
Organ tree missing text

### DIFF
--- a/Resources/Locale/en-US/_Starlight/seeds/seeds.ftl
+++ b/Resources/Locale/en-US/_Starlight/seeds/seeds.ftl
@@ -1,0 +1,2 @@
+seeds-organ-tree-name = organ tree
+seeds-organ-tree-display-name = organ tree

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Hydroponics/seeds.yml
@@ -1,6 +1,6 @@
 - type: entity
   parent: SeedBase
-  name: packet of organ tree
+  name: packet of organ tree seeds
   id: OrganTreeSeeds
   components:
   - type: Seed


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds missing text for organ tree locale symbols. Also adds the word 'seeds' to the seed packet text


## Why we need to add this
Organ trees currently display the symbol and not the expected text

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![image](https://github.com/user-attachments/assets/9dbf59f3-efdd-4069-8d73-2461d5eaf691)
![image](https://github.com/user-attachments/assets/c9a534ee-9e8c-4657-a8d9-59a70eec88e9)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.


-->

:cl: neurovermi
- fix: Adds missing locale text for organ tree and the word "seeds" to the seed packet
