### PR TITLE
Fix grid check for alert level condition

### DIFF
--- a/Content.Server/Weapons/Ranged/Conditions/AlertLevelCondition.cs
+++ b/Content.Server/Weapons/Ranged/Conditions/AlertLevelCondition.cs
@@ -5,6 +5,7 @@ using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
 using Robust.Shared.Serialization;
+using Robust.Shared.Map;
 
 namespace Content.Server.Weapons.Ranged.Conditions;
 
@@ -22,11 +23,24 @@ public sealed partial class AlertLevelCondition : FireModeCondition
         if (!entityManager.TryGetComponent<TransformComponent>(args.Shooter, out var transformComp))
             return false;
 
-        if (entityManager.TryGetComponent<StationMemberComponent>(transformComp.ParentUid, out var stationMember) &&
-            entityManager.TryGetComponent<AlertLevelComponent>(stationMember.Station, out var alertLevelComp))
+        IMapManager _mapManager = default!;
+        IoCManager.Resolve<IMapManager>(ref _mapManager);
+
+        //get all grids on the map the entity is on
+        var grids = _mapManager.GetAllGrids(transformComp.MapID);
+
+        foreach (var grid in grids)
         {
-            var currentAlertLevel = alertSystem.GetLevel(stationMember.Station, alertLevelComp);
-            return AlertLevels.Contains(currentAlertLevel);
+            if (entityManager.TryGetComponent<StationMemberComponent>(grid, out var stationMember) &&
+                entityManager.TryGetComponent<AlertLevelComponent>(stationMember.Station, out var alertLevelComp))
+            {
+                var currentAlertLevel = alertSystem.GetLevel(stationMember.Station, alertLevelComp);
+                if (AlertLevels.Contains(currentAlertLevel))
+                {
+                    return true; //return early
+                }
+                //return AlertLevels.Contains(currentAlertLevel);
+            }
         }
 
         return false;

--- a/Content.Server/Weapons/Ranged/Conditions/AlertLevelCondition.cs
+++ b/Content.Server/Weapons/Ranged/Conditions/AlertLevelCondition.cs
@@ -23,6 +23,7 @@ public sealed partial class AlertLevelCondition : FireModeCondition
         if (!entityManager.TryGetComponent<TransformComponent>(args.Shooter, out var transformComp))
             return false;
 
+        //starlight start
         IMapManager _mapManager = default!;
         IoCManager.Resolve<IMapManager>(ref _mapManager);
 
@@ -42,6 +43,8 @@ public sealed partial class AlertLevelCondition : FireModeCondition
                 //return AlertLevels.Contains(currentAlertLevel);
             }
         }
+
+        //starlight end
 
         return false;
     }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Makes the alert level condition be based on the map your in, not based on the grid you are on

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Unintended bugginess caused when used on fire modes, since leaving the grid means you cant use those modes even if the station is in red

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed Alert level condition being based on the grid you are on.