### PR TITLE
Add wildcard mode to disposal routers

### DIFF
--- a/Content.Client/Disposal/UI/DisposalRouterWindow.xaml
+++ b/Content.Client/Disposal/UI/DisposalRouterWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<DefaultWindow xmlns="https://spacestation14.io"
             Title="{Loc 'disposal-router-window-title'}"
-            MinSize="500 110"
-            SetSize="500 110">
+            MinSize="500 140"
+            SetSize="500 140">
     <BoxContainer Orientation="Vertical">
         <Label Text="{Loc 'disposal-router-window-tags-label'}" />
         <Control MinSize="0 10" />
@@ -16,5 +16,6 @@
                     Access="Public"
                     Text="{Loc 'disposal-router-window-tag-input-confirm-button'}" />
         </BoxContainer>
+        <Label Text="Use * to match any items that have tags on them" />
     </BoxContainer>
 </DefaultWindow>

--- a/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
+++ b/Content.Server/Disposal/Tube/DisposalTubeSystem.cs
@@ -216,7 +216,7 @@ namespace Content.Server.Disposal.Tube
             var ev = new GetDisposalsConnectableDirectionsEvent();
             RaiseLocalEvent(uid, ref ev);
 
-            if (args.Holder.Tags.Overlaps(component.Tags))
+            if (args.Holder.Tags.Overlaps(component.Tags) || (args.Holder.Tags.Count != 0 && component.Tags.Contains("*")))// starlight, wildcard support
             {
                 args.Next = ev.Connectable[1];
                 return;

--- a/Content.Shared/Disposal/Components/SharedDisposalRouterComponent.cs
+++ b/Content.Shared/Disposal/Components/SharedDisposalRouterComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.Disposal.Components
 {
     public sealed partial class SharedDisposalRouterComponent : Component
     {
-        public static readonly Regex TagRegex = new("^[a-zA-Z0-9, ]*$", RegexOptions.Compiled);
+        public static readonly Regex TagRegex = new("^[a-zA-Z0-9, *]*$", RegexOptions.Compiled);
 
         [Serializable, NetSerializable]
         public sealed class DisposalRouterUserInterfaceState : BoundUserInterfaceState


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds * as a wildcard to disposal routers

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Any maps that use a disposal loop with taggers on all disposal units currently incur a hazard of anyone adding units or modifying disposals, to trap people in a infinite loop in disposals. Adding this wildcard mode allows map makers to explicelty filter for if a tag exists or not, so instead of needing disposal units to all have taggers after them labelling them as waste, you can leave waste untagged, and filter it out explicitly using this router mode.

Maps that I know need updated for this are Starboard and Elkridge. There is likely more though

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

![image](https://github.com/user-attachments/assets/a931f303-9ff4-4dec-b053-2d35cac294fe)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- add: Added wildcard mode to disposal routers.