### PR TITLE
add default prototypes for all mail related entitys

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Disposal/mailingunits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Disposal/mailingunits.yml
@@ -1,0 +1,559 @@
+- type: entity
+  id: MailingUnitCommand
+  parent: MailingUnit   
+  suffix: Command       
+  components:
+  - type: MailingUnit
+    tag: Command
+
+- type: entity
+  id: MailingUnitBridge
+  parent: MailingUnit
+  suffix: Bridge
+  components:
+  - type: MailingUnit
+    tag: Bridge
+
+- type: entity
+  id: MailingUnitVault
+  parent: MailingUnit
+  suffix: Vault
+  components:
+  - type: MailingUnit
+    tag: Vault
+
+- type: entity
+  id: MailingUnitGateway
+  parent: MailingUnit
+  suffix: Gateway
+  components:
+  - type: MailingUnit
+    tag: Gateway
+
+- type: entity
+  id: MailingUnitCaptain
+  parent: MailingUnit
+  suffix: Captain
+  components:
+  - type: MailingUnit
+    tag: Captain
+
+- type: entity
+  id: MailingUnitHoP
+  parent: MailingUnit
+  suffix: HoP
+  components:
+  - type: MailingUnit
+    tag: HoP
+
+- type: entity
+  id: MailingUnitSecurity
+  parent: MailingUnit
+  suffix: Security
+  components:
+  - type: MailingUnit
+    tag: Security
+
+- type: entity
+  id: MailingUnitBrig
+  parent: MailingUnit
+  suffix: Brig
+  components:
+  - type: MailingUnit
+    tag: Brig
+
+- type: entity
+  id: MailingUnitBrigMed
+  parent: MailingUnit
+  suffix: BrigMed
+  components:
+  - type: MailingUnit
+    tag: BrigMed
+
+- type: entity
+  id: MailingUnitWarden
+  parent: MailingUnit
+  suffix: Warden
+  components:
+  - type: MailingUnit
+    tag: Warden
+
+- type: entity
+  id: MailingUnitHoS
+  parent: MailingUnit
+  suffix: HoS
+  components:
+  - type: MailingUnit
+    tag: HoS
+
+- type: entity
+  id: MailingUnitArmory
+  parent: MailingUnit
+  suffix: Armory
+  components:
+  - type: MailingUnit
+    tag: Armory
+
+- type: entity
+  id: MailingUnitPerma
+  parent: MailingUnit
+  suffix: Perma
+  components:
+  - type: MailingUnit
+    tag: Perma
+
+- type: entity
+  id: MailingUnitDetective
+  parent: MailingUnit
+  suffix: Detective
+  components:
+  - type: MailingUnit
+    tag: Detective
+
+- type: entity
+  id: MailingUnitCourtroom
+  parent: MailingUnit
+  suffix: Courtroom
+  components:
+  - type: MailingUnit
+    tag: Courtroom
+
+- type: entity
+  id: MailingUnitLaw
+  parent: MailingUnit
+  suffix: Law
+  components:
+  - type: MailingUnit
+    tag: Law
+
+- type: entity
+  id: MailingUnitSecurityCheckpoint
+  parent: MailingUnit
+  suffix: SecurityCheckpoint
+  components:
+  - type: MailingUnit
+    tag: SecurityCheckpoint
+
+- type: entity
+  id: MailingUnitMedical
+  parent: MailingUnit
+  suffix: Medical
+  components:
+  - type: MailingUnit
+    tag: Medical
+
+- type: entity
+  id: MailingUnitMedbay
+  parent: MailingUnit
+  suffix: Medbay
+  components:
+  - type: MailingUnit
+    tag: Medbay
+
+- type: entity
+  id: MailingUnitChemistry
+  parent: MailingUnit
+  suffix: Chemistry
+  components:
+  - type: MailingUnit
+    tag: Chemistry
+
+- type: entity
+  id: MailingUnitCryogenics
+  parent: MailingUnit
+  suffix: Cryogenics
+  components:
+  - type: MailingUnit
+    tag: Cryogenics
+
+- type: entity
+  id: MailingUnitCMO
+  parent: MailingUnit
+  suffix: CMO
+  components:
+  - type: MailingUnit
+    tag: CMO
+
+- type: entity
+  id: MailingUnitMorgue
+  parent: MailingUnit
+  suffix: Morgue
+  components:
+  - type: MailingUnit
+    tag: Morgue
+
+- type: entity
+  id: MailingUnitSurgery
+  parent: MailingUnit
+  suffix: Surgery
+  components:
+  - type: MailingUnit
+    tag: Surgery
+
+- type: entity
+  id: MailingUnitPsychology
+  parent: MailingUnit
+  suffix: Psychology
+  components:
+  - type: MailingUnit
+    tag: Psychology
+
+- type: entity
+  id: MailingUnitClinic
+  parent: MailingUnit
+  suffix: Clinic
+  components:
+  - type: MailingUnit
+    tag: Clinic
+
+- type: entity
+  id: MailingUnitScience
+  parent: MailingUnit
+  suffix: Science
+  components:
+  - type: MailingUnit
+    tag: Science
+
+- type: entity
+  id: MailingUnitR&D
+  parent: MailingUnit
+  suffix: R&D
+  components:
+  - type: MailingUnit
+    tag: R&D
+
+- type: entity
+  id: MailingUnitRD
+  parent: MailingUnit
+  suffix: RD
+  components:
+  - type: MailingUnit
+    tag: RD
+
+- type: entity
+  id: MailingUnitRobotics
+  parent: MailingUnit
+  suffix: Robotics
+  components:
+  - type: MailingUnit
+    tag: Robotics
+
+- type: entity
+  id: MailingUnitArtifact
+  parent: MailingUnit
+  suffix: Artifact
+  components:
+  - type: MailingUnit
+    tag: Artifact
+
+- type: entity
+  id: MailingUnitAnomaly
+  parent: MailingUnit
+  suffix: Anomaly
+  components:
+  - type: MailingUnit
+    tag: Anomaly
+
+- type: entity
+  id: MailingUnitSupply
+  parent: MailingUnit
+  suffix: Supply
+  components:
+  - type: MailingUnit
+    tag: Supply
+
+- type: entity
+  id: MailingUnitCargo
+  parent: MailingUnit
+  suffix: Cargo
+  components:
+  - type: MailingUnit
+    tag: Cargo
+
+- type: entity
+  id: MailingUnitCargoBay
+  parent: MailingUnit
+  suffix: CargoBay
+  components:
+  - type: MailingUnit
+    tag: CargoBay
+
+- type: entity
+  id: MailingUnitQM
+  parent: MailingUnit
+  suffix: QM
+  components:
+  - type: MailingUnit
+    tag: QM
+
+- type: entity
+  id: MailingUnitSalvage
+  parent: MailingUnit
+  suffix: Salvage
+  components:
+  - type: MailingUnit
+    tag: Salvage
+
+- type: entity
+  id: MailingUnitEngineering
+  parent: MailingUnit
+  suffix: Engineering
+  components:
+  - type: MailingUnit
+    tag: Engineering
+
+- type: entity
+  id: MailingUnitCE
+  parent: MailingUnit
+  suffix: CE
+  components:
+  - type: MailingUnit
+    tag: CE
+
+- type: entity
+  id: MailingUnitAME
+  parent: MailingUnit
+  suffix: AME
+  components:
+  - type: MailingUnit
+    tag: AME
+
+- type: entity
+  id: MailingUnitGravityGenerator
+  parent: MailingUnit
+  suffix: GravityGenerator
+  components:
+  - type: MailingUnit
+    tag: GravityGenerator
+
+- type: entity
+  id: MailingUnitAnchor
+  parent: MailingUnit
+  suffix: Anchor
+  components:
+  - type: MailingUnit
+    tag: Anchor
+
+- type: entity
+  id: MailingUnitParticleAccelerator
+  parent: MailingUnit
+  suffix: ParticleAccelerator
+  components:
+  - type: MailingUnit
+    tag: ParticleAccelerator
+
+- type: entity
+  id: MailingUnitTelecomms
+  parent: MailingUnit
+  suffix: Telecomms
+  components:
+  - type: MailingUnit
+    tag: Telecomms
+
+- type: entity
+  id: MailingUnitAtmos
+  parent: MailingUnit
+  suffix: Atmos
+  components:
+  - type: MailingUnit
+    tag: Atmos
+
+- type: entity
+  id: MailingUnitTEG
+  parent: MailingUnit
+  suffix: TEG
+  components:
+  - type: MailingUnit
+    tag: TEG
+
+- type: entity
+  id: MailingUnitTechVault
+  parent: MailingUnit
+  suffix: TechVault
+  components:
+  - type: MailingUnit
+    tag: TechVault
+
+- type: entity
+  id: MailingUnitService
+  parent: MailingUnit
+  suffix: Service
+  components:
+  - type: MailingUnit
+    tag: Service
+
+- type: entity
+  id: MailingUnitKitchen
+  parent: MailingUnit
+  suffix: Kitchen
+  components:
+  - type: MailingUnit
+    tag: Kitchen
+
+- type: entity
+  id: MailingUnitBar
+  parent: MailingUnit
+  suffix: Bar
+  components:
+  - type: MailingUnit
+    tag: Bar
+
+- type: entity
+  id: MailingUnitBotany
+  parent: MailingUnit
+  suffix: Botany
+  components:
+  - type: MailingUnit
+    tag: Botany
+
+- type: entity
+  id: MailingUnitJanitor
+  parent: MailingUnit
+  suffix: Janitor
+  components:
+  - type: MailingUnit
+    tag: Janitor
+
+- type: entity
+  id: MailingUnitAI
+  parent: MailingUnit
+  suffix: AI
+  components:
+  - type: MailingUnit
+    tag: AI
+
+- type: entity
+  id: MailingUnitAISatellite
+  parent: MailingUnit
+  suffix: AISatellite
+  components:
+  - type: MailingUnit
+    tag: AISatellite
+
+- type: entity
+  id: MailingUnitAICore
+  parent: MailingUnit
+  suffix: AICore
+  components:
+  - type: MailingUnit
+    tag: AICore
+
+- type: entity
+  id: MailingUnitAIUpload
+  parent: MailingUnit
+  suffix: AIUpload
+  components:
+  - type: MailingUnit
+    tag: AIUpload
+
+- type: entity
+  id: MailingUnitAIPower
+  parent: MailingUnit
+  suffix: AIPower
+  components:
+  - type: MailingUnit
+    tag: AIPower
+
+- type: entity
+  id: MailingUnitArrivals
+  parent: MailingUnit
+  suffix: Arrivals
+  components:
+  - type: MailingUnit
+    tag: Arrivals
+
+- type: entity
+  id: MailingUnitEvac
+  parent: MailingUnit
+  suffix: Evac
+  components:
+  - type: MailingUnit
+    tag: Evac
+
+- type: entity
+  id: MailingUnitDockingArm
+  parent: MailingUnit
+  suffix: DockingArm
+  components:
+  - type: MailingUnit
+    tag: DockingArm
+
+- type: entity
+  id: MailingUnitEVAStorage
+  parent: MailingUnit
+  suffix: EVAStorage
+  components:
+  - type: MailingUnit
+    tag: EVAStorage
+
+- type: entity
+  id: MailingUnitChapel
+  parent: MailingUnit
+  suffix: Chapel
+  components:
+  - type: MailingUnit
+    tag: Chapel
+
+- type: entity
+  id: MailingUnitLibrary
+  parent: MailingUnit
+  suffix: Library
+  components:
+  - type: MailingUnit
+    tag: Library
+
+- type: entity
+  id: MailingUnitReporter
+  parent: MailingUnit
+  suffix: Reporter
+  components:
+  - type: MailingUnit
+    tag: Reporter
+
+- type: entity
+  id: MailingUnitTheater
+  parent: MailingUnit
+  suffix: Theater
+  components:
+  - type: MailingUnit
+    tag: Theater
+
+- type: entity
+  id: MailingUnitDorms
+  parent: MailingUnit
+  suffix: Dorms
+  components:
+  - type: MailingUnit
+    tag: Dorms
+
+- type: entity
+  id: MailingUnitTools
+  parent: MailingUnit
+  suffix: Tools
+  components:
+  - type: MailingUnit
+    tag: Tools
+
+- type: entity
+  id: MailingUnitDisposals
+  parent: MailingUnit
+  suffix: Disposals
+  components:
+  - type: MailingUnit
+    tag: Disposals
+
+- type: entity
+  id: MailingUnitCryosleep
+  parent: MailingUnit
+  suffix: Cryosleep
+  components:
+  - type: MailingUnit
+    tag: Cryosleep
+
+- type: entity
+  id: MailingUnitVox
+  parent: MailingUnit
+  suffix: Vox
+  components:
+  - type: MailingUnit
+    tag: Vox

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Disposal/routersflipped.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Disposal/routersflipped.yml
@@ -1,0 +1,921 @@
+- type: entity
+  id: DisposalRouterFlippedCommand
+  parent: DisposalRouterFlipped   
+  suffix: Flipped, Command
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Command"]
+
+
+- type: entity
+  id: DisposalRouterFlippedBridge
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Bridge
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Bridge"]
+
+
+- type: entity
+  id: DisposalRouterFlippedVault
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Vault
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Vault"]
+
+
+- type: entity
+  id: DisposalRouterFlippedGateway
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Gateway
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Gateway"]
+
+
+- type: entity
+  id: DisposalRouterFlippedCaptain
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Captain
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Captain"]
+
+
+- type: entity
+  id: DisposalRouterFlippedHoP
+  parent: DisposalRouterFlipped
+  suffix: Flipped, HoP
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["HoP"]
+
+
+- type: entity
+  id: DisposalRouterFlippedSecurity
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Security
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Security"]
+
+
+- type: entity
+  id: DisposalRouterFlippedBrig
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Brig
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Brig"]
+
+
+- type: entity
+  id: DisposalRouterFlippedBrigMed
+  parent: DisposalRouterFlipped
+  suffix: Flipped, BrigMed
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["BrigMed"]
+
+
+- type: entity
+  id: DisposalRouterFlippedWarden
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Warden
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Warden"]
+
+
+- type: entity
+  id: DisposalRouterFlippedHoS
+  parent: DisposalRouterFlipped
+  suffix: Flipped, HoS
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["HoS"]
+
+
+- type: entity
+  id: DisposalRouterFlippedArmory
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Armory
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Armory"]
+
+
+- type: entity
+  id: DisposalRouterFlippedPerma
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Perma
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Perma"]
+
+
+- type: entity
+  id: DisposalRouterFlippedDetective
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Detective
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Detective"]
+
+
+- type: entity
+  id: DisposalRouterFlippedCourtroom
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Courtroom
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Courtroom"]
+
+
+- type: entity
+  id: DisposalRouterFlippedLaw
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Law
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Law"]
+
+
+- type: entity
+  id: DisposalRouterFlippedSecurityCheckpoint
+  parent: DisposalRouterFlipped
+  suffix: Flipped, SecurityCheckpoint
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["SecurityCheckpoint"]
+
+
+- type: entity
+  id: DisposalRouterFlippedMedical
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Medical
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Medical"]
+
+
+- type: entity
+  id: DisposalRouterFlippedMedbay
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Medbay
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Medbay"]
+
+
+- type: entity
+  id: DisposalRouterFlippedChemistry
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Chemistry
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Chemistry"]
+
+
+- type: entity
+  id: DisposalRouterFlippedCryogenics
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Cryogenics
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Cryogenics"]
+
+
+- type: entity
+  id: DisposalRouterFlippedCMO
+  parent: DisposalRouterFlipped
+  suffix: Flipped, CMO
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["CMO"]
+
+
+- type: entity
+  id: DisposalRouterFlippedMorgue
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Morgue
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Morgue"]
+
+
+- type: entity
+  id: DisposalRouterFlippedSurgery
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Surgery
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Surgery"]
+
+
+- type: entity
+  id: DisposalRouterFlippedPsychology
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Psychology
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Psychology"]
+
+
+- type: entity
+  id: DisposalRouterFlippedClinic
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Clinic
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Clinic"]
+
+
+- type: entity
+  id: DisposalRouterFlippedScience
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Science
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Science"]
+
+
+- type: entity
+  id: DisposalRouterFlippedR&D
+  parent: DisposalRouterFlipped
+  suffix: Flipped, R&D
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["R&D"]
+
+
+- type: entity
+  id: DisposalRouterFlippedRD
+  parent: DisposalRouterFlipped
+  suffix: Flipped, RD
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["RD"]
+
+
+- type: entity
+  id: DisposalRouterFlippedRobotics
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Robotics
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Robotics"]
+
+
+- type: entity
+  id: DisposalRouterFlippedArtifact
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Artifact
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Artifact"]
+
+
+- type: entity
+  id: DisposalRouterFlippedAnomaly
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Anomaly
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Anomaly"]
+
+
+- type: entity
+  id: DisposalRouterFlippedSupply
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Supply
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Supply"]
+
+
+- type: entity
+  id: DisposalRouterFlippedCargo
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Cargo
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Cargo"]
+
+
+- type: entity
+  id: DisposalRouterFlippedCargoBay
+  parent: DisposalRouterFlipped
+  suffix: Flipped, CargoBay
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["CargoBay"]
+
+
+- type: entity
+  id: DisposalRouterFlippedQM
+  parent: DisposalRouterFlipped
+  suffix: Flipped, QM
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["QM"]
+
+
+- type: entity
+  id: DisposalRouterFlippedSalvage
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Salvage
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Salvage"]
+
+
+- type: entity
+  id: DisposalRouterFlippedEngineering
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Engineering
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Engineering"]
+
+
+- type: entity
+  id: DisposalRouterFlippedCE
+  parent: DisposalRouterFlipped
+  suffix: Flipped, CE
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["CE"]
+
+
+- type: entity
+  id: DisposalRouterFlippedAME
+  parent: DisposalRouterFlipped
+  suffix: Flipped, AME
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["AME"]
+
+
+- type: entity
+  id: DisposalRouterFlippedGravityGenerator
+  parent: DisposalRouterFlipped
+  suffix: Flipped, GravityGenerator
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["GravityGenerator"]
+
+
+- type: entity
+  id: DisposalRouterFlippedAnchor
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Anchor
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Anchor"]
+
+
+- type: entity
+  id: DisposalRouterFlippedParticleAccelerator
+  parent: DisposalRouterFlipped
+  suffix: Flipped, ParticleAccelerator
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["ParticleAccelerator"]
+
+
+- type: entity
+  id: DisposalRouterFlippedTelecomms
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Telecomms
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Telecomms"]
+
+
+- type: entity
+  id: DisposalRouterFlippedAtmos
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Atmos
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Atmos"]
+
+
+- type: entity
+  id: DisposalRouterFlippedTEG
+  parent: DisposalRouterFlipped
+  suffix: Flipped, TEG
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["TEG"]
+
+
+- type: entity
+  id: DisposalRouterFlippedTechVault
+  parent: DisposalRouterFlipped
+  suffix: Flipped, TechVault
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["TechVault"]
+
+
+- type: entity
+  id: DisposalRouterFlippedService
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Service
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Service"]
+
+
+- type: entity
+  id: DisposalRouterFlippedKitchen
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Kitchen
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Kitchen"]
+
+
+- type: entity
+  id: DisposalRouterFlippedBar
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Bar
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Bar"]
+
+
+- type: entity
+  id: DisposalRouterFlippedBotany
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Botany
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Botany"]
+
+
+- type: entity
+  id: DisposalRouterFlippedJanitor
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Janitor
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Janitor"]
+
+
+- type: entity
+  id: DisposalRouterFlippedAI
+  parent: DisposalRouterFlipped
+  suffix: Flipped, AI
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["AI"]
+
+
+- type: entity
+  id: DisposalRouterFlippedAISatellite
+  parent: DisposalRouterFlipped
+  suffix: Flipped, AISatellite
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["AISatellite"]
+
+
+- type: entity
+  id: DisposalRouterFlippedAICore
+  parent: DisposalRouterFlipped
+  suffix: Flipped, AICore
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["AICore"]
+
+
+- type: entity
+  id: DisposalRouterFlippedAIUpload
+  parent: DisposalRouterFlipped
+  suffix: Flipped, AIUpload
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["AIUpload"]
+
+
+- type: entity
+  id: DisposalRouterFlippedAIPower
+  parent: DisposalRouterFlipped
+  suffix: Flipped, AIPower
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["AIPower"]
+
+
+- type: entity
+  id: DisposalRouterFlippedArrivals
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Arrivals
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Arrivals"]
+
+
+- type: entity
+  id: DisposalRouterFlippedEvac
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Evac
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Evac"]
+
+
+- type: entity
+  id: DisposalRouterFlippedDockingArm
+  parent: DisposalRouterFlipped
+  suffix: Flipped, DockingArm
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["DockingArm"]
+
+
+- type: entity
+  id: DisposalRouterFlippedEVAStorage
+  parent: DisposalRouterFlipped
+  suffix: Flipped, EVAStorage
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["EVAStorage"]
+
+
+- type: entity
+  id: DisposalRouterFlippedChapel
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Chapel
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Chapel"]
+
+
+- type: entity
+  id: DisposalRouterFlippedLibrary
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Library
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Library"]
+
+
+- type: entity
+  id: DisposalRouterFlippedReporter
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Reporter
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Reporter"]
+
+
+- type: entity
+  id: DisposalRouterFlippedTheater
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Theater
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Theater"]
+
+
+- type: entity
+  id: DisposalRouterFlippedDorms
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Dorms
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Dorms"]
+
+
+- type: entity
+  id: DisposalRouterFlippedTools
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Tools
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Tools"]
+
+
+- type: entity
+  id: DisposalRouterFlippedDisposals
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Disposals
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Disposals"]
+
+
+- type: entity
+  id: DisposalRouterFlippedCryosleep
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Cryosleep
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Cryosleep"]
+
+
+- type: entity
+  id: DisposalRouterFlippedVox
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Vox
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["Vox"]
+
+
+- type: entity
+  id: DisposalRouterFlippedWildcard
+  parent: DisposalRouterFlipped
+  suffix: Flipped, Wildcard
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - 90
+    - 180
+    tags: ["*"]

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Disposal/routersnormal.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Disposal/routersnormal.yml
@@ -1,0 +1,921 @@
+- type: entity
+  id: DisposalRouterCommand
+  parent: DisposalRouter   
+  suffix: Command
+  components:
+  - type: DisposalRouter   
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Command"]
+
+
+- type: entity
+  id: DisposalRouterBridge
+  parent: DisposalRouter
+  suffix: Bridge
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Bridge"]
+
+
+- type: entity
+  id: DisposalRouterVault
+  parent: DisposalRouter
+  suffix: Vault
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Vault"]
+
+
+- type: entity
+  id: DisposalRouterGateway
+  parent: DisposalRouter
+  suffix: Gateway
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Gateway"]
+
+
+- type: entity
+  id: DisposalRouterCaptain
+  parent: DisposalRouter
+  suffix: Captain
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Captain"]
+
+
+- type: entity
+  id: DisposalRouterHoP
+  parent: DisposalRouter
+  suffix: HoP
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["HoP"]
+
+
+- type: entity
+  id: DisposalRouterSecurity
+  parent: DisposalRouter
+  suffix: Security
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Security"]
+
+
+- type: entity
+  id: DisposalRouterBrig
+  parent: DisposalRouter
+  suffix: Brig
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Brig"]
+
+
+- type: entity
+  id: DisposalRouterBrigMed
+  parent: DisposalRouter
+  suffix: BrigMed
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["BrigMed"]
+
+
+- type: entity
+  id: DisposalRouterWarden
+  parent: DisposalRouter
+  suffix: Warden
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Warden"]
+
+
+- type: entity
+  id: DisposalRouterHoS
+  parent: DisposalRouter
+  suffix: HoS
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["HoS"]
+
+
+- type: entity
+  id: DisposalRouterArmory
+  parent: DisposalRouter
+  suffix: Armory
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Armory"]
+
+
+- type: entity
+  id: DisposalRouterPerma
+  parent: DisposalRouter
+  suffix: Perma
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Perma"]
+
+
+- type: entity
+  id: DisposalRouterDetective
+  parent: DisposalRouter
+  suffix: Detective
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Detective"]
+
+
+- type: entity
+  id: DisposalRouterCourtroom
+  parent: DisposalRouter
+  suffix: Courtroom
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Courtroom"]
+
+
+- type: entity
+  id: DisposalRouterLaw
+  parent: DisposalRouter
+  suffix: Law
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Law"]
+
+
+- type: entity
+  id: DisposalRouterSecurityCheckpoint
+  parent: DisposalRouter
+  suffix: SecurityCheckpoint
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["SecurityCheckpoint"]
+
+
+- type: entity
+  id: DisposalRouterMedical
+  parent: DisposalRouter
+  suffix: Medical
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Medical"]
+
+
+- type: entity
+  id: DisposalRouterMedbay
+  parent: DisposalRouter
+  suffix: Medbay
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Medbay"]
+
+
+- type: entity
+  id: DisposalRouterChemistry
+  parent: DisposalRouter
+  suffix: Chemistry
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Chemistry"]
+
+
+- type: entity
+  id: DisposalRouterCryogenics
+  parent: DisposalRouter
+  suffix: Cryogenics
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Cryogenics"]
+
+
+- type: entity
+  id: DisposalRouterCMO
+  parent: DisposalRouter
+  suffix: CMO
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["CMO"]
+
+
+- type: entity
+  id: DisposalRouterMorgue
+  parent: DisposalRouter
+  suffix: Morgue
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Morgue"]
+
+
+- type: entity
+  id: DisposalRouterSurgery
+  parent: DisposalRouter
+  suffix: Surgery
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Surgery"]
+
+
+- type: entity
+  id: DisposalRouterPsychology
+  parent: DisposalRouter
+  suffix: Psychology
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Psychology"]
+
+
+- type: entity
+  id: DisposalRouterClinic
+  parent: DisposalRouter
+  suffix: Clinic
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Clinic"]
+
+
+- type: entity
+  id: DisposalRouterScience
+  parent: DisposalRouter
+  suffix: Science
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Science"]
+
+
+- type: entity
+  id: DisposalRouterR&D
+  parent: DisposalRouter
+  suffix: R&D
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["R&D"]
+
+
+- type: entity
+  id: DisposalRouterRD
+  parent: DisposalRouter
+  suffix: RD
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["RD"]
+
+
+- type: entity
+  id: DisposalRouterRobotics
+  parent: DisposalRouter
+  suffix: Robotics
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Robotics"]
+
+
+- type: entity
+  id: DisposalRouterArtifact
+  parent: DisposalRouter
+  suffix: Artifact
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Artifact"]
+
+
+- type: entity
+  id: DisposalRouterAnomaly
+  parent: DisposalRouter
+  suffix: Anomaly
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Anomaly"]
+
+
+- type: entity
+  id: DisposalRouterSupply
+  parent: DisposalRouter
+  suffix: Supply
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Supply"]
+
+
+- type: entity
+  id: DisposalRouterCargo
+  parent: DisposalRouter
+  suffix: Cargo
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Cargo"]
+
+
+- type: entity
+  id: DisposalRouterCargoBay
+  parent: DisposalRouter
+  suffix: CargoBay
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["CargoBay"]
+
+
+- type: entity
+  id: DisposalRouterQM
+  parent: DisposalRouter
+  suffix: QM
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["QM"]
+
+
+- type: entity
+  id: DisposalRouterSalvage
+  parent: DisposalRouter
+  suffix: Salvage
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Salvage"]
+
+
+- type: entity
+  id: DisposalRouterEngineering
+  parent: DisposalRouter
+  suffix: Engineering
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Engineering"]
+
+
+- type: entity
+  id: DisposalRouterCE
+  parent: DisposalRouter
+  suffix: CE
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["CE"]
+
+
+- type: entity
+  id: DisposalRouterAME
+  parent: DisposalRouter
+  suffix: AME
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["AME"]
+
+
+- type: entity
+  id: DisposalRouterGravityGenerator
+  parent: DisposalRouter
+  suffix: GravityGenerator
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["GravityGenerator"]
+
+
+- type: entity
+  id: DisposalRouterAnchor
+  parent: DisposalRouter
+  suffix: Anchor
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Anchor"]
+
+
+- type: entity
+  id: DisposalRouterParticleAccelerator
+  parent: DisposalRouter
+  suffix: ParticleAccelerator
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["ParticleAccelerator"]
+
+
+- type: entity
+  id: DisposalRouterTelecomms
+  parent: DisposalRouter
+  suffix: Telecomms
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Telecomms"]
+
+
+- type: entity
+  id: DisposalRouterAtmos
+  parent: DisposalRouter
+  suffix: Atmos
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Atmos"]
+
+
+- type: entity
+  id: DisposalRouterTEG
+  parent: DisposalRouter
+  suffix: TEG
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["TEG"]
+
+
+- type: entity
+  id: DisposalRouterTechVault
+  parent: DisposalRouter
+  suffix: TechVault
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["TechVault"]
+
+
+- type: entity
+  id: DisposalRouterService
+  parent: DisposalRouter
+  suffix: Service
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Service"]
+
+
+- type: entity
+  id: DisposalRouterKitchen
+  parent: DisposalRouter
+  suffix: Kitchen
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Kitchen"]
+
+
+- type: entity
+  id: DisposalRouterBar
+  parent: DisposalRouter
+  suffix: Bar
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Bar"]
+
+
+- type: entity
+  id: DisposalRouterBotany
+  parent: DisposalRouter
+  suffix: Botany
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Botany"]
+
+
+- type: entity
+  id: DisposalRouterJanitor
+  parent: DisposalRouter
+  suffix: Janitor
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Janitor"]
+
+
+- type: entity
+  id: DisposalRouterAI
+  parent: DisposalRouter
+  suffix: AI
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["AI"]
+
+
+- type: entity
+  id: DisposalRouterAISatellite
+  parent: DisposalRouter
+  suffix: AISatellite
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["AISatellite"]
+
+
+- type: entity
+  id: DisposalRouterAICore
+  parent: DisposalRouter
+  suffix: AICore
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["AICore"]
+
+
+- type: entity
+  id: DisposalRouterAIUpload
+  parent: DisposalRouter
+  suffix: AIUpload
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["AIUpload"]
+
+
+- type: entity
+  id: DisposalRouterAIPower
+  parent: DisposalRouter
+  suffix: AIPower
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["AIPower"]
+
+
+- type: entity
+  id: DisposalRouterArrivals
+  parent: DisposalRouter
+  suffix: Arrivals
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Arrivals"]
+
+
+- type: entity
+  id: DisposalRouterEvac
+  parent: DisposalRouter
+  suffix: Evac
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Evac"]
+
+
+- type: entity
+  id: DisposalRouterDockingArm
+  parent: DisposalRouter
+  suffix: DockingArm
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["DockingArm"]
+
+
+- type: entity
+  id: DisposalRouterEVAStorage
+  parent: DisposalRouter
+  suffix: EVAStorage
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["EVAStorage"]
+
+
+- type: entity
+  id: DisposalRouterChapel
+  parent: DisposalRouter
+  suffix: Chapel
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Chapel"]
+
+
+- type: entity
+  id: DisposalRouterLibrary
+  parent: DisposalRouter
+  suffix: Library
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Library"]
+
+
+- type: entity
+  id: DisposalRouterReporter
+  parent: DisposalRouter
+  suffix: Reporter
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Reporter"]
+
+
+- type: entity
+  id: DisposalRouterTheater
+  parent: DisposalRouter
+  suffix: Theater
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Theater"]
+
+
+- type: entity
+  id: DisposalRouterDorms
+  parent: DisposalRouter
+  suffix: Dorms
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Dorms"]
+
+
+- type: entity
+  id: DisposalRouterTools
+  parent: DisposalRouter
+  suffix: Tools
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Tools"]
+
+
+- type: entity
+  id: DisposalRouterDisposals
+  parent: DisposalRouter
+  suffix: Disposals
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Disposals"]
+
+
+- type: entity
+  id: DisposalRouterCryosleep
+  parent: DisposalRouter
+  suffix: Cryosleep
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Cryosleep"]
+
+
+- type: entity
+  id: DisposalRouterVox
+  parent: DisposalRouter
+  suffix: Vox
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["Vox"]
+
+
+- type: entity
+  id: DisposalRouterWildcard
+  parent: DisposalRouter
+  suffix: Wildcard
+  components:
+  - type: DisposalRouter
+    degrees:
+    - 0
+    - -90
+    - 180
+    tags: ["*"]

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Disposal/taggingpipes.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Disposal/taggingpipes.yml
@@ -1,0 +1,628 @@
+- type: entity
+  id: DisposalTaggerCommand
+  parent: DisposalTagger   
+  suffix: Command
+  components:
+  - type: DisposalTagger   
+    tag: Command
+
+
+- type: entity
+  id: DisposalTaggerBridge
+  parent: DisposalTagger
+  suffix: Bridge
+  components:
+  - type: DisposalTagger
+    tag: Bridge
+
+
+- type: entity
+  id: DisposalTaggerVault
+  parent: DisposalTagger
+  suffix: Vault
+  components:
+  - type: DisposalTagger
+    tag: Vault
+
+
+- type: entity
+  id: DisposalTaggerGateway
+  parent: DisposalTagger
+  suffix: Gateway
+  components:
+  - type: DisposalTagger
+    tag: Gateway
+
+
+- type: entity
+  id: DisposalTaggerCaptain
+  parent: DisposalTagger
+  suffix: Captain
+  components:
+  - type: DisposalTagger
+    tag: Captain
+
+
+- type: entity
+  id: DisposalTaggerHoP
+  parent: DisposalTagger
+  suffix: HoP
+  components:
+  - type: DisposalTagger
+    tag: HoP
+
+
+- type: entity
+  id: DisposalTaggerSecurity
+  parent: DisposalTagger
+  suffix: Security
+  components:
+  - type: DisposalTagger
+    tag: Security
+
+
+- type: entity
+  id: DisposalTaggerBrig
+  parent: DisposalTagger
+  suffix: Brig
+  components:
+  - type: DisposalTagger
+    tag: Brig
+
+
+- type: entity
+  id: DisposalTaggerBrigMed
+  parent: DisposalTagger
+  suffix: BrigMed
+  components:
+  - type: DisposalTagger
+    tag: BrigMed
+
+
+- type: entity
+  id: DisposalTaggerWarden
+  parent: DisposalTagger
+  suffix: Warden
+  components:
+  - type: DisposalTagger
+    tag: Warden
+
+
+- type: entity
+  id: DisposalTaggerHoS
+  parent: DisposalTagger
+  suffix: HoS
+  components:
+  - type: DisposalTagger
+    tag: HoS
+
+
+- type: entity
+  id: DisposalTaggerArmory
+  parent: DisposalTagger
+  suffix: Armory
+  components:
+  - type: DisposalTagger
+    tag: Armory
+
+
+- type: entity
+  id: DisposalTaggerPerma
+  parent: DisposalTagger
+  suffix: Perma
+  components:
+  - type: DisposalTagger
+    tag: Perma
+
+
+- type: entity
+  id: DisposalTaggerDetective
+  parent: DisposalTagger
+  suffix: Detective
+  components:
+  - type: DisposalTagger
+    tag: Detective
+
+
+- type: entity
+  id: DisposalTaggerCourtroom
+  parent: DisposalTagger
+  suffix: Courtroom
+  components:
+  - type: DisposalTagger
+    tag: Courtroom
+
+
+- type: entity
+  id: DisposalTaggerLaw
+  parent: DisposalTagger
+  suffix: Law
+  components:
+  - type: DisposalTagger
+    tag: Law
+
+
+- type: entity
+  id: DisposalTaggerSecurityCheckpoint
+  parent: DisposalTagger
+  suffix: SecurityCheckpoint
+  components:
+  - type: DisposalTagger
+    tag: SecurityCheckpoint
+
+
+- type: entity
+  id: DisposalTaggerMedical
+  parent: DisposalTagger
+  suffix: Medical
+  components:
+  - type: DisposalTagger
+    tag: Medical
+
+
+- type: entity
+  id: DisposalTaggerMedbay
+  parent: DisposalTagger
+  suffix: Medbay
+  components:
+  - type: DisposalTagger
+    tag: Medbay
+
+
+- type: entity
+  id: DisposalTaggerChemistry
+  parent: DisposalTagger
+  suffix: Chemistry
+  components:
+  - type: DisposalTagger
+    tag: Chemistry
+
+
+- type: entity
+  id: DisposalTaggerCryogenics
+  parent: DisposalTagger
+  suffix: Cryogenics
+  components:
+  - type: DisposalTagger
+    tag: Cryogenics
+
+
+- type: entity
+  id: DisposalTaggerCMO
+  parent: DisposalTagger
+  suffix: CMO
+  components:
+  - type: DisposalTagger
+    tag: CMO
+
+
+- type: entity
+  id: DisposalTaggerMorgue
+  parent: DisposalTagger
+  suffix: Morgue
+  components:
+  - type: DisposalTagger
+    tag: Morgue
+
+
+- type: entity
+  id: DisposalTaggerSurgery
+  parent: DisposalTagger
+  suffix: Surgery
+  components:
+  - type: DisposalTagger
+    tag: Surgery
+
+
+- type: entity
+  id: DisposalTaggerPsychology
+  parent: DisposalTagger
+  suffix: Psychology
+  components:
+  - type: DisposalTagger
+    tag: Psychology
+
+
+- type: entity
+  id: DisposalTaggerClinic
+  parent: DisposalTagger
+  suffix: Clinic
+  components:
+  - type: DisposalTagger
+    tag: Clinic
+
+
+- type: entity
+  id: DisposalTaggerScience
+  parent: DisposalTagger
+  suffix: Science
+  components:
+  - type: DisposalTagger
+    tag: Science
+
+
+- type: entity
+  id: DisposalTaggerR&D
+  parent: DisposalTagger
+  suffix: R&D
+  components:
+  - type: DisposalTagger
+    tag: R&D
+
+
+- type: entity
+  id: DisposalTaggerRD
+  parent: DisposalTagger
+  suffix: RD
+  components:
+  - type: DisposalTagger
+    tag: RD
+
+
+- type: entity
+  id: DisposalTaggerRobotics
+  parent: DisposalTagger
+  suffix: Robotics
+  components:
+  - type: DisposalTagger
+    tag: Robotics
+
+
+- type: entity
+  id: DisposalTaggerArtifact
+  parent: DisposalTagger
+  suffix: Artifact
+  components:
+  - type: DisposalTagger
+    tag: Artifact
+
+
+- type: entity
+  id: DisposalTaggerAnomaly
+  parent: DisposalTagger
+  suffix: Anomaly
+  components:
+  - type: DisposalTagger
+    tag: Anomaly
+
+
+- type: entity
+  id: DisposalTaggerSupply
+  parent: DisposalTagger
+  suffix: Supply
+  components:
+  - type: DisposalTagger
+    tag: Supply
+
+
+- type: entity
+  id: DisposalTaggerCargo
+  parent: DisposalTagger
+  suffix: Cargo
+  components:
+  - type: DisposalTagger
+    tag: Cargo
+
+
+- type: entity
+  id: DisposalTaggerCargoBay
+  parent: DisposalTagger
+  suffix: CargoBay
+  components:
+  - type: DisposalTagger
+    tag: CargoBay
+
+
+- type: entity
+  id: DisposalTaggerQM
+  parent: DisposalTagger
+  suffix: QM
+  components:
+  - type: DisposalTagger
+    tag: QM
+
+
+- type: entity
+  id: DisposalTaggerSalvage
+  parent: DisposalTagger
+  suffix: Salvage
+  components:
+  - type: DisposalTagger
+    tag: Salvage
+
+
+- type: entity
+  id: DisposalTaggerEngineering
+  parent: DisposalTagger
+  suffix: Engineering
+  components:
+  - type: DisposalTagger
+    tag: Engineering
+
+
+- type: entity
+  id: DisposalTaggerCE
+  parent: DisposalTagger
+  suffix: CE
+  components:
+  - type: DisposalTagger
+    tag: CE
+
+
+- type: entity
+  id: DisposalTaggerAME
+  parent: DisposalTagger
+  suffix: AME
+  components:
+  - type: DisposalTagger
+    tag: AME
+
+
+- type: entity
+  id: DisposalTaggerGravityGenerator
+  parent: DisposalTagger
+  suffix: GravityGenerator
+  components:
+  - type: DisposalTagger
+    tag: GravityGenerator
+
+
+- type: entity
+  id: DisposalTaggerAnchor
+  parent: DisposalTagger
+  suffix: Anchor
+  components:
+  - type: DisposalTagger
+    tag: Anchor
+
+
+- type: entity
+  id: DisposalTaggerParticleAccelerator
+  parent: DisposalTagger
+  suffix: ParticleAccelerator
+  components:
+  - type: DisposalTagger
+    tag: ParticleAccelerator
+
+
+- type: entity
+  id: DisposalTaggerTelecomms
+  parent: DisposalTagger
+  suffix: Telecomms
+  components:
+  - type: DisposalTagger
+    tag: Telecomms
+
+
+- type: entity
+  id: DisposalTaggerAtmos
+  parent: DisposalTagger
+  suffix: Atmos
+  components:
+  - type: DisposalTagger
+    tag: Atmos
+
+
+- type: entity
+  id: DisposalTaggerTEG
+  parent: DisposalTagger
+  suffix: TEG
+  components:
+  - type: DisposalTagger
+    tag: TEG
+
+
+- type: entity
+  id: DisposalTaggerTechVault
+  parent: DisposalTagger
+  suffix: TechVault
+  components:
+  - type: DisposalTagger
+    tag: TechVault
+
+
+- type: entity
+  id: DisposalTaggerService
+  parent: DisposalTagger
+  suffix: Service
+  components:
+  - type: DisposalTagger
+    tag: Service
+
+
+- type: entity
+  id: DisposalTaggerKitchen
+  parent: DisposalTagger
+  suffix: Kitchen
+  components:
+  - type: DisposalTagger
+    tag: Kitchen
+
+
+- type: entity
+  id: DisposalTaggerBar
+  parent: DisposalTagger
+  suffix: Bar
+  components:
+  - type: DisposalTagger
+    tag: Bar
+
+
+- type: entity
+  id: DisposalTaggerBotany
+  parent: DisposalTagger
+  suffix: Botany
+  components:
+  - type: DisposalTagger
+    tag: Botany
+
+
+- type: entity
+  id: DisposalTaggerJanitor
+  parent: DisposalTagger
+  suffix: Janitor
+  components:
+  - type: DisposalTagger
+    tag: Janitor
+
+
+- type: entity
+  id: DisposalTaggerAI
+  parent: DisposalTagger
+  suffix: AI
+  components:
+  - type: DisposalTagger
+    tag: AI
+
+
+- type: entity
+  id: DisposalTaggerAISatellite
+  parent: DisposalTagger
+  suffix: AISatellite
+  components:
+  - type: DisposalTagger
+    tag: AISatellite
+
+
+- type: entity
+  id: DisposalTaggerAICore
+  parent: DisposalTagger
+  suffix: AICore
+  components:
+  - type: DisposalTagger
+    tag: AICore
+
+
+- type: entity
+  id: DisposalTaggerAIUpload
+  parent: DisposalTagger
+  suffix: AIUpload
+  components:
+  - type: DisposalTagger
+    tag: AIUpload
+
+
+- type: entity
+  id: DisposalTaggerAIPower
+  parent: DisposalTagger
+  suffix: AIPower
+  components:
+  - type: DisposalTagger
+    tag: AIPower
+
+
+- type: entity
+  id: DisposalTaggerArrivals
+  parent: DisposalTagger
+  suffix: Arrivals
+  components:
+  - type: DisposalTagger
+    tag: Arrivals
+
+
+- type: entity
+  id: DisposalTaggerEvac
+  parent: DisposalTagger
+  suffix: Evac
+  components:
+  - type: DisposalTagger
+    tag: Evac
+
+
+- type: entity
+  id: DisposalTaggerDockingArm
+  parent: DisposalTagger
+  suffix: DockingArm
+  components:
+  - type: DisposalTagger
+    tag: DockingArm
+
+
+- type: entity
+  id: DisposalTaggerEVAStorage
+  parent: DisposalTagger
+  suffix: EVAStorage
+  components:
+  - type: DisposalTagger
+    tag: EVAStorage
+
+
+- type: entity
+  id: DisposalTaggerChapel
+  parent: DisposalTagger
+  suffix: Chapel
+  components:
+  - type: DisposalTagger
+    tag: Chapel
+
+
+- type: entity
+  id: DisposalTaggerLibrary
+  parent: DisposalTagger
+  suffix: Library
+  components:
+  - type: DisposalTagger
+    tag: Library
+
+
+- type: entity
+  id: DisposalTaggerReporter
+  parent: DisposalTagger
+  suffix: Reporter
+  components:
+  - type: DisposalTagger
+    tag: Reporter
+
+
+- type: entity
+  id: DisposalTaggerTheater
+  parent: DisposalTagger
+  suffix: Theater
+  components:
+  - type: DisposalTagger
+    tag: Theater
+
+
+- type: entity
+  id: DisposalTaggerDorms
+  parent: DisposalTagger
+  suffix: Dorms
+  components:
+  - type: DisposalTagger
+    tag: Dorms
+
+
+- type: entity
+  id: DisposalTaggerTools
+  parent: DisposalTagger
+  suffix: Tools
+  components:
+  - type: DisposalTagger
+    tag: Tools
+
+
+- type: entity
+  id: DisposalTaggerDisposals
+  parent: DisposalTagger
+  suffix: Disposals
+  components:
+  - type: DisposalTagger
+    tag: Disposals
+
+
+- type: entity
+  id: DisposalTaggerCryosleep
+  parent: DisposalTagger
+  suffix: Cryosleep
+  components:
+  - type: DisposalTagger
+    tag: Cryosleep
+
+
+- type: entity
+  id: DisposalTaggerVox
+  parent: DisposalTagger
+  suffix: Vox
+  components:
+  - type: DisposalTagger
+    tag: Vox


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds presets for a bunch of departments for mail routing entities like taggers and routers. A wildcard one is also included for if https://github.com/ss14Starlight/space-station-14/pull/581 gets merged

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Simplifys the mapping process and allows us to easily rename these mail destinations later

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- add: Added mail routing default prototypes for mappers.