### PR TITLE
speculative fix

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -172,7 +172,6 @@ public sealed partial class AntagSelectionSystem
             return false;
         //starlight edit to remove error and hopefully fix event scheduler
         var sessionpref =  _pref.GetPreferencesOrNull(session.UserId);
-        //var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
         if (sessionpref == null)
             return false;
 
@@ -191,7 +190,12 @@ public sealed partial class AntagSelectionSystem
         if (def.FallbackRoles.Count == 0)
             return false;
 
-        var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
+        //starlight edit to remove error and hopefully fix event scheduler
+        var sessionpref =  _pref.GetPreferencesOrNull(session.UserId);
+        if (sessionpref == null)
+            return false;
+
+        var pref = (HumanoidCharacterProfile)sessionpref.SelectedCharacter;
         return pref.AntagPreferences.Any(p => def.FallbackRoles.Contains(p));
     }
 

--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -170,8 +170,13 @@ public sealed partial class AntagSelectionSystem
 
         if (def.PrefRoles.Count == 0)
             return false;
+        //starlight edit to remove error and hopefully fix event scheduler
+        var sessionpref =  _pref.GetPreferencesOrNull(session.UserId);
+        //var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
+        if (sessionpref == null)
+            return false;
 
-        var pref = (HumanoidCharacterProfile) _pref.GetPreferences(session.UserId).SelectedCharacter;
+        var pref = (HumanoidCharacterProfile)sessionpref.SelectedCharacter;
         return pref.AntagPreferences.Any(p => def.PrefRoles.Contains(p));
     }
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This is a speculative fix for a event scheduler bug we have been dealing with for a while now, where the event system just breaks down and stops working. This change is based on a few bits of information that show up once schedulers break.

1: Event schedulers are not running their Update() method it appears in game
2: There is consistent errors showing up related to gamerule updating in logs
  2a: ```Caught exception in entsys
System.Collections.Generic.KeyNotFoundException: The given key '0f6b9d15-eb9b-43d7-91c0-8b0af680efd4' was not present in the dictionary.
   at Content.Server.Preferences.Managers.ServerPreferencesManager.GetPreferences(NetUserId userId) in /home/runner/work/space-station-14/space-station-14/Content.Server/Preferences/Managers/ServerPreferencesManager.cs:line 256
   at Content.Server.Antag.AntagSelectionSystem.AssignPreSelectedSessions(Entity`1 ent) in /home/runner/work/space-station-14/space-station-14/Content.Server/Antag/AntagSelectionSystem.cs:line 352
   at Content.Server.Antag.AntagSelectionSystem.Started(EntityUid uid, AntagSelectionComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args) in /home/runner/work/space-station-14/space-station-14/Content.Server/Antag/AntagSelectionSystem.cs:line 247
   at Robust.Shared.GameObjects.EntityEventBus.<>c__DisplayClass67_0`1.<EntSubscribe>b__0(EntityUid uid, IComponent comp, Unit& ev) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 460
   at Robust.Shared.GameObjects.EntityEventBus.EntDispatch(EntityUid euid, Type eventType, Unit& args) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 633
   at Robust.Shared.GameObjects.EntityEventBus.RaiseLocalEvent[TEvent](EntityUid uid, TEvent& args, Boolean broadcast) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntityEventBus.Directed.cs:line 218
   at Content.Server.GameTicking.GameTicker.StartGameRule(EntityUid ruleEntity, GameRuleComponent ruleData) in /home/runner/work/space-station-14/space-station-14/Content.Server/GameTicking/GameTicker.GameRule.cs:line 171
   at Content.Server.GameTicking.GameTicker.UpdateGameRules() in /home/runner/work/space-station-14/space-station-14/Content.Server/GameTicking/GameTicker.GameRule.cs:line 324
   at Robust.Shared.GameObjects.EntitySystemManager.TickUpdate(Single frameTime, Boolean noPredictions) in /home/runner/work/space-station-14/space-station-14/RobustToolbox/Robust.Shared/GameObjects/EntitySystemManager.cs:line 318
 Catcher=entsys Sawmill=runtime```
2b: 30 day timespan, matches roughly with the times we update or restart servers
![image](https://github.com/user-attachments/assets/d6f3fb3c-0839-46c3-a193-044bea903c29)


## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
HOPEFULLY prevent the event scheduler from dying

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Speculative fix for event scheduler issues.