### PR TITLE
Several mech-related fixes.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mech_construction.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mech_construction.yml
@@ -105,7 +105,7 @@
   description: The right arm of the Clarke. It belongs on the chassis of the mech.
   components:
   - type: Sprite
-    state: clarke_l_arm
+    state: clarke_r_arm
   - type: Tag
     tags:
     - ClarkeRArm
@@ -117,7 +117,7 @@
   description: The left arm of the Clarke. It belongs on the chassis of the mech.
   components:
   - type: Sprite
-    state: clarke_r_arm
+    state: clarke_l_arm
   - type: Tag
     tags:
     - ClarkeLArm
@@ -137,7 +137,7 @@
 - type: entity
   id: ClarkeChassis
   parent: BaseClarkePart
-  name: calrke chassis
+  name: clarke chassis
   description: An in-progress construction of the Clarke mech.
   components:
   - type: Appearance

--- a/Resources/Prototypes/Recipes/Construction/Graphs/mechs/durand_construction.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/mechs/durand_construction.yml
@@ -135,9 +135,10 @@
         - !type:VisualizerDataInt
           key: "enum.MechAssemblyVisuals.State"
           data: 16
-
+    
       - tag: MechAirTank
         name: exosuit air tank
+        store: gas-tank-container
         icon:
           sprite: Objects/Specific/Mech/mecha_equipment.rsi
           state: mecha_air_tank

--- a/Resources/Prototypes/Recipes/Construction/Graphs/mechs/gygax_construction.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/mechs/gygax_construction.yml
@@ -138,6 +138,7 @@
 
       - tag: MechAirTank
         name: exosuit air tank
+        store: gas-tank-container
         icon:
           sprite: Objects/Specific/Mech/mecha_equipment.rsi
           state: mecha_air_tank

--- a/Resources/Prototypes/Recipes/Construction/Graphs/mechs/hamtr_construction.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/mechs/hamtr_construction.yml
@@ -109,6 +109,16 @@
           key: "enum.MechAssemblyVisuals.State"
           data: 17
 
+      - tag: MechAirTank
+        name: exosuit air tank
+        store: gas-tank-container
+        icon:
+          sprite: Objects/Specific/Mech/mecha_equipment.rsi
+          state: mecha_air_tank
+
+      - tool: Anchoring
+        doAfter: 1
+
       - material: MetalRod
         amount: 10
         completed:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/mechs/ripleymkii_construction.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/mechs/ripleymkii_construction.yml
@@ -108,6 +108,7 @@
 
       - tag: MechAirTank
         name: exosuit air tank
+        store: gas-tank-container
         icon:
           sprite: Objects/Specific/Mech/mecha_equipment.rsi
           state: mecha_air_tank


### PR DESCRIPTION
## Short description
Fixing pressurization for all the mechs where it's broken (Durand, Gygax, HAMTR, ripley mkii) and some typo fixes related to Clarke.
## Why we need to add this
As previously mentioned, it's a bug fix for the fact that several mechs refuse to pressurize. And it fixes typos. Fixes the following:
https://discord.com/channels/1272545509562777621/1369238058104393808
https://discord.com/channels/1272545509562777621/1368847018403041301
https://discord.com/channels/1272545509562777621/1368845952919535656


## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- add: Added construction step for exosuit air tank to HAMTR.
- fix: Fixed typo 'calrke chassis'.
- fix: Fixed Clarke's left arm and right arm being swapped internally.:
- fix: Fixed pressurization not working for Durand, Hamtr, Gygax & Ripley mk II.
