### PR TITLE
start lings at 40 biomass

### DIFF
--- a/Content.Shared/Changeling/ChangelingComponent.cs
+++ b/Content.Shared/Changeling/ChangelingComponent.cs
@@ -64,7 +64,7 @@ public sealed partial class ChangelingComponent : Component
     ///     Amount of biomass changeling currently has.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float Biomass = 30f;
+    public float Biomass = 40f;
 
     /// <summary>
     ///     Maximum amount of biomass a changeling can have.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Raises lings starting biomass to 40

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This PR seems stupid considering I just got another ling change merged in, but this PR is made because people brought up a good point after that was changed. TLDR, you used to have 15 minutes before you were outed, now you technically only have 11 before starting to get the itch jitter symptoms. This raises that timer to 21 minutes off of roundstart

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Lings start at 40 biomass