### PR TITLE
Mech air fix

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -77,6 +77,7 @@ public sealed partial class MechSystem : SharedMechSystem
         SubscribeLocalEvent<MechComponent, MechToggleThrustersEvent>(OnMechToggleThrusters);
         SubscribeLocalEvent<MechComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<MechComponent, EntInsertedIntoContainerMessage>(OnInsertBattery);
+        SubscribeLocalEvent<MechComponent, EntInsertedIntoContainerMessage>(OnInsertGasTank);
         SubscribeLocalEvent<MechComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<MechComponent, GetVerbsEvent<AlternativeVerb>>(OnAlternativeVerb);
         SubscribeLocalEvent<MechComponent, MechOpenUiEvent>(OnOpenUi);
@@ -331,7 +332,15 @@ public sealed partial class MechSystem : SharedMechSystem
 
         args.Handled = true;
     }
-    
+    private void OnInsertGasTank(EntityUid uid, MechComponent component, EntInsertedIntoContainerMessage args)
+    {
+        if (args.Container != component.GasTankSlot || !TryComp<GasTankComponent>(args.Entity, out var gasTank))
+            return;
+
+        Dirty(uid, component);
+        _actionBlocker.UpdateCanMove(uid);
+    }
+
     private void OnRemoveGasTank(EntityUid uid, MechComponent component, RemoveGasTankEvent args)
     {
         if (args.Cancelled || args.Handled)

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -335,17 +335,6 @@ public sealed partial class MechSystem : SharedMechSystem
             return;
         }
     }
-    // private void OnInsertBattery(EntityUid uid, MechComponent component, EntInsertedIntoContainerMessage args)
-    // {
-    //     if (args.Container != component.BatterySlot || !TryComp<BatteryComponent>(args.Entity, out var battery))
-    //         return;
-
-    //     component.Energy = battery.CurrentCharge;
-    //     component.MaxEnergy = battery.MaxCharge;
-
-    //     Dirty(uid, component);
-    //     _actionBlocker.UpdateCanMove(uid);
-    // }
 
     private void OnRemoveBattery(EntityUid uid, MechComponent component, RemoveBatteryEvent args)
     {
@@ -357,14 +346,6 @@ public sealed partial class MechSystem : SharedMechSystem
 
         args.Handled = true;
     }
-    // private void OnInsertGasTank(EntityUid uid, MechComponent component, EntInsertedIntoContainerMessage args)
-    // {
-    //     if (args.Container != component.GasTankSlot || !TryComp<GasTankComponent>(args.Entity, out var gasTank))
-    //         return;
-
-    //     Dirty(uid, component);
-    //     _actionBlocker.UpdateCanMove(uid);
-    // }
 
     private void OnRemoveGasTank(EntityUid uid, MechComponent component, RemoveGasTankEvent args)
     {


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Introducing/fixing the ability to insert gas tanks into fully built mechs.

## Why we need to add this
Right now it's impossible to insert a gas tank into a fully built airtight mech. This means that you cannot refill their air once they run out. This PR fixes that.
Fixes the following:
https://discord.com/channels/1272545509562777621/1349543905116553217

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: RoadTrain
- fix: Fixed being unable to insert exosuit air tanks into airtight mechs.
-->
