### PR TITLE
Update mechs.yml

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -289,7 +289,7 @@
   id: MechPaddy
   parent: [ BaseMech, CombatMech, BaseSecurityContraband ]
   name: Paddy
-  description: Autonomous Power Loader Unit Subtype Paddy. A Modified MK-I Ripley design intended for light security use.
+  description: Autonomous Power Loader Unit Subtype Paddy. A Modified MK-II Ripley design intended for light security use.
   components:
   - type: Sprite
     drawdepth: Mobs


### PR DESCRIPTION
## Short description
Turning Ripley MK-I into MK-II (as it's airtight)

## Why we need to add this
Lore accuracy. The Ripley mk-II is airtight so it'd make sense paddy is derived from it rather than the MK-I

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: RoadTrain
- tweak: Changed Paddy's description to say it's derived from the Ripley MK-II given it's airtight.
