### PR TITLE
Dictionary scaling hotfix

### DIFF
--- a/Content.Shared/CollectiveMind/CollectiveMindUpdateSystem.cs
+++ b/Content.Shared/CollectiveMind/CollectiveMindUpdateSystem.cs
@@ -58,10 +58,6 @@ public sealed class CollectiveMindUpdateSystem : EntitySystem
     {
         foreach (var prototype in _prototypeManager.EnumeratePrototypes<CollectiveMindPrototype>())
         {
-            //check if they dont already have it
-            if (collective.Minds.ContainsKey(prototype))
-                continue;
-
             var components = StringsToRegs(prototype.RequiredComponents);
 
             bool meetsRequirements = false;
@@ -88,6 +84,10 @@ public sealed class CollectiveMindUpdateSystem : EntitySystem
 
             if (meetsRequirements)
             {
+                //check if they dont already have it
+                if (collective.Minds.ContainsKey(prototype))
+                    continue;
+                
                 collective.Minds.TryAdd(prototype, CreateNewCollectiveMindMemberData(prototype));
             }
             else

--- a/Content.Shared/CollectiveMind/CollectiveMindUpdateSystem.cs
+++ b/Content.Shared/CollectiveMind/CollectiveMindUpdateSystem.cs
@@ -58,6 +58,10 @@ public sealed class CollectiveMindUpdateSystem : EntitySystem
     {
         foreach (var prototype in _prototypeManager.EnumeratePrototypes<CollectiveMindPrototype>())
         {
+            //check if they dont already have it
+            if (collective.Minds.ContainsKey(prototype))
+                continue;
+
             var components = StringsToRegs(prototype.RequiredComponents);
 
             bool meetsRequirements = false;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Hotfixes a bug where a internal dictionary would grow the tracking integer on EVERY message sent

This was me missing a case of when you send a message, we tell it to update collective minds. The issue is we increment the dictionary no matter what. This isn't a LARGE issue other than your collective mind ID late start will be very large quickly

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Possible memory and performance concerns

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed issue with collective mind ID selection.