### PR TITLE
Changes some weapons to by pump action

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -37,7 +37,7 @@
   name: china lake
   parent: [BaseWeaponLauncher, BaseGunWieldable, BaseSyndicateContraband]
   id: WeaponLauncherChinaLake
-  description: PLOOP.
+  description: A pump-action grenade launcher commonly used by the infamous Nuclear Operatives. PLOOP!
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/china_lake.rsi
@@ -51,7 +51,8 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
-    fireRate: 1
+    pump: true
+    fireRate: 0.8
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -32,6 +32,7 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
+    pump: true
     fireRate: 0.75
     selectedMode: SemiAuto
     availableModes:
@@ -78,7 +79,8 @@
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
   - type: GunRequiresWield
   - type: Gun
-    fireRate: 0.4
+    pump: true
+    fireRate: 0.5
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Changes the China-Lake, Kardashev-Mosin and Hristov to be pump action, so you have to cycle them in between shots. I also changed the China-Lake's description to fit its new function, reduced its firerate slightly from 1 to 0.8, and buffed the Hristov's firerate from 0.4 to 0.5
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
China-Lake changes are for slight balancing, making the weapon slightly easier to actually fight, and raises the skill-floor slightly, because the China-Lake is incredibly strong right now. Kardashev-Mosin and Hristov changes are more to make the guns slightly more fun/interesting to use, and slightly increases the Hristov's time to kill provided you can cycle it.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![image](https://github.com/user-attachments/assets/52eb7106-665c-42d4-a4ba-0f8d6a8e4962)
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: PubliclyExecutedPig
- tweak: Due to "Nostalgia Strikes" in Syndicate weapons subsidiaries, the Kardashev-Mosin, Hristov sniper rifle, and China-Lake grenade launcher once again need to be cycled in between shots
- tweak: The Hristov's firerate has gone up from 0.4 to 0.5
- tweak: The China-Lake's firerate has gone down from 1 to 0.8
