### PR TITLE
Removing Mech Light powerdraw.

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -113,29 +113,6 @@ public sealed partial class MechSystem : SharedMechSystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
-        var lightDraw = EntityQueryEnumerator<PowerCellDrawComponent, MechComponent>();
-
-        while (lightDraw.MoveNext(out var uid, out var comp, out var mechComp))
-        {
-            if (!mechComp.Light)
-                continue;
-
-            if (Timing.CurTime < comp.NextUpdateTime)
-                continue;
-
-            comp.NextUpdateTime += comp.Delay;
-
-            if (mechComp.BatterySlot.ContainedEntity == null 
-                || !TryComp<BatteryComponent>(mechComp.BatterySlot.ContainedEntity.Value, out var battery) )
-                continue;
-
-            if (!_battery.TryUseCharge(mechComp.BatterySlot.ContainedEntity.Value, comp.DrawRate))
-                continue;
-            
-            var ev = new ChargeChangedEvent(battery.CurrentCharge, battery.MaxCharge);
-            RaiseLocalEvent(uid, ref ev);
-        }
-        
         var thrustDraw = EntityQueryEnumerator<MechThrustersComponent, MechComponent>();
 
         while (thrustDraw.MoveNext(out var uid, out var comp, out var mechComp))


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removes the powerdraw from mech headlights.

## Why we need to add this
Mech light power draw is INCREDIBLY aggressive and massively limits how much you can use them. Hence I've removed the power draw entirely so you can use the lights without draining the mech in a matter of like, a minute.

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- remove: Removed the active power draw from mech lights.
