### PR TITLE
polymorphs nolonger cryosleep you if you are polymorphed for too long

### DIFF
--- a/Content.Server/Polymorph/Components/PolymorphedEntityComponent.cs
+++ b/Content.Server/Polymorph/Components/PolymorphedEntityComponent.cs
@@ -29,4 +29,12 @@ public sealed partial class PolymorphedEntityComponent : Component
 
     [DataField]
     public EntityUid? Action;
+
+    //#region Starlight
+    /// <summary>
+    /// if the old parent body allready had the Uncryoable component meaning it should not be removed when de-polymorphing them
+    /// <see cref="UncryoableComponent"/>
+    /// </summary>
+    public bool HadUncryoable = false;
+    //#endregion Starlight
 }

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -196,7 +196,7 @@ public sealed partial class PolymorphSystem : EntitySystem
 
         // mostly just for vehicles
         _buckle.TryUnbuckle(uid, uid, true);
-
+        
         var targetTransformComp = Transform(uid);
 
         if (configuration.PolymorphSound != null)
@@ -215,6 +215,16 @@ public sealed partial class PolymorphSystem : EntitySystem
         var polymorphedComp = _compFact.GetComponent<PolymorphedEntityComponent>();
         polymorphedComp.Parent = uid;
         polymorphedComp.Configuration = configuration;
+        //#region Starlight
+        if (HasComp<UncryoableComponent>(uid))
+        {
+            polymorphedComp.HadUncryoable = true;
+        }
+        else
+        {
+            EnsureComp<UncryoableComponent>(uid);
+        }
+        //#endregion Starlight
         AddComp(child, polymorphedComp);
 
         var childXform = Transform(child);
@@ -343,6 +353,13 @@ public sealed partial class PolymorphSystem : EntitySystem
         if (_mindSystem.TryGetMind(uid, out var mindId, out var mind))
             _mindSystem.TransferTo(mindId, parent, mind: mind);
 
+        //#region Starlight
+        if (!component.HadUncryoable)
+        {
+            RemComp<UncryoableComponent>(parent);
+        }
+        //#endregion Starlight
+        
         if (TryComp<PolymorphableComponent>(parent, out var polymorphableComponent))
             polymorphableComponent.LastPolymorphEnd = _gameTiming.CurTime;
 

--- a/Content.Server/_Starlight/CryoTeleportation/CryoTeleportationSystem.cs
+++ b/Content.Server/_Starlight/CryoTeleportation/CryoTeleportationSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Server.Bed.Cryostorage;
 using Content.Server.GameTicking;
 using Content.Server.Mind;
+using Content.Server.Polymorph.Components;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.Bed.Cryostorage;
@@ -63,8 +64,9 @@ public sealed class CryoTeleportationSystem : EntitySystem
                 || HasComp<BorgChassisComponent>(uid)
                 || mobStateComponent.CurrentState != MobState.Alive
                 || comp.ExitTime == null
-                || _timing.CurTime - comp.ExitTime < stationComp.TransferDelay
-                || HasComp<CryostorageContainedComponent>(uid))
+                || _timing.CurTime - comp.ExitTime < stationComp.TransferDelay 
+                || HasComp<CryostorageContainedComponent>(uid)
+                || HasComp<UncryoableComponent>(uid))
                 continue;
 
             var stationGrid = _stationSystem.GetLargestGrid(stationData);

--- a/Content.Server/_Starlight/Polymorph/Components/UncryoableComponent.cs
+++ b/Content.Server/_Starlight/Polymorph/Components/UncryoableComponent.cs
@@ -1,0 +1,7 @@
+﻿namespace Content.Server.Polymorph.Components;
+
+[RegisterComponent]
+public sealed partial class UncryoableComponent : Component
+{
+    
+}


### PR DESCRIPTION
## Short description
Fixes being cryoslept if you are polymorphed longer then the default time

## Why we need to add this
accidental RRs due to being a mouse/tree too long is annoying

## Media (Video/Screenshots)
N/A?

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- fix: polymorphing no longer cryosleeps you causing you to be round-removed

