### PR TITLE
Change ripley upgrade cost.

### DIFF
--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/mech_parts.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/mech_parts.yml
@@ -224,7 +224,7 @@
   - RipleyMKII
   completetime: 10
   materials:
-    Steel: 500
+    Plasteel: 1000
 
 # H.O.N.K.
 - type: latheRecipe


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Changes the cost of the exosuit upgrade kit from 5 steel to 10 plasteel.

## Why we need to add this
Right now it is INSANELY cheap to make a ripley mk2 if you simply build a mk1, then upgrade it. This addresses that issue. Side effect is that the exosuit fab can now store plasteel.

## Media (Video/Screenshots)
Nope.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: RoadTrain
- tweak: Exosuit upgrade kit cost. Was 5 steel, is 10 plasteel.