### PR TITLE
felionoid go normal speed with any damage

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
@@ -33,8 +33,9 @@
       150: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
-      45: 0.7 
-      60: 0.5
+      5: 0.7
+      45: 0.5
+      60: 0.2
   - type: Butcherable
     butcheringType: Spike
     spawned:


### PR DESCRIPTION
felionoid  are absurdly fast and obnoxious 
this makes them if they take any damage they run normal speed

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
slow down

## Why we need to add this
balance

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- fix: felionoid go to normal speeds if they have 5 damage
