### PR TITLE
Fix BSO and NTR playtime reqs

### DIFF
--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
@@ -6,10 +6,10 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 62000 # 20 hrs
+      time: 72000 # 20 hrs
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 62000 # 20 hrs
+      time: 72000 # 20 hrs
     - !type:AnyFlagsRequirement
       flags:
       - Staff

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 62000 # 20 hrs
+      time: 72000 # 20 hrs
     - !type:AnyFlagsRequirement
       flags:
       - Staff


### PR DESCRIPTION
## Short description
BSO and NTRep have their playtime incorrectly marked as 20 hours.
This fix adjusts it to be the correct value of 72000seconds

## Why we need to add this
AFAICT, this *is* supposed to be 20h

## Media (Video/Screenshots)
N/A

## Checks
- [ :heavy_check_mark: ] I do not require assistance to complete the PR.
- [ :heavy_check_mark: ] Before posting/requesting review of a PR, I have verified that the changes work.
- [N/A] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ :heavy_check_mark: ] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Cyanogen (AutumnalModding)
- tweak: NTR and BSO playtime, 62k seconds -> 72k (20h)
