### PR TITLE
Felinoid space cleaner hiss fix

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
@@ -68,7 +68,7 @@
       - !type:WashCreamPieReaction
       - !type:Emote
         emote: Hisses
-        showInChat: true
+        showInChat: false
   - type: Sprite 
     scale: 0.8, 0.8
   - type: Tag


### PR DESCRIPTION
## Short description
Makes felinoid hissing when covered in space cleaner not show in chat

## Why we need to add this
Fixes mild chat spam

## Media (Video/Screenshots)
N/A

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Cyanogen
- tweak: Felinoid hissing when in space cleaner no longer shows in chat