### PR TITLE
Added emaggable chefvend to dispense illegal foods

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -29,4 +29,11 @@
     FoodBoxDonkpocket: 1
     FoodFrozenSandwich: 2
     FoodFrozenSandwichStrawberry: 2
+    # Starlight-start
+    FoodMeatHuman: 4
+    FoodFriedfelionoid: 1
+    HeadVulpkanin: 1
+    FoodCakeResomiSlice: 2
+    # Starlight End
+    
     

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -30,6 +30,7 @@
     FoodFrozenSandwich: 2
     FoodFrozenSandwichStrawberry: 2
     # Starlight-start
+  emaggedInventory:
     FoodMeatHuman: 4
     FoodFriedfelionoid: 1
     HeadVulpkanin: 1


### PR DESCRIPTION

## Short description
Adds another way to get illegal food items using an emag and a chefven

## Why we need to add this
Adds ways to get illegal food and ingredients from emagging a chef vend. this makes it so making these foods dont require round removal of another player

## Media (Video/Screenshots)

![image](https://github.com/user-attachments/assets/fd1ff9d9-f360-4571-acea-beee716074df)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Floating Spore
- add: Emagging a chefvend now gives illegal food ingredients and foods