### PR TITLE
Add contraband labels to mechs and mech weapons

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -3,7 +3,7 @@
   name: eZ-14 mk2 Heavy pulse rifle
   description: Fires a heavy pulse laser.
   suffix: Mech Weapon, Gun, Combat, Pulse
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -26,7 +26,7 @@
   name: ZFI Immolation Beam Gun
   description: A gun for battlemechs, firing high-temperature beams.
   suffix: Mech Weapon, Gun, Combat, Laser
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -49,7 +49,7 @@
   name: CH-LC "Solaris" laser cannon
   description: An experimental combat mounted laser cannon that causes more damage, but also has a greater cooldown than a "Firedart".
   suffix: Mech Weapon, Gun, Combat, Laser
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -72,7 +72,7 @@
   name: CH-PS "Firedart" Laser
   description: The standard combat armament of the mechs is a combat mounted laser.
   suffix: Mech Weapon, Gun, Combat, Laser
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -95,7 +95,7 @@
   name: P-X Tesla Cannon
   description: A weapon for combat mechs, firing energy balls, based on the principle of an experimental Tesla engine.
   suffix: Mech Weapon, Gun, Combat, Tesla
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -122,7 +122,7 @@
   name: CH-PD Disabler
   description: A non-lethal mounted stun gun that allows you to immobilize intruders.
   suffix: Mech Weapon, Gun, Combat, Disabler
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -145,7 +145,7 @@
   name: PBT "Pacifier" Mounted Taser
   description: A mounted non-lethal taser that allows you to stun intruders.
   suffix: Mech Weapon, Gun, Combat, Disabler, admeme
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -168,7 +168,7 @@
   name: LBX AC 10 "Scattershot"
   description: A mounted non-lethal taser that allows you to stun intruders.
   suffix: Mech Weapon, Gun, Combat, Shotgun
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -191,7 +191,7 @@
   name: FNX-99 "Hades" Carbine
   description: Mounted carbine, firing incendiary cartridges.
   suffix: Mech Weapon, Gun, Combat, Shotgun, Incendiary
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -214,7 +214,7 @@
   name: Ultra AC-2
   description: Mounted carbine, firing incendiary cartridges.
   suffix: Mech Weapon, Gun, Combat, Rifle
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -239,7 +239,7 @@
   name: Mk.IV Ion Heavy Cannon
   description: A mounted ion weapon that operates on the same principle as a handheld ion carbine. Extremely effective against synthetics, robots and other mechs.
   suffix: Mech Weapon, Gun, Combat, Ion
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -268,7 +268,7 @@
   name: AMLG90
   description: Laser mounted machine gun.
   suffix: Mech Weapon, Gun, Combat, Laser
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -295,7 +295,7 @@
   name: S-1 X-Ray Projector
   description: Experimental mech weapon that fires X-rays that pass through obstacles.
   suffix: Mech Weapon, Gun, Combat, X-Ray
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -318,7 +318,7 @@
   name: SRM-8 Light Missile Rack
   description: Launches low-explosive breaching missiles designed to explode only when striking a sturdy target.
   suffix: Mech Weapon, Gun, Combat, Light Missile
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -341,7 +341,7 @@
   name: BRM-6 Missile Rack
   description: Tubes must be reloaded from the outside.
   suffix: Mech Weapon, Gun, Combat, Missile
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
@@ -367,7 +367,7 @@
   name: SGL-6 Flashbang Launcher
   description: Launches low-explosive breaching missiles designed to explode only when striking a sturdy target.
   suffix: Mech Weapon, Gun, Combat, Flashbang
-  parent: [ BaseMechWeaponRange, CombatMechEquipment ]
+  parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/industrial.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/industrial.yml
@@ -3,7 +3,7 @@
   name: exosuit proto-kinetic accelerator
   description: Fires normal-damage kinetic bolts at a short range.
   suffix: Mech Weapon, Gun, Industrial, Kinetic Accelerator
-  parent: [ BaseMechWeaponRange, IndustrialMechEquipment ]
+  parent: [ BaseMechWeaponRange, IndustrialMechEquipment, BaseCargoContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: WeaponMechChainSword
-  parent: [ BaseMechWeaponMelee, CombatMechEquipment  ]
+  parent: [ BaseMechWeaponMelee, CombatMechEquipment, BaseSecurityContraband ]
   name: exosuit chainsword
   suffix: Mech Weapon, Melee, Combat
   description: Equipment for combat exosuits. This is the mechanical chainsword that'll pierce the heavens!

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -1,9 +1,10 @@
 - type: entity
   id: WeaponMechMelleDrill
-  parent: BaseMechWeaponMelee
+  parent: [ BaseMechWeaponMelee, BaseCargoContraband ]
   name: exosuit drill
   suffix: Mech Weapon, Melee, Industrial
   description: Equipment for mining exosuits. This is the drill that'll pierce the rocks!
+  
   components:
   - type: Sprite
     state: mecha_drill
@@ -26,7 +27,7 @@
 
 - type: entity
   id: WeaponMechMelleDrillDiamond
-  parent: BaseMechWeaponMelee
+  parent: [ BaseMechWeaponMelee, BaseCargoContraband ]
   name: diamond-tipped exosuit drill
   suffix: Mech Weapon, Melee, Industrial
   description: Equipment for mining exosuits. This is an upgraded version of the drill that'll pierce the rocks!

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -4,7 +4,6 @@
   name: exosuit drill
   suffix: Mech Weapon, Melee, Industrial
   description: Equipment for mining exosuits. This is the drill that'll pierce the rocks!
-  
   components:
   - type: Sprite
     state: mecha_drill

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
@@ -65,7 +65,7 @@
 
 - type: entity
   id: MechEquipmentGrabber
-  parent: [ BaseMechEquipment, IndustrialMechEquipment ]
+  parent: [ BaseMechEquipment, IndustrialMechEquipment, BaseCargoContraband ]
   name: hydraulic clamp
   description: Gives the mech the ability to grab things and drag them around.
   components:
@@ -80,7 +80,7 @@
 
 - type: entity
   id: MechEquipmentGrabberSmall
-  parent: BaseMechEquipment
+  parent: [ BaseMechEquipment, BaseCargoContraband ]
   name: small hydraulic clamp
   description: Gives the mech the ability to grab things and drag them around.
   components:
@@ -102,7 +102,7 @@
 
 - type: entity
   id: MechEquipmentHorn
-  parent: [ BaseMechEquipment, SpecialMechEquipment ]
+  parent: [ BaseMechEquipment, SpecialMechEquipment, BaseCivilianContraband ]
   name: mech horn
   description: An enhanced bike horn that plays a hilarious array of sounds for the enjoyment of the crew. HONK!
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -590,7 +590,6 @@
 # Gygax
 - type: entity
   id: MechGygax
-  
   parent: [ BaseMech, CombatMech, BaseSecurityContraband ]
   name: Gygax
   description: While lightly armored, the Gygax has incredible mobility thanks to its ability that lets it smash through walls at high speeds.

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -590,7 +590,8 @@
 # Gygax
 - type: entity
   id: MechGygax
-  parent: [ BaseMech, CombatMech, BaseRestrictedContraband ]
+  
+  parent: [ BaseMech, CombatMech, BaseSecurityContraband ]
   name: Gygax
   description: While lightly armored, the Gygax has incredible mobility thanks to its ability that lets it smash through walls at high speeds.
   components:
@@ -646,7 +647,7 @@
 # Durand
 - type: entity
   id: MechDurand
-  parent: [ BaseMech, CombatMech, BaseRestrictedContraband ]
+  parent: [ BaseMech, CombatMech, BaseSecurityContraband ]
   name: Durand
   description: A slow but beefy combat exosuit that is extra scary in confined spaces due to its punches. Xenos hate it!
   components:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds contrband label to mechs and weapons

## Why we need to add this
Allows for basic crew to understand and know the contraband levels of each mech and their weapon. allows for sec to fully be aware of what mechs are specifically contraband for them
## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/0a046c5c-9ed1-415f-b62d-9af23289b1c0)
![image](https://github.com/user-attachments/assets/94419f20-681c-4969-a77c-23689bf91c03)

## Checks


- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: Floating Lotus
- fix: Mech's and Mech weapons now show their respective contraband level when inspected
