### PR TITLE
Nanotrasen-Central Command Consortium Officer

### DIFF
--- a/Resources/Locale/en-US/_Starlight/ghost/ghost-gui.ftl
+++ b/Resources/Locale/en-US/_Starlight/ghost/ghost-gui.ftl
@@ -9,3 +9,6 @@ ghost-gui-choose-theme = Choose Theme
 ghost-role-terror-spider-name = Terror spider
 ghost-role-terror-spider-description = The task of the Terror Spider is to destroy the station and everything alive on it.
 ghost-role-terror-spider-rules = You are a [color=red][bold]Team Antagonist[/bold][/color] with all other terror spiders.
+
+ghost-role-information-ntcc-consortium-officer-name = NT-CC Consortium Blueshield Officer
+ghost-role-information-ntcc-consortium-officer-description = You are charged directly from the Nanotrasen-Central Command Corporate Consortium to protect and serve the Central Command officials at all costs, nothing else subverts that.

--- a/Resources/Locale/en-US/_Starlight/job/job-desc.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job-desc.ftl
@@ -6,3 +6,4 @@ job-description-blueshield = Your primary job is to protect the heads. Remember,
 job-description-miningspec = Stay station side and enrich the station with materials using your salvage magnet and ore processors
 job-description-mailtech = Deliver letters and packages to the crew of the station to make cargo money.
 job-description-surgeon = Heal people, cripple enemies, and replace limbs and organs!
+job-description-ntccblueshield = Your primary job is to protect your charged Nanotrasen-Central Command Consortium officials, this overrules anything else.

--- a/Resources/Locale/en-US/_Starlight/job/job.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job.ftl
@@ -2,6 +2,7 @@ job-name-magistrate = Magistrate
 job-name-ntrep = NanoTrasen Representative
 job-name-iaa = Internal Affairs Agent
 job-name-blueshield = Officer “Blue Shield”
+job-name-ntccblueshield = NT-CC Consortium Officer
 job-name-miningspec = Mining Specialist
 job-name-surgeon = Surgeon
 job-name-mailtech = Mail Technician

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -49,6 +49,7 @@
   - ERTSecurity
   - ERTEngineer
   - DeathSquad
+  - NTCCBlueshield ## Starlight Addition
   editorHidden: true
   weight: 120
 

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
@@ -32,6 +32,13 @@
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: default
+      job: NTCCBlueshield
+      requirements:
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # 20h
+      - !type:RoleTimeRequirement
+        role: JobSecurityOfficer
+        time: 18000 # 5h
     - type: Loadout
       prototypes: [ NTCCBlueShieldGear ]
       roleLoadout: [ RoleSurvivalStandard ]

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
@@ -1,3 +1,12 @@
+- type: randomHumanoidSettings
+  id: EventHumanoidNTCC
+  parent: EventHumanoidMindShielded
+  components:
+  - type: AutoImplant
+    implants:
+    - DeathRattleImplantCentcomm
+    - RadioImplanterCentcomm
+
 - type: entity
   name: NTCC Consortium Blueshield
   id: RandomHumanoidNTCCConsortiumBlueshield
@@ -10,7 +19,7 @@
 
 - type: randomHumanoidSettings
   id: NTCCConsortiumBlueshield
-  parent: EventHumanoidMindShielded
+  parent: EventHumanoidNTCC
   components:
     - type: GhostRole
       name: ghost-role-information-centcom-official-name
@@ -21,3 +30,8 @@
     - type: Loadout
       prototypes: [ NTCCBlueShieldGear ]
       roleLoadout: [ RoleSurvivalStandard ]
+    - type: RandomMetadata
+      nameSegments:
+        - NamesMilitaryFirstLeader
+        - NamesMilitaryLast
+      nameFormat: name-format-ert

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
@@ -1,0 +1,23 @@
+- type: entity
+  name: NTCC Consortium Blueshield
+  id: RandomHumanoidNTCCConsortiumBlueshield
+  components:
+    - type: Sprite
+      sprite: _Starlight/Markers/jobs.rsi
+      state: obs
+    - type: RandomHumanoidSpawner
+      settings: NTCCConsortiumBlueshield
+
+- type: randomHumanoidSettings
+  id: NTCCConsortiumBlueshield
+  parent: EventHumanoidMindShielded
+  components:
+    - type: GhostRole
+      name: ghost-role-information-centcom-official-name
+      description: ghost-role-information-centcom-official-description
+      rules: ghost-role-information-nonantagonist-rules
+      raffle:
+        settings: default
+    - type: Loadout
+      prototypes: [ NTCCBlueShieldGear ]
+      roleLoadout: [ RoleSurvivalStandard ]

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
@@ -7,7 +7,7 @@
   - type: AutoImplant
     implants:
     - DeathRattleImplantCentcomm
-    - RadioImplanterCentcomm
+    - RadioImplantCentcomm
 
 ## NTCC Blueshield
 

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
@@ -1,3 +1,5 @@
+## NTCC Default Settings
+
 - type: randomHumanoidSettings
   id: EventHumanoidNTCC
   parent: EventHumanoidMindShielded
@@ -7,9 +9,11 @@
     - DeathRattleImplantCentcomm
     - RadioImplanterCentcomm
 
+## NTCC Blueshield
+
 - type: entity
-  name: NTCC Consortium Blueshield
-  id: RandomHumanoidNTCCConsortiumBlueshield
+  name: NT-CC Consortium Blueshield
+  id: RandomHumanoidNTCCConsortiumBlueshieldSpawner
   components:
     - type: Sprite
       sprite: _Starlight/Markers/jobs.rsi
@@ -20,6 +24,7 @@
 - type: randomHumanoidSettings
   id: NTCCConsortiumBlueshield
   parent: EventHumanoidNTCC
+  randomizeName: false
   components:
     - type: GhostRole
       name: ghost-role-information-centcom-official-name

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
@@ -27,8 +27,8 @@
   randomizeName: false
   components:
     - type: GhostRole
-      name: ghost-role-information-centcom-official-name
-      description: ghost-role-information-centcom-official-description
+      name: ghost-role-information-ntcc-consortium-officer-name
+      description: ghost-role-information-ntcc-consortium-officer-description
       rules: ghost-role-information-nonantagonist-rules
       raffle:
         settings: default

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/pda.yml
@@ -171,3 +171,32 @@
   - type: Icon
     sprite: _Starlight/Objects/Devices/pda.rsi
     state: pda-mailtech
+
+- type: entity
+  parent: BasePDA
+  id: NTCCBlueShieldPDA
+  name: consortium officer's PDA
+  components:
+  - type: Sprite
+    sprite: _Starlight/Objects/Devices/pda.rsi
+  - type: Pda
+    id: NTCCBlueShieldIDCard
+  - type: Appearance
+    appearanceDataInit:
+     enum.PdaVisuals.PdaType:
+       !type:String
+       pda-blueshield
+  - type: Icon
+    sprite: _Starlight/Objects/Devices/pda.rsi
+    state: pda-blueshield
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NanoTaskCartridge
+      - NewsReaderCartridge
+      - MedTekCartridge
+      - WantedListCartridge
+      - LogProbeCartridge
+      - AstroNavCartridge

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/identification_cards.yml
@@ -87,6 +87,19 @@
 
 - type: entity
   parent: IDCardStandard
+  id: NTCCBlueShieldIDCard
+  name: CC-NT consortium officer's ID card
+  components:
+  - type: Sprite
+    sprite: _Starlight/Objects/Misc/id_cards.rsi
+    layers:
+    - state: gold
+    - state: idblueshield
+  - type: PresetIdCard
+    job: BlueShield
+
+- type: entity
+  parent: IDCardStandard
   id: MiningIDCard
   name: mining ID card
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/identification_cards.yml
@@ -88,7 +88,7 @@
 - type: entity
   parent: IDCardStandard
   id: NTCCBlueShieldIDCard
-  name: CC-NT consortium officer's ID card
+  name: NT-CC consortium officer's ID card
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Misc/id_cards.rsi

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/identification_cards.yml
@@ -96,7 +96,7 @@
     - state: gold
     - state: idblueshield
   - type: PresetIdCard
-    job: BlueShield
+    job: ntccblueshield
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/identification_cards.yml
@@ -96,7 +96,7 @@
     - state: gold
     - state: idblueshield
   - type: PresetIdCard
-    job: ntccblueshield
+    job: NTCCBlueshield
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
@@ -14,7 +14,7 @@
   - CentralCommand
   special:
     - !type:AddImplantSpecial
-      implants: [ MindShieldImplant, DeathRattleImplantCentcomm, RadioImplanterCentcomm ]
+      implants: [ MindShieldImplant, DeathRattleImplantCentcomm, RadioImplantCentcomm ]
 
 - type: startingGear
   id: NTCCBlueShieldGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
@@ -2,7 +2,7 @@
   id: NTCCBlueshield
   name: job-name-ntccblueshield
   description: job-description-ntccblueshield
-  playTimeTracker: JobCentralCommandOperator
+  playTimeTracker: ConsortiumBlueShield
   setPreference: false
   startingGear: NTCCBlueShieldGear
   icon: JobIconBlueShield

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
@@ -23,7 +23,7 @@
     head: ClothingHeadHatBeretBlueShield
     outerClothing: ClothingOuterArmorBlueShield
     id: NTCCBlueShieldPDA
-    eyes: BlueShieldGlasses
+    eyes: ClothingEyesGlassesBlueShield
     ears: ClothingHeadsetAltCommand
     belt: ClothingBeltBlueShieldWebbingFilled
     gloves: ClothingHandsGlovesCombat

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
@@ -1,0 +1,34 @@
+- type: job
+  id: NTCCBlueshield
+  name: job-name-ntccblueshield
+  description: job-description-ntccblueshield
+  playTimeTracker: JobCentralCommandOperator
+  setPreference: false
+  startingGear: NTCCBlueShieldGear
+  icon: JobIconBlueShield
+  supervisors: job-supervisors-centcom
+  canBeAntag: false
+  accessGroups:
+  - AllAccess
+  access:
+  - CentralCommand
+  special:
+    - !type:AddImplantSpecial
+      implants: [ MindShieldImplant, DeathRattleImplantCentcomm, RadioImplanterCentcomm ]
+
+- type: startingGear
+  id: NTCCBlueShieldGear
+  equipment:
+    shoes: ClothingShoesBootsCombatFilled
+    head: ClothingHeadHatBeretBlueShield
+    outerClothing: ClothingOuterArmorBlueShield
+    id: NTCCBlueShieldPDA
+    ears: ClothingHeadsetAltCommand
+    belt: ClothingBeltBlueShieldWebbingFilled
+    gloves: ClothingHandsGlovesCombat
+    pocket1: WeaponMultiphaseGun
+    pocket2: WeaponPistolN1984
+  storage:
+    back:
+    - Flash
+    - ClothingMaskGasBSO

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
@@ -19,6 +19,7 @@
 - type: startingGear
   id: NTCCBlueShieldGear
   equipment:
+    jumpsuit: ClothingUniformJumpsuitFormalBlueShield
     shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatBeretBlueShield
     outerClothing: ClothingOuterArmorBlueShield

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
@@ -2,7 +2,7 @@
   id: NTCCBlueshield
   name: job-name-ntccblueshield
   description: job-description-ntccblueshield
-  playTimeTracker: ConsortiumBlueShield
+  playTimeTracker: JobConsortiumBlueShield
   setPreference: false
   startingGear: NTCCBlueShieldGear
   icon: JobIconBlueShield

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
@@ -23,6 +23,7 @@
     head: ClothingHeadHatBeretBlueShield
     outerClothing: ClothingOuterArmorBlueShield
     id: NTCCBlueShieldPDA
+    eyes: BlueShieldGlasses
     ears: ClothingHeadsetAltCommand
     belt: ClothingBeltBlueShieldWebbingFilled
     gloves: ClothingHandsGlovesCombat

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntccblueshield.yml
@@ -20,6 +20,7 @@
   id: NTCCBlueShieldGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitFormalBlueShield
+    back: ClothingBackpackERTLeader
     shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatBeretBlueShield
     outerClothing: ClothingOuterArmorBlueShield

--- a/Resources/Prototypes/_StarLight/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/_StarLight/Roles/play_time_trackers.yml
@@ -20,7 +20,7 @@
   id: JobBlueShield
 
 - type: playTimeTracker
-  id: ConsortiumBlueShield
+  id: JobConsortiumBlueShield
 
 - type: playTimeTracker
   id: JobMiningSpecialist

--- a/Resources/Prototypes/_StarLight/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/_StarLight/Roles/play_time_trackers.yml
@@ -20,6 +20,9 @@
   id: JobBlueShield
 
 - type: playTimeTracker
+  id: ConsortiumBlueShield
+
+- type: playTimeTracker
   id: JobMiningSpecialist
 
 - type: playTimeTracker


### PR DESCRIPTION
## Short description
This adds an entity spawner, and new ghostrole job for any official NT-CC business that requires posted guards or officers to attend with any NT-CC officials.

## Why we need to add this
In-Lore and Procedures stipulate that NT-CC officials are to be guarded by a specific branch of the Blueshield Officer Corps, this addresses that and should set the framework for less reliance on ERT ghostroles as guards when it does not make any sense.

## Media (Video/Screenshots)
<!--
https://github.com/user-attachments/assets/a4f97496-e025-422d-8ed8-6d6dd267594f
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: InanimateIJK
- add: The Nanotrasen-Central Command Corporate Consortium officially forms a separate Blueshield Officers corps branch, dedicated to more direct Consortium affairs and protection.
