### PR TITLE
Added MK58 and SP Ammo to Sec Officer and Brigmedic loadouts

### DIFF
--- a/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
@@ -17,3 +17,6 @@ loadout-group-blueshield-eyewear = Blueshield eyewear
 # Security
 
 loadout-group-brigmedic-gloves = Brigmedic gloves
+loadout-group-security-non-lethal-weapon = Security Non-Lethal Weapon
+loadout-group-security-sidearm = Security Sidearm
+

--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -163,8 +163,6 @@ loadout-group-security-shoes = Security shoes
 loadout-group-security-id = Security ID
 loadout-group-security-weapon = Security Weapon
 loadout-group-security-eyewear = Security eyewear
-loadout-group-security-non-lethal-weapon = Security Non-Lethal Weapon
-loadout-group-security-sidearm = Security Sidearm
 
 loadout-group-brigmedic-head = Brigmedic head
 loadout-group-brigmedic-jumpsuit = Brigmedic jumpsuit

--- a/Resources/Locale/en-US/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/preferences/loadout-groups.ftl
@@ -163,6 +163,8 @@ loadout-group-security-shoes = Security shoes
 loadout-group-security-id = Security ID
 loadout-group-security-weapon = Security Weapon
 loadout-group-security-eyewear = Security eyewear
+loadout-group-security-non-lethal-weapon = Security Non-Lethal Weapon
+loadout-group-security-sidearm = Security Sidearm
 
 loadout-group-brigmedic-head = Brigmedic head
 loadout-group-brigmedic-jumpsuit = Brigmedic jumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -200,16 +200,6 @@
     - Dinkystar
 
 - type: loadout
-  id: SecurityDominator
-  equipment:
-    pocket1: WeaponDominator
-    
-- type: loadout
-  id: SecurityTaser
-  equipment:
-    pocket1: WeaponAdvancedTaser
-
-- type: loadout
   id: SecurityGlasses
   equipment:
     eyes: ClothingEyesGlassesSecurity
@@ -219,9 +209,35 @@
   equipment:
     eyes: ClothingEyesHudSecurity
 
-# Side-Arm Options
+# Starlight
+# Non-Lethal Weapons
+- type: loadout
+  id: SecurityDominator
+  equipment:
+    pocket1: WeaponDominator
+
+- type: loadout
+  id: SecurityTaser
+  equipment:
+    pocket1: WeaponAdvancedTaser
+
+# Sidearm Options
 - type: loadout
   id: SecurityMk58
+  dummyEntity: WeaponPistolMk58
   storage:
     back:
     - WeaponPistolMk58
+    - MagazinePistolSP
+      
+- type: loadout
+  id: SecurityPistolDP
+  effects:
+    - !type:GroupLoadoutEffect
+      proto: SeniorOfficer
+  dummyEntity: WeaponPistolDP
+  storage:
+    back:
+      - WeaponPistolDP
+      - MagazinePistol40SP
+#Starlight

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -208,36 +208,3 @@
   id: SecurityHud
   equipment:
     eyes: ClothingEyesHudSecurity
-
-# Starlight
-# Non-Lethal Weapons
-- type: loadout
-  id: SecurityDominator
-  equipment:
-    pocket1: WeaponDominator
-
-- type: loadout
-  id: SecurityTaser
-  equipment:
-    pocket1: WeaponAdvancedTaser
-
-# Sidearm Options
-- type: loadout
-  id: SecurityMk58
-  dummyEntity: WeaponPistolMk58
-  storage:
-    back:
-    - WeaponPistolMk58
-    - MagazinePistolSP
-      
-- type: loadout
-  id: SecurityPistolDP
-  effects:
-    - !type:GroupLoadoutEffect
-      proto: SeniorOfficer
-  dummyEntity: WeaponPistolDP
-  storage:
-    back:
-      - WeaponPistolDP
-      - MagazinePistol40SP
-#Starlight

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -218,3 +218,10 @@
   id: SecurityHud
   equipment:
     eyes: ClothingEyesHudSecurity
+
+# Side-Arm Options
+- type: loadout
+  id: SecurityMk58
+  storage:
+    back:
+    - WeaponPistolMk58

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -954,19 +954,6 @@
 
 # Security
 - type: loadoutGroup
-  id: SecurityNonLethalWeapon
-  name: loadout-group-security-non-lethal-weapon
-  loadouts:
-  - SecurityTaser
-  - SecurityDominator
-    
-- type: loadoutGroup
-  id: SecuritySidearm
-  name: loadout-group-security-sidearm
-  loadouts:
-    - SecurityMk58
-
-- type: loadoutGroup
   id: HeadofSecurityHead
   name: loadout-group-head-of-security-head
   minLimit: 0

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -954,11 +954,17 @@
 
 # Security
 - type: loadoutGroup
-  id: SecurityWeapon
-  name: loadout-group-security-weapon
+  id: SecurityNonLethalWeapon
+  name: loadout-group-security-non-lethal-weapon
   loadouts:
   - SecurityTaser
   - SecurityDominator
+    
+- type: loadoutGroup
+  id: SecuritySidearm
+  name: loadout-group-security-sidearm
+  loadouts:
+    - SecurityMk58
 
 - type: loadoutGroup
   id: HeadofSecurityHead

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -380,26 +380,8 @@
   - SecurityShoes
   - SecurityPDA
   - SecurityBelt
-  - SecurityNonLethalWeapon
-  - SecuritySidearm
-  - SurvivalSecurity
-  - Trinkets
-  - SecurityStar
-  - GroupSpeciesBreathToolSecurity
-
-- type: roleLoadout
-  id: JobBrigmedic
-  groups:
-  - BrigmedicHead
-  - BrigmedicJumpsuit
-  - BrigmedicBackpack
-  - BrigmedicOuterClothing
-  - BrigmedicBelt
-  - BrigmedicGloves
-  - BrigmedicEyewear
-  - SecurityShoes
-  - SecurityNonLethalWeapon
-  - SecuritySidearm
+  - SecurityNonLethalWeapon #Starlight
+  - SecuritySidearm # Starlight
   - SurvivalSecurity
   - Trinkets
   - SecurityStar

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -345,7 +345,7 @@
   - HeadofSecurityJumpsuit
   - SecurityBackpack
   - SecurityBelt
-  - SecurityNonLethalWeapon
+  - SecurityNonLethalWeapon #Starlight
   - HeadofSecurityOuterClothing
   - SecurityEyewear
   - SecurityShoes
@@ -380,8 +380,8 @@
   - SecurityShoes
   - SecurityPDA
   - SecurityBelt
-  - SecurityNonLethalWeapon #Starlight
-  - SecuritySidearm # Starlight
+  - SecurityNonLethalWeapon
+  - SecuritySidearm
   - SurvivalSecurity
   - Trinkets
   - SecurityStar

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -380,8 +380,8 @@
   - SecurityShoes
   - SecurityPDA
   - SecurityBelt
-  - SecurityNonLethalWeapon
-  - SecuritySidearm
+  - SecurityNonLethalWeapon #Starlight
+  - SecuritySidearm #Starlight
   - SurvivalSecurity
   - Trinkets
   - SecurityStar

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -345,7 +345,7 @@
   - HeadofSecurityJumpsuit
   - SecurityBackpack
   - SecurityBelt
-  - SecurityWeapon
+  - SecurityNonLethalWeapon
   - HeadofSecurityOuterClothing
   - SecurityEyewear
   - SecurityShoes
@@ -380,7 +380,8 @@
   - SecurityShoes
   - SecurityPDA
   - SecurityBelt
-  - SecurityWeapon
+  - SecurityNonLethalWeapon
+  - SecuritySidearm
   - SurvivalSecurity
   - Trinkets
   - SecurityStar
@@ -397,7 +398,8 @@
   - BrigmedicGloves
   - BrigmedicEyewear
   - SecurityShoes
-  - SecurityWeapon
+  - SecurityNonLethalWeapon
+  - SecuritySidearm
   - SurvivalSecurity
   - Trinkets
   - SecurityStar
@@ -423,7 +425,7 @@
   groups:
   - SecurityCadetJumpsuit
   - SecurityBackpack
-  - SecurityWeapon
+  - SecurityNonLethalWeapon
   - SecurityEyewear
   - SurvivalSecurity
   - Trinkets

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -29,4 +29,3 @@
   storage:
     back:
     - Flash
-    - MagazinePistolSP

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -29,3 +29,5 @@
   storage:
     back:
     - Flash
+    - WeaponPistolMk58
+    - MagazinePistolSP

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -29,5 +29,4 @@
   storage:
     back:
     - Flash
-    - WeaponPistolMk58
     - MagazinePistolSP

--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/security_officer.yml
@@ -1,0 +1,31 @@
+﻿
+# Non-Lethal Weapons
+- type: loadout
+  id: SecurityDominator
+  equipment:
+    pocket1: WeaponDominator
+
+- type: loadout
+  id: SecurityTaser
+  equipment:
+    pocket1: WeaponAdvancedTaser
+
+# Sidearm Options
+- type: loadout
+  id: SecurityMk58
+  dummyEntity: WeaponPistolMk58
+  storage:
+    back:
+      - WeaponPistolMk58
+      - MagazinePistolSP
+
+- type: loadout
+  id: SecurityPistolDP
+  effects:
+    - !type:GroupLoadoutEffect
+      proto: SeniorOfficer
+  dummyEntity: WeaponPistolDP
+  storage:
+    back:
+      - WeaponPistolDP
+      - MagazinePistol40SP

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -67,3 +67,18 @@
   loadouts:
   - BlueShieldGlasses
   - BlueShieldHud
+    
+- type: loadoutGroup
+  id: SecurityNonLethalWeapon
+  name: loadout-group-security-non-lethal-weapon
+  loadouts:
+  - SecurityTaser
+  - SecurityDominator
+
+- type: loadoutGroup
+  id: SecuritySidearm
+  name: loadout-group-security-sidearm
+  loadouts:
+  - SecurityMk58
+  - SecurityPistolDP
+

--- a/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
@@ -80,3 +80,21 @@
   - Survival
   - Trinkets
   - GroupSpeciesBreathTool
+
+- type: roleLoadout
+  id: JobBrigmedic
+  groups:
+    - BrigmedicHead
+    - BrigmedicJumpsuit
+    - BrigmedicBackpack
+    - BrigmedicOuterClothing
+    - BrigmedicBelt
+    - BrigmedicGloves
+    - BrigmedicEyewear
+    - SecurityShoes
+    - SecurityNonLethalWeapon
+    - SecuritySidearm
+    - SurvivalSecurity
+    - Trinkets
+    - SecurityStar
+    - GroupSpeciesBreathToolSecurity

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
@@ -40,4 +40,3 @@
     - Flash
     - SecurityMedkit
     - DefibrillatorBrigmedical
-    - MagazinePistolSP

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
@@ -40,3 +40,5 @@
     - Flash
     - SecurityMedkit
     - DefibrillatorBrigmedical
+    - WeaponPistolMk58
+    - MagazinePistolSP

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
@@ -40,5 +40,4 @@
     - Flash
     - SecurityMedkit
     - DefibrillatorBrigmedical
-    - WeaponPistolMk58
     - MagazinePistolSP


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

Returned Security Officer and Brigmed sidearms
## Why we need to add this

SEC starts with side-arms on most other servers. Our SOP allows them to carry side-arms, but most armory's don't have enough. The station regularly goes on red alert so SEC can arm just to deal with vent critters or Lings.
## Media (Video/Screenshots)


## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: KarmaKitsuna
- add: Sidearm loadout for Security Officer and Brigmedic.  Mk58 is the default but senior officers have the option of picking the Due Process. Both loadouts come with one magazine of SP ammo.

