### PR TITLE
syndicate PAI changes and added to thief toolkit

### DIFF
--- a/Resources/Locale/en-US/_Starlight/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/ghost/roles/ghost-role-component.ftl
@@ -1,0 +1,5 @@
+ghost-role-information-syndicate-pai-rules =    You shall [color=red]NOT[/color] reveal the communications of any nuclear operatives to non nuclear operatives. otherwise...
+                                                You are a [color={role-type-familiar-color}][bold]{role-type-familiar-name}[/bold][/color]. Serve the interests of your master, whatever those may be.
+                                                You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+                                                You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
+                                                You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.

--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -58,6 +58,7 @@
   - Lighter
   - CigPackSyndicate
   - Telecrystal10 #The thief cannot use them, but it may induce communication with traitors
+  - SyndicatePersonalAI # [Starlight] allows the thief to be able to communicate indirectly with traitors, without accidentally spoiling nukies.
 
 - type: thiefBackpackSet
   id: SleeperSet

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -94,7 +94,7 @@
   - type: ToggleableGhostRole
     roleName: pai-system-role-name-syndicate
     roleDescription: pai-system-role-description-syndicate
-    roleRules: ghost-role-information-familiar-rules
+    roleRules: ghost-role-information-syndicate-pai-rules
     mindRoles:
     - MindRoleGhostRoleFamiliar
   - type: IntrinsicRadioTransmitter


### PR DESCRIPTION
## Short description
gives the syndicate pAI new rules that they shall not reveal nuclear operative communications. and gives the syndicate pai to the syndicate kit to facilitate communication with traitors.

## Why we need to add this
makes connecting and planning with traitors also may increase the chance of traitors buying comms keys as it increses the chance of linking up not only with other traitors but with thieves and their free 10 tc.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/f98742c1-97a9-444f-8798-b37910276b07)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: Syndicate pAI in the syndicate thieving kit
- tweak: Syndicate pAI is not allowed to share nuclear operative communications with non nuclear operatives.
