### PR TITLE
Surgery no longer makes numb individuals scream

### DIFF
--- a/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
@@ -132,8 +132,14 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
     }
 
     private void OnStepEmoteEffectComplete(Entity<SurgeryStepEmoteEffectComponent> ent, ref SurgeryStepEvent args)
-        => _chat.TryEmoteWithChat(args.Body, ent.Comp.Emote);
+    {
         
+        if (!HasComp(args.Body, typeof(PainNumbnessComponent)))
+        {
+             _chat.TryEmoteWithChat(args.Body, ent.Comp.Emote);
+        }
+    }
+
     private void OnStepSpawnComplete(Entity<SurgeryStepSpawnEffectComponent> ent, ref SurgeryStepEvent args)
     {
         if (TryComp(args.Body, out TransformComponent? xform))

--- a/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
@@ -134,7 +134,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
     private void OnStepEmoteEffectComplete(Entity<SurgeryStepEmoteEffectComponent> ent, ref SurgeryStepEvent args)
     {
         
-        if (!HasComp(args.Body, typeof(PainNumbnessComponent)))
+        if (!HasComp<PainNumbnessComponent>(args.Body))
         {
              _chat.TryEmoteWithChat(args.Body, ent.Comp.Emote);
         }

--- a/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
@@ -9,10 +9,11 @@ using Content.Shared.Body.Part;
 using Content.Shared.Body.Systems;
 using Content.Shared.Damage;
 using Content.Shared.Humanoid;
+using Content.Shared.Traits.Assorted;
 using Microsoft.CodeAnalysis;
 using Content.Server._Starlight.Medical.Limbs;
 using Content.Server.Administration.Systems;
-using Content.Shared.Traits.Assorted;
+
 
 namespace Content.Server.Starlight.Medical.Surgery;
 // Based on the RMC14.

--- a/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
@@ -12,6 +12,7 @@ using Content.Shared.Humanoid;
 using Microsoft.CodeAnalysis;
 using Content.Server._Starlight.Medical.Limbs;
 using Content.Server.Administration.Systems;
+using Content.Shared.Traits.Assorted;
 
 namespace Content.Server.Starlight.Medical.Surgery;
 // Based on the RMC14.


### PR DESCRIPTION
## Short description
Makes it so you no longer scream when you take the numb trait and undergo surgery

## Why we need to add this
Gives Numb another affect to the game

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: Floating Spore
- tweak: Numb people no longer scream when in surgery
-->

:cl: Floating Spore
- tweak: Numb people no longer scream when in surgery