### PR TITLE
fix vulp tails and glowing

### DIFF
--- a/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
@@ -123,6 +123,8 @@ public sealed partial class HumanoidAppearanceSystem : SharedHumanoidAppearanceS
             marking.SetColor(i, markings[index].MarkingColors[i]);
         }
 
+        marking.IsGlowing = markings[index].IsGlowing; //starlight
+
         humanoid.MarkingSet.Replace(category, index, marking);
         Dirty(uid, humanoid);
     }

--- a/Content.Server/Wagging/WaggingSystem.cs
+++ b/Content.Server/Wagging/WaggingSystem.cs
@@ -67,34 +67,37 @@ public sealed class WaggingSystem : EntitySystem
 
         for (var idx = 0; idx < markings.Count; idx++) // Animate all possible tails
         {
-            var currentMarkingId = markings[idx].MarkingId;
-            string newMarkingId;
+            foreach (var possibleSuffix in wagging.Suffixes)
+            {
+                var currentMarkingId = markings[idx].MarkingId;
+                string newMarkingId;
 
-            if (wagging.Wagging)
-            {
-                newMarkingId = $"{currentMarkingId}{wagging.Suffix}";
-            }
-            else
-            {
-                if (currentMarkingId.EndsWith(wagging.Suffix))
+                if (wagging.Wagging)
                 {
-                    newMarkingId = currentMarkingId[..^wagging.Suffix.Length];
+                    newMarkingId = $"{currentMarkingId}{possibleSuffix}";
                 }
                 else
                 {
-                    newMarkingId = currentMarkingId;
-                    Log.Warning($"Unable to revert wagging for {currentMarkingId}");
+                    if (currentMarkingId.EndsWith(possibleSuffix))
+                    {
+                        newMarkingId = currentMarkingId[..^possibleSuffix.Length];
+                    }
+                    else
+                    {
+                        newMarkingId = currentMarkingId;
+                        Log.Warning($"Unable to revert wagging for {currentMarkingId}");
+                    }
                 }
-            }
 
-            if (!_prototype.HasIndex<MarkingPrototype>(newMarkingId))
-            {
-                Log.Warning($"{ToPrettyString(uid)} tried toggling wagging but {newMarkingId} marking doesn't exist");
-                continue;
-            }
+                if (!_prototype.HasIndex<MarkingPrototype>(newMarkingId))
+                {
+                    Log.Warning($"{ToPrettyString(uid)} tried toggling wagging but {newMarkingId} marking doesn't exist");
+                    continue;
+                }
 
-            _humanoidAppearance.SetMarkingId(uid, MarkingCategories.Tail, idx, newMarkingId,
-                humanoid: humanoid);
+                _humanoidAppearance.SetMarkingId(uid, MarkingCategories.Tail, idx, newMarkingId,
+                    humanoid: humanoid);
+            }
         }
 
         return true;

--- a/Content.Server/Wagging/WaggingSystem.cs
+++ b/Content.Server/Wagging/WaggingSystem.cs
@@ -67,6 +67,7 @@ public sealed class WaggingSystem : EntitySystem
 
         for (var idx = 0; idx < markings.Count; idx++) // Animate all possible tails
         {
+            //starlight for loop
             foreach (var possibleSuffix in wagging.Suffixes)
             {
                 var currentMarkingId = markings[idx].MarkingId;
@@ -74,13 +75,13 @@ public sealed class WaggingSystem : EntitySystem
 
                 if (wagging.Wagging)
                 {
-                    newMarkingId = $"{currentMarkingId}{possibleSuffix}";
+                    newMarkingId = $"{currentMarkingId}{possibleSuffix}"; //starlight edit
                 }
                 else
                 {
-                    if (currentMarkingId.EndsWith(possibleSuffix))
+                    if (currentMarkingId.EndsWith(possibleSuffix)) //starlight edit
                     {
-                        newMarkingId = currentMarkingId[..^possibleSuffix.Length];
+                        newMarkingId = currentMarkingId[..^possibleSuffix.Length]; //starlight edit
                     }
                     else
                     {

--- a/Content.Shared/Wagging/WaggingComponent.cs
+++ b/Content.Shared/Wagging/WaggingComponent.cs
@@ -20,7 +20,8 @@ public sealed partial class WaggingComponent : Component
     /// <summary>
     /// Suffix to add to get the animated marking.
     /// </summary>
-    public string Suffix = "Animated";
+    public string[] Suffixes = ["Wag", "Animated"];
+    //public string Suffix = "Animated";
 
     /// <summary>
     /// Is the entity currently wagging.

--- a/Content.Shared/Wagging/WaggingComponent.cs
+++ b/Content.Shared/Wagging/WaggingComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class WaggingComponent : Component
     /// <summary>
     /// Suffix to add to get the animated marking.
     /// </summary>
-    public string[] Suffixes = ["Wag", "Animated"];
+    public string[] Suffixes = ["Wag", "Animated"]; //starlight
     //public string Suffix = "Animated";
 
     /// <summary>


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes vulp tails not properly switching to their wagging variants

This also fixes a issue with the wagging system, where it wouldn't transfer the glowing information of the marking, making it lose glowing when you toggled it

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
its broken, and only like one vulp tail can wag right now

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed Vulp tails not toggling between wagging and not wagging properly.
- fix: Fixed tails that can be toggled for wagging losing their glowing state when doing so.