### PR TITLE
Added ERT-request to Document printer

### DIFF
--- a/Resources/Locale/en-US/_Starlight/paper/doc-printer.ftl
+++ b/Resources/Locale/en-US/_Starlight/paper/doc-printer.ftl
@@ -710,8 +710,36 @@ doc-text-printer-request-modernization =
 
 
 
+doc-text-printer-request-ert =
+   ⠀[logo]            [cclogo] 
+
+                             [head=3]NT-CC Consortium Services[/head]
+
+                  [center][color=#1f75bb][italic][bold]   OFFICIAL CENTCOMM DOCUMENTATION[/bold][/italic][/color][/center]
+    ────────────────────────────────────────
+   ⠀⠀           [bold]EMERGENCY RESPONSE TEAM REQUEST[/bold]
+    ────────────────────────────────────────
+    Time and Date:
+    Compiler of the document:
+    Position of Document Compiler:
+
+    Threat(s) to the station:
+    ⠀[bullet] ...
+
+    Type of ERT requested:
+    (Security / Engineering / Janitorial / Medical / ...)
+
+    Fatalities (approximate number):
+
+   ⠀ [italic]Warning, abuse of this form may lead to immediate termination[/italic]
+   ⠀ [italic]of the contract of the person(s) involved in this request.[/italic]
+    ────────────────────────────────────────
+   ⠀                                    [italic]Place for stamps[/italic]
+
+
+
    
-# Complaintst
+# Complaints
 
 doc-text-printer-complaint-violation-labor-rules =
    ⠀[logo]            [cclogo] 

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/documents.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/documents.yml
@@ -267,6 +267,15 @@
     - type: Paper
       content: doc-text-printer-request-modernization
       
+- type: entity
+  parent: PrintedDocument
+  id: PrintedDocumentRequestERT
+  name: Request for ERT
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Paper
+      content: doc-text-printer-request-ert
+      
 # Complaintst
 
 - type: entity

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/docs.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/docs.yml
@@ -31,6 +31,7 @@
   - PrintedDocumentRequestEuthanasiaRecipe
   - PrintedDocumentRequestConstructionWorkRecipe
   - PrintedDocumentRequestModernizationRecipe
+  - PrintedDocumentRequestERTRecipe
   # Complaints
   - PrintedDocumentComplaintViolationLaborRulesRecipe
   - PrintedDocumentComplaintOffenseRecipe

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/printer.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/printer.yml
@@ -284,6 +284,16 @@
   materials:
     SheetPrinter: 100
     
+- type: latheRecipe
+  id: PrintedDocumentRequestERTRecipe
+  result: PrintedDocumentRequestERT
+  categories:
+  - InquiriesAndAppeals
+  completetime: 2
+  applyMaterialDiscount: false
+  materials:
+    SheetPrinter: 100
+    
 # Complaintst
 
 - type: latheRecipe


### PR DESCRIPTION
## Short description
New ERT-Request document in Document Printer.

## Why we need to add this
This way we have a standardised ERT request and not the colour book that is constantly used to request it.
It also includes some extra information and specification towards what kind of ERT.

## Media (Video/Screenshots)
- [ERT-request in printer](https://imgur.com/a/Evu7lXj)
- [ERT-request printed out](https://imgur.com/hIWKcm0)

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Quini98
- add: Added ERT-request document to Document Printer
