### PR TITLE
ripleymk2 construction fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mech_construction.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mech_construction.yml
@@ -597,10 +597,6 @@
   - type: Appearance
   - type: ItemMapper
     mapLayers:
-      ripleymkii_upgrade_kit+o:
-        whitelist:
-          tags:
-          - RipleyMKIIUpgradeKit
       ripleymkii_l_arm+o:
         whitelist:
           tags:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mech_construction.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mech_construction.yml
@@ -624,7 +624,6 @@
   - type: MechAssembly
     finishedPrototype: RipleyMKIIChassis
     requiredParts:
-      RipleyMKIIUpgradeKit: false
       RipleyLArm: false
       RipleyRArm: false
       RipleyLLeg: false


### PR DESCRIPTION
## Short description

Somehow the exosuit upgrade kit is a part of the construction requirements to make a ripley mk2... Idk how this never got noticed. Anyway, this removes that. (maybe hotfix?)

## Why we need to add this
the exosuit upgrade kit no longer serves this purpose, it's used for turning a mk1 ripley into a mk2.

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- fix: Fixed the ripley mk2 requiring the exosuit upgrade kit for SOME reason as part of its' construction.
