### PR TITLE
fix all custom maps having incorrect IDs in protos

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/amber.yml
+++ b/Resources/Prototypes/_StarLight/Maps/amber.yml
@@ -5,7 +5,7 @@
   minPlayers: 7
   maxPlayers: 50
   stations:
-    Amber:
+    StarlightAmber:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/bagel.yml
+++ b/Resources/Prototypes/_StarLight/Maps/bagel.yml
@@ -5,7 +5,7 @@
   minPlayers: 35
   maxPlayers: 70
   stations:
-    Bagel:
+    StarlightBagel:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/box.yml
+++ b/Resources/Prototypes/_StarLight/Maps/box.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/_Starlight/Stations/Box.yml
   minPlayers: 50
   stations:
-    Boxstation:
+    StarlightBox:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/cog.yml
+++ b/Resources/Prototypes/_StarLight/Maps/cog.yml
@@ -5,7 +5,7 @@
   minPlayers: 40
   maxPlayers: 100 #big map
   stations:
-    Cog:
+    StarlightCog:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/core.yml
+++ b/Resources/Prototypes/_StarLight/Maps/core.yml
@@ -5,7 +5,7 @@
   minPlayers: 35
   maxPlayers: 80
   stations:
-    Core:
+    StarlightCore:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/crescent.yml
+++ b/Resources/Prototypes/_StarLight/Maps/crescent.yml
@@ -5,7 +5,7 @@
   minPlayers: 40
   maxPlayers: 95
   stations:
-    Crescent:
+    StarlightCrescent:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/elkridge.yml
+++ b/Resources/Prototypes/_StarLight/Maps/elkridge.yml
@@ -5,7 +5,7 @@
   minPlayers: 15
   maxPlayers: 65
   stations:
-    Elkridge:
+    StarlightElkridge:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/fland.yml
+++ b/Resources/Prototypes/_StarLight/Maps/fland.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/_Starlight/Stations/Fland.yml
   minPlayers: 65
   stations:
-    Fland:
+    StarlightFland:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/hotel.yml
+++ b/Resources/Prototypes/_StarLight/Maps/hotel.yml
@@ -5,7 +5,7 @@
   minPlayers: 7
   maxPlayers: 55
   stations:
-    Hotel:
+    StarlightHotel:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/marathon.yml
+++ b/Resources/Prototypes/_StarLight/Maps/marathon.yml
@@ -5,7 +5,7 @@
   minPlayers: 35
   maxPlayers: 70
   stations:
-    Marathon:
+    StarlightMarathon:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/meta.yml
+++ b/Resources/Prototypes/_StarLight/Maps/meta.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/_Starlight/Stations/Meta.yml
   minPlayers: 50
   stations:
-    Meta:
+    StarlightMeta:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/oasis.yml
+++ b/Resources/Prototypes/_StarLight/Maps/oasis.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/_Starlight/Stations/Oasis.yml
   minPlayers: 65
   stations:
-    Oasis:
+    StarlightOasis:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/omega.yml
+++ b/Resources/Prototypes/_StarLight/Maps/omega.yml
@@ -5,7 +5,7 @@
   minPlayers: 0
   maxPlayers: 35
   stations:
-    Omega:
+    StarlightOmega:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/packed.yml
+++ b/Resources/Prototypes/_StarLight/Maps/packed.yml
@@ -5,7 +5,7 @@
   minPlayers: 0
   maxPlayers: 35
   stations:
-    Packed:
+    StarlightPacked:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/reach.yml
+++ b/Resources/Prototypes/_StarLight/Maps/reach.yml
@@ -5,7 +5,7 @@
   minPlayers: 0
   maxPlayers: 12
   stations:
-    Reach:
+    StarlightReach:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/retro.yml
+++ b/Resources/Prototypes/_StarLight/Maps/retro.yml
@@ -4,7 +4,7 @@
   mapPath: /Maps/_Starlight/Stations/Retro.yml
   minPlayers: 60
   stations:
-    Retro:
+    StarlightRetro:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup

--- a/Resources/Prototypes/_StarLight/Maps/saltern.yml
+++ b/Resources/Prototypes/_StarLight/Maps/saltern.yml
@@ -5,7 +5,7 @@
   minPlayers: 0
   maxPlayers: 35
   stations:
-    Saltern:
+    StarlightSaltern:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes the map loading for all of these stations

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Wizden changed the upstream function for doing this, and in tern fixed a bug related to this dictionary where the key name didn't matter. now it does. this fixes all the maps that weren't following the standard properly

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed All Starlightified upstream maps not initializing properly due to wizden bugfix.