### PR TITLE
fix species speeds

### DIFF
--- a/Resources/Prototypes/_StarLight/Body/Parts/cyclorite.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/cyclorite.yml
@@ -109,6 +109,8 @@
     - type: Icon
       sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
       state: "l_leg"
+    - type: MovementBodyPart
+      sprintSpeed : 3.825
 
 - type: entity
   id: RightLegCyclorite
@@ -121,6 +123,8 @@
     - type: Icon
       sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
       state: "r_leg"
+    - type: MovementBodyPart
+      sprintSpeed : 3.825
 
 - type: entity
   id: LeftFootCyclorite

--- a/Resources/Prototypes/_StarLight/Body/Parts/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/felionoid.yml
@@ -147,6 +147,7 @@
       partType: Leg
       symmetry: Left
     - type: MovementBodyPart
+      sprintSpeed : 5.625
 
 - type: entity
   id: RightLegFelionoid
@@ -163,6 +164,7 @@
       partType: Leg
       symmetry: Right
     - type: MovementBodyPart
+      sprintSpeed : 5.625
 
 - type: entity
   id: LeftFootFelionoid


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes the speeds of species after the movement component was reworked to not have the species modifier fields

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Right now all species have the same speed, this reintroduces the system that felionoids and cyclorites have. there is LIKELY other bugs related to things here, but this fixes the most egregious ones first

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed Cyclorites and Felionoids sprinting at the same speed as everyone else.