### PR TITLE
fix species speeds

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -8,6 +8,8 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Movement.Components;
 using Robust.Shared.Containers;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Body.Systems;
@@ -465,6 +467,7 @@ public partial class SharedBodySystem
         var walkSpeed = 0f;
         var sprintSpeed = 0f;
         var acceleration = 0f;
+        var maxDensity = 0f; // 🌟Starlight🌟
         foreach (var legEntity in body.LegEntities)
         {
             if (!TryComp<MovementBodyPartComponent>(legEntity, out var legModifier))
@@ -473,7 +476,24 @@ public partial class SharedBodySystem
             walkSpeed += legModifier.WalkSpeed;
             sprintSpeed += legModifier.SprintSpeed;
             acceleration += legModifier.Acceleration;
+            maxDensity += legModifier.MaxDensity; // 🌟Starlight🌟
         }
+
+        // 🌟Starlight🌟 Start
+        var density = TryComp<FixturesComponent>(bodyId, out var fixtures)
+            && fixtures.Fixtures.TryGetValue("fix1", out var fixture) 
+            ? fixture.Density : 185f;
+
+        var speedFactor = density > maxDensity && maxDensity > 0f
+            ? maxDensity / density
+            : 1f;
+
+        walkSpeed *= speedFactor;
+        sprintSpeed *= speedFactor;
+        acceleration *= speedFactor;
+
+        // 🌟Starlight🌟 End
+
         walkSpeed /= body.RequiredLegs;
         sprintSpeed /= body.RequiredLegs;
         acceleration /= body.RequiredLegs;

--- a/Content.Shared/Movement/Components/MovementBodyPartComponent.cs
+++ b/Content.Shared/Movement/Components/MovementBodyPartComponent.cs
@@ -1,4 +1,6 @@
-using Robust.Shared.GameStates;
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared.Movement.Components;
 
@@ -13,4 +15,11 @@ public sealed partial class MovementBodyPartComponent : Component
 
     [DataField("acceleration")]
     public float Acceleration = MovementSpeedModifierComponent.DefaultAcceleration;
+
+    // 🌟Starlight🌟 Start
+    /// <summary>
+    /// The density this leg can effectively move, it’s a temporary solution until we implement proper weight calculations for all body parts.
+    /// </summary>
+    [DataField]
+    public float MaxDensity = 92.5f;
 }

--- a/Resources/Prototypes/_StarLight/Body/Parts/cyberlimbs.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/cyberlimbs.yml
@@ -79,6 +79,9 @@
     - type: Icon
       sprite: _Starlight/Mobs/Species/Cyberlimbs/parts.rsi
       state: "l_leg"
+    - type: MovementBodyPart
+      sprintSpeed : 4.725 # +5%
+      maxDensity: 111
 
 - type: entity
   id: RightLegCyber
@@ -93,6 +96,9 @@
     - type: Icon
       sprite: _Starlight/Mobs/Species/Cyberlimbs/parts.rsi
       state: "r_leg"
+    - type: MovementBodyPart
+      sprintSpeed : 4.725 # +5%
+      maxDensity: 111
 
 - type: entity
   id: LeftFootCyber

--- a/Resources/Prototypes/_StarLight/Body/Parts/cyclorite.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/cyclorite.yml
@@ -109,7 +109,10 @@
     - type: Icon
       sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
       state: "l_leg"
-
+    - type: MovementBodyPart
+      sprintSpeed : 3.825
+      maxDensity: 111
+      
 - type: entity
   id: RightLegCyclorite
   name: "right cyclorite leg"
@@ -121,6 +124,9 @@
     - type: Icon
       sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
       state: "r_leg"
+    - type: MovementBodyPart
+      sprintSpeed : 3.825
+      maxDensity: 111
 
 - type: entity
   id: LeftFootCyclorite

--- a/Resources/Prototypes/_StarLight/Body/Parts/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/felionoid.yml
@@ -147,6 +147,8 @@
       partType: Leg
       symmetry: Left
     - type: MovementBodyPart
+      sprintSpeed : 5.625
+      maxDensity: 55
 
 - type: entity
   id: RightLegFelionoid
@@ -163,6 +165,8 @@
       partType: Leg
       symmetry: Right
     - type: MovementBodyPart
+      sprintSpeed : 5.625
+      maxDensity: 55
 
 - type: entity
   id: LeftFootFelionoid

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
@@ -21,11 +21,21 @@
     hideLayersOnEquip:
     - Hair
     - Snout
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 3.825
   - type: Body
     prototype: Cyclorite
     requiredLegs: 2
+  - type: Fixtures
+    fixtures: # TODO: This needs a second fixture just for mob collisions.
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.35
+        density: 222 # 120%
+        restitution: 0.0
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
   - type: MobThresholds
     thresholds:
       0: Alive

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
@@ -4,8 +4,6 @@
   abstract: true
   components:
   - type: Absorbable
-  - type: MovementSpeedModifier
-    baseSprintSpeed : 5.625
   - type: Speech
     speechVerb: Felionoid
     allowedEmotes: ['Mew', 'Hisses', 'Meow', 'Growl', 'Purr', 'Trill']


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33 Darkrell
- fix: Fixed Cyclorites and Felionoids sprinting at the same speed as everyone else.
- fix: Legs now depend on density, so stitching Felinoid legs onto a Cyclorite is a bad idea.