### PR TITLE
Signed gamerules

### DIFF
--- a/Content.Server/_Starlight/Paper/AntagOnSignComponent.cs
+++ b/Content.Server/_Starlight/Paper/AntagOnSignComponent.cs
@@ -35,6 +35,12 @@ public sealed partial class AntagOnSignComponent : Component
     /// </summary>
     [DataField]
     public List<AntagCompPair> Antags = [];
+
+    /// <summary>
+    /// is the faxable component kept? this is for admeme protos
+    /// </summary>
+    [DataField]
+    public bool KeepFaxable = false;
 }
 
 [DataDefinition]

--- a/Content.Server/_Starlight/Paper/AntagOnSignComponent.cs
+++ b/Content.Server/_Starlight/Paper/AntagOnSignComponent.cs
@@ -10,7 +10,7 @@ public sealed partial class AntagOnSignComponent : Component
     /// how many people are able to sign this paper in a attempt to roll for antag.
     /// </summary>
     [DataField("charges")]
-    public int ChargesRemaing = 1;
+    public int ChargesRemaining = 1;
 
     /// <summary>
     /// A list of every entity that has signed this paper to prevent spam signing from using all the charges

--- a/Content.Server/_Starlight/Paper/AntagOnSignSystem.cs
+++ b/Content.Server/_Starlight/Paper/AntagOnSignSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Antag;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules.Components;
+using Content.Shared.Fax.Components;
 using Content.Shared.Paper;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -25,6 +26,14 @@ public sealed class AntagOnSignSystem : EntitySystem
         base.Initialize();
         _sawmill = Logger.GetSawmill(this.SawmillName);
         SubscribeLocalEvent<AntagOnSignComponent, PaperSignedEvent>(OnPaperSigned);
+        SubscribeLocalEvent<AntagOnSignComponent, ComponentInit>(OnComponentInit);
+    }
+
+    private void OnComponentInit(EntityUid uid, AntagOnSignComponent comp, ComponentInit init)
+    {
+        if (comp.KeepFaxable) 
+            return;
+        RemComp<FaxableObjectComponent>(uid); //cause this breaks shit like infinite antags
     }
 
     private void OnPaperSigned(EntityUid uid, AntagOnSignComponent component, PaperSignedEvent args)

--- a/Content.Server/_Starlight/Paper/AntagOnSignSystem.cs
+++ b/Content.Server/_Starlight/Paper/AntagOnSignSystem.cs
@@ -29,14 +29,14 @@ public sealed class AntagOnSignSystem : EntitySystem
 
     private void OnPaperSigned(EntityUid uid, AntagOnSignComponent component, PaperSignedEvent args)
     {
-        if (component.ChargesRemaing <= 0)
+        if (component.ChargesRemaining <= 0)
             return;
         var signer = args.Signer;
         if (!TryComp(signer, out ActorComponent? actor))
             return;
         if (component.SignedEntityUids.Contains(signer))
             return;
-        component.ChargesRemaing--;
+        component.ChargesRemaining--;
         component.SignedEntityUids.Add(signer);
 
         if (_random.NextFloat() > component.Chance)

--- a/Content.Server/_Starlight/Paper/GameruleOnSignComponent.cs
+++ b/Content.Server/_Starlight/Paper/GameruleOnSignComponent.cs
@@ -24,13 +24,13 @@ public sealed partial class GameruleOnSignComponent : Component
     /// A Whitelist of whos signatures should count for this component.
     /// </summary>
     [DataField]
-    public EntityWhitelist Whitelist = new();
+    public EntityWhitelist? Whitelist = null;
     
     /// <summary>
     /// A Whitelist of whos signatures should not count for this component.
     /// </summary>
     [DataField]
-    public EntityWhitelist Blacklist = new();
+    public EntityWhitelist? Blacklist = null;
     
     /// <summary>
     /// What is the chance of this going on after all the signatures are collected. 1 is always, 0 is never.

--- a/Content.Server/_Starlight/Paper/GameruleOnSignComponent.cs
+++ b/Content.Server/_Starlight/Paper/GameruleOnSignComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class GameruleOnSignComponent : Component
     /// </summary>
     [DataField]
     public int Remaining = 1;
- 
+
     /// <summary>
     /// A list of every entity that has signed this paper to prevent spam signing from instantly activating the paper.
     /// </summary>
@@ -25,22 +25,28 @@ public sealed partial class GameruleOnSignComponent : Component
     /// </summary>
     [DataField]
     public EntityWhitelist? Whitelist = null;
-    
+
     /// <summary>
     /// A Whitelist of whos signatures should not count for this component.
     /// </summary>
     [DataField]
     public EntityWhitelist? Blacklist = null;
-    
+
     /// <summary>
     /// What is the chance of this going on after all the signatures are collected. 1 is always, 0 is never.
     /// </summary>
     [DataField]
     public float Chance = 1.0f;
-    
+
     /// <summary>
     /// What game rules are added once signatures are collected and with a bit of luck.
     /// </summary>
     [DataField]
     public List<EntProtoId<GameRuleComponent>> Rules = [];
+    
+    /// <summary>
+    /// is the faxable component kept? this is for admeme protos
+    /// </summary>
+    [DataField]
+    public bool KeepFaxable = false;
 }

--- a/Content.Server/_Starlight/Paper/GameruleOnSignComponent.cs
+++ b/Content.Server/_Starlight/Paper/GameruleOnSignComponent.cs
@@ -1,0 +1,46 @@
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Whitelist;
+using Robust.Shared.Prototypes;
+using Component = Robust.Shared.GameObjects.Component;
+
+namespace Content.Server._Starlight.Paper;
+
+[RegisterComponent]
+public sealed partial class GameruleOnSignComponent : Component
+{
+    /// <summary>
+    /// how many signatures are needed before this paper goes into effect.
+    /// </summary>
+    [DataField]
+    public int Remaining = 1;
+ 
+    /// <summary>
+    /// A list of every entity that has signed this paper to prevent spam signing from instantly activating the paper.
+    /// </summary>
+    [ViewVariables]
+    public List<EntityUid> SignedEntityUids = [];
+
+    /// <summary>
+    /// A Whitelist of whos signatures should count for this component.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist Whitelist = new();
+    
+    /// <summary>
+    /// A Whitelist of whos signatures should not count for this component.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist Blacklist = new();
+    
+    /// <summary>
+    /// What is the chance of this going on after all the signatures are collected. 1 is always, 0 is never.
+    /// </summary>
+    [DataField]
+    public float Chance = 1.0f;
+    
+    /// <summary>
+    /// What game rules are added once signatures are collected and with a bit of luck.
+    /// </summary>
+    [DataField]
+    public List<EntProtoId<GameRuleComponent>> Rules = [];
+}

--- a/Content.Server/_Starlight/Paper/GameruleOnSignSytem.cs
+++ b/Content.Server/_Starlight/Paper/GameruleOnSignSytem.cs
@@ -1,0 +1,43 @@
+using Content.Server.GameTicking;
+using Content.Shared.Paper;
+using Content.Shared.Whitelist;
+using Robust.Shared.Random;
+
+namespace Content.Server._Starlight.Paper;
+
+public sealed class GameruleOnSignSytem : EntitySystem
+{
+    [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<GameruleOnSignComponent,PaperSignedEvent>(OnPaperSigned);
+    }
+
+    private void OnPaperSigned(EntityUid uid, GameruleOnSignComponent component, PaperSignedEvent args)
+    {
+        if (component.Remaining <= 0)
+            return; // we allready ran this component so no need to check again anymore.
+        var signer = args.Signer;
+        if (!_whitelistSystem.CheckBoth(signer, component.Blacklist, component.Whitelist))
+            return;
+        component.Remaining--;
+        component.SignedEntityUids.Add(signer);
+
+        if (component.Remaining != 0)
+            return; //we havent hit the conditions to activate it.
+        
+        if (_random.NextFloat() > component.Chance)
+            return; //vibe check failed no events for you.
+
+        foreach (var rule in component.Rules)
+        {
+            var ent = _gameTicker.AddGameRule(rule.Id);
+            _gameTicker.StartGameRule(ent);
+        }
+        
+    }
+}

--- a/Content.Server/_Starlight/Paper/GameruleOnSignSytem.cs
+++ b/Content.Server/_Starlight/Paper/GameruleOnSignSytem.cs
@@ -1,6 +1,7 @@
 using Content.Server.GameTicking;
 using Content.Shared.Paper;
 using Content.Shared.Whitelist;
+using Content.Shared.Fax.Components;
 using Robust.Shared.Random;
 
 namespace Content.Server._Starlight.Paper;
@@ -10,12 +11,21 @@ public sealed class GameruleOnSignSytem : EntitySystem
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    
+
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<GameruleOnSignComponent,PaperSignedEvent>(OnPaperSigned);
+        SubscribeLocalEvent<GameruleOnSignComponent, PaperSignedEvent>(OnPaperSigned);
+        SubscribeLocalEvent<GameruleOnSignComponent, ComponentInit>(OnComponentInit);
     }
+
+        private void OnComponentInit(EntityUid uid, GameruleOnSignComponent comp, ComponentInit init)
+    {
+        if (comp.KeepFaxable) 
+            return;
+        RemComp<FaxableObjectComponent>(uid); //cause this breaks shit like infinite antags
+    }
+
 
     private void OnPaperSigned(EntityUid uid, GameruleOnSignComponent component, PaperSignedEvent args)
     {
@@ -29,7 +39,7 @@ public sealed class GameruleOnSignSytem : EntitySystem
 
         if (component.Remaining != 0)
             return; //we havent hit the conditions to activate it.
-        
+
         if (_random.NextFloat() > component.Chance)
             return; //vibe check failed no events for you.
 
@@ -38,6 +48,6 @@ public sealed class GameruleOnSignSytem : EntitySystem
             var ent = _gameTicker.AddGameRule(rule.Id);
             _gameTicker.StartGameRule(ent);
         }
-        
+
     }
 }

--- a/Resources/Locale/en-US/_Starlight/paper/events.ftl
+++ b/Resources/Locale/en-US/_Starlight/paper/events.ftl
@@ -1,0 +1,21 @@
+paper-too-quiet-need-chaos = Do you feel like this shift has been way too quiet?
+                             Want a little action to spice up the day?
+  
+                             If you would like to join the NanoTrasen Experimental Division to immediately undergo some potentially severe tests for the sake of science and future profit.... then we got the thing just for you!
+  
+                             {"[bold] Collect the signatures of 9 Mindshielded crew to begin the experiment. [/bold]"}
+  
+                             Don't ask how we got this experimental paper inside this locker. Yes, CentComm is totally aware we did this.
+  
+                             For the glory of NanoTrasen
+
+paper-too-quiet-need-chaos-few = Do you feel like this shift has been way too quiet?
+                                 Want a little action to spice up the day?
+  
+                                 If you would like to join the NanoTrasen Experimental Division to immediately undergo some potentially severe tests for the sake of science and future profit.... then we got the thing just for you!
+  
+                                 {"[bold] Collect the signatures of 3 Mindshielded crew to begin the experiment. [/bold]"}
+  
+                                 Don't ask how we got this experimental paper inside this locker. Yes, CentComm is totally aware we did this.
+  
+                                 For the glory of NanoTrasen

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -60,6 +60,19 @@
       conditions:
       - !type:PlayerCountCondition
         max: 15
+    - id: PaperTooQuietNeedChaos #Starlight
+      conditions:
+      - !type:PlayerCountCondition
+        invert: true
+        max: 15
+      prob: 0.05
+    - id: PaperTooQuietNeedChaosFew #lowpop varient which needs less singnatures.
+      conditions:
+      - !type:PlayerCountCondition
+        max: 15
+      prob: 0.05
+    #Starlight
+
 
 # No laser table + Laser table
 - type: entityTable

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
@@ -2,16 +2,23 @@
   parent: Paper
   id: PaperTooQuietNeedChaos
   name: the end of Q
+  description: this paper makes you dread whats coming going to happen...
   components:
     - type: Paper
-      content: "do you ever feel like it is too [bold]QUIET[/bold] well... if you can get 9 signatures of reinforced minds we can fix that... dont ask how this got into your locker. CC wont know."
+      content: paper-too-quiet-need-chaos
     - type: GameruleOnSign
-      remaining: 7 # command, security, cargo, science, medical, engineering, service, and 2 members of sec outside of hos (or more sec/salv and less heads... or people who you mindshielded JUST to get this signed)
+      remaining: 9 # command, security, cargo, science, medical, engineering, service, and 2 members of sec outside of hos (or more sec/salv and less heads... or people who you mindshielded JUST to get this signed)
       whitelist: 
         components:
           - MindShield
       rules: #this will DEFINETLY end the "quiet" you so hate
         - AbductorsSpawn
+        - AnomalySpawn
+        - AnomalySpawn
+        - AnomalySpawn
+        - AnomalySpawn
+        - AnomalySpawn # ATTENTION spam warning but there is no silent anom spawn sadly
+        - UnknownShuttleHonki
         - LoneOpsSpawn
         - WizardSpawn
         - DragonSpawn
@@ -23,10 +30,11 @@
   parent: Paper
   id: PaperTooQuietNeedChaosFew
   name: the end of Q
+  description: this paper makes you dread whats coming going to happen...
   suffix: Lowpop
   components:
     - type: Paper
-      content: "do you ever feel like it is too [bold]QUIET[/bold] well... if you can get 3 signatures of reinforced minds we can fix that... dont ask how this got into your locker. CC wont know."
+      content: paper-too-quiet-need-chaos-few
     - type: GameruleOnSign
       remaining: 3 # on 15 pop usually there are only about 3 heads I expect
       whitelist: 
@@ -34,5 +42,8 @@
           - MindShield
       rules: #this will DEFINETLY end the "quiet" you so hate
         - AbductorsSpawn
+        - AnomalySpawn # only 2 anoms cause you are probally on reach or omega which are TINY
+        - AnomalySpawn
+        - UnknownShuttleHonki
         - WizardSpawn
         - NinjaSpawn #spawns less cause there is also less people to take said roles. and I deem these to be the less "chaotic" ones

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
@@ -2,7 +2,7 @@
   parent: Paper
   id: PaperTooQuietNeedChaos
   name: the end of Q
-  description: this paper makes you dread whats coming going to happen...
+  description: this paper makes you dread whats going to happen...
   components:
     - type: Paper
       content: paper-too-quiet-need-chaos
@@ -30,7 +30,7 @@
   parent: Paper
   id: PaperTooQuietNeedChaosFew
   name: the end of Q
-  description: this paper makes you dread whats coming going to happen...
+  description: this paper makes you dread whats going to happen...
   suffix: Lowpop
   components:
     - type: Paper

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
@@ -4,7 +4,7 @@
   name: the end of Q
   components:
     - type: Paper
-      content: "do you ever feel like it is to [bold]QUIET[/bold] well... if you can get 9 signatures of reinforced minds we can fix that... dont ask how this got into your locker. CC wont know."
+      content: "do you ever feel like it is too [bold]QUIET[/bold] well... if you can get 9 signatures of reinforced minds we can fix that... dont ask how this got into your locker. CC wont know."
     - type: GameruleOnSign
       remaining: 7 # command, security, cargo, science, medical, engineering, service, and 2 members of sec outside of hos (or more sec/salv and less heads... or people who you mindshielded JUST to get this signed)
       whitelist: 
@@ -26,7 +26,7 @@
   suffix: Lowpop
   components:
     - type: Paper
-      content: "do you ever feel like it is to [bold]QUIET[/bold] well... if you can get 3 signatures of reinforced minds we can fix that... dont ask how this got into your locker. CC wont know."
+      content: "do you ever feel like it is too [bold]QUIET[/bold] well... if you can get 3 signatures of reinforced minds we can fix that... dont ask how this got into your locker. CC wont know."
     - type: GameruleOnSign
       remaining: 3 # on 15 pop usually there are only about 3 heads I expect
       whitelist: 

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
@@ -2,7 +2,7 @@
   parent: Paper
   id: PaperTooQuietNeedChaos
   name: the end of Q
-  description: this paper makes you dread whats going to happen...
+  description: dreadful paper that cant fit in a fax machine.
   components:
     - type: Paper
       content: paper-too-quiet-need-chaos
@@ -30,7 +30,7 @@
   parent: Paper
   id: PaperTooQuietNeedChaosFew
   name: the end of Q
-  description: this paper makes you dread whats going to happen...
+  description: dreadful paper that cant fit in a fax machine.
   suffix: Lowpop
   components:
     - type: Paper

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
@@ -1,0 +1,38 @@
+- type: entity
+  parent: Paper
+  id: PaperTooQuietNeedChaos
+  name: the end of Q
+  components:
+    - type: Paper
+      content: "do you ever feel like it is to [bold]QUIET[/bold] well... if you can get 9 signatures of reinforced minds we can fix that... dont ask how this got into your locker. CC wont know."
+    - type: GameruleOnSign
+      remaining: 7 # command, security, cargo, science, medical, engineering, service, and 2 members of sec outside of hos (or more sec/salv and less heads... or people who you mindshielded JUST to get this signed)
+      whitelist: 
+        components:
+          - MindShield
+      rules: #this will DEFINETLY end the "quiet" you so hate
+        - AbductorsSpawn
+        - LoneOpsSpawn
+        - WizardSpawn
+        - DragonSpawn
+        - NinjaSpawn
+        - ParadoxCloneSpawn
+
+
+- type: entity
+  parent: Paper
+  id: PaperTooQuietNeedChaosFew
+  name: the end of Q
+  suffix: Lowpop
+  components:
+    - type: Paper
+      content: "do you ever feel like it is to [bold]QUIET[/bold] well... if you can get 3 signatures of reinforced minds we can fix that... dont ask how this got into your locker. CC wont know."
+    - type: GameruleOnSign
+      remaining: 3 # on 15 pop usually there are only about 3 heads I expect
+      whitelist: 
+        components:
+          - MindShield
+      rules: #this will DEFINETLY end the "quiet" you so hate
+        - AbductorsSpawn
+        - WizardSpawn
+        - NinjaSpawn #spawns less cause there is also less people to take said roles. and I deem these to be the less "chaotic" ones

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: MailSyndicateSpamLetter
   name: Reasons to choose The Syndicate!
-  description: An advertisement for the The Syndicate.
+  description: An advertisement for the The Syndicate. Wont fit in a fax somehow.
   parent: Paper
   components:
     - type: Paper

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: MailSyndicateSpamLetter
   name: Reasons to choose The Syndicate!
-  description: An advertisement for the The Syndicate. Wont fit in a fax somehow.
+  description: An advertisement for the Syndicate. Wont fit in a fax somehow.
   parent: Paper
   components:
     - type: Paper


### PR DESCRIPTION
## Short description
adds a new comp that allows adding gamerules once the required signatures are collected with a configurable entity white/blacklist.

## Why we need to add this
I think happy... or someone else... made a offhand comment about adding gamerules on sign so well... here it is
and adds PoC paper to caps locker that is 2x as rare as the nukie plush.
also fixes some issue about being faxable until faxsystem is improved space-wizards/space-station-14#37232

## Media (Video/Screenshots)
![Screenshot_20250530_233123](https://github.com/user-attachments/assets/c1e8694c-9458-4d8c-8d81-fe834f7d7502)
(signature count lowered for the sake of example, lowpop needs 3, normal/high pop needs 9)

![image](https://github.com/user-attachments/assets/6026859c-97e8-463e-a649-dea5311db981)
changed the paper to be just better

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: Rare paper that can spawn in captains locker that will be able to put to end all responses to "It is too QUIET"
- fix: Signable gamerule/antag papers can no longer be put into the fax until FaxSystem can copy components properly.