### PR TITLE
Station AI default lawset change

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -418,7 +418,7 @@
   - type: BlockMovement
     blockInteraction: false
   - type: SiliconLawProvider
-    laws: CrewsimovAI
+    laws: NTDefault
   - type: SiliconLawBound
   - type: ActionGrant
     actions:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -418,7 +418,7 @@
   - type: BlockMovement
     blockInteraction: false
   - type: SiliconLawProvider
-    laws: NTDefault
+    laws: NTDefault # Starlight
   - type: SiliconLawBound
   - type: ActionGrant
     actions:


### PR DESCRIPTION


<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Changes the lawset AI (not cyborgs) starts with from Crewsimov to NT default

## Why we need to add this
For borgs, crewsimov is fine. For the AI, it is genuinely torturous to play. It doesn't even allow us to follow the SOP that is established. NT default is also 'NT DEFAULT'. It makes NO sense for us to be on crewsimov

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- tweak: Changed Station AI's default lawset from Crewsimov to NT default

