### PR TITLE
PKA Range Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -503,7 +503,7 @@
         Structural: 30
   # Short lifespan
   - type: TimedDespawn
-    lifetime: 0.22 # roughly 5.5 tiles
+    lifetime: 0.275 # roughly 6.5 tiles
   - type: GatheringProjectile
 
 - type: entity


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

## Why we need to add this
With Wizden's nerf to the base range of the PKA, the weapon has become far more unwieldy to use, given its innately low firerate and now its short (nearly CQC) range of 5.5 tiles. The sole change made in this PR is to increase the lifetime of the PKA's projectile so that it has a base range of 6.5 tiles. Once the range modkit is installed, this increases to approximately 9.5 tiles. 

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/1057c4ba-d343-45ab-a440-72624b402caf



## Checks


- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- tweak: Increased the PKA's base range to ~6.5 tiles, from Wizden-nerfed 5.5. With modkit, range is now ~9.5 tiles.

