### PR TITLE
Remove Abyss Expeditions

### DIFF
--- a/Resources/Locale/en-US/_Starlight/procedural/expeditions.ftl
+++ b/Resources/Locale/en-US/_Starlight/procedural/expeditions.ftl
@@ -2,4 +2,4 @@ salvage-dungeon-mod-syndie-stronghold =  Unknown complex
 salvage-dungeon-mod-soviet-stronghold = United complex
 salvage-dungeon-mod-soviet-warehouse = Warehouse of strategic resources
 
-salvage-biome-mod-abyss = Abyss
+# salvage-biome-mod-abyss = Abyss


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Comments out Abyss Expedition types. They are content poor and their lack of any source of ore (other than useless abyssium) deprives the station of resources for extended periods of time. 

## Why we need to add this
Abyss Expeditions, as they currently stand, are incomplete and effectively a trap for inexperienced salvagers that deprives the station of resources for an extended period of time. There are no ores on these expeds, and the facility and enemies are the same as on other worldtypes. There is no reason to pick one of these. A future rework might help, but as it stands, these expeditions are pointless and actively harmful to the station.
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: deltaVelocity
- remove: Removed Abyss Expeditions.

