### PR TITLE
let Emag destroy the transponder of borgs with a admeme field

### DIFF
--- a/Content.Shared/Emag/Components/EmagComponent.cs
+++ b/Content.Shared/Emag/Components/EmagComponent.cs
@@ -33,4 +33,13 @@ public sealed partial class EmagComponent : Component
     [DataField]
     [AutoNetworkedField]
     public SoundSpecifier EmagSound = new SoundCollectionSpecifier("sparks");
+
+    //#region Starlight
+    /// <summary>
+    /// should this emag also destroy the transponder
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public bool DestroyTransponder = false;
+    //#endregion Starlight
 }

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -68,7 +68,7 @@ public sealed class EmagSystem : EntitySystem
             return false;
         }
 
-        var emaggedEvent = new GotEmaggedEvent(user, ent.Comp.EmagType);
+        var emaggedEvent = new GotEmaggedEvent(user, ent.Comp.EmagType, DestroyTransponder: ent.Comp.DestroyTransponder);
         RaiseLocalEvent(target, ref emaggedEvent);
 
         if (!emaggedEvent.Handled)
@@ -144,4 +144,4 @@ public enum EmagType : byte
 /// <param name="Repeatable">Can the entity be emagged more than once? Prevents adding of <see cref="EmaggedComponent"/></param>
 /// <remarks>Needs to be handled in shared/client, not just the server, to actually show the emagging popup</remarks>
 [ByRefEvent]
-public record struct GotEmaggedEvent(EntityUid UserUid, EmagType Type, bool Handled = false, bool Repeatable = false);
+public record struct GotEmaggedEvent(EntityUid UserUid, EmagType Type, bool Handled = false, bool Repeatable = false, bool DestroyTransponder = false);

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -68,7 +68,7 @@ public sealed class EmagSystem : EntitySystem
             return false;
         }
 
-        var emaggedEvent = new GotEmaggedEvent(user, ent.Comp.EmagType, DestroyTransponder: ent.Comp.DestroyTransponder);
+        var emaggedEvent = new GotEmaggedEvent(user, ent.Comp.EmagType, DestroyTransponder: ent.Comp.DestroyTransponder); // Starlight
         RaiseLocalEvent(target, ref emaggedEvent);
 
         if (!emaggedEvent.Handled)
@@ -144,4 +144,4 @@ public enum EmagType : byte
 /// <param name="Repeatable">Can the entity be emagged more than once? Prevents adding of <see cref="EmaggedComponent"/></param>
 /// <remarks>Needs to be handled in shared/client, not just the server, to actually show the emagging popup</remarks>
 [ByRefEvent]
-public record struct GotEmaggedEvent(EntityUid UserUid, EmagType Type, bool Handled = false, bool Repeatable = false, bool DestroyTransponder = false);
+public record struct GotEmaggedEvent(EntityUid UserUid, EmagType Type, bool Handled = false, bool Repeatable = false, bool DestroyTransponder = false); // Starlight

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Shared.Emag.Systems;
 using Content.Shared.Mind;
 using Content.Shared.Popups;
+using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Stunnable;
 using Content.Shared.Wires;
@@ -46,6 +47,11 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
         {
             _popup.PopupClient(Loc.GetString("law-emag-require-panel"), uid, args.UserUid);
             return;
+        }
+
+        if (args.DestroyTransponder)
+        {
+            RemComp<BorgTransponderComponent>(uid);
         }
 
         var ev = new SiliconEmaggedEvent(args.UserUid);

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
@@ -1,7 +1,7 @@
 ﻿using Content.Shared.Emag.Systems;
 using Content.Shared.Mind;
 using Content.Shared.Popups;
-using Content.Shared.Silicons.Borgs.Components;
+using Content.Shared.Silicons.Borgs.Components; // Starlight
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Stunnable;
 using Content.Shared.Wires;
@@ -49,10 +49,12 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
             return;
         }
 
+        //#region Starlight
         if (args.DestroyTransponder)
         {
             RemComp<BorgTransponderComponent>(uid);
         }
+        //#endregion Starlight
 
         var ev = new SiliconEmaggedEvent(args.UserUid);
         RaiseLocalEvent(uid, ref ev);


### PR DESCRIPTION
## Short description
adds a field on EmagComponent that allows it to destroy transponders when it is used

## Why we need to add this
Meant mainly for the Syndicate Shadow ops emag to keep them stealthy and their numbers unknown as borgis will now show up on transponder once borgi chassis is merged

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/81bbb588-8591-41c0-8b53-d4cd545120ef)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
admeme only