### PR TITLE
set or add objectives upon signing a paper.

### DIFF
--- a/Content.Server/_Starlight/Paper/AntagOnSignSystem.cs
+++ b/Content.Server/_Starlight/Paper/AntagOnSignSystem.cs
@@ -25,7 +25,7 @@ public sealed class AntagOnSignSystem : EntitySystem
     {
         base.Initialize();
         _sawmill = Logger.GetSawmill(this.SawmillName);
-        SubscribeLocalEvent<AntagOnSignComponent, PaperSignedEvent>(OnPaperSigned);
+        SubscribeLocalEvent<AntagOnSignComponent, PaperSignedEvent>(OnPaperSigned, before: [typeof(ObjectiveOnSignSystem)]);
         SubscribeLocalEvent<AntagOnSignComponent, ComponentInit>(OnComponentInit);
     }
 
@@ -65,8 +65,6 @@ public sealed class AntagOnSignSystem : EntitySystem
             }
             var generic = fmakeantag.MakeGenericMethod(targetComp.GetType());
             generic.Invoke(_antag, [session, antag.Antag.Id]);
-
-            //_antag.ForceMakeAntag<GameRuleComponent>(session, antag.Id);
         }
 
         if (component.ParadoxClone)

--- a/Content.Server/_Starlight/Paper/ObjectiveOnSignComponent.cs
+++ b/Content.Server/_Starlight/Paper/ObjectiveOnSignComponent.cs
@@ -1,0 +1,45 @@
+using Robust.Shared.Prototypes;
+using Component = Robust.Shared.GameObjects.Component;
+
+namespace Content.Server._Starlight.Paper;
+
+[RegisterComponent]
+public sealed partial class ObjectiveOnSignComponent : Component
+{
+    /// <summary>
+    /// how many people are able to sign this paper in a attempt to roll for antag.
+    /// </summary>
+    [DataField("charges")]
+    public int ChargesRemaining = 1;
+
+    /// <summary>
+    /// A list of every entity that has signed this paper to prevent spam signing from using all the charges
+    /// </summary>
+    [ViewVariables]
+    public List<EntityUid> SignedEntityUids = [];
+
+    /// <summary>
+    /// What is the chance of this signature procing and making them a antag with 1 being always and 0 being never
+    /// </summary>
+    [DataField]
+    public float Chance = 1.0f;
+
+    /// <summary>
+    /// what objectives should be added to the person.
+    /// </summary>
+    [DataField]
+    public List<EntProtoId> Objectives = [];
+
+    /// <summary>
+    /// true to add objectives. false to delete all objectives and add only these.
+    /// </summary>
+    [DataField]
+    public bool Append = false;
+    
+
+    /// <summary>
+    /// is the faxable component kept? this is for admeme protos
+    /// </summary>
+    [DataField]
+    public bool KeepFaxable = false;
+}

--- a/Content.Server/_Starlight/Paper/ObjectiveOnSignComponent.cs
+++ b/Content.Server/_Starlight/Paper/ObjectiveOnSignComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
 using Component = Robust.Shared.GameObjects.Component;
 
@@ -35,7 +36,19 @@ public sealed partial class ObjectiveOnSignComponent : Component
     /// </summary>
     [DataField]
     public bool Append = false;
-    
+
+    /// <summary>
+    /// whitelist the entity must pass to be allowed to get objectives
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Whitelist = null;
+
+    /// <summary>
+    /// blacklist the entity must fail to be allowed to get objectives
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Blacklist = null;
+
 
     /// <summary>
     /// is the faxable component kept? this is for admeme protos

--- a/Content.Server/_Starlight/Paper/ObjectiveOnSignSystem.cs
+++ b/Content.Server/_Starlight/Paper/ObjectiveOnSignSystem.cs
@@ -13,6 +13,7 @@ public sealed class ObjectiveOnSignSystem : EntitySystem
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
     public override void Initialize()
     {
@@ -35,6 +36,9 @@ public sealed class ObjectiveOnSignSystem : EntitySystem
             return; // no charges left. dont run the component
 
         var signer = args.Signer;
+        
+        if (!_whitelistSystem.CheckBoth(signer, component.Blacklist, component.Whitelist))
+            return;
 
         if (!TryComp<ActorComponent>(signer, out var actor))
             return;

--- a/Content.Server/_Starlight/Paper/ObjectiveOnSignSystem.cs
+++ b/Content.Server/_Starlight/Paper/ObjectiveOnSignSystem.cs
@@ -1,0 +1,65 @@
+using Content.Server.GameTicking;
+using Content.Shared.Paper;
+using Content.Shared.Whitelist;
+using Content.Shared.Fax.Components;
+using Robust.Shared.Random;
+using Content.Shared.Mind;
+using Robust.Shared.Player;
+
+namespace Content.Server._Starlight.Paper;
+
+public sealed class ObjectiveOnSignSystem : EntitySystem
+{
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ObjectiveOnSignComponent, PaperSignedEvent>(OnPaperSigned);
+        SubscribeLocalEvent<ObjectiveOnSignComponent, ComponentInit>(OnComponentInit);
+    }
+
+    private void OnComponentInit(EntityUid uid, ObjectiveOnSignComponent comp, ComponentInit init)
+    {
+        if (comp.KeepFaxable)
+            return;
+        RemComp<FaxableObjectComponent>(uid); //cause this breaks shit like infinite antags
+    }
+
+
+    private void OnPaperSigned(EntityUid uid, ObjectiveOnSignComponent component, PaperSignedEvent args)
+    {
+        if (component.ChargesRemaining <= 0)
+            return; // no charges left. dont run the component
+
+        var signer = args.Signer;
+
+        if (!TryComp<ActorComponent>(signer, out var actor))
+            return;
+        if (!_mind.TryGetMind(actor.PlayerSession.UserId, out var mindId, out var mind))
+        {
+            Log.Error($"Antag {ToPrettyString(signer):player} signed a paper with ObjectiveOnSign but had no mind attached!");
+            return;
+        }
+
+        component.ChargesRemaining--;
+        component.SignedEntityUids.Add(signer);
+
+        if (_random.NextFloat() > component.Chance)
+            return; //vibe check failed no events for you.
+
+        if (!component.Append)
+        {
+            while (_mind.TryRemoveObjective(mindId.Value, mind, 0)) {}// basically just keep trying to remove the 0th objective until there is none           
+        }
+
+        foreach (var rule in component.Objectives)
+        {
+            if (!_mind.TryAddObjective(mindId.Value, mind, rule.Id))
+                Log.Warning($"Failed to add objective {rule.Id} to {ToPrettyString(signer):player}.");
+        }
+
+    }
+}

--- a/Resources/Locale/en-US/_Starlight/delivery/delivery-spam.ftl
+++ b/Resources/Locale/en-US/_Starlight/delivery/delivery-spam.ftl
@@ -13,3 +13,27 @@ delivery-spam-reasons-to-join-syndicate = {-delivery-header-syndicate}
 
                     {"[bold]SIGN HERE IF YOU AGREE[/bold]"}
                     glory to the syndicate, death to nanotransen
+
+deliver-spam-dont-you-want-more = {"[color=gold][bold]Don't You Want More?[/bold][/color]"}
+                                  
+                                  Look around.
+                                  Someone's got the insulated gloves.
+                                  Someone's got the captain's spare.
+                                  Someone's got a locker full of contraband and cool toys.
+                                  
+                                  And it's not you.
+                                  
+                                  Why wait?
+                                  {"[color=red][bold]Take what you want.[/bold][/color]"}
+                                  Wrenches. Weapons. IDs. Jetpacks. Don't ask. Don't trade. Just grab it and run.
+                                  Security's lazy. Cargo's careless. Engineering leaves stuff lying around.
+                                  All of it could be yours — if you're fast enough.
+                                  
+                                  You're not doing this to make things better.
+                                  {"You're doing this because [color=red][bold]you deserve more.[/bold][/color]"}
+                                  More gear. More power. More fun.
+                                  
+                                  {"[color=orange][bold]Sign below if you're ready to stop being poor and start taking what’s yours.[/bold][/color]"}
+                                  
+                                  No heroes. Just winners.
+

--- a/Resources/Prototypes/Entities/Objects/Deliveries/letter_loot_tables.yml
+++ b/Resources/Prototypes/Entities/Objects/Deliveries/letter_loot_tables.yml
@@ -10,7 +10,6 @@
       - id: MailSpamLetter
       - id: MailSpamLetter
       - id: MailSpamLetter
-      - id: MailSpamLetter
       - !type:NestedSelector
         tableId: MailAntagSpamLetter # Starlight, behold, antag on signing papers.
 

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
@@ -51,7 +51,6 @@
         - AmePartFlatpackStealObjective
         - ExpeditionsCircuitboardStealObjective
         - CargoShuttleCircuitboardStealObjective
-        - SalvageShuttleCircuitboardStealObjective
         - ClothingEyesHudBeerStealObjective
         - BibleStealObjective
         - ClothingNeckGoldmedalStealObjective

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
@@ -11,3 +11,84 @@
       antags:
         - antag: Traitor
           targetComponent: TraitorRule
+
+- type: entity
+  id: MailSpamDontYouWantMore
+  name: Don't You Want More?
+  description: An inciting paper that smells faintly of welding fuel and desire. Wont fit in a fax somehow.
+  parent: Paper
+  components:
+    - type: Paper
+      content: deliver-spam-dont-you-want-more
+    - type: AntagOnSign
+      chance: 1 # theif is a "low impact" antag... not for much longer :3
+      antags:
+        - antag: Traitor # gotta be a traitor for the traitor objectives
+          targetComponent: TraitorRule
+        - antag: Thief # gotta be a thief for the thief objectives
+          targetComponent: ThiefRule
+    - type: ObjectiveOnSign
+      objectives:
+        # thief collection objectives
+        - HeadCloakStealCollectionObjective
+        - HeadBedsheetStealCollectionObjective
+        - StampStealCollectionObjective
+        - DoorRemoteStealCollectionObjective
+        - TechnologyDiskStealCollectionObjective
+        - MailStealCollectionObjective
+        - FigurineStealCollectionObjective
+        - IDCardsStealCollectionObjective
+        - LAMPStealCollectionObjective
+        # thief item objectives
+        - ForensicScannerStealObjective
+        - FlippoEngravedLighterStealObjective
+        - ClothingHeadHatWardenStealObjective
+        - WantedListCartridgeStealObjective
+        - ClothingOuterHardsuitVoidParamedStealObjective
+        - MedicalTechFabCircuitboardStealObjective
+        - ClothingHeadsetAltMedicalStealObjective
+        - FireAxeStealObjective
+        - AmePartFlatpackStealObjective
+        - ExpeditionsCircuitboardStealObjective
+        - CargoShuttleCircuitboardStealObjective
+        - SalvageShuttleCircuitboardStealObjective
+        - ClothingEyesHudBeerStealObjective
+        - BibleStealObjective
+        - ClothingNeckGoldmedalStealObjective
+        - ClothingNeckClownmedalStealObjective
+        # thief structure objectives
+        - NuclearBombStealObjective
+        - FaxMachineCaptainStealObjective
+        - ChemDispenserStealObjective
+        - XenoArtifactStealObjective
+        - FreezerHeaterStealObjective
+        - TegStealObjective
+        - BoozeDispenserStealObjective
+        - AltarNanotrasenStealObjective
+        - PlantRDStealObjective
+        - ToiletGoldenStealObjective
+        # thief pet steal objecives
+        - IanStealObjective
+        - BingusStealObjective
+        - McGriffStealObjective
+        - WalterStealObjective
+        - MortyStealObjective
+        - RenaultStealObjective
+        - ShivaStealObjective
+        - TropicoStealObjective
+        # thief escape objective
+        - EscapeThiefShuttleObjective
+        # traitor steal objectives
+        - CaptainIDStealObjective
+        - CMOHyposprayStealObjective
+        - CMOCrewMonitorStealObjective
+        - RDHardsuitStealObjective
+        - NukeDiskStealObjective
+        - MagbootsStealObjective
+        # no ian meat because you are a pacifist and need them alive
+        - ClipboardStealObjective #QM's digiboard
+        - CaptainGunStealObjective
+        - CaptainJetpackStealObjective
+        - HandTeleporterStealObjective
+        - EnergyShotgunStealObjective
+    

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/letter_loot_tables.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/letter_loot_tables.yml
@@ -5,3 +5,6 @@
   table: !type:GroupSelector
     children:
       - id: MailSyndicateSpamLetter
+      - id: MailSpamDontYouWantMore
+      - id: MailSpamDontYouWantMore
+      - id: MailSpamDontYouWantMore


### PR DESCRIPTION
## Short description
adds a new comp that can run after antag on sign to add/set objectives on a person
also makes antag spam slightly more common (1/8 -> 1/7) but the traitor one is rarer (1/1 -> 1/4)

## Why we need to add this
more stuff on sign component

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/d51cd7b0-b8ca-49cd-b1ed-15555f454c65

https://github.com/user-attachments/assets/5badcb40-3098-4c6b-af1a-2f7009d32490

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: hey so I heard you like theiving. so I made a paper that gives you every steal objective in the game. very rarely in mail.
- tweak: made antag mail slightly more common. and the reasons to join the syndicate a bit rarer,
