### PR TITLE
allow station AIs to be ionstormed 75% as often as borgs.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -301,6 +301,10 @@
       state: ai_female
   - type: NameIdentifier
     group: StationAi
+    #region Starlight
+  - type: IonStormTarget
+    chance: 0.6 # lets just try it at 3/4th the chance of a borg and see how bad it gets
+    #endregion
 
 # Hologram projection that the AI's eye tracks.
 - type: entity


### PR DESCRIPTION
## Short description
allows the station AI to be ionstormed at a lower rate then borgs

## Why we need to add this
gives the RD more of a reason to enter AI upload aside from nukies, gamemaster, or getting them off crewsimov.
and LORD MEGATRON demands it :>

## Media or Screenshots
![image](https://github.com/user-attachments/assets/f27a8702-33cb-42ab-8352-3e9145aa9b0c)

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: the AI core can now be ionstormed a little bit less often then borgs though.
