### PR TITLE
Buff Nitrous Oxide

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -370,7 +370,7 @@
           shouldHave: false
         key: ForcedSleep
         component: ForcedSleeping
-        time: 3
+        time: 12
         type: Add
       - !type:HealthChange
         conditions:

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -370,7 +370,7 @@
           shouldHave: false
         key: ForcedSleep
         component: ForcedSleeping
-        time: 12
+        time: 12 # Starlight change
         type: Add
       - !type:HealthChange
         conditions:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Due to its previous nerf, nitrous oxide couldn't be utilized by syndicates at all. This buff promotes antag gameplay without causing any major damage. For instance, atmoses tend to frezon flood departments where they have their target or whenever they steal stuff from command. Now they can use a much safer method without accidentally killing and ruining gameplay of other people.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
https://discord.com/channels/1272545509562777621/1380296399794737313/1380296399794737313
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
None
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: AndrewTateOfficialSS14
- tweak: Nitrous Oxide has a longer sleep effect now.

