### PR TITLE
Syndi shadow factory update

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/ShuttleEvent/ShadowBorgiGrid.yml
+++ b/Resources/Maps/_Starlight/Shuttles/ShuttleEvent/ShadowBorgiGrid.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 260.2.0
   forkId: Starlight
   forkVersion: 1732131340
-  time: 06/03/2025 11:30:57
-  entityCount: 676
+  time: 06/06/2025 00:23:08
+  entityCount: 677
 maps: []
 grids:
 - 1
@@ -330,7 +330,7 @@ entities:
       pos: -0.5,11.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4168.0547
+      secondsUntilStateChange: -4399.784
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -2940,6 +2940,15 @@ entities:
       rot: 3.141592653589793 rad
       pos: -11.5,5.5
       parent: 1
+- proto: HolopadBluespace
+  entities:
+  - uid: 677
+    components:
+    - type: MetaData
+      name: Borgi Factory Holopad
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
 - proto: hydroponicsTray
   entities:
   - uid: 421
@@ -3535,7 +3544,7 @@ entities:
       pos: -6.5,11.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -9702.616
+      secondsUntilStateChange: -9934.346
       state: Opening
 - proto: SpawnSmartSubwoofer
   entities:

--- a/Resources/Prototypes/_StarLight/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/unknown_shuttles.yml
@@ -1,9 +1,8 @@
 - type: entity
-  parent: BaseUnknownShuttleRule
+  parent: BaseGameRule
   id: ShuttleSyndiShadowOps
   components:
     - type: StationEvent
       startAnnouncement: null # It should be silent.
-      maxOccurrences: 1 # should be the same as [copies] in shuttle_incoming_event.yml
     - type: LoadMapRule
-      preloadedGrid: ShuttleSyndiShadowOps
+      gridPath: /Maps/_Starlight/Shuttles/ShuttleEvent/ShadowBorgiGrid.yml # no preload cause that leads to a warp point in shuttle space

--- a/Resources/Prototypes/_StarLight/Shuttles/shuttles.yml
+++ b/Resources/Prototypes/_StarLight/Shuttles/shuttles.yml
@@ -1,4 +1,1 @@
-- type: preloadedGrid
-  id: ShuttleSyndiShadowOps
-  path: /Maps/_Starlight/Shuttles/ShuttleEvent/ShadowBorgiGrid.yml
-  copies: 1
+


### PR DESCRIPTION
## Short description
readded the holopad. but this time it is dial only so it is harder to notice.
moved the shuttle to a loaded grid like wizards and loneops

## Why we need to add this
no more warping to it in shuttle space and getting stuck

## Media (Video/Screenshots)

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- fix: removed the "Syndicate Borgi Factory" warp point that teleports you to a unloaded map.