### PR TITLE
Custom Species Name - Tiny Patch

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -578,9 +578,6 @@ namespace Content.Shared.Preferences
                 var speciesPrototypes = prototypeManager.EnumeratePrototypes<SpeciesPrototype>();
                 foreach (var specieNames in speciesPrototypes)
                 {
-                    if (specieNames == speciesPrototype)
-                        continue;
-
                     if (Loc.GetString(specieNames.Name).ToLower() == customspeciename.ToLower())
                     {
                         customspeciename = "";

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -7,3 +7,4 @@
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobDwarfDummy
   skinColoration: HumanToned
+  customName: true # Starlight


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Apply two fixes:

1. When Species Auto-populate blacklist was ingored when your putting the name of the same specie your playing and when just pressing enter (like by mistake) without changing anything, its considered as a custom name and applied it, making it said double: 
![image](https://github.com/user-attachments/assets/62ed8046-8d10-4c14-adf5-ab9990932329)
This tiny fix, fixes that.

2. I forgot to allow Drawfs Prototype to have CustomName, this PR fixes it.

I will mention, with this PR, mention if there typoes i made in my previous PR, FTL, files, ect..., so i can edit this PR to fix it!

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes my oversights

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: foxxotrystan
- fix: Custom Species Names can now be assigned to Drawfs
