### PR TITLE
Abductor return pod fix

### DIFF
--- a/Content.Shared/Containers/ExitContainerOnMoveSystem.cs
+++ b/Content.Shared/Containers/ExitContainerOnMoveSystem.cs
@@ -28,7 +28,7 @@ public sealed class ExitContainerOnMoveSystem : EntitySystem
             return;
 
         //🌟Starlight🌟 Prevent sleeping or stunned entities from exiting containers
-        if (TryComp<SleepingComponent>(args.Entity, out _) || TryComp<StunnedComponent>(args.Entity, out _))
+        if (HasComp<SleepingComponent>(args.Entity) || HasComp<StunnedComponent>(args.Entity))
             return;
 
         _climb.ForciblySetClimbing(args.Entity, ent);

--- a/Content.Shared/Containers/ExitContainerOnMoveSystem.cs
+++ b/Content.Shared/Containers/ExitContainerOnMoveSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Climbing.Systems;
 using Content.Shared.Movement.Events;
 using Robust.Shared.Containers;
 using Content.Shared.Bed.Sleep;
+using Content.Shared.Stunnable;
 
 namespace Content.Shared.Containers;
 
@@ -26,8 +27,8 @@ public sealed class ExitContainerOnMoveSystem : EntitySystem
         if (!_container.TryGetContainer(ent, comp.ContainerId, out var container, containerManager) || !container.Contains(args.Entity))
             return;
 
-        //🌟Starlight🌟 Prevent sleping entities from exiting containers
-        if (TryComp<SleepingComponent>(args.Entity, out _))
+        //🌟Starlight🌟 Prevent sleeping or stunned entities from exiting containers
+        if (TryComp<SleepingComponent>(args.Entity, out _) || TryComp<StunnedComponent>(args.Entity, out _))
             return;
 
         _climb.ForciblySetClimbing(args.Entity, ent);

--- a/Content.Shared/Containers/ExitContainerOnMoveSystem.cs
+++ b/Content.Shared/Containers/ExitContainerOnMoveSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Climbing.Systems;
 using Content.Shared.Movement.Events;
 using Robust.Shared.Containers;
+using Content.Shared.Bed.Sleep;
 
 namespace Content.Shared.Containers;
 
@@ -23,6 +24,10 @@ public sealed class ExitContainerOnMoveSystem : EntitySystem
             return;
 
         if (!_container.TryGetContainer(ent, comp.ContainerId, out var container, containerManager) || !container.Contains(args.Entity))
+            return;
+
+        //🌟Starlight🌟 Prevent sleping entities from exiting containers
+        if (TryComp<SleepingComponent>(args.Entity, out _))
             return;
 
         _climb.ForciblySetClimbing(args.Entity, ent);

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Specific/abductor_experimentator.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Specific/abductor_experimentator.yml
@@ -16,6 +16,8 @@
     canCollide: false
   - type: DragInsertContainer
     containerId: storage
+  - type: ExitContainerOnMove
+    containerId: storage
   - type: ContainerContainer
     containers:
       storage: !type:ContainerSlot

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Specific/abductor_experimentator.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Specific/abductor_experimentator.yml
@@ -16,8 +16,6 @@
     canCollide: false
   - type: DragInsertContainer
     containerId: storage
-  - type: ExitContainerOnMove
-    containerId: storage
   - type: ContainerContainer
     containers:
       storage: !type:ContainerSlot


### PR DESCRIPTION
## Short description
abductor return pod can not be exited by people while they are asleep

## Why we need to add this


## Media (Video/Screenshots)

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: CringeCursed
- fix: Now you cant exit abductor return pod when you're asleep or stunned.