### PR TITLE
Ammo type examine

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -8,6 +8,7 @@ using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
 
@@ -15,6 +16,7 @@ public abstract partial class SharedGunSystem
 {
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
 
     protected virtual void InitializeBallistic()
@@ -181,7 +183,32 @@ public abstract partial class SharedGunSystem
         if (!args.IsInDetailsRange)
             return;
 
-        args.PushMarkup(Loc.GetString("gun-magazine-examine", ("color", AmmoExamineColor), ("count", GetBallisticShots(component))));
+        // 🌟Starlight🌟 -- get next ammo in feed
+        var shots = GetBallisticShots(component);
+        string ammoTypeName = "";
+
+        if (component.Entities.Count > 0)
+        {
+            var firstAmmo = component.Entities[^1];
+            if (TryComp<MetaDataComponent>(firstAmmo, out var meta) && meta.EntityPrototype?.ID != null &&
+                _prototypeManager.TryIndex<EntityPrototype>(meta.EntityPrototype.ID, out var entity))
+            {
+                ammoTypeName = entity.Name;
+            }
+        }
+
+        else if (component.UnspawnedCount > 0 && component.Proto != null && _prototypeManager.TryIndex(component.Proto, out EntityPrototype? proto))
+        {
+            ammoTypeName = proto.Name;
+        }
+
+        args.PushMarkup(Loc.GetString("gun-magazine-examine", ("color", AmmoExamineColor), ("count", shots)));
+
+        if (ammoTypeName != null)
+            args.PushMarkup(Loc.GetString("gun-magazine-ammo-type", ("color", "green"), ("type", ammoTypeName)));
+        else
+            args.PushMarkup(Loc.GetString("gun-magazine-empty"));
+        // 🌟Starlight🌟 end me
     }
 
     private void ManualCycle(EntityUid uid, BallisticAmmoProviderComponent component, MapCoordinates coordinates, EntityUid? user = null, GunComponent? gunComp = null)

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -8,7 +8,7 @@ using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Serialization;
-using Robust.Shared.Prototypes;
+using Robust.Shared.Prototypes; // 🌟Starlight🌟
 
 namespace Content.Shared.Weapons.Ranged.Systems;
 
@@ -16,7 +16,7 @@ public abstract partial class SharedGunSystem
 {
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!; // 🌟Starlight🌟
 
 
     protected virtual void InitializeBallistic()

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -42,8 +42,8 @@ gun-chamber-rack = Rack
 
 # MagazineAmmoProvider
 gun-magazine-examine = It has [color={$color}]{$count}[/color] shots remaining.
-gun-magazine-ammo-type = It contains [color={$color}]{$type}[/color].
-gun-magazine-empty = Magazine is empty.
+gun-magazine-ammo-type = It contains [color={$color}]{$type}[/color]. # 🌟Starlight🌟
+gun-magazine-empty = Magazine is empty. # 🌟Starlight🌟
 
 # RevolverAmmoProvider
 gun-revolver-empty = Empty revolver

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -42,6 +42,8 @@ gun-chamber-rack = Rack
 
 # MagazineAmmoProvider
 gun-magazine-examine = It has [color={$color}]{$count}[/color] shots remaining.
+gun-magazine-ammo-type = It contains [color={$color}]{$type}[/color].
+gun-magazine-empty = Magazine is empty.
 
 # RevolverAmmoProvider
 gun-revolver-empty = Empty revolver

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -42,8 +42,10 @@ gun-chamber-rack = Rack
 
 # MagazineAmmoProvider
 gun-magazine-examine = It has [color={$color}]{$count}[/color] shots remaining.
-gun-magazine-ammo-type = It contains [color={$color}]{$type}[/color]. # 🌟Starlight🌟
-gun-magazine-empty = Magazine is empty. # 🌟Starlight🌟
+# 🌟Starlight - Start🌟
+gun-magazine-ammo-type = It contains [color={$color}]{$type}[/color].
+gun-magazine-empty = Magazine is empty.
+# 🌟Starlight - End🌟
 
 # RevolverAmmoProvider
 gun-revolver-empty = Empty revolver


### PR DESCRIPTION
## Short description
adds the ability to check ammo type

## Why we need to add this
QOL

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/f7151391-ec0d-4e56-88a7-7a0a7fadaff8)


## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl:  CringeCursed
- tweak:  Examining magazines now shows ammo type.
