### PR TITLE
Adds a wielding requirement to the smart LMG

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -17,6 +17,7 @@
     slots:
     - Back
     - suitStorage
+  - type: GunRequiresWield
   - type: MagazineVisuals
     magState: mag
     steps: 4


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
You now have to wield the sec lmg to shoot it
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
shooting a heavy lmg 1 handed makes no sense. tamashi also approved this change
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![image](https://github.com/user-attachments/assets/b13b7691-31b1-485f-8b98-a54e62c2599d)
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.-->

:cl: PubliclyExecutedPig
- tweak: Studies show trying to shoot the smart LMG one handed often results in broken bones.

