### PR TITLE
End of q more mystical

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
@@ -1,5 +1,80 @@
 - type: entity
-  parent: Paper
+  parent: BaseItem
+  id: BaseStarlightAdmemePaper
+  abstract: true
+  components:
+    - type: Tag
+      tags:
+        - Document
+    - type: Appearance
+    - type: Item
+      size: Tiny
+    - type: PaperVisuals
+    - type: PaperLabelType
+    - type: ActivatableUI
+      key: enum.PaperUiKey.Key
+      requiresComplex: false
+    - type: UserInterface
+      interfaces:
+        enum.PaperUiKey.Key:
+          type: PaperBoundUserInterface
+    - type: Sprite
+      sprite: Objects/Misc/bureaucracy.rsi
+      layers:
+      - state: paper
+      - state: paper_words
+        map: ["enum.PaperVisualLayers.Writing"]
+        visible: false
+      - state: paper_stamp-generic
+        map: ["enum.PaperVisualLayers.Stamp"]
+        visible: false
+
+- type: entity
+  parent: BaseStarlightAdmemePaper
+  id: BasePaperQuietChaos
+  name: end of Q # no longer "the" since when you emote it would come out to "the the end of Q x"
+  description: dreadful paper that cant be faxed. but has it's own ways of getting around.
+  abstract: true
+  components:
+    - type: Tag
+      tags:
+        - GhostOnlyWarp
+        - Document
+        - Paper
+    - type: WarpPoint # if someone takes the ghost role it appears twice. once as a ghost warp. once as a player but oh well.
+      follow: true
+      location: end of Q
+      blacklist:
+        tags:
+        - GhostOnlyWarp
+    - type: GhostRole
+      makeSentient: true
+      name: ghost-role-information-chaospaper-name
+      description: ghost-role-information-chaospaper-description
+      rules: ghost-role-information-freeagent-rules
+      allowSpeech: true
+      reregister: true
+      raffle: 
+        settings: default
+      mindRoles: 
+        - MindRoleGhostRoleFreeAgent
+    - type: ShowMindShieldIcons # gotta know your targets.
+    - type: Speech
+    - type: TextToSpeech
+    - type: GhostTakeoverAvailable
+    - type: MobState
+
+    - type: Examiner # allow inspecting stuff and using verbs (you still dont have hands though)
+      skipChecks: true #anything on screen is fair game to be observed.
+    - type: Polymorphable # so the paper CAN jaunt.
+    - type: ActionGrant
+      actions:
+        # I would give it ghost Boo! action. but that requires ghost component...
+        - ActionPolymorphJauntIII
+        - ActionVoidApplause
+
+- type: entity
+  parent: BasePaperQuietChaos
   id: PaperTooQuietNeedChaos
   name: the end of Q
   description: dreadful paper that cant fit in a fax machine.
@@ -24,38 +99,10 @@
         - DragonSpawn
         - NinjaSpawn
         - ParadoxCloneSpawn
-    - type: Tag
-      tags:
-        - GhostOnlyWarp
-        - Document
-        - Paper
-    - type: WarpPoint
-      follow: true
-      location: the end of Q
-      blacklist:
-        tags:
-        - GhostOnlyWarp
-    - type: GhostRole
-      makeSentient: true
-      name: ghost-role-information-chaospaper-name
-      description: ghost-role-information-chaospaper-description
-      rules: ghost-role-information-freeagent-rules
-      allowSpeech: true
-      reregister: true
-      mindRoles: 
-        - MindRoleGhostRoleFreeAgent
-    - type: ShowMindShieldIcons # gotta know your targets.
-    - type: Speech
-    - type: TextToSpeech
-    - type: GhostTakeoverAvailable
-    - type: MobState
-
-
+    
 - type: entity
-  parent: Paper
+  parent: BasePaperQuietChaos
   id: PaperTooQuietNeedChaosFew
-  name: the end of Q
-  description: dreadful paper that cant fit in a fax machine.
   suffix: Lowpop
   components:
     - type: Paper
@@ -72,27 +119,3 @@
         - UnknownShuttleHonki
         - WizardSpawn
         - NinjaSpawn #spawns less cause there is also less people to take said roles. and I deem these to be the less "chaotic" ones
-    - type: Tag
-      tags:
-        - GhostOnlyWarp
-        - Document
-        - Paper
-    - type: WarpPoint
-      follow: true
-      location: the end of Q
-      blacklist:
-        tags:
-        - GhostOnlyWarp
-    - type: GhostRole
-      makeSentient: true
-      name: ghost-role-information-chaospaper-name
-      description: ghost-role-information-chaospaper-description
-      rules: ghost-role-information-freeagent-rules
-      allowSpeech: true
-      reregister: true
-      mindRoles: 
-        - MindRoleGhostRoleFreeAgent
-    - type: ShowMindShieldIcons # gotta know your targets.
-    - type: Speech
-    - type: GhostTakeoverAvailable
-    - type: MobState

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
@@ -30,7 +30,7 @@
         visible: false
 
 - type: entity
-  parent: BaseStarlightAdmemePaper
+  parent: Paper
   id: BasePaperQuietChaos
   name: end of Q # no longer "the" since when you emote it would come out to "the the end of Q x"
   description: dreadful paper that cant be faxed. but has it's own ways of getting around.
@@ -63,7 +63,6 @@
     - type: TextToSpeech
     - type: GhostTakeoverAvailable
     - type: MobState
-
     - type: Examiner # allow inspecting stuff and using verbs (you still dont have hands though)
       skipChecks: true #anything on screen is fair game to be observed.
     - type: Polymorphable # so the paper CAN jaunt.


### PR DESCRIPTION
## Short description
makes the end of Q more chaotic by giving it some of it's own movement abilities

## Why we need to add this
currently it was very dependent and only really had words and it's only action being the end result. nothing really in the middle to demonstrate that yes you are infact a magical paper of immense power.

## Media (Video/Screenshots)
it is just the jaunt/void applause actions

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: The rare paper in Cap's locker now has some EXTREMELY limited movement options. all magical in nature of course.
