### PR TITLE
Handheld artifact container now filters for the right component

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -124,7 +124,7 @@
     - 0,0,1,1
     whitelist:
       components:
-      - Artifact
+      - XenoArtifact
   - type: Item
     sprite: Objects/Storage/artifact_container.rsi  
     size: Huge


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes handheld artifact containers

## Why we need to add this
Handheld artifact containers were filtered for whitelist Artifact, but the actual component needed is XenoArtifact

## Media (Video/Screenshots)
Works now!
![image](https://github.com/user-attachments/assets/788b3d06-991f-49f5-a967-3412eede195a)


## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Handheld artifact containers can actually be used now

