### PR TITLE
roundstart maid outfits + cat ears

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -55,6 +55,8 @@
   - SuperSynthesizerInstrument # 🌟Starlight🌟
   - ClothingUnderSocksCoder # 🌟Starlight🌟
   - ClothWrap # 🌟Starlight🌟
+  - ClothingUniformJumpskirtElegantMaid # 🌟Starlight🌟
+  - ClothingHeadHatCatEars # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: Glasses

--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
@@ -29,3 +29,27 @@
   storage:
     back:
     - ClothingClothWrap
+
+- type: loadout
+  id: ClothingUniformJumpskirtElegantMaid
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:AnyFlagsRequirement
+      flags:
+      - Staff
+  storage:
+    back:
+    - ClothingUniformJumpskirtElegantMaid
+
+- type: loadout
+  id: ClothingHeadHatCatEars
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:AnyFlagsRequirement
+      flags:
+      - Staff
+  storage:
+    back:
+    - ClothingHeadHatCatEars


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Gives staff the ability to have cat ears and maid outfits on roundstart.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Mrrp mrreow

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![image](https://github.com/user-attachments/assets/99cd731d-f35f-4fba-a95d-bb3b52795076)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Cyanogen
- add: Mrrp mrreow!! (Roundstart femboy staff.)
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
