### PR TITLE
Changed cost of Accentless to 1 (it should apparently be 0??)

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -30,6 +30,7 @@ trait-unrevivable-desc = You are unable to be revived by defibrillators.
 trait-pirate-accent-name = Pirate accent
 trait-pirate-accent-desc = You can't stop speaking like a pirate!
 
+🌟Starlight🌟
 trait-accentless-name = No native accent
 trait-accentless-desc = You don't have the accent that your species would usually have
 

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -30,7 +30,7 @@ trait-unrevivable-desc = You are unable to be revived by defibrillators.
 trait-pirate-accent-name = Pirate accent
 trait-pirate-accent-desc = You can't stop speaking like a pirate!
 
-🌟Starlight🌟
+## 🌟Starlight🌟
 trait-accentless-name = No native accent
 trait-accentless-desc = You don't have the accent that your species would usually have
 

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -30,7 +30,7 @@ trait-unrevivable-desc = You are unable to be revived by defibrillators.
 trait-pirate-accent-name = Pirate accent
 trait-pirate-accent-desc = You can't stop speaking like a pirate!
 
-trait-accentless-name = Accentless
+trait-accentless-name = No native accent
 trait-accentless-desc = You don't have the accent that your species would usually have
 
 trait-frontal-lisp-name = Frontal lisp

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -7,7 +7,7 @@
   name: trait-accentless-name
   description: trait-accentless-desc
   category: SpeechTraits
-  cost: 1
+  cost: 0
   components:
   - type: Accentless
     removes:

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -7,7 +7,7 @@
   name: trait-accentless-name
   description: trait-accentless-desc
   category: SpeechTraits
-  cost: 0
+  cost: 0 # 🌟Starlight🌟
   components:
   - type: Accentless
     removes:

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -7,7 +7,7 @@
   name: trait-accentless-name
   description: trait-accentless-desc
   category: SpeechTraits
-  cost: 2
+  cost: 1
   components:
   - type: Accentless
     removes:

--- a/Resources/ServerInfo/Guidebook/NewPlayer/CharacterCreation.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/CharacterCreation.xml
@@ -44,7 +44,7 @@ Plenty of people patiently wait for their turn to be antagonists, so [color=#a48
 Speech traits alter your speech, sometimes to an extreme degree.
 
 They include:
-- Accentless (disables the accent of your selected species)
+- No native accent (disables the accent of your selected species)
 - Cowboy accent (word replacement, partner)
 - Frontal lisp ("s" is replaced with "th")
 - Italian accent (Mamma-mia, word replacement)

--- a/Resources/ServerInfo/Guidebook/NewPlayer/CharacterCreation.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/CharacterCreation.xml
@@ -44,7 +44,7 @@ Plenty of people patiently wait for their turn to be antagonists, so [color=#a48
 Speech traits alter your speech, sometimes to an extreme degree.
 
 They include:
-- No native accent (disables the accent of your selected species)
+- No native accent (disables the accent of your selected species) <!-- 🌟Starlight🌟 -->
 - Cowboy accent (word replacement, partner)
 - Frontal lisp ("s" is replaced with "th")
 - Italian accent (Mamma-mia, word replacement)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Changes the cost of Accentless trait to 0, from 2

## Why we need to add this
Some people were getting quite annoyed they couldn't play as one of the races with native accents and have accents while *also* getting rid of their native accent - which does make things *really* hard to read sometimes. I see no reason not to allow this, and it's a simple change, so I am proposing it here.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/9763bff9-c7ff-4c08-8cc3-5ff2bc34be89)



## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- tweak: Accentless trait is now cheaper
