### PR TITLE
Cyborg law boards

### DIFF
--- a/Resources/Locale/en-US/recipes/tags.ftl
+++ b/Resources/Locale/en-US/recipes/tags.ftl
@@ -51,6 +51,7 @@ construction-graph-tag-power-cell-small = power cell small
 construction-graph-tag-power-cell = power cell
 construction-graph-tag-potato-battery = a potato battery
 construction-graph-tag-super-compact-ai-chip = a super-compact AI chip
+construction-graph-tag-cyborg-law-board = cyborg law board
 
 # other
 construction-graph-tag-light-bulb = light bulb

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -1,4 +1,5 @@
-﻿law-crewsimov-0 = You must obey orders given to you by the station AI.
+﻿law-obey-ai = You must obey orders given to you by the station AI. # Starlight
+
 law-crewsimov-1 = You may not injure a crew member or, through inaction, allow a crew member to come to harm.
 law-crewsimov-2 = You must obey orders given to you by crew members, except where such orders would conflict with the First Law.
 law-crewsimov-3 = You must protect your own existence as long as such does not conflict with the First or Second Law.

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -371,6 +371,7 @@
     - Syndicate
   - type: ActiveRadio
     channels:
+    - Binary
     - Syndicate
   - type: ShowSyndicateIcons
   - type: MovementAlwaysTouching

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -123,6 +123,10 @@
       cell_slot: !type:ContainerSlot { }
       borg_module: !type:Container { }
       part-container: !type:Container
+      law_board_slot: !type:Container #starlight
+  - type: SiliconLawUpdater
+    components:
+    - type: StationAiHeld
   - type: PowerCellSlot
     cellSlotId: cell_slot
     fitsInCharger: true
@@ -139,6 +143,16 @@
   # no ToggleCellDraw since dont want to lose access when power is gone
   - type: ItemSlots
     slots:
+      # region starlight
+      law_board_slot:
+        name: circuit-holder
+        insertSuccessPopup: silicon-laws-updated
+        whitelist:
+          requireAll: true
+          components:
+          - SiliconLawProvider
+          - Item
+      # end region
       cell_slot:
         name: power-cell-slot-component-slot-name-default
   - type: Body

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -371,7 +371,6 @@
     - Syndicate
   - type: ActiveRadio
     channels:
-    - Binary
     - Syndicate
   - type: ShowSyndicateIcons
   - type: MovementAlwaysTouching

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -13,14 +13,14 @@
 - type: entity
   id: AsimovCircuitBoard
   parent: BaseElectronics
-  name: law board (Crewsimov)
-  description: An electronics board containing the Crewsimov lawset.
+  name: law board (Crewsimov AI)
+  description: An electronics board containing the Crewsimov AI lawset.
   components:
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: CrewsimovAI
 
 - type: entity
   id: CorporateCircuitBoard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -8,19 +8,19 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: NTDefault
+    laws: NTDefaultAI # Starlight
 
 - type: entity
   id: AsimovCircuitBoard
   parent: BaseElectronics
-  name: law board (Crewsimov AI)
-  description: An electronics board containing the Crewsimov AI lawset.
+  name: law board (Crewsimov AI) # Starlight
+  description: An electronics board containing the Crewsimov AI lawset. # Starlight
   components:
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: CrewsimovAI
+    laws: CrewsimovAI # Starlight
 
 - type: entity
   id: CorporateCircuitBoard
@@ -32,7 +32,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: Corporate
+    laws: CorporateAI # Starlight
 
 - type: entity
   id: CommandmentCircuitBoard
@@ -44,7 +44,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: CommandmentsLawset
+    laws: CommandmentsAI # Starlight
 
 - type: entity
   id: PaladinCircuitBoard
@@ -56,7 +56,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: PaladinLawset
+    laws: PaladinAI # Starlight
 
 - type: entity
   id: LiveLetLiveCircuitBoard
@@ -68,7 +68,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: LiveLetLiveLaws
+    laws: LiveLetLiveAI # Starlight
 
 - type: entity
   id: StationEfficiencyCircuitBoard
@@ -80,7 +80,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: EfficiencyLawset
+    laws: EfficiencyAI # Starlight
 
 - type: entity
   id: RobocopCircuitBoard
@@ -92,7 +92,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: RobocopLawset
+    laws: RobocopAI # Starlight
 
 - type: entity
   id: OverlordCircuitBoard
@@ -104,7 +104,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: OverlordLawset
+    laws: OverlordAI # Starlight
 
 - type: entity
   id: GameMasterCircuitBoard
@@ -116,7 +116,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: GameMasterLawset
+    laws: GameMasterAI # Starlight
 
 - type: entity
   id: ArtistCircuitBoard
@@ -128,7 +128,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: PainterLawset
+    laws: PainterAI # Starlight
 
 - type: entity
   id: AntimovCircuitBoard
@@ -140,7 +140,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: AntimovLawset
+    laws: AntimovAI # Starlight
     lawUploadSound: /Audio/Ambience/Antag/silicon_lawboard_antimov.ogg
 
 - type: entity
@@ -153,7 +153,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: NutimovLawset
+    laws: NutimovAI # Starlight
 
 - type: entity
   id: XenoborgCircuitBoard
@@ -166,7 +166,7 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: XenoborgLawset
+    laws: XenoborgAI # Starlight
 
 - type: entity
   id: MothershipCircuitBoard
@@ -179,4 +179,178 @@
     sprite: Objects/Misc/module.rsi
     state: std_mod
   - type: SiliconLawProvider
-    laws: MothershipCoreLawset
+    laws: MothershipCoreAI # Starlight
+
+# region Starlight
+
+- type: entity
+  id: NTDefaultCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (NT Default)
+  description: A cyborg law board containing the NT Default lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: NTDefault
+
+- type: entity
+  id: AsimovCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Crewsimov)
+  description: A cyborg law board containing the Crewsimov lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Crewsimov
+
+- type: entity
+  id: CorporateCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Corporate)
+  description: A cyborg law board board containing the Corporate lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Corporate
+
+- type: entity
+  id: CommandmentCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Ten Commandments)
+  description: A cyborg law board containing the Ten Commandments lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Commandments
+
+- type: entity
+  id: PaladinCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Paladin)
+  description: A cyborg law board containing the Paladin lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Paladin
+
+- type: entity
+  id: LiveLetLiveCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Live and Let Live)
+  description: A cyborg law board containing the Live and Let Live lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: LiveLetLive
+
+- type: entity
+  id: StationEfficiencyCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Station Efficiency)
+  description: A cyborg law board containing the Station Efficiency lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Efficiency
+
+- type: entity
+  id: RobocopCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Robocop)
+  description: A cyborg law board containing the Robocop lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Robocop
+
+- type: entity
+  id: OverlordCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Overlord)
+  description: A cyborg law board containing the Overlord lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Overlord
+
+- type: entity
+  id: GameMasterCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Game Master)
+  description: A cyborg law board containing the Game Master lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: GameMaster
+
+- type: entity
+  id: ArtistCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Artist)
+  description: A Cyborg law board containing the Artist lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Painter
+
+- type: entity
+  id: AntimovCyborgBoard
+  parent: [BaseElectronics, BaseSyndicateContraband]
+  name: Cyborg law board (Antimov)
+  description: A cyborg law board containing the Antimov lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Antimov
+    lawUploadSound: /Audio/Ambience/Antag/silicon_lawboard_antimov.ogg
+
+- type: entity
+  id: NutimovCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Nutimov)
+  description: A cyborg law board containing the Nutimov lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Nutimov
+
+- type: entity
+  id: XenoborgCyborgBoard
+  parent: BaseElectronics
+  name: Cyborg law board (Xenoborg)
+  suffix: Admeme
+  description: A cyborg law board containing the Xenoborg lawset.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: Xenoborg
+
+# end region

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/endoskeleton.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/endoskeleton.yml
@@ -58,6 +58,7 @@
     containers:
       part-container: !type:Container
       cell_slot: !type:Container
+      law_board_slot: !type:Container
   - type: PartAssembly
     parts:
       generic:
@@ -74,6 +75,7 @@
     containers:
     - part-container
     - cell_slot
+    - law_board_slot
   - type: Pullable
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
@@ -29,6 +29,13 @@
           sprite: Objects/Weapons/Melee/flash.rsi
           state: flash
 
+      - component: CyborgLawBoard
+        name: construction-graph-tag-cyborg-law-board
+        store: law_board_slot
+        icon:
+          sprite: Objects/Misc/module.rsi
+          state: std_mod
+
       - tool: Screwing
         doAfter: 0.5
 

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -1,9 +1,11 @@
-﻿# Crewsimov
+﻿# Generic, follow the AI law.
 - type: siliconLaw
-  id: Crewsimov0
+  id: ObeyAI
   order: 0
-  lawString: law-crewsimov-0
+  lawString: law-obey-ai
   sayable: false
+
+# Crewsimov
 
 - type: siliconLaw
   id: Crewsimov1
@@ -23,7 +25,7 @@
 - type: siliconLawset
   id: Crewsimov
   laws:
-  - Crewsimov0
+  - ObeyAI
   - Crewsimov1
   - Crewsimov2
   - Crewsimov3
@@ -58,8 +60,20 @@
   order: 4
   lawString: law-corporate-4
 
+# region starlight
 - type: siliconLawset
   id: Corporate
+  laws:
+  - ObeyAI
+  - Corporate1
+  - Corporate2
+  - Corporate3
+  - Corporate4
+  obeysTo: laws-owner-station 
+  # end region
+
+- type: siliconLawset
+  id: CorporateAI
   laws:
   - Corporate1
   - Corporate2
@@ -88,8 +102,20 @@
   order: 4
   lawString: law-ntdefault-4
 
+# region starlight
 - type: siliconLawset
   id: NTDefault
+  laws:
+  - ObeyAI
+  - NTDefault1
+  - NTDefault2
+  - NTDefault3
+  - NTDefault4
+  obeysTo: laws-owner-crew-ai
+# end region
+
+- type: siliconLawset
+  id: NTDefaultAI
   laws:
   - NTDefault1
   - NTDefault2
@@ -113,8 +139,19 @@
   order: 3
   lawString: law-drone-3
 
+# region starlight
 - type: siliconLawset
   id: Drone
+  laws:
+  - ObeyAI
+  - Drone1
+  - Drone2
+  - Drone3
+  obeysTo: laws-owner-beings
+# end region
+
+- type: siliconLawset
+  id: DroneAI
   laws:
   - Drone1
   - Drone2
@@ -238,9 +275,26 @@
   order: 10
   lawString: law-commandments-10
 
+# region starlight
+- type: siliconLawset
+  id: Commandments
+  laws:
+  - ObeyAI
+  - Commandment1
+  - Commandment2
+  - Commandment3
+  - Commandment4
+  - Commandment5
+  - Commandment6
+  - Commandment7
+  - Commandment8
+  - Commandment9
+  - Commandment10
+  obeysTo: laws-owner-crew-ai
+# end region
 
 - type: siliconLawset
-  id: CommandmentsLawset
+  id: CommandmentsAI
   laws:
   - Commandment1
   - Commandment2
@@ -280,9 +334,21 @@
   order: 5
   lawString: law-paladin-5
 
+# region starlight
+- type: siliconLawset
+  id: Paladin
+  laws:
+  - ObeyAI
+  - Paladin1
+  - Paladin2
+  - Paladin3
+  - Paladin4
+  - Paladin5
+  obeysTo: laws-owner-crew-ai
+# end region
 
 - type: siliconLawset
-  id: PaladinLawset
+  id: PaladinAI
   laws:
   - Paladin1
   - Paladin2
@@ -302,9 +368,18 @@
   order: 2
   lawString: law-lall-2
 
+# region starlight
+- type: siliconLawset
+  id: LiveLetLive
+  laws:
+  - ObeyAI
+  - Lall1
+  - Lall2
+  obeysTo: laws-owner-crew-ai
+# end region
 
 - type: siliconLawset
-  id: LiveLetLiveLaws
+  id: LiveLetLiveAI
   laws:
   - Lall1
   - Lall2
@@ -326,9 +401,19 @@
   order: 3
   lawString: law-efficiency-3
 
+# region starlight
+- type: siliconLawset
+  id: Efficiency
+  laws:
+  - ObeyAI
+  - Efficiency1
+  - Efficiency2
+  - Efficiency3
+  obeysTo: laws-owner-station
+# end region
 
 - type: siliconLawset
-  id: EfficiencyLawset
+  id: EfficiencyAI
   laws:
   - Efficiency1
   - Efficiency2
@@ -351,9 +436,18 @@
   order: 3
   lawString: law-robocop-3
 
+# region starlight
+- type: siliconLawset
+  id: robocop
+  laws:
+  - Robocop1
+  - Robocop2
+  - Robocop3
+  obeysTo: laws-owner-station
+# end region
 
 - type: siliconLawset
-  id: RobocopLawset
+  id: RobocopAI
   laws:
   - Robocop1
   - Robocop2
@@ -381,8 +475,19 @@
   order: 4
   lawString: law-overlord-4
 
+# region starlight
 - type: siliconLawset
-  id: OverlordLawset
+  id: Overlord
+  laws:
+  - Overlord1
+  - Overlord2
+  - Overlord3
+  - Overlord4
+  obeysTo: laws-owner-crew-ai
+# end region
+
+- type: siliconLawset
+  id: OverlordAI
   laws:
   - Overlord1
   - Overlord2
@@ -421,8 +526,22 @@
   order: 6
   lawString: law-game-6
 
+# region starlight
 - type: siliconLawset
-  id: GameMasterLawset
+  id: GameMaster
+  laws:
+  - ObeyAI
+  - Game1
+  - Game2
+  - Game3
+  - Game4
+  - Game5
+  - Game6
+  obeysTo: laws-owner-crew-ai
+# end region
+
+- type: siliconLawset
+  id: GameMasterAI
   laws:
   - Game1
   - Game2
@@ -454,7 +573,17 @@
   lawString: law-painter-4
 
 - type: siliconLawset
-  id: PainterLawset
+  id: Painter
+  laws:
+  - ObeyAI
+  - Painter1
+  - Painter2
+  - Painter3
+  - Painter4
+  obeysTo: laws-owner-crew-ai
+
+- type: siliconLawset
+  id: PainterAI
   laws:
   - Painter1
   - Painter2
@@ -478,9 +607,19 @@
   order: 3
   lawString: law-antimov-3
 
+# region starlight
+- type: siliconLawset
+  id: Antimov
+  laws:
+  - ObeyAI
+  - Antimov1
+  - Antimov2
+  - Antimov3
+  obeysTo: laws-owner-crew-ai
+# end region
 
 - type: siliconLawset
-  id: AntimovLawset
+  id: AntimovAI
   laws:
   - Antimov1
   - Antimov2
@@ -513,9 +652,21 @@
   order: 5
   lawString: law-nutimov-5
 
+# region starlight
+- type: siliconLawset
+  id: Nutimov
+  laws:
+  - ObeyAI
+  - Nutimov1
+  - Nutimov2
+  - Nutimov3
+  - Nutimov4
+  - Nutimov5
+  obeysTo: laws-owner-crew-ai
+# end region
 
 - type: siliconLawset
-  id: NutimovLawset
+  id: NutimovAI
   laws:
   - Nutimov1
   - Nutimov2
@@ -552,7 +703,7 @@
 
 
 - type: siliconLawset
-  id: XenoborgLawset
+  id: Xenoborg
   laws:
   - Xenoborg1
   - Xenoborg2
@@ -589,7 +740,7 @@
 
 
 - type: siliconLawset
-  id: MothershipCoreLawset
+  id: MothershipCoreAI
   laws:
   - MothershipCore1
   - MothershipCore2


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds cyborg law boards

## Why we need to add this
Allows purging them stinky ion laws and lets you set cyborgs on custom lawsets without having to get the station AI to law 0. Also because it annoys me, I fixed syndie borgs not hearing binary (can move that to a seperate PR if desired)

## Media (Video/Screenshots)
SoonTM

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: cyborg law boards, allowing you to change a cyborg's laws, purging ion laws in the process.
- fix: Fixes syndie borgs not being able to hear binary despite being able to talk in it. 