### PR TITLE
Revert Wizden cargo food adjustments

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -4,7 +4,17 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita-slice
   product: CrateFoodPizza
-  cost: 1600
+  cost: 450
+  category: cargoproduct-category-name-food
+  group: market
+
+- type: cargoProduct
+  id: FoodPizzaLarge
+  icon:
+    sprite: Objects/Consumable/Food/Baked/pizza.rsi
+    state: margherita
+  product: CrateFoodPizzaLarge
+  cost: 1800
   category: cargoproduct-category-name-food
   group: market
 
@@ -14,7 +24,7 @@
     sprite: Objects/Consumable/Food/snacks.rsi
     state: nutribrick
   product: CrateFoodMRE
-  cost: 1400
+  cost: 1000
   category: cargoproduct-category-name-food
   group: market
 
@@ -54,7 +64,17 @@
     sprite: Objects/Consumable/Drinks/cola.rsi
     state: icon
   product: CrateFoodSoftdrinks
-  cost: 1500
+  cost: 1200
+  category: cargoproduct-category-name-food
+  group: market
+
+- type: cargoProduct
+  id: FoodSoftdrinksLarge
+  icon:
+    sprite: Objects/Consumable/Drinks/colabottle.rsi
+    state: icon
+  product: CrateFoodSoftdrinksLarge
+  cost: 2400
   category: cargoproduct-category-name-food
   group: market
 
@@ -74,7 +94,7 @@
     sprite: Objects/Consumable/Food/burger.rsi
     state: bigbite
   product: CrateFoodHappyHonkBigBite
-  cost: 2800
+  cost: 1400
   category: cargoproduct-category-name-food
   group: market
 
@@ -84,7 +104,7 @@
     sprite: Objects/Consumable/Food/frozen.rsi
     state: sandwich
   product: CrateFoodIceCream
-  cost: 2000
+  cost: 1200
   category: cargoproduct-category-name-food
   group: market
 
@@ -94,6 +114,6 @@
     sprite: Objects/Consumable/Food/frozen.rsi
     state: cone
   product: CrateFoodSnowcone
-  cost: 2000
+  cost: 1100
   category: cargoproduct-category-name-food
   group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -13,6 +13,20 @@
       prob: 0.01
 
 - type: entity
+  id: CrateFoodPizzaLarge
+  parent: CratePlastic
+  name: disaster pizza delivery
+  description: In the ultimate event that all else has failed, Find comfort in that more pizza solves everything. Includes 16 pizzas.
+  components:
+  - type: StorageFill
+    contents:
+    - id: FoodBoxPizzaFilled
+      amount: 15
+    - id: FoodBoxPizzaCotton
+    - id: LidSalami
+      prob: 0.04
+
+- type: entity
   id: CrateFoodMRE
   parent: CratePlastic
   name: MRE crate
@@ -126,6 +140,31 @@
       amount: 2
     - id: DrinkFourteenLokoCan
       amount: 2
+
+- type: entity
+  id: CrateFoodSoftdrinksLarge
+  parent: CratePlastic
+  name: softdrinks bulk crate
+  description: Lots of sodas taken straight out of Centcomm's own vending machines, because you just can't leave your department. Includes 32 sodas.
+  components:
+  - type: EntityStorage
+    capacity: 32 # Slightly over-sized CratePlastic to accomodate over 30 drink cans at once.
+  - type: StorageFill
+    contents:
+      - id: DrinkColaCan
+        amount: 8
+      - id: DrinkGrapeCan
+        amount: 4
+      - id: DrinkRootBeerCan
+        amount: 4
+      - id: DrinkIcedTeaCan
+        amount: 4
+      - id: DrinkLemonLimeCan
+        amount: 4
+      - id: DrinkLemonLimeCranberryCan
+        amount: 4
+      - id: DrinkFourteenLokoCan
+        amount: 4
 
 - type: entity
   id: CrateFoodGetMore

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -63,9 +63,9 @@
     description: cargo-gift-pizza-large
     dest: cargo-gift-dest-bar
     gifts:
-      FoodPizza: 4              # 16 pizzas
+      FoodPizzaLarge: 1              # 16 pizzas
       FoodBarSupply: 1
-      FoodSoftdrinks: 2         # 32 sodas
+      FoodSoftdrinksLarge: 1
 
 - type: entity
   id: GiftsEngineering

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -8,7 +8,7 @@
     CrateMaterialSteel: 1.0
     # things the station might want
     CrateEngineeringAMEJar: 0.25
-    CrateFoodPizza: 0.25
+    CrateFoodPizzaLarge: 0.25
     CrateFoodSoftdrinks: 0.25
     CrateFunInstrumentsVariety: 0.25
     CrateSalvageEquipment: 0.25

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -645,10 +645,6 @@ CapacitorStockPart: MicroManipulatorStockPart
 # 2025-05-30
 SpawnHonkBot: SpawnMobHonkBot
 
-# 2025-06-01
-CrateFoodPizzaLarge: CrateFoodPizza
-CrateFoodSoftdrinksLarge: CrateFoodSoftdrinks
-
 # 2025-06-09
 BarSignAlignTile: BarSign
 BarSignComboCafeAlignTile: BarSignComboCafe


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Wizden just straight up hates cargo and salv for some reason.
Give me back my pizza, damnit!!

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I want my pizza back & these changes don't make sense

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Cyanogen
- tweak: Reverted Wizden cargo food price changes
- add: Disaster pizza deliveries are back on the menu!
- add: Soft drinks bulk crates are back too~

<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
