### PR TITLE
Change roboticist outfit selection

### DIFF
--- a/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
@@ -3,6 +3,7 @@ loadout-group-roboticist-head = Roboticist head
 loadout-group-roboticist-jumpsuit = Roboticist jumpsuit
 loadout-group-roboticist-outerclothing = Roboticist outer clothing
 loadout-group-roboticist-gloves = Roboticist gloves
+loadout-group-roboticist-goggles = Roboticist eyewear
 loadout-group-roboticist-backpack = Roboticist backpack
 
 # Command

--- a/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
@@ -2,6 +2,7 @@
 loadout-group-roboticist-head = Roboticist head
 loadout-group-roboticist-jumpsuit = Roboticist jumpsuit
 loadout-group-roboticist-outerclothing = Roboticist outer clothing
+loadout-group-roboticist-gloves = Roboticist gloves
 loadout-group-roboticist-backpack = Roboticist backpack
 
 # Command

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -131,10 +131,21 @@
   equipment:
     gloves: ClothingHandsGlovesLatex
 
-#- type: loadout Only for roboticist
-#  id: RobohandsGloves
-#  equipment:
-#    gloves: ClothingHandsGlovesRobohands
+- type: loadout
+  id: RobohandsGloves
+  equipment:
+    gloves: ClothingHandsGlovesRobohands
+
+# Goggles
+- type: loadout
+  id: RoboticistWeldingGoggles
+  equipment:
+    eyes: ClothingEyesWeldingGoggles
+
+- type: loadout
+  id: RoboticistDiagnosticsHud
+  equipment:
+    eyes: ClothingEyesHudDiagnostic
 
 # Shoes
 - type: loadout

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -28,7 +28,16 @@
   loadouts:
   - LatexGloves
   - PurpleGloves
-  - RobohandsGloves Only for roboticist
+  - RobohandsGloves
+
+- type: loadoutGroup
+  id: RoboticistGoggles
+  name: loadout-group-roboticist-goggles
+  minLimit: 0
+  loadouts:
+  - RoboticistWeldingGoggles
+  - RoboticistDiagnosticsHud
+  
   
 - type: loadoutGroup
   id: RoboticistBackpack

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -20,6 +20,15 @@
   loadouts:
   - RoboticistCap
   - SkullBandana
+
+- type: loadoutGroup
+  id: RoboticistGloves
+  name: loadout-group-roboticist-gloves
+  minLimit: 0
+  loadouts:
+  - LatexGloves
+  - PurpleGloves
+  - RobohandsGloves Only for roboticist
   
 - type: loadoutGroup
   id: RoboticistBackpack

--- a/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
@@ -3,6 +3,7 @@
   groups:
   - RoboticistHead
   - RoboticistJumpsuit
+  - RoboticistGloves
   - RoboticistOuterClothing
   - RoboticistBackpack
   - ScientistShoes

--- a/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
@@ -2,6 +2,7 @@
   id: JobRoboticist
   groups:
   - RoboticistHead
+  - RoboticistGoggles
   - RoboticistJumpsuit
   - RoboticistGloves
   - RoboticistOuterClothing

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Science/roboticist.yml
@@ -21,7 +21,5 @@
   id: RoboticistGear
   equipment:
     id: RoboticistPDA
-    gloves: ClothingHandsGlovesRobohands
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetRobotics
-    eyes: ClothingEyesWeldingGoggles

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Science/roboticist.yml
@@ -20,7 +20,6 @@
 - type: startingGear
   id: RoboticistGear
   equipment:
-    outerClothing: ClothingOuterCoatRobo
     id: RoboticistPDA
     gloves: ClothingHandsGlovesRobohands
     belt: ClothingBeltUtilityEngineering


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Expanded roboticist outfit selection to let you choose between welding goggles and diagnostics HUD (both are available at a robotics vendor anyway) and what science gloves you want - if any. Also fixed long-standing bug where outer clothing selection was just not respected at all.

## Why we need to add this
Roboticist outer clothing outfit selection has been broken for a *while* now, so that is fixed. Expanding on this, we should probably also be allowed to choose whether we want to have gloves, and not have welding goggles forced upon us.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/12c5d386-e9e8-4724-abde-7dd8a306111a)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Citrea
- tweak: Roboticists can now choose their eyewear, gloves and coat.
