### PR TITLE
Added Command-Only Turnstile

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Doors/turnstile.yml
@@ -1,0 +1,9 @@
+# Command
+
+- type: entity
+  id: TurnstileCommand
+  parent: Turnstile
+  suffix: Command
+  components:
+  - type: AccessReader
+    access: [["Command"]]


### PR DESCRIPTION
## Short description
Turnstile that only Command can use.

## Why we need to add this
Adding more usability to turnstiles.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/db33efdc-4a6a-4ef3-ac88-73ebcfec6b1e)

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Quini98
- add: Added Command-Only Turnstile
