### PR TITLE
Rod Changes (No body deleting, much faster)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -11,6 +11,14 @@
     state: icon
     noRot: false
   - type: ImmovableRod
+    minSpeed: 35
+    maxSpeed: 35
+    randomizeVelocity: false
+    shouldGib: false
+    damage:
+      types:
+        Blunt: 175 # Damage is applied twice
+        Piercing: 25
   - type: Physics
     bodyType: Dynamic
     linearDamping: 0
@@ -52,8 +60,14 @@
   suffix: Slow
   components:
   - type: ImmovableRod
-    minSpeed: 1
-    maxSpeed: 5
+    minSpeed: 35
+    maxSpeed: 35
+    randomizeVelocity: false
+    shouldGib: false
+    damage:
+      types:
+        Blunt: 175
+        Piercing: 25
 
 - type: entity
   parent: ImmovableRodDespawn
@@ -63,6 +77,14 @@
   - type: ImmovableRod
     destroyTiles: false
     hitSoundProbability: 1.0
+    minSpeed: 35
+    maxSpeed: 35
+    randomizeVelocity: false
+    shouldGib: false
+    damage:
+      types:
+        Blunt: 175
+        Piercing: 25
 
 # For Wizard Polymorph
 - type: entity
@@ -93,12 +115,13 @@
 
 - type: entity
   parent: ImmovableRodKeepTiles
-  id: ImmovableRodKeepTilesStill
+  id: ImmovableRodKeepTilesStill #for some GOD FORSAKEN REASON, the event draws from THIS one.
   suffix: Keep Tiles, Still
   components:
   - type: ImmovableRod
     randomizeVelocity: false
-    maxSpeed: 0
+    minSpeed: 35
+    maxSpeed: 35 
 
 - type: entity
   parent: ImmovableRodKeepTilesStill


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
It no longer deletes bodies, and doesn't instagib (so long as you're healthy)
It is also much FASTER now.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The Rod sucks. It's a round removal device that's been nerfed into the ground because no one likes a round removal device. So! I made it not suck. It now no longer instantly round removes you if you're healthy, and if you're not, you will get gibbed instead of deleted. I also reverted the speed changes to make the rod an actual THREAT again.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![tykutylk](https://github.com/user-attachments/assets/f254574f-1e61-4cec-b294-af08bb0338eb)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- tweak: Removed Body Deletion of Rod (it now does 350 blunt + 50 pierce, gib threshold is 400 blunt)
- tweak: Undid Rod Speed Nerf (5 -> 35)