### PR TITLE
PR that lets you shut up medibots

### DIFF
--- a/Resources/Locale/en-US/wires/wire-names.ftl
+++ b/Resources/Locale/en-US/wires/wire-names.ftl
@@ -45,6 +45,7 @@ wires-board-name-holopad = Holopad
 wires-board-name-barsign = Bar Sign
 wires-board-name-weapon-energy-turret = Sentry turret
 wires-board-name-turret-controls = Sentry turret control panel
+wires-board-name-medibot = Medibot
 
 # names that get displayed in the wire hacking hud & admin logs.
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -360,6 +360,15 @@
   - type: Inventory
     templateId: medibot
   - type: DoAfter
+  - type: WiresPanel
+  - type: Wires
+    boardName: wires-board-name-medibot
+    layoutId: MedibotControls
+    alwaysRandomize: true
+  - type: UserInterface
+    interfaces:
+      enum.WiresUiKey.Key:
+        type: WiresBoundUserInterface
 
 - type: entity
   parent:

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -226,3 +226,9 @@
   - !type:AiInteractWireAction
   - !type:AccessWireAction 
   
+- type: wireLayout
+  id: MedibotControls
+  dummyWires: 9
+  wires:
+  - !type:SpeechWireAction
+  


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds a wire panel to medibot with 9 dummy wires and 1 speaker wire, randomized per each bot.

## Why we need to add this
You know why

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/5fb1803c-b3c5-4880-8f48-38fef0d033fd

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: princess_gurchi
- add: You can now shut up medibots by snipping their wires
