### PR TITLE
Give vulpkanin an increased (25%) solution metabolisation rate

### DIFF
--- a/Resources/Prototypes/_StarLight/Body/Organs/vulpkanin.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/vulpkanin.yml
@@ -23,3 +23,12 @@
           Quantity: 5
   - type: Metabolizer
     updateInterval: 1.5
+
+- type: entity
+  id: OrganVulpkaninHeart
+  parent: OrganAnimalHeart
+  name: heart
+  description: "A disgustingly hyperactive pump designed to keep things animate."
+  components:
+    - type: Metabolizer
+      updateInterval: 0.8

--- a/Resources/Prototypes/_StarLight/Body/Prototypes/vulpkanin.yml
+++ b/Resources/Prototypes/_StarLight/Body/Prototypes/vulpkanin.yml
@@ -20,7 +20,7 @@
       - right leg
       - left leg
       organs:
-        heart: OrganAnimalHeart
+        heart: OrganVulpkaninHeart
         lungs: OrganHumanLungs
         stomach: OrganVulpkaninStomach
         liver: OrganAnimalLiver

--- a/Resources/ServerInfo/Guidebook/Mobs/Vulpkanin.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Vulpkanin.xml
@@ -10,6 +10,7 @@
   
   - Receive [color=#ffa500]50% more fire damage[/color] and [color=#1e90ff]50% less cold damage[/color].
   - Need to eat and drink 1.5 times more.
+  - Metabolise chemicals in their bloodstream at a 25% faster rate.
   - Easily intoxicated.
   - Animal stomach, takes poison damage from chocolate and allows consuming other creatures' organs.
   - Deal [color=red]5[/color] slashing damage with claws.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Make Vulpkanins metabolise chemicals in their bloodstream at a 1.25x rate as compared to a base human. This is done by replacing their animal heart with a "vulpkanin heart" organ which has an update interval of 0.8.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Currently there is no apparent benefit to the vulpkanin grind :tm:  thirst/hunger rate, as well as a lack of "positive" features for the species. This is aimed to be a minor quirk/positive for the species that plays into their pre-existing theme.

Faster chemical metabolisation directly means that both poisons and medicines will have a higher instantaneous damage/heal rate, from what I have been playing around with 25% increase is a good mark - initially I wanted to make it a 50% increase but at that rate the "benefits" to Those Who Know (punct combat monkeys) outweigh the negatives presented by toxins - with a hypo and a jug of punc you could get a perpetual 6 pierce heal/s indefinitely.

"effect stack" toxins like chloral hydrate and nocturine still keep you asleep/effected for the same amount of time, it just makes the effects stack up faster (i.e. vulp with chloral hydrate will now drop faster than their human counterpart), however it is a net positive for some toxins like mechanotoxin where the slowdown is only felt when there is more than a certain amount within the bloodstream - because it purges faster the same toxin damage is dealt but the slowdown effect is felt for a shorter period of time.

This change does not have any effect on solutions that are thrown onto skin.

If anyone thinks this number is too low or too high or wrong entirely i'm all ears, this isn't intended to be "The Feature" for vulpkanin but merely something new/a slight stopgap while binocular vision or what have you is in the making.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![Screenshot_20250619_140555](https://github.com/user-attachments/assets/0f1d163d-47aa-42a7-9081-84bbf167c456)

*(Example, 10u of weh added to human and vulpkanin simultaneously, vulp processes solution faster)*

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: arkanic
- add: Vulpkanin now metabolise solutions in their bloodstream at a 25% faster rate
