### PR TITLE
force shadekin non glowing but have eye colors

### DIFF
--- a/Content.Server/_Starlight/ShadekinSystem.cs
+++ b/Content.Server/_Starlight/ShadekinSystem.cs
@@ -76,8 +76,8 @@ public sealed class ShadekinSystem : EntitySystem
         if (!TryComp<HumanoidAppearanceComponent>(uid, out var humanoid))
             return;
 
-        humanoid.EyeColor = Color.Black;
-        humanoid.EyeGlowing = true;
+        //humanoid.EyeColor = Color.Black;
+        humanoid.EyeGlowing = false; //enforce shadekin to not have glowing eyes. Lightkin when implemented should be forced to have glowing eyes.
         Dirty(uid, humanoid);
     }
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Allows shadekin to set their eye color but forces them to not be glowing

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Player customization

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Allowed shadekin to have custom eye colors, but they are forced to be non glowing.