### PR TITLE
Wizard spell nerfs

### DIFF
--- a/Content.Shared/Magic/Events/SmiteSpellEvent.cs
+++ b/Content.Shared/Magic/Events/SmiteSpellEvent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Actions;
+using Content.Shared.Damage;
 
 namespace Content.Shared.Magic.Events;
 
@@ -9,5 +10,8 @@ public sealed partial class SmiteSpellEvent : EntityTargetActionEvent
     /// Should this smite delete all parts/mechanisms gibbed except for the brain?
     /// </summary>
     [DataField]
-    public bool DeleteNonBrainParts = true;
+    public bool DeleteNonBrainParts = false;
+
+    [DataField]
+    public DamageSpecifier Damage;
 }

--- a/Content.Shared/Magic/Events/SmiteSpellEvent.cs
+++ b/Content.Shared/Magic/Events/SmiteSpellEvent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Actions;
 using Content.Shared.Damage;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Magic.Events;
 
@@ -13,5 +14,11 @@ public sealed partial class SmiteSpellEvent : EntityTargetActionEvent
     public bool DeleteNonBrainParts = false;
 
     [DataField]
-    public DamageSpecifier Damage;
+    public DamageSpecifier Damage = new()
+    {
+        DamageDict = new()
+        {
+            { "Shock", 400 }
+        }
+    };
 }

--- a/Content.Shared/Magic/Events/SmiteSpellEvent.cs
+++ b/Content.Shared/Magic/Events/SmiteSpellEvent.cs
@@ -13,6 +13,7 @@ public sealed partial class SmiteSpellEvent : EntityTargetActionEvent
     [DataField]
     public bool DeleteNonBrainParts = false;
 
+    //starlight start
     [DataField]
     public DamageSpecifier Damage = new()
     {
@@ -21,4 +22,5 @@ public sealed partial class SmiteSpellEvent : EntityTargetActionEvent
             { "Shock", 400 }
         }
     };
+    //starlight end
 }

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Systems;
 using Content.Shared.Coordinates.Helpers;
+using Content.Shared.Damage;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
 using Content.Shared.Hands.Components;
@@ -62,6 +63,8 @@ public abstract class SharedMagicSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
+    //starlight
+    [Dependency] private readonly DamageableSystem _damageable = default!;
 
     private static readonly ProtoId<TagPrototype> InvalidForGlobalSpawnSpellTag = "InvalidForGlobalSpawnSpell";
 
@@ -389,7 +392,11 @@ public abstract class SharedMagicSystem : EntitySystem
         if (!TryComp<BodyComponent>(ev.Target, out var body))
             return;
 
-        _body.GibBody(ev.Target, true, body);
+        //_body.GibBody(ev.Target, true, body); //starlight commented out
+        //starlight start
+        //apply damage to the target
+        _damageable.TryChangeDamage(ev.Target, ev.Damage, true); //ignore resistances
+        //starlight end
     }
 
     // End Touch Spells

--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -39,7 +39,8 @@ spellbook-animate-name = Animate
 spellbook-animate-description = Bring an inanimate object to life!
 
 spellbook-smite-name = Smite
-spellbook-smite-desc = Don't like them? EXPLODE them into giblets! Requires Wizard Robe & Hat.
+#starlight edit
+spellbook-smite-desc = Don't like them? SHOCK them into death! Requires Wizard Robe & Hat.
 
 spellbook-cluwne-name = Cluwne's Curse
 spellbook-cluwne-desc = For when you really hate someone and Smite isn't enough. Requires Wizard Robe & Hat.

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -45,7 +45,7 @@
   description: spellbook-cluwne-desc
   productAction: ActionCluwne
   cost:
-    WizCoin: 3
+    WizCoin: 300 #starlight make stupid expensive
   categories:
   - SpellbookOffensive
   conditions:

--- a/Resources/Prototypes/Magic/projectile_spells.yml
+++ b/Resources/Prototypes/Magic/projectile_spells.yml
@@ -2,11 +2,11 @@
   parent: BaseAction
   id: ActionFireball
   name: Fireball
-  description: Fires an explosive fireball towards the clicked location.
+  description: Fires an explosive fireball towards the clicked location. (Cooldown of 10 minutes)
   components:
   - type: Magic
   - type: Action
-    useDelay: 15
+    useDelay: 600 #starlight, 10 minutes
     itemIconStyle: BigAction
     raiseOnUser: true
     sound: !type:SoundPathSpecifier
@@ -31,16 +31,16 @@
   parent: ActionFireball
   id: ActionFireballII
   name: Fireball II
-  description: Fires a fireball, but faster!
+  description: Fires a fireball, but faster! (Cooldown of 8 minutes)
   components:
   - type: Action
-    useDelay: 10
+    useDelay: 480 #starlight, 8 minutes
 
 - type: entity
   parent: ActionFireball
   id: ActionFireballIII
   name: Fireball III
-  description: The fastest fireball in the west!
+  description: The fastest fireball in the west! (Cooldown of 5 minutes)
   components:
   - type: Action
-    useDelay: 8
+    useDelay: 300 #starlight, 5 minutes

--- a/Resources/Prototypes/Magic/projectile_spells.yml
+++ b/Resources/Prototypes/Magic/projectile_spells.yml
@@ -2,11 +2,11 @@
   parent: BaseAction
   id: ActionFireball
   name: Fireball
-  description: Fires an explosive fireball towards the clicked location. (Cooldown of 10 minutes)
+  description: Fires an explosive fireball towards the clicked location. (Cooldown of 5 minutes)
   components:
   - type: Magic
   - type: Action
-    useDelay: 600 #starlight, 10 minutes
+    useDelay: 300 #starlight, 5 minutes
     itemIconStyle: BigAction
     raiseOnUser: true
     sound: !type:SoundPathSpecifier
@@ -31,16 +31,16 @@
   parent: ActionFireball
   id: ActionFireballII
   name: Fireball II
-  description: Fires a fireball, but faster! (Cooldown of 8 minutes)
+  description: Fires a fireball, but faster! (Cooldown of 3 minutes)
   components:
   - type: Action
-    useDelay: 480 #starlight, 8 minutes
+    useDelay: 180 #starlight, 3 minutes
 
 - type: entity
   parent: ActionFireball
   id: ActionFireballIII
   name: Fireball III
-  description: The fastest fireball in the west! (Cooldown of 5 minutes)
+  description: The fastest fireball in the west! (Cooldown of 2 minutes)
   components:
   - type: Action
-    useDelay: 300 #starlight, 5 minutes
+    useDelay: 120 #starlight, 2 minutes

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -27,7 +27,7 @@
   parent: BaseSmiteAction
   id: ActionSmite
   name: Smite
-  description: Instantly gibs a target.
+  description: Instantly shocks a target.
   components:
   - type: Action
     sound: !type:SoundPathSpecifier
@@ -37,6 +37,9 @@
       state: gib
   - type: EntityTargetAction
     event: !type:SmiteSpellEvent
+    damage: #starlight damage
+      types:
+        Shock: 400
   - type: SpeakOnAction
     sentence: action-speech-spell-smite
   - type: Magic

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -37,9 +37,6 @@
       state: gib
   - type: EntityTargetAction
     event: !type:SmiteSpellEvent
-    damage: #starlight damage
-      types:
-        Shock: 400
   - type: SpeakOnAction
     sentence: action-speech-spell-smite
   - type: Magic


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Increases the cooldowns of fireballs to way higher to avoid spam
Makes cluwne spell impossible to purchase normally
Smite no longer gibs, acting more like a lightning bolt spell

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Wizard moment. People were spamming this and mass deleting departments

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Increased wizard fireball cooldown significantly, to 10, 8 and 5 minutes per the respective fireball level
- tweak: Smite now no longer gibs, doing 400 shock damage instead, bypassing resistances
- tweak: Cluwne spell is no longer purchasable, requiring 300 wizcoins