### PR TITLE
Cyborg Medals

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/borg.yml
+++ b/Resources/Prototypes/InventoryTemplates/borg.yml
@@ -8,6 +8,18 @@
     strippingWindowPos: 0,0
     displayName: Head
     offset: 0.015625, -0.09375
+  # 🌟Starlight🌟 start
+  - name: neck
+    slotTexture: neck
+    slotFlags: NECK
+    uiWindowPos: 0,2
+    strippingWindowPos: 0,1
+    displayName: Medal
+    offset: 0.03, -0.15
+    whitelist:
+      tags:
+        - Medal
+  # 🌟Starlight🌟 end
 
 - type: inventoryTemplate
   id: borgShort
@@ -19,6 +31,18 @@
     strippingWindowPos: 0,0
     displayName: Head
     offset: 0.015625, -0.1875
+  # 🌟Starlight🌟 start
+  - name: neck
+    slotTexture: neck
+    slotFlags: NECK
+    uiWindowPos: 0,2
+    strippingWindowPos: 0,1
+    displayName: Medal
+    offset: 0.075, -0.22
+    whitelist:
+      tags:
+        - Medal
+  # 🌟Starlight🌟 end
 
 - type: inventoryTemplate
   id: borgTall
@@ -30,6 +54,18 @@
     strippingWindowPos: 0,0
     displayName: Head
     offset: 0.015625, 0
+  # 🌟Starlight🌟 start
+  - name: neck
+    slotTexture: neck
+    slotFlags: NECK
+    uiWindowPos: 0,2
+    strippingWindowPos: 0,1
+    displayName: Medal
+    offset: 0.01, -0.125
+    whitelist:
+      tags:
+        - Medal
+  # 🌟Starlight🌟 end
 
 # taller than tall
 - type: inventoryTemplate
@@ -42,3 +78,15 @@
     strippingWindowPos: 0,0
     displayName: Head
     offset: 0, 0.09375
+  # 🌟Starlight🌟 start
+  - name: neck
+    slotTexture: neck
+    slotFlags: NECK
+    uiWindowPos: 0,2
+    strippingWindowPos: 0,1
+    displayName: Medal
+    offset: 0.02, -0.125
+    whitelist:
+      tags:
+        - Medal
+  # 🌟Starlight🌟 end


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds a medal slot to cyborg chassis, so borgs can properly receive medals.

## Why we need to add this
Borgs have been awarded medals multiple times, but have never been able to wear them.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/65c924ad-8641-4919-8ccf-34629abab35a)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- add: Cyborgs can now wear medals
