### PR TITLE
Fixes the fact that headrevs cryoed dont end

### DIFF
--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.Ghost;
 using Content.Server.Hands.Systems;
 using Content.Server.Inventory;
 using Content.Server.Popups;
+using Content.Server.Revolutionary.Components;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Server.StationRecords;
@@ -238,8 +239,10 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
             _stationRecords.RemoveRecord(key, stationRecords);
         }
 
-        //starlight remove headrev comp
+        //starlight start
         RemComp<HeadRevolutionaryComponent>(ent.Owner);
+        RemComp<CommandStaffComponent>(ent.Owner);
+        //starlight end
 
         _chatSystem.DispatchStationAnnouncement(station.Value,
             Loc.GetString(

--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -17,6 +17,9 @@ using Content.Shared.Database;
 using Content.Shared.GameTicking;
 using Content.Shared.Hands.Components;
 using Content.Shared.Mind.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Revolutionary.Components;
 using Content.Shared.StationRecords;
 using Content.Shared.UserInterface;
 using Robust.Server.Audio;
@@ -234,6 +237,9 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
 
             _stationRecords.RemoveRecord(key, stationRecords);
         }
+
+        //starlight remove headrev comp
+        RemComp<HeadRevolutionaryComponent>(ent.Owner);
 
         _chatSystem.DispatchStationAnnouncement(station.Value,
             Loc.GetString(

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -81,6 +81,12 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         {
             component.CommandCheck = _timing.CurTime + component.TimerWait;
 
+            //starlight, check if revs have lost
+            if (CheckRevsLose())
+            {
+                GameTicker.EndGameRule(uid, gameRule);
+            }
+
             if (CheckCommandLose())
             {
                 _roundEnd.DoRoundEndBehavior(RoundEndBehavior.ShuttleCall, component.ShuttleCallTime);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes headrevs cryoing not ending the round if they are all gone

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Game breaking bug is fixed :3

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- fix: Fixed Headrevs cyroing not being considered removed from revolution, preventing the game from ending.