### PR TITLE
Rechargers can once again charge power cells

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -165,6 +165,7 @@
           - HitscanBatteryAmmoProvider
           - ProjectileBatteryAmmoProvider
           - Stunbaton
+          - PowerCell # 🌟Starlight🌟
 
 - type: entity
   parent: BaseItemRecharger


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Rechargers can once again recharge power cells

## Why we need to add this
This broke recently, despite there being no changes to the code which would cause them, *somehow*. Turbochargers could still charge batteries the entire time, so even though this *technically* wasn't a bug, it very much felt like one. Now it is intended behaviour for rechargers to recharge batteries.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/1347e679-b2a1-4f54-9fd1-62401994ad1a)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Citrea
- add: Rechargers charging power cells is now intended behaviour and works again.
