### PR TITLE
Cargo Expedition Radio - add to salvage borg mining modules

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -506,6 +506,7 @@
     - Shovel
     - MineralScannerUnpowered
     - BorgOreBag
+    - RadioHandheldExpedition # Starlight
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: mining-module }
 
@@ -525,6 +526,7 @@
     - Shovel
     - AdvancedMineralScannerUnpowered
     - OreBagOfHolding
+    - RadioHandheldExpedition # Starlight
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: adv-mining-module }
 


### PR DESCRIPTION
## Short description
Forgot to add the cargo exped radio to the salvage borg modules.
Original PR: https://github.com/ss14Starlight/space-station-14/pull/779

## Why we need to add this
Salvage borg needs access to salvage/miner comms when apart

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/179dc242-07ca-4011-97fd-1bb80ee5a781)

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: biteless-dot
- add: Added the cargo expedition radio to the salvage borg mining modules

