### PR TITLE
Removed instant roundenders from survival and kessler syndrome

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -410,7 +410,7 @@
   components:
   - type: RampingStationEventScheduler
     scheduledGameRules: !type:NestedSelector
-      tableId: BasicGameRulesTable
+      tableId: BasicGameRulesTableNoRoundenders # 🌟Starlight🌟
 
 - type: entity
   id: SpaceTrafficControlEventScheduler # iff we make a selector for EntityTables that can respect StationEventComp restrictions, or somehow impliment them otherwise in said tables,

--- a/Resources/Prototypes/_StarLight/GameRules/events.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/events.yml
@@ -173,3 +173,28 @@
     - type: RuleGrids
     - type: LoadMapRule
       mapPath: /Maps/_Starlight/EventMaps/research_outpost_map.yml
+
+
+
+
+
+
+
+# Roundender-less events table for survival
+- type: entityTable
+  id: BasicAntagEventsTableNoRoundenders
+  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+    children:
+    - id: ClosetSkeleton
+    - id: DragonSpawn
+    - id: KingRatMigration
+    - id: NinjaSpawn
+    - id: ParadoxCloneSpawn
+    - id: RevenantSpawn
+    - id: SleeperAgents
+#    - id: ZombieOutbreak
+#    - id: LoneOpsSpawn
+    - id: DerelictCyborgSpawn
+    - id: WizardSpawn
+
+    - id: AbductorsSpawn # Starlight

--- a/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
@@ -1,0 +1,16 @@
+# event schedulers
+
+- type: entityTable
+  id: BasicGameRulesTableNoRoundenders
+  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+    children:
+      - !type:NestedSelector
+        tableId: BasicCalmEventsTable
+      - !type:NestedSelector
+        tableId: BasicAntagEventsTableNoRoundenders
+      - !type:NestedSelector
+        tableId: CargoGiftsTable
+      - !type:NestedSelector
+        tableId: CalmPestEventsTable
+      - !type:NestedSelector
+        tableId: SpicyPestEventsTable


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removes instant roundenders from survival and kessler syndrome gamemodes

## Why we need to add this
Zombies and Nuclear operatives are instant roundenders, and go against *everything* those two gamemodes are supposed to be. The fact they are even possible there baffles me, this commit fixes that.
Survival, and by extension kessler syndrome, are about how long you can endure a constant barrage of problems. Most of the events which are in the list can be recovered from. A lategame nuclear operative or a zombie outbreak at any time instantly ends the round, and by the time the ramping event system spawns them, is a giant middle finger to the players. Survival rounds should end because the crew had enough, not because some random nukie completely forewent their objective to murder everybody.

## Media (Video/Screenshots)
No ingame screenshots of an event not happening.

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- remove: Survival and Kessler Syndrome game modes can no longer spawn instantly roundending threats.
