### PR TITLE
Increase number of construction ghosts per tile

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -364,6 +364,20 @@ namespace Content.Client.Construction
         }
 
         /// <summary>
+        /// Checks if any construction ghosts are present at the given position
+        /// </summary>
+        private bool GhostPresent(EntityCoordinates loc)
+        {
+            foreach (var ghost in _ghosts)
+            {
+                if (EntityManager.GetComponent<TransformComponent>(ghost.Value).Coordinates.Equals(loc))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Checks if the maximum number of construction ghosts has been reached at the given location.
         /// </summary>
         private bool HasReachedMaximumGhosts(EntityCoordinates loc)

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -6,11 +6,15 @@ using Content.Shared.Construction.Prototypes;
 using Content.Shared.Examine;
 using Content.Shared.Input;
 using Content.Shared.Wall;
-using Content.Shared.CCVar;
+// Starlight start
+using Content.Shared.Starlight.CCVar;
+// Starlight end
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.Player;
+// Starlight start
 using Robust.Shared.Configuration;
+// Starlight end
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
@@ -31,7 +35,9 @@ namespace Content.Client.Construction
         [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
         [Dependency] private readonly SpriteSystem _sprite = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
+        // Starlight-edit start
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+        // Starlight-edit end
 
         private readonly Dictionary<int, EntityUid> _ghosts = new();
         private readonly Dictionary<string, ConstructionGuide> _guideCache = new();
@@ -279,8 +285,10 @@ namespace Content.Client.Construction
             if (!TryGetRecipePrototype(prototype.ID, out var targetProtoId) || !PrototypeManager.TryIndex(targetProtoId, out EntityPrototype? targetProto))
                 return false;
 
+            // Starlight-edit start
             if (HasReachedMaximumGhosts(loc))
                 return false;
+            // Starlight-edit end
 
             var predicate = GetPredicate(prototype.CanBuildInImpassable, _transformSystem.ToMapCoordinates(loc));
             if (!_examineSystem.InRangeUnOccluded(user, loc, 20f, predicate: predicate))
@@ -377,6 +385,7 @@ namespace Content.Client.Construction
             return false;
         }
 
+        // Starlight start
         /// <summary>
         /// Checks if the maximum number of construction ghosts has been reached at the given location.
         /// </summary>
@@ -386,8 +395,9 @@ namespace Content.Client.Construction
             var ghostCount = _ghosts.Values.Count(ghost =>
                 EntityManager.GetComponent<TransformComponent>(ghost).Coordinates.Equals(loc));
 
-            return ghostCount >= _configurationManager.GetCVar(CCVars.ConstructionMaxGhostsPerTile);
+            return ghostCount >= _configurationManager.GetCVar(StarlightCCVars.ConstructionMaxGhostsPerTile);
         }
+        // Starlight end
 
         public void TryStartConstruction(EntityUid ghostId, ConstructionGhostComponent? ghostComp = null)
         {

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -6,9 +6,11 @@ using Content.Shared.Construction.Prototypes;
 using Content.Shared.Examine;
 using Content.Shared.Input;
 using Content.Shared.Wall;
+using Content.Shared.CCVar;
 using JetBrains.Annotations;
 using Robust.Client.GameObjects;
 using Robust.Client.Player;
+using Robust.Shared.Configuration;
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
@@ -29,6 +31,7 @@ namespace Content.Client.Construction
         [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
         [Dependency] private readonly SpriteSystem _sprite = default!;
         [Dependency] private readonly PopupSystem _popupSystem = default!;
+        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
         private readonly Dictionary<int, EntityUid> _ghosts = new();
         private readonly Dictionary<string, ConstructionGuide> _guideCache = new();
@@ -365,11 +368,11 @@ namespace Content.Client.Construction
         /// </summary>
         private bool HasReachedMaximumGhosts(EntityCoordinates loc)
         {
-            // Count ghosts at the given location and allow up to 6 per tile
-            var ghostCount = _ghosts.Values.Count(ghost => 
+            // Count ghosts at the given location and allow up to the maximum allowed per tile
+            var ghostCount = _ghosts.Values.Count(ghost =>
                 EntityManager.GetComponent<TransformComponent>(ghost).Coordinates.Equals(loc));
-            
-            return ghostCount >= 6;
+
+            return ghostCount >= _configurationManager.GetCVar(CCVars.ConstructionMaxGhostsPerTile);
         }
 
         public void TryStartConstruction(EntityUid ghostId, ConstructionGhostComponent? ghostComp = null)

--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -276,7 +276,7 @@ namespace Content.Client.Construction
             if (!TryGetRecipePrototype(prototype.ID, out var targetProtoId) || !PrototypeManager.TryIndex(targetProtoId, out EntityPrototype? targetProto))
                 return false;
 
-            if (GhostPresent(loc))
+            if (HasReachedMaximumGhosts(loc))
                 return false;
 
             var predicate = GetPredicate(prototype.CanBuildInImpassable, _transformSystem.ToMapCoordinates(loc));
@@ -361,17 +361,15 @@ namespace Content.Client.Construction
         }
 
         /// <summary>
-        /// Checks if any construction ghosts are present at the given position
+        /// Checks if the maximum number of construction ghosts has been reached at the given location.
         /// </summary>
-        private bool GhostPresent(EntityCoordinates loc)
+        private bool HasReachedMaximumGhosts(EntityCoordinates loc)
         {
-            foreach (var ghost in _ghosts)
-            {
-                if (EntityManager.GetComponent<TransformComponent>(ghost.Value).Coordinates.Equals(loc))
-                    return true;
-            }
-
-            return false;
+            // Count ghosts at the given location and allow up to 6 per tile
+            var ghostCount = _ghosts.Values.Count(ghost => 
+                EntityManager.GetComponent<TransformComponent>(ghost).Coordinates.Equals(loc));
+            
+            return ghostCount >= 6;
         }
 
         public void TryStartConstruction(EntityUid ghostId, ConstructionGhostComponent? ghostComp = null)

--- a/Content.Shared/CCVar/CCVars.Construction.cs
+++ b/Content.Shared/CCVar/CCVars.Construction.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    ///     The maximum number of construction ghosts allowed per tile.
+    /// </summary>
+    public static readonly CVarDef<int> ConstructionMaxGhostsPerTile =
+        CVarDef.Create("construction.max_ghosts_per_tile", 6, CVar.SERVER | CVar.REPLICATED);
+} 

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Construction.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Construction.cs
@@ -8,5 +8,5 @@ public sealed partial class StarlightCCVars
     ///     The maximum number of construction ghosts allowed per tile.
     /// </summary>
     public static readonly CVarDef<int> ConstructionMaxGhostsPerTile =
-        CVarDef.Create("construction.max_ghosts_per_tile", 6, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("construction.max_ghosts_per_tile", 6, CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE);
 } 

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Construction.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Construction.cs
@@ -1,8 +1,8 @@
 using Robust.Shared.Configuration;
 
-namespace Content.Shared.CCVar;
+namespace Content.Shared.Starlight.CCVar;
 
-public sealed partial class CCVars
+public sealed partial class StarlightCCVars
 {
     /// <summary>
     ///     The maximum number of construction ghosts allowed per tile.


### PR DESCRIPTION
## Short description
I propose increasing the amount of allowed construction ghosts per tile to 6.

## Why we need to add this
This is a change related to a new pipe layering system, that makes it easier to interact with that system, and easier implement into atmos day to day job.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/71bf965e-79e7-42c0-b13b-709b4b87657d)
![image](https://github.com/user-attachments/assets/1c25aa99-98bf-4ddd-ad76-f9bd69d903d1)
![image](https://github.com/user-attachments/assets/61a7ff1c-b62e-4e5e-9e5f-47cd03f6561a)
![image](https://github.com/user-attachments/assets/8928288f-ef32-4e0a-bd69-3cd959f732cb)
![image](https://github.com/user-attachments/assets/9e2eddfa-1e8c-4e64-813d-25a591603bb0)


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- tweak: Increase amount of construction ghosts allowed per tile.