### PR TITLE
Silicon faction/fixing zombie AI

### DIFF
--- a/Resources/Locale/en-US/zombies/zombie.ftl
+++ b/Resources/Locale/en-US/zombies/zombie.ftl
@@ -1,10 +1,10 @@
 zombie-transform = {CAPITALIZE(THE($target))} turned into a zombie!
-zombie-infection-greeting = You have become a zombie. Your goal is to seek out the living and to try to infect them.  Work together with the other zombies and remaining initial infected to overtake the station.
+zombie-infection-greeting = You have become a zombie. Your goal is to seek out the living and to try to infect them.  Work together with the other zombies and remaining initial infected to overtake the station. [color=red]You should avoid attacking silicons unless they attack you first, as they are immune to being zombified![/color]
 
 zombie-generic = zombie
 zombie-name-prefix = zombified {$baseName}
 zombie-role-desc =  A malevolent creature of the dead.
-zombie-role-rules = You are a [color={role-type-team-antagonist-color}][bold]{role-type-team-antagonist-name}[/bold][/color]. Search out the living and bite them in order to infect them and turn them into zombies. Work together with the other zombies and remaining initial infected to overtake the station.
+zombie-role-rules = You are a [color={role-type-team-antagonist-color}][bold]{role-type-team-antagonist-name}[/bold][/color]. Search out the living and bite them in order to infect them and turn them into zombies. Work together with the other zombies and remaining initial infected to overtake the station. [color=red]You should avoid attacking silicons unless they attack you first, as they are immune to being zombified![/color]
 
 zombie-permadeath = This time, you're dead for real.
 

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -319,7 +319,7 @@
     - NamesBorg
   - type: NpcFactionMember
     factions:
-    - NanoTrasen
+    - NanoTrasenSilicon # starlight
   - type: Access
     enabled: false
     groups:
@@ -341,7 +341,7 @@
   - type: TextToSpeech
   - type: NpcFactionMember
     factions:
-    - Syndicate
+    - SyndicateSilicon # starlight
   - type: Access
     tags:
     - NuclearOperative
@@ -378,7 +378,7 @@
   components:
   - type: NpcFactionMember
     factions:
-    - NanoTrasen #The seemingly best fit. It was a regular NT cyborg once, after all.
+    - NanoTrasenSilicon #The seemingly best fit. It was a regular NT cyborg once, after all. starlight
   - type: Access
     enabled: false
     groups:

--- a/Resources/Prototypes/_StarLight/ai_factions.yml
+++ b/Resources/Prototypes/_StarLight/ai_factions.yml
@@ -5,10 +5,12 @@
     - DungeonSyndicate
     - Dragon
     - NanoTrasen
+    - NanoTrasenSilicon
     - Mouse
     - PetsNT
     - SimpleHostile
     - Syndicate
+    - SyndicateSilicon
     - Xeno
     - Zombie
     - Revolutionary
@@ -21,10 +23,12 @@
   id: DungeonSoviet
   hostile:
     - NanoTrasen
+    - NanoTrasenSilicon
     - SimpleHostile
     - Xeno
     - PetsNT
     - Syndicate
+    - SyndicateSilicon
     - DungeonSyndicate
     - Zombie
     - Revolutionary
@@ -38,10 +42,12 @@
   id: DungeonSyndicate
   hostile:
     - NanoTrasen
+    - NanoTrasenSilicon
     - SimpleHostile
     - Xeno
     - PetsNT
     - Syndicate
+    - SyndicateSilicon
     - DungeonSoviet
     - Zombie
     - Revolutionary
@@ -55,10 +61,12 @@
   id: Gorilla
   hostile:
     - NanoTrasen
+    - NanoTrasenSilicon
     - Dragon
     - PetsNT
     - SimpleHostile
     - Syndicate
+    - SyndicateSilicon
     - Xeno
     - Zombie
     - Revolutionary
@@ -70,3 +78,42 @@
     - Abyss
     - DungeonSoviet
     - DungeonSyndicate
+
+- type: npcFaction
+  id: NanoTrasenSilicon # purely making this so zombies STOP ATTACKING FUCKING SILICONS
+  hostile:
+  - SimpleHostile
+  - Syndicate
+  - SyndicateSilicon
+  - DungeonSyndicate
+  - DungeonSoviet
+  - Xeno
+  - Revolutionary
+  - Abyss
+  - Vampire
+  - Changeling
+  - AllHostile
+  - Wizard
+  - Xenoborg
+  - Dragon
+  - Gorilla
+
+- type: npcFaction
+  id: SyndicateSilicon # Again, zombies fuck you.
+  hostile:
+    - NanoTrasen
+    - NanoTrasenSilicon
+    - SimpleHostile
+    - Xeno
+    - PetsNT
+    - Zombie
+    - DungeonSyndicate
+    - DungeonSoviet
+    - Abyss
+    - Vampire
+    - Changeling
+    - AllHostile
+    - Wizard
+    - Xenoborg
+    - Dragon
+    - Gorilla

--- a/Resources/Prototypes/_StarLight/ai_factions.yml
+++ b/Resources/Prototypes/_StarLight/ai_factions.yml
@@ -106,7 +106,6 @@
     - SimpleHostile
     - Xeno
     - PetsNT
-    - Zombie
     - DungeonSyndicate
     - DungeonSoviet
     - Abyss

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -2,7 +2,7 @@
   id: Dragon
   hostile:
     - NanoTrasen
-    - NanotrasenSilicon # starlight
+    - NanoTrasenSilicon # starlight
     - Syndicate
     - SyndicateSilicon # starlight
     - DungeonSyndicate
@@ -67,7 +67,7 @@
   id: SimpleHostile
   hostile:
     - NanoTrasen
-    - NanotrasenSilicon # starlight
+    - NanoTrasenSilicon # starlight
     - Syndicate
     - SyndicateSilicon # starlight
     - DungeonSyndicate
@@ -93,7 +93,7 @@
   id: Syndicate
   hostile:
     - NanoTrasen
-    - NanotrasenSilicon # starlight
+    - NanoTrasenSilicon # starlight
     - SimpleHostile
     - Xeno
     - PetsNT
@@ -154,7 +154,7 @@
   id: Revolutionary
   hostile:
     - NanoTrasen
-    - NanotrasenSilicon # starlight
+    - NanoTrasenSilicon # starlight
     - Zombie
     - SimpleHostile
     - Dragon
@@ -170,7 +170,7 @@
   id: Changeling
   hostile:
     - NanoTrasen
-    - NanotrasenSilicon # starlight
+    - NanoTrasenSilicon # starlight
     - Syndicate
     - SyndicateSilicon # starlight
     - Zombie
@@ -182,7 +182,7 @@
   id: Vampire
   hostile:
     - NanoTrasen
-    - NanotrasenSilicon # starlight
+    - NanoTrasenSilicon # starlight
     - Syndicate
     - SyndicateSilicon # starlight
     - Zombie
@@ -196,7 +196,7 @@
   id: HonkHostile
   hostile:
     - NanoTrasen
-    - NanotrasenSilicon # starlight
+    - NanoTrasenSilicon # starlight
     - Syndicate
     - SyndicateSilicon # starlight
     - Passive
@@ -222,7 +222,7 @@
   id: AllHostile
   hostile:
     - NanoTrasen
-    - NanotrasenSilicon # starlight
+    - NanoTrasenSilicon # starlight
     - Dragon
     - Mouse
     - Passive
@@ -246,7 +246,7 @@
   id: Wizard
   hostile:
     - NanoTrasen
-    - NanotrasenSilicon # starlight
+    - NanoTrasenSilicon # starlight
     - Dragon
     - Mouse
     - Passive
@@ -275,7 +275,7 @@
     - Wizard
     # rivalry
     - Xeno
-    - NanotrasenSilicon # starlight
+    - NanoTrasenSilicon # starlight
     - SyndicateSilicon # starlight
     # cause they are hostile to them
     - SimpleHostile

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -113,6 +113,7 @@
   id: Xeno
   hostile:
     - NanoTrasen
+    - NanoTrasenSilicon # starlight
     - Syndicate
     - SyndicateSilicon # starlight
     - DungeonSyndicate

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -2,7 +2,9 @@
   id: Dragon
   hostile:
     - NanoTrasen
+    - NanotrasenSilicon # starlight
     - Syndicate
+    - SyndicateSilicon # starlight
     - DungeonSyndicate
     - DungeonSoviet
     - Xeno
@@ -21,6 +23,7 @@
   hostile:
     - SimpleHostile
     - Syndicate
+    - SyndicateSilicon # starlight
     - DungeonSyndicate
     - DungeonSoviet
     - Xeno
@@ -64,7 +67,9 @@
   id: SimpleHostile
   hostile:
     - NanoTrasen
+    - NanotrasenSilicon # starlight
     - Syndicate
+    - SyndicateSilicon # starlight
     - DungeonSyndicate
     - DungeonSoviet
     - Passive
@@ -88,6 +93,7 @@
   id: Syndicate
   hostile:
     - NanoTrasen
+    - NanotrasenSilicon # starlight
     - SimpleHostile
     - Xeno
     - PetsNT
@@ -108,6 +114,7 @@
   hostile:
     - NanoTrasen
     - Syndicate
+    - SyndicateSilicon # starlight
     - DungeonSyndicate
     - DungeonSoviet
     - Passive
@@ -125,7 +132,7 @@
 
 - type: npcFaction
   id: Zombie
-  hostile:
+  hostile: # starlight, no silicon roles here as IT HAS NO MEAT, THEREFORE IS NOT FOOD.
     - NanoTrasen
     - SimpleNeutral
     - SimpleHostile
@@ -141,13 +148,13 @@
     - AllHostile
     - Wizard
     - Dragon
-    - Xenoborg
     - Gorilla
 
 - type: npcFaction
   id: Revolutionary
   hostile:
     - NanoTrasen
+    - NanotrasenSilicon # starlight
     - Zombie
     - SimpleHostile
     - Dragon
@@ -163,7 +170,9 @@
   id: Changeling
   hostile:
     - NanoTrasen
+    - NanotrasenSilicon # starlight
     - Syndicate
+    - SyndicateSilicon # starlight
     - Zombie
     - Revolutionary
     - AllHostile
@@ -173,7 +182,9 @@
   id: Vampire
   hostile:
     - NanoTrasen
+    - NanotrasenSilicon # starlight
     - Syndicate
+    - SyndicateSilicon # starlight
     - Zombie
     - Revolutionary
     - Xeno
@@ -185,7 +196,9 @@
   id: HonkHostile
   hostile:
     - NanoTrasen
+    - NanotrasenSilicon # starlight
     - Syndicate
+    - SyndicateSilicon # starlight
     - Passive
     - PetsNT
     - Zombie
@@ -199,6 +212,7 @@
   hostile:
     - SimpleHostile
     - Syndicate
+    - SyndicateSilicon # starlight
     - Xeno
     - Zombie
     - AllHostile
@@ -208,6 +222,7 @@
   id: AllHostile
   hostile:
     - NanoTrasen
+    - NanotrasenSilicon # starlight
     - Dragon
     - Mouse
     - Passive
@@ -215,6 +230,7 @@
     - SimpleHostile
     - SimpleNeutral
     - Syndicate
+    - SyndicateSilicon # starlight
     - Xeno
     - Zombie
     - Revolutionary
@@ -230,6 +246,7 @@
   id: Wizard
   hostile:
     - NanoTrasen
+    - NanotrasenSilicon # starlight
     - Dragon
     - Mouse
     - Passive
@@ -237,6 +254,7 @@
     - SimpleHostile
     - SimpleNeutral
     - Syndicate
+    - SyndicateSilicon # starlight
     - Xeno
     - Zombie
     - Revolutionary
@@ -255,9 +273,10 @@
     - Zombie
     - Revolutionary
     - Wizard
-
-    - Xeno # rivalry
-
+    # rivalry
+    - Xeno
+    - NanotrasenSilicon # starlight
+    - SyndicateSilicon # starlight
     # cause they are hostile to them
     - SimpleHostile
     - AllHostile


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Turns silicons (and syndicate silicons) into their own faction, and stops the zombie AI from attacking silicons automatically.

## Why we need to add this
I'm fucking tired of being attacked/gibbed by zombies every single round despite me not attacking zombies at all. This PR stops the AI from doing it, and adds warnings to the zombie greeting/rules (for ghost roles) that you should NOT attack silicons unless in self defense.

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

:cl: RoadTrain
- add: NanoTrasenSilicon and SyndicateSilicon as seperate factions. They mimic the NanoTrasen/Syndicate relations, except for not being hostile to zeds.
- add: Added warning texts to the zombie greeting/ghost role rules informing people that they should NOT attack silicons unless in self defense as they cannot be zombified.
- fix: Zombie AI no longer tries to attack any form of silicon (NT/Syndicate/Xenoborg)
- remove: Zeds are no longer hostile against xenoborgs (but xenoborgs are still hostile to zombies for having a brain)