### PR TITLE
Avali can now EAT what apparently passes as for food (MRE brick)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -445,6 +445,7 @@
   - type: Tag
     tags:
       - ReptilianFood
+      - AvianFood # Starlight
   - type: Sprite
     state: nutribrick-open
   - type: Food

--- a/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
@@ -10,6 +10,7 @@
       - Pill
       - Crayon
       - Paper
+      - AvianFood
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_StarLight/tags.yml
+++ b/Resources/Prototypes/_StarLight/tags.yml
@@ -7,6 +7,9 @@
   id: Avali
 
 - type: Tag
+  id: AvianFood
+
+- type: Tag
   id: CantInteract
 
 - type: Tag


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
title.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- fix: Avali can now eat the MRE brick. 