### PR TITLE
Syndieborg tweaks

### DIFF
--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -246,6 +246,7 @@ ghost-role-information-syndicate-kobold-reinforcement-description = Someone need
 
 ghost-role-information-syndicate-cyborg-assault-name = Syndicate Assault Cyborg
 ghost-role-information-syndicate-cyborg-saboteur-name = Syndicate Saboteur Cyborg
+ghost-role-information-syndicate-cyborg-medical-name = Syndicate Medical Cyborg
 ghost-role-information-syndicate-cyborg-description = The Syndicate needs reinforcements. You, a cold silicon killing machine, will help them.
 
 ghost-role-information-derelict-cyborg-name = Derelict Cyborg

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -106,7 +106,7 @@
           map: ["light"]
           visible: false
     - type: BorgChassis
-      maxModules: 3
+      maxModules: 4 # starlight
       moduleWhitelist:
         tags:
           - BorgModuleGeneric
@@ -139,7 +139,7 @@
           map: ["light"]
           visible: false
     - type: BorgChassis
-      maxModules: 3
+      maxModules: 4 # starlight
       moduleWhitelist:
         tags:
           - BorgModuleGeneric
@@ -179,7 +179,7 @@
           map: ["light"]
           visible: false
     - type: BorgChassis
-      maxModules: 3
+      maxModules: 4 # starlight
       moduleWhitelist:
         tags:
           - BorgModuleGeneric

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -391,6 +391,7 @@
       borg_brain:
         - PositronicBrain
       borg_module:
+        - BorgModuleTool
         - BorgModuleOperative
         - BorgModuleL6C
         - BorgModuleEsword
@@ -425,6 +426,7 @@
         - PositronicBrain
       borg_module:
         - BorgModuleTool
+        - BorgModuleRCD
         - BorgModuleOperative
         - BorgModuleSyndicateWeapon
   - type: ItemSlots
@@ -440,6 +442,40 @@
   components:
     - type: GhostRole
       name: ghost-role-information-syndicate-cyborg-saboteur-name
+      description: ghost-role-information-syndicate-cyborg-description
+      rules: ghost-role-information-silicon-rules
+      raffle:
+        settings: default
+    - type: GhostTakeoverAvailable
+
+- type: entity
+  id: PlayerBorgSyndicateMedicalBattery
+  parent: BorgChassisSyndicateMedical
+  suffix: Battery, Module, Operative
+  components:
+  - type: NukeOperative
+  - type: ContainerFill
+    containers:
+      borg_brain:
+        - PositronicBrain
+      borg_module:
+        - BorgModuleTool
+        - BorgModuleChemical
+        - BorgModuleTopicals
+        - BorgModuleRescue
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellHyper
+
+- type: entity
+  id: PlayerBorgSyndicateMedicalGhostRole
+  parent: PlayerBorgSyndicateMedicalBattery
+  suffix: Ghost role
+  components:
+    - type: GhostRole
+      name: ghost-role-information-syndicate-cyborg-medical-name
       description: ghost-role-information-syndicate-cyborg-description
       rules: ghost-role-information-silicon-rules
       raffle:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -905,6 +905,7 @@
   id: BorgModuleSyndicateWeapon
   parent: [ BaseBorgModule, BaseProviderBorgModule, BaseSyndicateContraband ]
   name: weapon cyborg module
+  description: a simple weapon module that comes with an Echis and energy dagger. # starlight
   components:
   - type: Sprite
     layers:
@@ -973,7 +974,7 @@
 
 - type: entity
   id: BorgModuleL6C
-  parent: [ BaseBorgModuleSyndicateAssault, BaseProviderBorgModule, BaseSyndicateContraband ]
+  parent: [ BaseBorgModule, BaseProviderBorgModule, BaseSyndicateContraband ] # starlight
   name: L6C ROW cyborg module
   description: A module that comes with a L6C.
   components:
@@ -992,7 +993,7 @@
   id: BorgModuleMartyr
   parent: [ BaseBorgModule, BaseProviderBorgModule, BaseSyndicateContraband ]
   name: martyr cyborg module
-  description: "A module that comes with an explosive you probably don't want to handle yourself."
+  description: A module that comes with an explosive you probably don't want to handle yourself.
   components:
     - type: Sprite
       layers:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Gives all syndie borgs 1 more module slot (3 > 4). Gives the assault borg tools and the saboteur an RCD. Also makes it possible for admins to spawn pre-filled syndie medical borgs (also a ghost role spawner). Lastly, makes the L6 module fit all borgs.

## Why we need to add this
3 module slots is absolutely CRIPPLING. The assault borg's lack of an ability to heal its' teammates sucks, and for the saboteur to be properly stealthy it needs the RCD module or it's gonna get outed immediately. The L6 is available to NT via emagging the exosuit fab, but cannot be used by any borg except the assault borg (which you cannot make). And you couldn't even spawn the medical borg in with modules. So I've fixed all that.

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: RoadTrain
- add: Added admin spawners for the Syndie medical borg, both as just 'filled' and a ghost role
- tweak: The L6 can now be used by all borgs (given you can get it from the exosuit fab).
- tweak: All syndie borgs get 1 more module slot (3 > 4). Assault borg gets tools, saboteur gets RCD. Medical borg copies the NT version