### PR TITLE
Fix stasis animation being shared for all Avali

### DIFF
--- a/Content.Client/_Starlight/Actions/Stasis/StasisSystem.cs
+++ b/Content.Client/_Starlight/Actions/Stasis/StasisSystem.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Timing;
 using Robust.Client.GameObjects;
 using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
 using Content.Shared._Starlight.Actions.Stasis;
+using Robust.Shared.GameStates;
 
 namespace Content.Client._Starlight.Actions.Stasis;
 
@@ -18,13 +19,53 @@ public sealed class StasisSystem : SharedStasisSystem
     [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
-    private EntityUid? _continuousEffect;
-    private EntityUid? _enterEffect;
-
     public override void Initialize()
     {
         base.Initialize();
         SubscribeNetworkEvent<StasisAnimationEvent>(OnStasisAnimation);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        // Periodic cleanup of orphaned effects
+        CleanupOrphanedEffects();
+    }
+
+    private void CleanupOrphanedEffects()
+    {
+        var query = AllEntityQuery<StasisComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            // Skip if the entity is being deleted
+            if (EntityManager.IsQueuedForDeletion(uid))
+                continue;
+
+            // If the entity is no longer in stasis but has a continuous effect, clean it up
+            if (!comp.IsInStasis && comp.ClientContinuousEffectEntity != null)
+            {
+                if (Exists(comp.ClientContinuousEffectEntity.Value))
+                {
+                    QueueDel(comp.ClientContinuousEffectEntity.Value);
+                }
+                comp.ClientContinuousEffectEntity = null;
+                Dirty(uid, comp);
+            }
+            // If the continuous effect entity no longer exists, clear the reference
+            else if (comp.ClientContinuousEffectEntity != null && !Exists(comp.ClientContinuousEffectEntity.Value))
+            {
+                comp.ClientContinuousEffectEntity = null;
+                Dirty(uid, comp);
+            }
+            
+            // Clean up orphaned enter effects
+            if (comp.ClientEnterEffectEntity != null && !Exists(comp.ClientEnterEffectEntity.Value))
+            {
+                comp.ClientEnterEffectEntity = null;
+                Dirty(uid, comp);
+            }
+        }
     }
 
     private void OnStasisAnimation(StasisAnimationEvent ev)
@@ -56,13 +97,17 @@ public sealed class StasisSystem : SharedStasisSystem
                 // Play the exit animation.
                 StasisExitAnimation(entity, comp);
                 // End the continuous animation.
-                EndStasisContinuousAnimation();
+                EndStasisContinuousAnimation(entity, comp);
                 break;
         }
     }
 
     private void StasisPrepareAnimation(EntityUid uid, StasisComponent comp)
     {
+        // Safety check to ensure the entity still exists
+        if (!Exists(uid))
+            return;
+
         EnsureComp<TransformComponent>(uid, out var xform);
         var effectEnt = SpawnAttachedTo(comp.StasisEnterEffect, xform.Coordinates);
         _xformSystem.SetParent(effectEnt, uid);
@@ -78,23 +123,33 @@ public sealed class StasisSystem : SharedStasisSystem
 
         // Play the sound effect.
         _audioSystem.PlayPvs(comp.StasisEnterSound, effectEnt);
-        _enterEffect = effectEnt;
+        comp.ClientEnterEffectEntity = effectEnt;
+        Dirty(uid, comp);
     }
 
     private void StasisEnterAnimation(EntityUid uid, StasisComponent comp)
     {
+        // Safety check to ensure the entity still exists
+        if (!Exists(uid))
+            return;
+            
         // Start the continuous animation.
         StartStasisContinuousAnimation(uid, comp);
         // Delete the prepare animation.
-        if (_enterEffect != null)
+        if (comp.ClientEnterEffectEntity != null)
         {
-            QueueDel(_enterEffect.Value);
-            _enterEffect = null;
+            QueueDel(comp.ClientEnterEffectEntity.Value);
+            comp.ClientEnterEffectEntity = null;
+            Dirty(uid, comp);
         }
     }
 
     private void StasisExitAnimation(EntityUid uid, StasisComponent comp)
     {
+        // Safety check to ensure the entity still exists
+        if (!Exists(uid))
+            return;
+
         EnsureComp<TransformComponent>(uid, out var xform);
         var effectEnt = SpawnAttachedTo(comp.StasisExitEffect, xform.Coordinates);
         _xformSystem.SetParent(effectEnt, uid);
@@ -121,6 +176,13 @@ public sealed class StasisSystem : SharedStasisSystem
 
     private void StartStasisContinuousAnimation(EntityUid uid, StasisComponent comp)
     {
+        // Safety check to ensure the entity still exists
+        if (!Exists(uid))
+            return;
+
+        // Clean up any existing continuous effect for this entity first
+        EndStasisContinuousAnimation(uid, comp);
+
         EnsureComp<TransformComponent>(uid, out var xform);
         var effectEnt = SpawnAttachedTo(comp.StasisContinuousEffect, xform.Coordinates);
         _xformSystem.SetParent(effectEnt, uid);
@@ -144,17 +206,42 @@ public sealed class StasisSystem : SharedStasisSystem
             entitySprite.Color = entitySprite.Color.WithAlpha(0f);
         }
 
-        // Set the continuous effect to the effect entity.
-        _continuousEffect = effectEnt;
+        // Store the continuous effect in the component
+        comp.ClientContinuousEffectEntity = effectEnt;
+        Dirty(uid, comp);
     }
 
-    private void EndStasisContinuousAnimation()
+    private void EndStasisContinuousAnimation(EntityUid uid, StasisComponent comp)
     {
-        // If the continuous effect is set, delete it.
-        if (_continuousEffect != null)
+        // If there's a continuous effect for this entity, delete it.
+        if (comp.ClientContinuousEffectEntity != null)
         {
-            QueueDel(_continuousEffect.Value);
-            _continuousEffect = null;
+            // Validate that the effect entity still exists before trying to delete it
+            if (Exists(comp.ClientContinuousEffectEntity.Value))
+            {
+                QueueDel(comp.ClientContinuousEffectEntity.Value);
+            }
+            comp.ClientContinuousEffectEntity = null;
+            Dirty(uid, comp);
+        }
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        
+        // Clean up all continuous effects on shutdown
+        var query = AllEntityQuery<StasisComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.ClientContinuousEffectEntity != null && Exists(comp.ClientContinuousEffectEntity.Value))
+            {
+                QueueDel(comp.ClientContinuousEffectEntity.Value);
+            }
+            if (comp.ClientEnterEffectEntity != null && Exists(comp.ClientEnterEffectEntity.Value))
+            {
+                QueueDel(comp.ClientEnterEffectEntity.Value);
+            }
         }
     }
 }

--- a/Content.Shared/_Starlight/Actions/Stasis/StasisComponent.cs
+++ b/Content.Shared/_Starlight/Actions/Stasis/StasisComponent.cs
@@ -146,4 +146,16 @@ public sealed partial class StasisComponent : Component
     /// The entity reference for the continuous stasis effect.
     /// </summary>
     [DataField] [AutoNetworkedField] public EntityUid? ContinuousEffectEntity;
+
+    /// <summary>
+    /// Client-side reference to the continuous stasis effect entity.
+    /// This is used to properly track and clean up the visual effect.
+    /// </summary>
+    [DataField] public EntityUid? ClientContinuousEffectEntity;
+
+    /// <summary>
+    /// Client-side reference to the enter stasis effect entity.
+    /// This is used to properly track and clean up the visual effect.
+    /// </summary>
+    [DataField] public EntityUid? ClientEnterEffectEntity;
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR Fixes Avali animation breaking, and lingering on the character sprite.

## Why we need to add this
I think its a rather annoying bug

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Avali animation lingering after leaving stasis

