### PR TITLE
Medfab emaggng

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -382,6 +382,7 @@
   - type: EmagLatheRecipes
     emagStaticPacks:
     - HostileCubesStatic
+    - ShadowBorgiCubeRecipePack # starlight
 
 - type: entity
   id: ShadowBorgiFabricator
@@ -520,6 +521,9 @@
     - StarlightCyberOrgansDynamic
     - StarlightImplantDynamic
     - Chemistry
+  - type: EmagLatheRecipes
+    emagStaticPacks:
+    - StarlightSyndicateSurgery
   - type: Machine
     board: MedicalTechFabCircuitboard
   - type: StealTarget

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/medical.yml
@@ -52,3 +52,11 @@
   - EyeImplantWelding
   - EyeImplantMedical
   - EyeImplantSecurity
+
+#
+- type: latheRecipePack
+  id: StarlightSyndicateSurgery
+  recipes:
+  - LeftArmCyberMantisBlade
+  - RightArmCyberMantisBlade
+  - EyeImplantSyndie

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/medical.yml
@@ -196,6 +196,33 @@
     Steel: 550
     Silver: 100
     Glass: 100
+#
+- type: latheRecipe
+  id: LeftArmCyberMantisBlade
+  result: LeftArmCyberMantisBlade
+  categories:
+  - Cyberlimbs
+  completetime: 10
+  materials:
+    Plastic: 450
+    Steel: 450
+    Silver: 100
+    Glass: 100
+    Plasma: 100
+
+- type: latheRecipe
+  id: RightArmCyberMantisBlade
+  result: RightArmCyberMantisBlade
+  categories:
+  - Cyberlimbs
+  completetime: 10
+  materials:
+    Plastic: 450
+    Steel: 450
+    Silver: 100
+    Glass: 100
+    Plasma: 100
+
 # IMPLANTS
 
 # Eye
@@ -233,6 +260,18 @@
     Steel: 200
     Plasma: 300
     Glass: 150
+
+- type: latheRecipe
+  id: EyeImplantSyndie
+  result: EyeImplantSyndie
+  categories:
+  - Implants
+  completeTime: 6
+  materials:
+    Steel: 300
+    Plasma: 450
+    Glass: 225
+    Plasma: 100
 
 - type: latheRecipe
   id: CyberEyeNightVision


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Allows you to emag the medfab for syndie implants and mantis arms. Also adds shadow borgis to the biocube generator's emag recipes as a treat.

## Why we need to add this
Because... it's funny? No other reason.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: RoadTrain
- add: Adds the ability to emag medfabs for mantis arms/syndie eye implants. Arms are bulwark cost, syndie implants are 1.5x the time/cost of sec implants.
- add: Added the ability to make shadow borgis if you emag a biocube generator.
