### PR TITLE
Revert: Borgs require prying to open

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -113,7 +113,6 @@
       - BorgChassis
       - RoboticsConsole
   - type: WiresPanel
-    openingTool: Prying
   - type: ActivatableUIRequiresPanel
   - type: NameIdentifier
     group: Silicon


### PR DESCRIPTION
Reverted commit: (c979370d57cc12492eb7ee7cb328c82b102a45f9)

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Reverts change to borg panel behaviour

## Why we need to add this
This was a nonsensical change, done in *apparent* preparation for a feature which simply does not exist yet. It is confusing to *everyone*, and also just inconsistent with how every other maintenance panel behaves.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/58e8ac56-65e6-48d2-ac5a-7937c7f52043)


## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- tweak: Reverted a change; Cyborg maintenance panels are now once again opened with screwdrivers
