### PR TITLE
Update the state of the ready up button after dragging priorities.

### DIFF
--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -68,6 +68,7 @@ namespace Content.Client.Lobby
             UpdateLobbyUi();
 
             Lobby.CharacterPreview.CharacterSetupButton.OnPressed += OnSetupPressed;
+            Lobby.CharacterPreview.PrioritiesUpdated += UpdateReadyAllowed;
             Lobby.ReadyButton.OnPressed += OnReadyPressed;
             Lobby.ReadyButton.OnToggled += OnReadyToggled;
             Lobby.ReadyButton.TooltipSupplier = GetReadyButtonTooltip;

--- a/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.xaml.cs
+++ b/Content.Client/Lobby/UI/LobbyCharacterPreviewPanel.xaml.cs
@@ -33,6 +33,11 @@ public sealed partial class LobbyCharacterPreviewPanel : Control
     public Button CharacterSetupButton => CharacterSetup;
 
     /// <summary>
+    /// Action invoked when the player's job priorities have been updated.
+    /// </summary>
+    public event Action? PrioritiesUpdated;
+
+    /// <summary>
     /// Just a helper function to grab the appropriate <see cref="DraggableJobTarget"/> control corresponding to the
     /// job priority
     /// </summary>
@@ -229,6 +234,7 @@ public sealed partial class LobbyCharacterPreviewPanel : Control
     private void SendUpdatedPriorities()
     {
         _preferences.UpdateJobPriorities(GetJobPriorities());
+        PrioritiesUpdated?.Invoke();
     }
 
     /// <summary>

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -174,7 +174,7 @@ namespace Content.Server.GameTicking
             }
 
             // Ensure that the player has a character enabled with a compatible job that can even join.
-            var readyPossible = (_preferences.GetPreferencesOrNull(player.UserId)?.JobPrioritiesFiltered().Count ?? 0) != 0;
+            var readyPossible = (_prefsManager.GetPreferencesOrNull(player.UserId)?.JobPrioritiesFiltered().Count ?? 0) != 0;
 
             _playerGameStatuses[player.UserId] = ready && readyPossible
                 ? PlayerGameStatus.ReadyToPlay

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -44,7 +44,6 @@ namespace Content.Server.GameTicking
         [Dependency] private readonly NewLifeSystem _newLifeSystem = default!; //🌟Starlight🌟
         [Dependency] private readonly IPlayerRolesManager _playerRolesManager = default!; //🌟Starlight🌟
         [Dependency] private readonly PolymorphSystem _polymorphSystem = default!;
-        [Dependency] private readonly IServerPreferencesManager _preferencesManager = default!;
 
         [ValidatePrototypeId<EntityPrototype>]
         public const string ObserverPrototypeName = "MobObserver";
@@ -134,7 +133,7 @@ namespace Content.Server.GameTicking
                 var playerSession = _playerManager.GetSessionById(player);
 
                 // Select a profile for the player
-                var playerPrefs = _preferencesManager.GetPreferences(player);
+                var playerPrefs = _prefsManager.GetPreferences(player);
                 var playerProfiles = playerPrefs.GetAllEnabledProfilesForJob(job.Value);
 
                 // Filter out job requirements
@@ -277,7 +276,7 @@ namespace Content.Server.GameTicking
                 restrictedRoles.UnionWith(jobBans);
 
             // Pick best job best on prefs.
-            var playerPreferences = _preferencesManager.GetPreferences(player.UserId);
+            var playerPreferences = _prefsManager.GetPreferences(player.UserId);
             var jobPrioritiesFiltered = playerPreferences.JobPrioritiesFiltered();
             jobId ??= _stationJobs.PickBestAvailableJobWithPriority(station,
                 jobPrioritiesFiltered,

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -66,7 +66,6 @@ namespace Content.Server.GameTicking
         [Dependency] private readonly MetaDataSystem _metaData = default!;
         [Dependency] private readonly SharedRoleSystem _roles = default!;
         [Dependency] private readonly ServerDbEntryManager _dbEntryManager = default!;
-        [Dependency] private readonly IServerPreferencesManager _preferences = default!;
         [Dependency] private readonly AntagSelectionSystem _antagSelection = default!;
 
         [ViewVariables] private bool _initialized;


### PR DESCRIPTION
## Short description

small update from my upstream pr.

fixes a little bug where the ready button might have an incorrect state after dragging job priorities

## Why we need to add this

bug fix

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Quantumcross
- fix: Fixes to ready up button after changing job priorities in some cases
