### PR TITLE
Partial Revert of #887

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -532,7 +532,7 @@
   - type: StationEvent
     earliestStart: 55 # 🌟Starlight🌟 Casualization
     weight: 4.5 # 🌟Starlight🌟 Casualization
-    minimumPlayers: 20
+    minimumPlayers: 35
     duration: null # LoneOpsSpawn needs an infinite duration so that it inherits the NukeOpsRule things of an actually appropriate end scrreen (not always "Neutral outcome!") and... ending the game if the station is nuked.
   - type: RuleGrids
   - type: LoadMapRule

--- a/Resources/Prototypes/_StarLight/GameRules/events.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/events.yml
@@ -174,12 +174,6 @@
     - type: LoadMapRule
       mapPath: /Maps/_Starlight/EventMaps/research_outpost_map.yml
 
-
-
-
-
-
-
 # Roundender-less events table for survival
 - type: entityTable
   id: BasicAntagEventsTableNoRoundenders
@@ -193,7 +187,7 @@
     - id: RevenantSpawn
     - id: SleeperAgents
 #    - id: ZombieOutbreak
-#    - id: LoneOpsSpawn
+    - id: LoneOpsSpawn
     - id: DerelictCyborgSpawn
     - id: WizardSpawn
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Partially reverts https://github.com/ss14Starlight/space-station-14/pull/887 by re-adding the lone operative into survival, but raises the minpop so it cant fuck up beta rounds
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Loneops aren't "instantly round-ending", survival is kinda boring without em, PR creator was re-considering the loneops before it got merged, and loneops are just really fun
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.-->

:cl: PubliclyExecutedPig
- tweak: Re-Added Lone Operatives to survival
- tweak: Loneops minpop 20 -> 35

