### PR TITLE
Fix error were Avali could become invisible for some people

### DIFF
--- a/Content.Shared/_Starlight/Actions/Stasis/StasisComponent.cs
+++ b/Content.Shared/_Starlight/Actions/Stasis/StasisComponent.cs
@@ -15,6 +15,11 @@ public sealed partial class StasisComponent : Component
     [DataField] [AutoNetworkedField] public bool IsInStasis = false;
 
     /// <summary>
+    /// Whether the entity should be visible. This is synced to ensure proper PVS handling.
+    /// </summary>
+    [DataField] [AutoNetworkedField] public bool IsVisible = true;
+
+    /// <summary>
     /// The second entity needed to preform stasis. This is used to leave stasis.
     /// </summary>
     [DataField(required: true)] [ViewVariables(VVAccess.ReadWrite)] [AutoNetworkedField]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fix the behavior where some people could see avali as invisible after they left stasis.

## Why we need to add this
It fixes a bug.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Fix Avali becoming invisible after stasis.
