### PR TITLE
adds SKB suffix to the SKB show mindshields sunglasses

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Eyes/glasses.yml
@@ -98,6 +98,7 @@
   id: ClothingEyesGlassesSKBGlasses
   name: cheap sunglasses
   description: A pair of black sunglasses. Doesn't block light well, more of an accessory than something useful.
+  suffix: SKB
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/sunglasses.rsi


### PR DESCRIPTION
## Short description
adds the suffix before I fall asleep

## Why we need to add this
diffrentiate both of the cheap sunglases

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/e120f670-3c55-4e67-bf7c-8c406e32c566)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
N/A
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
