### PR TITLE
Butchering CMOs cats for cat paw gloves

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -148,6 +148,11 @@
     - VimPilot
   - type: StealTarget
     stealGroup: AnimalNamedCat
+  #region Starlight
+  - type: Butcherable
+    spawned:
+      - id: ClothingHandsCatPawsBlack
+  #endregion Starlight
 
 - type: entity
   name: Exception
@@ -168,6 +173,11 @@
     - VimPilot
   - type: StealTarget
     stealGroup: AnimalNamedCat
+  #region Starlight
+  - type: Butcherable
+    spawned:
+      - id: ClothingHandsCatPawsBrown
+  #endregion Starlight
 
 - type: entity
   name: Floppa
@@ -195,6 +205,11 @@
     - VimPilot
   - type: StealTarget
     stealGroup: AnimalNamedCat
+    #region Starlight
+  - type: Butcherable
+    spawned:
+      - id: ClothingHandsCatPawsBrown
+    #endregion Starlight
 
 - type: entity
   name: Bandito
@@ -250,6 +265,7 @@
     spawned:
     - id: FoodMeat
       amount: 2
+    - id: ClothingHandsCatPawsWhite # Starlight
   - type: InteractionPopup
     successChance: 0.9
     interactSuccessString: petting-success-bingus


### PR DESCRIPTION
## Short description
you can now butcher the CMOs cats for cat paw gloves.

## Why we need to add this
https://www.youtube.com/watch?v=Yy3dIicSI_0

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/187336b7-7c59-4534-8681-13bc0fd1d0c3)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksantora
- add: you can now butcher the CMOs cat for cat paw gloves