### PR TITLE
Starlight multi slot updates -- many round start "stuck in lobby" fixes

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -364,7 +364,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     {
         _adminLogger.Add(LogType.AntagSelection, $"Start trying to make {session} become the antagonist: {ToPrettyString(ent)}");
 
-        if (checkPref && !HasPrimaryAntagPreference(session, def))
+        if (checkPref && !HasPrimaryAntagPreference(session, def, ent.Comp.SelectionTime))
             return false;
 
         if (!IsSessionValid(ent, session, def) || !IsEntityValid(session?.AttachedEntity, def))
@@ -517,11 +517,11 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             if (ent.Comp.PreSelectedSessions.TryGetValue(def, out var preSelected) && preSelected.Contains(session))
                 continue;
 
-            if (HasPrimaryAntagPreference(session, def))
+            if (HasPrimaryAntagPreference(session, def, ent.Comp.SelectionTime))
             {
                 preferredList.Add(session);
             }
-            else if (HasFallbackAntagPreference(session, def))
+            else if (HasFallbackAntagPreference(session, def, ent.Comp.SelectionTime))
             {
                 fallbackList.Add(session);
             }

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -108,7 +108,7 @@ namespace Content.Server.GameTicking
             var stationJobCounts = spawnableStations.ToDictionary(e => e, _ => 0);
             foreach (var netUser in netUserIds)
             {
-                if(!assignedJobs.TryGetValue(netUser, out var assignedJobAndStation) || assignedJobAndStation.Item1 is null)
+                if(!assignedJobs.TryGetValue(netUser, out var assignment) || assignment.job is null)
                 {
                     var playerSession = _playerManager.GetSessionById(netUser);
                     var evNoJobs = new NoJobsAvailableSpawningEvent(playerSession); // Used by gamerules to wipe their antag slot, if they got one
@@ -118,7 +118,7 @@ namespace Content.Server.GameTicking
                 }
                 else
                 {
-                    stationJobCounts[assignedJobAndStation.Item2] += 1;
+                    stationJobCounts[assignment.station] += 1;
                 }
             }
 

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -5,6 +5,7 @@ using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Preferences.Managers;
 using Content.Server.Station.Components;
 using Content.Server.Station.Events;
+using Content.Shared.Antag;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Robust.Server.Player;
@@ -299,8 +300,12 @@ public sealed partial class StationJobsSystem
 
         foreach (var player in players)
         {
+            if (!_player.TryGetSessionById(player, out var session))
+                continue;
+
             var roleBans = _banManager.GetJobBans(player);
-            var antagBlocked = _antag.GetPreSelectedAntagSessions();
+            var isPreselectedAntag = _antag.GetPreSelectedAntagSessions().Contains(session);
+            var preselectedAntags = _antag.GetPreSelectedAntagDefinitions(session);
 
             // Get all the jobs that a player has selected with a priority greater than Never and also that they
             // have an enabled character with that job preference selected
@@ -340,7 +345,14 @@ public sealed partial class StationJobsSystem
                 if (!_prototypeManager.TryIndex(jobId, out var job))
                     continue;
 
-                if (!job.CanBeAntag && (!_player.TryGetSessionById(player, out var session) || antagBlocked.Contains(session)))
+                // If we're an antag but the job can't be an antag, don't allow this job
+                if (isPreselectedAntag && !job.CanBeAntag)
+                    continue;
+
+                // If we're an antag, make sure that we have a character that is eligible to
+                // become all of our selected antags
+                if (isPreselectedAntag && !preselectedAntags.All(antag =>
+                        _antag.HasPrimaryAntagPreference(session, antag, AntagSelectionTime.IntraPlayerSpawn, job)))
                     continue;
 
                 if (weight is not null && job.Weight != weight.Value)

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -56,7 +56,7 @@ public sealed partial class StationJobsSystem
     /// as there may end up being more round-start slots than available slots, which can cause weird behavior.
     /// A warning to all who enter ye cursed lands: This function is long and mildly incomprehensible. Best used without touching.
     /// </remarks>
-    public Dictionary<NetUserId, (ProtoId<JobPrototype>?, EntityUid)> AssignJobs(IReadOnlySet<NetUserId> userIdsIn, IReadOnlyList<EntityUid> stations, bool useRoundStartJobs = true)
+    public Dictionary<NetUserId, (ProtoId<JobPrototype>? job, EntityUid station)> AssignJobs(IReadOnlySet<NetUserId> userIdsIn, IReadOnlyList<EntityUid> stations, bool useRoundStartJobs = true)
     {
         DebugTools.Assert(stations.Count > 0);
 

--- a/Content.Shared/Preferences/PlayerPreferences.cs
+++ b/Content.Shared/Preferences/PlayerPreferences.cs
@@ -148,25 +148,6 @@ namespace Content.Shared.Preferences
         }
 
         /// <summary>
-        /// Return true if any enabled character profile is asking for any antag in antagList
-        /// </summary>
-        public bool HasAntagPreference(ICollection<ProtoId<AntagPrototype>> antagList)
-        {
-            foreach (var profile in Characters.Values)
-            {
-                if (profile is not HumanoidCharacterProfile { Enabled: true } humanoid)
-                    continue;
-                foreach (var antag in antagList)
-                {
-                    if (humanoid.AntagPreferences.Contains(antag))
-                        return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// Given an antag, return a random enabled character asking for this antag
         /// </summary>
         public HumanoidCharacterProfile? SelectProfileForAntag(ICollection<ProtoId<AntagPrototype>> antags)

--- a/Content.Shared/Roles/Jobs/SharedJobSystem.cs
+++ b/Content.Shared/Roles/Jobs/SharedJobSystem.cs
@@ -216,4 +216,12 @@ public abstract class SharedJobSystem : EntitySystem
 
         return prototype.CanBeAntag;
     }
+
+    /// <summary>
+    /// Returns true if the given job can be antag.
+    /// </summary>
+    public bool CanBeAntag(ProtoId<JobPrototype> jobId)
+    {
+        return _prototypes.TryIndex(jobId, out var prototype) && prototype.CanBeAntag;
+    }
 }


### PR DESCRIPTION
## Short description

Cherry pick from upstream PR.


Fixes these cases:

### Failure case 1

- One character enabled
- Only job preference is Captain
- Only job priority is Captain on High
- Captain has Syndicate Agent On
- You will be considered to be pre-selected for an antag even though you don't have any characters enabled that can get the antag status
- If you are selected for antag status, you will fail to join since your only character is captain
- You will fail to join

Fix: If a character has ONLY mind-shielded roles, they will not be considered for IntraPlayerSpawn antagonists even if they are set to ON.


### Failure case 2

- One character is set to Cargo with Syndicate Agent ***ON***
- Second character is set to Janitor with Syndicate agent *OFF*
- You become pre-selected for Syndicate Agent
- You roll Janitor
- You fail to join because your Janitor cannot become a syndicate agent.

Fix: If you are pre-selected to become an antagonist, when building the player's set of eligible jobs, it will exclude the job preferences of characters for which the character's antagonist preferences are incompatible.

## Why we need to add this

Lots of complaints about this, pretty nasty bug that was really hard to wrap my head around. I think finally all of the selection logic should be ROCK. SOLID.

## Media (Video/Screenshots)


## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Quantumcross
- fix: Fixed multiple edge cases for job selection causing round join failure, esp if only mindshielded roles selected
