### PR TITLE
Grapegifter Shuttles

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/GR-4P3.yml
+++ b/Resources/Maps/_Starlight/Shuttles/GR-4P3.yml
@@ -6,6 +6,12 @@ meta:
   forkVersion: 1732131340
   time: 06/27/2025 21:25:06
   entityCount: 272
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
 tilemap:
   0: Space
   3: FloorDarkMini

--- a/Resources/Maps/_Starlight/Shuttles/GR-4P3.yml
+++ b/Resources/Maps/_Starlight/Shuttles/GR-4P3.yml
@@ -1,0 +1,2070 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 261.2.0
+  forkId: Starlight
+  forkVersion: 1732131340
+  time: 06/27/2025 21:25:06
+  entityCount: 272
+tilemap:
+  0: Space
+  3: FloorDarkMini
+  1: Lattice
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: GR-4P3
+    - type: Transform
+      pos: -1.2063751,-0.30715814
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAAAAAAAAAABAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        1,0:
+          ind: 1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: ImplicitRoof
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            62: 5,4
+            63: 6,4
+            64: 7,4
+            65: 8,4
+            66: 9,4
+            67: 10,4
+            68: 11,4
+            69: 12,4
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteCornerNe
+          decals:
+            1: 12,6
+            11: 13,5
+            38: 11,9
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteCornerNw
+          decals:
+            0: 5,6
+            10: 4,5
+            33: 6,9
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteCornerSe
+          decals:
+            19: 13,3
+            29: 10,1
+            39: 11,8
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteCornerSw
+          decals:
+            18: 4,3
+            28: 7,1
+            32: 6,8
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteInnerNe
+          decals:
+            17: 12,5
+            45: 10,6
+            46: 7,6
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteInnerNw
+          decals:
+            16: 5,5
+            44: 10,6
+            47: 7,6
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteInnerSe
+          decals:
+            25: 10,3
+            43: 10,8
+            49: 7,8
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteInnerSw
+          decals:
+            24: 7,3
+            42: 10,8
+            48: 7,8
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteLineE
+          decals:
+            12: 13,4
+            26: 10,2
+            50: 10,7
+            51: 7,7
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteLineN
+          decals:
+            2: 11,6
+            3: 6,6
+            4: 8,6
+            5: 9,6
+            34: 7,9
+            35: 8,9
+            36: 9,9
+            37: 10,9
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteLineS
+          decals:
+            20: 12,3
+            21: 11,3
+            22: 5,3
+            23: 6,3
+            30: 9,1
+            31: 8,1
+            40: 8,8
+            41: 9,8
+        - node:
+            color: '#2D1DC393'
+            id: MiniTileWhiteLineW
+          decals:
+            14: 4,4
+            27: 7,2
+            52: 10,7
+            53: 7,7
+        - node:
+            color: '#2D1DC393'
+            id: WarnLineGreyscaleE
+          decals:
+            60: 15,3
+            61: 15,4
+        - node:
+            color: '#2D1DC393'
+            id: WarnLineGreyscaleN
+          decals:
+            54: 3,6
+            55: 4,6
+            56: 13,6
+            57: 14,6
+        - node:
+            color: '#2D1DC393'
+            id: WarnLineGreyscaleW
+          decals:
+            58: 2,4
+            59: 2,3
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 232
+            1: 57344
+          0,1:
+            1: 2190
+            0: 8704
+          0,2:
+            0: 12
+          1,0:
+            1: 63616
+            2: 32
+          1,1:
+            1: 36863
+          1,2:
+            0: 17
+            1: 204
+          2,0:
+            1: 63344
+          2,1:
+            1: 20479
+          2,2:
+            1: 255
+          3,0:
+            3: 16
+            1: 61440
+            0: 196
+          3,1:
+            1: 1919
+          3,2:
+            0: 46
+          4,0:
+            0: 16
+            1: 4096
+          4,1:
+            1: 1
+            0: 4352
+        uniqueMixes:
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirAlarm
+  entities:
+  - uid: 181
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 141
+      - 160
+      - 170
+      - 163
+      - 182
+      - 143
+      - 161
+      - 183
+      - 259
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,3.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,4.5
+      parent: 1
+- proto: AirlockMining
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+- proto: AirSensor
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 181
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 8.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 181
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 181
+- proto: APCBasic
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,7.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,3.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,4.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+- proto: AtmosFixNitrogenMarker
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 1
+- proto: AtmosFixOxygenMarker
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+- proto: BlastDoor
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 13.5,7.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 14.5,7.5
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 123
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,6.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 14.5,5.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 13.5,4.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 14.5,4.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 15.5,4.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 14.5,6.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 15.5,3.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 12.5,3.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 12.5,5.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 12.5,6.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 76
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,8.5
+      parent: 1
+- proto: ComputerSalvageExpedition
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 1
+- proto: Floodlight
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 12.270733,6.263557
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 12.645733,6.5241547
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 5.811899,6.451187
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 5.186899,6.232285
+      parent: 1
+- proto: GasMinerNitrogen
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 1
+- proto: GasMinerOxygen
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+- proto: GasMixer
+  entities:
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,2.5
+      parent: 1
+    - type: GasMixer
+      inletTwoConcentration: 0.76
+      inletOneConcentration: 0.24
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 139
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+  - uid: 157
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 14.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 135
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+  - uid: 137
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+  - uid: 138
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 153
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 165
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 166
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 168
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 169
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 173
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 174
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 176
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 12.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 162
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasVentPump
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 181
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 181
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 170
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 181
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 181
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 181
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 163
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 181
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 10.5,10.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 11.5,10.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 12.5,10.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 12.5,9.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 1
+- proto: MiningWindow
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 12.5,9.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 12.5,10.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 11.5,10.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 10.5,10.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 9.5,10.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+- proto: OreBox
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 1
+- proto: OreProcessor
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 246
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,3.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,8.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,3.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,3.5
+      parent: 1
+- proto: PoweredlightExterior
+  entities:
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 14.5,1.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,8.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,6.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+- proto: RandomSpawner
+  entities:
+  - uid: 269
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 1
+- proto: RandomSpawner100
+  entities:
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 1
+- proto: ReinforcedPlasmaWindow
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 1
+- proto: SalvageMagnet
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,6.5
+      parent: 1
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,6.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        66:
+        - Pressed: Toggle
+        65:
+        - Pressed: Toggle
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        64:
+        - Pressed: Toggle
+        63:
+        - Pressed: Toggle
+- proto: SubstationWallBasic
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,2.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 16.5,7.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,1.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,6.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,1.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,0.5
+      parent: 1
+- proto: WallMining
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 15.5,7.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 15.5,6.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 15.5,5.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 16.5,5.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 16.5,2.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 15.5,2.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 14.5,2.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 13.5,2.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 13.5,1.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 12.5,0.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 13.5,0.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 12.5,2.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+- proto: WarningN2
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 12.5,2.5
+      parent: 1
+- proto: WarningO2
+  entities:
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 1
+- proto: WindoorSecureSalvageLocked
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,2.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,2.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,2.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,2.5
+      parent: 1
+...

--- a/Resources/Maps/_Starlight/Shuttles/SP-4C3.yml
+++ b/Resources/Maps/_Starlight/Shuttles/SP-4C3.yml
@@ -6,6 +6,12 @@ meta:
   forkVersion: 1732131340
   time: 06/27/2025 20:57:13
   entityCount: 160
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
 tilemap:
   0: Space
   3: FloorDarkMini

--- a/Resources/Maps/_Starlight/Shuttles/SP-4C3.yml
+++ b/Resources/Maps/_Starlight/Shuttles/SP-4C3.yml
@@ -1,0 +1,1278 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 261.2.0
+  forkId: Starlight
+  forkVersion: 1732131340
+  time: 06/27/2025 20:57:13
+  entityCount: 160
+tilemap:
+  0: Space
+  3: FloorDarkMini
+  1: Lattice
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: SP-4C3
+    - type: Transform
+      pos: 0.33333337,-0.29673386
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAgAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAACAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAMAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: ImplicitRoof
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteCornerNe
+          decals:
+            2: -3,9
+            3: -2,7
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteCornerNw
+          decals:
+            0: -6,7
+            1: -5,9
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteCornerSe
+          decals:
+            14: -2,4
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteCornerSw
+          decals:
+            13: -6,4
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteEndN
+          decals:
+            4: -4,10
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteInnerNe
+          decals:
+            5: -4,9
+            8: -3,7
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteInnerNw
+          decals:
+            6: -4,9
+            7: -5,7
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteLineE
+          decals:
+            9: -3,8
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteLineN
+          decals:
+            28: -4,2
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteLineS
+          decals:
+            15: -4,4
+        - node:
+            color: '#DE3A3A96'
+            id: MiniTileWhiteLineW
+          decals:
+            10: -5,8
+            11: -6,6
+            12: -6,5
+        - node:
+            color: '#DE3A3A96'
+            id: WarnLineGreyscaleE
+          decals:
+            16: -2,5
+            17: -2,6
+        - node:
+            color: '#DE3A3A96'
+            id: WarnLineGreyscaleN
+          decals:
+            22: -5,2
+            25: -3,2
+        - node:
+            color: '#DE3A3A96'
+            id: WarnLineGreyscaleS
+          decals:
+            23: -3,4
+            24: -5,4
+        - node:
+            color: '#DE3A3A96'
+            id: arrow
+          decals:
+            20: -5,2
+            26: -5,4
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#DE3A3A96'
+            id: arrow
+          decals:
+            21: -3,4
+            27: -3,2
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -2,0:
+            0: 546
+            1: 34944
+          -2,1:
+            1: 52428
+          -2,2:
+            0: 16928
+            1: 136
+          -1,0:
+            1: 9008
+            0: 2184
+          -1,1:
+            1: 32759
+          -1,2:
+            1: 307
+            0: 18560
+        uniqueMixes:
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirAlarm
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 66
+      - 64
+      - 127
+      - 82
+      - 126
+      - 65
+- proto: AirCanister
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+- proto: AirSensor
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 63
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 63
+- proto: APCBasic
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+- proto: BlastDoorOpen
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 1
+- proto: ComputerIFF
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+- proto: CrateContrabandStorageSecure
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 56
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 57
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 61
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 72
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 74
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 75
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 76
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 77
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 78
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 79
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 86
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 68
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPort
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 63
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 63
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 63
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 63
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+- proto: LockerSecurityLargeFilled
+  entities:
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+- proto: PlasmaWindoorSecureSecurityLocked
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+- proto: PosterLegitEnlist
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+- proto: PosterLegitSecWatch
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+- proto: PoweredlightExterior
+  entities:
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+- proto: RandomSpawner
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+- proto: RandomSpawner100
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 137
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        37:
+        - Pressed: DoorBolt
+        36:
+        - Pressed: DoorBolt
+        135:
+        - Pressed: Toggle
+        92:
+        - Pressed: Toggle
+- proto: SteelBench
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,1.5
+      parent: 1
+- proto: Stunbaton
+  entities:
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -2.5669122,8.682009
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 25
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+- proto: TurnstileGenpopEnter
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+- proto: TurnstileGenpopLeave
+  entities:
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,3.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+- proto: Wrench
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -4.5586543,8.606427
+      parent: 1
+...

--- a/Resources/Maps/_Starlight/Shuttles/ShuttleEvent/ShadowBorgiGrid.yml
+++ b/Resources/Maps/_Starlight/Shuttles/ShuttleEvent/ShadowBorgiGrid.yml
@@ -13409,32 +13409,23 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         2243:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2244:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2245:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2246:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2247:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2248:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2292:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2291:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2290:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
   - uid: 2275
     components:
     - type: Transform
@@ -13444,80 +13435,55 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         2273:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2272:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2271:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2270:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2269:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2268:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2267:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2266:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2265:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2264:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2263:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2262:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2261:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2260:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2259:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2258:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2257:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2256:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2255:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2254:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2253:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2252:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2251:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2250:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2249:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
   - uid: 2276
     components:
     - type: Transform
@@ -13538,20 +13504,15 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         2283:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2284:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2286:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2285:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2287:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
   - uid: 2289
     components:
     - type: Transform
@@ -13560,20 +13521,15 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         2278:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2279:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2280:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2281:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         2282:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
 - proto: SignBar
   entities:
   - uid: 2416

--- a/Resources/Maps/_Starlight/Shuttles/scarletNUKIEWARSHIP.yml
+++ b/Resources/Maps/_Starlight/Shuttles/scarletNUKIEWARSHIP.yml
@@ -705,8 +705,7 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         11:
-        - - DoorStatus
-          - DoorBolt
+        - DoorStatus: DoorBolt
   - uid: 8
     components:
     - type: Transform
@@ -717,8 +716,7 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         10:
-        - - DoorStatus
-          - DoorBolt
+        - DoorStatus: DoorBolt
   - uid: 9
     components:
     - type: Transform
@@ -735,8 +733,7 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         8:
-        - - DoorStatus
-          - DoorBolt
+        - DoorStatus: DoorBolt
   - uid: 11
     components:
     - type: Transform
@@ -747,8 +744,7 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         7:
-        - - DoorStatus
-          - DoorBolt
+        - DoorStatus: DoorBolt
   - uid: 12
     components:
     - type: Transform
@@ -7693,59 +7689,41 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         137:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         138:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         135:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         136:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         131:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         128:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         127:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         132:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         129:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         130:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         133:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         124:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         134:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         126:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         123:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         125:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         153:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         154:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
   - uid: 1078
     components:
     - type: MetaData
@@ -7757,47 +7735,33 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         164:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         165:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         163:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         161:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         162:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         155:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         156:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         157:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         158:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         166:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         167:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         169:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         168:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         170:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
   - uid: 1079
     components:
     - type: MetaData
@@ -7809,17 +7773,13 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         149:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         147:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         150:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         152:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
 - proto: SignChem
   entities:
   - uid: 1080

--- a/Resources/Maps/_Starlight/Shuttles/scarletSHCdefenderFinal.yml
+++ b/Resources/Maps/_Starlight/Shuttles/scarletSHCdefenderFinal.yml
@@ -4942,32 +4942,23 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         65:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         66:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         67:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         68:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         69:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         70:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         71:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         72:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
         73:
-        - - Pressed
-          - Toggle
+        - Pressed: Toggle
 - proto: SignSomethingOld2
   entities:
   - uid: 629


### PR DESCRIPTION
## Short description
Added two shuttles influenced by Grapegifter.

## Why we need to add this
Sec ship. Mining ship. needed for obvious reasons. Will be figuring out how to make consoles to remote control them from station, as well as getting them to spawn round start. Variant of sec shuttle for visitors event coming later. SP-4C3 Security Pursuit. GR-4P3 Geological Retrieval.

## Media (Video/Screenshots)
![image](https://github.com/user-attachments/assets/e93d9b93-ed98-4d6f-b2be-298df7b1745a)
![image](https://github.com/user-attachments/assets/c634e9ed-6a91-4a5d-be8f-1a7720297518)


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Trep_Maul
- add: GR-4P3 Geological Retrieval style mining shuttle.
- add: SP-4C3 Security Pursuit style security shuttle.
