### PR TITLE
Fix visual glitch of avali seemingly performing actions when in stasis.

### DIFF
--- a/Content.Client/_Starlight/Actions/Stasis/StasisFrozenSystem.cs
+++ b/Content.Client/_Starlight/Actions/Stasis/StasisFrozenSystem.cs
@@ -1,0 +1,11 @@
+using Content.Shared._Starlight.Actions.Stasis;
+
+namespace Content.Client._Starlight.Actions.Stasis;
+
+/// <summary>
+/// Client-side system that handles the freezing behavior of entities in stasis.
+/// This needs to be defined so client actually is using the SharedStasisFrozenSystem.
+/// </summary>
+public sealed class StasisFrozenSystem : SharedStasisFrozenSystem
+{
+} 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fix a bug where Avali seemingly could attack very fast and were immune to any recoil from that attack, additionally they could unbuckle and do a whole bunch of other interactions that were then cancelled by the server. Mostly a visual bug.

## Why we need to add this
It fixes a bug.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Avali visual bugs when in stasis and performing attacks.
