### PR TITLE
Moves medical research from civilian to medical

### DIFF
--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -114,35 +114,6 @@
   - Service
 
 - type: technology
-  id: BiochemicalStasis
-  name: research-technology-biochemical-stasis
-  icon:
-    sprite: Structures/Machines/stasis_bed.rsi
-    state: icon
-  discipline: CivilianServices
-  tier: 2
-  cost: 7500
-  recipeUnlocks:
-  - StasisBedMachineCircuitboard
-  - CryoPodMachineCircuitboard
-  - CryostasisBeaker
-  - SyringeCryostasis
-  radioChannels:
-  - Medical
-
-- type: technology # Merge with other T2 medical research if possible!
-  id: MechanizedTreatment
-  name: research-technology-mechanized-treatment
-  icon:
-    sprite: Mobs/Silicon/chassis.rsi
-    state: medical
-  discipline: CivilianServices
-  tier: 2
-  cost: 5000
-  recipeUnlocks:
-  - BorgModuleAdvancedChemical
-
-- type: technology
   id: AdvancedCleaning
   name: research-technology-advanced-cleaning
   icon:
@@ -247,33 +218,3 @@
   - ClothingShoesBootsSpeed
   radioChannels:
   - Service
-
-- type: technology
-  id: BluespaceChemistry
-  name: research-technology-bluespace-chemistry
-  icon:
-    sprite: Objects/Specific/Chemistry/beaker_bluespace.rsi
-    state: beakerbluespace
-  discipline: CivilianServices
-  tier: 3
-  cost: 10000
-  recipeUnlocks:
-  - BluespaceBeaker
-  - SyringeBluespace
-  radioChannels:
-  - Medical
-
-- type: technology
-  id: LauncherSyringe
-  name: research-technology-launcher-syringe
-  icon:
-    sprite: Objects/Weapons/Guns/Cannons/syringe_gun.rsi
-    state: syringe_gun
-  discipline: CivilianServices
-  tier: 3
-  cost: 15000
-  recipeUnlocks:
-  - LauncherSyringe
-  - MiniSyringe
-  radioChannels:
-  - Medical

--- a/Resources/Prototypes/_StarLight/Research/medical.yml
+++ b/Resources/Prototypes/_StarLight/Research/medical.yml
@@ -83,6 +83,7 @@
   - Security
   - Medical
 
+#starlight, moved from civilian to medical
 - type: technology
   id: BiochemicalStasis
   name: research-technology-biochemical-stasis
@@ -100,6 +101,7 @@
   radioChannels:
   - Medical
 
+#starlight, moved from civilian to medical
 - type: technology
   id: MechanizedTreatment
   name: research-technology-mechanized-treatment
@@ -170,6 +172,7 @@
   - Security
   - Medical
 
+#starlight, moved from civilian to medical
 - type: technology
   id: BluespaceChemistry
   name: research-technology-bluespace-chemistry
@@ -185,6 +188,7 @@
   radioChannels:
   - Medical
 
+#starlight, moved from civilian to medical
 - type: technology
   id: LauncherSyringe
   name: research-technology-launcher-syringe

--- a/Resources/Prototypes/_StarLight/Research/medical.yml
+++ b/Resources/Prototypes/_StarLight/Research/medical.yml
@@ -83,6 +83,35 @@
   - Security
   - Medical
 
+- type: technology
+  id: BiochemicalStasis
+  name: research-technology-biochemical-stasis
+  icon:
+    sprite: Structures/Machines/stasis_bed.rsi
+    state: icon
+  discipline: Biochemical
+  tier: 2
+  cost: 7500
+  recipeUnlocks:
+  - StasisBedMachineCircuitboard
+  - CryoPodMachineCircuitboard
+  - CryostasisBeaker
+  - SyringeCryostasis
+  radioChannels:
+  - Medical
+
+- type: technology
+  id: MechanizedTreatment
+  name: research-technology-mechanized-treatment
+  icon:
+    sprite: Mobs/Silicon/chassis.rsi
+    state: medical
+  discipline: Biochemical
+  tier: 2
+  cost: 5000
+  recipeUnlocks:
+  - BorgModuleAdvancedChemical
+
 # Tier 3
 
 - type: technology
@@ -139,4 +168,34 @@
     - CyberEyeNightVision
   radioChannels:
   - Security
+  - Medical
+
+- type: technology
+  id: BluespaceChemistry
+  name: research-technology-bluespace-chemistry
+  icon:
+    sprite: Objects/Specific/Chemistry/beaker_bluespace.rsi
+    state: beakerbluespace
+  discipline: Biochemical
+  tier: 3
+  cost: 10000
+  recipeUnlocks:
+  - BluespaceBeaker
+  - SyringeBluespace
+  radioChannels:
+  - Medical
+
+- type: technology
+  id: LauncherSyringe
+  name: research-technology-launcher-syringe
+  icon:
+    sprite: Objects/Weapons/Guns/Cannons/syringe_gun.rsi
+    state: syringe_gun
+  discipline: Biochemical
+  tier: 3
+  cost: 15000
+  recipeUnlocks:
+  - LauncherSyringe
+  - MiniSyringe
+  radioChannels:
   - Medical


### PR DESCRIPTION
## Short description

It moves four civilian research that announced their completion on the Medical frequency, to the Medical category.

[Suggested by Piksqu on Discord](https://discord.com/channels/1272545509562777621/1388152670648406027/1388152670648406027):

![image](https://github.com/user-attachments/assets/dc5013e8-3634-43d2-a2c6-4c6114b6cf38)

## Why we need to add this

They were in the incorrect research group.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/7a3972fb-498f-46c6-bae1-20259627dc90

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Adri
- fix: Moved four medical research (cryostasis and bluespace items, advanced medical cyborg, launcher syringes) from the civilian tree to the medical one.
