### PR TITLE
Ratking Speed Bugfix (temp/jank)

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -63,7 +63,7 @@
         Piercing: 8
   - type: Body
     prototype: Rat
-    requiredLegs: 0 # TODO: Figure out why requiring 1 leg broke movespeed for ratking. (Jank Temp Fix)
+    requiredLegs: 0 # Starlight TODO: Figure out why requiring 1 leg broke movespeed for ratking. (Jank Temp Fix)
   - type: Hunger # probably should be prototyped
     thresholds:
       Overfed: 200

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -63,7 +63,7 @@
         Piercing: 8
   - type: Body
     prototype: Rat
-    requiredLegs: 1 # TODO: More than 1 leg
+    requiredLegs: 0 # TODO: Figure out why requiring 1 leg broke movespeed for ratking. (Jank Temp Fix)
   - type: Hunger # probably should be prototyped
     thresholds:
       Overfed: 200


### PR DESCRIPTION
## Short description
- ratkings don't need legs anymore.
- Shouldn't come up since they're not surgeryable anyway.
- Might be weird if they get a leg blown off later and it doesn't slow them.
- fixed the move speed issue though.

## Why we need to add this
Ratking speed was super bugged slow.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Trep_Maul
- fix: ratking speed