### PR TITLE
Avali custom name fix + Minor grammar fix

### DIFF
--- a/Resources/Locale/en-US/_Starlight/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/_Starlight/preferences/ui/humanoid-profile-editor.ftl
@@ -1,1 +1,1 @@
-humanoid-profile-editor-customspeciename-label = Custom Specie Name:
+humanoid-profile-editor-customspeciename-label = Custom Species Name:

--- a/Resources/Prototypes/_StarLight/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Species/avali.yml
@@ -16,6 +16,7 @@
   youngAge: 103
   oldAge: 257
   maxAge: 430
+  customName: true # Starlight
 
 - type: speciesBaseSprites
   id: MobAvaliSprites


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Sets custom species to true on Avali, seemed like an oversight.
Also changes "Custom Specie Name" to "Custom Species Name" because it was inflicting psychic damage to me.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Adds functionality to Avali that they seemingly should have.
Reduces psychic damage to English-speakers using the customization menu.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Forgot to take a picture, but it's exactly what you think.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: Trosling
- add: Custom species naming to Avali
- fix: Fixed misguided conjugation of species to specie in the customization menu
-->
:cl: Trosling
- add: Custom species naming to Avali
- fix: Fixed misguided conjugation of species to specie in the customization menu
