### PR TITLE
nanotask 0G travel fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -217,6 +217,17 @@
     - Document
     - Trash
     - Paper
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.08,-0.20,0.08,0.20"
+        density: 2.5
+        mask:
+          - ItemMask
+        restitution: 0.3  # fite me
+        friction: 0.2
   - type: StaticPrice
     price: 0
   - type: NanoTaskPrinted


### PR DESCRIPTION
## Short description
nanotask density and hitbox down. Significantly more time consuming to use to negate zero-g environment.

## Why we need to add this
Exploit fix.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Trep_Maul
- fix: Nanotask 0G exploit
