### PR TITLE
Vote - Crew Shift Changes

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -21,6 +21,8 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.DeviceNetwork.Components;
 using Timer = Robust.Shared.Timing.Timer;
+using Content.Server.Voting.Managers;
+using Content.Server.Voting; // Starlight
 
 namespace Content.Server.RoundEnd
 {
@@ -41,6 +43,7 @@ namespace Content.Server.RoundEnd
         [Dependency] private readonly EmergencyShuttleSystem _shuttle = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly StationSystem _stationSystem = default!;
+        [Dependency] private readonly IVoteManager _voteManager = default!; // Starlight
 
         public TimeSpan DefaultCooldownDuration { get; set; } = TimeSpan.FromSeconds(30);
 
@@ -232,7 +235,7 @@ namespace Content.Server.RoundEnd
                 _adminLogger.Add(LogType.ShuttleRecalled, LogImpact.High, $"Shuttle recalled");
             }
 
-            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("round-end-system-shuttle-recalled-announcement"),
+            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("round-end-system-shuttle-vote-announcement"),
                 Loc.GetString("round-end-system-shuttle-sender-announcement"), false, colorOverride: Color.Gold);
 
             _audio.PlayGlobal("/Audio/_Starlight/Announcements/recallEvac.ogg", Filter.Broadcast(), true); //🌟Starlight🌟
@@ -357,7 +360,39 @@ namespace Content.Server.RoundEnd
             {
                 if (!_shuttle.EmergencyShuttleArrived && ExpectedCountdownEnd is null)
                 {
-                    RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
+                    // Starlight - start
+                    _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("round-end-system-shuttle-vote-announcement"),
+                        Loc.GetString("round-end-system-shuttle-sender-announcement"), false, colorOverride: Color.Gold);
+
+                    var options = new VoteOptions
+                    {
+                        InitiatorText = Loc.GetString("ui-vote-shuttle-initiator"),
+                        Title = Loc.GetString("ui-vote-shuttle-title"),
+                        Duration = TimeSpan.FromSeconds(30),
+                        Options =
+                        {
+                            (Loc.GetString("ui-vote-shuttle-yes"), "yes"),
+                            (Loc.GetString("ui-vote-shuttle-no"), "no")
+                        },
+                    };
+
+                    var vote = _voteManager.CreateVote(options);
+
+                    vote.OnFinished += (_, eventArgs) =>
+                    {
+                        if (eventArgs.Winner == "yes")
+                            RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
+                        else
+                            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("round-end-system-shuttle-continue-announcement"),
+                                Loc.GetString("round-end-system-shuttle-sender-announcement"), false, colorOverride: Color.Gold);
+                    };
+
+                    vote.OnCancelled += _ =>
+                    {
+                        RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
+                    };
+                    // Starlight - End
+
                     _autoCalledBefore = true;
                 }
 
@@ -365,7 +400,7 @@ namespace Content.Server.RoundEnd
                 SetAutoCallTime();
             }
         }
-        
+
         public TimeSpan TimeToCallShuttle()
         {
             var autoCalledBefore = _autoCalledBefore

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -21,7 +21,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.DeviceNetwork.Components;
 using Timer = Robust.Shared.Timing.Timer;
-using Content.Server.Voting.Managers;
+using Content.Server.Voting.Managers; // Starlight
 using Content.Server.Voting; // Starlight
 
 namespace Content.Server.RoundEnd
@@ -235,7 +235,7 @@ namespace Content.Server.RoundEnd
                 _adminLogger.Add(LogType.ShuttleRecalled, LogImpact.High, $"Shuttle recalled");
             }
 
-            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("round-end-system-shuttle-vote-announcement"),
+            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("round-end-system-shuttle-recalled-announcement"),
                 Loc.GetString("round-end-system-shuttle-sender-announcement"), false, colorOverride: Color.Gold);
 
             _audio.PlayGlobal("/Audio/_Starlight/Announcements/recallEvac.ogg", Filter.Broadcast(), true); //🌟Starlight🌟

--- a/Resources/Locale/en-US/_Starlight/voting/vote-manager.ftl
+++ b/Resources/Locale/en-US/_Starlight/voting/vote-manager.ftl
@@ -1,0 +1,7 @@
+ui-vote-shuttle-title = End the shift?
+ui-vote-shuttle-initiator = Central Command
+ui-vote-shuttle-yes = Initiate Crew Transfer
+ui-vote-shuttle-no = Continue The Shift
+
+round-end-system-shuttle-vote-announcement = An automatic crew shift vote is about to begin. Please vote on your PDA to determine if you want to continue this shift.
+round-end-system-shuttle-continue-announcement = The crew has voted to continue the shift. The shuttle will not be called.

--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -2,7 +2,7 @@
 
 round-end-system-shuttle-called-announcement = An emergency shuttle has been sent. ETA: {$time} {$units}.
 round-end-system-shuttle-already-called-announcement = An emergency shuttle has already been sent.
-round-end-system-shuttle-auto-called-announcement = An automatic crew shift change shuttle has been sent. ETA: {$time} {$units}. Recall the shuttle to extend the shift.
+round-end-system-shuttle-auto-called-announcement = The crew transfer shuttle has been called. ETA: {$time} {$units}.
 round-end-system-shuttle-recalled-announcement = The emergency shuttle has been recalled.
 round-end-system-shuttle-sender-announcement = Station
 round-end-system-round-restart-eta-announcement = Restarting the round in {$time} {$units}...


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
I really hate how Crew Shift changed is handeled on SS14 SO... I changed it.

Following things to know.
This does not block the ability of command to call/recall the shuttle, they are free to do so.
If there is a tie or the vote is cancelled, its will auto-call the shuttle.

Nothing really else is changed, the vote triggers instead of the auto-call and has a timer of 30s before the vote is over, Tie/Yes will result in normal behavior.

Note: First time the vote is done, even if they continue the shift the value "hasbeencalledbefore" will be still valid!

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/cb48606b-d644-4e25-9bb5-b6aa8ebe1472)
![image](https://github.com/user-attachments/assets/204b6672-b514-40cb-b37e-eb5a7233a4d3)
![image](https://github.com/user-attachments/assets/3a91c9f4-8f72-43d9-a2e2-81fb6123de34)

</p>
</details>

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

:cl: FoxxoTrystan
- tweak: Crew Shift Changes will now be voted.
