### PR TITLE
Admeme'ing of End of Q

### DIFF
--- a/Resources/Maps/_Starlight/nukieplanet.yml
+++ b/Resources/Maps/_Starlight/nukieplanet.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Map
+  engineVersion: 261.2.0
+  forkId: Starlight
+  forkVersion: 1732131340
+  time: 07/06/2025 05:23:12
+  entityCount: 4163
+maps:
+- 1295
+grids:
+- 1
+orphans: []
+nullspace: []
 tilemap:
   10: Space
   7: FloorArcadeRed
@@ -2254,9 +2265,7 @@ entities:
     - type: Transform
     - type: Map
       mapPaused: True
-    - type: PhysicsMap
     - type: GridTree
-    - type: MovedGrids
     - type: FTLDestination
       whitelist:
         tags:
@@ -14897,7 +14906,7 @@ entities:
       pos: -3.5,1.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -17597.717
+      secondsUntilStateChange: -17863.53
       state: Opening
   - uid: 730
     components:
@@ -14905,7 +14914,7 @@ entities:
       pos: -3.5,2.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -17598.584
+      secondsUntilStateChange: -17864.396
       state: Opening
 - proto: MinimoogInstrument
   entities:
@@ -15124,15 +15133,6 @@ entities:
     - type: Transform
       pos: 1.8436577,3.5806565
       parent: 1
-- proto: PaperTooQuietNeedChaos
-  entities:
-  - uid: 4157
-    components:
-    - type: Transform
-      pos: -14.498461,8.569751
-      parent: 1
-    missingComponents:
-    - FaxableObject
 - proto: PartRodMetal
   entities:
   - uid: 828
@@ -18320,21 +18320,29 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         118:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         119:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         120:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         117:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         116:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         121:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         122:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         123:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 1277
     components:
     - type: MetaData
@@ -18346,9 +18354,11 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         1273:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1274:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
 - proto: SignalButtonDirectional
   entities:
   - uid: 1568
@@ -18362,21 +18372,29 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         1559:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1560:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1561:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1562:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1569:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1570:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1571:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1572:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
 - proto: SignalTrigger
   entities:
   - uid: 582
@@ -19067,6 +19085,8 @@ entities:
     - type: Transform
       pos: 1.4812105,4.649179
       parent: 1
+    - type: StockLimitedProcessing
+      processingListings: {}
 - proto: SyndieFlag
   entities:
   - uid: 2720
@@ -25165,7 +25185,7 @@ entities:
       pos: -15.5,-5.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -19867.28
+      secondsUntilStateChange: -20133.092
       state: Opening
   - uid: 1244
     components:
@@ -25173,6 +25193,6 @@ entities:
       pos: -15.5,-4.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -19867.713
+      secondsUntilStateChange: -20133.525
       state: Opening
 ...

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -62,19 +62,6 @@
       conditions:
       - !type:PlayerCountCondition
         max: 15
-    - id: PaperTooQuietNeedChaos #Starlight
-      conditions:
-      - !type:PlayerCountCondition
-        invert: true
-        max: 15
-      prob: 0.05
-    - id: PaperTooQuietNeedChaosFew #lowpop varient which needs less singnatures.
-      conditions:
-      - !type:PlayerCountCondition
-        max: 15
-      prob: 0.05
-    #Starlight
-
 
 # No laser table + Laser table
 - type: entityTable


### PR DESCRIPTION


## Short description
removes the end of q spawn from cap locker and nukie outpost

## Why we need to add this

end of q has introduced too much chaos. this lets admins choose when it shows up, for example when people are complaining about it being quiet.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Gensy
- remove: Removed End of Q spawn from nukie outpost and Cap's locker, making it admeme only for now.
