### PR TITLE
Dragons store brains of devoured borgs

### DIFF
--- a/Content.Server/Devour/DevourSystem.cs
+++ b/Content.Server/Devour/DevourSystem.cs
@@ -1,15 +1,22 @@
+using Content.Server.Administration.Logs;
 using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 using Content.Shared.Chemistry.Components;
+using Content.Shared.Database;
 using Content.Shared.Devour;
 using Content.Shared.Devour.Components;
 using Content.Shared.Humanoid;
+using Content.Shared.Silicons.Borgs.Components;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Robust.Shared.Containers;
 
 namespace Content.Server.Devour;
 
 public sealed class DevourSystem : SharedDevourSystem
 {
     [Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly IAdminLogManager _adminLog = default!;
 
     public override void Initialize()
     {
@@ -27,7 +34,7 @@ public sealed class DevourSystem : SharedDevourSystem
         var ichorInjection = new Solution(component.Chemical, component.HealRate);
 
         if (component.FoodPreference == FoodPreference.All ||
-            (component.FoodPreference == FoodPreference.Humanoid && HasComp<HumanoidAppearanceComponent>(args.Args.Target)))
+            component.FoodPreference == FoodPreference.Humanoid && HasComp<HumanoidAppearanceComponent>(args.Args.Target))
         {
             if (component.ShouldStoreDevoured && args.Args.Target is not null)
             {
@@ -35,15 +42,37 @@ public sealed class DevourSystem : SharedDevourSystem
             }
             _bloodstreamSystem.TryAddToChemicals(uid, ichorInjection);
         }
+        // 🌟Starlight🌟 start
+        else if (TryComp<BorgChassisComponent>(args.Args.Target, out var borgChassis))
+		{
+			if (borgChassis.BrainEntity is not { } brain)
+			{ }
+			else
+			{
+				if (component.ShouldStoreDevoured && args.Args.Target is not null)
+                {
+                    Logger.Log(LogLevel.Debug, "Attempting to remove brain");
+                    _adminLog.Add(LogType.Action, LogImpact.Medium,
+                        $"{ToPrettyString(uid):player} devoured brain {ToPrettyString(brain)} from borg {ToPrettyString(args.Args.Target.Value)}");
+                    _container.Remove(brain, borgChassis.BrainContainer);
+					ContainerSystem.Insert(brain, component.Stomach);
+                    if(args.Args.Target != null)
+                    {
+                        QueueDel(args.Args.Target.Value);
+                    }
+				}
+			}
+		}
+        // 🌟Starlight🌟 end
 
-        //TODO: Figure out a better way of removing structures via devour that still entails standing still and waiting for a DoAfter. Somehow.
-        //If it's not human, it must be a structure
-        else if (args.Args.Target != null)
-        {
-            QueueDel(args.Args.Target.Value);
-        }
+		//TODO: Figure out a better way of removing structures via devour that still entails standing still and waiting for a DoAfter. Somehow.
+		//If it's not human, it must be a structure
+		else if (args.Args.Target != null)
+		{
+			QueueDel(args.Args.Target.Value);
+		}
 
-        _audioSystem.PlayPvs(component.SoundDevour, uid);
+		_audioSystem.PlayPvs(component.SoundDevour, uid);
     }
 
     private void OnGibContents(EntityUid uid, DevourerComponent component, ref BeingGibbedEvent args)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Makes dragons devouring borgs not instant RR

## Why we need to add this
Borgs being devoured by dragons at this time just get deleted instantly. This change still destroys the chassis, but preserves the brain so the borg may be repaired for roughly the same resource cost, maintaining RP continuity.

## Media (Video/Screenshots)
![grafik](https://github.com/user-attachments/assets/d8c931a7-e14b-4dc2-befc-3caa480af5ed)
![grafik](https://github.com/user-attachments/assets/1dc18a5e-f4d8-411f-a940-33034cbe02d0)



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- tweak: Dragons no longer digest cyborg brains, making recovery possible.
