### PR TITLE
Added more loadout options to surgeons, MDs and security

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1166,6 +1166,7 @@
   loadouts:
   - JackBoots
   - SecurityWinterBoots
+  - HighHeelBoots # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: SecurityPDA
@@ -1324,6 +1325,9 @@
   loadouts:
   - WhiteShoes
   - MedicalWinterBoots
+  - Heels # 🌟Starlight🌟
+  - LaceupShoes # 🌟Starlight🌟
+  - LeatherShoes # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: MedicalDoctorPDA

--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/shoes.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/shoes.yml
@@ -2,6 +2,11 @@
   id: Heels
   equipment:
     shoes: ClothingShoesHighheelShoes
+  
+- type: loadout
+  id: HighHeelBoots
+  equipment:
+    shoes: ClothingShoesHighheelBoots
 
 - type: loadout
   id: LaceupShoes

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -194,6 +194,8 @@
   - CowboyBootsBrown
   - CowboyBootsBlack
   - CowboyBootsWhite
+  - Heels
+  - HighHeelBoots
 
 - type: loadoutGroup
   id: CivilianShoes

--- a/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
@@ -24,9 +24,19 @@
 - type: roleLoadout
   id: JobSurgeon
   groups:
-  - Survival
+  - GroupTankHarness
+  - MedicalDoctorHead
+  - MedicalMask
+  - MedicalDoctorJumpsuit
+  - MedicalGloves
+  - MedicalBackpack
+  - MedicalDoctorOuterClothing
+  - MedicalShoes
+  - MedicalDoctorPDA
+  - MedicalEyewear
+  - SurvivalMedical
   - Trinkets
-  - GroupSpeciesBreathTool
+  - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
   id: JobNanoTrasenRepresentative

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Medical/surgeon.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Medical/surgeon.yml
@@ -18,12 +18,6 @@
 - type: startingGear
   id: SurgeonGear
   equipment:
-    jumpsuit: UniformScrubsColorGreen
-    shoes: ClothingShoesColorBrown
-    mask: ClothingMaskSterile
-    gloves: ClothingHandsGlovesNitrile
-    outerClothing: ClothingOuterCoatLabOpened
-    id: MedicalPDA
     ears: ClothingHeadsetMedical
-    head: ClothingHeadHatSurgcapGreen
-    back: ClothingBackpackDuffelSurgeryFilled
+  inhand:
+    - ClothingBackpackDuffelSurgeryFilled


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Added more outfit options.

## Why we need to add this
Surgeons, as of right now, are hard-coded to spawn with a specific loadout and no starting bag whatsoever (as they get a filled surgical bag instead), which also means they get no survival kit. As all the gear Surgeons received was already available in the Medical Doctor's loadout, I simply gave surgeons access to the MD customisations and moved the surgical bag to being an in-hand starting item, so they receive their usual starting gear in their starting bag.

While I was at it, I also added heels to the medical shoes loadout group and heeled boots to the security shoes loadout group, as both felt like they were missing them (and heeled boots are apparently just combat boots with a reskin), so both departments now get access to being fancy, too.

## Media (Video/Screenshots)
![grafik](https://github.com/user-attachments/assets/aa993342-ab62-4592-af25-5541c5da0f07)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- add: Surgeons may now choose from the standard medical uniforms available to other doctors.
- add: Security and Medical uniform restrictions have been slightly loosened to allow for slightly more varied footwear.
