### PR TITLE
Laser Cartridge Contraband Fix

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/battery.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/battery.yml
@@ -17,6 +17,8 @@
       map: ["enum.AmmoVisualLayers.Base"]
   - type: Appearance
   - type: SpentAmmoVisuals
+  - type: Contraband
+    allowedDepartments: [ Security, CentralCommand, Command ]
   
 - type: entity
   id: CartridgeBattery


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adding departments to the contraband type of the laser cartridges, which was previously left unspecified

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It looks odd that there is no department specified in the contraband type.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![image](https://github.com/user-attachments/assets/ca503e2c-a7ca-426e-89b4-a67ff7fd7c05)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- fix: Fixed missing contraband type on laser cartridges