### PR TITLE
added toggle for mail and ore bags

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Cargo/mail_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Cargo/mail_bag.yml
@@ -28,4 +28,10 @@
       #- Document
       #- Paper
   - type: Dumpable
-  - type: MagnetPickup
+  - type: ItemToggle  #starlight edit, added toggle
+    onUse: false
+    verbToggleOn: "Activate Magnet"
+    verbToggleOff: "Deactivate Magnet"
+  - type: ComponentToggler
+    components: 
+    - type: MagnetPickup

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -4,7 +4,13 @@
   parent: BaseStorageItem
   description: A robust bag for salvage specialists and miners alike to carry large amounts of ore. Magnetises any nearby ores when attached to a belt.
   components:
-  - type: MagnetPickup
+  - type: ItemToggle  #starlight edit, added toggle
+    onUse: false
+    verbToggleOn: "Activate Magnet"
+    verbToggleOff: "Deactivate Magnet"
+  - type: ComponentToggler
+    components: 
+    - type: MagnetPickup
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Mining/ore_bag.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
@@ -4,8 +4,14 @@
   parent: OreBag
   description: A robust bag of holding for salvage billionaires and rich miners alike to carry large amounts of ore. Magnetises any nearby ores when attached to a belt.
   components:
-  - type: MagnetPickup
-    range: 2
+  - type: ItemToggle  #starlight edit, added toggle
+    onUse: false
+    verbToggleOn: "Activate Magnet"
+    verbToggleOff: "Deactivate Magnet"
+  - type: ComponentToggler
+    components: 
+    - type: MagnetPickup
+      range: 2
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Mining/ore_bag_holding.rsi
     state: icon


### PR DESCRIPTION


## Short description
added the ability to toggle the magnet for mail and ore bags

## Why we need to add this
QoL

## Media (Video/Screenshots)

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Gensy
- tweak: Magnet on mail bags and ore bags can now be toggled