### PR TITLE
new life limit system

### DIFF
--- a/Content.Client/_Starlight/NewLife/NewLifeEui.cs
+++ b/Content.Client/_Starlight/NewLife/NewLifeEui.cs
@@ -47,6 +47,6 @@ public sealed class NewLifeEui : BaseEui
 
         if (state is not NewLifeEuiState newLifeEuiState)
             return;
-        _window.ReloadUI(newLifeEuiState.UsedSlots);
+        _window.ReloadUI(newLifeEuiState.UsedSlots, newLifeEuiState.RemainingLives, newLifeEuiState.MaxLives);
     }
 }

--- a/Content.Client/_Starlight/NewLife/NewLifeWindow.cs
+++ b/Content.Client/_Starlight/NewLife/NewLifeWindow.cs
@@ -15,6 +15,8 @@ public sealed partial class NewLifeWindow : DefaultWindow
     private readonly Dictionary<NetEntity, Dictionary<string, List<JobButton>>> _jobButtons = new();
     private readonly Dictionary<NetEntity, Dictionary<string, BoxContainer>> _jobCategories = new();
     private HashSet<int> _usedSlots = [];
+    private int _remainingLives = 5;
+    private int _maxLives = 5;
 
     public readonly LateJoinGui LateJoinGui = default!;
     
@@ -26,7 +28,7 @@ public sealed partial class NewLifeWindow : DefaultWindow
         MinSize = new Vector2(685, 560);
         LateJoinGui = new LateJoinGui();
         IoCManager.InjectDependencies(this);
-        Title = Loc.GetString("ghost-new-life-window-title");
+        UpdateTitle();
 
         LateJoinGui.Contents.Orphan();
         LateJoinGui.Contents.Margin = new Thickness(0, 25, 0, 0);
@@ -49,14 +51,20 @@ public sealed partial class NewLifeWindow : DefaultWindow
 
     private void RemoveUsedCharacters()
     {
-        if(_preferencesManager.Preferences is null)
+        if (_preferencesManager.Preferences is null)
             return;
         foreach (var control in LateJoinGui.CharList.Children)
         {
-            if(control is not CharacterPickerButton pickerButton)
+            if (control is not CharacterPickerButton pickerButton)
                 continue;
 
             pickerButton.Disabled = _usedSlots.Contains(_preferencesManager.Preferences.IndexOfCharacter(pickerButton.Profile));
+            //if we have no lives left, disable all buttons
+            if (_remainingLives <= 0)
+            {
+                pickerButton.Disabled = true;
+            }
+
             if (pickerButton is { Disabled: true, Pressed: true })
             {
                 pickerButton.Pressed = false;
@@ -64,9 +72,17 @@ public sealed partial class NewLifeWindow : DefaultWindow
         }
     }
 
-    public void ReloadUI(HashSet<int> usedSlots)
+    private void UpdateTitle()
+    {
+        Title = Loc.GetString("ghost-new-life-window-title", ("remainingLives", _remainingLives), ("maxLives", _maxLives));
+    }
+
+    public void ReloadUI(HashSet<int> usedSlots, int remainingLives, int maxLives)
     {
         _usedSlots = usedSlots;
+        _remainingLives = remainingLives;
+        _maxLives = maxLives;
         RemoveUsedCharacters();
+        UpdateTitle();
     }
 }

--- a/Content.Server/_Starlight/NewLife/NewLifeEui.cs
+++ b/Content.Server/_Starlight/NewLife/NewLifeEui.cs
@@ -9,15 +9,21 @@ public sealed class NewLifeEui : BaseEui
 {
     private readonly NewLifeSystem _newLifeSystem;
     private readonly HashSet<int> _usedSlots;
-    public NewLifeEui(HashSet<int> usedSlots)
+    private int _remainingLives;
+    private int _maxLives;
+    public NewLifeEui(HashSet<int> usedSlots, int remainingLives, int maxLives)
     {
         _newLifeSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<NewLifeSystem>();
         _usedSlots = usedSlots;
+        _remainingLives = remainingLives;
+        _maxLives = maxLives;
     }
 
     public override NewLifeEuiState GetNewState() => new()
     {
-        UsedSlots = _usedSlots
+        UsedSlots = _usedSlots,
+        RemainingLives = _remainingLives,
+        MaxLives = _maxLives
     };
 
     public override void HandleMessage(EuiMessageBase msg)

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVar.Newlife.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVar.Newlife.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.Starlight.CCVar;
+
+public sealed partial class StarlightCCVars
+{
+    /// <summary>
+    /// THe ammount of new lifes a player can have in a round.
+    /// </summary>
+    public static readonly CVarDef<int> MaxNewLifes =
+        CVarDef.Create("newlife.max_new_lifes", 5, CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE,
+            "The maximum number of new lifes a player can have in a round.");
+}

--- a/Content.Shared/_Starlight/NewLife/NewLifeEuiState.cs
+++ b/Content.Shared/_Starlight/NewLife/NewLifeEuiState.cs
@@ -11,6 +11,8 @@ namespace Content.Shared.Starlight.NewLife;
 public sealed class NewLifeEuiState : EuiStateBase
 {
     public HashSet<int> UsedSlots { get; set; } = [];
+    public int RemainingLives { get; set; }
+    public int MaxLives { get; set; }
 }
 [NetSerializable, Serializable]
 public sealed class NewLifeOpenedEvent : EntityEventArgs

--- a/Resources/Locale/en-US/_Starlight/ghost/ghost-gui.ftl
+++ b/Resources/Locale/en-US/_Starlight/ghost/ghost-gui.ftl
@@ -1,5 +1,5 @@
 ghost-gui-new-life-button = New life
-ghost-new-life-window-title = New life
+ghost-new-life-window-title = New life ({$remainingLives} out of {$maxLives} spawns remaining)
 ghost-new-life-unavailable = lost
 
 ghost-gui-ghost-theme-button = Ghost Themes


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a limiter to the ammount of new lifes a person can use in a round

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This allows us to reign in antag rolling, and ALSO allows us to raise the max character slots back up to 30 so people can have all the variations they may want, especially with our high species count

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![image](https://github.com/user-attachments/assets/f4bbde2b-835b-4d79-ac25-f70e657aa215)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- add: Added New Life usage limit of 5 per round.
- tweak: Planned increase of maximum character slots from 10 to 30 following this change.