### PR TITLE
Holster Update

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -470,6 +470,12 @@
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: Storage
+    grid: # Starlight
+    - 0,0,1,0 #left
+    - 0,1,0,1 #left - cube
+    - 3,0,10,1
+    - 12,0,13,0 #right
+    - 12,1,12,1 #right - cube
     whitelist:
       tags:
         - CigPack

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/belts.yml
@@ -62,6 +62,12 @@
   - type: Clothing
     sprite: _Starlight/Clothing/Belt/tactical_trauma.rsi
   - type: Storage
+    grid:
+    - 0,0,1,0 #left
+    - 0,1,0,1 #left - cube
+    - 3,0,10,1
+    - 12,0,13,0 #right
+    - 12,1,12,1 #right - cube
     whitelist:
       tags:
         - SecBeltEquip
@@ -101,6 +107,10 @@
   name: Blueshield Webbing
   description: A tactical rig that can hold many items to save the lives of command.
   components:
+  - type: Storage
+    grid:
+    - 3,0,10,1
+    - 12,0,13,1 #right
   - type: Sprite
     sprite: _Starlight/Clothing/Belt/blueshieldwebbing.rsi
   - type: Clothing


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Gives security belts/webbings two holsters, and the BSO rig one but slightly larger, holster.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It always struck me as odd that security, and BSO by extension, got sidearms but no real place to put them. Sure, you could "put them" in your belt, but the shape was odd for it and it took up valuable space when you COULD.. just shove it in your pocket. So! I came up with a little idea. Why not give pistol-sized slots in the belts? In purely practical terms, it means 2 more 1x2 slots to shove something in if you are not using as intended, which isn't a lot. If you use as intended, it frees up your pockets/boots for something else.

Regardless how it's used, I expect the impact to be minimal, it's more a QoL thing.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
BSO
![tdkdyuluj](https://github.com/user-attachments/assets/e3987e2d-9b3d-4b72-9434-e2a2bf47626b)
SEC/BRIG
![dytulklyi](https://github.com/user-attachments/assets/a43d66a8-865e-43fb-ae25-7b3a3cbcaf94)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- tweak: Gave Security/Brigmedic Belt/Rig 2 pistol-shaped slots (3 spaces in an L shape)
- tweak: Gave BSO Rig 1 normal sized slot (4 spaces. This is due to the BSO gun being 2x2)