### PR TITLE
fix duplicate name spawn menu

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -143,7 +143,7 @@ namespace Content.Server.Administration.Systems
 
                         args.Verbs.Add(new Verb()
                         {
-                            Text = profile.Name,
+                            Text = $"{slot}. {profile.Name}",
                             Category = VerbCategory.Spawn,
                             Act = () =>
                             {


### PR DESCRIPTION

## Short description

it just adds the slot number to the name on the spawn menu so that the verbs remain unique.

Future fix I would love to put a sprite preview of the character in there but that's pretty non-trivial.

## Why we need to add this

bug fix

## Media (Video/Screenshots)

![image](https://github.com/user-attachments/assets/433ac0a0-aa6b-4cd6-aad3-e520515d8ea1)

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

