### PR TITLE
Changed salvage contraband prototypes and fixed several broken contraband markers

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -290,7 +290,7 @@
     fiberColor: fibers-black
 
 - type: entity
-  parent: [ ClothingHandsGlovesCombat, BaseSalvageContraband ] #Starlight salvContra
+  parent: [ BaseEngineeringSecuritySalvageContraband, ClothingHandsGlovesCombat ] #Starlight salvContra
   id: ClothingHandsMercGlovesCombat
   name: mercenary combat gloves
   description: High-quality combat gloves to protect hands from mechanical damage during combat.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -83,7 +83,7 @@
 - type: entity
   name: seismic charge
   description: Concussion based explosive designed to destroy large amounts of rock.
-  parent: [ BaseSalvageMiningContraband, BasePlasticExplosive ] #Starlight SalvContra
+  parent: [ BaseSalvageContraband, BasePlasticExplosive ] #Starlight SalvContra
   id: SeismicCharge
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridgeMagnum
   name: cartridge (.45 magnum) 
-  parent: [ BaseCartridge, BaseSecurityContraband ]
+  parent: [ BaseCartridge, BaseSecuritySalvageContraband ]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseCartridgeMagnum
   name: cartridge (.45 magnum) 
-  parent: [ BaseCartridge, BaseSecuritySalvageContraband ]
+  parent: [ BaseCartridge, BaseSecuritySalvageContraband ] #Starlight
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -119,7 +119,7 @@
 
 - type: entity
   name: survival knife
-  parent: [ BaseSecurityMiningSalvageContraband, CombatKnife ] #Starlight salvContra
+  parent: [ BaseSecuritySalvageContraband, CombatKnife ] #Starlight salvContra
   id: SurvivalKnife
   description: Weapon of first and last resort for combatting space carp.
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseMagazineMagnum
   name: pistol magazine (.45 magnum)
-  parent: [ BaseMagazinePistol, BaseSecuritySalvageContraband ]
+  parent: [ BaseSecuritySalvageContraband, BaseMagazinePistol ]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
@@ -56,6 +56,16 @@
     allowedDepartments: [ Engineering ]
     allowedJobs: [ SalvageSpecialist ]
 
+# This might look really stupid but it's sadly necessary as conflicting base contra groups tend to be mutually exclusive...
+- type: entity
+  id: BaseEngineeringSecuritySalvageContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Engineering, Security ]
+    allowedJobs: [SalvageSpecialist]
+
 - type: entity
   id: BaseLawContraband
   parent: BaseRestrictedContraband

--- a/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
@@ -19,14 +19,6 @@
   abstract: true
   components:
   - type: Contraband
-    allowedJobs: [ SalvageSpecialist ]
-
-- type: entity
-  id: BaseSalvageMiningContraband
-  parent: BaseRestrictedContraband
-  abstract: true
-  components:
-  - type: Contraband
     allowedJobs: [ SalvageSpecialist, MiningSpecialist ]
 
 - type: entity
@@ -36,16 +28,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security ]
-    allowedJobs: [ SalvageSpecialist ]
-
-- type: entity
-  id: BaseSecurityMiningSalvageContraband
-  parent: BaseRestrictedContraband
-  abstract: true
-  components:
-  - type: Contraband
-    allowedDepartments: [ Security ]
-    allowedJobs: [ SalvageSpecialist, MiningSpecialist ]
+    allowedJobs: [ SalvageSpecialist, SalvageSpecialist ]
 
 - type: entity
   id: BaseEngineeringSalvageContraband
@@ -54,7 +37,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Engineering ]
-    allowedJobs: [ SalvageSpecialist ]
+    allowedJobs: [ SalvageSpecialist, MiningSpecialist ]
 
 # This might look really stupid but it's sadly necessary as conflicting base contra groups tend to be mutually exclusive...
 - type: entity
@@ -64,7 +47,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Engineering, Security ]
-    allowedJobs: [SalvageSpecialist]
+    allowedJobs: [SalvageSpecialist, MiningSpecialist]
 
 - type: entity
   id: BaseLawContraband

--- a/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
@@ -28,7 +28,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security ]
-    allowedJobs: [ SalvageSpecialist, SalvageSpecialist ]
+    allowedJobs: [ SalvageSpecialist, MiningSpecialist ]
 
 - type: entity
   id: BaseEngineeringSalvageContraband


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removed separation between mining and salvage in terms of contra, as they use the same ticket vending machine and before a proper separate reward system is set up for them it's asking for security incidents to have items easily accessible to mining be contraband for them.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The bug fixes speak for themselves, a lot of magazines had the contraband groups overwritten by their security prototypes and were contraband for no reason, despite the weapon not being contra.

The removal of the mining category is mainly until a decisive decision is taken on the matter of Mining Specialists and the ticket machine. While they still have full access to it, what they  buy from it should not be legal cause for arrest. It's simply too easy to make that mistake right now, and either they should be allowed to do so, or unable to do so. Not in-between. 

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="2500" height="1388" alt="billede" src="https://github.com/user-attachments/assets/560b824c-4cc8-4f81-b931-c34964c122ca" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- tweak: Removed differentiation between salvage and mining for the purposes of contraband while they still share the ticket vend
- fix: Mercenary combat gloves no longer contra for salvage
- fix: .45 magnum magazines and the cartridge itself no longer contra for salvage
