### PR TITLE
Max Cap Nerf

### DIFF
--- a/Content.Shared/CCVar/CCVars.Atmos.cs
+++ b/Content.Shared/CCVar/CCVars.Atmos.cs
@@ -147,6 +147,7 @@ public sealed partial class CCVars
     /// <summary>
     ///     Maximum explosion radius for explosions caused by bursting a gas tank ("max caps").
     ///     Setting this to zero disables the explosion but still allows the tank to burst and leak.
+    ///    Adjusted for STARLIGHT use
     /// </summary>
     public static readonly CVarDef<float> AtmosTankFragment =
         CVarDef.Create("atmos.max_explosion_range", 10f, CVar.SERVERONLY);

--- a/Content.Shared/CCVar/CCVars.Atmos.cs
+++ b/Content.Shared/CCVar/CCVars.Atmos.cs
@@ -149,5 +149,5 @@ public sealed partial class CCVars
     ///     Setting this to zero disables the explosion but still allows the tank to burst and leak.
     /// </summary>
     public static readonly CVarDef<float> AtmosTankFragment =
-        CVarDef.Create("atmos.max_explosion_range", 26f, CVar.SERVERONLY);
+        CVarDef.Create("atmos.max_explosion_range", 10f, CVar.SERVERONLY);
 }

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -37,8 +37,8 @@
     tankLowPressure: 30.0
   - type: Explosive
     explosionType: MicroBomb
-    maxIntensity: 8
-    canCreateVacuum: false
+    maxIntensity: 8 # STARLIGHT
+    canCreateVacuum: false # STARLIGHT
   - type: MeleeWeapon
     wideAnimationRotation: 45
     attackRate: 0.8

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -37,7 +37,8 @@
     tankLowPressure: 30.0
   - type: Explosive
     explosionType: MicroBomb
-    maxIntensity: 20
+    maxIntensity: 8
+    canCreateVacuum: false
   - type: MeleeWeapon
     wideAnimationRotation: 45
     attackRate: 0.8


### PR DESCRIPTION
## Short description
max cap max radius: 26 -> 10
Tile destruction: true -> false
intensity: 20 -> 8

Tested, still plenty dangerous and can destroy walls. Takes 2 for a nukie elite, 3 for jugg.

## Why we need to add this
Way too stronk.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Trep_Maul
- tweak: Max Cap radius and intensity adjusted down.
- tweak: Max Cap can't break tiles anymore.