### PR TITLE
QM's Luxury Mining Hardsuit in locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -23,7 +23,7 @@
     - id: MailTeleporterMachineCircuitboard
     - id: PlushieLance #starlight
     - id: RadioHandheldExpedition #starlight
-    - id: ClothingOuterHardsuitLuxury #starlight
+    - id: ClothingOuterHardsuitLuxury #starlight 
 
 - type: entity
   id: LockerQuarterMasterFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -23,6 +23,7 @@
     - id: MailTeleporterMachineCircuitboard
     - id: PlushieLance #starlight
     - id: RadioHandheldExpedition #starlight
+    - id: ClothingOuterHardsuitLuxury #starlight
 
 - type: entity
   id: LockerQuarterMasterFilled


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? --> to make it so that a lux suit spawns in the `Quatermaster's locker [filled]` prototype

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. --> I (as a semi QM main) hate having to harass the mining techs for 150 tickets to buy a lux suit to replace the dodgy basic hardsuits, as they put in the effort, so should reap the reward. as a solution, I have added the lux suit to the filled QM's locker prototype, which should auto populate to maps (I'm not sure if I have to change anything else to get it to work)

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
--> no media

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: stickycheZ101
- tweak: Quartermasters no longer have to beg mining for tickets for a Lux suit
