### PR TITLE
Patch Subtick/Subframe Atmos exploits

### DIFF
--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -9,6 +9,9 @@ permissions:
   contents: write
   pull-requests: read
 
+env:
+ BRANCH_NAME: ${{ github.ref_name	 }} 
+
 jobs:
   update-changelog:
     runs-on: ubuntu-latest
@@ -71,8 +74,8 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit."
           else
-            git pull origin HEAD:Starlight
+            git pull origin HEAD:${BRANCH_NAME}
             git commit -m "Update changelog for PR #${{ steps.get_pr.outputs.PR_NUMBER }} [skip ci]"
-            git push origin HEAD:Starlight
+            git push origin HEAD:${BRANCH_NAME}
           fi
           

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
@@ -69,8 +69,13 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
             if (pump.Blocked)
                 return;
 
+            //starlight fix subtick
+            float wantToTransfer = pump.TransferRate * _atmosphereSystem.PumpSpeedup() * args.dt;
+            float clamped = Math.Min(wantToTransfer, pump.HigherThreshold);
+            //starlight end
+
             // We multiply the transfer rate in L/s by the seconds passed since the last process to get the liters.
-            var removed = inlet.Air.RemoveVolume(pump.TransferRate * _atmosphereSystem.PumpSpeedup() * args.dt);
+            var removed = inlet.Air.RemoveVolume(clamped); //starlight edit
 
             // Some of the gas from the mixture leaks when overclocked.
             if (pump.Overclocked)

--- a/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Binary/EntitySystems/GasVolumePumpSystem.cs
@@ -71,7 +71,8 @@ namespace Content.Server.Atmos.Piping.Binary.EntitySystems
 
             //starlight fix subtick
             float wantToTransfer = pump.TransferRate * _atmosphereSystem.PumpSpeedup() * args.dt;
-            float clamped = Math.Min(wantToTransfer, pump.HigherThreshold);
+            float spaceLeft = Math.Clamp(pump.HigherThreshold - outlet.Air.Pressure, 0, pump.HigherThreshold);
+            float clamped = Math.Clamp(wantToTransfer, 0, spaceLeft); 
             //starlight end
 
             // We multiply the transfer rate in L/s by the seconds passed since the last process to get the liters.

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
@@ -61,8 +61,13 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
                 return;
             }
 
+            //starlight fix subtick
+            float wantToTransfer = filter.TransferRate * _atmosphereSystem.PumpSpeedup() * args.dt;
+            float clamped = Math.Min(wantToTransfer, Atmospherics.MaxOutputPressure);
+            //starlight end
+
             // We multiply the transfer rate in L/s by the seconds passed since the last process to get the liters.
-            var transferVol = filter.TransferRate * _atmosphereSystem.PumpSpeedup() * args.dt;
+            var transferVol = clamped; //starlight edit
 
             if (transferVol <= 0)
             {

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
@@ -63,7 +63,8 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
 
             //starlight fix subtick
             float wantToTransfer = filter.TransferRate * _atmosphereSystem.PumpSpeedup() * args.dt;
-            float clamped = Math.Min(wantToTransfer, Atmospherics.MaxOutputPressure);
+            float spaceLeft = Math.Clamp(Atmospherics.MaxOutputPressure - outletNode.Air.Pressure, 0, Atmospherics.MaxOutputPressure);
+            float clamped = Math.Clamp(wantToTransfer, 0, spaceLeft); 
             //starlight end
 
             // We multiply the transfer rate in L/s by the seconds passed since the last process to get the liters.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Patches subtick/subframe atmos exploits like infinite gas storage

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Obvious exploit, 0 clue why wizden hasn't done this yet. ill probably take this upstream too

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
- -->
:cl: Happyrobot33
- fix: Patched subframe atmos exploits