### PR TITLE
SImplifying brain yaml and increasing bites required to 4 instead of 1

### DIFF
--- a/Resources/Prototypes/Body/Organs/base.yml
+++ b/Resources/Prototypes/Body/Organs/base.yml
@@ -2,7 +2,39 @@
   id: BaseOrganBrain
   abstract: true
   components:
+  - type: Item
+    size: Small
+    heldPrefix: brain
+  - type: Organ
+  - type: Input
+    context: "ghost"
+  - type: Brain
+  - type: InputMover
+  - type: Examiner
+  - type: BlockMovement
+  - type: BadFood
+  - type: Tag
+    tags:
+      - Meat
   - type: OrganBrain
+  - type: SolutionContainerManager
+    solutions:
+      organ:
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 10
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: GreyMatter
+          Quantity: 20
+  - type: FlavorProfile
+    flavors:
+      - people
+  - type: FoodSequenceElement
+    entries:
+      Burger: Brain
+      Taco: Brainy
 
 - type: entity
   id: BaseOrganEyes

--- a/Resources/Prototypes/Body/Organs/base.yml
+++ b/Resources/Prototypes/Body/Organs/base.yml
@@ -34,7 +34,7 @@
   - type: FoodSequenceElement
     entries:
       Burger: Brain
-      Taco: Brainy
+      Taco: Brain
 
 - type: entity
   id: BaseOrganEyes

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -27,30 +27,13 @@
 
 - type: entity
   id: OrganDionaBrain
-  parent: [BaseDionaOrgan, OrganHumanBrain, BaseOrganBrain]
+  parent: [BaseOrganBrain, BaseDionaOrgan]
   name: brain
   description: "The central hub of a diona's pseudo-neurological activity, its root-like tendrils search for its former body."
   components:
-  - type: Item
-    size: Small
-    heldPrefix: brain
   - type: Sprite
     state: brain
-  - type: SolutionContainerManager
-    solutions:
-      organ:
-        maxVol: 10
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
-      Lung:
-        maxVol: 100
-        canReact: False
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: GreyMatter
-          Quantity: 5
+
 
 - type: entity
   id: OrganDionaEyes

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -36,45 +36,13 @@
 
 - type: entity
   id: OrganHumanBrain
-  parent: [BaseHumanOrganUnGibbable, BaseOrganBrain]
+  parent: [BaseOrganBrain, BaseHumanOrganUnGibbable]
   name: brain
   description: "The source of incredible, unending intelligence. Honk."
   components:
   - type: Sprite
     state: brain
-  - type: Organ
-  - type: Input
-    context: "ghost"
-  - type: Brain
-  - type: InputMover
-  - type: Examiner
-  - type: BlockMovement
-  - type: BadFood
-  - type: Tag
-    tags:
-      - Meat
-  - type: SolutionContainerManager
-    solutions:
-      organ:
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: GreyMatter
-          Quantity: 5
-  - type: FlavorProfile
-    flavors:
-      - people
-  - type: FoodSequenceElement
-    entries:
-      Burger: Brain
-      Taco: Brain
-  - type: Item
-    size: Small
-    heldPrefix: brain
-  
+
 - type: entity
   id: OrganHumanEyes
   parent: [BaseHumanOrgan, BaseOrganEyes]

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: SentientSlimeCore
-  parent: [BaseItem, OrganHumanBrain]
+  parent: [BaseItem, BaseOrganBrain]
   name: sentient slime core
   description: "The source of incredible, unending gooeyness."
   components:
@@ -21,18 +21,10 @@
       solutions:
         stomach:
           maxVol: 50.0
-        food:
-          maxVol: 5
-          reagents:
-          - ReagentId: GreyMatter
-            Quantity: 5
         organ:
           reagents:
           - ReagentId: Slime
             Quantity: 10
-    - type: Item
-      size: Small
-      heldPrefix: brain
 
       
 - type: entity

--- a/Resources/Prototypes/_StarLight/Body/Organs/abductor.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/abductor.yml
@@ -36,41 +36,12 @@
 
 - type: entity
   id: OrganAbductorBrain
-  parent: [BaseAbductorOrganUnGibbable, BaseOrganBrain]
+  parent: [BaseOrganBrain, BaseAbductorOrganUnGibbable]
   name: brain
   description: "The source of incredible, unending intelligence. Honk."
   components:
   - type: Sprite
     state: brain
-  - type: Organ
-  - type: Input
-    context: "ghost"
-  - type: Brain
-  - type: InputMover
-  - type: Examiner
-  - type: BlockMovement
-  - type: BadFood
-  - type: Tag
-    tags:
-      - Meat
-  - type: SolutionContainerManager
-    solutions:
-      organ:
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: GreyMatter
-          Quantity: 5
-  - type: FlavorProfile
-    flavors:
-      - people
-  - type: FoodSequenceElement
-    entries:
-      Burger: Brain
-      Taco: Brain
   
 - type: entity
   id: OrganAbductorEyes

--- a/Resources/Prototypes/_StarLight/Body/Organs/cyclorite.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/cyclorite.yml
@@ -36,41 +36,12 @@
 
 - type: entity
   id: OrganCycloriteBrain
-  parent: [BaseCycloriteOrganUnGibbable, BaseOrganBrain]
+  parent: [BaseOrganBrain, BaseCycloriteOrganUnGibbable]
   name: brain
   description: "The source of incredible, unending intelligence. Honk."
   components:
   - type: Sprite
     state: brain
-  - type: Organ
-  - type: Input
-    context: "ghost"
-  - type: Brain
-  - type: InputMover
-  - type: Examiner
-  - type: BlockMovement
-  - type: BadFood
-  - type: Tag
-    tags:
-      - Meat
-  - type: SolutionContainerManager
-    solutions:
-      organ:
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: GreyMatter
-          Quantity: 5
-  - type: FlavorProfile
-    flavors:
-      - people
-  - type: FoodSequenceElement
-    entries:
-      Burger: Brain
-      Taco: Brain
   
 - type: entity
   id: OrganCycloriteEye


### PR DESCRIPTION

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adjusted brain yaml so that all brains properly use BaseOrganBrain instead of having the same values indicated for each brain. Also made them contain quadruple the food so they are gone in more bites.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It is currently possible to accidentally eat a brain, and it's pretty easy, as it's only a single bite. This will lower that somewhat. Realistically, a burger is gone in two bites. Brains are very big, it's sensible for them to have more mass, and take longer to eat.

Additionally, making changes to all brains will now be significantly easier.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/e2ceede0-1ca3-443b-bdad-6bd203dca96a



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: RHSvenson
- tweak: Brains now take 4 bites to eat, instead of one
