### PR TITLE
remove Dummy non antag chance.

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -159,7 +159,7 @@
   minPlayers: 4
   showInVote: true # 🌟Starlight🌟
   rules:
-  - DummyNonAntagChance
+  # - DummyNonAntagChance 🌟Starlight🌟
   - Traitor
   - SubGamemodesRule
   - BasicStationEventScheduler
@@ -191,7 +191,7 @@
   showInVote: true # 🌟Starlight🌟
   rules:
   - Nukeops
-  - DummyNonAntagChance
+  # - DummyNonAntagChance 🌟Starlight🌟
   - SubGamemodesRule
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
@@ -209,7 +209,7 @@
   minPlayers: 30
   showInVote: true # 🌟Starlight🌟
   rules:
-  - DummyNonAntagChance
+  # - DummyNonAntagChance 🌟Starlight🌟
   - Revolutionary
   - SubGamemodesRule
   - BasicStationEventScheduler
@@ -226,7 +226,7 @@
   showInVote: false
   rules:
   - Wizard
-  - DummyNonAntagChance
+  # - DummyNonAntagChance 🌟Starlight🌟
   - SubGamemodesRuleNoWizard #No Dual Wizards at the start, midround is fine
   - BasicStationEventScheduler
   - MeteorSwarmScheduler


### PR DESCRIPTION
## Short description
removed `DummyNonAntagChance` from all gamerules

## Why we need to add this
Some people complain about getting booted out of jobs when they have antags and command enabled. wizden added this as a anti-metagame thing but we dont need it for two reasons
1. we have a consistent 150+ pop or can be expected to not metagame so good luck remembering
2. we can have antags be seperate chars from our command jobs so it becomes even harder to rememebr/metagame

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksnatora
- tweak: removed dummy antag chance. Which was cause of eg: "NTRep on high but it put me as surgeon and I didn't get antag and there is no NTRep"


