### PR TITLE
Knives can now be used as really shitty screwdrivers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -20,11 +20,17 @@
   - type: Sprite
   - type: Item
     size: Small
-  - type: Tool
-    qualities:
-      - Slicing
-    useSound:
-      path: /Audio/Items/Culinary/chop.ogg
+  - type: Tool # Starlight start
+    qualities: Screwing
+    enabled: false
+    speedModifier: 0.10
+  - type: MultipleTool
+    statusShowBehavior: true
+    entries:
+      - behavior: Slicing
+        useSound: /Audio/Items/Culinary/chop.ogg
+      - behavior: Screwing
+        useSound: /Audio/Items/screwdriver.ogg
   - type: Scalpel
   - type: SurgeryTool
     successRate: 0.9
@@ -32,6 +38,7 @@
       path: /Audio/_Starlight/Medical/Surgery/scalpel1.ogg
     endSound:
       path: /Audio/_Starlight/Medical/Surgery/scalpel2.ogg
+# Starlight end
 
 - type: entity
   name: kitchen knife

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -22,7 +22,6 @@
     size: Small
   - type: Tool # Starlight start
     qualities: Screwing
-    enabled: false
     speedModifier: 0.05
   - type: MultipleTool
     statusShowBehavior: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -23,7 +23,7 @@
   - type: Tool # Starlight start
     qualities: Screwing
     enabled: false
-    speedModifier: 0.10
+    speedModifier: 0.05
   - type: MultipleTool
     statusShowBehavior: true
     entries:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Title

Uses the Multitool type, defaults to slicing so most won't know the difference.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It was requested and makes sense in my opinion. The snails pace it does this at, combined with knives being significantly harder to acquire than screwdrivers, means that I doubt this will affect any kind of balance. It's basically realism flavour.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/edd8004c-8818-4296-b438-afc06ba9f386




## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- tweak: Knives can now be used as really terrible screwdrivers in a pinch
