### PR TITLE
Fix abductors not being able to reconnect after using the camera view

### DIFF
--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.cs
@@ -39,7 +39,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     {
         SubscribeLocalEvent<AbductorHumanObservationConsoleComponent, BeforeActivatableUIOpenEvent>(OnBeforeActivatableUIOpen);
         SubscribeLocalEvent<AbductorHumanObservationConsoleComponent, ActivatableUIOpenAttemptEvent>(OnActivatableUIOpenAttemptEvent);
-        
+
         SubscribeLocalEvent<AbductorComponent, GetVisMaskEvent>(OnAbductorGetVis);
 
         Subs.BuiEvents<AbductorHumanObservationConsoleComponent>(AbductorCameraConsoleUIKey.Key, subs => subs.Event<AbductorBeaconChosenBuiMsg>(OnAbductorBeaconChosenBuiMsg));
@@ -51,7 +51,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         InitializeExtractor();
         base.Initialize();
     }
-    
+
     private void OnAbductorGetVis(Entity<AbductorComponent> ent, ref GetVisMaskEvent args)
     {
         args.VisibilityMask |= (int)VisibilityFlags.Abductor;
@@ -65,20 +65,20 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
             var beacon = _entityManager.GetEntity(args.Beacon.NetEnt);
             var eye = SpawnAtPosition(ent.Comp.RemoteEntityProto, Transform(beacon).Coordinates);
             ent.Comp.RemoteEntity = GetNetEntity(eye);
-            
+
             if (TryComp<HandsComponent>(args.Actor, out var handsComponent))
             {
                 foreach (var hand in _hands.EnumerateHands(args.Actor, handsComponent))
                 {
                     if (hand.HeldEntity == null)
                         continue;
-                    
+
                     if (HasComp<UnremoveableComponent>(hand.HeldEntity))
                         continue;
 
                     _hands.DoDrop(args.Actor, hand, true, handsComponent);
                 }
-                
+
                 if (_virtualItem.TrySpawnVirtualItemInHand(ent.Owner, args.Actor, out var virtItem1))
                 {
                     EnsureComp<UnremoveableComponent>(virtItem1.Value);
@@ -122,16 +122,16 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     {
         AbductorScientistComponent? scientistComp = null;
         AbductorAgentComponent? agentComp = null;
-        
+
         if (TryComp<RelayInputMoverComponent>(actor, out var comp) && TryComp<AbductorScientistComponent>(actor, out scientistComp) || TryComp<AbductorAgentComponent>(actor, out agentComp))
         {
             EntityUid? console = null;
-            
+
             if (scientistComp != null && scientistComp.Console.HasValue)
                 console = scientistComp.Console.Value;
             else if (agentComp != null && agentComp.Console.HasValue)
                 console = agentComp.Console.Value;
-            
+
             if (console == null || comp == null)
                 return;
 
@@ -145,6 +145,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
                 if (HasComp<StationAiOverlayComponent>(actor))
                     RemComp<StationAiOverlayComponent>(actor);
 
+                _eye.SetTarget(actor, null);
                 _eye.SetVisibilityMask(actor, eyeComp.VisibilityMask ^ (int)VisibilityFlags.Abductor, eyeComp);
                 _eye.SetDrawFov(actor, true);
             }
@@ -162,15 +163,15 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     private void OnBeforeActivatableUIOpen(Entity<AbductorHumanObservationConsoleComponent> ent, ref BeforeActivatableUIOpenEvent args)
     {
         AbductorAgentComponent? agentComp = null;
-        
+
         if (!TryComp<AbductorScientistComponent>(args.User, out var scientistComp) && !TryComp<AbductorAgentComponent>(args.User, out agentComp))
             return;
-            
+
         if (scientistComp != null)
             scientistComp.Console = ent.Owner;
         else if (agentComp != null)
             agentComp.Console = ent.Owner;
-        
+
         var stations = _stationSystem.GetStations();
         var result = new Dictionary<int, StationBeacons>();
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes EyeComponent target getting set to 0 instead of null when exiting the camera view as an abductor, which makes them unable to reconnect since EyeSystem throws a server error when trying to reattach them to an entity that no longer exists.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
https://discord.com/channels/1272545509562777621/1376419054050349146/1376419054050349146
https://discord.com/channels/1272545509562777621/1367353955407106108/1367353955407106108
https://discord.com/channels/1272545509562777621/1347731673663537152/1347731673663537152

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/1c99813f-197c-4069-9664-6b8637ac6a47

## Checks
<!-- check boxes for faster reviewing of your PR -->
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- fix: Fixed abductors not being able to reconnect after using the camera view.
