### PR TITLE
Make the starlight changelog the first tab on the changelog window, hide maps changelog tab

### DIFF
--- a/Resources/Changelog/ChangelogStarlight.yml
+++ b/Resources/Changelog/ChangelogStarlight.yml
@@ -1,3 +1,4 @@
+Order: -1
 Entries:
 - author: Rinary
   changes:

--- a/Resources/Changelog/Maps.yml
+++ b/Resources/Changelog/Maps.yml
@@ -1,4 +1,5 @@
-﻿Entries:
+﻿AdminOnly: true
+Entries:
 - author: ArtisticRoomba
   changes:
   - message: The mapping changelog has been added! This primarily serves as a way


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
First change uses the order field on changelog tabs (negative numbers show up first), the second makes the tab admin only since that's the easiest way to hide it for regular players without code changes that would cause merge conflicts.
Not sure if the maps change will conflict when the first entry is removed, but would need to wait for 500 map changes before finding out.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
For the first change, figured the ordering would be preferred so that Starlight players would see the Starlight changelog first.
For the latter, I think Happyrobot asked for it in VC, but I might be mistaking who asked for it, saying that it doesn't apply to Starlight maps so it shouldn't be shown to players.
Both are in separate commits in case one or the other needs to be reverted before merging.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
(The changelog tabs flashing briefly before updating is an unrelated known bug when re/de-adminning)

https://github.com/user-attachments/assets/362d6a2d-92f5-40e1-a848-bc027d4898b7

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: DrSmugleaf
- tweak: Made the Starlight changelog tab the first tab on the changelog window, and hid the maps changelog tab.
