### PR TITLE
Fix simple hostiles and dragons not being hostile to abductors

### DIFF
--- a/Resources/Prototypes/_StarLight/GameRules/events.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/events.yml
@@ -40,7 +40,7 @@
           - CanPilot
       - type: NpcFactionMember
         factions:
-        - SimpleHostile
+        - Abductor
       mindRoles:
       - MindRoleLoneAbductor
     - spawnerPrototype: AbductorAgentSpawner
@@ -65,7 +65,7 @@
           - CanPilot
       - type: NpcFactionMember
         factions:
-        - SimpleHostile
+        - Abductor
       mindRoles:
       - MindRoleLoneAbductor
       

--- a/Resources/Prototypes/_StarLight/ai_factions.yml
+++ b/Resources/Prototypes/_StarLight/ai_factions.yml
@@ -18,6 +18,7 @@
     - Changeling
     - AllHostile
     - Gorilla
+    - Abductor
 
 - type: npcFaction
   id: DungeonSoviet
@@ -37,6 +38,7 @@
     - Changeling
     - AllHostile
     - Gorilla
+    - Abductor
 
 - type: npcFaction
   id: DungeonSyndicate
@@ -56,6 +58,7 @@
     - Changeling
     - AllHostile
     - Gorilla
+    - Abductor
 
 - type: npcFaction
   id: Gorilla
@@ -78,6 +81,7 @@
     - Abyss
     - DungeonSoviet
     - DungeonSyndicate
+    - Abductor
 
 - type: npcFaction
   id: NanoTrasenSilicon # purely making this so zombies STOP ATTACKING FUCKING SILICONS
@@ -97,6 +101,7 @@
   - Xenoborg
   - Dragon
   - Gorilla
+  - Abductor
 
 - type: npcFaction
   id: SyndicateSilicon # Again, zombies fuck you.
@@ -116,6 +121,7 @@
     - Xenoborg
     - Dragon
     - Gorilla
+    - Abductor
 
 - type: npcFaction
   id: Abductor

--- a/Resources/Prototypes/_StarLight/ai_factions.yml
+++ b/Resources/Prototypes/_StarLight/ai_factions.yml
@@ -116,3 +116,29 @@
     - Xenoborg
     - Dragon
     - Gorilla
+
+- type: npcFaction
+  id: Abductor
+  hostile: # SimpleHostile with additions so that it gets attacked by mobs
+  - NanoTrasen
+  - NanoTrasenSilicon # starlight
+  - Syndicate
+  - SyndicateSilicon # starlight
+  - DungeonSyndicate
+  - DungeonSoviet
+  - Passive
+  - PetsNT
+  - Zombie
+  - Revolutionary
+  - Abyss
+  - Vampire
+  - Changeling
+  - AllHostile
+  - Wizard
+  - Xenoborg
+  - Dragon
+  - Xeno
+  - Gorilla
+  # New
+  - Dragon
+  - SimpleHostile

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -17,6 +17,7 @@
     - AllHostile
     - Wizard
     - Gorilla
+    - Abductor # starlight
 
 - type: npcFaction
   id: NanoTrasen
@@ -37,6 +38,7 @@
     - Xenoborg
     - Dragon
     - Gorilla
+    - Abductor # starlight
 
 - type: npcFaction
   id: Mouse
@@ -62,6 +64,7 @@
     - Dragon
     - HonkHostile
     - Gorilla
+    - Abductor # starlight
 
 - type: npcFaction
   id: SimpleHostile
@@ -85,6 +88,7 @@
     - Dragon
     - Xeno
     - Gorilla
+    - Abductor # starlight
 
 - type: npcFaction
   id: SimpleNeutral
@@ -108,6 +112,7 @@
     - Xenoborg
     - Dragon
     - Gorilla
+    - Abductor # starlight
 
 - type: npcFaction
   id: Xeno
@@ -150,6 +155,7 @@
     - Wizard
     - Dragon
     - Gorilla
+    - Abductor # starlight
 
 - type: npcFaction
   id: Revolutionary
@@ -166,6 +172,7 @@
     - Changeling
     - AllHostile
     - Gorilla
+    - Abductor # starlight
 
 - type: npcFaction
   id: Changeling
@@ -218,6 +225,7 @@
     - Zombie
     - AllHostile
     - Gorilla
+    - Abductor # starlight
 
 - type: npcFaction
   id: AllHostile
@@ -242,6 +250,7 @@
     - Wizard
     - Xenoborg
     - Gorilla
+    - Abductor # starlight
 
 - type: npcFaction
   id: Wizard
@@ -262,6 +271,7 @@
     - AllHostile
     - Xenoborg
     - Gorilla
+    - Abductor # starlight
 
 - type: npcFaction
   id: Xenoborg
@@ -281,3 +291,4 @@
     # cause they are hostile to them
     - SimpleHostile
     - AllHostile
+    - Abductor # starlight


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a new Abductor faction that is the same as SimpleHostile + SimpleHostile and Dragon
Adds Abductor as a hostile to all factions that would normally target SimpleHostile
Not sure if I missed anything that would spawn an abductor-related entity that hasn't been changed, if there's anything it needs to be updated to use Abductor faction too or it will kill player abductors.
Might be better to just specify the faction on the abductor mob itself instead in case it's ever manually spawned, but not sure if that's wanted.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
https://discord.com/channels/1272545509562777621/1391096515891822592

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/c595569a-0f5b-4599-8935-bd28ad66eb58

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: DrSmugleaf
- fix: Fixed carps, goliaths, and other hostile AI not targeting abductors.