### PR TITLE
Update IFF names for Cargo shuttles

### DIFF
--- a/Resources/Maps/Shuttles/cargo.yml
+++ b/Resources/Maps/Shuttles/cargo.yml
@@ -15,7 +15,7 @@ entities:
   - uid: 173
     components:
     - type: MetaData
-      name: Cargo shuttle
+      name: CS-2S4 "Ferry" # Starlight rename
     - type: Transform
       pos: 2.2710133,-2.4148211
       parent: invalid

--- a/Resources/Maps/Shuttles/cargo_core.yml
+++ b/Resources/Maps/Shuttles/cargo_core.yml
@@ -14,7 +14,7 @@ entities:
   - uid: 2
     components:
     - type: MetaData
-      name: Cargo shuttle
+      name: CS-1S3 "Comet" # Starlight rename
     - type: Transform
       pos: -1.828125,2.078125
       parent: invalid

--- a/Resources/Maps/Shuttles/cargo_elkridge.yml
+++ b/Resources/Maps/Shuttles/cargo_elkridge.yml
@@ -13,7 +13,7 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      name: Cargo shuttle
+      name: CS-4S2 "Sidehaul" # Starlight rename
     - type: Transform
       pos: -0.453125,-0.53125
       parent: invalid

--- a/Resources/Maps/Shuttles/cargo_fland.yml
+++ b/Resources/Maps/Shuttles/cargo_fland.yml
@@ -15,7 +15,7 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      name: Cargo shuttle
+      name: CS-2S2 "Loadstar" # Starlight rename
     - type: Transform
       pos: -0.59375,1.0312805
       parent: invalid

--- a/Resources/Maps/Shuttles/cargo_plasma.yml
+++ b/Resources/Maps/Shuttles/cargo_plasma.yml
@@ -14,7 +14,7 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      name: Cargo Shuttle
+      name: CS-2P6 "Plasma" # Starlight rename
     - type: Transform
       pos: -6.0262413,-2.31304
       parent: invalid

--- a/Resources/Maps/Shuttles/cargo_relic.yml
+++ b/Resources/Maps/Shuttles/cargo_relic.yml
@@ -27,7 +27,7 @@ entities:
   - uid: 173
     components:
     - type: MetaData
-      name: Cargo shuttle
+      name: CS-1S1 "Junker" # Starlight rename
     - type: Transform
       pos: 2.2710133,-2.4148211
       parent: invalid

--- a/Resources/Maps/Shuttles/mining.yml
+++ b/Resources/Maps/Shuttles/mining.yml
@@ -17,7 +17,7 @@ entities:
   - uid: 181
     components:
     - type: MetaData
-      name: SR-3S2 "Reclaimer"
+      name: SR-3S2 "Reclaimer" # Starlight rename
     - type: Transform
       pos: 2.2710133,-2.4148211
       parent: invalid

--- a/Resources/Maps/Shuttles/mining.yml
+++ b/Resources/Maps/Shuttles/mining.yml
@@ -17,7 +17,7 @@ entities:
   - uid: 181
     components:
     - type: MetaData
-      name: NT-Reclaimer
+      name: SR-3S2 "Reclaimer"
     - type: Transform
       pos: 2.2710133,-2.4148211
       parent: invalid

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -62,6 +62,7 @@
         mining: !type:GridSpawnGroup
           paths:
             - /Maps/Shuttles/mining.yml
+          nameGrid: false # Starlight - honors entityName in mining.yml
         # Spawn last
         ruins: !type:GridSpawnGroup
           hide: true


### PR DESCRIPTION
## Short description
Starlight has set names for the cargo department shuttles in the lore ([see wiki](https://ss14-starlight.wiki/Lore_Portal#Shuttles)), but they were not updated in-game to accurately reflect the new names. And in the case of the cargo shuttles, they had no lore names at all.

## Why we need to add this
The salvage shuttle being named "mining" was very confusing, especially as a proper mining shuttle will be added soon.

Also updates the cargo shuttle names to match the lore, as well as giving each shuttle design a nickname and model designation.

Discord conversation - [link](https://discord.com/channels/1272545509562777621/1274328216768872470/1394072333014011995)

## Media (Video/Screenshots)
<img width="252" height="84" alt="image" src="https://github.com/user-attachments/assets/c986f84f-0cd0-4287-8300-62bff900e92e" />
<img width="212" height="96" alt="image" src="https://github.com/user-attachments/assets/3339c070-d8e3-41db-b8dc-ec087b5473ef" />
<img width="2157" height="2253" alt="cargo shuttle renames" src="https://github.com/user-attachments/assets/b30a6fea-d322-4f17-bacf-165b69f9970b" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: biteless-dot
- tweak: Renamed the salvage shuttle to lore name SR-3S2 "Reclaimer"
- tweak: Updated IFF so salvage shuttle name actually shows instead of just "mining"
- tweak: Renamed the cargo shuttles and variants to include new lore friendly names
