### PR TITLE
Fix TTS memory leaking in replays

### DIFF
--- a/Content.Client/_Starlight/TextToSpeech/ClientTTSAudioComponent.cs
+++ b/Content.Client/_Starlight/TextToSpeech/ClientTTSAudioComponent.cs
@@ -1,0 +1,10 @@
+﻿using System.IO;
+
+namespace Content.Client._Starlight.TTS;
+
+[RegisterComponent]
+[Access(typeof(TextToSpeechSystem))]
+public sealed partial class ClientTTSAudioComponent : Component
+{
+    public MemoryStream? Stream;
+}

--- a/Content.Client/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Client/_Starlight/TextToSpeech/TTSSystem.cs
@@ -90,7 +90,12 @@ public sealed class TextToSpeechSystem : EntitySystem
 
         try
         {
+            // Setting capacity to 0 makes MemoryStream drop the reference to its buffer (byte array),
+            // letting it be garbage collected
+            // Dispose does not do this, at least as of time of writing
             stream.Capacity = 0;
+
+            // We also dispose it since we don't want it to be reused after the data is dropped
             stream.Dispose();
         }
         catch

--- a/Content.Client/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Client/_Starlight/TextToSpeech/TTSSystem.cs
@@ -47,6 +47,8 @@ public sealed class TextToSpeechSystem : EntitySystem
         _cfg.OnValueChanged(StarlightCCVars.TTSClientEnabled, OnTtsClientOptionChanged, true);
         SubscribeNetworkEvent<PlayTTSEvent>(OnPlayTTS);
         SubscribeNetworkEvent<AnnounceTtsEvent>(OnAnnounceTTSPlay);
+        SubscribeLocalEvent<ClientTTSAudioComponent, ComponentRemove>(OnClientTTSAudioRemove);
+        SubscribeLocalEvent<ClientTTSAudioComponent, EntityTerminatingEvent>(OnClientTTSAudioRemove);
     }
 
     public override void Shutdown()
@@ -80,6 +82,15 @@ public sealed class TextToSpeechSystem : EntitySystem
 
     private void OnAnnounceTTSPlay(AnnounceTtsEvent ev)
         => _ttsQueue.Enqueue((ev.Data, ev.AnnouncementSound, _announceVolume));
+
+    private void OnClientTTSAudioRemove<T>(Entity<ClientTTSAudioComponent> ent, ref T args)
+    {
+        if (ent.Comp.Stream is not { } stream)
+            return;
+
+        stream.Capacity = 0;
+        stream.Dispose();
+    }
 
     private void PlayQueue()
     {
@@ -126,11 +137,16 @@ public sealed class TextToSpeechSystem : EntitySystem
         using var stream = new MemoryStream(data);
         var audioStream = _audioManager.LoadAudioOggVorbis(stream);
 
-        return globally
+        var ent = globally
             ? _audio.PlayGlobal(audioStream, null, @params)
             : sourceUid != null
                 ? _audio.PlayEntity(audioStream, sourceUid.Value, null, @params)
                 : _audio.PlayGlobal(audioStream, null, @params);
+
+        if (ent != null)
+            EnsureComp<ClientTTSAudioComponent>(ent.Value.Entity).Stream = stream;
+
+        return ent;
     }
 
     public override void Update(float frameTime)

--- a/Content.Client/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Client/_Starlight/TextToSpeech/TTSSystem.cs
@@ -88,8 +88,15 @@ public sealed class TextToSpeechSystem : EntitySystem
         if (ent.Comp.Stream is not { } stream)
             return;
 
-        stream.Capacity = 0;
-        stream.Dispose();
+        try
+        {
+            stream.Capacity = 0;
+            stream.Dispose();
+        }
+        catch
+        {
+            // ignored, stream might be closed but we don't care as long as the data goes away
+        }
     }
 
     private void PlayQueue()

--- a/Resources/Changelog/Maps.yml
+++ b/Resources/Changelog/Maps.yml
@@ -1,4 +1,4 @@
-﻿AdminOnly: true
+﻿AdminOnly: true # Starlight
 Entries:
 - author: ArtisticRoomba
   changes:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Not relevant anymore with https://github.com/ss14Starlight/space-station-14/pull/1030 merged but it was brought up that this happened
This makes it so when the audio entity is deleted, the memory stream used to play that audio stops holding a reference to the byte array obtained from the server, and then disposes
Also marks Maps.yml changelog with # starlight comment as requested by @Happyrobot33 in https://github.com/ss14Starlight/space-station-14/pull/1026#discussion_r2203409906

Client-side replays will still record TTS messages, so this prevents memory leaks for them

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Before

https://github.com/user-attachments/assets/f0ef3c3c-d7b9-4466-b38b-9be73370fb61

After

https://github.com/user-attachments/assets/8511482b-5098-4bc3-9dd7-fe5d8b38628a


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: DrSmugleaf
- fix: Fixed TTS leaking memory in replays.