### PR TITLE
Suitstorage shortcut

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -74,6 +74,7 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.OpenInventoryMenu);
             human.AddFunction(ContentKeyFunctions.SmartEquipBackpack);
             human.AddFunction(ContentKeyFunctions.SmartEquipBelt);
+            human.AddFunction(ContentKeyFunctions.SmartEquipSuitStorage); // Starlight edit - Suit storage Equip
             human.AddFunction(ContentKeyFunctions.OpenBackpack);
             human.AddFunction(ContentKeyFunctions.OpenBelt);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -190,6 +190,7 @@ namespace Content.Client.Options.UI.Tabs
             AddHeader("ui-options-header-interaction-adv");
             AddButton(ContentKeyFunctions.SmartEquipBackpack);
             AddButton(ContentKeyFunctions.SmartEquipBelt);
+            AddButton(ContentKeyFunctions.SmartEquipSuitStorage); // Starlight edit - Suit storage Equip
             AddButton(ContentKeyFunctions.OpenBackpack);
             AddButton(ContentKeyFunctions.OpenBelt);
             AddButton(ContentKeyFunctions.ThrowItemInHand);

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -32,6 +32,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction OpenInventoryMenu = "OpenInventoryMenu";
         public static readonly BoundKeyFunction SmartEquipBackpack = "SmartEquipBackpack";
         public static readonly BoundKeyFunction SmartEquipBelt = "SmartEquipBelt";
+        public static readonly BoundKeyFunction SmartEquipSuitStorage = "SmartEquipSuitStorage"; // Starlight edit - Suit storage Equip
         public static readonly BoundKeyFunction OpenBackpack = "OpenBackpack";
         public static readonly BoundKeyFunction OpenBelt = "OpenBelt";
         public static readonly BoundKeyFunction OpenAHelp = "OpenAHelp";

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -35,6 +35,7 @@ public sealed class SmartEquipSystem : EntitySystem
         CommandBinds.Builder
             .Bind(ContentKeyFunctions.SmartEquipBackpack, InputCmdHandler.FromDelegate(HandleSmartEquipBackpack, handle: false, outsidePrediction: false))
             .Bind(ContentKeyFunctions.SmartEquipBelt, InputCmdHandler.FromDelegate(HandleSmartEquipBelt, handle: false, outsidePrediction: false))
+            .Bind(ContentKeyFunctions.SmartEquipSuitStorage, InputCmdHandler.FromDelegate(HandleSmartEquipSuitStorage, handle: false, outsidePrediction: false)) // Starlight edit - Suit storage Equip
             .Register<SmartEquipSystem>();
     }
 
@@ -55,6 +56,13 @@ public sealed class SmartEquipSystem : EntitySystem
         HandleSmartEquip(session, "belt");
     }
 
+    // Starlight Start - Suit storage equip
+    private void HandleSmartEquipSuitStorage(ICommonSession? session)
+    {
+        HandleSmartEquip(session, "suitstorage");
+    }
+    // Starlight End
+    
     private void HandleSmartEquip(ICommonSession? session, string equipmentSlot)
     {
         if (session is not { } playerSession)

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -174,6 +174,20 @@ public sealed class SmartEquipSystem : EntitySystem
         // case 3 (itemslot item):
         if (TryComp<ItemSlotsComponent>(slotItem, out var slots))
         {
+            // Starlight Start - Suit storage equip
+            if (handItem == null && equipmentSlot == "suitstorage")
+            {
+                if (!_inventory.CanUnequip(uid, equipmentSlot, out var suitStorageReason))
+                {
+                    _popup.PopupClient(Loc.GetString(suitStorageReason), uid, uid);
+                    return;
+                }
+
+                _inventory.TryUnequip(uid, equipmentSlot, inventory: inventory, predicted: true, checkDoafter: true);
+                _hands.TryPickup(uid, slotItem, handsComp: hands);
+                return;
+            }
+            // Starlight End
             if (handItem == null)
             {
                 ItemSlot? toEjectFrom = null;

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -28,6 +28,7 @@ public sealed class SmartEquipSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    private const string SuitStorageSlot = "suitstorage"; // Starlight edit - Suit storage equip
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -59,7 +60,7 @@ public sealed class SmartEquipSystem : EntitySystem
     // Starlight Start - Suit storage equip
     private void HandleSmartEquipSuitStorage(ICommonSession? session)
     {
-        HandleSmartEquip(session, "suitstorage");
+        HandleSmartEquip(session, SuitStorageSlot);
     }
     // Starlight End
     
@@ -175,7 +176,7 @@ public sealed class SmartEquipSystem : EntitySystem
         if (TryComp<ItemSlotsComponent>(slotItem, out var slots))
         {
             // Starlight Start - Suit storage equip
-            if (handItem == null && equipmentSlot == "suitstorage")
+            if (handItem == null && equipmentSlot == SuitStorageSlot)
             {
                 if (!_inventory.CanUnequip(uid, equipmentSlot, out var suitStorageReason))
                 {

--- a/Resources/Locale/en-US/_Starlight/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/_Starlight/escape-menu/ui/options-menu.ftl
@@ -1,3 +1,7 @@
 ui-options-function-open-m-help = Open mentor help
 ui-escape-connect-discord = Link Discord
 server-info-connect-discord-button = Link Discord
+
+## Controls menu
+
+ui-options-function-smart-equip-suit-storage = Smart-equip to suit storage

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -255,6 +255,11 @@ binds:
   type: State
   key: E
   mod1: Shift
+  # Starlight Start - Suit storage equip
+- function: SmartEquipSuitStorage
+  type: State
+  key: F
+  # Starlight End
 - function: OpenBackpack
   type: State
   key: V


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Add a shortcut for pulling items out of suit storage, the one used by most people to either carry a gun or a tank with air

## Why we need to add this
I have been asked to implement this since this is a change already existing on other servers, i think it is a good QoL change.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/9a1f0441-0589-4dc1-a2fa-53d2aa533034

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- add: Shortcut for pulling from and putting items into suit storage

