### PR TITLE
Make End of Quiet admeme only

### DIFF
--- a/Resources/Maps/_Starlight/nukieplanet.yml
+++ b/Resources/Maps/_Starlight/nukieplanet.yml
@@ -15124,15 +15124,6 @@ entities:
     - type: Transform
       pos: 1.8436577,3.5806565
       parent: 1
-- proto: PaperTooQuietNeedChaos
-  entities:
-  - uid: 4157
-    components:
-    - type: Transform
-      pos: -14.498461,8.569751
-      parent: 1
-    missingComponents:
-    - FaxableObject
 - proto: PartRodMetal
   entities:
   - uid: 828

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -62,18 +62,6 @@
       conditions:
       - !type:PlayerCountCondition
         max: 15
-#    - id: PaperTooQuietNeedChaos #Starlight
-#      conditions:
-#      - !type:PlayerCountCondition
-#        invert: true
-#        max: 15
-#      prob: 0.05
-#    - id: PaperTooQuietNeedChaosFew #lowpop varient which needs less singnatures.
-#      conditions:
-#      - !type:PlayerCountCondition
-#        max: 15
-#      prob: 0.05
-    #Starlight
 
 
 # No laser table + Laser table

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -62,17 +62,17 @@
       conditions:
       - !type:PlayerCountCondition
         max: 15
-    - id: PaperTooQuietNeedChaos #Starlight
-      conditions:
-      - !type:PlayerCountCondition
-        invert: true
-        max: 15
-      prob: 0.05
-    - id: PaperTooQuietNeedChaosFew #lowpop varient which needs less singnatures.
-      conditions:
-      - !type:PlayerCountCondition
-        max: 15
-      prob: 0.05
+#    - id: PaperTooQuietNeedChaos #Starlight
+#      conditions:
+#      - !type:PlayerCountCondition
+#        invert: true
+#        max: 15
+#      prob: 0.05
+#    - id: PaperTooQuietNeedChaosFew #lowpop varient which needs less singnatures.
+#      conditions:
+#      - !type:PlayerCountCondition
+#        max: 15
+#      prob: 0.05
     #Starlight
 
 


### PR DESCRIPTION
## Short description
EoQ:
- Unmapped from Nukie Planet.
- Removed from captain locker table. (commented out in case we change our minds.)

## Why we need to add this
1: It's LRP.
2: It overrules the lobby vote.
3: It ruins planned events and admemes.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Trep_Maul
- remove: EoQ from Nukie Planet
- remove: EoQ from Captain's Locker
