### PR TITLE
feat(Pipes): Add new colors for pipes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -25,9 +25,22 @@
       blue: '#0335FCFF'
       white: '#FFFFFFFF'
       black: '#333333FF'
+      # starlight edit start - add new colors
+      purple: '#AA7DCEFF'
+      pink: '#E49AB0FF'
+      light yellow: '#F2E94EFF'
+      light green: '#C4FFB2FF'
+      # starlight edit end
       # standard atmos pipes
       waste: '#990000'
       distro: '#0055cc'
+      # starlight edit start - add new colors for standard pipes
+      cold: '#087CA7FF'
+      hot: '#EF6F6CFF'
+      frezon: '#05B2DCFF'
+      ammonia: '#426B69FF'
+      tritium: '#8DE969FF'
+      # starlight edit end
       air: '#03fcd3'
       mix: '#947507'
   - type: StaticPrice


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Add new colors for atmos pipes.

## Why we need to add this
Atmos pipes coloring is very useful when teaching new people atmos, and working with people you are not fully yet coordinated with, it helps us understand the logic in atmos. I believe that since pipes stacking atmos has become even harder to understand to new players, and adding new colors is one way of giving players a way to better organize their work. 

## Media (Video/Screenshots)
<img width="498" height="632" alt="spray_painter" src="https://github.com/user-attachments/assets/a329e842-f2fe-4c85-8784-38fa70b6e89c" />
Top row is the already existing colors, 
middle row is the regular colors - purple, pink, light yellow, light green
bottom row is the special colors - hot, cold, frezon, ammonia, tritium
<img width="1590" height="476" alt="pipes" src="https://github.com/user-attachments/assets/ed5798b4-d884-4384-a6dd-b66e064f200e" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- add: Add new colors to atmos pipes.
