### PR TITLE
Fixed Atmos Tech and TA weights

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -7,7 +7,7 @@
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 54000 # 15 hrs
-  weight: -1
+  weight: 0 # Starlight
   startingGear: AtmosphericTechnicianGear
   icon: "JobIconAtmosphericTechnician"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -10,6 +10,7 @@
       department: Engineering
       time: 18000 #5 hrs
       inverted: true # stop playing intern if you're good at engineering!
+  weight: -1 #Starlight
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixed Atmos Tech and Technical Assistant weights. Currently, Atmos Techs have the same weight as learner roles in other departments (as in negative), and Technical Assistants have no weight. This swaps the two weights to match other departments.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I'm sure many people have noticed that if you set Atmos Tech to high and Engineer to medium, you will always get Engineer before Atmos Tech, unless all the Engineer slots somehow are full. This will fix that, and as a byproduct put TA at the bottom of the Engineering list to match other departments.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="378" height="155" alt="New Priorities" src="https://github.com/user-attachments/assets/04c5a042-c5f6-4072-969a-14a61393a2e5" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CommanderAlex365
- tweak: Made Atmospheric Technicians more important than Technical Assistants
