### PR TITLE
Shotgun casings fix

### DIFF
--- a/Content.Client/Weapons/Ranged/Components/SpentAmmoVisualsComponent.cs
+++ b/Content.Client/Weapons/Ranged/Components/SpentAmmoVisualsComponent.cs
@@ -9,7 +9,7 @@ public sealed partial class SpentAmmoVisualsComponent : Component
     /// Should we do "{_state}-spent" or just "spent"
     /// </summary>
     [DataField("suffix")] public bool Suffix = true;
-    
+
     /// <summary>
     /// Should we remove Tip?
     /// </summary>
@@ -17,6 +17,11 @@ public sealed partial class SpentAmmoVisualsComponent : Component
 
     [DataField("state")]
     public string? State = "base";
+
+    /// <summary>
+    /// Is there a hidden layer that should be revealed when spent?
+    /// </summary>
+    [DataField("revealSpent")] public bool revealSpent = false;
 }
 
 public enum AmmoVisualLayers : byte

--- a/Content.Client/Weapons/Ranged/Components/SpentAmmoVisualsComponent.cs
+++ b/Content.Client/Weapons/Ranged/Components/SpentAmmoVisualsComponent.cs
@@ -19,6 +19,7 @@ public sealed partial class SpentAmmoVisualsComponent : Component
     public string? State = "base";
 
     /// <summary>
+    /// Starlight
     /// Is there a hidden layer that should be revealed when spent?
     /// </summary>
     [DataField("revealSpent")] public bool revealSpent = false;

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.SpentAmmo.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.SpentAmmo.cs
@@ -21,13 +21,19 @@ public sealed partial class GunSystem
             return;
         }
 
-        var spent = (bool) varSpent;
+        var spent = (bool)varSpent;
         string? state = null;
 
         if (spent && component.State != null)
             state = component.Suffix ? $"{component.State}-spent" : "spent";
         else
             state = component.State;
+
+        if (spent && component.revealSpent)
+        {
+            _sprite.LayerSetVisible((uid, sprite), AmmoVisualLayers.Spent, true);
+            return;
+        }
 
         _sprite.LayerSetRsiState((uid, sprite), AmmoVisualLayers.Base, state);
         _sprite.RemoveLayer((uid, sprite), AmmoVisualLayers.Tip, false);

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.SpentAmmo.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.SpentAmmo.cs
@@ -29,7 +29,7 @@ public sealed partial class GunSystem
         else
             state = component.State;
 
-        if (spent && component.revealSpent)
+        if (spent && component.revealSpent) /// Starlight
         {
             _sprite.LayerSetVisible((uid, sprite), AmmoVisualLayers.Spent, true);
             return;

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -15,7 +15,7 @@
         map: [ "enum.AmmoVisualLayers.Base" ]
   - type: Appearance
   - type: SpentAmmoVisuals
-    revealSpent: true
+    revealSpent: true # Starlight
     tip: true
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -15,7 +15,7 @@
         map: [ "enum.AmmoVisualLayers.Base" ]
   - type: Appearance
   - type: SpentAmmoVisuals
-    state: null
+    revealSpent: true
     tip: true
 
 - type: entity


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Make spent shotgun casings visible when ejected

This was done by adding a new datafield to the SpentAmmoVisuals component that, when true, sets the "spent" layer of the cartridge to be visible.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Because right now they are invisible and that's wack

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/61182ea0-adee-4e70-9452-e9fab3c586e5


https://github.com/user-attachments/assets/5e1c8beb-948a-4e58-818e-9d4d6331bd38



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- fix: Spent shotgun casings are now visually spent and eject as normal

