### PR TITLE
Add a toolshed command "subtlemessage"

### DIFF
--- a/Content.Server/Prayer/PrayerSystem.cs
+++ b/Content.Server/Prayer/PrayerSystem.cs
@@ -1,17 +1,17 @@
-using System.Linq;
+using System.Linq; // Starlight (upstream #39080)
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;
 using Content.Server.Bible.Components;
 using Content.Server.Chat.Managers;
 using Content.Server.Popups;
-using Content.Shared.Administration;
+using Content.Shared.Administration; // Starlight (upstream #39080)
 using Content.Shared.Database;
 using Content.Shared.Popups;
 using Content.Shared.Chat;
 using Content.Shared.Prayer;
 using Content.Shared.Verbs;
 using Robust.Shared.Player;
-using Robust.Shared.Toolshed;
+using Robust.Shared.Toolshed; // Starlight (upstream #39080)
 
 namespace Content.Server.Prayer;
 /// <summary>
@@ -111,6 +111,7 @@ public sealed class PrayerSystem : EntitySystem
     }
 }
 
+// Begin Starlight (upstream #39080)
 [ToolshedCommand, AdminCommand(AdminFlags.Fun)]
 public sealed class SubtleMessageCommand : ToolshedCommand
 {
@@ -145,3 +146,4 @@ public sealed class SubtleMessageCommand : ToolshedCommand
         return input.Select(e => Send(ctx, e, message, popup)).Where(e => e != null).Cast<EntityUid>();
     }
 }
+// End Starlight (upstream #39080)

--- a/Resources/Locale/en-US/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/commands/toolshed-commands.ftl
@@ -48,6 +48,7 @@ command-description-stationevent-lsprobtheoretical =
     Given a BasicStationEventScheduler prototype, player count, and round time, lists the probability of different station events occuring based on the specified number of players and round time.
 command-description-stationevent-prob =
     Given a BasicStationEventScheduler prototype and an event prototype, returns the probability of a single station event occuring out of the entire pool with current conditions.
+### Starlight (upstream #39080)
 command-description-subtlemessage =
     Sends a subtle message to all the input entities.
 command-description-admins-active =

--- a/Resources/Locale/en-US/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/commands/toolshed-commands.ftl
@@ -48,6 +48,8 @@ command-description-stationevent-lsprobtheoretical =
     Given a BasicStationEventScheduler prototype, player count, and round time, lists the probability of different station events occuring based on the specified number of players and round time.
 command-description-stationevent-prob =
     Given a BasicStationEventScheduler prototype and an event prototype, returns the probability of a single station event occuring out of the entire pool with current conditions.
+command-description-subtlemessage =
+    Sends a subtle message to all the input entities.
 command-description-admins-active =
     Returns a list of active admins.
 command-description-admins-all =


### PR DESCRIPTION
## Short description
Adds a toolshed command to send a subtle message to multiple filtered entities

## Why we need to add this

Requested by @karmakitsuna for event usage

See upstream space-wizards/space-station-14#39080 for details and media.

If I need to make changes due to upstream review I'll cherry pick them here.

## Media (Video/Screenshots)

see upstream

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Quantum-Cross
- add: Add admin tooling to send subtle messages to multiple players via toolshed
