### PR TITLE
removes nukie's end of Q and gives them something more fitting.

### DIFF
--- a/Resources/Locale/en-US/_Starlight/paper/events.ftl
+++ b/Resources/Locale/en-US/_Starlight/paper/events.ftl
@@ -19,3 +19,16 @@ paper-too-quiet-need-chaos-few = Do you feel like this shift has been way too qu
                                  Don't ask how we got this experimental paper inside this locker. Yes, CentComm is totally aware we did this.
   
                                  For the glory of NanoTrasen
+
+paper-send-nukie-reinforcements =       {-delivery-header-nanotrasen-alternate-timeline}
+                    {"[head=2]This is an official notice from the [color=red]Chief Security Officer[/color] at a Nanotrasen's Space Station 15.[/head]"}
+
+                    To whoever receives this letter. I am Sergeant Rigel. My occupation is the CSO. We need immediate assistance.
+
+                    Our station is currently under attack by Atomic Agents, this letter is being thrown into a destabilized bluespace anomaly created by our [color=purple]Head of Research[/color].
+
+                    I am currently bolted in the Bridge, if you receive this message, please send aid immediately. I don't know how much longer we can last.
+
+                    We need 27 signatures for CentComm to send us help. Please take mercy and sign this petition.
+
+                    Glory to Nanotrasen.

--- a/Resources/Maps/_Starlight/nukieplanet.yml
+++ b/Resources/Maps/_Starlight/nukieplanet.yml
@@ -15124,7 +15124,7 @@ entities:
     - type: Transform
       pos: 1.8436577,3.5806565
       parent: 1
-- proto: PaperTooQuietNeedChaos
+- proto: PaperSendNukieReinforcements
   entities:
   - uid: 4157
     components:

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
@@ -118,3 +118,17 @@
         - UnknownShuttleHonki
         - WizardSpawn
         - NinjaSpawn #spawns less cause there is also less people to take said roles. and I deem these to be the less "chaotic" ones
+
+- type: entity
+  parent: Paper
+  id: PaperSendNukieReinforcements
+  name: Send reinforcements!
+  description: An official notice from... an alternate timeline?
+  components:
+    - type: Paper
+      content: paper-send-nukie-reinforcements
+    - type: GameruleOnSign
+      remaining: 27 #on low pop this is basically the entire station. on hihpop this is nothing.
+      rules: 
+        - LoneOpsSpawn
+        - LoneOpsSpawn


### PR DESCRIPTION
## Short description
replaces their end of Q which opens pandora's box with a paper that needs 27 (!) signatures and adds two loneops as reinforcements to the nukies

## Why we need to add this
complaints about end of Q. so made something more fitting.
and if it is merged with #955 the end of Q will become fully admeme only

## Media (Video/Screenshots)
N/A

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: Replaced the end of Q on nukie planet with a paper that after getting 27 signatures spawns two loneops as reinforcements. as was the initial intention I heard for mapping eoq.
