### PR TITLE
behold. salvage console

### DIFF
--- a/Resources/Locale/en-US/_Starlight/objectives/conditions/steal-target-groups.ftl
+++ b/Resources/Locale/en-US/_Starlight/objectives/conditions/steal-target-groups.ftl
@@ -1,3 +1,4 @@
 # Traitor single items
 steal-target-groups-rddiploma = diploma
 steal-target-groups-cmolicense = medical license
+steal-target-groups-salvage-shuttle-console-circuitboard = salvege shuttle console board

--- a/Resources/Locale/en-US/_Starlight/objectives/conditions/steal-target-groups.ftl
+++ b/Resources/Locale/en-US/_Starlight/objectives/conditions/steal-target-groups.ftl
@@ -1,4 +1,4 @@
 # Traitor single items
 steal-target-groups-rddiploma = diploma
 steal-target-groups-cmolicense = medical license
-steal-target-groups-salvage-shuttle-console-circuitboard = salvege shuttle console board
+steal-target-groups-salvage-shuttle-console-circuitboard = salvage shuttle console board

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -24,6 +24,7 @@
     - id: PlushieLance #starlight
     - id: RadioHandheldExpedition #starlight
     - id: ClothingOuterHardsuitLuxmax #starlight
+    - id: SalvageShuttleConsoleCircuitboard #starlight
 
 - type: entity
   id: LockerQuarterMasterFilled

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/Circuitboards/computers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/Circuitboards/computers.yml
@@ -13,3 +13,16 @@
     - type: Tag
       tags:
       - HighRiskItem
+
+- type: entity
+  parent: BaseComputerCircuitboard
+  id: SalvageShuttleConsoleCircuitboard
+  name: salvage shuttle console board
+  description: A computer printed circuit board for a salvage shuttle console.
+  components:
+  - type: Sprite
+    state: cpu_supply
+  - type: ComputerBoard
+    prototype: CompuerShuttleSalvage
+  - type: StealTarget
+    stealGroup: SalvageShuttleConsoleCircuitboard

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Machines/Computers/computers.yml
@@ -42,6 +42,7 @@
       board: !type:Container
 
 #abductor
+
 - type: entity
   parent: BaseComputer
   id: AbductorConsole
@@ -95,7 +96,6 @@
       energy: 1.6
       color: "#90EE90"
 
-
 - type: entity
   parent: BaseComputer
   id: AbductorHumanObservationConsole
@@ -145,3 +145,34 @@
   - type: Tag
     tags:
     - CantInteract
+
+- type: entity
+  parent: BaseComputerShuttle
+  id: CompuerShuttleSalvage
+  name: salvage shuttle console
+  components:
+  - type: Sprite
+    layers:
+    - map: ["computerLayerBody"]
+      state: computer
+    - map: ["computerLayerKeyboard"]
+      state: generic_keyboard
+    - map: ["computerLayerScreen"]
+      state: shuttle
+    - map: ["computerLayerKeys"]
+      state: generic_keys
+    - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
+      state: generic_panel_open
+  - type: DroneConsole
+    components:
+      - type: SalvageShuttle
+  - type: RadarConsole
+    maxRange: 256
+  - type: PointLight
+    radius: 1.5
+    energy: 1.6
+    color: "#43ccb5"
+  - type: Computer
+    board: CargoShuttleConsoleCircuitboard
+  - type: StealTarget
+    stealGroup: SalvageShuttleConsoleCircuitboard

--- a/Resources/Prototypes/_StarLight/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/_StarLight/Objectives/stealTargetGroups.yml
@@ -13,3 +13,10 @@
   sprite:
     sprite: _Starlight/Objects/Specific/legalpapers/cmo-license.rsi
     state: cmo-license
+
+- type: stealTargetGroup
+  id: SalvageShuttleConsoleCircuitboard
+  name: steal-target-groups-salvage-shuttle-console-circuitboard
+  sprite:
+    sprite: Objects/Misc/module.rsi
+    state: cpuboard

--- a/Resources/Prototypes/_StarLight/Objectives/thief.yml
+++ b/Resources/Prototypes/_StarLight/Objectives/thief.yml
@@ -1,0 +1,10 @@
+- type: entity
+  parent: BaseThiefStealObjective
+  id: SalvageShuttleCircuitboardStealObjective
+  components:
+  - type: NotJobRequirement
+    job: CargoTechnician
+  - type: StealCondition
+    stealGroup: SalvageShuttleConsoleCircuitboard
+  - type: Objective
+    difficulty: 0.7


### PR DESCRIPTION
## Short description
adds a mappable salvage shuttle console and puts the board in QMs room

## Why we need to add this
stops shitsalv from flying off and being generally unrecoverable. lets the QM impound their ship.

## Media (Video/Screenshots)

<img width="339" height="81" alt="image" src="https://github.com/user-attachments/assets/0cc743d4-f511-4e75-b65c-83d76b556e82" />


## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: Salvage shuttle console. now salvage's little ship can be remote controlled
- add: Salvage shuttle console board in QM's locker
- add: thieves now have a chance to have to steal the salvage shuttle console board