### PR TITLE
Chat sanatize comms console.

### DIFF
--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Popups;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
+using Content.Server.Speech;
 
 namespace Content.Server.Communications
 {
@@ -230,6 +231,10 @@ namespace Content.Server.Communications
         {
             var maxLength = _cfg.GetCVar(CCVars.ChatMaxAnnouncementLength);
             var msg = SharedChatSystem.SanitizeAnnouncement(message.Message, maxLength);
+            msg = _chatSystem.SanitizeMessageReplaceWords(msg);
+            var accentEv = new AccentGetEvent(uid, msg);
+            RaiseLocalEvent(uid,accentEv);
+            msg = accentEv.Message;
             var author = Loc.GetString("comms-console-announcement-unknown-sender");
             if (message.Actor is { Valid: true } mob)
             {

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -231,10 +231,12 @@ namespace Content.Server.Communications
         {
             var maxLength = _cfg.GetCVar(CCVars.ChatMaxAnnouncementLength);
             var msg = SharedChatSystem.SanitizeAnnouncement(message.Message, maxLength);
+            //#region Starlight
             msg = _chatSystem.SanitizeMessageReplaceWords(msg);
             var accentEv = new AccentGetEvent(uid, msg);
             RaiseLocalEvent(uid,accentEv);
             msg = accentEv.Message;
+            //#endregion Starlight
             var author = Loc.GetString("comms-console-announcement-unknown-sender");
             if (message.Actor is { Valid: true } mob)
             {

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -19,7 +19,7 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Popups;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
-using Content.Server.Speech;
+using Content.Server.Speech; //Starlight
 
 namespace Content.Server.Communications
 {


### PR DESCRIPTION
## Short description
the comms console is now chat sanatized and now applies accents.

## Why we need to add this
death of netspeak all netspeak should be sanatized into normal text.

## Media (Video/Screenshots)
chatsan at work
<img width="767" height="190" alt="image" src="https://github.com/user-attachments/assets/1dd5d542-7f91-4392-9e05-73d3b82d9b65" />

added owo comp to the console
<img width="1016" height="215" alt="image" src="https://github.com/user-attachments/assets/f861951d-b140-434c-93f9-faab9c459284" />


## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksantora
- add: Communications consoles can now accept accents
- add: Communications consoles now use chat sanitization (eg: smth -> something)
