### PR TITLE
Roles pick by priority first

### DIFF
--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -104,10 +104,10 @@ public sealed partial class StationJobsSystem
 
         // Ok so the general algorithm:
         // We start with the highest weight jobs and work our way down. We filter jobs by weight when selecting as well.
-        // Weight > Priority > Station.
-        foreach (var weight in _orderedWeights)
+        // Priority > Weight > Station. 🌟Starlight🌟
+        for (var selectedPriority = JobPriority.High; selectedPriority > JobPriority.Never; selectedPriority--)
         {
-            for (var selectedPriority = JobPriority.High; selectedPriority > JobPriority.Never; selectedPriority--)
+            foreach (var weight in _orderedWeights)
             {
                 if (userIds.Count == 0)
                     goto endFunc;

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -103,12 +103,14 @@ public sealed partial class StationJobsSystem
         var stationShares = new Dictionary<EntityUid, int>(stations.Count);
 
         // Ok so the general algorithm:
-        // We start with the highest weight jobs and work our way down. We filter jobs by weight when selecting as well.
-        // Priority > Weight > Station. 🌟Starlight🌟
+        // Changed by 🌟Starlight🌟
+        // We start with the highest priority jobs and work our way down. We filter jobs by weight when selecting as well. 
+        // Priority > Weight > Station.
         for (var selectedPriority = JobPriority.High; selectedPriority > JobPriority.Never; selectedPriority--)
         {
             foreach (var weight in _orderedWeights)
             {
+                // 🌟Starlight🌟 end
                 if (userIds.Count == 0)
                     goto endFunc;
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Changes role selection to be more intuitive and cause less frustrations.

## Why we need to add this
Role selection by priority *intuitively* works by picking a job in order of priority. This makes sense - if you really want to play a job, you put it on high priority - and then you get a job on low priority anyway, because right now, it picks by weight first. I flipped that order, so it is now more sensible. You get picked for your highest priority first, then your mediums (where weight is once again prioritised) and only then your lows (also with weight priority). This should make the new role system a *lot* less grating to those players who had an issue with it, though it will *also* mean command roles can go unfilled if every command member really wants to play something else. Which is a good thing, since it leaves those roles open for late joins, rather than having unmotivated command.

## Media (Video/Screenshots)
<img width="587" height="276" alt="image" src="https://github.com/user-attachments/assets/20f295b1-bf87-411d-b5bc-a7ba90daaf6a" />
<img width="132" height="168" alt="image" src="https://github.com/user-attachments/assets/282bcb14-dc51-46ca-955d-2be1031ced42" />




## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Role weight no longer takes precendence over role priority 
