### PR TITLE
Added a servername string to the round-notifications

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -14,6 +14,7 @@ using Content.Shared.Players;
 using Content.Shared.Preferences;
 using JetBrains.Annotations;
 using Prometheus;
+using Robust.Shared;
 using Robust.Shared.Asynchronous;
 using Robust.Shared.Audio;
 using Robust.Shared.EntitySerialization;
@@ -24,8 +25,8 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using Content.Shared.Starlight.CCVar;
 using System.Text.RegularExpressions;
+using Discord;
 
 namespace Content.Server.GameTicking
 {
@@ -58,7 +59,7 @@ namespace Content.Server.GameTicking
 
         private string? _replayRoundText;
 
-        private static readonly Regex GreekRegex = new (@"{.}", RegexOptions.Compiled);
+        private static readonly Regex GreekRegex = new (@"(?<={).(?=})", RegexOptions.Compiled);
 
         [ViewVariables]
         public GameRunLevel RunLevel
@@ -606,11 +607,10 @@ namespace Content.Server.GameTicking
                     return;
 
                 var duration = RoundDuration();
-                var serverName = _cfg.GetCVar(StarlightCCVars.ServerName);
-                var greekIndicator = GreekRegex.Match(serverName);
+                var greekIndicator = GreekRegex.Match(_cfg.GetCVar(CVars.GameHostName));
                 var content = Loc.GetString("discord-round-notifications-end",
                     ("id", RoundId),
-                    ("serverIndicator", greekIndicator),
+                    ("serverIndicator", greekIndicator.Value),
                     ("hours", Math.Truncate(duration.TotalHours)),
                     ("minutes", duration.Minutes),
                     ("seconds", duration.Seconds));
@@ -687,10 +687,9 @@ namespace Content.Server.GameTicking
                 if (_webhookIdentifier == null)
                     return;
 
-                var serverName = _cfg.GetCVar(StarlightCCVars.ServerName);
-                var greekIndicator = GreekRegex.Match(serverName);
+                var greekIndicator = GreekRegex.Match(_cfg.GetCVar(CVars.GameHostName));
 
-                var content = Loc.GetString("discord-round-notifications-new", ("serverIndicator", greekIndicator));
+                var content = Loc.GetString("discord-round-notifications-new", ("serverIndicator", greekIndicator.Value));
 
                 var payload = new WebhookPayload { Content = content };
 
@@ -812,9 +811,8 @@ namespace Content.Server.GameTicking
                     return;
 
                 var mapName = _gameMapManager.GetSelectedMap()?.MapName ?? Loc.GetString("discord-round-notifications-unknown-map");
-                var serverName = _cfg.GetCVar(StarlightCCVars.ServerName);
-                var greekIndicator = GreekRegex.Match(serverName);
-                var content = Loc.GetString("discord-round-notifications-started", ("id", RoundId), ("map", mapName), ("serverIndicator", greekIndicator));
+                var greekIndicator = GreekRegex.Match(_cfg.GetCVar(CVars.GameHostName));
+                var content = Loc.GetString("discord-round-notifications-started", ("id", RoundId), ("map", mapName), ("serverIndicator", greekIndicator.Value));
 
                 var payload = new WebhookPayload { Content = content };
 

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -26,7 +26,6 @@ using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using Content.Shared.Starlight.CCVar;
 using System.Text.RegularExpressions;
-using 
 
 namespace Content.Server.GameTicking
 {

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -26,7 +26,6 @@ using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using System.Text.RegularExpressions;
-using Discord;
 
 namespace Content.Server.GameTicking
 {

--- a/Resources/Locale/en-US/discord/round-notifications.ftl
+++ b/Resources/Locale/en-US/discord/round-notifications.ftl
@@ -1,5 +1,5 @@
-﻿discord-round-notifications-new = A new round is starting!
-discord-round-notifications-started = Round #{$id} on map "{$map}" started.
-discord-round-notifications-end = Round #{$id} has ended. It lasted for {$hours} hours, {$minutes} minutes, and {$seconds} seconds.
-discord-round-notifications-end-ping = <@&{$roleId}>, the server will reboot shortly!
+﻿discord-round-notifications-new = {$serverIndicator} - A new round is starting!
+discord-round-notifications-started = {$serverIndicator} - Round #{$id} on map "{$map}" started.
+discord-round-notifications-end = {$serverIndicator} - Round #{$id} has ended. It lasted for {$hours} hours, {$minutes} minutes, and {$seconds} seconds.
+discord-round-notifications-end-ping = {$serverIndicator} - <@&{$roleId}>, the server will reboot shortly!
 discord-round-notifications-unknown-map = Unknown


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds the servers' Greek letters to round start and round end notifications.
Done by fetching the letter from GameHostName with Regex. 
Simple to implement and non-invasive in Discord, but obviously relies on the server name to maintain the same standard.

**It would be WAY better to have a new CCVar** which exclusively defines this letter. This would be easy to implement, **if someone is willing to change the server config post-merge** to include said new CCVar.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Requested in approved suggestion: https://discordapp.com/channels/1272545509562777621/1398083690843869244

## Media
<img width="426" height="78" alt="image" src="https://github.com/user-attachments/assets/c7be95f9-43c5-4a71-8d84-9bb6912a262b" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- tweak: Discord notifications now show the server's Greek letter to differentiate the notifications
