### PR TITLE
Add more paper to NT Clipboard

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/folders.yml
@@ -22,4 +22,4 @@
     - type: StorageFill
       contents:
         - id: Paper
-          amount: 10
+          amount: 20

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/folders.yml
@@ -19,3 +19,7 @@
       sprite: _Starlight/Objects/Misc/nt-clipboard.rsi
     - type: Clothing
       sprite: _Starlight/Objects/Misc/nt-clipboard.rsi
+    - type: StorageFill
+      contents:
+        - id: Paper
+          amount: 10


### PR DESCRIPTION
## Short description
Overrides clipboard spawn contents to guarantee 20 blank paper, ready for administrative work.

## Why we need to add this
Discussion thread: https://discord.com/channels/1272545509562777621/1398212087314120735

## Media (Video/Screenshots)
<img width="155" height="113" alt="Screenshot 2025-07-26 144616" src="https://github.com/user-attachments/assets/52940411-0130-4f8a-bb51-66511f804b79" />
<img width="259" height="154" alt="Screenshot 2025-07-26 144608" src="https://github.com/user-attachments/assets/53960ccc-0782-4f7c-8d78-98e947471c63" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: biteless-dot
- tweak: Updated NT-Clipboard to spawn with 20 guaranteed blank papers. No more office paper getting in the way of bureaucracy!
