### PR TITLE
scurret uppies!

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
@@ -4,7 +4,7 @@
 - type: entity
   name: scurret
   id: MobBaseScurret
-  parent: MobBaseAncestor
+  parent: [ MobBaseAncestor, BaseSpeciesPickupable ] #Starlight - give the scurret uppies.
   abstract: true
   components:
   # Custom names


### PR DESCRIPTION
## Short description
The scurrets can now be picked up like felinoids, resomi and monkies.

## Why we need to add this
allow the scurrets to be picked up and thrown.

## Media (Video/Screenshots)
<img width="381" height="555" alt="image" src="https://github.com/user-attachments/assets/05d2021d-ee21-4df2-843a-28729b9271c1" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora.
- add: Scurrets can now be picked up like a felinoid.