### PR TITLE
fixed the surgery boss.

### DIFF
--- a/Content.Shared/_Starlight/Medical/Surgery/SharedSurgerySystem.BaseSteps.cs
+++ b/Content.Shared/_Starlight/Medical/Surgery/SharedSurgerySystem.BaseSteps.cs
@@ -119,14 +119,8 @@ public abstract partial class SharedSurgerySystem
             AddComp(args.Part, newComp);
         }
 
-        foreach (var reg in (ent.Comp.BodyAdd ?? []).Values)
-        {
-            var compType = reg.Component.GetType();
-            if (HasComp(args.Body, compType))
-                continue;
-
-            AddComp(args.Part, _compFactory.GetComponent(compType));
-        }
+        if (ent.Comp.BodyAdd != null)
+            EntityManager.AddComponents(args.Body, ent.Comp.BodyAdd, false);
 
         foreach (var reg in (ent.Comp.Remove ?? []).Values)
             RemComp(args.Part, reg.Component.GetType());
@@ -148,7 +142,7 @@ public abstract partial class SharedSurgerySystem
 
         if (args.Invalid != StepInvalidReason.None)
             return;
-        
+
         if (_inventory.TryGetContainerSlotEnumerator(args.Body, out var enumerator, args.TargetSlots))
         {
             var items = 0f;
@@ -270,7 +264,7 @@ public abstract partial class SharedSurgerySystem
             foreach (var requirementId in requirementsIds)
             {
                 if (!_entitySystem.TryGetSingleton(requirementId, out var requirement)
-                    && GetNextStep(body, part, requirement, requirements) is { } requiredNext 
+                    && GetNextStep(body, part, requirement, requirements) is { } requiredNext
                     && IsSurgeryValid(body, part, requirementId, requiredNext.Surgery.Comp.Steps[requiredNext.Step], out _, out _, out _))
                     return requiredNext;
             }
@@ -296,8 +290,8 @@ public abstract partial class SharedSurgerySystem
             foreach (var requirement in requirements)
             {
                 if (!_entitySystem.TryGetSingleton(requirement, out var requiredEnt)
-                    || !TryComp(requiredEnt, out SurgeryComponent? requiredComp) 
-                    || !PreviousStepsComplete(body, part, (requiredEnt, requiredComp), step) 
+                    || !TryComp(requiredEnt, out SurgeryComponent? requiredComp)
+                    || !PreviousStepsComplete(body, part, (requiredEnt, requiredComp), step)
                     && IsSurgeryValid(body, part, requirement, step, out _, out _, out _))
                     return false;
             }

--- a/Resources/Prototypes/_StarLight/Surgery/organs_steps.yml
+++ b/Resources/Prototypes/_StarLight/Surgery/organs_steps.yml
@@ -297,7 +297,7 @@
   - type: Sprite
     sprite: Objects/Specific/Medical/Surgery/scalpel.rsi
     state: scalpel
-    
+
 # eye implants
 - type: entity
   parent: SurgeryStepBase
@@ -551,6 +551,8 @@
     duration: 5
     tools:
     - type: Retractor
+    bodyAdd:
+    - type: Uncryoable
   - type: SurgeryStepOrganExtract
     organ:
     - type: OrganBrain
@@ -604,7 +606,7 @@
     state: hemostat
 
 # kidneys
-    
+
 - type: entity
   parent: SurgeryStepBase
   id: SurgeryStepPrepareImplantSiteKidneys
@@ -649,7 +651,7 @@
     state: hemostat
 
 # stomach
-    
+
 - type: entity
   parent: SurgeryStepBase
   id: SurgeryStepPrepareImplantSiteStomach
@@ -692,7 +694,7 @@
     state: hemostat
 
 # lungs
-    
+
 - type: entity
   parent: SurgeryStepBase
   id: SurgeryStepPrepareImplantSiteLungs
@@ -735,7 +737,7 @@
     state: hemostat
 
 # heart
-    
+
 - type: entity
   parent: SurgeryStepBase
   id: SurgeryStepPrepareImplantSiteHeart
@@ -821,7 +823,7 @@
   - type: Sprite
     sprite: Objects/Specific/Medical/Surgery/scissors.rsi
     state: hemostat
-    
+
 # eye implants
 
 - type: entity
@@ -864,6 +866,8 @@
     duration: 2
     tools:
     - type: OrganTongue
+    bodyRemove:
+    - type: Muted
   - type: SurgeryStepOrganInsert
     slot: tongue
   - type: Sprite
@@ -934,6 +938,8 @@
     duration: 5
     tools:
     - type: OrganBrain
+    bodyRemove:
+    - type: Uncryoable
   - type: SurgeryStepOrganInsert
     slot: brain
   - type: Sprite
@@ -1048,7 +1054,7 @@
     sprite: Objects/Specific/Medical/Surgery/scalpel.rsi
     state: scalpel
   - type: SurgeryStepEmoteEffect
-  
+
 # Cavity
 
 - type: entity
@@ -1079,7 +1085,7 @@
     organ:
     - type: Item
     slot: cavity
-    
+
 - type: entity
   parent: SurgeryStepBase
   id: SurgeryStepPrepareImplantSiteCavity


### PR DESCRIPTION
## Short description
fixes a bug with surgery that caused tongue removal's mute to be permanent. also fixed the "bug" that bodies with no brain physically in them get cryoed

## Why we need to add this
bugfix and something that makes brain surgeries easier to do

## Media (Video/Screenshots)
N/A

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: bodies can no longer be automatically cryoslept when their brain is surgically removed.
- fix: Surgically putting a tongue into someone's mouth now lets them speak again.
