### PR TITLE
gamemode display override cvars

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -82,8 +82,8 @@ namespace Content.Server.GameTicking
                 ("playerCount", playerCount),
                 ("readyCount", readyCount),
                 ("mapName", stationNames.ToString()),
-                ("gmTitle", gmTitle),
-                ("desc", desc));
+                ("gmTitle", string.IsNullOrWhiteSpace(GamemodeNameOverride) ? gmTitle : Loc.GetString(GamemodeNameOverride)), //Starlight edit: gamemode name override
+                ("desc", string.IsNullOrWhiteSpace(GamemodeDescOverride) ? desc : Loc.GetString(GamemodeDescOverride))); //Starlight edit: gamemode desc override
         }
 
         private TickerConnectionStatusEvent GetConnectionStatusMsg()

--- a/Content.Server/GameTicking/GameTicker.Starlight.cs
+++ b/Content.Server/GameTicking/GameTicker.Starlight.cs
@@ -12,6 +12,14 @@ using static Content.Shared.Administration.Notes.AdminMessageEuiState;
 namespace Content.Server.GameTicking;
 public sealed partial class GameTicker //🌟Starlight🌟
 {
+
+    #region Starlight
+    [ViewVariables]
+    public string GamemodeNameOverride = "";
+    [ViewVariables]
+    public string GamemodeDescOverride = "";
+    #endregion
+
     private WebhookIdentifier? _statusWebhookIdentifier;
     private WebhookIdentifier? _statusWebhookStaffIdentifier;
     private ulong _statusMessageId = 0;
@@ -125,6 +133,9 @@ public sealed partial class GameTicker //🌟Starlight🌟
         Subs.CVar(_cfg, StarlightCCVars.StatusMessageId, v => _statusMessageId = v, true);
         Subs.CVar(_cfg, StarlightCCVars.StatusMessageStaffId, v => _statusStaffMessageId = v, true);
         Subs.CVar(_cfg, CVars.GameHostName, v => _serverName = v[..Math.Min(v.Length, 1500)], true);
+        Subs.CVar(_cfg, StarlightCCVars.OverrideGamemodeName, v => GamemodeNameOverride = v, true);
+        Subs.CVar(_cfg, StarlightCCVars.OverrideGamemodeDescription, v => GamemodeDescOverride = v, true);
+
 
         _timer = new(StarlightStatus, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
     }

--- a/Content.Server/GameTicking/GameTicker.Starlight.cs
+++ b/Content.Server/GameTicking/GameTicker.Starlight.cs
@@ -157,7 +157,7 @@ public sealed partial class GameTicker //🌟Starlight🌟
 
         embed.Fields[0] = embed.Fields[0] with { Value = $"{_playerManager.PlayerCount}/{_playerManager.MaxPlayers}" };
         embed.Fields[1] = embed.Fields[1] with { Value = mapName };
-        embed.Fields[2] = embed.Fields[2] with { Value = preset };
+        embed.Fields[2] = embed.Fields[2] with { Value = string.IsNullOrWhiteSpace(GamemodeDescOverride) ? preset : Loc.GetString(GamemodeDescOverride) };
         embed.Fields[3] = embed.Fields[3] with { Value = RoundDuration().ToString("hh\\:mm\\:ss") };
 
         _payload.Embeds[0] = embed;

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVar.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVar.cs
@@ -1,4 +1,6 @@
 using Robust.Shared.Configuration;
+using Content.Shared.CCVar.CVarAccess;
+using Content.Shared.Administration;
 
 namespace Content.Shared.Starlight.CCVar;
 
@@ -14,8 +16,10 @@ public sealed partial class StarlightCCVars
     public static readonly CVarDef<string> ServerName =
         CVarDef.Create("lobby.server_name", "☆ Starlight ☆", CVar.SERVER | CVar.REPLICATED);
 
+    [CVarControl(AdminFlags.AdminChat)]
     public static readonly CVarDef<string> OverrideGamemodeName =
         CVarDef.Create("lobby.gamemode_name_override", "", CVar.SERVER | CVar.REPLICATED);
+    [CVarControl(AdminFlags.AdminChat)]
     public static readonly CVarDef<string> OverrideGamemodeDescription =
         CVarDef.Create("lobby.gamemode_desc_override", "", CVar.SERVER | CVar.REPLICATED);
 }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVar.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVar.cs
@@ -16,10 +16,10 @@ public sealed partial class StarlightCCVars
     public static readonly CVarDef<string> ServerName =
         CVarDef.Create("lobby.server_name", "☆ Starlight ☆", CVar.SERVER | CVar.REPLICATED);
 
-    [CVarControl(AdminFlags.AdminChat)]
+    [CVarControl(AdminFlags.Adminchat)]
     public static readonly CVarDef<string> OverrideGamemodeName =
         CVarDef.Create("lobby.gamemode_name_override", "", CVar.SERVER | CVar.REPLICATED);
-    [CVarControl(AdminFlags.AdminChat)]
+    [CVarControl(AdminFlags.Adminchat)]
     public static readonly CVarDef<string> OverrideGamemodeDescription =
         CVarDef.Create("lobby.gamemode_desc_override", "", CVar.SERVER | CVar.REPLICATED);
 }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVar.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVar.cs
@@ -1,6 +1,7 @@
 using Robust.Shared.Configuration;
 
 namespace Content.Shared.Starlight.CCVar;
+
 [CVarDefs]
 public sealed partial class StarlightCCVars
 {
@@ -9,7 +10,12 @@ public sealed partial class StarlightCCVars
     /// </summary>
     public static readonly CVarDef<string> LobbyChangelogsList =
         CVarDef.Create("lobby_changelog.list", "ChangelogStarlight.yml,Changelog.yml", CVar.SERVER | CVar.REPLICATED);
-        
+
     public static readonly CVarDef<string> ServerName =
         CVarDef.Create("lobby.server_name", "☆ Starlight ☆", CVar.SERVER | CVar.REPLICATED);
+
+    public static readonly CVarDef<string> OverrideGamemodeName =
+        CVarDef.Create("lobby.gamemode_name_override", "", CVar.SERVER | CVar.REPLICATED);
+    public static readonly CVarDef<string> OverrideGamemodeDescription =
+        CVarDef.Create("lobby.gamemode_desc_ocerride", "", CVar.SERVER | CVar.REPLICATED);
 }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVar.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVar.cs
@@ -17,5 +17,5 @@ public sealed partial class StarlightCCVars
     public static readonly CVarDef<string> OverrideGamemodeName =
         CVarDef.Create("lobby.gamemode_name_override", "", CVar.SERVER | CVar.REPLICATED);
     public static readonly CVarDef<string> OverrideGamemodeDescription =
-        CVarDef.Create("lobby.gamemode_desc_ocerride", "", CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("lobby.gamemode_desc_override", "", CVar.SERVER | CVar.REPLICATED);
 }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVar.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVar.cs
@@ -18,8 +18,8 @@ public sealed partial class StarlightCCVars
 
     [CVarControl(AdminFlags.Adminchat)]
     public static readonly CVarDef<string> OverrideGamemodeName =
-        CVarDef.Create("lobby.gamemode_name_override", "", CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("lobby.gamemode_name_override", "", CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE);
     [CVarControl(AdminFlags.Adminchat)]
     public static readonly CVarDef<string> OverrideGamemodeDescription =
-        CVarDef.Create("lobby.gamemode_desc_override", "", CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("lobby.gamemode_desc_override", "", CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE);
 }


### PR DESCRIPTION
## Short description
adds a pair of CVars that allow overriding the displayed preset and description on the lobby screen

## Why we need to add this
as per https://discord.com/channels/1272545509562777621/1399153888740769884/1399153888740769884
allows setting it to always display a specific gamemode/desc no matter the preset. 
eg: by setting
`lobby.gamemode_name_override` to `"secret-title"` and
`lobby.gamemode_desc_override` to `"secret-description"`
it will always show as secret no matter the preset.

## Media (Video/Screenshots)
<img width="582" height="546" alt="image" src="https://github.com/user-attachments/assets/46439a21-2ad8-4b21-9312-73816c1f3828" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: Server hosts can now force the preset to always be displayed as a specific type.
