### PR TITLE
adds a replacement for the intended use of end of Q for stealthop nukies

### DIFF
--- a/Resources/Locale/en-US/_Starlight/paper/events.ftl
+++ b/Resources/Locale/en-US/_Starlight/paper/events.ftl
@@ -1,21 +1,34 @@
 paper-too-quiet-need-chaos = Do you feel like this shift has been way too quiet?
                              Want a little action to spice up the day?
-  
+
                              If you would like to join the NanoTrasen Experimental Division to immediately undergo some potentially severe tests for the sake of science and future profit.... then we got the thing just for you!
-  
+
                              {"[bold] Collect the signatures of 9 Mindshielded crew to begin the experiment. [/bold]"}
-  
+
                              Don't ask how we got this experimental paper inside this locker. Yes, CentComm is totally aware we did this.
-  
+
                              For the glory of NanoTrasen
 
 paper-too-quiet-need-chaos-few = Do you feel like this shift has been way too quiet?
                                  Want a little action to spice up the day?
-  
+
                                  If you would like to join the NanoTrasen Experimental Division to immediately undergo some potentially severe tests for the sake of science and future profit.... then we got the thing just for you!
-  
+
                                  {"[bold] Collect the signatures of 3 Mindshielded crew to begin the experiment. [/bold]"}
-  
+
                                  Don't ask how we got this experimental paper inside this locker. Yes, CentComm is totally aware we did this.
-  
+
                                  For the glory of NanoTrasen
+
+paper-send-nukie-reinforcements =       {-delivery-header-nanotrasen-alternate-timeline}
+                    {"[head=2]This is an official notice from the [color=red]Chief Security Officer[/color] at a Nanotrasen's Space Station 15.[/head]"}
+
+                    To whoever receives this letter. I am Sergeant Rigel. My occupation is the CSO. We need immediate assistance.
+
+                    Our station is currently under attack by Atomic Agents, this letter is being thrown into a destabilized bluespace anomaly created by our [color=purple]Head of Research[/color].
+
+                    I am currently bolted in the Bridge, if you receive this message, please send aid immediately. I don't know how much longer we can last.
+
+                    We need 27 signatures for CentComm to send us help. Please take mercy and sign this petition.
+
+                    Glory to Nanotrasen.

--- a/Resources/Maps/_Starlight/nukieplanet.yml
+++ b/Resources/Maps/_Starlight/nukieplanet.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Map
+  engineVersion: 264.0.0
+  forkId: Starlight
+  forkVersion: 1732131340
+  time: 07/28/2025 17:31:24
+  entityCount: 4164
+maps:
+- 1295
+grids:
+- 1
+orphans: []
+nullspace: []
 tilemap:
   10: Space
   7: FloorArcadeRed
@@ -2254,9 +2265,7 @@ entities:
     - type: Transform
     - type: Map
       mapPaused: True
-    - type: PhysicsMap
     - type: GridTree
-    - type: MovedGrids
     - type: FTLDestination
       whitelist:
         tags:
@@ -3326,7 +3335,7 @@ entities:
             - -0.45,0.45
           mask:
           - Impassable
-          - TableLayer
+          - MidImpassable
           - LowImpassable
           layer:
           - BulletImpassable
@@ -11775,11 +11784,41 @@ entities:
     - type: Transform
       pos: -28.605858,-0.8710441
       parent: 1
+    - type: Tool
+      useSound: !type:SoundPathSpecifier
+        params:
+          variation: null
+          playOffsetSeconds: 0
+          loop: False
+          referenceDistance: 1
+          rolloffFactor: 1
+          maxDistance: 15
+          pitch: 1
+          volume: 0
+        path: /Audio/Items/Culinary/chop.ogg
+      speedModifier: 1
+      qualities:
+      - Slicing
   - uid: 3880
     components:
     - type: Transform
       pos: -28.324608,-0.8710441
       parent: 1
+    - type: Tool
+      useSound: !type:SoundPathSpecifier
+        params:
+          variation: null
+          playOffsetSeconds: 0
+          loop: False
+          referenceDistance: 1
+          rolloffFactor: 1
+          maxDistance: 15
+          pitch: 1
+          volume: 0
+        path: /Audio/Items/Culinary/chop.ogg
+      speedModifier: 1
+      qualities:
+      - Slicing
 - proto: ComfyChair
   entities:
   - uid: 629
@@ -14464,6 +14503,21 @@ entities:
     - type: Transform
       pos: -14.518055,-23.473787
       parent: 1
+    - type: Tool
+      useSound: !type:SoundPathSpecifier
+        params:
+          variation: null
+          playOffsetSeconds: 0
+          loop: False
+          referenceDistance: 1
+          rolloffFactor: 1
+          maxDistance: 15
+          pitch: 1
+          volume: 0
+        path: /Audio/Items/Culinary/chop.ogg
+      speedModifier: 1
+      qualities:
+      - Slicing
 - proto: KitchenOven
   entities:
   - uid: 1403
@@ -14698,7 +14752,7 @@ entities:
   - uid: 4156
     components:
     - type: Transform
-      pos: -14.775839,8.616626
+      pos: -14.741358,8.557928
       parent: 1
     missingComponents:
     - FaxableObject
@@ -14897,7 +14951,7 @@ entities:
       pos: -3.5,1.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -17597.717
+      secondsUntilStateChange: -17629.387
       state: Opening
   - uid: 730
     components:
@@ -14905,7 +14959,7 @@ entities:
       pos: -3.5,2.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -17598.584
+      secondsUntilStateChange: -17630.254
       state: Opening
 - proto: MinimoogInstrument
   entities:
@@ -15124,6 +15178,15 @@ entities:
     - type: Transform
       pos: 1.8436577,3.5806565
       parent: 1
+- proto: PaperSendNukieReinforcements
+  entities:
+  - uid: 4157
+    components:
+    - type: Transform
+      pos: -14.958039,8.575979
+      parent: 1
+    missingComponents:
+    - FaxableObject
 - proto: PartRodMetal
   entities:
   - uid: 828
@@ -18311,21 +18374,29 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         118:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         119:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         120:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         117:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         116:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         121:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         122:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         123:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
   - uid: 1277
     components:
     - type: MetaData
@@ -18337,9 +18408,11 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         1273:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1274:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
 - proto: SignalButtonDirectional
   entities:
   - uid: 1568
@@ -18353,21 +18426,29 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         1559:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1560:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1561:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1562:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1569:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1570:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1571:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
         1572:
-        - Pressed: Toggle
+        - - Pressed
+          - Toggle
 - proto: SignalTrigger
   entities:
   - uid: 582
@@ -19058,6 +19139,8 @@ entities:
     - type: Transform
       pos: 1.4812105,4.649179
       parent: 1
+    - type: StockLimitedProcessing
+      processingListings: {}
 - proto: SyndieFlag
   entities:
   - uid: 2720
@@ -25156,7 +25239,7 @@ entities:
       pos: -15.5,-5.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -19867.28
+      secondsUntilStateChange: -19898.95
       state: Opening
   - uid: 1244
     components:
@@ -25164,6 +25247,6 @@ entities:
       pos: -15.5,-4.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -19867.713
+      secondsUntilStateChange: -19899.383
       state: Opening
 ...

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Paper/events.yml
@@ -54,9 +54,9 @@
       rules: ghost-role-information-freeagent-rules
       allowSpeech: true
       reregister: true
-      raffle: 
+      raffle:
         settings: default
-      mindRoles: 
+      mindRoles:
         - MindRoleGhostRoleFreeAgent
     - type: ShowMindShieldIcons # gotta know your targets.
     - type: Speech
@@ -82,7 +82,7 @@
       content: paper-too-quiet-need-chaos
     - type: GameruleOnSign
       remaining: 9 # command, security, cargo, science, medical, engineering, service, and 2 members of sec outside of hos (or more sec/salv and less heads... or people who you mindshielded JUST to get this signed)
-      whitelist: 
+      whitelist:
         components:
           - MindShield
       rules: #this will DEFINETLY end the "quiet" you so hate
@@ -98,7 +98,7 @@
         - DragonSpawn
         - NinjaSpawn
         - ParadoxCloneSpawn
-    
+
 - type: entity
   parent: BasePaperQuietChaos
   id: PaperTooQuietNeedChaosFew
@@ -108,7 +108,7 @@
       content: paper-too-quiet-need-chaos-few
     - type: GameruleOnSign
       remaining: 3 # on 15 pop usually there are only about 3 heads I expect
-      whitelist: 
+      whitelist:
         components:
           - MindShield
       rules: #this will DEFINETLY end the "quiet" you so hate
@@ -118,3 +118,16 @@
         - UnknownShuttleHonki
         - WizardSpawn
         - NinjaSpawn #spawns less cause there is also less people to take said roles. and I deem these to be the less "chaotic" ones
+
+- type: entity
+  parent: Paper
+  id: PaperSendNukieReinforcements
+  name: Send reinforcements!
+  description: An official notice from... an alternate timeline?
+  components:
+    - type: Paper
+      content: paper-send-nukie-reinforcements
+    - type: GameruleOnSign
+      remaining: 27 #on low pop this is basically the entire station. on hihpop this is nothing.
+      rules:
+        - LoneOpsSpawn

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/letter_loot_tables.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/letter_loot_tables.yml
@@ -7,6 +7,8 @@
       - id: MailSyndicateSpamLetter
         weight: .25
       - id: MailSpamDontYouWantMore
-        weight: .40
+        weight: .30
+      - id: PaperSendNukieReinforcements
+        weight: .10
       - id: MailSovietSpamLetter25
         weight: .35


### PR DESCRIPTION
## Short description
adds a paper that replaces the intended usage of end of Q (spawning a reinforcement upon collecting signatures). and also adds it to the antag mail pool to make it harder to metagame seeing this and knowing there is nukies.

## Why we need to add this
the end of Q was overkill and not what was indended for it to be mapped there. this replaces it with a similar and more tame alternative.

## Media (Video/Screenshots)

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: Added "Send Reinforcements" paper to antag paper pool with 10% chance. after 27 signatures sends a lone-op.
- add: Mapped "Send Reinforcements" paper on nukie outpost on one of the tables. where the end of Q was.
- tweak: Made "Dont you want more" antag paper 10% rarer

