### PR TITLE
Ticker no longer shows gamemode

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-ticker.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-ticker.ftl
@@ -12,8 +12,9 @@ game-ticker-get-info-text = Hi and welcome to [color=white]Space Station 14![/co
                             The current round is: [color=white]#{$roundId}[/color]
                             The current player count is: [color=white]{$playerCount}[/color]
                             The current map is: [color=white]{$mapName}[/color]
-                            The current game mode is: [color=white]{$gmTitle}[/color]
-                            >[color=yellow]{$desc}[/color]
+## STARLIGHT removed
+#                            The current game mode is: [color=white]{$gmTitle}[/color]
+#                            >[color=yellow]{$desc}[/color]
 game-ticker-get-info-preround-text = Hi and welcome to [color=white]Space Station 14![/color]
                             The current round is: [color=white]#{$roundId}[/color]
                             The current player count is: [color=white]{$playerCount}[/color] ([color=white]{$readyCount}[/color] {$readyCount ->
@@ -21,8 +22,9 @@ game-ticker-get-info-preround-text = Hi and welcome to [color=white]Space Statio
                                 *[other] are
                             } ready)
                             The current map is: [color=white]{$mapName}[/color]
-                            The current game mode is: [color=white]{$gmTitle}[/color]
-                            >[color=yellow]{$desc}[/color]
+## STARLIGHT removed
+#                            The current game mode is: [color=white]{$gmTitle}[/color]
+#                            >[color=yellow]{$desc}[/color]
 game-ticker-no-map-selected = [color=yellow]Map not yet selected![/color]
 game-ticker-player-no-jobs-available-when-joining = When attempting to join to the game, no jobs were available.
 game-ticker-player-no-character-for-job-available-when-joining = When attempting to join the game, no characters were available for selected job {$job}.


### PR DESCRIPTION
## Short description
Comments out the part of the ticker that shows gamemode.

## Why we need to add this
Metagaming issues.

## Media (Video/Screenshots)
<img width="761" height="254" alt="image" src="https://github.com/user-attachments/assets/9ff657ea-4eb2-4fc8-984f-6735d3c5de3d" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Trep_Maul
- remove: gamemode display on ticker.
