### PR TITLE
Character sizes HOTFIX

### DIFF
--- a/Content.Server.Database/StartLightModel.cs
+++ b/Content.Server.Database/StartLightModel.cs
@@ -11,7 +11,7 @@ public sealed class StarLightModel
         public virtual Profile Profile { get; set; } = null!;
         public string? CustomSpecieName { get; set; }
         public List<string> CyberneticIds { get; set; } = [];
-        public float Width { get; set; }
-        public float Height { get; set; }
+        public float Width { get; set; } = 1f;
+        public float Height { get; set; } = 1f;
     }
 }

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -225,7 +225,7 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
                 break;
             default:
                 break;
-                
+
         }
         // Starlight - End
 
@@ -309,11 +309,11 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
                 eyeColor = Humanoid.EyeColor.ValidEyeColor(speciesProto.EyeColoration, eyeColor);
             }
 
-            if(width > speciesProto.MaxWidth) width = speciesProto.DefaultWidth;
-            if(height > speciesProto.MaxHeight) height = speciesProto.DefaultHeight;
-
-            width = Math.Clamp(width, speciesProto.MinWidth, speciesProto.MaxWidth);
-            height = Math.Clamp(height, speciesProto.MinHeight, speciesProto.MaxHeight);
+            // this isn't a clamp, it's a reset if either is out of range
+            // maximum is done so that small species will get the correct height if they are defaulted (1f dwarf becoming 0.8f for example)
+            // minimum is done so that null values (interpreted as 0f) will get the default height and not become miniatures
+            if (width > speciesProto.MaxWidth || width < speciesProto.MinWidth) width = speciesProto.DefaultWidth;
+            if (height > speciesProto.MaxHeight || height < speciesProto.MinHeight) height = speciesProto.DefaultHeight;
             // Starlight - End
 
             markingSet.EnsureSpecies(species, skinColor, markingManager);


### PR DESCRIPTION
Messed up with the switch to the starlight model, because null was being interpreted as 0f it meant that all previously saved characters (prior to update) were defaulting to minimum by minimum, resulting in a bunch of minions running around as people didn't check or change their characters in the character editor

Fix just addresses the defaults and resets minimums/maximums properly, so that an untouched migrated character will have the species' default size (i.e. exactly what we are used to right now, humans being 1x1, dwarves being short, felionoids being small, etc, etc)

No functionality change, imo merge asap

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
