### PR TITLE
Make felionoid minimum size more reasonable

### DIFF
--- a/Resources/Prototypes/_StarLight/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Species/felionoid.yml
@@ -12,10 +12,10 @@
   femaleFirstNames: names_felionoid
   naming: First
   customName: true
-  minWidth: 0.6
+  minWidth: 0.7
   defaultWidth: 0.8
   maxWidth: 0.9
-  minHeight: 0.6
+  minHeight: 0.7
   defaultHeight: 0.8
   maxHeight: 0.9
   standardSize: 170


### PR DESCRIPTION
I overtuned it

<img width="433" height="256" alt="image" src="https://github.com/user-attachments/assets/9eb28023-3077-4ea7-91e9-5920343d9af7" />

smaller than a plushie

for reference their "normal" size is 0.8
felionoids are the only ones affected because they are the only ones that can go this small

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
