### PR TITLE
Remove ling lesser form

### DIFF
--- a/Content.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -61,7 +61,6 @@ public sealed partial class ChangelingSystem : EntitySystem
         SubscribeLocalEvent<ChangelingComponent, ActionEphedrineOverdoseEvent>(OnEphedrineOverdose);
         SubscribeLocalEvent<ChangelingComponent, ActionFleshmendEvent>(OnHealUltraSwag);
         SubscribeLocalEvent<ChangelingComponent, ActionLastResortEvent>(OnLastResort);
-        SubscribeLocalEvent<ChangelingComponent, ActionLesserFormEvent>(OnLesserForm);
         SubscribeLocalEvent<ChangelingComponent, ActionSpacesuitEvent>(OnSpacesuit);
         SubscribeLocalEvent<ChangelingComponent, ActionHivemindAccessEvent>(OnHivemindAccess);
         SubscribeLocalEvent<ChangelingComponent, FakeMindShieldToggleEvent>(OnFakeMindShieldToggle);
@@ -595,24 +594,7 @@ public sealed partial class ChangelingSystem : EntitySystem
 
         // todo: implement
     }
-    public void OnLesserForm(EntityUid uid, ChangelingComponent comp, ref ActionLesserFormEvent args)
-    {
-        if (!TryUseAbility(uid, comp, args))
-            return;
 
-        var newUid = TransformEntity(uid, protoId: "MobMonkey", comp: comp);
-        if (newUid == null)
-        {
-            comp.Chemicals += Comp<ChangelingActionComponent>(args.Action).ChemicalCost;
-            return;
-        }
-
-        PlayMeatySound((EntityUid) newUid, comp);
-        var loc = Loc.GetString("changeling-transform-others", ("user", Identity.Entity((EntityUid) newUid, EntityManager)));
-        _popup.PopupEntity(loc, (EntityUid) newUid, PopupType.LargeCaution);
-
-        comp.IsInLesserForm = true;
-    }
     public void OnSpacesuit(EntityUid uid, ChangelingComponent comp, ref ActionSpacesuitEvent args)
     {
         if (!TryUseAbility(uid, comp, args))

--- a/Content.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Server/Changeling/ChangelingSystem.cs
@@ -229,7 +229,7 @@ public sealed partial class ChangelingSystem : EntitySystem
             if (stamina.StaminaDamage >= stamina.CritThreshold || _gravity.IsWeightless(uid))
                 ToggleStrainedMuscles(uid, comp);
         }
-        
+
         if (comp.StealthEnabled)
         {
             if (comp.Chemicals > comp.StealthDrain)
@@ -308,12 +308,6 @@ public sealed partial class ChangelingSystem : EntitySystem
         if (comp.Biomass < 1 && lingAction.RequireBiomass)
         {
             _popup.PopupEntity(Loc.GetString("changeling-biomass-deficit"), uid, uid);
-            return false;
-        }
-
-        if (!lingAction.UseInLesserForm && comp.IsInLesserForm)
-        {
-            _popup.PopupEntity(Loc.GetString("changeling-action-fail-lesserform"), uid, uid);
             return false;
         }
 
@@ -422,7 +416,7 @@ public sealed partial class ChangelingSystem : EntitySystem
     {
         if (!TryComp<HumanoidAppearanceComponent>(target, out var appearance)
         || !TryComp<MetaDataComponent>(target, out var metadata)
-        || !TryComp<DnaComponent>(target, out var dna) 
+        || !TryComp<DnaComponent>(target, out var dna)
         || dna.DNA == null
         || !TryComp<FingerprintComponent>(target, out var fingerprint))
             return false;
@@ -471,7 +465,6 @@ public sealed partial class ChangelingSystem : EntitySystem
         newComp.Biomass = comp.Biomass;
         newComp.MaxBiomass = comp.MaxBiomass;
 
-        newComp.IsInLesserForm = comp.IsInLesserForm;
         newComp.CurrentForm = comp.CurrentForm;
 
         newComp.TotalAbsorbedEntities = comp.TotalAbsorbedEntities;
@@ -543,7 +536,7 @@ public sealed partial class ChangelingSystem : EntitySystem
             EnsureComp<HeadRevolutionaryComponent>(newEnt);
         if (HasComp<RevolutionaryComponent>(uid))
             EnsureComp<RevolutionaryComponent>(newEnt);
-        
+
         _factionSystem.Up(uid, newEnt);
 
         QueueDel(uid);

--- a/Content.Shared/Changeling/ChangelingComponent.cs
+++ b/Content.Shared/Changeling/ChangelingComponent.cs
@@ -47,8 +47,6 @@ public sealed partial class ChangelingComponent : Component
 
     public bool StrainedMusclesActive = false;
 
-    public bool IsInLesserForm = false;
-    
     public bool StealthEnabled = false;
 
     [DataField]

--- a/Resources/Prototypes/Catalog/changeling_catalog.yml
+++ b/Resources/Prototypes/Catalog/changeling_catalog.yml
@@ -299,20 +299,6 @@
 #    stock: 1
 
 - type: listing
-  id: EvolutionMenuUtilityLesserForm
-  name: evolutionmenu-utility-lesserform-name
-  description: evolutionmenu-utility-lesserform-desc
-  icon: { sprite: Changeling/changeling_abilities.rsi, state: lesser_form }
-  productAction: ActionToggleLesserForm
-  cost:
-    EvolutionPoint: 2
-  categories:
-  - ChangelingAbilityUtility
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
   id: EvolutionMenuUtilitySpacesuit
   name: evolutionmenu-utility-spacesuit-name
   description: evolutionmenu-utility-spacesuit-desc

--- a/Resources/Prototypes/_StarLight/Actions/changeling.yml
+++ b/Resources/Prototypes/_StarLight/Actions/changeling.yml
@@ -523,24 +523,6 @@
     useInLesserForm: true
 
 - type: entity
-  id: ActionToggleLesserForm
-  name: Lesser Form
-  description: Abandon your current form and transform into a monkey. Costs 20 chemicals.
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: Action
-    useDelay: 5
-    itemIconStyle: NoItem
-    icon:
-      sprite: Changeling/changeling_abilities.rsi
-      state: lesser_form
-    checkCanInteract: false
-  - type: InstantAction
-    event: !type:ActionLesserFormEvent {}
-  - type: ChangelingAction
-    chemicalCost: 20
-
-- type: entity
   id: ActionToggleSpacesuit
   name: Toggle Space Suit
   description: Make your body space proof. Costs 20 chemicals.

--- a/Resources/ServerInfo/Guidebook/Antagonist/Changelings.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Changelings.xml
@@ -30,7 +30,7 @@
   You can only have a maximum of 5 DNA strands at a time, and must transform to obtain more.
 
   Acquiring DNA via absorption requires the victim's incapacitation, critical condition or death. Simply, handcuff, put him into crit or kill him if you need to absorb him.
-  
+
   - Absorbing someone takes a lot of time, so prepare a safe spot or do it somewhere with the least amount of ears possible.
   - Absorbing a victim will recover all of your biomass, increase your maximum chemical capacity and give you bonus evolution points to buy new abilities.
   - Absorbing another changeling will, on top of that, increase your maximum biomass capacity, allowing you to stay alive for more time and give you even more chemicals and evolution points.
@@ -39,9 +39,8 @@
   ### You exclaim, "I am the only one here!"
   Changelings are limited, however, to how much DNA they can absorb at once! If a changeling has 5 DNAs stored and attempts to gain another, they must purge the older DNA by transforming. Eventually, any changeling will have to be a twin of someone else on the station, living or dead.
   The changeling can shift its appearance, making them look and sound exactly like a victim of which they have absorbed. This can be massive compromise in security, especially if command staff are absorbed and the changeling is able to imitate them.
-  Changelings can also, via their lesser form ability, transform into monkeys and do monkey things.
 
-  
+
   ### Regeneration
   Also known as Regenerative Stasis, changelings have the ability to 'kill' themselves, and appear dead. After an uncertain amount of time, the changeling can revive at will, fully healed of all injuries and illness.
   Entering stasis drains all of the changeling's chemicals, and leaving costs 60. Chemicals will still regenerate while a changeling is dead, meaning it can always enter stasis unless it's biomass levels are critical.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Deletes changeling's lesser form ability.

## Why we need to add this
Lings as an antag are already quite strong. But lesser form is just on another level of strong. And it's extremely unfun to play against. Therefore, BEGONE!

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- remove: Removes lesser form as an ability for changelings, and any reference to it.
