### PR TITLE
job-name-warden fix

### DIFF
--- a/Resources/Locale/en-US/job/job-names.ftl
+++ b/Resources/Locale/en-US/job/job-names.ftl
@@ -1,3 +1,4 @@
+job-name-warden = Warden
 job-name-assistant = Assistant
 job-name-atmostech = Atmospheric Technician
 job-name-bartender = Bartender


### PR DESCRIPTION
## Short description
fixes job-name-warden I noticed while playing on delta in the ghost select screen. apperently I accidentally dropped this line when merging. no starlight comment cause it is directly copied from upstream's FTL file.

## Why we need to add this
cause raw FTL strings look bad

## Media (Video/Screenshots)
<img width="691" height="90" alt="image" src="https://github.com/user-attachments/assets/a665c623-b36b-45af-8a1c-aa4b3087a191" />


## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
not worthy of a CL
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
