### PR TITLE
adds clumsy to trait selection

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -66,3 +66,7 @@ trait-spanish-desc = Hola señor, donde esta la biblioteca.
 
 trait-painnumbness-name = Numb
 trait-painnumbness-desc = You lack any sense of feeling pain, being unaware of how hurt you may be.
+
+## 🌟Starlight🌟
+trait-clumsy-name = Clumsy
+trait-clumsy-desc = You are a bit accident-prone

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -83,17 +83,3 @@
   category: Disabilities
   components:
   - type: PainNumbness
-
-- type: trait #starlight 
-  id: Clumsy
-  name: Clumsy
-  description: "You are a bit accident-prone."
-  category: Disabilities
-  components:
-    - type: Clumsy
-      gunShootFailDamage:
-        types: 
-          Blunt: 5
-          Piercing: 4
-        groups:
-          Burn: 3

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -83,3 +83,17 @@
   category: Disabilities
   components:
   - type: PainNumbness
+
+- type: trait #starlight 
+  id: Clumsy
+  name: Clumsy
+  description: "You are a bit accident-prone."
+  category: Disabilities
+  components:
+    - type: Clumsy
+      gunShootFailDamage:
+        types: 
+          Blunt: 5
+          Piercing: 4
+        groups:
+          Burn: 3

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -24,3 +24,17 @@
   category: Quirks
   components:
   - type: Snoring
+
+- type: trait #starlight 
+  id: Clumsy
+  name: Clumsy
+  description: "You are a bit accident-prone."
+  category: Quirks
+  components:
+    - type: Clumsy
+      gunShootFailDamage:
+        types: 
+          Blunt: 5
+          Piercing: 4
+        groups:
+          Burn: 3

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -27,8 +27,8 @@
 
 - type: trait #starlight 
   id: Clumsy
-  name: Clumsy
-  description: "You are a bit accident-prone."
+  name: trait-clumsy-name
+  description: trait-clumsy-desc
   category: Quirks
   components:
     - type: Clumsy


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
adds clumsy as a selection under quirks

## Why we need to add this
more sillies

## Media (Video/Screenshots)
<img width="337" height="130" alt="image" src="https://github.com/user-attachments/assets/85a7474a-703d-48af-a077-d7264062c8c0" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: Gensy
- add: Clumsy trait

