### PR TITLE
Slightly less heels

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -57,8 +57,6 @@
   - ClothWrap # 🌟Starlight🌟
   - ClothingUniformJumpskirtElegantMaid # 🌟Starlight🌟
   - ClothingHeadHatCatEars # 🌟Starlight🌟
-  - ClothingShoesHighheelShoes # 🌟Starlight🌟
-  - ClothingShoesHighheelBoots # 🌟Starlight🌟
   - RolliePack #SL
   - GoldRing #SL
   - SilverRing #SL
@@ -288,6 +286,7 @@
   - BrownShoes
   - WhiteShoes
   - WinterBoots
+  - Heels # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: BartenderHead
@@ -700,6 +699,7 @@
   - SalvageBoots # 🌟Starlight🌟
   - WorkBoots # 🌟Starlight🌟
   - CargoWinterBoots
+  - Heels # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: CargoTechnicianHead
@@ -739,6 +739,7 @@
   - CargoWinterBoots
   - LeatherShoes # 🌟Starlight🌟
   - WorkBoots # 🌟Starlight🌟
+  - Heels # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: SalvageSpecialistBackpack
@@ -762,6 +763,7 @@
   - SalvageBoots
   - CargoWinterBoots
   - WorkBoots # 🌟Starlight🌟
+  - HighHeelBoots # 🌟Starlight🌟
 
 # Engineering
 - type: loadoutGroup
@@ -803,6 +805,7 @@
   - BrownShoes
   - WorkBoots # 🌟Starlight🌟
   - EngineeringWinterBoots
+  - Heels # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: TechnicalAssistantJumpsuit
@@ -853,6 +856,7 @@
   loadouts:
   - WorkBoots
   - EngineeringWinterBoots
+  - Heels # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: StationEngineerID
@@ -891,6 +895,7 @@
   - WhiteShoes
   - WorkBoots # 🌟Starlight🌟
   - EngineeringWinterBoots
+  - Heels # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: SurvivalExtended
@@ -1206,7 +1211,7 @@
   loadouts:
   - JackBoots
   - SecurityWinterBoots
-  - HighHeelBoots # 🌟Starlight🌟
+  - HighHeelBootsFilled # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: SecurityPDA
@@ -1451,6 +1456,7 @@
   - BlueShoes
   - WhiteShoes
   - MedicalWinterBoots
+  - Heels # 🌟Starlight🌟
 
 - type: loadoutGroup
   id: MedicalEyewear

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -162,6 +162,7 @@
   - BotanistJumpsuit
   - BotanistBackpack
   - BotanistOuterClothing
+  - CivilianShoes
   - Glasses
   - Survival
   - Trinkets

--- a/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/botanist.yml
@@ -21,7 +21,7 @@
 - type: startingGear
   id: BotanistGear
   equipment:
-    shoes: ClothingShoesColorBrown
+    #shoes: ClothingShoesColorBrown 🌟Starlight🌟
     id: BotanistPDA
     ears: ClothingHeadsetService
     belt: ClothingBeltPlantFilled

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Shoes/highheels.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Shoes/highheels.yml
@@ -20,20 +20,3 @@
       params:
         volume: -6
         variation: 0.09
-
-- type: entity
-  parent: ClothingShoesBaseButcherable
-  id: ClothingShoesHighheelShoesAesthetic
-  name: high-heels
-  description: Snazy shoes for when you want to be stylish and noticed.
-  components:
-  - type: Sprite
-    sprite: _Starlight/Clothing/Shoes/Boots/highheelshoes.rsi
-  - type: Clothing
-    sprite: _Starlight/Clothing/Shoes/Boots/highheelshoes.rsi
-  - type: FootstepModifier
-    footstepSoundCollection:
-      collection: FootstepHighHeels
-      params:
-        volume: -6
-        variation: 0.09

--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/shoes.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/shoes.yml
@@ -2,7 +2,7 @@
   id: Heels
   equipment:
     shoes: ClothingShoesHighheelShoes
-  
+
 - type: loadout
   id: HighHeelBoots
   equipment:
@@ -32,13 +32,33 @@
   id: LeatherShoes
   equipment:
     shoes: ClothingShoesLeather
-    
+
 - type: loadout
   id: YellowShoes
   equipment:
     shoes: ClothingShoesColorYellow
-    
+
 - type: loadout
   id: GreenShoes
   equipment:
     shoes: ClothingShoesColorGreen
+
+- type: loadout
+  id: HighHeelBootsFilled
+  equipment:
+    shoes: ClothingShoesHighheelBootsFilled
+
+- type: loadout
+  id: CowboyBootsBrownFilled
+  equipment:
+    shoes: ClothingShoesBootsCowboyBrownFilled
+
+- type: loadout
+  id: CowboyBootsBlackFilled
+  equipment:
+    shoes: ClothingShoesBootsCowboyBlackFilled
+
+- type: loadout
+  id: CowboyBootsWhiteFilled
+  equipment:
+    shoes: ClothingShoesBootsCowboyWhiteFilled

--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
@@ -24,28 +24,6 @@
     - ClothingUnderSocksCoder
 
 - type: loadout
-  id: ClothingShoesHighheelBoots
-  effects:
-    - !type:JobRequirementLoadoutEffect
-      requirement:
-        !type:OverallPlaytimeRequirement
-        time: 144000 # 40hr
-  storage:
-    back:
-    - ClothingShoesHighheelBoots
-
-- type: loadout
-  id: ClothingShoesHighheelShoes
-  effects:
-    - !type:JobRequirementLoadoutEffect
-      requirement:
-        !type:OverallPlaytimeRequirement
-        time: 144000 # 40hr
-  storage:
-    back:
-    - ClothingShoesHighheelShoesAesthetic
-
-- type: loadout
   id: ClothWrap
   storage:
     back:

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -70,8 +70,8 @@
   loadouts:
   - RoboticistWeldingGoggles
   - RoboticistDiagnosticsHud
-  
-  
+
+
 - type: loadoutGroup
   id: RoboticistBackpack
   name: loadout-group-roboticist-backpack
@@ -79,7 +79,7 @@
   - RoboticistBackpack
   - RoboticistSatchel
   - RoboticistDuffel
-  
+
 - type: loadoutGroup
   id: NanoTrasenRepresentativeJumpsuit
   name: loadout-group-nanotrasenrepresentative-jumpsuit
@@ -94,7 +94,7 @@
   loadouts:
   - NanoTrasenRepresentativeGlasses
   - NanoTrasenRepresentativeHud
-  
+
 - type: loadoutGroup
   id: BlueShieldBackpack
   name: loadout-group-blueshield-backpack
@@ -119,21 +119,21 @@
   loadouts:
   - BlueShieldVest
   - BlueShieldCoat
-  
+
 - type: loadoutGroup
   id: BlueShieldNeck
   name: Loadout-group-blueshield-neck
   loadouts:
   - BlueShieldFormalCloak
   - BlueShieldEliteCloak
-  
+
 - type: loadoutGroup
   id: BlueShieldEyewear
   name: loadout-group-blueshield-eyewear
   loadouts:
   - BlueShieldGlasses
   - BlueShieldHud
-    
+
 - type: loadoutGroup
   id: SecurityNonLethalWeapon
   name: loadout-group-security-non-lethal-weapon
@@ -167,9 +167,10 @@
   - LaceupShoes
   - Heels
   - LeatherShoes
-  - CowboyBootsBrown
-  - CowboyBootsBlack
-  - CowboyBootsWhite
+  - CowboyBootsBrownFilled
+  - CowboyBootsBlackFilled
+  - CowboyBootsWhiteFilled
+  - HighHeelBootsFilled
 
 - type: loadoutGroup
   id: HoPShoes
@@ -206,11 +207,11 @@
   - JackBoots
   - SecurityWinterBoots
   - LaceupShoes
-  - CowboyBootsBrown
-  - CowboyBootsBlack
-  - CowboyBootsWhite
+  - CowboyBootsBrownFilled
+  - CowboyBootsBlackFilled
+  - CowboyBootsWhiteFilled
   - Heels
-  - HighHeelBoots
+  - HighHeelBootsFilled
 
 - type: loadoutGroup
   id: CivilianShoes
@@ -233,4 +234,11 @@
   - LaceupShoes
   - Heels
   - LeatherShoes
+
+- type: loadoutGroup
+  id: BlueShieldShoes
+  name: loadout-group-security-shoes
+  loadouts:
+  - CombatBoots
+  - HighHeelBootsFilled
 

--- a/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
@@ -20,7 +20,7 @@
   - Survival
   - Trinkets
   - GroupSpeciesBreathTool
-  
+
 - type: roleLoadout
   id: JobSurgeon
   groups:
@@ -66,6 +66,7 @@
   - BlueShieldJumpsuit
   - BlueShieldBackpack
   - BlueShieldOuterclothing
+  - BlueShieldShoes
   - BlueShieldNeck
   - BlueShieldEyewear
   - Trinkets

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
@@ -50,7 +50,6 @@
 - type: startingGear
   id: BlueShieldGear
   equipment:
-    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatBeretBlueShield
     id: BlueShieldPDA
     ears: ClothingHeadsetAltBSO # Starlight


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removed Heels from trinket loadout and instead added them to shoe selections for most roles.

## Why we need to add this
[PR 1093](https://github.com/ss14Starlight/space-station-14/pull/1093) added heels and heeled boots as trinkets to *everyone*, which is redundant with the shoe selection options already available to most roles. I had, however, apparently forgotten to add them to BSO loadouts (and botanists), which was the stated goal of 1093. As especially the boots are also a balance concern (as they can easily conceal a knife *or gun*), I have removed them from trinkets again and instead fixed the oversight of BSO and Captain not having them as loadout options (as well as Botanist getting access to all civilian shoes).
At the same time, I fixed another oversight; namely that all SEC boots normally come pre-filled with a knife, which was not the case for cowboy boots or heeled boots.

## Media (Video/Screenshots)
<img width="1223" height="572" alt="image" src="https://github.com/user-attachments/assets/2cef759c-071e-4a45-bc52-77311c935951" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- add: Botanists and BSO have been informed they can bring other shoes to work.
- remove: Crew can no longer bring a second pair of heels to work.
- fix: Sec no longer forgets to bring knives to their shift if they choose fancy boots.
