### PR TITLE
Auto assign workflow fix

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,13 +1,7 @@
 name: Auto Assign Reviewers
 
 on:
-  pull_request_target:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
-      - unlabeled
-      - ready_for_review
+- pull_request_target
 
 jobs:
   assign:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,8 +1,13 @@
 name: Auto Assign Reviewers
 
 on:
-  pull_request:
-    types: [labeled, opened, synchronize]
+  pull_request_target:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
 
 jobs:
   assign:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

It's not a content fix, it's just Github workflow fix, fixes:
- github access issues when just regular contibutor without access creates pr and auto-assign don't have enought rights.
- not enought events like opened/reopened/labeled/unlabeled/ready_for_review.
