### PR TITLE
Fix profile editor not representing true scale for width/height

### DIFF
--- a/Content.Client/Lobby/UI/ProfileEditorControls/ProfilePreviewSpriteView.cs
+++ b/Content.Client/Lobby/UI/ProfileEditorControls/ProfilePreviewSpriteView.cs
@@ -60,6 +60,8 @@ public sealed partial class ProfilePreviewSpriteView : SpriteView
         _prototypeManager = protoMan;
         _playerManager = playerMan;
         _metaDataSystem = EntMan.System<MetaDataSystem>();
+
+        Stretch = StretchMode.None; //starlight
     }
 
     /// <summary>


### PR DESCRIPTION
## Short description
Previously the profile editor character preview scaled sprites to fit the viewport, which meant that the character editor only visually appeared to display the "ratio" of width to height, with no visual indication as to how large a character actually is.

Change removes any scaling to fit, so that small characters visually appear smaller than large characters in the profile editor.

## Why we need to add this

There was a bug report raised mistaking the scaling to fit as "reducing character width makes it taller in the profile editor"

Because there is no physical reference to gauge against it isn't really a true scale indicator, but hopefully this will reduce confusion a bit

## Media (Video/Screenshots)
<img width="1352" height="649" alt="Screenshot_20250731_142338" src="https://github.com/user-attachments/assets/8ddda195-39cd-4995-b738-aff21f7a776a" />
<img width="1376" height="650" alt="Screenshot_20250731_142345" src="https://github.com/user-attachments/assets/c5048633-ced9-49b2-92ea-76fef4588551" />
(currently in delta these two characters would look exactly the same in size in the profile editor)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.