### PR TITLE
Remove AdminOOC colour restriction

### DIFF
--- a/Content.Server/Administration/Commands/SetAdminOOC.cs
+++ b/Content.Server/Administration/Commands/SetAdminOOC.cs
@@ -35,14 +35,6 @@ namespace Content.Server.Administration.Commands
                 return;
             }
 
-            var luminance = (0.2126f * color.Value.R) + (0.7152f * color.Value.G) + (0.0722f * color.Value.B);
-
-            if (luminance is < 0.2f or > 0.8f)
-            {
-                shell.WriteError("The color is too close to black or white — pick a more contrasting shade.");
-                return;
-            }
-
             var userId = shell.Player.UserId;
             // Save the DB
             _dbManager.SaveAdminOOCColorAsync(userId, color.Value);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes the colour restriction for admin OOC colours

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
If an admin is using a colour that they shouldn't, you can just... tell them?
This system has too many false positives. For example, #FFC0CB (transflag pink) is identified as "too close to white".
<img width="221" height="136" alt="image" src="https://github.com/user-attachments/assets/a692047c-8d90-48bc-bd3d-cef666bf3b0b" />
The hell it ain't.

Also, the message had an invalid character; causing `grep` (and potentially other tools?) to identify it, or at least that line, as a binary file. Not good!

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Fractalflower
- remove: AdminOOC no longer has a colour restriction
