### PR TITLE
Sizes 1984

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -57,11 +57,11 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         //starlight start
         if (humanoidAppearance.EyeGlowing)
             sprite.LayerSetShader(HumanoidVisualLayers.Eyes, "unshaded");
-        else 
+        else
             if(_sprite.LayerMapTryGet((entity.Owner, sprite), HumanoidVisualLayers.Eyes, out var layerIndex, true))
                 sprite.LayerSetShader(layerIndex, (ShaderInstance?)null);
 
-        sprite.Scale = new Vector2(humanoidAppearance.Width, humanoidAppearance.Height);
+        sprite.Scale = new Vector2(humanoidAppearance.Width * humanoidAppearance.Height, humanoidAppearance.Height);
         //starlight end
     }
 
@@ -249,7 +249,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
         {
             return;
         }
-        
+
         humanoid.CustomBaseLayers = layers;
         UpdateSprite((uid, humanoid, Comp<SpriteComponent>(uid)));
     }

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -484,7 +484,7 @@ namespace Content.Client.Lobby.UI
             Markings.OnMarkingRankChange += OnMarkingChange;
 
             #endregion Markings
-            
+
             // Starlight
             #region Cybernetics
             TabContainer.SetTabTitle(5, Loc.GetString("humanoid-profile-editor-cybernetics-tab"));
@@ -1333,8 +1333,8 @@ namespace Content.Client.Lobby.UI
         private void UpdateSizeText() {
             if(Profile is null) return;
             if (_prototypeManager.TryIndex<SpeciesPrototype>(Profile.Species, out var speciesPrototype)) {
-                var height = speciesPrototype.StandardSize * Profile.Appearance.Height;
-                var weight = speciesPrototype.StandardWeight + speciesPrototype.StandardDensity * ((Profile.Appearance.Width * Profile.Appearance.Height) - 1);
+                var height = speciesPrototype.StandardSize * (Profile.Appearance.Height - 1f) * 2f + speciesPrototype.StandardSize;
+                var weight = speciesPrototype.StandardWeight + speciesPrototype.StandardDensity * (Profile.Appearance.Width * Profile.Appearance.Height * Profile.Appearance.Height - 1);
                 HeightDescribeLabel.Text = Loc.GetString("humanoid-profile-editor-height-label", ("height", Math.Round(height)));
                 WidthDescribeLabel.Text = Loc.GetString("humanoid-profile-editor-width-label", ("weight", Math.Round(weight, 1)));
             }
@@ -1496,7 +1496,7 @@ namespace Content.Client.Lobby.UI
                 HeightSlider.MinValue = speciesPrototype.MinHeight;
                 HeightSlider.MaxValue = speciesPrototype.MaxHeight;
                 HeightSlider.Value = Profile.Appearance.Height;
-                
+
                 UpdateSizeText();
             }
         }

--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -143,13 +143,13 @@ public sealed partial class SpeciesPrototype : IPrototype
     ///     Characters must not crumple under earth-like gravity.
     /// </summary>
     [DataField]
-    public float MinWidth = 0.8f;
+    public float MinWidth = 0.9f;
 
     /// <summary>
     ///     Characters must not exhibit a measurable gravitational pull on nearby objects.
     /// </summary>
     [DataField]
-    public float MaxWidth = 1.2f;
+    public float MaxWidth = 1.1f;
 
     /// <summary>
     ///     The normal width for this species.
@@ -161,13 +161,13 @@ public sealed partial class SpeciesPrototype : IPrototype
     ///     Sentient microbial lifeforms are not currently hireable under contract.
     /// </summary>
     [DataField]
-    public float MinHeight = 0.8f;
+    public float MinHeight = 0.9f;
 
     /// <summary>
     ///     You cannot fit in our cloning pods.
     /// </summary>
     [DataField]
-    public float MaxHeight = 1.2f;
+    public float MaxHeight = 1.1f;
 
     /// <summary>
     ///     The normal height for this species.

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -7,10 +7,10 @@
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobDwarfDummy
   skinColoration: HumanToned
-  customName: true # Starlight
-  minWidth: 0.9 # Starlight
-  defaultWidth: 1 # Starlight
-  maxWidth: 1.2 # Starlight
-  minHeight: 0.6 # Starlight
-  defaultHeight: 0.8 # Starlight
-  maxHeight: 0.8 # Starlight
+  customName: true # Starlight start
+  minWidth: 1.2
+  defaultWidth: 1.2
+  maxWidth: 1.5
+  minHeight: 0.75
+  defaultHeight: 0.8
+  maxHeight: 0.85 # Starlight end

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -11,6 +11,6 @@
   minWidth: 1.2
   defaultWidth: 1.2
   maxWidth: 1.5
-  minHeight: 0.75
+  minHeight: 0.8
   defaultHeight: 0.8
   maxHeight: 0.85 # Starlight end

--- a/Resources/Prototypes/Species/resomi.yml
+++ b/Resources/Prototypes/Species/resomi.yml
@@ -17,12 +17,6 @@
   oldAge: 257
   maxAge: 430
   customName: true # Starlight
-  minWidth: 0.9
-  defaultWidth: 1
-  maxWidth: 1.2
-  minHeight: 0.8
-  defaultHeight: 1
-  maxHeight: 1.1
   standardSize: 150
   standardWeight: 40
   standardDensity: 17

--- a/Resources/Prototypes/_StarLight/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Species/avali.yml
@@ -16,9 +16,6 @@
   youngAge: 103
   oldAge: 257
   maxAge: 430
-  minWidth: 0.8
-  defaultWidth: 0.91
-  maxWidth: 1
   minHeight: 0.8
   defaultHeight: 0.91
   maxHeight: 1

--- a/Resources/Prototypes/_StarLight/Species/cyclorite.yml
+++ b/Resources/Prototypes/_StarLight/Species/cyclorite.yml
@@ -12,12 +12,9 @@
   femaleFirstNames: names_cyclorite
   naming: First
   customName: true
-  minWidth: 0.9
-  defaultWidth: 1
-  maxWidth: 1.25
   minHeight: 0.9
   defaultHeight: 1
-  maxHeight: 1.25
+  maxHeight: 1.15
   standardSize: 170
   standardWeight: 100
   standardDensity: 110

--- a/Resources/Prototypes/_StarLight/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Species/felionoid.yml
@@ -12,10 +12,7 @@
   femaleFirstNames: names_felionoid
   naming: First
   customName: true
-  minWidth: 0.7
-  defaultWidth: 0.8
-  maxWidth: 0.9
-  minHeight: 0.7
+  minHeight: 0.8
   defaultHeight: 0.8
   maxHeight: 0.9
   standardSize: 170

--- a/Resources/Prototypes/_StarLight/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_StarLight/Species/vulpkanin.yml
@@ -13,7 +13,7 @@
   customName: true
   minHeight: 0.9
   defaultHeight: 1
-  maxHeight: 1.25
+  maxHeight: 1.15
   standardSize: 170
   standardWeight: 75
   standardDensity: 110


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
- Now makes width value change character width *relative* to height rather than being an absolute value, so no more ridiculous min-maxxing (i.e. a character with 0 height and xyz width will have the same sprite scale ratio as a character with 1 billion height and the same xyz width), this is how it should always have been
- Basically nuke all the max width/height values to be roughly half of what they are now (still enough to be noticable, but more nuanced now)
- felionoids cannot go smaller than 0.8, in order to stop them on average becoming even smaller than they are now
- edit the pretty cm/kg equation in the profile editor so that it looks like Nothing Ever Happened

## Why we need to add this
shit's fucked

## Media (Video/Screenshots)
<img width="884" height="584" alt="Screenshot_20250801_180140" src="https://github.com/user-attachments/assets/0f9da421-0820-43ba-bff2-357b0f6d2cd2" />
max/min/norm/max dwarf

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- tweak: 1984 the character min/max sizes to something more reasonable
- tweak: Width slider now acts more like an "aspect ratio" slider to stop goofy min width max height characters
