### PR TITLE
Nerf Dragon, buff carp

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -181,6 +181,18 @@
     - type: HTN
       rootTask:
         task: DragonCarpCompound
+   #Starlight
+    - type: Flammable
+      damage:
+        types: {}
+    - type: Damageable
+      damageModifierSet: DragonCarpResistances
+    - type: Prying
+      pryPowered: true
+      force: true
+      speedModifier: 1.5 # faster because carp are kinda strong
+      useSound:
+         path: /Audio/Items/crowbar.ogg 
 
 - type: entity
   id: MobCarpDungeon

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -55,7 +55,7 @@
   flatReductions:
     Piercing: 4
   coefficients:
-    Piercing: 0.2
+    Piercing: 0.3
     Slash: 2
     Heat: 0.5
     Bloodloss: 0

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -53,9 +53,19 @@
 - type: damageModifierSet
   id: DragonResistances
   flatReductions:
-    Piercing: 10
+    Piercing: 4
   coefficients:
-    Piercing: 0.25
+    Piercing: 0.2
     Slash: 2
-    Heat: 0
+    Heat: 0.5
+    Bloodloss: 0
+
+- type: damageModifierSet
+  id: DragonCarpResistances
+  flatReductions:
+    Piercing: 2.5
+  coefficients:
+    Piercing: 0.5
+    Slash: 2
+    Heat: 0.75
     Bloodloss: 0


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Makes dragon less resistant to pierce and heat, to compensate makes the carp more resistant (and gives them QOL like prying and such)
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Dragon was way overtuned and forces evac with literally no skill
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.-->

:cl: PubliclyExecutedPig
- fix: Fixed dragons being wayyy too powerful
- tweak: Buffed carp a little to encourage actual strategy instead of just running in

