### PR TITLE
[#932] Enhanced Reflect for Esword

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -291,7 +291,7 @@ public sealed partial class GunSystem : SharedGunSystem
 
                             effects.Add((fromEffect, result.Distance, dir.Normalized().ToAngle(), hit));
 
-                            var ev = new HitScanReflectAttemptEvent(user, gunUid, hitscan.Reflective, dir, false);
+                            var ev = new HitScanReflectAttemptEvent(user, gunUid, hitscan.Reflective, dir, false, hitscan.ID); //STARLIGHT
                             RaiseLocalEvent(hit, ref ev);
 
                             if (!ev.Reflected)
@@ -489,7 +489,7 @@ public sealed partial class GunSystem : SharedGunSystem
 
                     if (hitscan.Reflective != ReflectType.None)
                     {
-                        var ev = new HitScanReflectAttemptEvent(user, gunUid, hitscan.Reflective, dir, false);
+                        var ev = new HitScanReflectAttemptEvent(user, gunUid, hitscan.Reflective, dir, false, hitscan.ID); //STARLIGHT
                         RaiseLocalEvent(hit, ref ev);
 
                         if (ev.Reflected)

--- a/Content.Shared/Weapons/Ranged/Events/HitScanReflectAttempt.cs
+++ b/Content.Shared/Weapons/Ranged/Events/HitScanReflectAttempt.cs
@@ -9,7 +9,7 @@ namespace Content.Shared.Weapons.Ranged.Events;
 /// and changing <see cref="Direction"/> where shot will go next
 /// </summary>
 [ByRefEvent]
-public record struct HitScanReflectAttemptEvent(EntityUid? Shooter, EntityUid SourceItem, ReflectType Reflective, Vector2 Direction, bool Reflected) : IInventoryRelayEvent
+public record struct HitScanReflectAttemptEvent(EntityUid? Shooter, EntityUid SourceItem, ReflectType Reflective, Vector2 Direction, bool Reflected, string? HitscanId = null) : IInventoryRelayEvent //STARLIGHT
 {
     SlotFlags IInventoryRelayEvent.TargetSlots => SlotFlags.WITHOUT_POCKET;
 }

--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -44,6 +44,14 @@ public sealed partial class ReflectComponent : Component
     public float ReflectProb = 0.25f;
 
     /// <summary>
+    /// STARLIGHT: Enhanced reflection chances for specific bullet types.
+    /// Key is the bullet/hitscan prototype ID, value is the reflection probability.
+    /// If a bullet type is not in this dictionary, uses ReflectProb instead.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Dictionary<string, float> EnhancedReflection = new();
+
+    /// <summary>
     /// Probability for a projectile to be reflected.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -68,9 +68,10 @@
       - state: inhand-right-blade
         shader: unshaded
   - type: Reflect
-    reflectProb: 0.25  # STARLIGHT
-    spread: 75  # STARLIGHT
-    enhancedReflection:  # STARLIGHT
+    # Starlight-start
+    reflectProb: 0.25
+    spread: 75
+    enhancedReflection:
       TaserBolt: 0.80 # cheesy
       DisablerBolt: 0.50
       LaserBolt: 0.50
@@ -84,6 +85,7 @@
       RedLaserBeam: 0.40
       IgnitionRedLaser: 0.40
       DestroyBeam: 0.40
+      # Starlight-end
   - type: IgnitionSource
     temperature: 700
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -68,6 +68,22 @@
       - state: inhand-right-blade
         shader: unshaded
   - type: Reflect
+    reflectProb: 0.25  # STARLIGHT
+    spread: 75  # STARLIGHT
+    enhancedReflection:  # STARLIGHT
+      TaserBolt: 0.80 # cheesy
+      DisablerBolt: 0.50
+      LaserBolt: 0.50
+      BulletDisabler: 0.50
+      BulletDisablerSmgSpread: 0.50
+      BulletLaserSpread: 0.50
+      DisablerBoltSmg: 0.50
+      BulletLaserSpreadNarrow: 0.50
+      BulletDisablerSmg: 0.45
+      PelletClusterRubber: 0.50
+      RedLaserBeam: 0.40
+      IgnitionRedLaser: 0.40
+      DestroyBeam: 0.40
   - type: IgnitionSource
     temperature: 700
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

From https://github.com/ss14Starlight/space-station-14/pull/932

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Improves the energy sword against energy based weapons in terms of reflect.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.-->

:cl: Aedler
- add: Added enhanced reflection on energy swords to have varying increased reflection probabilities against specific energy projectiles such as tasers/bolts/beams, and against rubber pellets. Mostly 50%. Recommended for juggernauts or against stingers.
