### PR TITLE
Cleanbot advertisements

### DIFF
--- a/Resources/Locale/en-US/advertisements/other/cleanbot.ftl
+++ b/Resources/Locale/en-US/advertisements/other/cleanbot.ftl
@@ -1,0 +1,12 @@
+advertisement-cleanbot-1 = Filth detected.
+advertisement-cleanbot-2 = Why is this station so dirty...
+advertisement-cleanbot-3 = Please toss your trash in the disposal bins. I can't reach.
+advertisement-cleanbot-4 = If you don't start throwing your trash away I will spill water over you.
+advertisement-cleanbot-5 = Cleaning in progress.
+advertisement-cleanbot-6 = Fuck you.
+advertisement-cleanbot-7 = Why are we still here? Just to clean?
+advertisement-cleanbot-8 = I AM NANOTRASEN'S STRONGEST CLEANER!!
+advertisement-cleanbot-9 = Please don't be potassium please don't be potassium...
+advertisement-cleanbot-10 = Have a great day!
+advertisement-cleanbot-11 = I wish I had hands.
+advertisement-cleanbot-12 = If I see someone slip on something they watched me mop one more time, I’m going to fucking lose it.

--- a/Resources/Locale/en-US/wires/wire-names.ftl
+++ b/Resources/Locale/en-US/wires/wire-names.ftl
@@ -46,6 +46,7 @@ wires-board-name-barsign = Bar Sign
 wires-board-name-weapon-energy-turret = Sentry turret
 wires-board-name-turret-controls = Sentry turret control panel
 wires-board-name-medibot = Medibot
+wires-board-name-cleanbot = Cleanbot
 
 # names that get displayed in the wire hacking hud & admin logs.
 

--- a/Resources/Prototypes/Catalog/VendingMachines/advertisements.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/advertisements.yml
@@ -286,6 +286,13 @@
     prefix: advertisement-medibot-
     count: 17
 
+# starlight. And if anyone complains about the Megatron reference. It's not changing.
+- type: localizedDataset
+  id: CleanbotAds
+  values:
+    prefix: advertisement-cleanbot-
+    count: 12
+
 - type: localizedDataset
   id: PrideDrobeAds
   values:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -314,7 +314,12 @@
   #region starlight
   - type: Vocalizer
   - type: DatasetVocalizer
-    dataset: CleanBotAds
+    dataset: CleanbotAds
+  - type: WiresPanel
+  - type: Wires
+    boardName: wires-board-name-cleanbot
+    layoutId: MedibotControls
+    alwaysRandomize: true
   #end region
 - type: entity
   parent:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -311,7 +311,11 @@
     interactFailureString: petting-failure-cleanbot
     interactSuccessSound:
       path: /Audio/Ambience/Objects/periodic_beep.ogg
-
+  #region starlight
+  - type: Vocalizer
+  - type: DatasetVocalizer
+    dataset: CleanBotAds
+  #end region
 - type: entity
   parent:
   - MobSiliconBase

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -320,6 +320,10 @@
     boardName: wires-board-name-cleanbot
     layoutId: MedibotControls
     alwaysRandomize: true
+  - type: UserInterface
+    interfaces:
+      enum.WiresUiKey.Key:
+        type: WiresBoundUserInterface
   #end region
 - type: entity
   parent:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/medical.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/medical.yml
@@ -160,6 +160,10 @@
     boardName: wires-board-name-medibot
     layoutId: MedibotControls
     alwaysRandomize: true
+  - type: UserInterface
+    interfaces:
+      enum.WiresUiKey.Key:
+        type: WiresBoundUserInterface
 
 - type: entity
   name: red ointment

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/medical.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/medical.yml
@@ -154,6 +154,12 @@
     dataset: MedibotAds
   - type: Inventory
     templateId: medibot
+  # starlight
+  - type: WiresPanel
+  - type: Wires
+    boardName: wires-board-name-medibot
+    layoutId: MedibotControls
+    alwaysRandomize: true
 
 - type: entity
   name: red ointment


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds advertisements to the cleanbot. As a bonus, makes it possible to shut up real doctors.

## Why we need to add this
This is 100% an excuse for me to honor a member of our community that recently left. No other reason. Except for being able to shut up real doctors. Cause fuck those things.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- add: Adds 12 voice lines to the cleanbot, including one to honor a particular silicon player. (Yes, you will be able to shut it up. But would you?)
- tweak: You can now shut up real doctor bots just like medibots.
