### PR TITLE
Commie radio channel.

### DIFF
--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -157,6 +157,27 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
         // Show the silicon has been subverted.
         component.Subverted = true;
 
+        #region Starlight: Add the new channel to the silicon.
+        var emag = args.emagComp;
+        if (emag != null)
+        {
+            if (TryComp(uid, out ActiveRadioComponent? activeRadio))
+            {
+                activeRadio.Channels.UnionWith(emag.ChannelAdd.Select(item => item.Id.ToString()).ToHashSet());
+            }
+            if (TryComp(uid, out IntrinsicRadioTransmitterComponent? transmitter))
+            {
+                transmitter.Channels.UnionWith(emag.ChannelAdd.Select(item => item.Id.ToString()).ToHashSet());
+            }
+            var lawset = emag.Lawset;
+            if (lawset != null)
+            {
+                component.Lawset = GetLawset(lawset.Value);
+                return;
+            }
+        }
+        #endregion
+
         // Add the first emag law before the others
         component.Lawset?.Laws.RemoveAt(0);
 
@@ -173,17 +194,6 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
             LawString = Loc.GetString("law-emag-secrecy", ("faction", Loc.GetString(component.Lawset.ObeysTo))),
             Order = component.Lawset.Laws.Max(law => law.Order) + 1
         });
-
-        //Starlight: Add the syndicate channel to the silicon.
-        //TODO: When different types of emags are added, update this.
-        if (TryComp(uid, out ActiveRadioComponent? activeRadio))
-        {
-            activeRadio.Channels.Add("Syndicate");
-        }
-        if (TryComp(uid, out IntrinsicRadioTransmitterComponent? transmitter))
-        {
-            transmitter.Channels.Add("Syndicate");
-        }
     }
 
     protected override void EnsureSubvertedSiliconRole(EntityUid mindId)

--- a/Content.Shared/Emag/Components/EmagComponent.cs
+++ b/Content.Shared/Emag/Components/EmagComponent.cs
@@ -5,7 +5,8 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization;
-using Content.Shared.Silicons.Laws; //#Starlight
+using Content.Shared.Silicons.Laws;
+using Content.Shared.Radio; //#Starlight
 
 namespace Content.Shared.Emag.Components;
 
@@ -55,5 +56,11 @@ public sealed partial class EmagComponent : Component
     /// </summary>
     [DataField]
     public ComponentRegistry? Components = null;
+
+    /// <summary>
+    /// What radio channels should be added to a emagged borg chassis
+    /// </summary>
+    [DataField]
+    public HashSet<ProtoId<RadioChannelPrototype>> ChannelAdd = ["Syndicate"];
     //#endregion Starlight
 }

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Stunnable;
 using Content.Shared.Wires;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes; // Starlight
+using Content.Shared.Emag.Components; //Starlight
 
 namespace Content.Shared.Silicons.Laws;
 
@@ -61,16 +62,12 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
                 RemComp<BorgTransponderComponent>(uid);
             }
 
-
-            if (args.EmagComponent.Lawset != null)
-                proto = _prototype.Index<SiliconLawsetPrototype>(args.EmagComponent.Lawset);
-
             if (args.EmagComponent.Components != null)
                 _entMan.AddComponents(uid, args.EmagComponent.Components);
         }
         //#endregion Starlight
 
-            var ev = new SiliconEmaggedEvent(args.UserUid, proto); // Starlight
+        var ev = new SiliconEmaggedEvent(args.UserUid, args.EmagComponent); // Starlight
         RaiseLocalEvent(uid, ref ev);
 
         component.OwnerName = Name(args.UserUid);
@@ -101,4 +98,4 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
 }
 
 [ByRefEvent]
-public record struct SiliconEmaggedEvent(EntityUid user, SiliconLawsetPrototype? lawset);
+public record struct SiliconEmaggedEvent(EntityUid user, EmagComponent? emagComp);

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Tools/emag.yml
@@ -7,10 +7,13 @@
   components:
   - type: Emag
     lawset: CommiemovLawset
-    components: 
+    components:
       - type: ShowAntagIcons # behold. you can now see revs.
+    channelAdd:
+      - Soviet # Report in comrade.
   - type: Sprite
     sprite: _Starlight/Objects/Tools/emag.rsi
+    state: icon
   - type: Item
     sprite: _Starlight/Objects/Tools/emag.rsi
   - type: LimitedCharges


### PR DESCRIPTION
## Short description
Report in comrade

## Why we need to add this
fixes the sprite of the commie-emag and makes it add stations

## Media (Video/Screenshots)
<img width="647" height="829" alt="image" src="https://github.com/user-attachments/assets/4e3dc22d-455a-4448-9a4b-df291d1ecee8" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: Using a wooden emag on borgs adds soviet emag
- fix: Wooden Emag is now visible
