### PR TITLE
Fix for #910 - Update SharedSurgerySystem.BaseSteps.cs

### DIFF
--- a/Content.Shared/_Starlight/Medical/Surgery/SharedSurgerySystem.BaseSteps.cs
+++ b/Content.Shared/_Starlight/Medical/Surgery/SharedSurgerySystem.BaseSteps.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.Body.Part;
+﻿using Content.Shared.Atmos.Components;
+using Content.Shared.Body.Part;
 using Content.Shared.Buckle.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.Inventory;
@@ -151,16 +152,21 @@ public abstract partial class SharedSurgerySystem
         
         if (_inventory.TryGetContainerSlotEnumerator(args.Body, out var enumerator, args.TargetSlots))
         {
-            var items = 0f;
-            var total = 0f;
+            var hasBlockingItems = false;
             while (enumerator.MoveNext(out var con))
             {
-                total++;
                 if (con.ContainedEntity != null)
-                    items++;
+                {
+                    // Allow medical masks (items with BreathToolComponent) for head surgeries
+                    if (con.ID == "mask" && HasComp<BreathToolComponent>(con.ContainedEntity.Value))
+                        continue;
+                    
+                    hasBlockingItems = true;
+                    break;
+                }
             }
 
-            if (items > 0)
+            if (hasBlockingItems)
             {
                 args.Invalid = StepInvalidReason.Armor;
                 args.Popup = $"You need to take off armor from patient to perform this step!";


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->




                                                                                                                                                                                                                                                                                                                 ## Short description
<!-- What do you propose to change with your PR? -->
 Allow medical masks with BreathToolComponent during head surgeries while still blocking other equipment.
Fixes #910

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Fixes #910
This enables proper anesthetic delivery during eye operations without compromising surgical safety.

- Modified surgery validation logic to check for BreathToolComponent on masks
                                                                                                                                                                                                                                                   - Medical masks (ClothingMaskBreathMedical, ClothingMaskBreathMedicalSecurity) now allowed
                                                                                                                                                                                                                                    - Other blocking equipment still prevented as intended

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ x] I do not require assistance to complete the PR.
- [ x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Magwitch
- Fixes #910 
- Modified surgery validation logic to check for BreathToolComponent on masks                                                                                                                                                                                                                                               - Medical masks (ClothingMaskBreathMedical, ClothingMaskBreathMedicalSecurity) now allowed                                                                                                                                                                                                                                  - Other blocking equipment still prevented as intended
