### PR TITLE
Emaggable mail

### DIFF
--- a/Content.Shared/Delivery/DeliverySpawnerComponent.cs
+++ b/Content.Shared/Delivery/DeliverySpawnerComponent.cs
@@ -40,4 +40,13 @@ public sealed partial class DeliverySpawnerComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier? OpenSound = new SoundCollectionSpecifier("storageRustle");
+
+    #region Starlight
+
+    /// <summary>
+    /// the table to switch to when this device is emagged. if it is null cant be emagged.
+    /// </summary>
+    [DataField]
+    public EntityTableSelector? EmagTable;
+    #endregion
 }

--- a/Content.Shared/Delivery/SharedDeliverySystem.cs
+++ b/Content.Shared/Delivery/SharedDeliverySystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
+using Content.Shared.Emag.Systems; //Starlight
 
 namespace Content.Shared.Delivery;
 
@@ -31,7 +32,7 @@ public abstract class SharedDeliverySystem : EntitySystem
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly NameModifierSystem _nameModifier = default!;
-
+    [Dependency] private readonly EmagSystem _emag = default!; //Starlight
     private static readonly ProtoId<TagPrototype> TrashTag = "Trash";
     private static readonly ProtoId<TagPrototype> RecyclableTag = "Recyclable";
 
@@ -47,6 +48,8 @@ public abstract class SharedDeliverySystem : EntitySystem
 
         SubscribeLocalEvent<DeliverySpawnerComponent, ExaminedEvent>(OnSpawnerExamine);
         SubscribeLocalEvent<DeliverySpawnerComponent, GetVerbsEvent<AlternativeVerb>>(OnGetSpawnerVerbs);
+
+        SubscribeLocalEvent<DeliverySpawnerComponent, GotEmaggedEvent>(OnGotEmagged); //Starlight
     }
 
     private void OnDeliveryExamine(Entity<DeliveryComponent> ent, ref ExaminedEvent args)
@@ -288,6 +291,18 @@ public abstract class SharedDeliverySystem : EntitySystem
 
         return totalMultiplier;
     }
+
+    #region Starlight
+    protected void OnGotEmagged(Entity<DeliverySpawnerComponent> deliverySpawner, ref GotEmaggedEvent args)
+    {
+        if (!_emag.CompareFlag(args.Type, EmagType.Interaction))
+            return;
+        var emagTable = deliverySpawner.Comp.EmagTable;
+        if (emagTable != null)
+            deliverySpawner.Comp.Table = emagTable;
+        args.Handled = true;
+    }
+    #endregion
 
     protected virtual void GrantSpesoReward(Entity<DeliveryComponent?> ent) { }
 

--- a/Resources/Prototypes/Entities/Structures/Machines/mail_teleporter.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/mail_teleporter.yml
@@ -52,3 +52,5 @@
   - type: DeliverySpawner
     table: !type:NestedSelector
       tableId: RandomDeliveryBasic
+    emagTable: !type:NestedSelector #Starlight
+      tableId: RandomDeliveryEvil #Starlight

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_tables.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_tables.yml
@@ -1,0 +1,111 @@
+### Spawners
+- type: entityTable
+  id: RandomDeliveryEvil
+  table: !type:GroupSelector
+    children:
+    - !type:NestedSelector
+      tableId: RandomDeliveryLetterEvil
+      weight: 0.7
+    - !type:NestedSelector
+      tableId: RandomDeliveryPackageEvil
+      weight: 0.3
+
+# Letters
+
+- type: entityTable # Used to pick between all different letter types, if there will be more
+  id: RandomDeliveryLetterEvil
+  table: !type:GroupSelector
+    children:
+    - id: LetterDeliveryEvil
+
+# Packages
+
+- type: entityTable # Used to pick between all different package types, if there will be more
+  id: RandomDeliveryPackageEvil
+  table: !type:GroupSelector
+    children:
+    - id: PackageDeliveryEvil
+
+### Reward Tables
+
+- type: entityTable
+  id: LetterDeliveryRewardsEvil
+  table: !type:GroupSelector
+    children:
+    - !type:NestedSelector
+      tableId: LetterCommonEntityTableEvil
+      weight: 0.6
+    - !type:NestedSelector
+      tableId: LetterUncommonEntityTable
+      weight: 0.1
+    - !type:NestedSelector
+      tableId: LetterRareEntityTable
+      weight: 0.3
+
+- type: entityTable
+  id: PackageDeliveryRewardsEvil
+  table: !type:GroupSelector
+    children:
+    - !type:NestedSelector
+      tableId: PackageCommonEntityTable
+      weight: 0.4
+    - !type:NestedSelector
+      tableId: PackageUncommonEntityTable
+      weight: 0.3
+    - !type:NestedSelector
+      tableId: PackageRareEntityTable
+      weight: 0.3
+
+### Loot Tables
+# Letters
+- type: entityTable
+  id: LetterCommonEntityTableEvil # Basically trash and spam mail, maybe something barely useful here and there
+  table: !type:GroupSelector
+    children:
+    - !type:NestedSelector
+      weight: .5
+      tableId: SpamMailTableEvil
+    - !type:NestedSelector
+      weight: .1
+      tableId: RandomBookTable
+    - !type:NestedSelector
+      weight: .2
+      tableId: RandomSnackTable
+    - !type:NestedSelector
+      weight: .2
+      tableId: RandomAllSodaTable
+
+# Packages
+# TODO: Currently mostly maints loot, should be updated in the future.
+- type: entityTable # TODO: Add more variety!
+  id: PackageCommonEntityTable
+  table: !type:GroupSelector
+    children:
+    - !type:NestedSelector
+      tableId: MaintToolsTable
+      weight: .25
+      rolls: !type:RangeNumberSelector
+        range: 1, 2
+    - !type:NestedSelector
+      tableId: FoodRandomCakeTable
+      weight: .5
+    - id: FoodBoxPizzaFilled
+      weight: .25
+
+- type: entityTable
+  id: PackageUncommonEntityTable
+  table: !type:GroupSelector
+    children:
+    - !type:NestedSelector
+      tableId: MaintFluffTable
+      weight: 0.4
+      rolls: !type:RangeNumberSelector
+        range: 1, 2
+    - !type:NestedSelector
+      tableId: AllPlushiesTable
+      weight: 0.4
+    - !type:NestedSelector
+      tableId: RandomAllAlcoholTable
+      weight: 0.2
+      rolls: !type:RangeNumberSelector
+        range: 2, 3

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/letter_loot_tables.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/letter_loot_tables.yml
@@ -1,3 +1,16 @@
+
+# Common
+- type: entityTable
+  id: SpamMailTableEvil
+  table: !type:GroupSelector
+    children:
+      - id: MailSpamLetter
+        weight: .83
+      - !type:NestedSelector
+        tableId: MailAntagSpamLetter
+        weight: .17
+
+
 # all the letters here should have a `AntagOnSign` component of some sort so that when they are signed it can antag them
 
 - type: entityTable

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/letter_loot_tables.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/letter_loot_tables.yml
@@ -8,7 +8,7 @@
         weight: .83
       - !type:NestedSelector
         tableId: MailAntagSpamLetter
-        weight: .17
+        weight: .17 #pre-nerf antag mail chance
 
 
 # all the letters here should have a `AntagOnSign` component of some sort so that when they are signed it can antag them


### PR DESCRIPTION
## Short description
Emagged Mail teleporters now have a diffrent loot table then normal

## Why we need to add this
adds another niche emag interaction for traitors that do it. this one is V E R Y subtle but honestly may have the biggest impact ona  round tbh.

## Media (Video/Screenshots)
N/A all code-wise nothing a player could physically see

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: Cargo's Mail teleporter can now be emagged to re-weight it's tables towards more chaotic and evil items
