### PR TITLE
Fix kudzu to check for neighboring entity not grid

### DIFF
--- a/Content.Server/Spreader/SpreaderSystem.cs
+++ b/Content.Server/Spreader/SpreaderSystem.cs
@@ -298,7 +298,7 @@ public sealed class SpreaderSystem : EntitySystem
     public void ActivateSpreadableNeighbors(EntityUid uid, (EntityUid Grid, Vector2i Tile)? position = null)
     {
         Vector2i tile;
-        EntityUid ent;
+        EntityUid gridId;
         MapGridComponent? grid;
 
         if (position == null)
@@ -308,35 +308,36 @@ public sealed class SpreaderSystem : EntitySystem
                 return;
 
             tile = _map.TileIndicesFor(transform.GridUid.Value, grid, transform.Coordinates);
-            ent = transform.GridUid.Value;
+            gridId = transform.GridUid.Value;
         }
         else
         {
             if (!TryComp(position.Value.Grid, out grid))
                 return;
-            (ent, tile) = position.Value;
+            (gridId, tile) = position.Value;
         }
 
-        var anchored = _map.GetAnchoredEntitiesEnumerator(ent, grid, tile);
+        // Reactivate spreaders on the same tile.
+        var anchored = _map.GetAnchoredEntitiesEnumerator(gridId, grid, tile);
         while (anchored.MoveNext(out var entity))
         {
-            if (entity == ent)
+            if (entity == uid)
                 continue;
-            DebugTools.Assert(Transform(entity.Value).Anchored);
-            if (_query.HasComponent(ent) && !TerminatingOrDeleted(entity.Value))
+
+            if (_query.HasComponent(entity.Value) && !TerminatingOrDeleted(entity.Value))
                 EnsureComp<ActiveEdgeSpreaderComponent>(entity.Value);
         }
 
+        // Reactivate spreaders on adjacent tiles.
         for (var i = 0; i < Atmospherics.Directions; i++)
         {
             var direction = (AtmosDirection) (1 << i);
-            var adjacentTile = SharedMapSystem.GetDirection(tile, direction.ToDirection());
-            anchored = _map.GetAnchoredEntitiesEnumerator(ent, grid, adjacentTile);
+            var adjacentTile = tile.Offset(direction.ToDirection());
+            anchored = _map.GetAnchoredEntitiesEnumerator(gridId, grid, adjacentTile);
 
             while (anchored.MoveNext(out var entity))
             {
-                DebugTools.Assert(Transform(entity.Value).Anchored);
-                if (_query.HasComponent(ent) && !TerminatingOrDeleted(entity.Value))
+                if (_query.HasComponent(entity.Value) && !TerminatingOrDeleted(entity.Value))
                     EnsureComp<ActiveEdgeSpreaderComponent>(entity.Value);
             }
         }

--- a/Resources/Changelog/ChangelogStarlight.yml
+++ b/Resources/Changelog/ChangelogStarlight.yml
@@ -10036,5 +10036,20 @@ Entries:
   id: 1382
   time: '2025-08-01T16:02:15.000000+00:00'
   url: https://github.com/ss14Starlight/space-station-14/pull/1174
+- author: PubliclyExecutedPig
+  changes:
+  - message: Fixed dragons being wayyy too powerful
+    type: Fix
+  id: 1383
+  time: '2025-08-02T13:53:28.000000+00:00'
+  url: https://github.com/ss14Starlight/space-station-14/pull/1177
+- author: PubliclyExecutedPig
+  changes:
+  - message: Buffed carp a little to encourage actual strategy instead of just running
+      in
+    type: Tweak
+  id: 1384
+  time: '2025-08-02T13:53:28.000000+00:00'
+  url: https://github.com/ss14Starlight/space-station-14/pull/1177
 Order: -1
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -181,6 +181,18 @@
     - type: HTN
       rootTask:
         task: DragonCarpCompound
+   #Starlight
+    - type: Flammable
+      damage:
+        types: {}
+    - type: Damageable
+      damageModifierSet: DragonCarpResistances
+    - type: Prying
+      pryPowered: true
+      force: true
+      speedModifier: 1.5 # faster because carp are kinda strong
+      useSound:
+         path: /Audio/Items/crowbar.ogg 
 
 - type: entity
   id: MobCarpDungeon

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -55,7 +55,7 @@
   flatReductions:
     Piercing: 4
   coefficients:
-    Piercing: 0.2
+    Piercing: 0.3
     Slash: 2
     Heat: 0.5
     Bloodloss: 0

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -53,9 +53,19 @@
 - type: damageModifierSet
   id: DragonResistances
   flatReductions:
-    Piercing: 10
+    Piercing: 4
   coefficients:
-    Piercing: 0.25
+    Piercing: 0.2
     Slash: 2
-    Heat: 0
+    Heat: 0.5
+    Bloodloss: 0
+
+- type: damageModifierSet
+  id: DragonCarpResistances
+  flatReductions:
+    Piercing: 2.5
+  coefficients:
+    Piercing: 0.5
+    Slash: 2
+    Heat: 0.75
     Bloodloss: 0


### PR DESCRIPTION
## Short description
This fixes a bug in SpreaderSystem that prevented kudzu from regrowing into cleared spaces. Specifically there was an issue in ActivateSpreadableNeighbors, where it seemed to have targeted the map grid instead of neighboring entities 

## Why we need to add this
This re-enables kudzu to spread as intended. Kudzu is funner when it works right!

## Media (Video/Screenshots)
Before:
https://github.com/user-attachments/assets/e08437c5-1440-4aaf-9d7b-02380be116b8


After:
https://github.com/user-attachments/assets/13522bfd-a53e-4c59-a948-260c151f99da

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citeria
- fix: Fixed an issue where kudzu would not regrow into cleared spaces or after adjacent walls were removed, making it permanently dormant. Kudzu will now correctly reactivate and spread as intended. The kudzu spreads. Glory to the kudzu
