### PR TITLE
Railroading System: Reagents Update

### DIFF
--- a/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingConsumeTaskSystem.cs
+++ b/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingConsumeTaskSystem.cs
@@ -70,8 +70,6 @@ public sealed partial class RailroadingConsumeTaskSystem : EntitySystem
         args.IsCompleted = ent.Comp.IsCompleted;
     }
 
-    private void OnConsumeTaskPicked(Entity<RailroadConsumeTaskComponent> ent, ref RailroadingCardChosenEvent args)
-    {
-        EnsureComp<RailroadConsumeWatcherComponent>(args.Subject.Owner);
-    }
+    private void OnConsumeTaskPicked(Entity<RailroadConsumeTaskComponent> ent, ref RailroadingCardChosenEvent args) 
+        => EnsureComp<RailroadConsumeWatcherComponent>(args.Subject.Owner);
 }

--- a/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingMetabolizeTaskSystem.cs
+++ b/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingMetabolizeTaskSystem.cs
@@ -1,0 +1,87 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Content.Server._Starlight.Objectives.Events;
+using Content.Server.Administration.Managers;
+using Content.Server.Administration.Systems;
+using Content.Server.EUI;
+using Content.Shared._Starlight.Railroading;
+using Content.Shared._Starlight.Railroading.Events;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Alert;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Nutrition;
+using Content.Shared.Objectives;
+using Robust.Server.Player;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Starlight.Railroading;
+
+public sealed partial class RailroadingMetabolizeTaskSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IPlayerManager _players = default!;
+    [Dependency] private readonly IAdminManager _admins = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly EuiManager _euiManager = default!;
+    [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly RailroadingSystem _railroading = default!;
+    [Dependency] private readonly StarlightEntitySystem _entitySystem = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RailroadMetabolizeTaskComponent, RailroadingCardChosenEvent>(OnConsumeTaskPicked);
+        SubscribeLocalEvent<RailroadMetabolizeTaskComponent, RailroadingCardCompletionQueryEvent>(OnConsumeTaskCompletionQuery);
+        SubscribeLocalEvent<RailroadMetabolizeTaskComponent, CollectObjectiveInfoEvent>(OnCollectObjectiveInfo);
+
+        SubscribeLocalEvent<RailroadMetabolizerWatcherComponent, RailroadingReagentMetabolizedEvent>(OnMetabolized);
+    }
+
+    private void OnMetabolized(Entity<RailroadMetabolizerWatcherComponent> ent, ref RailroadingReagentMetabolizedEvent args)
+    {
+        if (!TryComp<RailroadableComponent>(ent, out var railroadable)
+            || railroadable.ActiveCard is null
+            || !TryComp<RailroadMetabolizeTaskComponent>(railroadable.ActiveCard, out var task))
+            return;
+
+        var reagent = args.Reagent.Reagent;
+        if (!task.Reagents.Any(x => x.Reagent == reagent))
+            return;
+
+        if (task.MetabolizedReagents.TryGetValue(reagent.Prototype, out var current))
+            task.MetabolizedReagents[reagent.Prototype] = current + args.Reagent.Quantity;
+        else
+            task.MetabolizedReagents[reagent.Prototype] = args.Reagent.Quantity;
+
+        if (task.Reagents.All(x => task.MetabolizedReagents.TryGetValue(x.Reagent.Prototype, out var quantity) && quantity >= x.Quantity))
+        {
+            RemComp<RailroadMetabolizerWatcherComponent>(ent);
+            _railroading.InvalidateProgress((ent, railroadable));
+        }
+    }
+
+    private void OnCollectObjectiveInfo(Entity<RailroadMetabolizeTaskComponent> ent, ref CollectObjectiveInfoEvent args)
+    {
+        foreach (var quantity in ent.Comp.Reagents)
+        {
+            var reagentProto = _proto.Index<ReagentPrototype>(quantity.Reagent.Prototype);
+            args.Objectives.Add(new ObjectiveInfo
+            {
+                Title = Loc.GetString(ent.Comp.Message, ("Target", Loc.GetString(reagentProto.LocalizedName))),
+                Icon = ent.Comp.Icon,
+                Progress = ent.Comp.MetabolizedReagents.TryGetValue(quantity.Reagent.Prototype, out var metabolizedQuantity)
+                    && quantity.Quantity > 0
+                    ? Math.Clamp((metabolizedQuantity / quantity.Quantity).Float(), 0f, 1f) : 0f,
+            });
+        }
+    }
+
+    private void OnConsumeTaskCompletionQuery(Entity<RailroadMetabolizeTaskComponent> ent, ref RailroadingCardCompletionQueryEvent args)
+    {
+        if (args.IsCompleted == false) return;
+
+        args.IsCompleted = ent.Comp.Reagents.All(x => ent.Comp.MetabolizedReagents.TryGetValue(x.Reagent.Prototype, out var quantity) && quantity >= x.Quantity);
+    }
+
+    private void OnConsumeTaskPicked(Entity<RailroadMetabolizeTaskComponent> ent, ref RailroadingCardChosenEvent args) 
+        => EnsureComp<RailroadMetabolizerWatcherComponent>(args.Subject.Owner);
+}

--- a/Content.Shared/_Starlight/Railroading/Components/Tasks/RailroadMetabolizeTaskComponent.cs
+++ b/Content.Shared/_Starlight/Railroading/Components/Tasks/RailroadMetabolizeTaskComponent.cs
@@ -1,0 +1,27 @@
+using System;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._Starlight.Railroading;
+
+/// <summary>
+/// Components like Task describe the objectives that need to be completed and store progress.
+/// Ideally, progress should be separated, but I’d rather not create a separate progress component for each one.
+/// </summary>
+[RegisterComponent]
+public sealed partial class RailroadMetabolizeTaskComponent : Component
+{
+    [DataField]
+    public string Message = "rail-metabolize-task";
+
+    [DataField]
+    public HashSet<ReagentQuantity> Reagents = [];
+    
+    public Dictionary<string, FixedPoint2> MetabolizedReagents = [];
+
+    [DataField]
+    public SpriteSpecifier Icon;
+}
+

--- a/Content.Shared/_Starlight/Railroading/Components/Watchers/RailroadMetabolizeWatcherComponent.cs
+++ b/Content.Shared/_Starlight/Railroading/Components/Watchers/RailroadMetabolizeWatcherComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._Starlight.Railroading;
+
+/// <summary>
+/// Components like watch act as a kind of subscription to specific events, for relaying them onto the card entity.
+/// </summary>
+[RegisterComponent, Virtual]
+public partial class RailroadMetabolizerWatcherComponent : Component
+{
+}

--- a/Content.Shared/_Starlight/Railroading/Events/RailroadingReagentMetabolizedEvent.cs
+++ b/Content.Shared/_Starlight/Railroading/Events/RailroadingReagentMetabolizedEvent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.Chemistry.Reagent;
+
+namespace Content.Shared._Starlight.Railroading.Events;
+
+[ByRefEvent]
+public record struct RailroadingReagentMetabolizedEvent(
+    ReagentQuantity Reagent
+)
+{ }

--- a/Resources/Locale/en-US/_Starlight/rail/rail.ftl
+++ b/Resources/Locale/en-US/_Starlight/rail/rail.ftl
@@ -28,3 +28,9 @@ rr-stew = Stew
 rr-stew-desc = Space makes a lot of ordinary things feel exotic. Just try not to think about how it was cooked in a microwave.
 
 
+# Metabolize
+
+rail-metabolize-task = Metabolize {INDEFINITE($Target)} {$Target}
+
+rr-smoke = Smokeables
+rr-smoking-desc = I can always quit, I’m not addicted.

--- a/Resources/Prototypes/_StarLight/GameRules/railroading.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/railroading.yml
@@ -13,9 +13,10 @@
     cards:
 #    - RRCardFoodSashimi
 #    - RRCardFoodApplePie
-    - RRCardFoodDumplings
-    - RRCardFoodHerbSalad
-    - RRCardFoodMelonFruitBowl
+#    - RRCardFoodDumplings
+#    - RRCardFoodHerbSalad
+    - RRCardMetabolizeNicotine
+#    - RRCardFoodMelonFruitBowl
 #    - RRCardFoodStew
 
 - type: entity
@@ -37,3 +38,4 @@
     - RRCardFoodHerbSalad
     - RRCardFoodMelonFruitBowl
     - RRCardFoodStew
+    - RRCardMetabolizeNicotine

--- a/Resources/Prototypes/_StarLight/Railroading/metabolize.yml
+++ b/Resources/Prototypes/_StarLight/Railroading/metabolize.yml
@@ -1,6 +1,18 @@
 - type: entity
+  id: MetabolizeCondition
+  categories: [ HideSpawnMenu ]
+  abstract: true
+  components:
+  - type: Conditions
+    conditions:
+    - !type:SubjectSpeciesCondition
+      blacklist:
+      - Abductor
+      - Skeleton
+
+- type: entity
   id: RRCardMetabolizeNicotine
-  parent: [FoodConditionWithReptilian]
+  parent: MetabolizeCondition
   categories: [ HideSpawnMenu ]
   components:
   - type: RailroadSpawnFlow

--- a/Resources/Prototypes/_StarLight/Railroading/metabolize.yml
+++ b/Resources/Prototypes/_StarLight/Railroading/metabolize.yml
@@ -1,0 +1,27 @@
+- type: entity
+  id: RRCardMetabolizeNicotine
+  parent: [FoodConditionWithReptilian]
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: RailroadSpawnFlow
+    count: 
+      min: 1
+      max: 3
+  - type: RailroadCard
+    title: rr-smoke
+    icon: ""
+    iconColor: '#9FED5896'
+    color: '#515151'
+    image: /Textures/_Starlight/Railroading/smoking.png
+    description: rr-smoking-desc
+  - type: RailroadMetabolizeTask
+    reagents:
+    - ReagentId: Nicotine
+      Quantity: 100
+    icon:
+      sprite: Objects/Consumable/Smokeables/Cigars/cigar-gold.rsi
+      state: lit-icon
+  - type: RailroadDonationReward
+    amount: 
+      min: 10
+      max: 25


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

This pr updates Railroading system to add compatability with Reagents such as Nicotine, Alcohol or anything else(Drinks will be added later).

## Why we need to add this

Currently system works only with food, this pr improves system and adds more ways to add new content.

## Technically details

- In PR changed metabolizm system, for catching reagent metabolizm.

## Media (Video/Screenshots)

<img width="260" height="367" alt="image" src="https://github.com/user-attachments/assets/878f6989-beab-413c-9ef9-5a9c06052ee0" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Rinary, Darkrell
- tweak: Now Railroading system works with reagents.
- add: Added new task in railroading, task is offering you a little smoke.