### PR TITLE
Fix VulpTailTip and VulpTailFoxTip being unable to wag

### DIFF
--- a/Content.Server/Wagging/WaggingSystem.cs
+++ b/Content.Server/Wagging/WaggingSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.Actions;
 using Content.Server.Humanoid;
+using Content.Shared._Starlight.Humanoid.Markings;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Mobs;
@@ -17,6 +18,8 @@ public sealed class WaggingSystem : EntitySystem
     [Dependency] private readonly ActionsSystem _actions = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearance = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    [Dependency] private readonly StarlightMarkingSystem _starlightMarking = default!; //starlight edit
 
     public override void Initialize()
     {
@@ -71,7 +74,7 @@ public sealed class WaggingSystem : EntitySystem
             foreach (var possibleSuffix in wagging.Suffixes)
             {
                 var currentMarkingId = markings[idx].MarkingId;
-                string newMarkingId;
+                string? newMarkingId;
 
                 if (wagging.Wagging)
                 {
@@ -90,7 +93,8 @@ public sealed class WaggingSystem : EntitySystem
                     }
                 }
 
-                if (!_prototype.HasIndex<MarkingPrototype>(newMarkingId))
+                if (!_prototype.HasIndex<MarkingPrototype>(newMarkingId) &&
+                    !_starlightMarking.TryGetWaggingId(currentMarkingId, out newMarkingId)) //starlight edit
                 {
                     Log.Warning($"{ToPrettyString(uid)} tried toggling wagging but {newMarkingId} marking doesn't exist");
                     continue;

--- a/Content.Shared/_Starlight/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/_Starlight/Humanoid/Markings/MarkingPrototype.cs
@@ -1,0 +1,20 @@
+﻿using System.Numerics;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
+
+// ReSharper disable CheckNamespace
+
+namespace Content.Shared.Humanoid.Markings;
+
+public sealed partial class MarkingPrototype : IInheritingPrototype
+{
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<MarkingPrototype>))]
+    public string[]? Parents { get; }
+
+    [AbstractDataField]
+    [NeverPushInheritance]
+    public bool Abstract { get; }
+
+    [DataField]
+    public string? WaggingId;
+}

--- a/Content.Shared/_Starlight/Humanoid/Markings/StarlightMarkingSystem.cs
+++ b/Content.Shared/_Starlight/Humanoid/Markings/StarlightMarkingSystem.cs
@@ -1,0 +1,23 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Humanoid.Markings;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Starlight.Humanoid.Markings;
+
+public sealed class StarlightMarkingSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    public bool TryGetWaggingId(ProtoId<MarkingPrototype> markingId, [NotNullWhen(true)] out string? waggingId)
+    {
+        waggingId = null!;
+        if (!_prototype.TryIndex(markingId, out var marking) ||
+            marking.WaggingId == null)
+        {
+            return false;
+        }
+
+        waggingId = marking.WaggingId;
+        return true;
+    }
+}

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Customization/Marking/vulpkanin.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Customization/Marking/vulpkanin.yml
@@ -404,6 +404,7 @@
   bodyPart: Tail
   markingCategory: Tail
   speciesRestriction: [Vulpkanin]
+  waggingId: VulpTailWagTip
   sprites:
     - sprite: _Starlight/Mobs/Customization/vulpkanin/tail_markings.rsi
       state: vulp
@@ -481,6 +482,7 @@
   bodyPart: Tail
   markingCategory: Tail
   speciesRestriction: [Vulpkanin]
+  waggingId: VulpTailFoxWagTip
   sprites:
     - sprite: _Starlight/Mobs/Customization/vulpkanin/tail_markings.rsi
       state: fox


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
The alternative is fixing the ids to be consistent, but that would remove it from any characters that currently have it.
This also lets you specify a custom id per tail if you want to, defaulting to the current system of inferring the id.
Also adds parenting support to marking prototypes, because copy-paste is going to kill me.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/a4faeade-fb2b-4ef0-8a22-6a09ee06a89d

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: DrSmugleaf
- fix: Fixed vulp tail tip and vulp tail fox tip being unable to wag.