### PR TITLE
Gives Chemistry Permissions to Brigmedics

### DIFF
--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
@@ -23,6 +23,7 @@
   - External
   - Cryogenics
   - Brigmedic
+  - Chemistry
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
## Short description
Simply gives access to Brigmedic to Chemist only areas.

## Why we need to add this
Simply to let Brigmedics be able to open things like the Chemist crate without having to break it. Allows also the brigmedic to help the crew in case security falls examples are zombies where security can be overrun in some maps really easily and medical can be left abandoned prime for the pickings of the surviving secoffs. Or having to move brig medbay to medbay due to threats like nukies destroying security, the brigmedic could help create chems if there are no chemists around.

## Media (Video/Screenshots)
<img width="1088" height="515" alt="GithubMedia1" src="https://github.com/user-attachments/assets/052b0828-6f07-4c42-a5d8-8c8679275769" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: AthenaAI
- tweak: Gives Chemist permissions to Brigmedic for ease of access.


