### PR TITLE
[hotfix] Sayable component hotfix

### DIFF
--- a/Content.Shared/Silicons/Laws/SiliconLawPrototype.cs
+++ b/Content.Shared/Silicons/Laws/SiliconLawPrototype.cs
@@ -13,7 +13,7 @@ public partial class SiliconLaw : IComparable<SiliconLaw>, IEquatable<SiliconLaw
     /// </summary>
     [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
     public string LawString = string.Empty;
-    
+
     [DataField(required: false), ViewVariables(VVAccess.ReadWrite)]
     public bool Sayable = true;
 
@@ -72,7 +72,8 @@ public partial class SiliconLaw : IComparable<SiliconLaw>, IEquatable<SiliconLaw
         {
             LawString = LawString,
             Order = Order,
-            LawIdentifierOverride = LawIdentifierOverride
+            LawIdentifierOverride = LawIdentifierOverride,
+            Sayable = Sayable //Starlight
         };
     }
 }

--- a/Resources/Changelog/ChangelogStarlight.yml
+++ b/Resources/Changelog/ChangelogStarlight.yml
@@ -10036,5 +10036,20 @@ Entries:
   id: 1382
   time: '2025-08-01T16:02:15.000000+00:00'
   url: https://github.com/ss14Starlight/space-station-14/pull/1174
+- author: PubliclyExecutedPig
+  changes:
+  - message: Fixed dragons being wayyy too powerful
+    type: Fix
+  id: 1383
+  time: '2025-08-02T13:53:28.000000+00:00'
+  url: https://github.com/ss14Starlight/space-station-14/pull/1177
+- author: PubliclyExecutedPig
+  changes:
+  - message: Buffed carp a little to encourage actual strategy instead of just running
+      in
+    type: Tweak
+  id: 1384
+  time: '2025-08-02T13:53:28.000000+00:00'
+  url: https://github.com/ss14Starlight/space-station-14/pull/1177
 Order: -1
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -181,6 +181,18 @@
     - type: HTN
       rootTask:
         task: DragonCarpCompound
+   #Starlight
+    - type: Flammable
+      damage:
+        types: {}
+    - type: Damageable
+      damageModifierSet: DragonCarpResistances
+    - type: Prying
+      pryPowered: true
+      force: true
+      speedModifier: 1.5 # faster because carp are kinda strong
+      useSound:
+         path: /Audio/Items/crowbar.ogg 
 
 - type: entity
   id: MobCarpDungeon

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -55,7 +55,7 @@
   flatReductions:
     Piercing: 4
   coefficients:
-    Piercing: 0.2
+    Piercing: 0.3
     Slash: 2
     Heat: 0.5
     Bloodloss: 0

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -53,9 +53,19 @@
 - type: damageModifierSet
   id: DragonResistances
   flatReductions:
-    Piercing: 10
+    Piercing: 4
   coefficients:
-    Piercing: 0.25
+    Piercing: 0.2
     Slash: 2
-    Heat: 0
+    Heat: 0.5
+    Bloodloss: 0
+
+- type: damageModifierSet
+  id: DragonCarpResistances
+  flatReductions:
+    Piercing: 2.5
+  coefficients:
+    Piercing: 0.5
+    Slash: 2
+    Heat: 0.75
     Bloodloss: 0


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes sayable component not working from the yml.

## Why we need to add this
Tagging as a hotfix because right now you can metagame the fuck out of emagged borgs by forcing them to state law 0. This fixes that.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- fix: Fixes the sayable component not working when specified in yml, causing law 0 to be sayable until emagged.
