### PR TITLE
Fix kudzu reactivation by checking contents of grid and not grid itself

### DIFF
--- a/Content.Server/Spreader/SpreaderSystem.cs
+++ b/Content.Server/Spreader/SpreaderSystem.cs
@@ -321,10 +321,10 @@ public sealed class SpreaderSystem : EntitySystem
         var anchored = _map.GetAnchoredEntitiesEnumerator(ent, grid, tile);
         while (anchored.MoveNext(out var entity))
         {
-            if (entity == uid)
+            if (entity == uid) // Starlight-edit
                 continue;
             DebugTools.Assert(Transform(entity.Value).Anchored);
-            if (_query.HasComponent(entity.Value) && !TerminatingOrDeleted(entity.Value))
+            if (_query.HasComponent(entity.Value) && !TerminatingOrDeleted(entity.Value)) // Starlight-edit
                 EnsureComp<ActiveEdgeSpreaderComponent>(entity.Value);
         }
 
@@ -332,13 +332,13 @@ public sealed class SpreaderSystem : EntitySystem
         for (var i = 0; i < Atmospherics.Directions; i++)
         {
             var direction = (AtmosDirection) (1 << i);
-            var adjacentTile = tile.Offset(direction.ToDirection());
+            var adjacentTile = tile.Offset(direction.ToDirection()); // Starlight-edit
             anchored = _map.GetAnchoredEntitiesEnumerator(ent, grid, adjacentTile);
 
             while (anchored.MoveNext(out var entity))
             {
                 DebugTools.Assert(Transform(entity.Value).Anchored);
-                if (_query.HasComponent(entity.Value) && !TerminatingOrDeleted(entity.Value))
+                if (_query.HasComponent(entity.Value) && !TerminatingOrDeleted(entity.Value)) // Starlight-edit
                     EnsureComp<ActiveEdgeSpreaderComponent>(entity.Value);
             }
         }

--- a/Content.Server/Spreader/SpreaderSystem.cs
+++ b/Content.Server/Spreader/SpreaderSystem.cs
@@ -317,26 +317,28 @@ public sealed class SpreaderSystem : EntitySystem
             (ent, tile) = position.Value;
         }
 
+        // Reactivate spreaders on the same tile
         var anchored = _map.GetAnchoredEntitiesEnumerator(ent, grid, tile);
         while (anchored.MoveNext(out var entity))
         {
-            if (entity == ent)
+            if (entity == uid)
                 continue;
             DebugTools.Assert(Transform(entity.Value).Anchored);
-            if (_query.HasComponent(ent) && !TerminatingOrDeleted(entity.Value))
+            if (_query.HasComponent(entity.Value) && !TerminatingOrDeleted(entity.Value))
                 EnsureComp<ActiveEdgeSpreaderComponent>(entity.Value);
         }
 
+        // Reactivate spreaders on adjacent tiles
         for (var i = 0; i < Atmospherics.Directions; i++)
         {
             var direction = (AtmosDirection) (1 << i);
-            var adjacentTile = SharedMapSystem.GetDirection(tile, direction.ToDirection());
+            var adjacentTile = tile.Offset(direction.ToDirection());
             anchored = _map.GetAnchoredEntitiesEnumerator(ent, grid, adjacentTile);
 
             while (anchored.MoveNext(out var entity))
             {
                 DebugTools.Assert(Transform(entity.Value).Anchored);
-                if (_query.HasComponent(ent) && !TerminatingOrDeleted(entity.Value))
+                if (_query.HasComponent(entity.Value) && !TerminatingOrDeleted(entity.Value))
                     EnsureComp<ActiveEdgeSpreaderComponent>(entity.Value);
             }
         }


### PR DESCRIPTION
## Short description
This fixes a bug in SpreaderSystem that prevented kudzu from regrowing into cleared spaces. Specifically there was an issue in ActivateSpreadableNeighbors, where it seemed to have targeted the map grid instead of neighboring entities 

Duplicate of https://github.com/ss14Starlight/space-station-14/pull/1205 because the branch got destroyed when I synced it. This four line change which took like five minutes to figure out is taking HOURS to maintain the git of: it's insanity

## Why we need to add this
This re-enables kudzu to spread as intended. Kudzu is funner when it works right!

## Media (Video/Screenshots)
Before:
https://github.com/user-attachments/assets/e08437c5-1440-4aaf-9d7b-02380be116b8


After:
https://github.com/user-attachments/assets/13522bfd-a53e-4c59-a948-260c151f99da

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citeria
- fix: Fixed an issue where kudzu would not regrow into cleared spaces or after adjacent walls were removed, making it permanently dormant. Kudzu will now correctly reactivate and spread as intended. The kudzu spreads. Glory to the kudzu
