### PR TITLE
Add guard to unbuckling to help it to not act upon terminating entities

### DIFF
--- a/Content.Shared/Bed/SharedBedSystem.cs
+++ b/Content.Shared/Bed/SharedBedSystem.cs
@@ -56,8 +56,13 @@ public abstract class SharedBedSystem : EntitySystem
 
     private void OnUnstrapped(Entity<HealOnBuckleComponent> bed, ref UnstrappedEvent args)
     {
-        _actionsSystem.RemoveAction(args.Buckle.Owner, bed.Comp.SleepAction);
-        _sleepingSystem.TryWaking(args.Buckle.Owner);
+        // If the entity being unbuckled is terminating, we shouldn't try to act upon it, as some components may be gone
+        if (!Terminating(args.Buckle.Owner))
+        {
+            _actionsSystem.RemoveAction(args.Buckle.Owner, bed.Comp.SleepAction);
+            _sleepingSystem.TryWaking(args.Buckle.Owner);
+        }
+        
         RemComp<HealOnBuckleHealingComponent>(bed);
     }
 

--- a/Content.Shared/Bed/SharedBedSystem.cs
+++ b/Content.Shared/Bed/SharedBedSystem.cs
@@ -57,11 +57,11 @@ public abstract class SharedBedSystem : EntitySystem
     private void OnUnstrapped(Entity<HealOnBuckleComponent> bed, ref UnstrappedEvent args)
     {
         // If the entity being unbuckled is terminating, we shouldn't try to act upon it, as some components may be gone
-        if (Terminating(args.Buckle.Owner))
-            return;
-
-        _actionsSystem.RemoveAction(args.Buckle.Owner, bed.Comp.SleepAction);
-        _sleepingSystem.TryWaking(args.Buckle.Owner);
+        if (!Terminating(args.Buckle.Owner))
+        {
+            _actionsSystem.RemoveAction(args.Buckle.Owner, bed.Comp.SleepAction);
+            _sleepingSystem.TryWaking(args.Buckle.Owner);
+        }
 
         RemComp<HealOnBuckleHealingComponent>(bed);
     }

--- a/Content.Shared/Bed/SharedBedSystem.cs
+++ b/Content.Shared/Bed/SharedBedSystem.cs
@@ -56,12 +56,14 @@ public abstract class SharedBedSystem : EntitySystem
 
     private void OnUnstrapped(Entity<HealOnBuckleComponent> bed, ref UnstrappedEvent args)
     {
+        // Starlight-edit start
         // If the entity being unbuckled is terminating, we shouldn't try to act upon it, as some components may be gone
         if (!Terminating(args.Buckle.Owner))
         {
             _actionsSystem.RemoveAction(args.Buckle.Owner, bed.Comp.SleepAction);
             _sleepingSystem.TryWaking(args.Buckle.Owner);
         }
+        // Starlight-edit end
 
         RemComp<HealOnBuckleHealingComponent>(bed);
     }

--- a/Content.Shared/Bed/SharedBedSystem.cs
+++ b/Content.Shared/Bed/SharedBedSystem.cs
@@ -57,12 +57,12 @@ public abstract class SharedBedSystem : EntitySystem
     private void OnUnstrapped(Entity<HealOnBuckleComponent> bed, ref UnstrappedEvent args)
     {
         // If the entity being unbuckled is terminating, we shouldn't try to act upon it, as some components may be gone
-        if (!Terminating(args.Buckle.Owner))
-        {
-            _actionsSystem.RemoveAction(args.Buckle.Owner, bed.Comp.SleepAction);
-            _sleepingSystem.TryWaking(args.Buckle.Owner);
-        }
-        
+        if (Terminating(args.Buckle.Owner))
+            return;
+
+        _actionsSystem.RemoveAction(args.Buckle.Owner, bed.Comp.SleepAction);
+        _sleepingSystem.TryWaking(args.Buckle.Owner);
+
         RemComp<HealOnBuckleHealingComponent>(bed);
     }
 


### PR DESCRIPTION
## Short description
Adds a small guard in `OnUnstrapped()` to prevent it from acting upon potentially null entities

## Why we need to add this
To prevent errors and potential instability caused by interacting with the buckling system

## Media (Video/Screenshots)
Before:
https://github.com/user-attachments/assets/957ba50d-0c0d-48ac-851f-cb5a8e97ed84

After:
https://github.com/user-attachments/assets/c5416a0a-e766-48e9-b358-05115a217d8f

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citeria
- fix: Fixed error upon exploding buckled mobs
