### PR TITLE
Add null guard to GetBodyChildren() to prevent NullReferenceException

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -196,7 +196,7 @@ public partial class SharedBodySystem
         {
             var slot = CreateOrganSlot((ent, ent), organSlotId);
             if (organProto == "null")
-                continue; // Ensure the loop properly skips the null entry and processes the remaining organs
+                continue; // Ensure the loop properly skips the null entry and processes the remaining organs : Starlight-edit
             SpawnInContainerOrDrop(organProto, ent, GetOrganContainerId(organSlotId));
 
             if (slot is null)
@@ -214,6 +214,7 @@ public partial class SharedBodySystem
         BodyComponent? body = null,
         BodyPartComponent? rootPart = null)
     {
+        // Starlight-edit start
         // Resolve BodyComponent first so we can access RootContainer
         if (!Resolve(id, ref body, logMissing: false))
             yield break;
@@ -225,7 +226,7 @@ public partial class SharedBodySystem
         // body.RootContainer should not be null after the check
         yield return body.RootContainer!;
 
-        foreach (var childContainer in GetPartContainers(root.Entity, root.BodyPart))
+        foreach (var childContainer in GetPartContainers(root.Entity, root.BodyPart)) // Starlight-edit end
         {
             yield return childContainer;
         }
@@ -239,11 +240,11 @@ public partial class SharedBodySystem
         BodyComponent? body = null,
         BodyPartComponent? rootPart = null)
     {
-        if (id is null || GetRootPartOrNull(id.Value, body) is not { } root)
+        if (id is null || GetRootPartOrNull(id.Value, body) is not { } root) // Starlight-edit
             yield break;
 
         // 'root' should be a tuple containing the validated root entity and its BodyPartComponent
-        foreach (var child in GetBodyPartChildren(root.Entity, root.BodyPart))
+        foreach (var child in GetBodyPartChildren(root.Entity, root.BodyPart)) // Starlight-edit
         {
             yield return child;
         }
@@ -272,10 +273,10 @@ public partial class SharedBodySystem
         EntityUid bodyId,
         BodyComponent? body = null)
     {
-        if (GetRootPartOrNull(bodyId, body) is not { } root)
+        if (GetRootPartOrNull(bodyId, body) is not { } root) // Starlight-edit
             yield break;
 
-        foreach (var slot in GetAllBodyPartSlots(root.Entity))
+        foreach (var slot in GetAllBodyPartSlots(root.Entity)) // Starlight-edit
         {
             yield return slot;
         }

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -237,15 +237,20 @@ public partial class SharedBodySystem
         BodyComponent? body = null,
         BodyPartComponent? rootPart = null)
     {
-        if (id is null
-            || !Resolve(id.Value, ref body, logMissing: false)
-            || body.RootContainer.ContainedEntity is null
-            || !Resolve(body.RootContainer.ContainedEntity.Value, ref rootPart))
+        if (id is null || !Resolve(id.Value, ref body, logMissing: false))
         {
             yield break;
         }
 
-        foreach (var child in GetBodyPartChildren(body.RootContainer.ContainedEntity.Value, rootPart))
+        // Safely get the root contained entity, checking for null before proceeding
+        // This prevents a NullReferenceException if the container is empty during state application
+        var rootContainedEntity = body.RootContainer?.ContainedEntity;
+        if (rootContainedEntity is null || !Resolve(rootContainedEntity.Value, ref rootPart, logMissing: false))
+        {
+            yield break;
+        }
+
+        foreach (var child in GetBodyPartChildren(rootContainedEntity.Value, rootPart))
         {
             yield return child;
         }

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -350,14 +350,18 @@ public partial class SharedBodySystem
     /// </summary>
     public (EntityUid Entity, BodyPartComponent BodyPart)? GetRootPartOrNull(EntityUid bodyId, BodyComponent? body = null)
     {
-        if (!Resolve(bodyId, ref body)
+        if (!Resolve(bodyId, ref body, logMissing: false)
+            || body.RootContainer is null
             || body.RootContainer.ContainedEntity is null)
         {
             return null;
         }
 
-        return (body.RootContainer.ContainedEntity.Value,
-            Comp<BodyPartComponent>(body.RootContainer.ContainedEntity.Value));
+        var rootEntity = body.RootContainer.ContainedEntity.Value;
+        if (!TryComp<BodyPartComponent>(rootEntity, out var rootPart))
+            return null;
+
+        return (rootEntity, rootPart);
     }
 
     /// <summary>

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -350,18 +350,18 @@ public partial class SharedBodySystem
     /// </summary>
     public (EntityUid Entity, BodyPartComponent BodyPart)? GetRootPartOrNull(EntityUid bodyId, BodyComponent? body = null)
     {
-        if (!Resolve(bodyId, ref body, logMissing: false)
-            || body.RootContainer is null
+        if (!Resolve(bodyId, ref body, logMissing: false) // Starlight-edit
+            || body.RootContainer is null // Starlight-edit
             || body.RootContainer.ContainedEntity is null)
         {
             return null;
         }
 
-        var rootEntity = body.RootContainer.ContainedEntity.Value;
-        if (!TryComp<BodyPartComponent>(rootEntity, out var rootPart))
-            return null;
+        var rootEntity = body.RootContainer.ContainedEntity.Value; // Starlight-edit
+        if (!TryComp<BodyPartComponent>(rootEntity, out var rootPart)) // Starlight-edit
+            return null; // Starlight-edit
 
-        return (rootEntity, rootPart);
+        return (rootEntity, rootPart); // Starlight-edit
     }
 
     /// <summary>


### PR DESCRIPTION
## Short description
Add defensive null checks in `SharedBodySystem.GetBodyChildren` to handle transient body state during client state application and prevent a `NullReferenceException`

## Why we need to add this
A `NullReferenceException` occurs when `SharedBodySystem.GetBodyChildren` runs during client game state application and it seems to attempt to access `body.RootContainer.ContainedEntity` before the root body part entity has been inserted into the container. This partial state happens while components update and events (eg `DamageChangedEvent` ) fire during state merge, cascading into client inconsistency and follow up errors 

This PR adds a safe early exit if the root contained entity is absent or unresolved, allowing the state application to continue without erroring

At the moment, I consider this a band-aid solution and possible long term solution for SL. Band-aid because there is potential for this to be a RT issue creating a race condition with their order of operation in `ApplyEntityStates()`, but potentially long term solution if it's the best SL can do to fix the issue as it currently stands

More info at: https://discord.com/channels/1272545509562777621/1400959803798454443/1400959803798454443

## Media (Video/Screenshots)
The bug depicted that this is trying to mitigate:
<img width="1481" height="1198" alt="image" src="https://github.com/user-attachments/assets/2c012f0e-6578-4db1-be46-43e9bcc6eea0" />
<img width="2959" height="291" alt="image" src="https://github.com/user-attachments/assets/9d7eefac-4171-4836-98aa-9bb860554a06" />

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citeria
- fix: Added attempt to fix the proverbial "medbay rendering error"
