### PR TITLE
Adds Improvised tools to belts whitelist and adds some missing items to CE's belt whitelist.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -35,6 +35,13 @@
         - GPS
         - WeldingMask
         - RemoteSignaller
+
+        #Starlight
+        - ImprovisedCrowbar
+        - ImprovisedScrewdriver
+        - ImprovisedWirecutter
+        - ImprovisedWrench
+        - ImprovisedMultitool
       components:
         - StationMap
         - SprayPainter
@@ -58,10 +65,16 @@
         whitelist:
           tags:
           - Wirecutter
+
+          #Starlight
+          - ImprovisedWirecutter
       crowbar:
         whitelist:
           tags:
           - Crowbar
+
+          #Starlight
+          - ImprovisedCrowbar
       crowbar_red:
         whitelist:
           tags:
@@ -74,14 +87,23 @@
         whitelist:
           tags:
           - Screwdriver
+
+          #Starlight
+          - ImprovisedScrewdriver
       wrench:
         whitelist:
           tags:
           - Wrench
+
+          #Starlight
+          - ImprovisedWrench
       multitool:
         whitelist:
           tags:
             - Multitool
+
+            #Starlight
+            - ImprovisedMultitool
     sprite: Clothing/Belt/belt_overlay.rsi
   - type: Appearance
   - type: Tag
@@ -120,6 +142,16 @@
         - HolofanProjector
         - Multitool
         - AppraisalTool
+        - GPS
+        - WeldingMask
+        - RemoteSignaller
+        
+        #Starlight
+        - ImprovisedCrowbar
+        - ImprovisedScrewdriver
+        - ImprovisedWirecutter
+        - ImprovisedWrench
+        - ImprovisedMultitool
       components:
         - StationMap
         - SprayPainter
@@ -144,10 +176,16 @@
         whitelist:
           tags:
           - Wirecutter
+          
+          #Starlight
+          - ImprovisedWirecutter
       crowbar:
         whitelist:
           tags:
           - Crowbar
+
+          #Starlight
+          - ImprovisedCrowbar
       crowbar_red:
         whitelist:
           tags:
@@ -160,14 +198,23 @@
         whitelist:
           tags:
           - Screwdriver
+          
+          #Starlight
+          - ImprovisedScrewdriver
       multitool:
         whitelist:
           tags:
             - Multitool
+            
+            #Starlight
+            - ImprovisedMultitool
       wrench:
         whitelist:
           tags:
           - Wrench
+          
+          #Starlight
+          - ImprovisedWrench
     sprite: Clothing/Belt/belt_overlay.rsi
   - type: Appearance
 

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/belts.yml
@@ -202,6 +202,13 @@
         - JawsOfLife
         - GPS
         - WeldingMask
+                
+        #Starlight
+        - ImprovisedCrowbar
+        - ImprovisedScrewdriver
+        - ImprovisedWirecutter
+        - ImprovisedWrench
+        - ImprovisedMultitool
       components:
         - SprayPainter
         - NetworkConfigurator
@@ -240,10 +247,16 @@
         whitelist:
           tags:
           - Wirecutter
+          
+          #Starlight
+          - ImprovisedWirecutter
       crowbar:
         whitelist:
           tags:
           - Crowbar
+
+          #Starlight
+          - ImprovisedCrowbar
       crowbar_red:
         whitelist:
           tags:
@@ -256,14 +269,23 @@
         whitelist:
           tags:
           - Screwdriver
+
+          #Starlight
+          - ImprovisedScrewdriver
       wrench:
         whitelist:
           tags:
           - Wrench
+          
+          #Starlight
+          - ImprovisedWrench
       multitool:
         whitelist:
           tags:
             - Multitool
+
+            #Starlight
+            - ImprovisedMultitool
     sprite: Clothing/Belt/belt_overlay.rsi
   - type: Appearance
   - type: StaticPrice


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
It simply whitelists the improvised tools to the utility belt, CE belt (just for parity sake), and Soviet Belt. As well as adding some more parity between CE's belt and utility belt letting them carry the GPS, Remote Signaler and Welding Mask. 

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Simply put it improvised tools are amazing but can take a lot of inventory space because they aren't able to be put in a utility belt. While there is the toolbox sometimes just raiding youtool or a lathe in cargo makes the improsived tools be overlooked especially when you need to weld them. As for the second change its just for CE to have more options in their toolbelt like a remote signaler for an igniter or GPS if they are building a shuttle and crash and lose the shuttle console.

## Media (Video/Screenshots)
<img width="490" height="168" alt="Capture1" src="https://github.com/user-attachments/assets/3ede8490-fd69-49f2-bfa7-7b372814685f" />
<img width="510" height="160" alt="Capture2" src="https://github.com/user-attachments/assets/111d4e2e-a091-40c3-85c7-03db651e7031" />
<img width="529" height="187" alt="Capture 3" src="https://github.com/user-attachments/assets/626060ec-aa68-4475-b7c5-baaa1fc2e810" />


## Checks
- [ X] I do not require assistance to complete the PR.
- [X ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X ] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: AthenaAI
- tweak: the utility toolbelt to allow storage of the improvised tools.
- tweak: the chief engineer's toolbelt to allow storage of the improvised tools as well as the GPS, welder mask and remote signaler.
- tweak: the soviet tool belt  to allow storage of the improvised tools.

