### PR TITLE
Visual refresh bug fix

### DIFF
--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -219,7 +219,8 @@ public sealed partial class SleepingSystem : EntitySystem
     /// </summary>
     private void OnDamageChanged(Entity<SleepingComponent> ent, ref DamageChangedEvent args)
     {
-        if (!args.DamageIncreased || args.DamageDelta == null)
+        // Starlight - prevent wakeup during initial entity replication
+        if (!args.DamageIncreased || args.DamageDelta == null || _gameTiming.ApplyingState)
             return;
 
         if (args.DamageDelta.GetTotal() >= ent.Comp.WakeThreshold)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This prevents the sleep system from attempting to wake up sleeping mobs entirely during application of entity damage state, which was the cause of the bug plaguing people who entered medbay recently.

Verification steps:
- Join server and damage self, sleep on a bed
- Join server on another client (or disconnect and reconnect), enter vicinity of sleeping mob. Nothing should happen.
- Beat sleeping mob over head with wrench. Mob should wake up.

## Why we need to add this
Bugfix

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
No in-game changes besides absence of visual glitch.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: neurovermi
- fix: Entering medbay no longer causes your client to die.
