### PR TITLE
Increases MechTankFill moles to aleviate current tank swap issue

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -232,5 +232,5 @@
     air:
       volume: 3000
       moles:
-        - 2.051379050
+        - 50.051379050
       temperature: 293.15

--- a/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/gas_tanks.yml
@@ -232,5 +232,5 @@
     air:
       volume: 3000
       moles:
-        - 50.051379050
+        - 50.051379050 #starlight, increase to 50 default
       temperature: 293.15


### PR DESCRIPTION

## Short description
Increases the Exosuit Air tank (filled) default oxygen gas mix from 2 moles to 50 moles.

## Why we need to add this
The exosuit tank has a gigantic 3000L volume yet by default only holds as much oxygen as a 2L bottle. Moreover when pressurizing a mech, those 2 moles get consumed nearly instantly, and since the tanks currently can't get pulled out after construction to be filled with a bottle, it leaves the pilot to experience pressure damage inside the mech atmosphere after a few minutes of breathing.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ ] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
changing the base because I am an idiot and targetted the wrong thing

:cl: CMDROverwerk
- tweak: increased default moles in mech air tank from 2 to 50