### PR TITLE
Player count listing condition

### DIFF
--- a/Content.Server/_Starlight/Store/Conditions/ListingPlayerCountCondition.cs
+++ b/Content.Server/_Starlight/Store/Conditions/ListingPlayerCountCondition.cs
@@ -1,0 +1,36 @@
+using Content.Shared.Store;
+using Robust.Shared.Player;
+
+namespace Content.Server.Store.Conditions;
+
+/// <summary>
+/// Only allows a listing to be purchased if population is at a certain number.
+/// </summary>
+/// <remarks>
+/// Basically copied from PlayerCountConidition.
+/// </remarks>
+public sealed partial class ListingPlayerCountCondition : ListingCondition
+{   
+    /// <summary>
+    /// Minimum players needed for this listing to be available.
+    /// </summary>
+    [DataField]
+    public int Minimum = 0;
+
+    /// <summary>
+    /// Maximum players allowed for this listing to be available.
+    /// </summary>
+    [DataField]
+    public int Maximum = 500;
+
+    private static ISharedPlayerManager? _playerManager;
+
+    public override bool Condition(ListingConditionArgs args)
+    {
+        _playerManager ??= IoCManager.Resolve<ISharedPlayerManager>();
+
+        var playerCount = _playerManager.PlayerCount;
+
+        return playerCount >= Minimum && playerCount <= Maximum;
+    }
+}

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -45,12 +45,14 @@
   description: spellbook-cluwne-desc
   productAction: ActionCluwne
   cost:
-    WizCoin: 300 #starlight make stupid expensive
+    WizCoin: 5 # Starlight: More expensive than usual, back on trial basis.
   categories:
   - SpellbookOffensive
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
+  - !type:ListingPlayerCountCondition # Starlight, make this only buyable on highpop
+    minimum: 80
 
 - type: listing
   id: SpellbookSlip


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a new listing condition, allowing antag purchasables to be locked behind playercount.

Additionally, re-added the Cluwne spell for wizard at 5 wizcoin and minimum playercount of 80.
This can be reverted if desired, but I saw it as a good test-case.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
We need more dynamic scaling of antags, and antag items are simply too destructive at low-pop.
Spells like Cluwne are disproportionally devastating on low-pop, while also loosing a lot of humor value as there's too few people to react to it, and too few assistants that nobody will miss.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

I wasn't going to spawn in 80 players on the dev environment, so you're just gonna have to trust me on this one.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- tweak: Re-added Cluwne at 5 wizcoin, only available when server population is above 80, on trial basis
