### PR TITLE
Changeling and Traitor Gamerule fixes

### DIFF
--- a/Resources/Locale/en-US/_Starlight/gamerules.ftl
+++ b/Resources/Locale/en-US/_Starlight/gamerules.ftl
@@ -1,0 +1,5 @@
+traitorling-title = Traitorlings
+traitorling-description = Traitors taste delicious
+
+eventlight-title = Event Light
+eventlight-description = Not quite Greenshift, stuff still happens!

--- a/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
@@ -14,3 +14,16 @@
         tableId: CalmPestEventsTable
       - !type:NestedSelector
         tableId: SpicyPestEventsTable
+
+- type: entity
+  parent: BaseGameRule
+  id: SubGamemodesRuleNoChangelings
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: Thief
+      prob: 0.5
+    - id: Vampire
+      prob: 0.25
+    - id: SubWizard
+      prob: 0.05

--- a/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
@@ -27,3 +27,12 @@
       prob: 0.25
     - id: SubWizard
       prob: 0.05
+      
+- type: entity
+  parent: BaseGameRule
+  id: ThiefGamerule
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: Thief
+      prob: 1

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -313,6 +313,6 @@
   rules:
     - Changeling
     - Traitor
-    - SubGamemodesRule
+    - SubGamemodesRuleNoChangelings
     - BasicStationEventScheduler
     - BasicRoundstartVariation

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -307,8 +307,8 @@
   alias:
     - lingtraitor
     - traitorling
-  name: secret-title
-  description: secret-description
+  name: traitorling-title
+  description: traitorling-description
   showInVote: true #Starlight
   minPlayers: 50 #Starlight
   rules:
@@ -316,4 +316,19 @@
     - Traitor
     - SubGamemodesRuleNoChangelings #Starlight
     - BasicStationEventScheduler
+    - BasicRoundstartVariation
+
+#Starlight EventLight Gamemode for Event Usage 
+- type: gamePreset
+  id: EventLight
+  alias:
+    - eventlight
+    - eventlite
+    - eventdiet
+  name: eventlight-title
+  description: eventlight-description
+  showInVote: false
+  rules:
+    - SpaceTrafficControlEventScheduler
+    - ThiefGamerule
     - BasicRoundstartVariation

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -161,7 +161,7 @@
   rules:
   # - DummyNonAntagChance 🌟Starlight🌟
   - Traitor
-  - SubGamemodesRule
+  - SubGamemodesRuleNoChangelings #Starlight
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -313,6 +313,6 @@
   rules:
     - Changeling
     - Traitor
-    - SubGamemodesRuleNoChangelings
+    - SubGamemodesRuleNoChangelings #Starlight
     - BasicStationEventScheduler
     - BasicRoundstartVariation

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -309,7 +309,8 @@
     - traitorling
   name: secret-title
   description: secret-description
-  showInVote: false
+  showInVote: true #Starlight
+  minPlayers: 50 #Starlight
   rules:
     - Changeling
     - Traitor

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -11,6 +11,7 @@
     Revolutionary: 0.10
     Vampire: 0.15
     Wizard: 0.10
+    Traitorling: 0.10
 
 - type: weightedRandom
   id: SecretLP


### PR DESCRIPTION
## Short description
Adds a new gamerule, SubGamemodesRuleNoChangelings, and replaces the SubGamemodesRule in the Traitor and Traitorlings Gamemode with it. Adds Traitorlings to the vote pool as well.

## Why we need to add this
There is already a Gamemode for Traitors + Changelings, called Traitorling. Leaving Lings in with normal Traitor rounds, in my opinion, was unintentional given the fact that it also had its own gamemode specifically for that, so I fixed it.

Changelings also spawn in large groups, which eat up all the Antag slots. Number of max antags is determined by player count. Changelings would use 6-8 of those slots, making it so only 2 Traitors could spawn in the **Traitors** gamemode.

The SubGamemodesRule in Traitorlings rolled on top of the already added Changeling gamerule, which was likely the cause of the double-Changelings issue we've had for months where Lings spawn 2 groups to end up with 6-8 Lings in a round.

## Media (Video/Screenshots)
N/A

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed how the Traitor Gamemode rolls antags to exclude Changelings, since there is already a Traitorling Gamemode that can roll, it seems unintended. Changelings stole all antag slots, making it so the game only spawned 2 Traitors on average.
- fix: Fixed (maybe) the game sometimes spawning two groups of Changelings at once. The old Traitorling Gamemode called SubGamemodesRule which could roll a second set of Lings.
- add: Added Traitorling to the Vote Pool as an option, as a medium-chaos option.
- add: Added EventLight gamemode, does not roll naturally or appear in votes. It's like Greenshift but less boring! Rolls Shuttle Events and Thieves.
