### PR TITLE
Make armorPenetration unable to heal

### DIFF
--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -164,7 +164,7 @@ namespace Content.Shared.Damage
                 if (modifierSet.Coefficients.TryGetValue(key, out var coefficient))
                 {
                     // Starlight edit begin
-                    var effectiveCoefficient = coefficient + ((1f - coefficient) * armorPenetration);
+                    var effectiveCoefficient = coefficient + ((1f - coefficient) * armorPenetration); // coefficients can heal you, e.g. cauterizing bleeding, Starlight change: removed maximum coefficent allowing for weaknesses
 
                     // A negative armor penetration value can result in a negative effective coefficient, which results in
                     // healing. This isn't intended. This logic clamps the effective coefficient to zero if armor

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -151,7 +151,6 @@ namespace Content.Shared.Damage
             {
                 if (value == 0)
                     continue;
-
                 if (value < 0)
                 {
                     newDamage.DamageDict[key] = value;
@@ -159,12 +158,24 @@ namespace Content.Shared.Damage
                 }
 
                 float newValue = value.Float();
-
                 if (modifierSet.FlatReduction.TryGetValue(key, out var reduction))
                     newValue = Math.Max(0f, newValue - (reduction - (reduction * armorPenetration))); // flat reductions can't heal you
 
                 if (modifierSet.Coefficients.TryGetValue(key, out var coefficient))
-                    newValue *= (coefficient + ((1f - coefficient) * armorPenetration)); // coefficients can heal you, e.g. cauterizing bleeding, Starlight change: removed maximum coefficent allowing for weaknesses
+                {
+                    var effectiveCoefficient = coefficient + ((1f - coefficient) * armorPenetration);
+
+                    // A negative armor penetration value can result in a negative effective coefficient, which results in
+                    // healing. This isn't intended. This logic clamps the effective coefficient to zero if armor
+                    // penetration is negative, which nullifies the damage instead of causing healing. This also prevents
+                    // negative armor penetration from amplifying any existing weaknesses
+                    if (armorPenetration < 0f)
+                    {
+                        effectiveCoefficient = Math.Max(0f, effectiveCoefficient);
+                    }
+
+                    newValue *= effectiveCoefficient;
+                }
 
                 if (newValue != 0)
                     newDamage.DamageDict[key] = FixedPoint2.New(newValue);

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -163,6 +163,7 @@ namespace Content.Shared.Damage
 
                 if (modifierSet.Coefficients.TryGetValue(key, out var coefficient))
                 {
+                    // Starlight edit begin
                     var effectiveCoefficient = coefficient + ((1f - coefficient) * armorPenetration);
 
                     // A negative armor penetration value can result in a negative effective coefficient, which results in
@@ -175,6 +176,7 @@ namespace Content.Shared.Damage
                     }
 
                     newValue *= effectiveCoefficient;
+                    // Starlight edit end
                 }
 
                 if (newValue != 0)


### PR DESCRIPTION
## Short description
Make it so bullets with negative armor penetration do not heal armored targets


## Why we need to add this
Generally, bullets aren't intended to heal, but clamping the entire damage value could prevent future or current healing systems that rely on it


## Media (Video/Screenshots)
https://github.com/user-attachments/assets/9bfae499-a794-44cf-914b-ff3bab81a279


## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.


**Changelog**
:cl: Citeria
- fix: Remove HP bullets ability to heal