### PR TITLE
revert it back to old values

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -320,7 +320,7 @@ namespace Content.Shared.Atmos
         ///     (The pressure threshold is so low that it doesn't make sense to do any calculations,
         ///     so it just applies this flat value).
         /// </summary>
-        public const int LowPressureDamage = 4;
+        public const int LowPressureDamage = 1; //Starlight. nerf back to old values pending changes back to 4 or lower.
 
         public const float WindowHeatTransferCoefficient = 0.1f;
 


### PR DESCRIPTION
## Short description
reverts the spacing dammage multiplier from 4 to 1 as wizden had buffed spacing dammage and 10 seconds is considered "too short" of a time. (we had also buffed spacing dammage so these *compounded*

## Media (Video/Screenshots)
N/A

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: Spacing cut into a quarter of what it once was. reverting wizden spacing dammage buff.
