### PR TITLE
Adds Prism Station and Silica Station to the defual map pool

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
@@ -18,6 +18,8 @@
   - Starboard
   - Kiloton
   - StarlightElkridge
+  - Prism
+  - StarlightSilica
 
 # - StarlightBagel
 # - StarlightBox


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds Silica and Prism Stations to the default map pool

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: MaxAlpine
- add: Adds Silica Station and Prism Station to the default map pool
