### PR TITLE
plushie-redwoods-8 fix

### DIFF
--- a/Resources/Locale/en-US/_Starlight/plushies/redwoods_plushie.ftl
+++ b/Resources/Locale/en-US/_Starlight/plushies/redwoods_plushie.ftl
@@ -5,3 +5,4 @@ plushie-redwoods-4 = What the fuck does CC do even all day?
 plushie-redwoods-5 = Xenos? Where?
 plushie-redwoods-6 = Do I regret being a vulp? No.
 plushie-redwoods-7 = Oh my... so much guns... I can't control myself..!
+plushie-redwoods-8 = What did I say? It's always the FUCKING CLONW!


### PR DESCRIPTION
empty string leads the plushie to spew out "plushie-redwoods-8" felt silly so i added a new voiceline

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes Redwoods Plushie saying "plushie-redwoods-8", due to the 8th string in plushie-redwoods.flt being empty.

## Why we need to add this
Just a small fix, not that severe.

## Media (Video/Screenshots)
<img width="590" height="1005" alt="{0189ADA5-FE4D-4CC6-9AD8-CEE9F6A6EDB9}" src="https://github.com/user-attachments/assets/aeb159b8-f44b-4b48-b9a6-7483d5d6c10a" />
(bug in question)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: TheRealSlimRedwoods
- fix: bub fix (fixed Redwoods Plushie spewing out "redwoods-plushie-8", adding a new line on the 8th string)

