### PR TITLE
Shunting tweaks

### DIFF
--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Humanoid;
 using Content.Server.Inventory;
 using Content.Server.Mind.Commands;
 using Content.Server.Polymorph.Components;
+using Content.Shared._Starlight.Polymorph.Components;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Buckle;

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -154,6 +154,7 @@ public sealed class RadioSystem : EntitySystem
             jobName = Loc.GetString("job-name-borg");
         }
 
+        //starlight if statement edited for AI Shunt
         if (HasComp<StationAiHeldComponent>(messageSource) || (
             TryComp<StationAIShuntComponent>(messageSource, out var aiShunt) && aiShunt.Return.HasValue
         ))

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -31,6 +31,7 @@ using Content.Shared.Clothing.EntitySystems;
 using Content.Shared;
 using Content.Server.Radio.Components;
 using Content.Server._Starlight.Radio.Systems;
+using Content.Shared._Starlight.Silicons.Borgs;
 
 namespace Content.Server.Radio.EntitySystems;
 
@@ -146,14 +147,16 @@ public sealed class RadioSystem : EntitySystem
                 }
             }
         }
-        
+
         if (HasComp<BorgChassisComponent>(messageSource) || HasComp<BorgBrainComponent>(messageSource))
         {
             iconId = "JobIconBorg";
             jobName = Loc.GetString("job-name-borg");
         }
-        
-        if (HasComp<StationAiHeldComponent>(messageSource))
+
+        if (HasComp<StationAiHeldComponent>(messageSource) || (
+            TryComp<StationAIShuntComponent>(messageSource, out var aiShunt) && aiShunt.Return.HasValue
+        ))
         {
             iconId = "JobIconStationAi";
             jobName = Loc.GetString("job-name-station-ai");

--- a/Content.Server/_Starlight/CryoTeleportation/CryoTeleportationSystem.cs
+++ b/Content.Server/_Starlight/CryoTeleportation/CryoTeleportationSystem.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using Content.Server.Bed.Cryostorage;
 using Content.Server.GameTicking;
 using Content.Server.Mind;
-using Content.Server.Polymorph.Components;
+using Content.Shared._Starlight.Polymorph.Components;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.Bed.Cryostorage;

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
@@ -73,7 +73,7 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
         component.OwnerName = Name(args.UserUid);
 
         NotifyLawsChanged(uid, component.EmaggedSound);
-        if(_mind.TryGetMind(uid, out var mindId, out _))
+        if (_mind.TryGetMind(uid, out var mindId, out _))
             EnsureSubvertedSiliconRole(mindId);
 
         _stunSystem.TryParalyze(uid, component.StunTime, true);
@@ -95,6 +95,15 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
     {
 
     }
+
+    #region Starlight
+    public void SetLawset(EntityUid entity, SiliconLawset? laws)
+    {
+        if (!TryComp<SiliconLawProviderComponent>(entity, out var provider))
+            return;
+        provider.Lawset = laws;
+    }
+    #endregion
 }
 
 [ByRefEvent]

--- a/Content.Shared/_Starlight/Polymorph/Components/UncryoableComponent.cs
+++ b/Content.Shared/_Starlight/Polymorph/Components/UncryoableComponent.cs
@@ -1,4 +1,4 @@
-﻿namespace Content.Server.Polymorph.Components;
+﻿namespace Content.Shared._Starlight.Polymorph.Components;
 
 [RegisterComponent]
 public sealed partial class UncryoableComponent : Component

--- a/Content.Shared/_Starlight/Silicons/Borgs/StationAIShuntComponent.cs
+++ b/Content.Shared/_Starlight/Silicons/Borgs/StationAIShuntComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Silicons.Laws;
 using Robust.Shared.GameStates;
 
 
@@ -20,4 +21,10 @@ public sealed partial class StationAIShuntComponent : Component
     /// </summary>
     [ViewVariables]
     public EntityUid? ReturnAction = null;
+
+    /// <summary>
+    /// what was the lawset of the chassis before the AI shunted into it.
+    /// </summary>
+    [ViewVariables]
+    public SiliconLawset? OldLawset = null;
 }

--- a/Content.Shared/_Starlight/Silicons/Borgs/StationAIShuntSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/Borgs/StationAIShuntSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared._Starlight.Polymorph.Components;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Mind;
+using Content.Shared.Radio.Components;
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.Silicons.Laws;
 using Content.Shared.Silicons.Laws.Components;
@@ -19,7 +20,7 @@ public sealed class StationAIShuntSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actionSystem = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedSiliconLawSystem _siliconLaw = default!;
-
+    [Dependency] private readonly SharedContainerSystem _contaienr = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -102,9 +103,8 @@ public sealed class StationAIShuntSystem : EntitySystem
         _mindSystem.TransferTo(mindId, target);
         RemComp<UncryoableComponent>(target);
 
-
-
-        if (TryComp<StationAiCoreComponent>(target, out var core) &&
+        var aiCore = Transform(target).ParentUid;
+        if (TryComp<StationAiCoreComponent>(aiCore, out var core) &&
             core.RemoteEntity.HasValue
             )
         {

--- a/Content.Shared/_Starlight/Silicons/Borgs/StationAIShuntSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/Borgs/StationAIShuntSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared._Starlight.Polymorph.Components;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Mind;
@@ -48,7 +49,9 @@ public sealed class StationAIShuntSystem : EntitySystem
         _mindSystem.TransferTo(mindId, target);
         shunt.ReturnAction = _actionSystem.AddAction(target, shuntable.UnshuntAction.Id);
         shuntable.Inhabited = target;
-        
+
+        EnsureComp<UncryoableComponent>(uid);
+
         ev.Handled = true;
     }
 
@@ -65,7 +68,7 @@ public sealed class StationAIShuntSystem : EntitySystem
 
         if (!TryComp<StationAIShuntableComponent>(shunt.Return, out var shuntable))
             return; //trying to return to a body you cant leave from? weird...
-        
+
         if (TryComp<BorgChassisComponent>(uid, out var chassisComp))
         {
             var brain = chassisComp.BrainContainer.ContainedEntity;
@@ -79,12 +82,14 @@ public sealed class StationAIShuntSystem : EntitySystem
             brainShunt.Return = null; //cause we are returning now
             brainShunt.ReturnAction = null;
         }
-        
+
         _actionSystem.RemoveAction(new Entity<ActionComponent?>(shunt.ReturnAction.Value, act));
         _mindSystem.TransferTo(mindId, shunt.Return);
+        RemComp<UncryoableComponent>(shunt.Return.Value);
         shunt.ReturnAction = null;
         shunt.Return = null;
         shuntable.Inhabited = null;
+
     }
 }
 

--- a/Resources/Locale/en-US/_Starlight/station-ai/verbs.ftl
+++ b/Resources/Locale/en-US/_Starlight/station-ai/verbs.ftl
@@ -1,0 +1,2 @@
+ai-shunt-into = Enter Chassis
+ai-shunt-out-of = Exit Chassis


### PR DESCRIPTION
## Short description
some fixes and improvements.

## Why we need to add this
fixes and improvements.

## Media (Video/Screenshots)
N/A

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: AI shunting into borgs copies ai core laws.
- tweak: AI eye goes to borg chassis when unshunting.
- tweak: radio icons still show you as station AI when shunted into a borg.
- tweak: ghost following AI eye when they shunt into a borg are moved. inversly ghost following the borg start following the AI eye when they unshunt.
- add: you can now alt-click interfaces and chassis with interfaces to inhabit them
- add: you can now alt-click the chassis you inhabit to exit it.
- fix: being shunted for extended periods of time no longer cryos you.
