### PR TITLE
Slight nerfs to the wonderprod, and giving the stun mode a charge system

### DIFF
--- a/Content.Shared/_Starlight/Combat/OnHit/SharedOnHitSystem.cs
+++ b/Content.Shared/_Starlight/Combat/OnHit/SharedOnHitSystem.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 using Content.Shared.Bed.Sleep;
+using Content.Shared.Charges.Components;
+using Content.Shared.Charges.Systems;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
@@ -29,6 +31,8 @@ public abstract class SharedOnHitSystem : EntitySystem
     [Dependency] protected readonly SharedSolutionContainerSystem _solutionContainers = default!;
     [Dependency] protected readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] protected readonly SharedCuffableSystem _cuffs = default!;
+    [Dependency] protected readonly SharedChargesSystem _sharedCharges = default!;
+
     public override void Initialize()
     {
         SubscribeLocalEvent<InjectOnHitComponent, MeleeHitEvent>(OnInjectOnMeleeHit);
@@ -69,6 +73,26 @@ public abstract class SharedOnHitSystem : EntitySystem
 
     private void OnInjectOnMeleeHit(Entity<InjectOnHitComponent> ent, ref MeleeHitEvent args)
     {
+        if (HasComp<LimitedChargesComponent>(ent.Owner))
+        {
+            var charges = _sharedCharges.GetCurrentCharges(ent.Owner);
+            if (charges == 0)
+            {
+                return;
+            }
+            
+            InjectSolution(ent, ref args);
+            
+            _sharedCharges.AddCharges(ent.Owner, -1);
+        }
+        else
+        {
+            InjectSolution(ent, ref args);
+        }
+    }
+
+    private void InjectSolution(Entity<InjectOnHitComponent> ent, ref MeleeHitEvent args)
+    {
         if (!args.IsHit
             || !args.HitEntities.Any())
             return;
@@ -101,4 +125,3 @@ public abstract class SharedOnHitSystem : EntitySystem
     {
     }
 }
-

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/wonderprod.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/wonderprod.yml
@@ -36,14 +36,14 @@
         components:
         - type: MeleeWeapon
           wideAnimationRotation: -135
-          attackRate: 0.5
+          attackRate: 0.75
           damage:
             types:
               Shock: 0
           angle: 60
           animation: WeaponArcThrust
         - type: StaminaDamageOnHit
-          damage: 225
+          damage: 50
           sound: /Audio/Weapons/Guns/Hits/taser_hit.ogg
         soundStateActivate:
           collection: sparks
@@ -73,6 +73,10 @@
           sprite: _Starlight/Objects/Weapons/Melee/wonderprod.rsi
           state: sleep-icon
         components:
+        - type: LimitedCharges
+          maxCharges: 8
+        - type: AutoRecharge
+          rechargeDuration: 45
         - type: MeleeWeapon
           wideAnimationRotation: -135
           attackRate: 1
@@ -82,10 +86,10 @@
           angle: 60
           animation: WeaponArcThrust
         - type: InjectOnHit
-          limit: 20
+          limit: 10
           reagents:
           - ReagentId: Nocturine
-            Quantity: 5
+            Quantity: 3.5
 
       damage: !type:ItemSwitchState
         verb: damage


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
(this isnt a mald PR, I was asked to make this by a few people lmao)
Nobody likes abductors because there is quite literally nothing you can do against the "instant sleep" button, also having a 1 shot stun that deals _255_ stamina damage is stupid and insane, its a 2 hit instead of a 1 hit now lmao

## Why we need to add this
Making people who hate abductors (everyone) happier

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: Salem & Fasuh
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Wonderprod Fuckery™
- fix: Fixed Rinary.

