### PR TITLE
Knife embedding fix

### DIFF
--- a/Content.Shared/Tools/Systems/SharedToolSystem.MultipleTool.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.MultipleTool.cs
@@ -31,7 +31,8 @@ public abstract partial class SharedToolSystem
         if (args.Handled || !args.Complex)
             return;
 
-        args.Handled = CycleMultipleTool(uid, multiple, args.User);
+        //args.Handled =    🌟Starlight🌟 - This doesn't *appear* to ever be relevant, but messes with knife embedding now that they're semi-omnitools
+        CycleMultipleTool(uid, multiple, args.User);
     }
 
     public bool CycleMultipleTool(EntityUid uid, MultipleToolComponent? multiple = null, EntityUid? user = null)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -21,8 +21,8 @@
   - type: Item
     size: Small
   - type: Tool # Starlight start
-    qualities: Screwing
-    speedModifier: 0.05
+    qualities: Slicing
+    speedModifier: 1
   - type: MultipleTool
     statusShowBehavior: true
     entries:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes embedded knives not being retrievable

## Why we need to add this
Bugfix. _As far as I can tell_, there are no unintended side effects, but that is hard to say with a codebase this large.
Also switches knives back to show the slicing tool by default when inspected, as it is a little weird for a knife to say "can be used for screwing" rather than "can be used for slicing". The functionality stays intact.

## Media (Video/Screenshots)
<img width="165" height="143" alt="image" src="https://github.com/user-attachments/assets/f1858f7c-6f86-44af-bc24-0488cf9d7d5f" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Knives can once again be un-embedded.
