### PR TITLE
fix(drinks): Alt-Interact prefers open/close over drink; avoid double popups on closed+empty bottles

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
@@ -104,7 +104,8 @@ public sealed partial class OpenableSystem : EntitySystem
                 Text = Loc.GetString(comp.CloseVerbText),
                 Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/close.svg.192dpi.png")),
                 Act = () => TryClose(args.Target, comp, args.User),
-                // this verb is lower priority than drink verb (2) so it doesn't conflict
+                // Ensure open/close takes precedence over ingest (priority 2)
+                Priority = 3
             };
         }
         else
@@ -113,7 +114,9 @@ public sealed partial class OpenableSystem : EntitySystem
             {
                 Text = Loc.GetString(comp.OpenVerbText),
                 Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/open.svg.192dpi.png")),
-                Act = () => TryOpen(args.Target, comp, args.User)
+                Act = () => TryOpen(args.Target, comp, args.User),
+                // Ensure open takes precedence over ingest (priority 2)
+                Priority = 3
             };
         }
         args.Verbs.Add(verb);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

**Description
What changed**
OpenableSystem: 

- set AlternativeVerb Priority = 3 for Open/Close so Alt-Interact toggles open/close instead of drinking (ingest verbs are Priority  2).
- **SharedDrinkSystem**: resolved cherry-pick conflict to match Starlight’s codepath (TryDrink handles closed/empty + do-after); no duplicate OnDrink/OnIsDigestible/OnGetEdibleType added.
- Removed stray Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs reintroduced by cherry-pick (Starlight’s branch doesn’t include this file).


## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- Why
- Fixes bug where Interact (Z) and Alt-Interact (Alt+Z) both result in drinking on opened bottles; Alt-Interact should provide a distinct action (toggle open/close) and not mirror drink.
- Prevents multiple popups on closed+empty bottles by keeping the single codepath (Starlight TryDrink) and avoiding conflicting handlers.
- Testing
- With a bottle:
- Closed: Alt-Interact toggles open/close; does not try to drink.
- Open + contains liquid: Interact drinks; Alt-Interact still toggles close.
- Open + empty: Interact shows empty message; Alt-Interact toggles close.
- Verified on local server with admin verbs:
- Spawn a bottle, toggle open/close via Alt-Interact, drink via Interact.
- Impact
- Low risk; priority bump only for Open/Close verbs and cleanup to match Starlight layout.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X ] I do not require assistance to complete the PR.
- [X ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X ] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Magwitch / PGrayCS
- tweak: Alt-interact now opens/closes containers instead of drinking from them