### PR TITLE
Fix/starlight medical icons

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/medical.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/medical.yml
@@ -54,7 +54,7 @@
 - type: stack
   id: Bluebrutepack
   name: stack-brutepack
-  icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: bluebrutepack }
+  icon: { sprite: "/Textures/_Starlight/Objects/Specific/Medical/medical.rsi", state: bluebrutepack }
   spawn: Bluebrutepack1
   maxCount: 20
 
@@ -103,7 +103,7 @@
 - type: stack
   id: Blueointment
   name: stack-blueointment
-  icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: blueointment }
+  icon: { sprite: "/Textures/_Starlight/Objects/Specific/Medical/medical.rsi", state: blueointment }
   spawn: Blueointment1
   maxCount: 20
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes two stack icon sprite paths in Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/medical.yml to use /Textures/_Starlight/Objects/Specific/Medical/medical.rsi so inventory icons render correctly.
Purely visual, no behavior changes.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Changes the path to the images to be the correct path
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM

- fix: Fixed Rinary.
-->
:cl: Magwitch / PGrayCS
- fix: Updated path to the correct starlight medical icons