### PR TITLE
GMN presets

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -4,6 +4,9 @@
   id: Bola
   description: Linked together with some spare cuffs and metal.
   components:
+  - type: Tag
+    tags:
+    - Bola
   - type: Item
     size: Normal
   - type: Sprite

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Items/belt.yml
@@ -71,8 +71,42 @@
   parent: ClothingOuterVestWebElite
   suffix: Filled
   components:
+  - type: Storage #Starlight
+    maxItemSize: Normal
+    grid:
+    - 0,0,1,0 #left
+    - 0,1,0,1 #left - cube
+    - 3,0,10,1
+    - 12,0,13,1 #right
+    whitelist:
+      tags:
+        - Bola
+        - CigPack
+        - Taser
+        - SecBeltEquip
+        - Radio
+        - Sidearm
+        - MagazinePistol
+        - MagazineMagnum
+        - CombatKnife
+        - Truncheon
+        - HandGrenade
+      components:
+        - Stunbaton
+        - FlashOnTrigger
+        - SmokeOnTrigger
+        - Flash
+        - Handcuff
+        - BallisticAmmoProvider
+        - CartridgeAmmo
+        - DoorRemote
+        - Whistle
+        - BalloonPopper
   - type: StorageFill
     contents:
+    - id: WeaponPistolStechkin
+    - id: MagazinePistolFMJ
+    - id: MagazinePistolSP
     - id: Stunbaton
     - id: Handcuffs
     - id: Handcuffs
@@ -101,6 +135,10 @@
   components:
   - type: StorageFill
     contents:
+    - id: WeaponPistolCobra
+    - id: MagazinePistolCaselessRifle
+    - id: MagazinePistolCaselessRifle
+    - id: MagazinePistolCaselessRifle
     - id: Binoculars
     - id: ThrowingKnife
     - id: Whistle

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Items/belt.yml
@@ -64,3 +64,55 @@
     - id: GrenadeFlashBang
     - id: TearGasGrenade
     - id: MedkitCombatFilled
+
+# GMN webbings
+- type: entity
+  id: ClothingOuterVestWebEliteFilledMAA
+  parent: ClothingOuterVestWebElite
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: Stunbaton
+    - id: Handcuffs
+    - id: Handcuffs
+    - id: GrenadeShrapnel
+    - id: Bola
+    - id: HoloprojectorSecurity
+
+- type: entity
+  id: ClothingBeltMilitaryWebbingFilledDamageControle
+  parent: ClothingBeltMilitaryWebbing
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: SyndicateJawsOfLife
+    - id: PowerDrill
+    - id: Multitool
+    - id: MetalFoamGrenade
+    - id: MetalFoamGrenade
+    - id: AirGrenade
+
+- type: entity
+  id: ClothingBeltMilitaryWebbingFilledNavigator
+  parent: ClothingBeltMilitaryWebbing
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: Binoculars
+    - id: ThrowingKnife
+    - id: Whistle
+
+- type: entity
+  id: ClothingBeltMilitaryWebbingFilledGunner
+  parent: ClothingBeltMilitaryWebbing
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: MedkitCombatFilled
+    - id: CombatMedipen
+    - id: CrowbarRed
+    - id: Binoculars

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntnc.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/ntnc.yml
@@ -12,6 +12,10 @@
     belt: ClothingBeltBlueShieldWebbingFilled
     gloves: ClothingHandsGlovesCombat
     suitstorage: WeaponSubMachineGunWt550
+    pocket1: MindShieldImplanter
+    pocket2: DeathRattleImplanterCentcomm
+  inhand: 
+  - RadioImplanterCentcomm
 
 - type: startingGear
   id: NTNCTrainerGear
@@ -28,6 +32,10 @@
     belt: ClothingBeltBlueShieldWebbingFilled
     gloves: ClothingHandsGlovesCombat
     suitstorage: WeaponSubMachineGunWt550
+    pocket1: MindShieldImplanter
+    pocket2: DeathRattleImplanterCentcomm
+  inhand: 
+  - RadioImplanterCentcomm
 
 - type: startingGear
   id: NTNCBasicGear
@@ -44,6 +52,10 @@
     belt: ClothingBeltBlueShieldWebbingFilled
     gloves: ClothingHandsGlovesCombat
     suitstorage: WeaponSubMachineGunWt550
+    pocket1: MindShieldImplanter
+    pocket2: DeathRattleImplanterCentcomm
+  inhand: 
+  - RadioImplanterCentcomm
 
 - type: startingGear
   id: NTNCMedicGear
@@ -59,3 +71,7 @@
     belt: ClothingBeltBlueShieldWebbingFilled
     gloves: ClothingHandsGlovesCombat
     suitstorage: WeaponSubMachineGunWt550
+    pocket1: MindShieldImplanter
+    pocket2: DeathRattleImplanterCentcomm
+  inhand: 
+  - RadioImplanterCentcomm

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Syndicate/gmn.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Syndicate/gmn.yml
@@ -1,0 +1,122 @@
+- type: startingGear
+  id: GMNMAAGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSyndieFormal
+    back: ClothingBackpackSyndicateGMNMAA
+    shoes: ClothingShoesBootsJackFilled
+    outerClothing: ClothingOuterHardsuitSyndie
+    id: CommanderPDA
+    eyes: ClothingEyesHudSyndicate
+    ears: ClothingHeadsetAltSyndicateCommander
+    mask: ClothingMaskGasSyndicate
+    neck: CommanderWhistle
+    belt: ClothingOuterVestWebEliteFilledMAA
+    gloves: ClothingHandsGlovesCombat
+    pocket1: EmpImplanter
+    pocket2: FreedomImplanter
+
+- type: entity
+  id: ClothingBackpackSyndicateGMNMAA
+  parent: ClothingBackpackSyndicate
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponPistolStechkin
+    - id: MagazinePistolCaselessRifle
+    - id: MagazinePistolCaselessRifle
+    - id: MagazinePistolCaselessRifle
+
+- type: startingGear
+  id: GMNDamageControlGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitRepairmanSyndie
+    back: ClothingBackpackSyndicateGMNDamageControl
+    shoes: ClothingShoesBootsJackFilled
+    outerClothing: ClothingOuterHardsuitSyndieElite
+    id: SyndiPDA
+    eyes: ClothingEyesHudSyndicate
+    ears: ClothingHeadsetAltSyndicate
+    mask: ClothingMaskGasSyndicate
+    belt: ClothingBeltMilitaryWebbingFilledDamageControle
+    gloves: ClothingHandsGlovesCombat
+    
+- type: entity
+  id: ClothingBackpackSyndicateGMNDamageControl
+  parent: ClothingBackpackSyndicate
+  components:
+  - type: StorageFill
+    contents:
+    - id: SheetSteel
+    - id: SheetPlasteel
+    - id: SheetRPGlass
+
+- type: startingGear
+  id: GMNNavigatorGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCommandGeneric
+    back: ClothingBackpackSyndicateGMNNavigator
+    shoes: ClothingShoesBootsMagSyndie
+    outerClothing: ClothingOuterHardsuitSyndieElite
+    id: CommanderPDA
+    head: ClothingHeadHatSyndie
+    eyes: ClothingEyesHudSyndicate
+    ears: ClothingHeadsetAltSyndicate
+    mask: ClothingMaskGasSyndicate
+    belt: ClothingBeltMilitaryWebbingFilledNavigator
+    gloves: ClothingHandsGlovesCombat
+
+- type: entity
+  id: ClothingBackpackSyndicateGMNNavigator
+  parent: ClothingBackpackSyndicate
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponPistolCobra
+    - id: MagazinePistolCaselessRifle
+    - id: MagazinePistolCaselessRifle
+    - id: MagazinePistolCaselessRifle
+
+- type: startingGear
+  id: GMNMedicalTechnicianGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCorpsman
+    back: ClothingBackpackDuffelSyndicateMedicalGMN
+    shoes: ClothingShoesBootsMagSyndie
+    outerClothing: ClothingOuterHardsuitSyndieMedic
+    id: SyndiAgentPDA
+    eyes: ClothingEyesHudSyndicateAgent
+    ears: ClothingHeadsetAltSyndicateAgent
+    mask: ClothingMaskGasSyndicate
+    belt: ClothingBeltMilitaryWebbingMedFilled
+    gloves: ClothingHandsGlovesCombat
+
+- type: entity
+  id: ClothingBackpackDuffelSyndicateMedicalGMN
+  parent: ClothingBackpackDuffelSyndicateMedical
+  components:
+  - type: StorageFill
+    contents:
+    - id: SyndiHypo
+    - id: DefibrillatorSyndicate
+
+- type: startingGear
+  id: GMNGunnerGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitOperative
+    back: ClothingBackpackSyndicateGMNGunner
+    shoes: ClothingShoesBootsJackFilled
+    outerClothing: ClothingOuterHardsuitJuggernaut
+    id: SyndiPDA
+    eyes: ClothingEyesHudSyndicate
+    ears: ClothingHeadsetAltSyndicate
+    mask: ClothingMaskGasSyndicate
+    belt: ClothingBeltMilitaryWebbingFilledGunner
+    gloves: ClothingHandsGlovesCombat
+
+- type: entity
+  id: ClothingBackpackSyndicateGMNGunner
+  parent: ClothingBackpackSyndicate
+  components:
+  - type: StorageFill
+    contents:
+    - id: SheetSteel10

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Syndicate/gmn.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Syndicate/gmn.yml
@@ -2,7 +2,7 @@
   id: GMNMAAGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitSyndieFormal
-    back: ClothingBackpackSyndicateGMNMAA
+    back: ClothingBackpackSyndicate
     shoes: ClothingShoesBootsJackFilled
     outerClothing: ClothingOuterHardsuitSyndie
     id: CommanderPDA
@@ -14,17 +14,6 @@
     gloves: ClothingHandsGlovesCombat
     pocket1: EmpImplanter
     pocket2: FreedomImplanter
-
-- type: entity
-  id: ClothingBackpackSyndicateGMNMAA
-  parent: ClothingBackpackSyndicate
-  components:
-  - type: StorageFill
-    contents:
-    - id: WeaponPistolStechkin
-    - id: MagazinePistolCaselessRifle
-    - id: MagazinePistolCaselessRifle
-    - id: MagazinePistolCaselessRifle
 
 - type: startingGear
   id: GMNDamageControlGear
@@ -54,7 +43,7 @@
   id: GMNNavigatorGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitCommandGeneric
-    back: ClothingBackpackSyndicateGMNNavigator
+    back: ClothingBackpackSyndicate
     shoes: ClothingShoesBootsMagSyndie
     outerClothing: ClothingOuterHardsuitSyndieElite
     id: CommanderPDA
@@ -65,22 +54,11 @@
     belt: ClothingBeltMilitaryWebbingFilledNavigator
     gloves: ClothingHandsGlovesCombat
 
-- type: entity
-  id: ClothingBackpackSyndicateGMNNavigator
-  parent: ClothingBackpackSyndicate
-  components:
-  - type: StorageFill
-    contents:
-    - id: WeaponPistolCobra
-    - id: MagazinePistolCaselessRifle
-    - id: MagazinePistolCaselessRifle
-    - id: MagazinePistolCaselessRifle
-
 - type: startingGear
   id: GMNMedicalTechnicianGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitCorpsman
-    back: ClothingBackpackDuffelSyndicateMedicalGMN
+    back: ClothingBackpackDuffelSyndicateMedical
     shoes: ClothingShoesBootsMagSyndie
     outerClothing: ClothingOuterHardsuitSyndieMedic
     id: SyndiAgentPDA
@@ -88,16 +66,9 @@
     ears: ClothingHeadsetAltSyndicateAgent
     mask: ClothingMaskGasSyndicate
     belt: ClothingBeltMilitaryWebbingMedFilled
+    pocket1: SyndiHypo
+    pocket2: DefibrillatorSyndicate
     gloves: ClothingHandsGlovesCombat
-
-- type: entity
-  id: ClothingBackpackDuffelSyndicateMedicalGMN
-  parent: ClothingBackpackDuffelSyndicateMedical
-  components:
-  - type: StorageFill
-    contents:
-    - id: SyndiHypo
-    - id: DefibrillatorSyndicate
 
 - type: startingGear
   id: GMNGunnerGear

--- a/Resources/Prototypes/_StarLight/tags.yml
+++ b/Resources/Prototypes/_StarLight/tags.yml
@@ -17,6 +17,9 @@
   id: BladeSteel
 
 - type: Tag
+  id: Bola
+
+- type: Tag
   id: CantInteract
 
 - type: Tag


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds admeme presets for the GMN. As a bonus, will spawn all NT-NC presets with their implanters ready to use.

## Why we need to add this
Same as with the NT-NC presets: Makes it a LOT easier to run these events because you can spawn in the full set in 1 go.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- add: Adds 5 presets for use by the GMN in naval events. Glory to the sti- I mean syndicate!
- tweak: NT-NC presets now get mindshield, radio and death rattle implants upon spawning in so they can use them.
