### PR TITLE
Dragon nerf again (Hotfix)

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -8,7 +8,7 @@
   components:
   - type: ThermalVision
   - type: Bloodstream
-    bloodMaxVolume: 650
+    bloodMaxVolume: 600
   - type: GhostRole
     allowMovement: true
     allowSpeech: true
@@ -89,12 +89,13 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      450: Critical
-      500: Dead
+      350: Critical
+      400: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
+      200: 0.9
       250: 0.7
-      400: 0.5
+      300: 0.5
   # disable taking damage from fire, since its a fire breathing dragon
   - type: Flammable
     damage:

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -52,18 +52,14 @@
 
 - type: damageModifierSet
   id: DragonResistances
-  flatReductions:
-    Piercing: 4
   coefficients:
     Piercing: 0.3
-    Slash: 1
+    Slash: 2
     Heat: 0.5
     Bloodloss: 0
 
 - type: damageModifierSet
   id: DragonCarpResistances
-  flatReductions:
-    Piercing: 2
   coefficients:
     Piercing: 0.5
     Slash: 2

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -56,14 +56,14 @@
     Piercing: 4
   coefficients:
     Piercing: 0.3
-    Slash: 2
+    Slash: 1
     Heat: 0.5
     Bloodloss: 0
 
 - type: damageModifierSet
   id: DragonCarpResistances
   flatReductions:
-    Piercing: 2.5
+    Piercing: 2
   coefficients:
     Piercing: 0.5
     Slash: 2


### PR DESCRIPTION

## Short description
Reduce Dragon damage thresholds. Can still rapidly heal from injuries, but if you try to tank too much at once you will die. Play smarter.

## Why we need to add this
Still broken as fuck. Rolled all of security and salvage, and then the entire armed crew. Healed from 300+ damage 6 times.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed dragon's max blood from 650 to 600, critical state from 450 damage to 350 damage, and it's dead state from 500 damage to 400 damage. Adjusted wounded speed debuff to match.
