### PR TITLE
add a desc to the un-smart borgi so it doesn't get mixed up.

### DIFF
--- a/Resources/Prototypes/_StarLight/Mobs/Cyborgs/borgi_chassis.yml
+++ b/Resources/Prototypes/_StarLight/Mobs/Cyborgs/borgi_chassis.yml
@@ -253,6 +253,7 @@
 
 - type: entity
   parent: BaseStationBorgiChassis
+  description: A smart dog, loves stating it's laws.
   id: StationBorgiChassis
   components:
     - type: ReplacementAccent


### PR DESCRIPTION
## Short description
"fixes" un-smart borgis not having a unique description making them easy to mix up with smart borgis

## Why we need to add this
clarity in what your (un)lucked out and got

## Media (Video/Screenshots)
it is a yaml description change...

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: un-smart corgis now have a unqiue description so they can be telled apart.
