### PR TITLE
Make width respect a species prototype's max width and act as before

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -61,7 +61,7 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
             if(_sprite.LayerMapTryGet((entity.Owner, sprite), HumanoidVisualLayers.Eyes, out var layerIndex, true))
                 sprite.LayerSetShader(layerIndex, (ShaderInstance?)null);
 
-        sprite.Scale = new Vector2(humanoidAppearance.Width * humanoidAppearance.Height, humanoidAppearance.Height);
+        sprite.Scale = new Vector2(humanoidAppearance.Width, humanoidAppearance.Height);
         //starlight end
     }
 


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Not sure if this was intentional, but this change made it so even if you have maxWidth: 2, maxHeight: 2, you would end up at a horizontal scale of 4 with both set to max, and people's existing horizontal scaling would be different than before.
This also means it's very hard to judge how tall or wide a character is going to be in the customize menu, since it doesn't show you what the final scale will be and it doesn't snap to any values for non-mixel scaling.

This change brings it back how it was before but if this behavior is intended tell me so I can work on showing the final x, y scaling values on the UI instead.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: DrSmugleaf
- tweak: Width now acts as before.
