### PR TITLE
Kitsune Mask Fix

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Mask/masks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Mask/masks.yml
@@ -65,4 +65,4 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.05
+        Blunt: 0.90


### PR DESCRIPTION
## Short description
Changes Kitsune Mask from having 95% blunt resist to having 10% blunt resist

## Why we need to add this
oopsi

## Media (Video/Screenshots)
n/a

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Kitsune Mask now has 10% blunt resist instead of 95%. oopsi i made a fucky wucky (ᵕ•͈ω•͈)
