### PR TITLE
Add fallback check when unobstructed check is insufficient

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using Content.Client.Gameplay;
-using Content.Shared.Doors.Components; // Starlight edit
 using Content.Shared.Effects;
+using Content.Shared.Physics;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Components;
 using Content.Shared.Weapons.Melee.Events;
@@ -13,8 +13,10 @@ using Robust.Client.Player;
 using Robust.Client.State;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components; // Starlight edit
+using Robust.Shared.Map.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
+using Robust.Shared.Physics;
 
 namespace Content.Client.Weapons.Melee;
 
@@ -25,10 +27,10 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IStateManager _stateManager = default!;
     [Dependency] private readonly AnimationPlayerSystem _animation = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!; // Starlight edit
     [Dependency] private readonly InputSystem _inputSystem = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] private readonly MapSystem _map = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private EntityQuery<TransformComponent> _xformQuery;
@@ -153,46 +155,53 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
     protected override bool InRange(EntityUid user, EntityUid target, float range, ICommonSession? session)
     {
-        var xform = Transform(target);
-        var targetCoordinates = xform.Coordinates;
-        var targetLocalAngle = xform.LocalRotation;
-
-        // Default unobstructed check - Starlight edit begins
-        if (Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false))
+        // Client-side unobstructed check.
+        var targetXform = Transform(target);
+        if (Interaction.InRangeUnobstructed(user, target, targetXform.Coordinates, targetXform.LocalRotation, range, overlapCheck: false))
             return true;
 
-        // Fallback for entities on the same tile as a porous blocker
+        // Fallback for same-tile obstructions
         var userXform = Transform(user);
-        var targetXform = xform;
 
-        // Ensure both are on the same map
-        if (userXform.MapID != targetXform.MapID || userXform.MapID == MapId.Nullspace)
+        var userPos = TransformSystem.GetWorldPosition(userXform);
+        var targetPos = TransformSystem.GetWorldPosition(targetXform);
+        var delta = targetPos - userPos;
+        var distance = delta.Length();
+
+        if (distance > range)
             return false;
 
-        // Perform a simple distance check
-        if ((TransformSystem.GetWorldPosition(userXform) - TransformSystem.GetWorldPosition(targetXform)).Length() > range)
+        // If distance is near-zero, it's a point-blank attack. The path is definitionally "unobstructed"
+        if (distance < 0.001f)
+            return true;
+
+        var mapId = userXform.MapID;
+        if (mapId == MapId.Nullspace)
             return false;
 
-        // If within distance, check if the obstruction is a door-like entity on the same tile as the target
+        var dir = delta.Normalized();
+        const int attackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
+
+        var ray = new CollisionRay(userPos, dir, attackMask);
+        var rayCastResults = _physics.IntersectRay(mapId, ray, distance, user, false).ToList();
+
+        if (!rayCastResults.Any() || rayCastResults.First().HitEntity == target)
+            return true;
+
+        var hitEntity = rayCastResults.First().HitEntity;
+
         if (targetXform.GridUid is not { } gridUid || !TryComp<MapGridComponent>(gridUid, out var grid))
             return false;
 
-        var targetTileIndices = _map.CoordinatesToTile(gridUid, grid, targetXform.Coordinates);
+        var hitXform = Transform(hitEntity);
+        if (hitXform.GridUid != gridUid)
+            return false;
 
-        // Use an unambiguous overload by providing the enlargement parameter
-        var entitiesOnTile = _lookup.GetLocalEntitiesIntersecting(gridUid, targetTileIndices, 0.0f, flags: LookupFlags.Static);
+        var targetTile = _map.CoordinatesToTile(gridUid, grid, targetXform.Coordinates);
+        var hitTile = _map.CoordinatesToTile(gridUid, grid, hitXform.Coordinates);
 
-        foreach (var entity in entitiesOnTile)
-        {
-            if (entity == target || entity == user)
-                continue;
-
-            // If we find a DoorComponent OR a TurnstileComponent on this tile, we assume it was the blocker and allow the hit
-            if (HasComp<DoorComponent>(entity) || HasComp<TurnstileComponent>(entity))
-                return true;
-        }
-
-        return false; //Starlight edit ends
+        // If the first obstruction is on the same tile as the target, allow the attack
+        return targetTile == hitTile;
     }
 
     protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)
@@ -246,14 +255,21 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (mousePos.MapId != attackerPos.MapId || (attackerPos.Position - mousePos.Position).Length() > meleeComponent.Range)
             return;
 
+        // Find the entity directly under the cursor
         EntityUid? target = null;
-
         if (_stateManager.CurrentState is GameplayStateBase screen)
             target = screen.GetClickedEntity(mousePos);
 
-        // Don't light-attack if interaction will be handling this instead
-        if (Interaction.CombatModeCanHandInteract(attacker, target))
-            return;
+        // If no entity was clicked (a "miss"), we still want to play the swing animation.
+        // To do this, we target the grid entity itself. The server will should interpret
+        // an attack on a non-damageable grid as a miss
+        if (target == null)
+        {
+            if (MapManager.TryFindGridAt(mousePos, out var gridUid, out _))
+                target = gridUid;
+            else
+                target = _map.GetMapOrInvalid(mousePos.MapId);
+        }
 
         RaisePredictiveEvent(new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(coordinates)));
     }

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Content.Client.Gameplay;
-using Content.Shared.Doors.Components;
+using Content.Shared.Doors.Components; // Starlight edit
 using Content.Shared.Effects;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Components;
@@ -13,7 +13,7 @@ using Robust.Client.Player;
 using Robust.Client.State;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
+using Robust.Shared.Map.Components; // Starlight edit
 using Robust.Shared.Player;
 
 namespace Content.Client.Weapons.Melee;
@@ -25,11 +25,11 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IStateManager _stateManager = default!;
     [Dependency] private readonly AnimationPlayerSystem _animation = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!; // Starlight edit
     [Dependency] private readonly InputSystem _inputSystem = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
     private EntityQuery<TransformComponent> _xformQuery;
 
@@ -157,7 +157,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         var targetCoordinates = xform.Coordinates;
         var targetLocalAngle = xform.LocalRotation;
 
-        // Default unobstructed check
+        // Default unobstructed check - Starlight edit begins
         if (Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false))
             return true;
 
@@ -192,7 +192,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
                 return true;
         }
 
-        return false;
+        return false; //Starlight edit ends
     }
 
     protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using Content.Client.Gameplay;
 using Content.Shared.Effects;
-using Content.Shared.Physics;
+using Content.Shared.Physics; // Starlight-edit™
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Components;
 using Content.Shared.Weapons.Melee.Events;
@@ -13,10 +13,10 @@ using Robust.Client.Player;
 using Robust.Client.State;
 using Robust.Shared.Input;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
-using Robust.Shared.Physics.Systems;
+using Robust.Shared.Map.Components; // Starlight-edit™
+using Robust.Shared.Physics.Systems; // Starlight-edit™
 using Robust.Shared.Player;
-using Robust.Shared.Physics;
+using Robust.Shared.Physics; // Starlight-edit™
 
 namespace Content.Client.Weapons.Melee;
 
@@ -30,7 +30,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly InputSystem _inputSystem = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] private readonly MapSystem _map = default!;
-    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!; // Starlight-edit™
     [Dependency] private readonly SpriteSystem _sprite = default!;
 
     private EntityQuery<TransformComponent> _xformQuery;
@@ -155,12 +155,12 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
     protected override bool InRange(EntityUid user, EntityUid target, float range, ICommonSession? session)
     {
-        // Client-side unobstructed check.
-        var targetXform = Transform(target);
-        if (Interaction.InRangeUnobstructed(user, target, targetXform.Coordinates, targetXform.LocalRotation, range, overlapCheck: false))
-            return true;
+        // Client-side unobstructed check. // Starlight-edit™
+        var targetXform = Transform(target); // Starlight-edit™
+        if (Interaction.InRangeUnobstructed(user, target, targetXform.Coordinates, targetXform.LocalRotation, range, overlapCheck: false)) // Starlight-edit™
+            return true; // Starlight-edit™
 
-        // Fallback for same-tile obstructions
+        // Fallback for same-tile obstructions  // Starlight-edit-begin™
         var userXform = Transform(user);
 
         var userPos = TransformSystem.GetWorldPosition(userXform);
@@ -201,7 +201,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         var hitTile = _map.CoordinatesToTile(gridUid, grid, hitXform.Coordinates);
 
         // If the first obstruction is on the same tile as the target, allow the attack
-        return targetTile == hitTile;
+        return targetTile == hitTile; // Starlight-edit-end™
     }
 
     protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)
@@ -260,7 +260,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (_stateManager.CurrentState is GameplayStateBase screen)
             target = screen.GetClickedEntity(mousePos);
 
-        // If no entity was clicked (a "miss"), we still want to play the swing animation.
+        // If no entity was clicked (a "miss"), we still want to play the swing animation. // Starlight-edit-begin™
         // To do this, we target the grid entity itself. The server will should interpret
         // an attack on a non-damageable grid as a miss
         if (target == null)
@@ -269,7 +269,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
                 target = gridUid;
             else
                 target = _map.GetMapOrInvalid(mousePos.MapId);
-        }
+        } // Starlight-edit-end™
 
         RaisePredictiveEvent(new LightAttackEvent(GetNetEntity(target), GetNetEntity(weaponUid), GetNetCoordinates(coordinates)));
     }

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,17 +1,19 @@
+using System.Linq;
+using System.Numerics;
 using Content.Server.Chat.Systems;
 using Content.Server.Movement.Systems;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Systems;
-using Content.Shared.Doors.Components; // Starlight edit
 using Content.Shared.Effects;
+using Content.Shared.Physics;
 using Content.Shared.Speech.Components;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components; // Starlight edit
+using Robust.Shared.Map.Components;
 using Robust.Shared.Player;
-using System.Linq;
-using System.Numerics;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Server.Weapons.Melee;
 
@@ -19,10 +21,10 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly DamageExamineSystem _damageExamine = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!; // Starlight edit
     [Dependency] private readonly LagCompensationSystem _lag = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
-    [Dependency] private readonly SharedMapSystem _map = default!; // Starlight edit
+    [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 
     public override void Initialize()
     {
@@ -75,53 +77,64 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
     protected override bool InRange(EntityUid user, EntityUid target, float range, ICommonSession? session)
     {
-        // Unobstructed check
-        EntityCoordinates targetCoordinates;
-        Angle targetLocalAngle;
-
+        // Server-side unobstructed check with lag compensation
         if (session is { } pSession)
         {
-            (targetCoordinates, targetLocalAngle) = _lag.GetCoordinatesAngle(target, pSession);
-            if (Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false)) // Starlight edit begin
+            var (targetCoordinates, targetLocalAngle) = _lag.GetCoordinatesAngle(target, pSession);
+            if (Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false))
                 return true;
         }
         else
         {
-            if (Interaction.InRangeUnobstructed(user, target, range))
+            // Fallback for when no session is provided
+            var targetXformSimple = Transform(target);
+            if (Interaction.InRangeUnobstructed(user, target, targetXformSimple.Coordinates, targetXformSimple.LocalRotation, range, overlapCheck: false))
                 return true;
         }
 
-        // Fallback for entities on the same tile as a porous blocker
+        // Fallback for same-tile obstructions
         var userXform = Transform(user);
         var targetXform = Transform(target);
 
-        // Ensure both are on the same map
-        if (userXform.MapID != targetXform.MapID || userXform.MapID == MapId.Nullspace)
+        var userPos = TransformSystem.GetWorldPosition(userXform);
+        var targetPos = TransformSystem.GetWorldPosition(targetXform);
+        var delta = targetPos - userPos;
+        var distance = delta.Length();
+
+        if (distance > range)
             return false;
 
-        // Perform a simple distance check
-        if ((TransformSystem.GetWorldPosition(userXform) - TransformSystem.GetWorldPosition(targetXform)).Length() > range)
+        // If distance is near-zero, it's a point-blank attack. The path is definitionally "unobstructed"
+        if (distance < 0.001f)
+            return true;
+
+        var mapId = userXform.MapID;
+        if (mapId == MapId.Nullspace)
             return false;
 
-        // If within distance, check if the obstruction is a door-like entity on the same tile as the target
+        var dir = delta.Normalized();
+        const int attackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
+
+        var ray = new CollisionRay(userPos, dir, attackMask);
+        var rayCastResults = _physics.IntersectRay(mapId, ray, distance, user, false).ToList();
+
+        if (!rayCastResults.Any() || rayCastResults.First().HitEntity == target)
+            return true;
+
+        var hitEntity = rayCastResults.First().HitEntity;
+
         if (targetXform.GridUid is not { } gridUid || !TryComp<MapGridComponent>(gridUid, out var grid))
             return false;
 
-        var targetTileIndices = _map.CoordinatesToTile(gridUid, grid, targetXform.Coordinates);
+        var hitXform = Transform(hitEntity);
+        if (hitXform.GridUid != gridUid)
+            return false;
 
-        var entitiesOnTile = _lookup.GetLocalEntitiesIntersecting(gridUid, targetTileIndices, 0.0f, flags: LookupFlags.Static);
+        var targetTile = _map.CoordinatesToTile(gridUid, grid, targetXform.Coordinates);
+        var hitTile = _map.CoordinatesToTile(gridUid, grid, hitXform.Coordinates);
 
-        foreach (var entity in entitiesOnTile)
-        {
-            if (entity == target || entity == user)
-                continue;
-
-            // If we find a DoorComponent OR a TurnstileComponent on this tile, we assume it was the blocker and allow the hit
-            if (HasComp<DoorComponent>(entity) || HasComp<TurnstileComponent>(entity))
-                return true; // Starlight edit end
-        }
-
-        return false; // Starlight edit
+        // If the first obstruction is on the same tile as the target, allow the attack
+        return targetTile == hitTile;
     }
 
     protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)
@@ -154,7 +167,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             return;
         }
 
-        if (comp.Battlecry != null)//If the battlecry is set to empty, doesn't speak
+        if (comp.Battlecry != null) //If the battlecry is set to empty, doesn't speak
         {
             _chat.TrySendInGameICMessage(args.User, comp.Battlecry, InGameICChatType.Speak, true, true, checkRadioPrefix: false);  //Speech that isn't sent to chat or adminlogs
         }

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -2,16 +2,16 @@ using Content.Server.Chat.Systems;
 using Content.Server.Movement.Systems;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Systems;
+using Content.Shared.Doors.Components; // Starlight edit
 using Content.Shared.Effects;
 using Content.Shared.Speech.Components;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components; // Starlight edit
 using Robust.Shared.Player;
 using System.Linq;
 using System.Numerics;
-using Content.Shared.Doors.Components;
-using Robust.Shared.Map.Components;
 
 namespace Content.Server.Weapons.Melee;
 
@@ -19,10 +19,10 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly DamageExamineSystem _damageExamine = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!; // Starlight edit
     [Dependency] private readonly LagCompensationSystem _lag = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
-    [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!; // Starlight edit
 
     public override void Initialize()
     {
@@ -82,7 +82,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (session is { } pSession)
         {
             (targetCoordinates, targetLocalAngle) = _lag.GetCoordinatesAngle(target, pSession);
-            if (Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false))
+            if (Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false)) // Starlight edit begin
                 return true;
         }
         else
@@ -118,10 +118,10 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
             // If we find a DoorComponent OR a TurnstileComponent on this tile, we assume it was the blocker and allow the hit
             if (HasComp<DoorComponent>(entity) || HasComp<TurnstileComponent>(entity))
-                return true;
+                return true; // Starlight edit end
         }
 
-        return false;
+        return false; // Starlight edit
     }
 
     protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,19 +1,19 @@
-using System.Linq;
-using System.Numerics;
+using System.Linq; // Starlight-edit™
+using System.Numerics; // Starlight-edit™
 using Content.Server.Chat.Systems;
 using Content.Server.Movement.Systems;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Effects;
-using Content.Shared.Physics;
+using Content.Shared.Physics; // Starlight-edit™
 using Content.Shared.Speech.Components;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Player;
-using Robust.Shared.Physics;
-using Robust.Shared.Physics.Systems;
+using Robust.Shared.Physics; // Starlight-edit™
+using Robust.Shared.Physics.Systems; // Starlight-edit™
 
 namespace Content.Server.Weapons.Melee;
 
@@ -23,8 +23,8 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly DamageExamineSystem _damageExamine = default!;
     [Dependency] private readonly LagCompensationSystem _lag = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
-    [Dependency] private readonly SharedMapSystem _map = default!;
-    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!; // Starlight-edit™
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!; // Starlight-edit™
 
     public override void Initialize()
     {
@@ -80,7 +80,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         // Server-side unobstructed check with lag compensation
         if (session is { } pSession)
         {
-            var (targetCoordinates, targetLocalAngle) = _lag.GetCoordinatesAngle(target, pSession);
+            var (targetCoordinates, targetLocalAngle) = _lag.GetCoordinatesAngle(target, pSession); // Starlight-edit-begin™
             if (Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false))
                 return true;
         }
@@ -89,10 +89,10 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             // Fallback for when no session is provided
             var targetXformSimple = Transform(target);
             if (Interaction.InRangeUnobstructed(user, target, targetXformSimple.Coordinates, targetXformSimple.LocalRotation, range, overlapCheck: false))
-                return true;
+                return true; // Starlight-edit-end™
         }
 
-        // Fallback for same-tile obstructions
+        // Fallback for same-tile obstructions // Starlight-edit-begin™
         var userXform = Transform(user);
         var targetXform = Transform(target);
 
@@ -134,7 +134,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         var hitTile = _map.CoordinatesToTile(gridUid, grid, hitXform.Coordinates);
 
         // If the first obstruction is on the same tile as the target, allow the attack
-        return targetTile == hitTile;
+        return targetTile == hitTile; // Starlight-edit-end™
     }
 
     protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -10,6 +10,8 @@ using Robust.Shared.Map;
 using Robust.Shared.Player;
 using System.Linq;
 using System.Numerics;
+using Content.Shared.Doors.Components;
+using Robust.Shared.Map.Components;
 
 namespace Content.Server.Weapons.Melee;
 
@@ -19,6 +21,8 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
     [Dependency] private readonly DamageExamineSystem _damageExamine = default!;
     [Dependency] private readonly LagCompensationSystem _lag = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
 
     public override void Initialize()
     {
@@ -50,7 +54,7 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         ICommonSession? session)
     {
         // Originally the client didn't predict damage effects so you'd intuit some level of how far
-        // in the future you'd need to predict, but then there was a lot of complaining like "why would you add artifical delay" as if ping is a choice.
+        // in the future you'd need to predict, but then there was a lot of complaining like "why would you add artificial delay" as if ping is a choice.
         // Now damage effects are predicted but for wide attacks it differs significantly from client and server so your game could be lying to you on hits.
         // This isn't fair in the slightest because it makes ping a huge advantage and this would be a hidden system.
         // Now the client tells us what they hit and we validate if it's plausible.
@@ -71,16 +75,53 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
 
     protected override bool InRange(EntityUid user, EntityUid target, float range, ICommonSession? session)
     {
+        // Unobstructed check
         EntityCoordinates targetCoordinates;
         Angle targetLocalAngle;
 
         if (session is { } pSession)
         {
             (targetCoordinates, targetLocalAngle) = _lag.GetCoordinatesAngle(target, pSession);
-            return Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false);
+            if (Interaction.InRangeUnobstructed(user, target, targetCoordinates, targetLocalAngle, range, overlapCheck: false))
+                return true;
+        }
+        else
+        {
+            if (Interaction.InRangeUnobstructed(user, target, range))
+                return true;
         }
 
-        return Interaction.InRangeUnobstructed(user, target, range);
+        // Fallback for entities on the same tile as a porous blocker
+        var userXform = Transform(user);
+        var targetXform = Transform(target);
+
+        // Ensure both are on the same map
+        if (userXform.MapID != targetXform.MapID || userXform.MapID == MapId.Nullspace)
+            return false;
+
+        // Perform a simple distance check
+        if ((TransformSystem.GetWorldPosition(userXform) - TransformSystem.GetWorldPosition(targetXform)).Length() > range)
+            return false;
+
+        // If within distance, check if the obstruction is a door-like entity on the same tile as the target
+        if (targetXform.GridUid is not { } gridUid || !TryComp<MapGridComponent>(gridUid, out var grid))
+            return false;
+
+        var targetTileIndices = _map.CoordinatesToTile(gridUid, grid, targetXform.Coordinates);
+
+        var entitiesOnTile = _lookup.GetLocalEntitiesIntersecting(gridUid, targetTileIndices, 0.0f, flags: LookupFlags.Static);
+
+        foreach (var entity in entitiesOnTile)
+        {
+            if (entity == target || entity == user)
+                continue;
+
+            // If we find a DoorComponent OR a TurnstileComponent on this tile, we assume it was the blocker and allow the hit
+            if (HasComp<DoorComponent>(entity) || HasComp<TurnstileComponent>(entity))
+                return true;
+        }
+
+        return false;
     }
 
     protected override void DoDamageEffect(List<EntityUid> targets, EntityUid? user, TransformComponent targetXform)


### PR DESCRIPTION
## Short description
Fixes light melee attack targeting and validation by adding a fallback check when the unobstructed check is insufficient. This resolves an issue where attacks would fail against targets on the same tile as an occluding entity (eg Kudzu on a turnstile)

## Why we need to add this
When Kudzu grew on a tile occupied by an entity with a physics body and occluder (like a turnstile), it became impossible to damage. The client would correctly target the Kudzu (which is visually on top), but the server would reject the hit because the turnstile's body blocked the line-of-sight check

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/4c92f36d-6906-4075-97fe-08b6c223ad45

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: TopGuy
- fix: Fixed kudzu that grew on turnstiles being untargetable