### PR TITLE
Starlight custom changelog

### DIFF
--- a/Tools/_Starlight/update_changelog.py
+++ b/Tools/_Starlight/update_changelog.py
@@ -86,7 +86,6 @@ def update_changelog():
 
         last_id = 0
         for entry in entries:
-            last_id += 1
             #shift PR number up two digits
             #add current ID to it
             # e.g., PR number 123, last_id 5 -> calculatedID = (123 * 100) + 5 = 12305
@@ -102,6 +101,7 @@ def update_changelog():
                 "url": f"https://github.com/{repo_name}/pull/{pr_number}"
             }
             changelog_data["Entries"].append(changelog_entry)
+            last_id += 1
 
         os.makedirs(os.path.dirname(changelog_path), exist_ok=True)
 

--- a/Tools/_Starlight/update_changelog.py
+++ b/Tools/_Starlight/update_changelog.py
@@ -96,7 +96,7 @@ def update_changelog():
                     "message": entry["message"],
                     "type": entry["type"]
                 }],
-                "id": last_id,
+                "id": calculatedID,
                 "time": merge_time.isoformat(timespec='microseconds'),
                 "url": f"https://github.com/{repo_name}/pull/{pr_number}"
             }

--- a/Tools/_Starlight/update_changelog.py
+++ b/Tools/_Starlight/update_changelog.py
@@ -84,9 +84,13 @@ def update_changelog():
             print(f"Changelog file does not exist and will be created at {changelog_path}")
             changelog_data = {"Entries": []}
 
-        last_id = get_last_id(changelog_data)
+        last_id = 0
         for entry in entries:
             last_id += 1
+            #shift PR number up two digits
+            #add current ID to it
+            # e.g., PR number 123, last_id 5 -> calculatedID = (123 * 100) + 5 = 12305
+            calculatedID = (pr_number * 100) + last_id
             changelog_entry = {
                 "author": entry["author"],
                 "changes": [{


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a new way that changelog IDs are made, that should make them impervious to merge conflicts

uses the PR number in combiniation with each changelog entry to generate a unique integer for each

for example
PR number 123, last_id 5 -> calculatedID = (123 * 100) + 5 = 12305

supports up to 100 CL entrys per pull request

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This makes it so it doesnt matter when starlight and starlight-dev are out of sync, changelog entrys should always be unique

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
