### PR TITLE
Birb noises for Avali too

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -66,6 +66,7 @@
     - type: Speech
       speechVerb: Parrot # RMC did it right.
       speechSounds: MaleAvali
+      allowedEmotes: ['Chirp', 'Hisses', 'Purr', 'Growl', 'Trill', 'Scree', 'Call', 'Squawk']
     - type: MobThresholds
       thresholds:
         0: Alive

--- a/Resources/Prototypes/_StarLight/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_StarLight/Voice/speech_emote_sounds.yml
@@ -34,6 +34,8 @@
       collection: Whistles
     Weh:
       collection: Weh
+    Hew:
+      collection: Hew
     Gasp:
       collection: MaleGasp
     DefaultDeathgasp:
@@ -74,6 +76,8 @@
       collection: Whistles
     Weh:
       collection: Weh
+    Hew:
+      collection: Hew
     Gasp:
       collection: FemaleGasp
     DefaultDeathgasp:
@@ -118,6 +122,10 @@
       collection: MaleGasp
     DefaultDeathgasp:
       collection: MaleDeathGasp
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
 
 - type: emoteSounds
   id: FemaleFelionoid
@@ -158,6 +166,10 @@
       collection: FemaleGasp
     DefaultDeathgasp:
       collection: FemaleDeathGasp
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
 
 - type: emoteSounds
   id: MaleCyclorite
@@ -178,6 +190,10 @@
       collection: CycloriteWhistle
     Yawn:
       collection: CycloriteYawn
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
 
 - type: emoteSounds
   id: FemaleCyclorite
@@ -198,6 +214,10 @@
       collection: CycloriteWhistle
     Yawn:
       collection: CycloriteYawn
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
 
 # Avali Sounds
 - type: emoteSounds
@@ -208,7 +228,7 @@
     Scream:
       path: /Audio/_Starlight/Effects/avali_scream.ogg
     Laugh:
-      collection: MaleLaugh
+      collection: ResomiLaugh
     Sneeze:
       collection: MaleSneezes
     Cough:
@@ -219,16 +239,36 @@
       collection: Snores
     Sigh:
       collection: MaleSigh
-    Crying:
-      collection: MaleCry
-    Whistle:
-      collection: Whistles
     Weh:
       collection: Weh
+    Hew:
+      collection: Hew
     Gasp:
       collection: MaleGasp
     DefaultDeathgasp:
       collection: MaleDeathGasp
+    Hisses:
+      collection: FelionoidHisses
+    Purr:
+      collection: FelionoidPurrs
+    Growl:
+      collection: FelionoidGrowls
+    Trill:
+      collection: FelionoidTrills
+    Scree:
+      collection: ResomiScrees
+    Call:
+      collection: ResomiCalls
+    Squawk:
+      collection: ResomiSquawk
+    Crying:
+      collection: MaleCry
+    Honk:
+      collection: BikeHorn
+    Whistle:
+      path: /Audio/Voice/Resomi/resomi_whistle.ogg
+    Chirp:
+      collection: ResomiChirp
 
 - type: emoteSounds
   id: FemaleAvali
@@ -238,7 +278,7 @@
     Scream:
       path: /Audio/_Starlight/Effects/avali_scream.ogg
     Laugh:
-      collection: FemaleLaugh
+      collection: ResomiLaugh
     Sneeze:
       collection: FemaleSneezes
     Cough:
@@ -249,16 +289,36 @@
       collection: Snores
     Sigh:
       collection: FemaleSigh
-    Crying:
-      collection: FemaleCry
-    Whistle:
-      collection: Whistles
     Weh:
       collection: Weh
+    Hew:
+      collection: Hew
     Gasp:
       collection: FemaleGasp
     DefaultDeathgasp:
       collection: FemaleDeathGasp
+    Hisses:
+      collection: FelionoidHisses
+    Purr:
+      collection: FelionoidPurrs
+    Growl:
+      collection: FelionoidGrowls
+    Trill:
+      collection: FelionoidTrills
+    Scree:
+      collection: ResomiScrees
+    Call:
+      collection: ResomiCalls
+    Squawk:
+      collection: ResomiSquawk
+    Crying:
+      collection: FemaleCry
+    Honk:
+      collection: BikeHorn
+    Whistle:
+      path: /Audio/Voice/Resomi/resomi_whistle.ogg
+    Chirp:
+      collection: ResomiChirp
 
 - type: emoteSounds
   id: MaleShadekin
@@ -285,6 +345,8 @@
       collection: Whistles
     Weh:
       collection: Weh
+    Hew:
+      collection: Hew
     Gasp:
       collection: MaleGasp
     DefaultDeathgasp:
@@ -325,6 +387,8 @@
       collection: Whistles
     Weh:
       collection: Weh
+    Hew:
+      collection: Hew
     Gasp:
       collection: FemaleGasp
     DefaultDeathgasp:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
birb
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Resomi have bird noises, Avali do not. They're both birds. Clearly, Avali need to steal Resomi's bird noises.
Also fixes some missing noises for other species, notably [Weh] & [Hew]
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->
:cl: Killer Tamashi
- add: Bird noises to Avali
- fix: Fixed missing noises in other species, you can now Weh and Hew to your heart's content