### PR TITLE
QM Knuckleduster Mining

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -522,6 +522,7 @@
     damage:
       types:
         Blunt: 14
+        Structural: 10 #Starlight
     soundHit:
       collection: Knuckles #Starlight
       params:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Add 10 structural damage to QM's golden knuckledusters

## Why we need to add this
Knuckedusters replace your unarmed melee attack with whatever is attached to the knuckleduster in question. For Cyclorites, this means they loose their 10 structural damage when punching. readding that back to QM dusters specifically should not have an impact on the QM duster's combat performance - but *does* allow QMs to just... punch rocks to mine. And un-debuffs cyclorite QMs. Do I think this addition will actually see frequent use? Not really. But there certainly are situations where rocks show up on station (meteors, rock anomalies), where cyclorite QMs should not need to take off their knuckle dusters - and for everyone else it is fun to get the same very nieche ability. At the same time, it is still outclassed by even a basic pickaxe, so QMs should not be tempted to give their knuckledusters to mining specialists for this.

## Media (Video/Screenshots)
<img width="263" height="89" alt="grafik" src="https://github.com/user-attachments/assets/23971b93-43d3-4918-bb87-d68291fa6b7b" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Citrea
- tweak: Quartermasters can now destroy asteroids with the power of pure rage (and their knuckle dusters)
