### PR TITLE
Made various tools usable as extremely budget surgery tools

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
@@ -40,6 +40,14 @@
       - DrinkSpaceGlue
   - type: TrashOnSolutionEmpty
     solution: drink
+  - type: BoneGel # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.4 # really not ideal, but in a pinch...
+    speed: 1.5
+    startSound:
+      path: /Audio/Items/Medical/ointment_begin.ogg
+    endSound:
+      path: /Audio/Items/Medical/ointment_end.ogg
 
 - type: entity
   parent: DrinkBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
@@ -40,14 +40,16 @@
       - DrinkSpaceGlue
   - type: TrashOnSolutionEmpty
     solution: drink
-  - type: BoneGel # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: BoneGel
+  - type: SurgeryTool
     successRate: 0.4 # really not ideal, but in a pinch...
     speed: 1.5
     startSound:
       path: /Audio/Items/Medical/ointment_begin.ogg
     endSound:
       path: /Audio/Items/Medical/ointment_end.ogg
+  # 🌟Starlight-end🌟
 
 - type: entity
   parent: DrinkBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -364,6 +364,14 @@
   - type: PhysicalComposition
     materialComposition:
       Glass: 50
+  - type: BoneGel # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.01 # How.
+    speed: 0.5
+    startSound:
+      path: /Audio/Items/Medical/ointment_begin.ogg
+    endSound:
+      path: /Audio/Items/Medical/ointment_end.ogg
 
 - type: entity
   parent: BaseFoodCondimentBottle

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -364,14 +364,16 @@
   - type: PhysicalComposition
     materialComposition:
       Glass: 50
-  - type: BoneGel # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: BoneGel
+  - type: SurgeryTool
     successRate: 0.01 # How.
     speed: 0.5
     startSound:
       path: /Audio/Items/Medical/ointment_begin.ogg
     endSound:
       path: /Audio/Items/Medical/ointment_end.ogg
+  # 🌟Starlight-end🌟
 
 - type: entity
   parent: BaseFoodCondimentBottle

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -975,6 +975,14 @@
   - type: Tag
     tags:
     - DrinkSpaceGlue
+  - type: BoneGel # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.4 # really not ideal, but in a pinch...
+    speed: 1.5
+    startSound:
+      path: "/Audio/Items/bikehorn.ogg"
+    endSound:
+      path: "/Audio/Items/Toys/pushHornHonk.ogg"
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -975,14 +975,16 @@
   - type: Tag
     tags:
     - DrinkSpaceGlue
-  - type: BoneGel # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: BoneGel
+  - type: SurgeryTool
     successRate: 0.4 # really not ideal, but in a pinch...
     speed: 1.5
     startSound:
       path: "/Audio/Items/bikehorn.ogg"
     endSound:
       path: "/Audio/Items/Toys/pushHornHonk.ogg"
+  # 🌟Starlight-end🌟
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
@@ -26,3 +26,11 @@
     - type: Tag
       tags:
       - MicroManipulatorStockPart
+    # 🌟Starlight-start🌟
+    - type: Hemostat
+    - type: SurgeryTool
+      successRate: 0.3 # These are crude but, can grab things
+      speed: 1.5
+      startSound:
+        path: /Audio/_Starlight/Medical/Surgery/hemostat1.ogg
+    # 🌟Starlight-end🌟

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -100,6 +100,14 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 100
+  - type: BoneSaw # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.4
+    speed: 0.8
+    startSound:
+      path: /Audio/Effects/chop.ogg
+    endSound:
+      path: /Audio/Effects/chop.ogg
 
 - type: entity
   name: spade

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -100,14 +100,16 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 100
-  - type: BoneSaw # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: BoneSaw
+  - type: SurgeryTool
     successRate: 0.4
     speed: 0.8
     startSound:
       path: /Audio/Effects/chop.ogg
     endSound:
       path: /Audio/Effects/chop.ogg
+  # 🌟Starlight-end🌟
 
 - type: entity
   name: spade

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
@@ -84,6 +84,12 @@
   - type: ContainerContainer
     containers:
       item-container: !type:Container
+  - type: Retractor # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.05 # they are very much too large
+    speed: 1.5
+    startSound:
+      path: /Audio/Mecha/sound_mecha_hydraulic.ogg
 
 - type: entity
   id: MechEquipmentGrabberSmall
@@ -113,6 +119,12 @@
     tags:
     - IndustrialMech
     - SmallMech
+  - type: Retractor # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.1 # they are very much too large
+    speed: 1.5
+    startSound:
+      path: /Audio/Mecha/sound_mecha_hydraulic.ogg
 
 - type: entity
   id: MechEquipmentHorn

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
@@ -84,12 +84,14 @@
   - type: ContainerContainer
     containers:
       item-container: !type:Container
-  - type: Retractor # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: Retractor
+  - type: SurgeryTool
     successRate: 0.05 # they are very much too large
     speed: 1.5
     startSound:
       path: /Audio/Mecha/sound_mecha_hydraulic.ogg
+  # 🌟Starlight-end🌟
 
 - type: entity
   id: MechEquipmentGrabberSmall
@@ -119,12 +121,14 @@
     tags:
     - IndustrialMech
     - SmallMech
-  - type: Retractor # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: Retractor
+  - type: SurgeryTool
     successRate: 0.1 # they are very much too large
     speed: 1.5
     startSound:
       path: /Audio/Mecha/sound_mecha_hydraulic.ogg
+  # 🌟Starlight-end🌟
 
 - type: entity
   id: MechEquipmentHorn

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/barber.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/barber.yml
@@ -24,11 +24,10 @@
         Piercing: 6
     soundHit:
       path: "/Audio/Weapons/bladeslice.ogg"
-  - type: Scalpel
   # 🌟Starlight-start🌟
   - type: Hemostat
   - type: SurgeryTool
-    successRate: 0.2 # Using something sharp as a hemostat is very dangerous
+    successRate: 0.05 # Using something sharp as a hemostat is very dangerous
     speed: 1.5
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/hemostat1.ogg

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/barber.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/barber.yml
@@ -25,12 +25,12 @@
     soundHit:
       path: "/Audio/Weapons/bladeslice.ogg"
   - type: Scalpel
-  - type: SurgeryTool
-    successRate: 0.12
+  - type: Hemostat # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.2 # Using something sharp as a hemostat is very dangerous
+    speed: 1.5
     startSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel1.ogg
-    endSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel2.ogg
+      path: /Audio/_Starlight/Medical/Surgery/hemostat1.ogg
   - type: PhysicalComposition
     materialComposition:
       Steel: 200

--- a/Resources/Prototypes/Entities/Objects/Specific/Service/barber.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/barber.yml
@@ -25,12 +25,14 @@
     soundHit:
       path: "/Audio/Weapons/bladeslice.ogg"
   - type: Scalpel
-  - type: Hemostat # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: Hemostat
+  - type: SurgeryTool
     successRate: 0.2 # Using something sharp as a hemostat is very dangerous
     speed: 1.5
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/hemostat1.ogg
+  # 🌟Starlight-end🌟
   - type: PhysicalComposition
     materialComposition:
       Steel: 200

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -33,6 +33,14 @@
     guides:
     - VoltageNetworks
     - Power
+  - type: Retractor # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.6 # really not ideal, but in a pinch...
+    speed: 1.5
+    startSound:
+      path: /Audio/_Starlight/Medical/Surgery/retractor1.ogg
+    endSound:
+      path: /Audio/_Starlight/Medical/Surgery/retractor2.ogg
 
 - type: entity
   id: CableHVStack

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -33,14 +33,16 @@
     guides:
     - VoltageNetworks
     - Power
-  - type: Retractor # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: Retractor
+  - type: SurgeryTool
     successRate: 0.6 # really not ideal, but in a pinch...
     speed: 1.5
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/retractor1.ogg
     endSound:
       path: /Audio/_Starlight/Medical/Surgery/retractor2.ogg
+  # 🌟Starlight-end🌟
 
 - type: entity
   id: CableHVStack

--- a/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
@@ -41,12 +41,14 @@
     size: Normal
     shape:
     - 0,0,0,1
-  - type: BoneSetter # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: BoneSetter
+  - type: SurgeryTool
     successRate: 0.4
     speed: 1.5
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/bone_setter.ogg
+  # 🌟Starlight-end🌟
 
 # Standard (grey) Crowbar
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
@@ -41,6 +41,12 @@
     size: Normal
     shape:
     - 0,0,0,1
+  - type: BoneSetter # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.4
+    speed: 1.5
+    startSound:
+      path: /Audio/_Starlight/Medical/Surgery/bone_setter.ogg
 
 # Standard (grey) Crowbar
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -53,13 +53,13 @@
     netsync: false
   - type: IgnitionSource
     temperature: 1000
-  - type: SurgeryTool
+  - type: SurgeryTool # 🌟Starlight🌟
     successRate: 0.1
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery1.ogg
     endSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery2.ogg
-  - type: Cautery
+  - type: Cautery # 🌟Starlight🌟
   - type: LightBehaviour
     behaviours:
       - !type:FadeBehaviour # have the radius start small and get larger as it starts to burn

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -53,6 +53,13 @@
     netsync: false
   - type: IgnitionSource
     temperature: 1000
+  - type: SurgeryTool
+    successRate: 0.1
+    startSound:
+      path: /Audio/_Starlight/Medical/Surgery/cautery1.ogg
+    endSound:
+      path: /Audio/_Starlight/Medical/Surgery/cautery2.ogg
+  - type: Cautery
   - type: LightBehaviour
     behaviours:
       - !type:FadeBehaviour # have the radius start small and get larger as it starts to burn

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -53,13 +53,15 @@
     netsync: false
   - type: IgnitionSource
     temperature: 1000
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: SurgeryTool
     successRate: 0.1
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery1.ogg
     endSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery2.ogg
-  - type: Cautery # 🌟Starlight🌟
+  - type: Cautery
+  # 🌟Starlight-end🌟
   - type: LightBehaviour
     behaviours:
       - !type:FadeBehaviour # have the radius start small and get larger as it starts to burn

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -49,6 +49,14 @@
         Blunt: 10
     soundHit:
       collection: MetalThud
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.8
+    speed: 0.8
+    startSound:
+      path: /Audio/Items/jaws_cut.ogg
+    endSound:
+      path: /Audio/Items/change_jaws.ogg
+  - type: BoneSaw # 🌟Starlight🌟
 
 - type: entity
   name: syndicate jaws of life

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -49,14 +49,16 @@
         Blunt: 10
     soundHit:
       collection: MetalThud
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: SurgeryTool
     successRate: 0.8
     speed: 0.8
     startSound:
       path: /Audio/Items/jaws_cut.ogg
     endSound:
       path: /Audio/Items/change_jaws.ogg
-  - type: BoneSaw # 🌟Starlight🌟
+  - type: BoneSaw
+  # 🌟Starlight-end🌟
 
 - type: entity
   name: syndicate jaws of life

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -44,12 +44,12 @@
   - type: StaticPrice
     price: 30
   - type: Scalpel
-  - type: SurgeryTool
-    successRate: 0.35
+  - type: Hemostat # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.2 # Using something sharp as a hemostat is very dangerous
+    speed: 1.5
     startSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel1.ogg
-    endSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel2.ogg
+      path: /Audio/_Starlight/Medical/Surgery/hemostat1.ogg
 
 - type: entity
   name: screwdriver
@@ -94,6 +94,12 @@
       Steel: 100
   - type: StaticPrice
     price: 30
+  - type: SurgicalDrill # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.4 # really not ideal, but in a pinch...
+    speed: 1.2
+    endSound:
+      path: /Audio/Weapons/smash.ogg
 
 - type: entity
   name: wrench
@@ -297,6 +303,12 @@
         Piercing: 10
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
+  - type: SurgicalDrill # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.6 # Not ideal, but it works
+    speed: 1.2
+    startSound:
+      path: /Audio/Items/drill_use.ogg
 
 - type: entity
   id: RCD

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -43,11 +43,10 @@
       Steel: 100
   - type: StaticPrice
     price: 30
-  - type: Scalpel
   # 🌟Starlight-start🌟
   - type: Hemostat
   - type: SurgeryTool
-    successRate: 0.2 # Using something sharp as a hemostat is very dangerous
+    successRate: 0.05 # Using something sharp as a hemostat is very dangerous
     speed: 1.5
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/hemostat1.ogg

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -44,12 +44,14 @@
   - type: StaticPrice
     price: 30
   - type: Scalpel
-  - type: Hemostat # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: Hemostat
+  - type: SurgeryTool
     successRate: 0.2 # Using something sharp as a hemostat is very dangerous
     speed: 1.5
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/hemostat1.ogg
+  # 🌟Starlight-end🌟
 
 - type: entity
   name: screwdriver
@@ -94,12 +96,14 @@
       Steel: 100
   - type: StaticPrice
     price: 30
-  - type: SurgicalDrill # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: SurgicalDrill
+  - type: SurgeryTool
     successRate: 0.4 # really not ideal, but in a pinch...
     speed: 1.2
     endSound:
       path: /Audio/Weapons/smash.ogg
+  # 🌟Starlight-end🌟
 
 - type: entity
   name: wrench
@@ -303,12 +307,14 @@
         Piercing: 10
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
-  - type: SurgicalDrill # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: SurgicalDrill
+  - type: SurgeryTool
     successRate: 0.6 # Not ideal, but it works
     speed: 1.2
     startSound:
       path: /Audio/Items/drill_use.ogg
+  # 🌟Starlight-end🌟
 
 - type: entity
   id: RCD

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -105,6 +105,13 @@
     price: 40
   - type: IgnitionSource
     temperature: 700
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.75
+    startSound:
+      path: /Audio/_Starlight/Medical/Surgery/cautery1.ogg
+    endSound:
+      path: /Audio/_Starlight/Medical/Surgery/cautery2.ogg
+  - type: Cautery # 🌟Starlight🌟
 
 - type: entity
   name: industrial welding tool

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -105,13 +105,15 @@
     price: 40
   - type: IgnitionSource
     temperature: 700
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: SurgeryTool
     successRate: 0.75
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery1.ogg
     endSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery2.ogg
-  - type: Cautery # 🌟Starlight🌟
+  - type: Cautery
+  # 🌟Starlight-end🌟
 
 - type: entity
   name: industrial welding tool

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
@@ -47,10 +47,11 @@
         maxVol: 300
   - type: UseDelay
     delay: 1
-  - type: Scalpel
   - type: SurgeryTool
-    successRate: 0.01
+    successRate: 0.6 # 🌟Starlight🌟
+    speed: 0.2 #Chainsaws are very fast 🌟Starlight🌟
     startSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel1.ogg
+      path: /Audio/Weapons/chainsawwield.ogg
     endSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel2.ogg
+      path: /Audio/Weapons/chainsaw.ogg
+  - type: BoneSaw # 🌟Starlight🌟

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -70,6 +70,13 @@
   - type: Reflect
   - type: IgnitionSource
     temperature: 700
+  - type: SurgeryTool
+    successRate: 0.8
+    startSound:
+      path: /Audio/_Starlight/Medical/Surgery/cautery1.ogg
+    endSound:
+      path: /Audio/_Starlight/Medical/Surgery/cautery2.ogg
+  - type: Cautery
 
 - type: entity
   name: energy sword
@@ -88,13 +95,6 @@
       map: [ "blade" ]
   - type: Item
     sprite: Objects/Weapons/Melee/e_sword-inhands.rsi
-  - type: Scalpel
-  - type: SurgeryTool
-    successRate: 0.6
-    startSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel1.ogg
-    endSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel2.ogg
   - type: StaticPrice
     price: 2500
 
@@ -159,13 +159,6 @@
     energy: 1.5
     color: white
     netsync: false
-  - type: Scalpel
-  - type: SurgeryTool
-    successRate: 0.6
-    startSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel1.ogg
-    endSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel2.ogg
 
 - type: entity
   name: pen
@@ -233,13 +226,6 @@
   - type: Tag
     tags:
     - Write
-  - type: Scalpel
-  - type: SurgeryTool
-    successRate: 0.6
-    startSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel1.ogg
-    endSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel2.ogg
 
 - type: entity
   parent: [BaseItem, BaseSyndicateContraband]
@@ -345,13 +331,6 @@
   - type: Reflect
     reflectProb: .75
     spread: 75
-  - type: Scalpel
-  - type: SurgeryTool
-    successRate: 0.6
-    startSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel1.ogg
-    endSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel2.ogg
 
 # Item will look weird in handslot. Will need to adjust handstorage visuals in a future PR
 - type: entity
@@ -415,13 +394,6 @@
   components: # could add energy-draining like the L6C
   - type: Wieldable
     freeHandsRequired: 0 # because borg has no off-hand to wield with.  Without this, it will be unable to activate the esword
-  - type: Scalpel
-  - type: SurgeryTool
-    successRate: 0.6
-    startSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel1.ogg
-    endSound:
-      path: /Audio/_Starlight/Medical/Surgery/scalpel2.ogg
 
 - type: entity
   parent: [ EnergyDaggerLoud, BaseXenoborgContraband ]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -72,7 +72,7 @@
     temperature: 700
   # 🌟Starlight-start🌟
   - type: SurgeryTool
-    successRate: 0.8
+    successRate: 0.6
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery1.ogg
     endSound:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -70,14 +70,16 @@
   - type: Reflect
   - type: IgnitionSource
     temperature: 700
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: SurgeryTool
     successRate: 0.8
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery1.ogg
     endSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery2.ogg
-  - type: Cautery # 🌟Starlight🌟
-  - type: Scalpel # 🌟Starlight🌟
+  - type: Cautery
+  - type: Scalpel
+  # 🌟Starlight-end🌟
 
 - type: entity
   name: energy sword

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -70,13 +70,14 @@
   - type: Reflect
   - type: IgnitionSource
     temperature: 700
-  - type: SurgeryTool
+  - type: SurgeryTool # 🌟Starlight🌟
     successRate: 0.8
     startSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery1.ogg
     endSound:
       path: /Audio/_Starlight/Medical/Surgery/cautery2.ogg
-  - type: Cautery
+  - type: Cautery # 🌟Starlight🌟
+  - type: Scalpel # 🌟Starlight🌟
 
 - type: entity
   name: energy sword

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -47,6 +47,14 @@
     stealGroup: FireAxe
   - type: IgniteOnMeleeHit
     fireStacks: -4
+  - type: BoneSaw # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.6
+    speed: 0.6
+    startSound:
+      path: "/Audio/Effects/chop.ogg"
+    endSound:
+      path: "/Audio/Effects/chop.ogg"
 
 - type: entity
   id: FireAxeFlaming

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -47,14 +47,16 @@
     stealGroup: FireAxe
   - type: IgniteOnMeleeHit
     fireStacks: -4
-  - type: BoneSaw # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: BoneSaw
+  - type: SurgeryTool
     successRate: 0.6
     speed: 0.6
     startSound:
       path: "/Audio/Effects/chop.ogg"
     endSound:
       path: "/Audio/Effects/chop.ogg"
+  # 🌟Starlight-end🌟
 
 - type: entity
   id: FireAxeFlaming

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -39,12 +39,14 @@
     materialComposition:
       Steel: 100
       Wood: 100
-  - type: SurgicalDrill # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: SurgicalDrill
+  - type: SurgeryTool
     successRate: 0.01 # You can try
     speed: 0.5
     endSound:
       path: "/Audio/Weapons/smash.ogg"
+  # 🌟Starlight-end🌟
 
 - type: entity
   name: mining drill
@@ -72,14 +74,16 @@
         Brute: 3
       types:
         Structural: 15
-  - type: SurgicalDrill # 🌟Starlight🌟
-  - type: SurgeryTool # 🌟Starlight🌟
+  # 🌟Starlight-start🌟
+  - type: SurgicalDrill
+  - type: SurgeryTool
     successRate: 0.2 # This drill is way too big, really
     speed: 0.8
     startSound:
       path: "/Audio/Items/drill_use.ogg"
     endSound:
       path: "/Audio/Items/drill_use.ogg"
+  # 🌟Starlight-end🌟
 
 - type: entity
   name: diamond tipped mining drill

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -39,6 +39,12 @@
     materialComposition:
       Steel: 100
       Wood: 100
+  - type: SurgicalDrill # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.01 # You can try
+    speed: 0.5
+    endSound:
+      path: "/Audio/Weapons/smash.ogg"
 
 - type: entity
   name: mining drill
@@ -66,6 +72,14 @@
         Brute: 3
       types:
         Structural: 15
+  - type: SurgicalDrill # 🌟Starlight🌟
+  - type: SurgeryTool # 🌟Starlight🌟
+    successRate: 0.2 # This drill is way too big, really
+    speed: 0.8
+    startSound:
+      path: "/Audio/Items/drill_use.ogg"
+    endSound:
+      path: "/Audio/Items/drill_use.ogg"
 
 - type: entity
   name: diamond tipped mining drill

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cyberlimb.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cyberlimb.yml
@@ -42,13 +42,16 @@
         Blunt: 0.5
   - type: Item
     sprite: _Starlight/Objects/Weapons/Melee/cyberchainsaw.rsi
-  - type: Scalpel
+  # 🌟Starlight-start🌟
+  - type: BoneSaw
   - type: SurgeryTool
-    successRate: 0.01
+    successRate: 0.6
+    speed: 0.2
     startSound:
-      path: /Audio/Weapons/chainsaw.ogg
+      path: /Audio/Weapons/chainsawwield.ogg
     endSound:
       path: /Audio/Weapons/chainsaw.ogg
+  # 🌟Starlight-end🌟
   - type: Reflect
     reflectProb: 0.1
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Add extreme-budget surgery tools

## Why we need to add this
Surgery, as of now, is impossible to fully do without using proper medical tools, which are only available to medical. This also means that the fancy cybernetic arm antagonists get - as well as the more regular, crew-accessible implants - are of very limited use to antagonists, as they *essentially* have to get them implanted by an accomplice working in specifically surgery. With this PR, I am intending to introduce options to fully complete any surgery - given enough time and creativity - with a variety of tools really not meant for the job. 

## Media (Video/Screenshots)
<img width="1086" height="349" alt="grafik" src="https://github.com/user-attachments/assets/14a79487-5ed9-4d9c-90de-5e3122d4dd37" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Citrea
- tweak: Several items can now be used as *very* inefficient surgery tools to enable full back-alley surgeries.