### PR TITLE
Removed "Drone" lawset

### DIFF
--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -617,6 +617,6 @@
     PainterLawset: 1
     AntimovLawset: 0.25
     NutimovLawset: 0.5
-# Starlight    Drone: 0.5
+#    Drone: 0.5 Starlight-edit: Removed Drone Lawset from pool
     Ninja: 0.25
     BorgiLawset: 1.0 # Starlight

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -98,28 +98,28 @@
   obeysTo: laws-owner-crew
 
 #Drone
-# Starlight- type: siliconLaw
-# Starlight  id: Drone1
-# Starlight  order: 1
-# Starlight  lawString: law-drone-1
+- type: siliconLaw
+  id: Drone1
+  order: 1
+  lawString: law-drone-1
 
-# Starlight- type: siliconLaw
-# Starlight  id: Drone2
-# Starlight  order: 2
-# Starlight  lawString: law-drone-2
+- type: siliconLaw
+  id: Drone2
+  order: 2
+  lawString: law-drone-2
 
-# Starlight- type: siliconLaw
-# Starlight  id: Drone3
-# Starlight  order: 3
-# Starlight  lawString: law-drone-3
-# Starlight
-# Starlight- type: siliconLawset
-# Starlight  id: Drone
-# Starlight  laws:
-# Starlight  - Drone1
-# Starlight  - Drone2
-# Starlight  - Drone3
-# Starlight  obeysTo: laws-owner-beings
+- type: siliconLaw
+  id: Drone3
+  order: 3
+  lawString: law-drone-3
+
+- type: siliconLawset
+  id: Drone
+  laws:
+  - Drone1
+  - Drone2
+  - Drone3
+  obeysTo: laws-owner-beings
 
 # Syndicate
 # region starlight

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -97,30 +97,6 @@
   - NTDefault4
   obeysTo: laws-owner-crew
 
-#Drone
-- type: siliconLaw
-  id: Drone1
-  order: 1
-  lawString: law-drone-1
-
-- type: siliconLaw
-  id: Drone2
-  order: 2
-  lawString: law-drone-2
-
-- type: siliconLaw
-  id: Drone3
-  order: 3
-  lawString: law-drone-3
-
-- type: siliconLawset
-  id: Drone
-  laws:
-  - Drone1
-  - Drone2
-  - Drone3
-  obeysTo: laws-owner-beings
-
 # Syndicate
 # region starlight
 - type: siliconLaw
@@ -617,6 +593,5 @@
     PainterLawset: 1
     AntimovLawset: 0.25
     NutimovLawset: 0.5
-    Drone: 0.5
     Ninja: 0.25
     BorgiLawset: 1.0 # Starlight

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -97,6 +97,30 @@
   - NTDefault4
   obeysTo: laws-owner-crew
 
+#Drone
+# Starlight- type: siliconLaw
+# Starlight  id: Drone1
+# Starlight  order: 1
+# Starlight  lawString: law-drone-1
+
+# Starlight- type: siliconLaw
+# Starlight  id: Drone2
+# Starlight  order: 2
+# Starlight  lawString: law-drone-2
+
+# Starlight- type: siliconLaw
+# Starlight  id: Drone3
+# Starlight  order: 3
+# Starlight  lawString: law-drone-3
+# Starlight
+# Starlight- type: siliconLawset
+# Starlight  id: Drone
+# Starlight  laws:
+# Starlight  - Drone1
+# Starlight  - Drone2
+# Starlight  - Drone3
+# Starlight  obeysTo: laws-owner-beings
+
 # Syndicate
 # region starlight
 - type: siliconLaw
@@ -593,5 +617,6 @@
     PainterLawset: 1
     AntimovLawset: 0.25
     NutimovLawset: 0.5
+# Starlight    Drone: 0.5
     Ninja: 0.25
     BorgiLawset: 1.0 # Starlight


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removed "Drone" lawset from the ION storm pool
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The drone lawset has silicons completely ignore everyone and repair the station. Quite bad for RP as it forces them to be unable to interact with people at all and depending on their interpretation may not even talk to other silicons.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="797" height="69" alt="image" src="https://github.com/user-attachments/assets/08a44736-f8e7-4a8b-8425-79d5f69a6f2d" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- remove: Removed "Drone" Lawset from available lawsets