### PR TITLE
holy fuck

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Fun/plushies.yml
@@ -1188,10 +1188,6 @@
       sprite: _Starlight/Objects/Fun/Plushies/percy_plushie.rsi
       layers:
         - state: icon
-    - type: Insulated
-      coefficient: 0.2
-    - type: Clothing
-      slots: [gloves]
     - type: ItemToggle
       onUse: false
       verbToggleOn: plushie-voicebox-activate


### PR DESCRIPTION
## Short description
Percy plushie has an insul coefficient of 0.2 and can be worn with gloves, this means that I can destroy powered HV cables with nothing but a baseball bat and 20 spesos, with no luck or rng involved while only taking 20 shock roundstart

This is bad because it doesn't stun you either, so you can just continually hit it while only taking 2 shock each time
## Media (Video/Screenshots)
<img width="1513" height="824" alt="image" src="https://github.com/user-attachments/assets/122dda1e-1f2e-4ae2-8388-0633668b5c09" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
