### PR TITLE
Make dragon gib rather than delete without a trace when it expires to no rifts

### DIFF
--- a/Content.Server/Dragon/Components/DragonComponent.cs
+++ b/Content.Server/Dragon/Components/DragonComponent.cs
@@ -59,6 +59,10 @@ namespace Content.Server.Dragon
                 Params = AudioParams.Default.WithVolume(3f),
             };
 
+        //starlight
+        [DataField]
+        public string NoRiftDeathEffect = "EffectFlashDragonDisappear";
+
         /// <summary>
         /// NPC faction to re-add after being zombified.
         /// Prevents zombie dragon from being attacked by its own carp.

--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Body.Systems;
 using Content.Server.Objectives.Components;
 using Content.Server.Objectives.Systems;
 using Content.Server.Popups;
@@ -30,6 +31,7 @@ public sealed partial class DragonSystem : EntitySystem
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
+    [Dependency] private readonly BodySystem _body = default!; //starlight
 
     private EntityQuery<CarpRiftsConditionComponent> _objQuery;
 
@@ -97,12 +99,14 @@ public sealed partial class DragonSystem : EntitySystem
             if (!_mobState.IsDead(uid))
                 comp.RiftAccumulator += frameTime;
 
-            // Delete it, naughty dragon!
-            if (comp.RiftAccumulator >= comp.RiftMaxAccumulator)
+            //starlight start
+            if (comp.RiftAccumulator >= comp.RiftMaxAccumulator && !_mobState.IsDead(uid)) // dragon has no rifts and has surpassed the timer
             {
-                Roar(uid, comp);
-                QueueDel(uid);
+                var xform = Transform(uid);
+                Spawn(comp.NoRiftDeathEffect, _transform.GetMapCoordinates(uid, xform: xform));
+                _body.GibBody(uid, gibOrgans: false); // REND HIS FLESH!!!!!!!!!!!!!
             }
+            //starlight end
         }
     }
 

--- a/Resources/Prototypes/_StarLight/Entities/Effects/dragon_disappear.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Effects/dragon_disappear.yml
@@ -1,0 +1,21 @@
+- type: entity
+  id: EffectFlashDragonDisappear
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: PointLight
+    radius: 15
+    energy: 5
+    color: "#ff0b0b"
+  - type: TimedDespawn
+    lifetime: 3
+  - type: EmitSoundOnSpawn
+    sound:
+      path: /Audio/Animals/space_dragon_roar.ogg
+  - type: Sprite
+    drawdepth: Effects
+    noRot: true
+    layers:
+    - shader: unshaded
+      map: ["enum.EffectLayers.Unshaded"]
+      sprite: Effects/chronofield.rsi
+      state: chronofield


### PR DESCRIPTION
## Short description
Makes the dragon gib and drop all contained bodies instead of silently deleting itself and all eaten bodies when it expires due to surpassing the rift timer

## Why we need to add this
Was in a round the other day where the dragon forgot to make rifts, and ended up getting deleted with over 30+ corpses inside of it, round removing everybody

As well as gibbing this adds a visual effect to provide some indication as to the fact that the dragon has died, rather than just disappearing instantaneously and leaving people wondering if it "bugged out"

## Media (Video/Screenshots)
<img width="1181" height="927" alt="Screenshot_20250813_171622" src="https://github.com/user-attachments/assets/2794d9a5-67e8-4b50-ac66-4e94e60e0d6b" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- fix: Space dragons no longer delete all bodies when they die to placing no rifts
- fix: Space dragons have a visual effect to indicate that they have died to placing no rifts