### PR TITLE
Damage interrupts vent crawl doafter + No more shooting from vents

### DIFF
--- a/Content.Server/VentCraw/VentCrawTubeSystem.cs
+++ b/Content.Server/VentCraw/VentCrawTubeSystem.cs
@@ -87,7 +87,7 @@ namespace Content.Server.VentCraw
             var args = new DoAfterArgs(EntityManager, user, crawler.EnterDelay, new EnterVentDoAfterEvent(), user, uid, user)
             {
                 BreakOnMove = true,
-                BreakOnDamage = true
+                BreakOnDamage = true // STARLIGHT
             };
 
             _doAfterSystem.TryStartDoAfter(args);

--- a/Content.Server/VentCraw/VentCrawTubeSystem.cs
+++ b/Content.Server/VentCraw/VentCrawTubeSystem.cs
@@ -87,7 +87,7 @@ namespace Content.Server.VentCraw
             var args = new DoAfterArgs(EntityManager, user, crawler.EnterDelay, new EnterVentDoAfterEvent(), user, uid, user)
             {
                 BreakOnMove = true,
-                BreakOnDamage = false
+                BreakOnDamage = true
             };
 
             _doAfterSystem.TryStartDoAfter(args);

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -9,8 +9,10 @@ using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Movement.Events;
+using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
+using Content.Shared.Pulling.Events;
 using Content.Shared.Stunnable;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
@@ -63,6 +65,7 @@ public sealed partial class ClimbSystem : VirtualController
         SubscribeLocalEvent<ClimbingComponent, EndCollideEvent>(OnClimbEndCollide);
         SubscribeLocalEvent<ClimbingComponent, BuckledEvent>(OnBuckled);
         SubscribeLocalEvent<ClimbingComponent, EntGotInsertedIntoContainerMessage>(OnStored);
+        SubscribeLocalEvent<ClimbingComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt); // STARLIGHT
 
         SubscribeLocalEvent<ClimbableComponent, CanDropTargetEvent>(OnCanDragDropOn);
         SubscribeLocalEvent<ClimbableComponent, GetVerbsEvent<AlternativeVerb>>(AddClimbableVerb);
@@ -137,6 +140,7 @@ public sealed partial class ClimbSystem : VirtualController
         // Can't move when transition.
         if (component.NextTransition != null)
             args.Cancel();
+
     }
 
     private void OnParentChange(EntityUid uid, ClimbingComponent component, ref EntParentChangedMessage args)
@@ -548,6 +552,17 @@ public sealed partial class ClimbSystem : VirtualController
     {
         StopOrCancelClimb(uid, component);
     }
+
+    // STARLIGHT START
+    private void OnBeingPulledAttempt(EntityUid uid, ClimbingComponent component, BeingPulledAttemptEvent args)
+    {
+        if (!TryComp(uid, out PullableComponent? pullableComp))
+            return;
+
+        if (pullableComp.BeingPulled)
+            StopOrCancelClimb(uid, component);
+    }
+    // STARLIGHT END
 
     private void StopOrCancelClimb(EntityUid uid, ClimbingComponent component)
     {

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -9,10 +9,8 @@ using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Movement.Events;
-using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
-using Content.Shared.Pulling.Events;
 using Content.Shared.Stunnable;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
@@ -65,7 +63,6 @@ public sealed partial class ClimbSystem : VirtualController
         SubscribeLocalEvent<ClimbingComponent, EndCollideEvent>(OnClimbEndCollide);
         SubscribeLocalEvent<ClimbingComponent, BuckledEvent>(OnBuckled);
         SubscribeLocalEvent<ClimbingComponent, EntGotInsertedIntoContainerMessage>(OnStored);
-        SubscribeLocalEvent<ClimbingComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt); // STARLIGHT
 
         SubscribeLocalEvent<ClimbableComponent, CanDropTargetEvent>(OnCanDragDropOn);
         SubscribeLocalEvent<ClimbableComponent, GetVerbsEvent<AlternativeVerb>>(AddClimbableVerb);
@@ -140,7 +137,6 @@ public sealed partial class ClimbSystem : VirtualController
         // Can't move when transition.
         if (component.NextTransition != null)
             args.Cancel();
-
     }
 
     private void OnParentChange(EntityUid uid, ClimbingComponent component, ref EntParentChangedMessage args)
@@ -552,17 +548,6 @@ public sealed partial class ClimbSystem : VirtualController
     {
         StopOrCancelClimb(uid, component);
     }
-
-    // STARLIGHT START
-    private void OnBeingPulledAttempt(EntityUid uid, ClimbingComponent component, BeingPulledAttemptEvent args)
-    {
-        if (!TryComp(uid, out PullableComponent? pullableComp))
-            return;
-
-        if (pullableComp.BeingPulled)
-            StopOrCancelClimb(uid, component);
-    }
-    // STARLIGHT END
 
     private void StopOrCancelClimb(EntityUid uid, ClimbingComponent component)
     {

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -39,6 +39,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Shared.VentCraw;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
 
@@ -143,6 +144,10 @@ public abstract partial class SharedGunSystem : EntitySystem
             return;
 
         if (ent != GetEntity(msg.Gun))
+            return;
+
+        if (TryComp(user, out VentCrawlerComponent? crawlerComp) //🌟Starlight🌟
+            && crawlerComp.InTube == true)
             return;
 
         gun.ShootCoordinates = GetCoordinates(msg.Coordinates);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Damage now interrupts entering vents.
Added a check in the ShootingSystem to disallow shooting while vented.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Ventcrawlers are currently only able to be stopped from crawling into vents by dragging them enough to trigger the OnMove interrupt on their DoAfter. In combat, this is obnoxious and unintuitive to do.

If syndicate monkeys or other player-controlled gear is disproportionally affected by this, it should be considered to lower the do_after time. Perhaps a variable on the VentCrawler component so that we can individually tune creatures' enter timer?

In addition to this, I am also fixing a bug in the crawling system that allowed for guns to be used when you had entered vents, but not moved yet. This was done by adding a clause in the shooting system that fails TryShoot when the shooter is InPipe.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/21764e09-d988-4bf8-a10c-89ea63103229

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- tweak: Entering vents is now interrupted by taking damage
- fix: You can no longer shoot guns from inside vents
