### PR TITLE
Voiceline fix for PR #1309

### DIFF
--- a/Resources/Locale/en-US/_Starlight/plushies/redwoods_plushie.ftl
+++ b/Resources/Locale/en-US/_Starlight/plushies/redwoods_plushie.ftl
@@ -1,8 +1,8 @@
 plushie-redwoods-1 = Nice contraband, ending up in my collection of cool stuff.
 plushie-redwoods-2 = I'm not trying to alarm you but there is a camera and a microphone in this device.
-plushie-redwoods-3 = I... I don't comprehend.
-plushie-redwoods-4 = What the fuck does CC do even all day?
-plushie-redwoods-5 = Xenos? Where?
-plushie-redwoods-6 = Do I regret being a vulp? No.
+plushie-redwoods-3 = Bwuh? What?
+plushie-redwoods-4 = This job? Not for everyone, I chose this job to suffer even more.
+plushie-redwoods-5 = Xenos... in MY STATION? KILL THE FUCKING BUGS!
+plushie-redwoods-6 = PAI, order more scurrets.
 plushie-redwoods-7 = Oh my... so much guns... I can't control myself..!
-plushie-redwoods-8 = What did I say? It's always the FUCKING CLONW!
+plushie-redwoods-8 = What did I say? It's always the FUCKING CLOWN!

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Fun/plushie_datasets.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Fun/plushie_datasets.yml
@@ -122,34 +122,34 @@
   id: PlushiesVirus
   values:
     prefix: plushie-virus-
-    count: 9
+    count: 5
 
 - type: localizedDataset
   id: PlushiesMahio
   values:
     prefix: plushie-mahio-
-    count: 9
+    count: 6
 
 - type: localizedDataset
   id: PlushiesRhea
   values:
     prefix: plushie-rhea-
-    count: 9
+    count: 6
 
 - type: localizedDataset
   id: PlushiesRemiie
   values:
     prefix: plushie-remiie-
-    count: 9
+    count: 6
 
 - type: localizedDataset
   id: PlushiesMalachi
   values:
     prefix: plushie-malachi-
-    count: 9
+    count: 10
 
 - type: localizedDataset
   id: PlushiesBrighteyes
   values:
     prefix: plushie-brighteyes-
-    count: 9
+    count: 10

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Fun/plushies.yml
@@ -1467,7 +1467,7 @@
       layers:
         - state: icon
     - type: ItemToggle
-      onUse: true
+      onUse: false
       verbToggleOn: plushie-voicebox-activate
       verbToggleOff: plushie-voicebox-deactivate
     - type: ComponentToggler
@@ -1626,12 +1626,6 @@
     sound:
       path: /Audio/Animals/cat_meow.ogg
   - type: EmitSoundOnLand
-    sound:
-      path: /Audio/Animals/cat_meow2.ogg
-  - type: EmitSoundOnActivate
-    sound:
-      path: /Audio/Animals/cat_meow.ogg
-  - type: EmitSoundOnTrigger
     sound:
       path: /Audio/Animals/cat_meow2.ogg
   - type: Food


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
So turns out... the dataset is the fix...

## Why we need to add this
Prevents the plushies from saying plushie-NAME-X

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: TheRealSlimRedwoods
- fix: Fixed plushies spewing out "phantom voicelines"

