### PR TITLE
Salvage Overhaul

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/mining.yml
+++ b/Resources/Maps/_Starlight/Shuttles/mining.yml
@@ -1,0 +1,3264 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 264.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 08/13/2025 20:17:34
+  entityCount: 440
+maps: []
+grids:
+- 181
+orphans:
+- 181
+nullspace: []
+tilemap:
+  0: Space
+  4: FloorDark
+  1: FloorGlass
+  51: FloorGrayConcrete
+  6: FloorGrayConcreteMono
+  2: FloorMetalDiamond
+  3: FloorMiningDark
+  5: FloorShuttleOrange
+  89: FloorSteel
+  104: FloorTechMaint
+  120: Lattice
+  121: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 181
+    components:
+    - type: MetaData
+      name: SR-3S2 "Reclaimer"
+    - type: Transform
+      pos: 2.2710133,-2.4148211
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAAEAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAABAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABQAAAAAAAAQAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAUAAAAAAAB5AAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB5AAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAABAAAAAAAAAQAAAAABAAEAAAAAAgABAAAAAAMAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAeQAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaAAAAAAAAGgAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGgAAAAAAABoAAAAAAAAeQAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABoAAAAAAAAaAAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAAQAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,0:
+          ind: 0,0
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAeQAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeAAAAAAAAHgAAAAAAAB4AAAAAAAAeAAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAAAGAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAABoAAAAAAAAaAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB5AAAAAAAAaAAAAAAAAGgAAAAAAAB5AAAAAAAAaAAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAGgAAAAAAABoAAAAAAAAaAAAAAAAAGgAAAAAAABoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAUAAAAAAAB5AAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAABAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAAQAAAAAAAAEAAAAAAAABQAAAAAAAAQAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAAEAAAAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAABAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAAQAAAAAAAAEAAAAAAAABQAAAAAAAAQAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAAEAAAAAAAAeQAAAAAAAAUAAAAAAAB5AAAAAAAABQAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: SalvageShuttle
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            80: -4,-6
+            81: -3,-6
+            82: -2,-6
+            83: -1,-6
+            84: 0,-6
+            85: -1,-5
+            86: -2,-5
+            87: -3,-5
+            88: -3,-7
+            89: -2,-7
+            90: -1,-7
+        - node:
+            color: '#FFFFFFFF'
+            id: BotRight
+          decals:
+            91: 0,-7
+            92: -4,-5
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: BotRight
+          decals:
+            93: -4,-7
+            94: 0,-5
+        - node:
+            color: '#8D1C9996'
+            id: MiniTileWhiteCornerSe
+          decals:
+            133: 1,-9
+        - node:
+            color: '#8D1C9996'
+            id: MiniTileWhiteCornerSw
+          decals:
+            132: -5,-9
+        - node:
+            color: '#8D1C9996'
+            id: MiniTileWhiteInnerNe
+          decals:
+            120: -5,-2
+        - node:
+            color: '#8D1C9996'
+            id: MiniTileWhiteInnerNw
+          decals:
+            119: 1,-2
+        - node:
+            color: '#8D1C9996'
+            id: MiniTileWhiteInnerSe
+          decals:
+            111: -5,0
+            112: 1,0
+        - node:
+            color: '#8D1C9996'
+            id: MiniTileWhiteInnerSw
+          decals:
+            113: -5,0
+            114: 1,0
+        - node:
+            color: '#8D1C9996'
+            id: MiniTileWhiteLineE
+          decals:
+            117: -5,-1
+            118: 1,-1
+            127: 1,-2
+            128: 1,-3
+            129: 1,-4
+            130: 1,-8
+        - node:
+            color: '#8D1C9996'
+            id: MiniTileWhiteLineN
+          decals:
+            97: -7,2
+            98: -6,2
+            99: -5,2
+            100: -4,2
+            101: -2,2
+            102: 0,2
+            103: 1,2
+            104: 2,2
+            105: 3,2
+            121: -4,-2
+            122: 0,-2
+            123: -2,-2
+        - node:
+            color: '#8D1C9996'
+            id: MiniTileWhiteLineS
+          decals:
+            95: -7,0
+            96: -6,0
+            106: 3,0
+            107: 2,0
+            108: 0,0
+            109: -2,0
+            110: -4,0
+            134: 0,-9
+            135: -2,-9
+            136: -4,-9
+        - node:
+            color: '#8D1C9996'
+            id: MiniTileWhiteLineW
+          decals:
+            115: -5,-1
+            116: 1,-1
+            124: -5,-2
+            125: -5,-3
+            126: -5,-4
+            131: -5,-8
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            77: 1,-7
+            78: 1,-6
+            79: 1,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            74: -5,-7
+            75: -5,-6
+            76: -5,-5
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -2,0:
+            0: 3820
+          -2,1:
+            1: 1026
+            0: 8
+          -1,0:
+            0: 45055
+          -1,1:
+            0: 4095
+          -1,-1:
+            0: 45055
+          0,0:
+            0: 4087
+          0,1:
+            0: 1299
+            1: 8
+          0,-4:
+            2: 256
+            0: 12288
+            1: 34880
+          0,-3:
+            0: 12339
+            1: 2184
+          -1,-4:
+            0: 61440
+            1: 112
+            3: 256
+          -1,-3:
+            0: 64255
+          0,-2:
+            0: 13107
+          -1,-2:
+            0: 65535
+          0,-1:
+            0: 819
+            1: 2048
+          -2,-4:
+            1: 8896
+            0: 32768
+          -2,-3:
+            1: 546
+            0: 32904
+          -2,-1:
+            1: 512
+            0: 2184
+          -2,-2:
+            0: 34952
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: OccluderTree
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: RadiationGridResistance
+    - type: SpreaderGrid
+    - type: GravityShake
+      shakeTimes: 10
+    - type: GasTileOverlay
+    - type: GridPathfinding
+    - type: ImplicitRoof
+- proto: AirAlarm
+  entities:
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 181
+    - type: DeviceList
+      devices:
+      - 146
+      - 54
+      - 124
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 181
+    - type: DeviceList
+      devices:
+      - 228
+      - 270
+      - 215
+      - 287
+      - 147
+      - 419
+      - 216
+      - 109
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-9.5
+      parent: 181
+    - type: DeviceList
+      devices:
+      - 108
+      - 61
+      - 158
+      - 122
+      - 101
+- proto: AirlockExternalGlassShuttleLocked
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 181
+  - uid: 240
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 181
+  - uid: 291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 181
+  - uid: 316
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 181
+- proto: AirlockMiningGlassLocked
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 181
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 181
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 181
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 181
+  - uid: 344
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 181
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 181
+- proto: AirSensor
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 181
+    - type: DeviceNetwork
+      deviceLists:
+      - 285
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 181
+    - type: DeviceNetwork
+      deviceLists:
+      - 50
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 181
+    - type: DeviceNetwork
+      deviceLists:
+      - 168
+  - uid: 419
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 181
+    - type: DeviceNetwork
+      deviceLists:
+      - 168
+- proto: APCBasic
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-9.5
+      parent: 181
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 181
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 181
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 181
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 181
+  - uid: 303
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 181
+  - uid: 328
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-5.5
+      parent: 181
+  - uid: 370
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 181
+  - uid: 385
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-4.5
+      parent: 181
+  - uid: 401
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 181
+- proto: AtmosFixNitrogenMarker
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 181
+- proto: AtmosFixOxygenMarker
+  entities:
+  - uid: 269
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 181
+- proto: BlastDoor
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 181
+  - uid: 81
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 181
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 181
+  - uid: 302
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-5.5
+      parent: 181
+  - uid: 365
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 181
+  - uid: 377
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 181
+  - uid: 386
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-4.5
+      parent: 181
+  - uid: 412
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 181
+- proto: BorgCharger
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 181
+  - uid: 226
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 181
+- proto: BoxBodyBag
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 181
+- proto: CableApcExtension
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 181
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 181
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 181
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 181
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 181
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 181
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 181
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 181
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 181
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 181
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 181
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 181
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 181
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 181
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 181
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 181
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 181
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 181
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 181
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 181
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 181
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 181
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 181
+  - uid: 296
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 181
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 181
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 181
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 181
+  - uid: 309
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 181
+  - uid: 310
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 181
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 181
+  - uid: 312
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 181
+  - uid: 314
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 181
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 181
+  - uid: 324
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 181
+  - uid: 329
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 181
+  - uid: 330
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 181
+  - uid: 334
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 181
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 181
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 181
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 181
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 181
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 181
+  - uid: 341
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 181
+  - uid: 342
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 181
+  - uid: 345
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 181
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 181
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 181
+  - uid: 359
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 181
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 181
+  - uid: 361
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 181
+  - uid: 364
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 181
+  - uid: 366
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 181
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 181
+  - uid: 378
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 181
+  - uid: 380
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 181
+  - uid: 381
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 181
+  - uid: 384
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 181
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 181
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 181
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 181
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 181
+  - uid: 393
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 181
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 181
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 181
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 181
+  - uid: 405
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 181
+  - uid: 411
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 181
+  - uid: 414
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 181
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 181
+  - uid: 417
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 181
+  - uid: 420
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 181
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 181
+  - uid: 422
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 181
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 181
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 181
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 181
+- proto: CableHV
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 181
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 181
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 181
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 181
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 181
+  - uid: 325
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 181
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 181
+  - uid: 374
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 181
+- proto: CableMV
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 181
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 181
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 181
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 181
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 181
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 181
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 181
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 181
+  - uid: 326
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 181
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 181
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 181
+  - uid: 346
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 181
+  - uid: 348
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 181
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 181
+  - uid: 372
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 181
+  - uid: 375
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 181
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 181
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 181
+  - uid: 425
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 181
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 181
+- proto: CableTerminal
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-12.5
+      parent: 181
+  - uid: 166
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-12.5
+      parent: 181
+- proto: Catwalk
+  entities:
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 181
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 181
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 181
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 181
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 3.5,-12.5
+      parent: 181
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 181
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 181
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 181
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 181
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 181
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 181
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 181
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 181
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 181
+  - uid: 244
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 181
+  - uid: 390
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 181
+  - uid: 426
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 181
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 181
+  - uid: 432
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 181
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 181
+  - uid: 451
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 181
+  - uid: 452
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 181
+  - uid: 453
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 181
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 181
+- proto: ChairPilotSeat
+  entities:
+  - uid: 62
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 181
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 181
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 181
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,5.5
+      parent: 181
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 181
+  - uid: 194
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 181
+  - uid: 327
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 181
+- proto: ClothingEyesGlassesMeson
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingHandsGlovesColorYellow
+  entities:
+  - uid: 140
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 142
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 145
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ComputerCargoBounty
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 181
+- proto: ComputerRadar
+  entities:
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 181
+- proto: ComputerSalvageExpedition
+  entities:
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 181
+- proto: ComputerSalvageJobBoard
+  entities:
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 181
+- proto: ComputerShuttle
+  entities:
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 181
+- proto: ConveyorBelt
+  entities:
+  - uid: 1
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 181
+  - uid: 49
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 181
+  - uid: 52
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 181
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 181
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 181
+  - uid: 193
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 181
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 181
+  - uid: 283
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 181
+  - uid: 351
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 181
+  - uid: 427
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 181
+- proto: CrateSalvageContrabandStorageSecure
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 181
+  - uid: 434
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 181
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 181
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-7.5
+      parent: 181
+- proto: FireAxeCabinetFilled
+  entities:
+  - uid: 135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 181
+- proto: GasMinerNitrogen
+  entities:
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 181
+- proto: GasMinerOxygen
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 181
+- proto: GasMixerFlipped
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: GasMixer
+      inletTwoConcentration: 0.24000001
+      inletOneConcentration: 0.76
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-13.5
+      parent: 181
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 257
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-13.5
+      parent: 181
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 331
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-14.5
+      parent: 181
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-12.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 172
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-11.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-12.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 252
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-11.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 253
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 286
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 59
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 60
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 118
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 121
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 159
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-11.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 241
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 254
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-10.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 255
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 262
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 281
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 282
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 290
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 67
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-11.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-10.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPort
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPressurePump
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-12.5
+      parent: 181
+    - type: GasPressurePump
+      targetPressure: 4500
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-12.5
+      parent: 181
+    - type: GasPressurePump
+      targetPressure: 4500
+    - type: VentCrawTube
+      connected: True
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasVentPump
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-10.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 50
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 61
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 285
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 158
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 285
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 215
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 168
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 168
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 168
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 285
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 168
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 122
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-7.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 285
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-11.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 50
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 168
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 287
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 181
+    - type: VentCrawTube
+      connected: True
+    - type: DeviceNetwork
+      deviceLists:
+      - 168
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 181
+- proto: Grille
+  entities:
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 181
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 181
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 181
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 181
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 181
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 181
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 181
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 181
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 181
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 181
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 181
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 181
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 181
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 181
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 181
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 181
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 181
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 181
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 181
+- proto: Gyroscope
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 181
+- proto: LockerEvacRepairFilled
+  entities:
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 181
+    - type: Lock
+      locked: False
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 138
+          - 139
+          - 140
+          - 141
+          - 142
+          - 143
+          - 144
+          - 145
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -4.4005084,-8.3005295
+      parent: 181
+- proto: MiningWindow
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 181
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 181
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 181
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 181
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 181
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 181
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 181
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 181
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 181
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 181
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 181
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 181
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 181
+  - uid: 293
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 181
+  - uid: 301
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 181
+  - uid: 304
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 181
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 181
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 181
+  - uid: 369
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 181
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 181
+- proto: NitrogenCanister
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 181
+- proto: OxygenCanister
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 181
+- proto: PersonalAI
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: StockLimitedProcessing
+      processingListings: {}
+    - type: InsideEntityStorage
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 320
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-13.5
+      parent: 181
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-13.5
+      parent: 181
+- proto: PlasticFlapsAirtightClear
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 181
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 181
+  - uid: 272
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 181
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 181
+- proto: PortableGeneratorPacman
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 181
+- proto: PortableGeneratorSuperPacman
+  entities:
+  - uid: 319
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 181
+- proto: PowerCellRecharger
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 181
+- proto: PoweredlightSodium
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-11.5
+      parent: 181
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 181
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 181
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 181
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 181
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 181
+  - uid: 117
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 181
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-8.5
+      parent: 181
+  - uid: 128
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 181
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-8.5
+      parent: 181
+  - uid: 130
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-11.5
+      parent: 181
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 181
+  - uid: 162
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 181
+  - uid: 169
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 181
+  - uid: 170
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 181
+  - uid: 265
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 181
+  - uid: 266
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,6.5
+      parent: 181
+  - uid: 352
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-11.5
+      parent: 181
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 181
+  - uid: 418
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 181
+- proto: Rack
+  entities:
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 181
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 181
+- proto: SalvageShuttleMarker
+  entities:
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 181
+- proto: SheetPlasma
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 1.5038271,-11.379414
+      parent: 181
+- proto: SheetUranium
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -4.433673,-11.316872
+      parent: 181
+- proto: SignalButtonDirectional
+  entities:
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-3.5
+      parent: 181
+    - type: DeviceLinkSource
+      linkedPorts:
+        80:
+        - Pressed: Toggle
+        83:
+        - Pressed: Toggle
+        81:
+        - Pressed: Toggle
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 181
+    - type: DeviceLinkSource
+      linkedPorts:
+        386:
+        - Pressed: Toggle
+        302:
+        - Pressed: Toggle
+        377:
+        - Pressed: Toggle
+- proto: SMESAdvanced
+  entities:
+  - uid: 373
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 181
+- proto: SubstationWallBasic
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 181
+- proto: TableReinforced
+  entities:
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 181
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 181
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 181
+- proto: Thruster
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-11.5
+      parent: 181
+  - uid: 31
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-14.5
+      parent: 181
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-12.5
+      parent: 181
+  - uid: 90
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-13.5
+      parent: 181
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 181
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 181
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 181
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 181
+    - type: Thruster
+      thrust: 300
+  - uid: 317
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-10.5
+      parent: 181
+  - uid: 333
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-1.5
+      parent: 181
+  - uid: 353
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 181
+  - uid: 355
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-10.5
+      parent: 181
+  - uid: 368
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-12.5
+      parent: 181
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 181
+  - uid: 403
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-1.5
+      parent: 181
+  - uid: 406
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-11.5
+      parent: 181
+  - uid: 408
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-13.5
+      parent: 181
+  - uid: 409
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-14.5
+      parent: 181
+- proto: TwoWayLever
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 181
+    - type: DeviceLinkSource
+      linkedPorts:
+        1:
+        - Left: Reverse
+        - Right: Forward
+        - Middle: Off
+        58:
+        - Left: Reverse
+        - Right: Forward
+        - Middle: Off
+        283:
+        - Left: Reverse
+        - Right: Forward
+        - Middle: Off
+        49:
+        - Left: Reverse
+        - Right: Forward
+        - Middle: Off
+        412:
+        - Left: Open
+        - Right: Open
+        - Middle: Close
+        52:
+        - Left: Reverse
+        - Right: Forward
+        - Middle: Off
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 181
+    - type: DeviceLinkSource
+      linkedPorts:
+        245:
+        - Left: Reverse
+        - Right: Forward
+        - Middle: Off
+        173:
+        - Left: Reverse
+        - Right: Forward
+        - Middle: Off
+        427:
+        - Left: Reverse
+        - Right: Forward
+        - Middle: Off
+        193:
+        - Left: Reverse
+        - Right: Forward
+        - Middle: Off
+        365:
+        - Left: Open
+        - Right: Open
+        - Middle: Close
+        351:
+        - Left: Reverse
+        - Right: Forward
+        - Middle: Off
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 181
+- proto: WallMining
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 181
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 181
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 181
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 181
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 181
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 181
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 181
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 181
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 181
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 181
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 181
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 181
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 181
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 181
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 181
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 181
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 181
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 181
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 181
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 181
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 181
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 1.5,-13.5
+      parent: 181
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 181
+  - uid: 238
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 181
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 181
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 181
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 181
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 181
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 181
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 181
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 181
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 181
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 181
+  - uid: 292
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 181
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 181
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 181
+  - uid: 332
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 181
+  - uid: 347
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 181
+  - uid: 354
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 181
+  - uid: 356
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 181
+  - uid: 362
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 181
+  - uid: 382
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 181
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 181
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 181
+  - uid: 398
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 181
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 181
+  - uid: 407
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 181
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 181
+- proto: WarningN2
+  entities:
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 1.5,-13.5
+      parent: 181
+- proto: WarningO2
+  entities:
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 181
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 181
+- proto: WeaponGrapplingGun
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: Welder
+  entities:
+  - uid: 138
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: Wrench
+  entities:
+  - uid: 139
+    components:
+    - type: Transform
+      parent: 137
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+...

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Storage/crates.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Storage/crates.yml
@@ -8,3 +8,14 @@
     sprite: _Starlight/Structures/Storage/USSP/soviet-crate.rsi
   - type: Sprite
     sprite: _Starlight/Structures/Storage/USSP/soviet-crate.rsi
+
+
+- type: entity
+  parent: [ CrateBaseSecure ]
+  suffix: Salvage, Secure
+  id: CrateSalvageContrabandStorageSecure
+  name: salvage storage crate
+  description: A security and salvage access locked crate for storing contraband.
+  components:
+  - type: AccessReader
+    access: [["Security"],["Salvage"]]


### PR DESCRIPTION
## Short description
major overhaul for mining.yml, the salvage shuttle. Also adds a proto for a shared salvage/sec crate for secure transport of contra.

It's only in the files for another dev's major salvage overhaul, so it shouldn't be used at all until then. However, mappers should make sure there's room for it, as it's a few tiles wider.

## Why we need to add this
The mining shuttle was barely functional, let's be real.

## Media (Video/Screenshots)
<img width="352" height="736" alt="image" src="https://github.com/user-attachments/assets/7f68d30e-2415-4889-8775-eac5042d1647" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Trep_Maul
- tweak: Major Salv Shuttle Overhaul
