### PR TITLE
fix nukeops not being able to end round once they are all dead.

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -36,7 +36,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     private static readonly Gauge NukeopsCount = Metrics.CreateGauge( // Startlight
         "nukie_count",
         "Number of all nukies Win/Loses Count.",
-        Enum.GetNames<WinType>());
+        ["results"]);
 
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly EmergencyShuttleSystem _emergency = default!;


### PR DESCRIPTION
## Short description
fixes grafana data collection and fixes nukies not ending round once they are all acidified.

## Why we need to add this
nukeops auto shuttle call is broken

## Media (Video/Screenshots)
<img width="393" height="107" alt="image" src="https://github.com/user-attachments/assets/3382d5e6-8694-470a-ab10-fb0f7a9b1be4" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- fix: Nukeops now properly call evac shuttle once everyone is dead.