### PR TITLE
disallow station-ai to shunt while in a card

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -80,6 +80,9 @@
     - sprite: Mobs/Silicon/station_ai.rsi
       state: default
   - type: ShowJobIcons
+  #region Starlight
+  - type: StationAIShuntable
+  #endregion Starlight
 
 - type: entity
   id: AiHeldIntellicard
@@ -305,7 +308,6 @@
     #region Starlight
   - type: IonStormTarget
     chance: 0.6 # lets just try it at 3/4th the chance of a borg and see how bad it gets
-  - type: StationAIShuntable # marker comp so that station AI is able to shunt into other borgs.
     #endregion
 
 # Hologram projection that the AI's eye tracks.


### PR DESCRIPTION
## Short description
get carded idiot

## Why we need to add this
the AI core has requisite facilities for piloting borgs remotely. the intellicard does not have such facilities.

## Media (Video/Screenshots)
N/A

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: You can no longer use AI-shunting when in a intellicard.
