### PR TITLE
Shit Station Gamemode

### DIFF
--- a/Resources/Locale/en-US/_Starlight/gamerules.ftl
+++ b/Resources/Locale/en-US/_Starlight/gamerules.ftl
@@ -3,3 +3,6 @@ traitorling-description = Traitors taste delicious
 
 eventlight-title = Event Light
 eventlight-description = Not quite Greenshift, stuff still happens!
+
+shitstation-title = Shit Station
+shitstation-description = The last shift was full of slobs

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -332,3 +332,24 @@
     - SpaceTrafficControlEventScheduler
     - ThiefGamerule
     - BasicRoundstartVariation
+
+- type: gamePreset
+  id: ShitStation
+  alias:
+    - shitstation
+    - trashstation
+  name: shitstation-title
+  description: shitstation-description
+  showInVote: true
+  minPlayers: 60
+  rules:
+    - DerelictCyborgSpawn
+    - BasicStationEventScheduler
+    - MeteorSwarmMildScheduler
+    - SubGamemodesRule
+    - IonStorm
+    - CockroachMigration
+    - MouseMigration
+    - BasicRoundstartVariation
+    - BasicRoundstartVariation
+    - BasicRoundstartVariation

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -4,14 +4,15 @@
     Nukeops: 0.03
     Traitor: 0.40
     Zombie: 0.05
-    Changeling: 0.10
+    Changeling: 0.10 #SL
     Zombieteors: 0.01
     Survival: 0.05
     KesslerSyndrome: 0.01
     Revolutionary: 0.10
-    Vampire: 0.15
+    Vampire: 0.15 #SL
     Wizard: 0.10
-    Traitorling: 0.10
+    Traitorling: 0.10 #SL
+    ShitStation: 0.10 #SL
 
 - type: weightedRandom
   id: SecretLP
@@ -19,11 +20,11 @@
     Nukeops: 0.028818444
     Traitor: 0.461095101
     Zombie: 0.005763689
-    Changeling: 0.057636888
+    Changeling: 0.057636888 #SL
     Zombieteors: 0.005763689
     Survival: 0.057636888
     KesslerSyndrome: 0.028818444
     Revolutionary: 0.057636888
-    Vampire: 0.115273775
+    Vampire: 0.115273775 #SL
     Extended: 0.152737752
     Wizard: 0.028818444


### PR DESCRIPTION
## Short description
Adds a new gamemode that has more broken lights, rusted walls, dirty floors, puddles, and trash at round start. Also has pending Derelict Borg, Mouse, and Cockroach migration events that will trigger over the first 2-5 minutes ish, to add to the shithole trashed dump vibe. Can roll in Secret and appear in votes when there are more than 60 players online.

## Why we need to add this
Adds another variant of a mostly normal round with a non-destructive gimmick for variety.

## Media (Video/Screenshots)
N/A

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added Shit Station gamemode, a mostly normal gamemode except there is more dirt, trash, spills, and broken lights round start (has vent events, mid round antags, etc too)
