### PR TITLE
NullLink whitelist

### DIFF
--- a/Content.Client/Launcher/LauncherConnectingGui.xaml
+++ b/Content.Client/Launcher/LauncherConnectingGui.xaml
@@ -28,6 +28,14 @@
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Bottom"
                                     StyleClasses="OpenRight"/>
+                          <!-- NullLink start-->
+                          <Button Name="LinkDiscordButton"
+                                  Text="{Loc 'link-discord'}"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Bottom"
+                                  Visible="False" 
+                                  StyleClasses="OpenBoth"/>
+                          <!-- NullLink end-->
                             <Button Name="CopyButton"
                                     Text="{Loc 'connecting-copy'}"
                                     HorizontalAlignment="Center"

--- a/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
+++ b/Content.Client/Launcher/LauncherConnectingGui.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Content.Client.Stylesheets;
 using Content.Shared.CCVar;
@@ -8,10 +9,10 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.XAML;
 using Robust.Shared.Configuration;
 using Robust.Shared.IoC;
-using Robust.Shared.Timing;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Client.Launcher
 {
@@ -21,6 +22,7 @@ namespace Content.Client.Launcher
         private const float RedialWaitTimeSeconds = 15f;
         private readonly LauncherConnecting _state;
         private float _waitTime;
+        private string? _discord; //NullLink
 
         // Pressing reconnect will redial instead of simply reconnecting.
         private bool _redial;
@@ -123,6 +125,14 @@ namespace Content.Client.Launcher
             else
             {
                 _redial = reason.RedialFlag;
+                //NullLink start
+                if (reason.Message.StringOf("discord") is { } link)
+                {
+                    _discord = link;
+                    LinkDiscordButton.Visible = true;
+                    LinkDiscordButton.OnPressed += _ => IoCManager.Resolve<IUriOpener>().OpenUri(link);
+                }
+                //NullLink end
 
                 if (reason.Message.Int32Of("delay") is { } delay)
                 {

--- a/Content.Server/Connection/ConnectionManager.Whitelist.cs
+++ b/Content.Server/Connection/ConnectionManager.Whitelist.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using Content.Server._NullLink;
 using Content.Server.Connection.Whitelist;
 using Content.Server.Connection.Whitelist.Conditions;
 using Content.Server.Database;
@@ -86,6 +87,12 @@ public sealed partial class ConnectionManager
                     matched = CheckConditionNotesPlaytimeRange(conditionNotesPlaytimeRange, cacheRemarks, cachePlaytime);
                     denyMessage = Loc.GetString("whitelist-notes");
                     break;
+                // NullLink Whitelist start
+                case NullLinkRolesCondition nullLinkRolesCondition:
+                    matched = await CheckNullLinkRolesCondition(nullLinkRolesCondition, data.UserId);
+                    denyMessage = Loc.GetString("whitelist-roles");
+                    break;
+                // NullLink Whitelist end
                 default:
                     throw new NotImplementedException($"Whitelist condition {condition.GetType().Name} not implemented");
             }
@@ -157,6 +164,12 @@ public sealed partial class ConnectionManager
 
         return tracker.TimeSpent.TotalMinutes >= conditionPlaytime.MinimumPlaytime;
     }
+
+    // NullLink Whitelist start
+    private async Task<bool> CheckNullLinkRolesCondition(NullLinkRolesCondition condition, NetUserId userId) 
+        => _actors.TryGetServerGrain(out var server) 
+            && await server.HasPlayerAnyRole(userId, [.. condition.Roles]);
+    // NullLink Whitelist end
 
     private bool CheckConditionNotesPlaytimeRange(
         ConditionNotesPlaytimeRange conditionNotesPlaytimeRange,

--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -8,6 +8,7 @@ using Content.Server.Administration.Managers;
 using Content.Server.Chat.Managers;
 using Content.Server.Connection.IPIntel;
 using Content.Server.Database;
+using Content.Server.Discord.DiscordLink;
 using Content.Server.GameTicking;
 using Content.Server.Preferences.Managers;
 using Content.Shared._NullLink;
@@ -56,6 +57,7 @@ namespace Content.Server.Connection
     public sealed partial class ConnectionManager : IConnectionManager
     {
         [Dependency] private readonly IActorRouter _actors = default!; // NullLink
+        [Dependency] private readonly INullLinkPlayerManager _nullLinkPlayerManager = default!; // NullLink
         [Dependency] private readonly IPlayerManager _plyMgr = default!;
         [Dependency] private readonly IPlayerRolesManager _plyRoles = default!;
         [Dependency] private readonly IServerNetManager _netMgr = default!;
@@ -163,6 +165,9 @@ namespace Content.Server.Connection
                 var properties = new Dictionary<string, object>();
                 if (reason == ConnectionDenyReason.Full)
                     properties["delay"] = _cfg.GetCVar(CCVars.GameServerFullReconnectDelay);
+
+                //NullLink discord link
+                properties["discord"] = _nullLinkPlayerManager.GetDiscordAuthUrl(e.UserId.ToString());
 
                 e.Deny(new NetDenyReason(msg, properties));
             }

--- a/Content.Server/_NullLink/ConditionPlayerCount.cs
+++ b/Content.Server/_NullLink/ConditionPlayerCount.cs
@@ -1,0 +1,9 @@
+﻿using Content.Server.Connection.Whitelist;
+
+namespace Content.Server._NullLink;
+
+public sealed partial class NullLinkRolesCondition : WhitelistCondition
+{
+    [DataField]
+    public List<ulong> Roles = [];
+}

--- a/Content.Server/_NullLink/HubSystem.cs
+++ b/Content.Server/_NullLink/HubSystem.cs
@@ -145,6 +145,9 @@ public sealed partial class HubSystem : EntitySystem, IServerObserver, IServerIn
 
     public Task Updated(string key, NLServer value)
     {
+        if (!value.IsAdultOnly == _isAdultOnly)
+            return Task.CompletedTask;
+
         _serverData.AddOrUpdate(key, Map(value), (k, v) => Map(value));
         _updateEvents.Enqueue(new NullLink.AddOrUpdateServer
         {

--- a/Content.Server/_NullLink/PlayerData/INullLinkPlayerManager.cs
+++ b/Content.Server/_NullLink/PlayerData/INullLinkPlayerManager.cs
@@ -8,6 +8,7 @@ public interface INullLinkPlayerManager
 {
     IEnumerable<ICommonSession> Mentors { get; }
 
+    string GetDiscordAuthUrl(string customState);
     void Initialize();
     void Shutdown();
     ValueTask SyncRoles(PlayerRolesSyncEvent ev);

--- a/Content.Server/_NullLink/PlayerData/NullLinkPlayerManager.Linking.cs
+++ b/Content.Server/_NullLink/PlayerData/NullLinkPlayerManager.Linking.cs
@@ -20,7 +20,7 @@ public sealed partial class NullLinkPlayerManager
         _discordCallback = _cfg.GetCVar(StarlightCCVars.DiscordCallback);
         _secret = _cfg.GetCVar(StarlightCCVars.Secret);
     }
-    private string GetDiscordAuthUrl(string customState)
+    public string GetDiscordAuthUrl(string customState)
     {
         if (string.IsNullOrEmpty(_discordCallback) || string.IsNullOrEmpty(_discordKey) || string.IsNullOrEmpty(_secret)) 
             return "";

--- a/Content.Shared/_NullLink/CCVar/NullLinkCCVars.cs
+++ b/Content.Shared/_NullLink/CCVar/NullLinkCCVars.cs
@@ -24,6 +24,9 @@ public sealed partial class NullLinkCCVars
 
     public static readonly CVarDef<string> Description =
         CVarDef.Create("nulllink.hub.description", "----", CVar.SERVERONLY);
+
+    public static readonly CVarDef<bool> IsAdultOnly =
+        CVarDef.Create("nulllink.is_adult_only", false, CVar.REPLICATED | CVar.SERVER);
 }
 
 public enum ServerType

--- a/Resources/Locale/en-US/_NullLink/connection-messages.ftl
+++ b/Resources/Locale/en-US/_NullLink/connection-messages.ftl
@@ -1,0 +1,2 @@
+﻿whitelist-roles = You need to have any of the whitelist roles in Discord.
+link-discord = Link Discord


### PR DESCRIPTION
Three problems:

- Passing information about 18+ servers.
- Whitelisting by Discord roles.
- When we deny a connection, the user can’t open the link to link their account, since the button is only available after connecting.

What’s left is to finish implementing the access check method, and add a CVAR with a filter for which servers to show in the hub.
I’m thinking of doing it with an enum for three options: 18+ only, non-18+ only, and any.

## Short description
<!-- What do you propose to change with your PR? -->

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- add: Nulllink whitelist
