### PR TITLE
add stats for dragon consumption and store buys.

### DIFF
--- a/Content.Server/GameTicking/Rules/DragonRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DragonRuleSystem.cs
@@ -6,13 +6,25 @@ using Content.Server.Roles;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.CharacterInfo;
+using Content.Shared.Devour.Components;
 using Content.Shared.Localizations;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Prometheus;
 using Robust.Server.GameObjects;
 
 namespace Content.Server.GameTicking.Rules;
 
 public sealed class DragonRuleSystem : GameRuleSystem<DragonRuleComponent>
 {
+    #region Starlight
+    private static readonly Histogram _dragonWinInfo = Metrics.CreateHistogram(
+        "sl_dragon_winning",
+        "Contains info on if a dragon won and if so how hard they won",
+        ["alive", "rifts", "eaten"]
+    );
+    #endregion
+
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly StationSystem _station = default!;
@@ -31,7 +43,7 @@ public sealed class DragonRuleSystem : GameRuleSystem<DragonRuleComponent>
     {
         var ent = args.Mind.Comp.OwnedEntity;
 
-        if(ent is null)
+        if (ent is null)
             return;
 
         args.Append(MakeBriefing(ent.Value));
@@ -44,7 +56,7 @@ public sealed class DragonRuleSystem : GameRuleSystem<DragonRuleComponent>
 
         _roleSystem.MindHasRole<DragonRoleComponent>(mindId, out var dragonRole);
 
-        if(dragonRole is null)
+        if (dragonRole is null)
             return;
 
         _antag.SendBriefing(args.EntityUid, MakeBriefing(args.EntityUid), null, null);
@@ -74,4 +86,25 @@ public sealed class DragonRuleSystem : GameRuleSystem<DragonRuleComponent>
 
         return briefing;
     }
+
+    #region Starlight data collection
+    private void OnRoundEnded(RoundEndTextAppendEvent _)
+    {
+        var query = EntityManager.AllEntities<DragonComponent>();
+        foreach (var dragon in query)
+        {
+            var devoured = 0;
+            if (TryComp<DevourerComponent>(dragon.Owner, out var devour))
+                devoured = devour.Devoured;
+            var alive = false;
+            if (TryComp<MobStateComponent>(dragon.Owner, out var state))
+                alive = state.CurrentState == MobState.Alive;
+            _dragonWinInfo.WithLabels([
+                alive.ToString(),
+                dragon.Comp.Rifts?.ToString() ?? "0",
+                devoured.ToString()
+            ]);  
+        }
+    }
+    #endregion
 }

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -22,11 +22,21 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Prometheus; //Starlight
+
 
 namespace Content.Server.Store.Systems;
 
 public sealed partial class StoreSystem
 {
+    #region Starlight
+    private static readonly Gauge _storePurchasesMetric = Metrics.CreateGauge(
+        "sl_store_purchases",
+        "Everything bounght from a \"store\" which include ling upgrades, traitor uplinks, wizard grimoires",
+        ["store_name", "purchased_item"]
+    );
+    #endregion
+
     [Dependency] private readonly IAdminLogManager _admin = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly ActionsSystem _actions = default!;
@@ -83,17 +93,17 @@ public sealed partial class StoreSystem
         _ui.CloseUi(uid, StoreUiKey.Key);
     }
 
-        /// <summary>
-        /// STARLIGHT: Updates the user interface for a store and refreshes the listings
-        /// </summary>
-        /// <param name="user">The person who if opening the store ui. Listings are filtered based on this.</param>
-        /// <param name="store">The store entity itself</param>
-        /// <param name="component">The store component being refreshed.</param>
-        public void UpdateUserInterface(EntityUid? user, EntityUid store, StoreComponent? component = null)
+    /// <summary>
+    /// STARLIGHT: Updates the user interface for a store and refreshes the listings
+    /// </summary>
+    /// <param name="user">The person who if opening the store ui. Listings are filtered based on this.</param>
+    /// <param name="store">The store entity itself</param>
+    /// <param name="component">The store component being refreshed.</param>
+    public void UpdateUserInterface(EntityUid? user, EntityUid store, StoreComponent? component = null)
     {
         if (!Resolve(store, ref component))
             return;
-            
+
         // STARLIGHT: Check if a rift has been destroyed and update the listing accordingly
         // This ensures the rift listing remains unavailable even when the UI is refreshed
         _revSupplyRift.CheckRiftDestroyedAndUpdateListing(component);
@@ -149,11 +159,11 @@ public sealed partial class StoreSystem
         }
 
         var buyer = msg.Actor;
-        
+
         // STARLIGHT: Raise an event to allow other systems to potentially cancel this purchase
         var purchaseAttemptEvent = new StorePurchaseAttemptEvent(listing.ID, uid, buyer);
         RaiseLocalEvent(ref purchaseAttemptEvent);
-        
+
         // STARLIGHT: If the event handler requested cancellation, cancel the purchase
         if (purchaseAttemptEvent.Cancel)
             return;
@@ -171,7 +181,7 @@ public sealed partial class StoreSystem
             if (!conditionsMet)
                 return;
         }
-        
+
         // Starlight: Check if the listing is unavailable (e.g., out of stock)
         // We still want to show the listing in the UI, but prevent purchase
         if (listing.Unavailable)
@@ -288,13 +298,13 @@ public sealed partial class StoreSystem
         //log dat shit.
         // Starlight: Get the resolved name without any placeholders
         var resolvedName = ListingLocalisationHelpers.GetLocalisedNameOrEntityName(listing, _proto);
-        
+
         // Remove any stock count or "Out of Stock" text for the log
         if (resolvedName.Contains(" ("))
         {
             resolvedName = resolvedName.Substring(0, resolvedName.IndexOf(" ("));
         }
-        
+
         _admin.Add(LogType.StorePurchase,
             LogImpact.Low,
             $"{ToPrettyString(buyer):player} purchased listing \"{resolvedName}\" from {ToPrettyString(uid)}"); // Starlight
@@ -315,7 +325,7 @@ public sealed partial class StoreSystem
                     {
                         buyerName = metadata.EntityName;
                     }
-                    
+
                     // Update the stock count and last purchaser
                     StockLimitedListingCondition.OnItemPurchased(listing.ID, buyerName, stockCondition.StockLimit);
                     break;
@@ -324,20 +334,20 @@ public sealed partial class StoreSystem
         }
 
         // STARLIGHT END
-        
+
         var buyFinished = new StoreBuyFinishedEvent
         {
             PurchasedItem = listing,
             StoreUid = uid
         };
         RaiseLocalEvent(ref buyFinished);
-        
+
         // STARLIGHT: Raise an event to notify other systems that a purchase was completed
         var purchaseCompletedEvent = new StorePurchaseCompletedEvent(listing.ID, uid, buyer);
         RaiseLocalEvent(ref purchaseCompletedEvent);
 
         UpdateUserInterface(buyer, uid, component);
-        
+
         // STARLIGHT START: If this was a stock-limited item, update all USSP uplink UIs
         if (listing.Conditions != null)
         {
@@ -350,8 +360,15 @@ public sealed partial class StoreSystem
                 }
             }
         }
+
+        #region Starlight statistics
+        _storePurchasesMetric.WithLabels([
+            ToPrettyString(uid),
+            resolvedName
+        ]).Inc();
+        #endregion
     }
-    
+
     /// <summary>
     /// Updates all USSP uplink UIs to ensure they show the latest stock counts and last purchaser information.
     /// </summary>
@@ -364,25 +381,25 @@ public sealed partial class StoreSystem
             // Skip if this is not a USSP uplink
             if (!storeComp.CurrencyWhitelist.Contains("Telebond"))
                 continue;
-                
+
             // Refresh all listings to ensure they have the latest stock count and last purchaser information
             RefreshAllListings(storeComp);
-            
+
             // Force a refresh of the available listings
             if (storeComp.AccountOwner != null)
             {
                 storeComp.LastAvailableListings = GetAvailableListings(storeComp.AccountOwner.Value, storeComp.Owner, storeComp)
                     .ToHashSet();
             }
-            
+
             // Update the UI to reflect the changes
             // We'll just update it with a null user to ensure the listings are refreshed
             // The next time someone opens the UI, they'll see the updated listings
             UpdateUserInterface(null, storeComp.Owner, storeComp);
-            
+
             // Force update the UI for all currently connected sessions
             ForceUpdateUiForAllSessions(storeComp.Owner, storeComp);
-            
+
             Logger.DebugS("store", $"Updated USSP uplink UI for {ToPrettyString(storeComp.Owner)}");
         }
     }
@@ -460,9 +477,9 @@ public sealed partial class StoreSystem
         foreach (var value in sortedCashValues)
         {
             var cashId = proto.Cash[value];
-            var amountToSpawn = (int) MathF.Floor((float) (amountRemaining / value));
+            var amountToSpawn = (int)MathF.Floor((float)(amountRemaining / value));
             var ents = _stack.SpawnMultiple(cashId, amountToSpawn, coordinates);
-            if (ents.FirstOrDefault() is {} ent)
+            if (ents.FirstOrDefault() is { } ent)
                 _hands.PickupOrDrop(buyer, ent);
             amountRemaining -= value * amountToSpawn;
         }

--- a/Content.Shared/Devour/Components/DevourerComponent.cs
+++ b/Content.Shared/Devour/Components/DevourerComponent.cs
@@ -111,5 +111,14 @@ public sealed partial class DevourerComponent : Component
     [DataField, AutoNetworkedField]
     public float HealRate = 15f;
 
+    #region Starlight
+
+    /// <summary>
+    /// how many people (things that grant reward chem) were eaten
+    /// </summary>
+    [ViewVariables]
+    public int Devoured = 0;
+    #endregion
+
 }
 

--- a/Content.Shared/Devour/DevourSystem.cs
+++ b/Content.Shared/Devour/DevourSystem.cs
@@ -109,6 +109,7 @@ public sealed class DevourSystem : EntitySystem
         if (args.Args.Target != null && _whitelistSystem.IsWhitelistPassOrNull(ent.Comp.FoodPreferenceWhitelist, (EntityUid)args.Args.Target))
         {
             _bloodstreamSystem.TryAddToChemicals(ent.Owner, ichorInjection);
+            ent.Comp.Devoured++; //Starlight devour counter.
         }
 
         // If the devoured thing meets the stomach whitelist criteria, add it to the stomach


### PR DESCRIPTION
## Short description
allows data collection for more stuff (without us having to yknow... scrape the DB)

## Why we need to add this
dragon balancing is V E R Y contentious so this should be usefull to help guide our decisions.

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
not player facing
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: walksanatora
- add: Added dragon consumption and uplink purchase statistics tracking