### PR TITLE
Give Brigmedic Perms to HoP

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -49,6 +49,9 @@
   - Cargo
   - Atmospherics
   - Medical
+  
+  #Starlight
+  - Brigmedic
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION


## Short description
<!-- What do you propose to change with your PR? -->
Gives HoP the permissions for Brigmedic.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
To fix the issue where a promoted brigmedic can't open their own locker.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1140" height="523" alt="Capture" src="https://github.com/user-attachments/assets/08929020-6ac6-4119-8e22-0dd3940fa690" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: AthenaAI
- tweak: Gives Hop permissions for Brigmedic to avoid issues with promoted Brigmedics.
