### PR TITLE
fixes wizard to actually load (since it is a loadmap not a loadgrid)

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/WizardShuttle.yml
+++ b/Resources/Maps/_Starlight/Shuttles/WizardShuttle.yml
@@ -1,0 +1,5196 @@
+meta:
+  format: 7
+  category: Map
+  engineVersion: 265.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 08/19/2025 20:49:28
+  entityCount: 796
+maps:
+- 1
+grids:
+- 2
+orphans: []
+nullspace: []
+tilemap:
+  0: Space
+  23: FloorCaveDrought
+  29: FloorDark
+  30: FloorDarkDiagonal
+  32: FloorDarkHerringbone
+  34: FloorDarkMono
+  35: FloorDarkOffset
+  36: FloorDarkPavement
+  37: FloorDarkPavementVertical
+  48: FloorGrassDark
+  89: FloorSteel
+  100: FloorSteelMono
+  104: FloorTechMaint
+  108: FloorWhite
+  112: FloorWhiteMini
+  118: FloorWood
+  120: Lattice
+  121: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: GridTree
+    - type: Broadphase
+    - type: OccluderTree
+  - uid: 2
+    components:
+    - type: MetaData
+    - type: Transform
+      pos: 0.3842575,0.4217209
+      parent: 1
+    - type: MapGrid
+      chunks:
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAGgAAAAAAABoAAAAAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAIgAAAAACAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAABkAAAAAAMAZAAAAAADAFkAAAAAAQB5AAAAAAAAdgAAAAACAHYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB5AAAAAAAAZAAAAAAAAGQAAAAAAgBZAAAAAAIAeQAAAAAAAHYAAAAAAwB2AAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAFkAAAAAAwBZAAAAAAMAWQAAAAAAAHkAAAAAAAB2AAAAAAMAdgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAIgAAAAACAHkAAAAAAAB5AAAAAAAAeQAAAAAAACIAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAAgAAAAAAEAJQAAAAABACAAAAAAAAAlAAAAAAIAIAAAAAABACUAAAAAAwAgAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAAgAAAAAAMAJAAAAAADACAAAAAAAAAkAAAAAAMAIAAAAAAAACQAAAAAAgAgAAAAAAAAIAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHgAAAAAAAB5AAAAAAAAJQAAAAACACAAAAAAAAAlAAAAAAIAIAAAAAABACUAAAAAAQAgAAAAAAEAJQAAAAABACAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAIgAAAAADAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAiAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAIgAAAAAAACIAAAAAAAB5AAAAAAAAHQAAAAABAB0AAAAAAAB5AAAAAAAAMAAAAAABADAAAAAAAAAwAAAAAAEAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIgAAAAAAACIAAAAAAwAiAAAAAAIAIgAAAAADAB0AAAAAAgAdAAAAAAMAeQAAAAAAADAAAAAAAQAeAAAAAAIAHgAAAAACAB4AAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAABZAAAAAAEAWQAAAAADAHkAAAAAAAAdAAAAAAAAHQAAAAADAHkAAAAAAAAwAAAAAAAAHgAAAAACAB4AAAAAAgAeAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAiAAAAAAAAIgAAAAABACIAAAAAAAAiAAAAAAIAHQAAAAAAAB0AAAAAAwB5AAAAAAAAMAAAAAABAB4AAAAAAwAeAAAAAAEAHgAAAAACAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: aAAAAAAAAGgAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHYAAAAAAAB5AAAAAAAAbAAAAAACAGwAAAAAAgBsAAAAAAIAeQAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB2AAAAAAIAeQAAAAAAAGwAAAAAAwBwAAAAAAIAbAAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdgAAAAACAHkAAAAAAABsAAAAAAIAbAAAAAAAAGwAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAACIAAAAAAgB5AAAAAAAAeQAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlAAAAAAIAIAAAAAADACUAAAAAAgAgAAAAAAEAJQAAAAADACAAAAAAAwB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACQAAAAAAAAgAAAAAAAAJAAAAAABACAAAAAAAAAkAAAAAAEAIAAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACUAAAAAAQAgAAAAAAEAJQAAAAACACAAAAAAAgAlAAAAAAIAIAAAAAACACUAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAACADAAAAAAAwAwAAAAAAAAeQAAAAAAABcAAAAABAAXAAAAAAYAFwAAAAAHABcAAAAAAgB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAQAeAAAAAAMAMAAAAAACAHkAAAAAAAAXAAAAAAMAFwAAAAADABcAAAAABgAXAAAAAAQAFwAAAAACACIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAMAHgAAAAACADAAAAAAAwB5AAAAAAAAFwAAAAAHABcAAAAABAAXAAAAAAMAFwAAAAADABcAAAAAAQB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAACAB4AAAAAAgAwAAAAAAMAeQAAAAAAABcAAAAABwAXAAAAAAIAFwAAAAABABcAAAAABAAXAAAAAAAAIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAIgAAAAADACIAAAAAAgB5AAAAAAAAHQAAAAABAB0AAAAAAgB5AAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAMAMAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAACIAAAAAAwB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAACIAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB4AAAAAAAAeQAAAAAAAHYAAAAAAgB2AAAAAAMAdgAAAAADAHYAAAAAAwB2AAAAAAMAeQAAAAAAACMAAAAAAAAjAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAB2AAAAAAEAdgAAAAADAHYAAAAAAQB2AAAAAAEAdgAAAAADAHkAAAAAAAAjAAAAAAAAIwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAHYAAAAAAQB2AAAAAAMAdgAAAAAAAHYAAAAAAAAiAAAAAAAAIwAAAAAAACMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHkAAAAAAAB5AAAAAAAAdgAAAAAAAHYAAAAAAQB2AAAAAAAAeQAAAAAAACMAAAAAAAAjAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB2AAAAAAEAdgAAAAACAHkAAAAAAAAjAAAAAAAAIwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAACIAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB5AAAAAAAAIwAAAAAAACMAAAAAAAAjAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAACMAAAAAAAAjAAAAAAAAIwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAIwAAAAAAACMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB4AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,0:
+          ind: 0,0
+          tiles: MAAAAAADADAAAAAAAQAwAAAAAAMAeQAAAAAAABcAAAAABQAXAAAAAAAAFwAAAAAFABcAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAjAAAAAAAAeQAAAAAAAHYAAAAAAAB2AAAAAAEAdgAAAAADAHYAAAAAAwB2AAAAAAMAeQAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAAAAAAHkAAAAAAAB2AAAAAAMAdgAAAAACAHYAAAAAAQB2AAAAAAMAdgAAAAACAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACMAAAAAAAAiAAAAAAEAdgAAAAABAHYAAAAAAAB2AAAAAAEAdgAAAAACAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAjAAAAAAAAeQAAAAAAAHYAAAAAAQB2AAAAAAEAdgAAAAAAAHkAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAAAAAAHkAAAAAAAB2AAAAAAIAdgAAAAADAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAjAAAAAAAAIwAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIwAAAAAAACMAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACMAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,-2:
+          ind: -1,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeAAAAAAAAHgAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAA==
+          version: 7
+        0,-2:
+          ind: 0,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeAAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            0: -6,-11
+            1: -5,-11
+            2: -5,-12
+            3: -6,-12
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNe
+          decals:
+            4: 1,-1
+            29: 0,6
+            30: 1,9
+            31: 0,10
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerNw
+          decals:
+            5: -3,-1
+            32: -2,10
+            33: -3,9
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSe
+          decals:
+            6: 1,-3
+            36: 1,8
+            39: 0,2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkCornerSw
+          decals:
+            7: -3,-3
+            37: -3,8
+            38: -2,2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkInnerNe
+          decals:
+            34: 0,9
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkInnerNw
+          decals:
+            35: -2,9
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineE
+          decals:
+            13: 1,-2
+            26: 0,5
+            27: 0,4
+            28: 0,3
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineN
+          decals:
+            8: -2,-1
+            9: -1,-1
+            10: 0,-1
+            19: -1,6
+            20: -1,10
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineS
+          decals:
+            14: -2,-3
+            15: -1,-3
+            16: 0,-3
+            17: -1,2
+            18: -1,8
+            21: -2,8
+            22: 0,8
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineW
+          decals:
+            11: -3,-1
+            12: -3,-2
+            23: -2,3
+            24: -2,4
+            25: -2,5
+        - node:
+            color: '#739D6FC3'
+            id: Busha3
+          decals:
+            123: 2.1557868,-0.9164014
+            124: -4.142126,-3.8997116
+            125: -4.017002,-0.6243291
+            126: -2.8074682,0.37706184
+            127: -3.683338,-2.0012412
+            128: -0.95146155,-3.6076393
+            129: 1.5301669,-0.019321948
+        - node:
+            color: '#739D6FC3'
+            id: Bushb3
+          decals:
+            118: -3.933586,-2.8148713
+            119: -1.9941614,-3.8162622
+            120: 0.13294822,-3.7953997
+            121: 0.696007,0.001540184
+            122: -1.6604974,-0.22794488
+        - node:
+            color: '#739D6FC3'
+            id: Bushc3
+          decals:
+            114: 2.0098097,-2.042966
+            115: -0.86804557,0.08498955
+            116: -3.683338,-0.019321948
+            117: -4.017002,-0.9164014
+        - node:
+            color: '#739D6FC3'
+            id: Bushf1
+          decals:
+            100: -3.725046,-3.8997116
+            101: 1.2799189,-3.9414358
+            102: -0.09644675,0.10585165
+            103: -2.5780752,-0.08190873
+            104: -2.0358694,-4.024885
+            105: 1.9681017,-2.8983202
+            113: -2.4946592,-4.191784
+        - node:
+            color: '#739D6FC3'
+            id: Bushf2
+          decals:
+            106: -3.933586,-1.6465821
+            107: 2.0306628,-0.18622068
+            108: 2.0098097,-2.856596
+            109: 1.9681017,-4.0666094
+            110: 0.11209321,-4.0040226
+            111: -2.2027032,0.022402763
+            112: -1.3893964,-3.98316
+        - node:
+            color: '#73CA6FC3'
+            id: Flowersbr3
+          decals:
+            133: 1.1130869,-4.1500587
+        - node:
+            color: '#73CA6FC3'
+            id: Flowerspv2
+          decals:
+            134: -2.9325922,-3.9414358
+            135: -2.1818483,0.043264866
+        - node:
+            color: '#73CA6FC3'
+            id: Flowersy1
+          decals:
+            131: -4.05871,-0.29053214
+            132: 2.0515177,-1.3127851
+            136: 0.34148818,-0.10277131
+            137: 2.1557868,-3.3364286
+        - node:
+            color: '#73CA6FC3'
+            id: Flowersy3
+          decals:
+            130: -3.9752939,-2.543661
+        - node:
+            color: '#0E7F1B67'
+            id: Grassa5
+          decals:
+            86: -3.579067,-4.024885
+            87: -4.204688,-2.522799
+        - node:
+            color: '#0E7F1BC3'
+            id: Grassa5
+          decals:
+            96: -3.01601,-4.1500587
+            97: 0.09124017,-0.144496
+            98: -4.142126,-0.24880746
+            99: 0.9254,-4.2126455
+        - node:
+            color: '#0E7F1BC3'
+            id: Grassb2
+          decals:
+            88: -3.9127328,-1.3545098
+            89: -3.036863,-0.144496
+            90: 0.779423,0.064127445
+        - node:
+            color: '#0E7F1BC3'
+            id: Grassb3
+          decals:
+            91: 1.8846858,-1.6883063
+            92: 1.6969988,-3.8579865
+            93: -0.30498672,-4.1083345
+            94: -4.079564,-2.4602118
+            95: -1.3685415,-0.019321948
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: LoadingArea
+          decals:
+            79: -10,-1
+            80: -10,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteInnerNe
+          decals:
+            46: 2,-12
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteInnerNw
+          decals:
+            47: 4,-12
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteInnerSe
+          decals:
+            45: 2,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteInnerSw
+          decals:
+            44: 4,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteLineE
+          decals:
+            40: 2,-11
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteLineN
+          decals:
+            41: 3,-12
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteLineS
+          decals:
+            43: 3,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteLineW
+          decals:
+            42: 4,-11
+        - node:
+            color: '#FFFFFFFF'
+            id: Rock01
+          decals:
+            82: 7.413066,-1.4588213
+        - node:
+            color: '#FFFFFFFF'
+            id: Rock02
+          decals:
+            83: 5.7864523,-3.1695304
+            85: 1.6761458,-0.18622068
+        - node:
+            color: '#FFFFFFFF'
+            id: Rock03
+          decals:
+            84: -3.891878,-3.628501
+        - node:
+            color: '#FFFFFFFF'
+            id: Rock04
+          decals:
+            81: 4.8271685,-0.9789882
+        - node:
+            color: '#FFFFFFFF'
+            id: Rock06
+          decals:
+            78: 5.2864194,-2.8357334
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            49: 1,-15
+            50: 1,-14
+            74: -9,-3
+            75: -9,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineN
+          decals:
+            48: -4,-12
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            72: -7,-3
+            73: -7,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            145: -5,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSe
+          decals:
+            58: -4,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinCornerSw
+          decals:
+            67: 2,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineE
+          decals:
+            59: -4,3
+            60: -4,4
+            61: -4,5
+            62: -4,6
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineN
+          decals:
+            51: -2,-10
+            52: -1,-10
+            53: 0,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineS
+          decals:
+            54: -8,2
+            55: -7,2
+            56: -6,2
+            57: -5,2
+            68: 3,2
+            69: 4,2
+            70: 5,2
+            71: 6,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WoodTrimThinLineW
+          decals:
+            63: 2,6
+            64: 2,5
+            65: 2,4
+            66: 2,3
+        - node:
+            color: '#175C138B'
+            id: grasssnowc1
+          decals:
+            138: -4.017002,-2.4810743
+            139: -4.142126,0.2518878
+            140: -3.933586,-0.3948436
+            141: 2.1140788,-1.3127851
+            142: 1.9472468,-3.3781538
+            143: 0.904547,-4.087472
+            144: 0.2997802,0.001540184
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          -1,-1:
+            0: 65535
+          0,-1:
+            0: 65535
+          -1,0:
+            0: 65535
+          -3,-2:
+            0: 61128
+          -3,-1:
+            0: 61166
+          -3,-3:
+            0: 32768
+          -2,-3:
+            0: 65535
+          -2,-2:
+            0: 65535
+          -2,-1:
+            0: 65535
+          -2,-4:
+            0: 61164
+          -1,-4:
+            0: 65535
+          -1,-3:
+            0: 65535
+          -1,-2:
+            0: 65535
+          0,-4:
+            0: 62271
+            1: 192
+            2: 3072
+          0,-3:
+            0: 65535
+          0,-2:
+            0: 65535
+          1,-4:
+            0: 13105
+          1,-3:
+            0: 63351
+          1,-2:
+            0: 65535
+          1,-1:
+            0: 65535
+          2,-2:
+            0: 12560
+          2,-1:
+            0: 13107
+          -3,0:
+            0: 52974
+          -3,1:
+            0: 136
+          -2,0:
+            0: 65535
+          -2,1:
+            0: 52991
+          -2,2:
+            0: 136
+          -1,1:
+            0: 65535
+          -1,2:
+            0: 65535
+          -1,3:
+            0: 14
+          0,0:
+            0: 65535
+          0,1:
+            0: 65535
+          0,2:
+            0: 30719
+          0,3:
+            0: 3
+          1,0:
+            0: 65535
+          1,1:
+            0: 5119
+          2,0:
+            0: 4403
+          -2,-5:
+            0: 32768
+          -1,-5:
+            0: 65280
+          0,-5:
+            0: 63232
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: SpreaderGrid
+    - type: GridPathfinding
+    - type: ImplicitRoof
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 2
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 2
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-0.5
+      parent: 2
+  - uid: 6
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-2.5
+      parent: 2
+- proto: APCBasic
+  entities:
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,5.5
+      parent: 2
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 9
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-2.5
+      parent: 2
+  - uid: 10
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-0.5
+      parent: 2
+- proto: AtmosFixNitrogenMarker
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 2
+- proto: AtmosFixOxygenMarker
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 2
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 2
+- proto: Bed
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 2
+- proto: BedsheetWiz
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 2
+- proto: BookRandom
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -7.387626,2.56149
+      parent: 2
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -7.700435,2.7283878
+      parent: 2
+- proto: BookRandomStory
+  entities:
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 3.5160534,-11.342207
+      parent: 2
+- proto: BooksBag
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -4.509771,6.4627414
+      parent: 2
+- proto: Bookshelf
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 2
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 2
+  - uid: 23
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 2
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 2
+- proto: BoxFolderBase
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -3.3141003,2.4580417
+      parent: 2
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -3.3558083,2.7709756
+      parent: 2
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -3.6477642,2.6040778
+      parent: 2
+- proto: CableApcExtension
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 2
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 2
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 2
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 2
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 2
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 2
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 2
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 2
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 2
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 2
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 2
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 2
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 2
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 2
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 2
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 2
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 2
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 2
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 2
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 2
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 2
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 2
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 2
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 2
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 2
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 2
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 2
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 2
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 2
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
+      parent: 2
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 2
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 1.5,-16.5
+      parent: 2
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 2
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 2
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 2
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 2
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 2
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 5.5,-10.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 2
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 2
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 2
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 2
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 2
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 2
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 2
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 2
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 2
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 2
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 2
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 2
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 2
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 2
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 2
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 2
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 2
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 2
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 2
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 2
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 2
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 2
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 2
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 2
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 2
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 2
+- proto: CableHV
+  entities:
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 1.5,-15.5
+      parent: 2
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 2
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -0.5,-15.5
+      parent: 2
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 2
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 2
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 2
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 2
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 2
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 2
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 2
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 2
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 2
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 2
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 2
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 2
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 2
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 2
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 2
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 2
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 5.5,-10.5
+      parent: 2
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 2
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 2
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 2
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 195
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+  - uid: 197
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 2
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 2
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 2
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 2
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 2
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 2
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 2
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 2
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 2
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 226
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+- proto: CableTerminal
+  entities:
+  - uid: 232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-15.5
+      parent: 2
+- proto: CarpetPurple
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-11.5
+      parent: 2
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 2
+  - uid: 235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 2
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-10.5
+      parent: 2
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 2
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 2
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 2
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 2
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 2
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 2
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 2
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 2
+- proto: Catwalk
+  entities:
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 2
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 2
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 2
+- proto: ChairFolding
+  entities:
+  - uid: 257
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 2
+- proto: ChairPilotSeat
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 2
+- proto: ChairWood
+  entities:
+  - uid: 259
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 2
+  - uid: 260
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 261
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,5.5
+      parent: 2
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 2
+  - uid: 266
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 2
+  - uid: 267
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 2
+- proto: ClockworkShield
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      pos: -2.780127,-2.51509
+      parent: 2
+- proto: ClothingBackpackSatchelLeather
+  entities:
+  - uid: 269
+    components:
+    - type: Transform
+      pos: -2.5143497,-5.278594
+      parent: 2
+- proto: ClothingBeltUtilityFilled
+  entities:
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -4.45475,-13.4387665
+      parent: 2
+- proto: ClothingBeltWand
+  entities:
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -2.4604146,-1.0363866
+      parent: 2
+- proto: ClothingHandsGlovesCombat
+  entities:
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -9.39363,-3.5328693
+      parent: 2
+- proto: ClothingHeadHatWitch1
+  entities:
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -5.52865,-9.359842
+      parent: 2
+- proto: ClothingHeadHatWizard
+  entities:
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -2.623579,-1.7162492
+      parent: 2
+- proto: ClothingHeadHelmetWizardHelm
+  entities:
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -1.3289549,-9.370714
+      parent: 2
+- proto: ClothingMaskGasChameleon
+  entities:
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -9.537922,-3.3987489
+      parent: 2
+- proto: ClothingShoesWizard
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -2.4604146,-2.2863867
+      parent: 2
+- proto: ClothingUniformJumpskirtColorBlack
+  entities:
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -5.617341,-9.575869
+      parent: 2
+- proto: ClothingUniformJumpsuitColorBlack
+  entities:
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -5.429654,-9.555006
+      parent: 2
+- proto: ComfyChair
+  entities:
+  - uid: 280
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,3.5
+      parent: 2
+  - uid: 281
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-10.5
+      parent: 2
+- proto: ComputerIFFSyndicate
+  entities:
+  - uid: 282
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 2
+- proto: ComputerShuttle
+  entities:
+  - uid: 283
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 2
+- proto: ComputerSurveillanceWirelessCameraMonitor
+  entities:
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 2
+- proto: CrayonBox
+  entities:
+  - uid: 285
+    components:
+    - type: Transform
+      pos: -3.8145962,2.6666646
+      parent: 2
+- proto: CrayonRainbow
+  entities:
+  - uid: 286
+    components:
+    - type: Transform
+      pos: -3.6894722,2.437179
+      parent: 2
+- proto: DiceBag
+  entities:
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 4.037085,4.423369
+      parent: 2
+- proto: Dresser
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 2
+- proto: DrinkAleBottleFull
+  entities:
+  - uid: 289
+    components:
+    - type: MetaData
+      desc: Made fresh on the mountain by me... And my army of little owls.
+      name: wizard ale
+    - type: Transform
+      pos: 1.9282424,-5.2112255
+      parent: 2
+- proto: DrinkGlass
+  entities:
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 2.6212802,-5.185618
+      parent: 2
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 2.3556552,-5.388743
+      parent: 2
+- proto: FaxMachineSyndie
+  entities:
+  - uid: 292
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+- proto: FigureSpawner
+  entities:
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 2
+- proto: FirelockGlass
+  entities:
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 2
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 2
+- proto: Fireplace
+  entities:
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 2
+- proto: FloorDrain
+  entities:
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: FloraRockSolid
+  entities:
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 6.5734406,0.1678339
+      parent: 2
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 5.280491,-2.8363385
+      parent: 2
+- proto: FoodBurgerSpell
+  entities:
+  - uid: 304
+    components:
+    - type: Transform
+      pos: -1.6417658,-9.454163
+      parent: 2
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -3.3355608,-5.270721
+      parent: 2
+- proto: FoodMeat
+  entities:
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 5.238783,-2.0018458
+      parent: 2
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 5.551594,-0.20768729
+      parent: 2
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 7.5535793,-3.0240989
+      parent: 2
+- proto: GasMinerNitrogen
+  entities:
+  - uid: 309
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-13.5
+      parent: 2
+- proto: GasMinerOxygen
+  entities:
+  - uid: 310
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-14.5
+      parent: 2
+- proto: GasMixerFlipped
+  entities:
+  - uid: 311
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-13.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+    - type: GasMixer
+      inletTwoConcentration: 0.22000003
+      inletOneConcentration: 0.78
+- proto: GasPassiveVent
+  entities:
+  - uid: 312
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 313
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-14.5
+      parent: 2
+- proto: GasPipeBend
+  entities:
+  - uid: 314
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-14.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 317
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-5.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 319
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,0.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 320
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 321
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 322
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 323
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,3.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+- proto: GasPipeFourway
+  entities:
+  - uid: 325
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 326
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+- proto: GasPipeStraight
+  entities:
+  - uid: 327
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-13.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 328
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-13.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 329
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-13.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 330
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 331
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-11.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 332
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-10.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 333
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 334
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 335
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 338
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,1.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 339
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,2.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 340
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 341
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 342
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 343
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 344
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 345
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 346
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 347
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 348
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-8.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 349
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-9.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 350
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-8.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 351
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-9.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 352
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-6.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 353
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 354
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 356
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 357
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 358
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 359
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,6.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 360
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 361
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 364
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 366
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-2.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 367
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-2.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 368
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 369
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+- proto: GasPipeTJunction
+  entities:
+  - uid: 370
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-13.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 371
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-9.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 372
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 373
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-5.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 374
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 375
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 376
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-0.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 377
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 378
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+- proto: GasPressurePump
+  entities:
+  - uid: 379
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-13.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+- proto: GasVentPump
+  entities:
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 381
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-14.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 383
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-10.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 384
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-10.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 386
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 389
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 391
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-0.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 392
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-2.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+  - uid: 393
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-6.5
+      parent: 2
+    - type: VentCrawTube
+      connected: True
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 394
+    components:
+    - type: Transform
+      pos: 1.5,-15.5
+      parent: 2
+  - uid: 395
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 2
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -2.5,-15.5
+      parent: 2
+- proto: Grille
+  entities:
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 2
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 2
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 2
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 2
+  - uid: 401
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 2
+  - uid: 402
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 2
+  - uid: 403
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 2
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 405
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 2
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 2
+  - uid: 407
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 2
+  - uid: 408
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 2
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -9.5,1.5
+      parent: 2
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 2
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
+      parent: 2
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 417
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 418
+    components:
+    - type: Transform
+      pos: 1.5,-16.5
+      parent: 2
+  - uid: 419
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 2
+  - uid: 420
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 423
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 424
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 427
+    components:
+    - type: Transform
+      pos: 5.5,-10.5
+      parent: 2
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 2
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 432
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 2
+  - uid: 433
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 434
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 2
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 2
+  - uid: 437
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+  - uid: 438
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+  - uid: 439
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 440
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 441
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 443
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 2
+  - uid: 446
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 447
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-2.5
+      parent: 2
+  - uid: 449
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-0.5
+      parent: 2
+- proto: Gyroscope
+  entities:
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 2
+- proto: HospitalCurtains
+  entities:
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 2
+    - type: Occluder
+      enabled: False
+    - type: Door
+      state: Open
+    - type: Physics
+      canCollide: False
+- proto: HospitalCurtainsOpen
+  entities:
+  - uid: 452
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 2
+- proto: IntercomAll
+  entities:
+  - uid: 453
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 2
+- proto: JetpackMiniFilled
+  entities:
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -9.508206,-3.3199291
+      parent: 2
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 455
+    components:
+    - type: Transform
+      pos: -2.5632703,-0.42328313
+      parent: 2
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 456
+    components:
+    - type: Transform
+      pos: -2.3338752,-0.5901818
+      parent: 2
+- proto: Mirror
+  entities:
+  - uid: 457
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 2
+- proto: MirrorShield
+  entities:
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 1.3163121,-0.3900899
+      parent: 2
+- proto: NitrogenCanister
+  entities:
+  - uid: 459
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 2
+- proto: OxygenCanister
+  entities:
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+- proto: Paper
+  entities:
+  - uid: 461
+    components:
+    - type: Transform
+      pos: -3.4183693,2.541491
+      parent: 2
+  - uid: 462
+    components:
+    - type: Transform
+      pos: -3.3349533,2.7083888
+      parent: 2
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 3.578297,4.715441
+      parent: 2
+  - uid: 464
+    components:
+    - type: Transform
+      pos: 4.349894,4.652854
+      parent: 2
+  - uid: 465
+    components:
+    - type: Transform
+      pos: 4.600142,4.193884
+      parent: 2
+  - uid: 466
+    components:
+    - type: Transform
+      pos: 4.662705,3.5888767
+      parent: 2
+- proto: Pen
+  entities:
+  - uid: 467
+    components:
+    - type: Transform
+      pos: 4.391602,3.9643984
+      parent: 2
+  - uid: 468
+    components:
+    - type: Transform
+      pos: 3.80769,4.652854
+      parent: 2
+- proto: PersonalAI
+  entities:
+  - uid: 469
+    components:
+    - type: Transform
+      pos: 1.5621729,-0.9631119
+      parent: 2
+    - type: StockLimitedProcessing
+      processingListings: {}
+- proto: PlasmaDoor
+  entities:
+  - uid: 470
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 2
+  - uid: 471
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 472
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 473
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 474
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 475
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 2
+  - uid: 476
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 2
+  - uid: 477
+    components:
+    - type: Transform
+      pos: -4.5,-8.5
+      parent: 2
+  - uid: 478
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 2
+  - uid: 479
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 2
+  - uid: 480
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 481
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-14.5
+      parent: 2
+  - uid: 482
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 483
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-14.5
+      parent: 2
+  - uid: 484
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-14.5
+      parent: 2
+  - uid: 485
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 2
+  - uid: 486
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 2
+  - uid: 487
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 2
+  - uid: 488
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 2
+  - uid: 489
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 2
+  - uid: 490
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 491
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 2
+  - uid: 492
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 2
+  - uid: 493
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 2
+  - uid: 494
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 495
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 2
+  - uid: 496
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 497
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 498
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-10.5
+      parent: 2
+  - uid: 499
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-10.5
+      parent: 2
+  - uid: 500
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-11.5
+      parent: 2
+  - uid: 501
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-11.5
+      parent: 2
+  - uid: 502
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-13.5
+      parent: 2
+  - uid: 503
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-14.5
+      parent: 2
+  - uid: 504
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-17.5
+      parent: 2
+  - uid: 505
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-17.5
+      parent: 2
+  - uid: 506
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-17.5
+      parent: 2
+  - uid: 507
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-17.5
+      parent: 2
+  - uid: 508
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 509
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-13.5
+      parent: 2
+  - uid: 510
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,2.5
+      parent: 2
+  - uid: 511
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,3.5
+      parent: 2
+  - uid: 512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 513
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 514
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-1.5
+      parent: 2
+  - uid: 515
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 516
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 517
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 518
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 2
+  - uid: 519
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 520
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 521
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 2
+  - uid: 522
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 2
+  - uid: 523
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+- proto: PonderingOrbWizard
+  entities:
+  - uid: 524
+    components:
+    - type: Transform
+      pos: 1.5532424,-1.6617236
+      parent: 2
+- proto: PottedPlantRandom
+  entities:
+  - uid: 525
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 526
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+- proto: PowerCellRecharger
+  entities:
+  - uid: 527
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 2
+- proto: Poweredlight
+  entities:
+  - uid: 528
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-7.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 529
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-7.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 530
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 531
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 532
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 533
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 534
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-0.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 535
+    components:
+    - type: Transform
+      pos: -9.5,-2.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 536
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-3.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 537
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 538
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-16.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 539
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-10.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 540
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 541
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,8.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 542
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 543
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 544
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,12.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 545
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 546
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,1.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 547
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,2.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -7.5,-9.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 550
+    components:
+    - type: Transform
+      pos: 6.5,-9.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 551
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-17.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 552
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-17.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 553
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-16.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+- proto: PoweredSmallLight
+  entities:
+  - uid: 554
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 556
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 557
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 2
+  - uid: 558
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+  - uid: 559
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 2
+- proto: Rack
+  entities:
+  - uid: 560
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+  - uid: 561
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 2
+- proto: RandomPosterAny
+  entities:
+  - uid: 562
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 563
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 2
+  - uid: 564
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 565
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 566
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 2
+  - uid: 567
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,4.5
+      parent: 2
+- proto: RandomPosterContraband
+  entities:
+  - uid: 568
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 2
+  - uid: 569
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-15.5
+      parent: 2
+- proto: RandomSpawner
+  entities:
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 2
+  - uid: 571
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 2
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 2
+- proto: ReinforcedPlasmaWindow
+  entities:
+  - uid: 573
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 2
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 2
+  - uid: 575
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 2
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 2
+  - uid: 578
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 579
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 2
+  - uid: 580
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 2
+  - uid: 581
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 2
+  - uid: 582
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 2
+  - uid: 583
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
+      parent: 2
+  - uid: 584
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 585
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 586
+    components:
+    - type: Transform
+      pos: 1.5,-16.5
+      parent: 2
+  - uid: 587
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 588
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 2
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 591
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 2
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 593
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 594
+    components:
+    - type: Transform
+      pos: 5.5,-10.5
+      parent: 2
+  - uid: 595
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 596
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+  - uid: 597
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 2
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 599
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 600
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 602
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 603
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 604
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 605
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+  - uid: 606
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+  - uid: 607
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 608
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 2
+  - uid: 609
+    components:
+    - type: Transform
+      pos: -9.5,1.5
+      parent: 2
+  - uid: 610
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 611
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 612
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 613
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 614
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 615
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 616
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 2
+  - uid: 617
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 618
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-2.5
+      parent: 2
+  - uid: 619
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-0.5
+      parent: 2
+  - uid: 620
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 2
+  - uid: 621
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 2
+  - uid: 622
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 2
+  - uid: 623
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 2
+  - uid: 624
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 2
+  - uid: 625
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 2
+- proto: SalvageHumanCorpseSpawner
+  entities:
+  - uid: 626
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-1.5
+      parent: 2
+- proto: SinkWide
+  entities:
+  - uid: 627
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-9.5
+      parent: 2
+- proto: Skub
+  entities:
+  - uid: 628
+    components:
+    - type: Transform
+      pos: 4.572705,-11.394358
+      parent: 2
+- proto: SMESBasic
+  entities:
+  - uid: 629
+    components:
+    - type: Transform
+      pos: -0.5,-15.5
+      parent: 2
+- proto: SoapOmega
+  entities:
+  - uid: 630
+    components:
+    - type: Transform
+      pos: 2.4979851,-9.465773
+      parent: 2
+- proto: SpawnMobBear
+  entities:
+  - uid: 631
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 2
+  - uid: 632
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+- proto: SpawnPointWizard
+  entities:
+  - uid: 633
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 2
+- proto: StealthBox
+  entities:
+  - uid: 634
+    components:
+    - type: Transform
+      pos: -5.369279,-11.020669
+      parent: 2
+    - type: Stealth
+      enabled: False
+    - type: EntityStorage
+      open: True
+- proto: SubstationBasic
+  entities:
+  - uid: 635
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 2
+- proto: SuitStorageWizard
+  entities:
+  - uid: 636
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 2
+- proto: TableCarpet
+  entities:
+  - uid: 637
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 638
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 2
+  - uid: 639
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+- proto: TableFancyBlack
+  entities:
+  - uid: 640
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 641
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 642
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+  - uid: 643
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+- proto: TableStone
+  entities:
+  - uid: 644
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 645
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 646
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 2
+  - uid: 647
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 648
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 649
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+- proto: TableWood
+  entities:
+  - uid: 650
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 2
+  - uid: 651
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 2
+  - uid: 652
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 2
+  - uid: 653
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 2
+  - uid: 654
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 2
+  - uid: 655
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,2.5
+      parent: 2
+  - uid: 656
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-9.5
+      parent: 2
+  - uid: 657
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 2
+  - uid: 658
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 2
+- proto: TargetStrange
+  entities:
+  - uid: 659
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 2
+- proto: Thruster
+  entities:
+  - uid: 660
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 2
+  - uid: 661
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 2
+  - uid: 662
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 663
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,5.5
+      parent: 2
+  - uid: 664
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-16.5
+      parent: 2
+  - uid: 665
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-17.5
+      parent: 2
+  - uid: 666
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-16.5
+      parent: 2
+  - uid: 667
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-8.5
+      parent: 2
+  - uid: 668
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-8.5
+      parent: 2
+- proto: ToiletEmpty
+  entities:
+  - uid: 669
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-11.5
+      parent: 2
+- proto: VendingMachineCoffee
+  entities:
+  - uid: 670
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 2
+- proto: VendingMachineDiscount
+  entities:
+  - uid: 671
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+- proto: VendingMachineGames
+  entities:
+  - uid: 672
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 2
+- proto: VendingMachineMagivend
+  entities:
+  - uid: 673
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 674
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+- proto: WallUranium
+  entities:
+  - uid: 675
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+  - uid: 676
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 2
+  - uid: 677
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 2
+  - uid: 678
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 2
+  - uid: 679
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 2
+  - uid: 680
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 2
+  - uid: 681
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 2
+  - uid: 682
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 2
+  - uid: 683
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 684
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 2
+  - uid: 685
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 2
+  - uid: 686
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 2
+  - uid: 687
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 2
+  - uid: 688
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 2
+  - uid: 689
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 2
+  - uid: 690
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 2
+  - uid: 691
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 2
+  - uid: 692
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 2
+  - uid: 693
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 2
+  - uid: 694
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 2
+  - uid: 695
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 696
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 697
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 2
+  - uid: 698
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 2
+  - uid: 699
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 2
+  - uid: 700
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 2
+  - uid: 701
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 2
+  - uid: 702
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 703
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 2
+  - uid: 704
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 2
+  - uid: 705
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+  - uid: 706
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 707
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 2
+  - uid: 708
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+  - uid: 709
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 710
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 711
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+  - uid: 712
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 713
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 714
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 715
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 716
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+  - uid: 717
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 718
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 2
+  - uid: 720
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 2
+  - uid: 721
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 722
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 723
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 724
+    components:
+    - type: Transform
+      pos: -8.5,-7.5
+      parent: 2
+  - uid: 725
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 2
+  - uid: 726
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 2
+  - uid: 727
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+  - uid: 728
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 2
+  - uid: 729
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+  - uid: 730
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 2
+  - uid: 731
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 2
+  - uid: 732
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 733
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 734
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 735
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 737
+    components:
+    - type: Transform
+      pos: -3.5,-17.5
+      parent: 2
+  - uid: 738
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 2
+  - uid: 739
+    components:
+    - type: Transform
+      pos: 2.5,-17.5
+      parent: 2
+  - uid: 740
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 2
+  - uid: 741
+    components:
+    - type: Transform
+      pos: -0.5,-16.5
+      parent: 2
+  - uid: 742
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 743
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 744
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 2
+  - uid: 745
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 746
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 747
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 2
+  - uid: 748
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 749
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 750
+    components:
+    - type: Transform
+      pos: -7.5,-8.5
+      parent: 2
+  - uid: 751
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 2
+  - uid: 752
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 2
+  - uid: 753
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 2
+  - uid: 754
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 2
+  - uid: 755
+    components:
+    - type: Transform
+      pos: -5.5,-15.5
+      parent: 2
+  - uid: 756
+    components:
+    - type: Transform
+      pos: -3.5,-15.5
+      parent: 2
+  - uid: 757
+    components:
+    - type: Transform
+      pos: 2.5,-15.5
+      parent: 2
+  - uid: 758
+    components:
+    - type: Transform
+      pos: 4.5,-15.5
+      parent: 2
+  - uid: 759
+    components:
+    - type: Transform
+      pos: -4.5,-15.5
+      parent: 2
+  - uid: 760
+    components:
+    - type: Transform
+      pos: 3.5,-15.5
+      parent: 2
+  - uid: 761
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 2
+  - uid: 762
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 763
+    components:
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 2
+  - uid: 764
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 2
+  - uid: 765
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 2
+  - uid: 766
+    components:
+    - type: Transform
+      pos: -10.5,-4.5
+      parent: 2
+  - uid: 767
+    components:
+    - type: Transform
+      pos: -10.5,1.5
+      parent: 2
+  - uid: 768
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+  - uid: 769
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
+      parent: 2
+  - uid: 770
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 771
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 2
+  - uid: 772
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 2
+  - uid: 773
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 2
+  - uid: 774
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 2
+  - uid: 775
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 2
+  - uid: 776
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 2
+  - uid: 777
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 2
+  - uid: 778
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 2
+  - uid: 779
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 2
+  - uid: 780
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 2
+  - uid: 781
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 2
+  - uid: 782
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 2
+  - uid: 783
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 2
+  - uid: 784
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 2
+  - uid: 785
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 2
+  - uid: 786
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 2
+  - uid: 787
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 2
+  - uid: 788
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 789
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 2
+  - uid: 790
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 2
+  - uid: 791
+    components:
+    - type: Transform
+      pos: 3.5,-12.5
+      parent: 2
+  - uid: 792
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+- proto: WarpPoint
+  entities:
+  - uid: 793
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+    - type: WarpPoint
+      location: Wizard Shuttle
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 794
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 2
+- proto: WizardComputerComms
+  entities:
+  - uid: 795
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 2
+- proto: WoodblockInstrument
+  entities:
+  - uid: 796
+    components:
+    - type: Transform
+      pos: 1.5449836,-2.289194
+      parent: 2
+...

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -278,7 +278,7 @@
     - WizardSurviveObjective
     - WizardDemonstrateObjective
   - type: LoadMapRule
-    mapPath: /Maps/Shuttles/wizard.yml #Starlight. wizard deserves their shuttle.
+    mapPath: /Maps/_Starlight/Shuttles/WizardShuttle.yml #Starlight. wizard deserves their shuttle. and it had to be re-saved as a map to get it to work.
   - type: RuleGrids
   - type: AntagSelection
   - type: AntagLoadProfileRule


### PR DESCRIPTION
## Short description
wizard rule was broken.

## Why we need to add this
I wanna summon cheese

## Media (Video/Screenshots)
N/A

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- fix: Wizard gamerule now actually spawns the wizard shuttle instead of doing nothing
