### PR TITLE
fixes the infinite client-sided cheese that spawns from the wizard.

### DIFF
--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -531,13 +531,15 @@ public abstract class SharedMagicSystem : EntitySystem
     private void OnSpawnItemInHand(SpawnItemInHandEvent ev)
     {
         if (ev.Handled || !PassesSpellPrerequisites(ev.Action, ev.Performer))
-            return;
+                return;
         var user = ev.Performer;
 
         // try to put item in hand, otherwise it goes on the ground
         var star = Spawn(ev.Spawned, Transform(user).Coordinates);
-        _hands.TryPickupAnyHand(user, star);
-
+        if (IsClientSide(star))
+            Del(star);//event has a tendency to produce client-sided cheese... this cleans those up...
+        else
+            _hands.TryPickupAnyHand(user, star);
         ev.Handled = true;
     }
     #endregion

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -531,7 +531,7 @@ public abstract class SharedMagicSystem : EntitySystem
     private void OnSpawnItemInHand(SpawnItemInHandEvent ev)
     {
         if (ev.Handled || !PassesSpellPrerequisites(ev.Action, ev.Performer))
-                return;
+            return;
         var user = ev.Performer;
 
         // try to put item in hand, otherwise it goes on the ground


### PR DESCRIPTION
## Short description
Fixes the wizard cheese spawn from spawning infinite client-sidded ghost cheese

## Why we need to add this
idk if the client can handle a thousand chesse entities all glued to your torso.

## Media (Video/Screenshots)
<img width="331" height="61" alt="image" src="https://github.com/user-attachments/assets/8707481f-f57b-4f09-8a6d-f99d9b0c1211" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- fix: the wizard has stopped halucinating extra cheese from spawning some from the void.