### PR TITLE
fix abductor gizmo not respecting the doafter failing

### DIFF
--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Gizmo.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Gizmo.cs
@@ -74,6 +74,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
 
     private void OnGizmoDoAfter(Entity<AbductorGizmoComponent> ent, ref AbductorGizmoMarkDoAfterEvent args)
     {
+        if (!args.DoAfter.Completed) return;
         if (args.Target is null) return;
         ent.Comp.Target = GetNetEntity(args.Target);
         EnsureComp<AbductorVictimComponent>(args.Target.Value, out var victimComponent);


### PR DESCRIPTION
## Short description
if you use the abdctor gizmo it will still mark them even if the doafter fails via eg: being moved/shot.

## Why we need to add this
I mean... isn't it obvious?

## Media (Video/Screenshots)
N/A

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksantora
- fix: Abductor scientist gizmo no longer implants the tracker no matter what.
