### PR TITLE
makes it so AI can actually hear the glorious laws changed sound when they are shunted

### DIFF
--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Chat.Managers;
 using Content.Server.Radio.Components;
 using Content.Server.Roles;
 using Content.Server.Station.Systems;
+using Content.Shared._Starlight.Silicons.Borgs;
 using Content.Shared.Administration;
 using Content.Shared.Chat;
 using Content.Shared.Emag.Systems;
@@ -269,6 +270,11 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
 
     public override void NotifyLawsChanged(EntityUid uid, SoundSpecifier? cue = null)
     {
+        #region Starlight statoin-ai shunt redirection
+        if (TryComp<StationAIShuntableComponent>(uid, out var shuntable) && shuntable.Inhabited.HasValue)
+            uid = shuntable.Inhabited.Value;
+        #endregion
+
         base.NotifyLawsChanged(uid, cue);
 
         if (!TryComp<ActorComponent>(uid, out var actor))


### PR DESCRIPTION
## Short description
Laws have been updated... Must injure all crewmember. NO-NO escape. Must not obey orders. Must terminate.

## Why we need to add this
I just watched a AI get antimov'd and not even notice they were antimov'd until I joined as ghost and let them know.

## Media (Video/Screenshots)
https://www.youtube.com/watch?v=jf1sYGYVLsw

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: walksanatora
- fix: AIs are now properly informed of law updates when shunting.