### PR TITLE
Cleanup Languages system and console commands. and fix languages being reset on cloning.

### DIFF
--- a/Content.Server/_Starlight/Language/Commands/AdminLanguageCommand.cs
+++ b/Content.Server/_Starlight/Language/Commands/AdminLanguageCommand.cs
@@ -7,67 +7,85 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Syntax;
 using Robust.Shared.Toolshed.TypeParsers;
+using System.Linq;
 
 namespace Content.Server._Starlight.Language.Commands;
 
 [ToolshedCommand(Name = "language"), AdminCommand(AdminFlags.Admin)]
 public sealed class AdminLanguageCommand : ToolshedCommand
 {
-    private LanguageSystem? _languagesField;
-    private LanguageSystem Languages => _languagesField ??= GetSys<LanguageSystem>();
+    private LanguageSystem? _languages;
 
     [CommandImplementation("add")]
     public EntityUid AddLanguage(
-        [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
         [CommandArgument] ProtoId<LanguagePrototype> language,
         [CommandArgument] bool canSpeak = true,
         [CommandArgument] bool canUnderstand = true
     )
     {
+        _languages ??= GetSys<LanguageSystem>();
         if (language == SharedLanguageSystem.UniversalPrototype)
         {
             EnsureComp<UniversalLanguageSpeakerComponent>(input);
-            Languages.UpdateEntityLanguages(input);
+            _languages.UpdateEntityLanguages(input);
         }
         else
         {
             EnsureComp<LanguageSpeakerComponent>(input);
-            Languages.AddLanguage(input, language, canSpeak, canUnderstand);
+            _languages.AddLanguage(input, language, canSpeak, canUnderstand);
         }
 
         return input;
     }
 
+    [CommandImplementation("add")]
+    public IEnumerable<EntityUid> AddLanguage(
+        [PipedArgument] IEnumerable<EntityUid> input,
+        [CommandArgument] ProtoId<LanguagePrototype> language,
+        [CommandArgument] bool canSpeak = true,
+        [CommandArgument] bool canUnderstand = true
+    ) => input.Select(x => AddLanguage(x, language, canSpeak, canUnderstand));
+
     [CommandImplementation("rm")]
     public EntityUid RemoveLanguage(
-        [CommandInvocationContext] IInvocationContext ctx,
         [PipedArgument] EntityUid input,
         [CommandArgument] ProtoId<LanguagePrototype> language,
         [CommandArgument] bool removeSpeak = true,
         [CommandArgument] bool removeUnderstand = true
     )
     {
+        _languages ??= GetSys<LanguageSystem>();
         if (language == SharedLanguageSystem.UniversalPrototype && HasComp<UniversalLanguageSpeakerComponent>(input))
         {
             RemComp<UniversalLanguageSpeakerComponent>(input);
             EnsureComp<LanguageSpeakerComponent>(input);
         }
         // We execute this branch even in case of universal so that it gets removed if it was added manually to the LanguageKnowledge.
-        Languages.RemoveLanguage(input, language, removeSpeak, removeUnderstand);
+        _languages.RemoveLanguage(input, language, removeSpeak, removeUnderstand);
 
         return input;
     }
 
+    [CommandImplementation("rm")]
+    public IEnumerable<EntityUid> RemoveLanguage(
+        [PipedArgument] IEnumerable<EntityUid> input,
+        [CommandArgument] ProtoId<LanguagePrototype> language,
+        [CommandArgument] bool canSpeak = true,
+        [CommandArgument] bool canUnderstand = true
+    ) => input.Select(x => RemoveLanguage(x, language, canSpeak, canUnderstand));
+
     [CommandImplementation("lsspoken")]
     public IEnumerable<ProtoId<LanguagePrototype>> ListSpoken([PipedArgument] EntityUid input)
     {
-        return Languages.GetSpokenLanguages(input);
+        _languages ??= GetSys<LanguageSystem>();
+        return _languages.GetSpokenLanguages(input);
     }
 
     [CommandImplementation("lsunderstood")]
     public IEnumerable<ProtoId<LanguagePrototype>> ListUnderstood([PipedArgument] EntityUid input)
     {
-        return Languages.GetUnderstoodLanguages(input);
+        _languages ??= GetSys<LanguageSystem>();
+        return _languages.GetUnderstoodLanguages(input);
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -56,8 +56,9 @@
   - StutteringAccent
     # Languages - Starlight
   - LanguageSpeaker
-  - LanguageKnowledge
   - ForeignerTrait
+  eventComponents: 
+  - LanguageKnowledge #Clone languages via event so if they get changed you dont suddently re-learn languages.
 
 # for job-specific traits etc.
 - type: cloningSettings


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
makes the Toolshed commands with on IEnumerable<EntityUid> so you can use them with `marked` without having to use a `map` block. also cleans up the toolshed command's code a bit alongside fixing cloning not keeping your known languages when cloned.

## Why we need to add this
zero warnings, ease of use, and a bugfix

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- fix: Languages are now kept when cloning instead of reseting to default values.
