### PR TITLE
fix for jarring color in text chat

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -72,7 +72,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     [Dependency] private readonly SharedPopupSystem _popups = default!; // Starlight
 
     public const float DefaultObfuscationFactor = 0.2f; // Percentage of symbols in a whispered message that can be seen even by "far" listeners - Starlight
-    public readonly Color DefaultSpeakColor = Color.White; // Starlight
+    public readonly Color DefaultSpeakColor = Color.LightGray; // Starlight
 
     private bool _loocEnabled = true;
     private bool _deadLoocEnabled;

--- a/Resources/Prototypes/_StarLight/Language/Galactic/solcommon.yml
+++ b/Resources/Prototypes/_StarLight/Language/Galactic/solcommon.yml
@@ -1,6 +1,8 @@
 - type: language
   id: SolCommon
   icon: LanguageIconSolCom
+  speech:
+    color: "#ffffff"
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 1


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Changes default lang color to the actual chat color instead of jarring white

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The white looked horrible

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Happyrobot33
- tweak: Changed Galactic Common color to original chat color