### PR TITLE
Fixed forged omnitool crowbar

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Tools/tools.yml
@@ -700,7 +700,9 @@
         components:
         - type: ToolTileCompatible
           delay: 1
-        - type: Prying
+        - type: Tool
+          qualities:
+            - Prying
           useSound:
             path: /Audio/Items/crowbar.ogg
         - type: MeleeWeapon

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Tools/tools.yml
@@ -448,8 +448,10 @@
         components:
         - type: ToolTileCompatible
           delay: 1
-        - type: Prying
+        - type: Tool
           speedModifier: 0.75
+          qualities:
+            - Prying
           useSound:
             path: /Audio/Items/crowbar.ogg
         - type: MeleeWeapon


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Made forged and improvised omnitool crowbar mode actually work.

## Why we need to add this
Forged and improvised omnitools' crowbar mode was broken and did not work, due to a mis-formatted component.

## Media (Video/Screenshots)
<img width="345" height="523" alt="image" src="https://github.com/user-attachments/assets/04384bc7-b3ea-400e-94c2-678bea3e4fe0" />
Works now

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Citrea
- fix: Forged and Improvised Omnitools' crowbar mode works properly now.
