### PR TITLE
zombified prevents language cloning

### DIFF
--- a/Content.Shared/_Starlight/Language/Systems/SharedLanguageSystem.cs
+++ b/Content.Shared/_Starlight/Language/Systems/SharedLanguageSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared._Starlight.Language.Events;
 using Content.Shared.GameTicking;
 using Robust.Shared.Prototypes;
 using Content.Shared.Cloning.Events;
+using Content.Shared.Zombies;
 
 namespace Content.Shared._Starlight.Language.Systems;
 
@@ -36,6 +37,8 @@ public abstract class SharedLanguageSystem : EntitySystem
 
     private void OnClone(Entity<LanguageKnowledgeComponent> ent, ref CloningEvent ev)
     {
+        if (HasComp<ZombieComponent>(ent))
+            return; //if we were zombified cloning will revert this so we dont clone the zed language 
         if (!ev.Settings.EventComponents.Contains(Factory.GetRegistration(ent.Comp.GetType()).Name))
             return;
         var clone = ev.CloneUid;


### PR DESCRIPTION
## Short description
makes it so cloning zeds causes you to lose the zed lang and re-gain species langs. this *may* be broken if you have eg: foreigner. but idk theres probally some lore reason why it wipes zed lang and gives you a language you may not have known.

## Why we need to add this
... *zeds*

## Media (Video/Screenshots)
<img width="552" height="440" alt="image" src="https://github.com/user-attachments/assets/3293284b-f76e-4fc1-b423-26613713d6b3" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- fix: Cloning a zed no longer only makes them only speak zed.
