### PR TITLE
borgs can now do the worm again.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -250,6 +250,7 @@
         Heat: 10 # capable of touching light bulbs and stoves without feeling pain!
   - type: CyborgSparkEffect #starlight
   - type: StationAIShunt #Starlight allow shunting into all borgs
+  - type: Crawler #Starlight *flop*
   # Starlight-start: Languages
   - type: LanguageKnowledge
     speaks:

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -248,9 +248,11 @@
     damageProtection:
       flatReductions:
         Heat: 10 # capable of touching light bulbs and stoves without feeling pain!
-  - type: CyborgSparkEffect #starlight
-  - type: StationAIShunt #Starlight allow shunting into all borgs
-  - type: Crawler #Starlight *flop*
+  #region Starlight
+  - type: CyborgSparkEffect
+  - type: StationAIShunt
+  - type: Crawler
+  #endregion
   # Starlight-start: Languages
   - type: LanguageKnowledge
     speaks:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
borgs can now go *flop*

## Why we need to add this
~~Let them Crawl like the worms they are~~. Adds mechanical choices to combat to make it less like napeolonic firing lines.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: Borgs can now crawl again.