### PR TITLE
Fix operating table

### DIFF
--- a/Content.Server/_Starlight/Medical/Surgery/BodyScannerSystem.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/BodyScannerSystem.cs
@@ -40,7 +40,7 @@ public sealed partial class BodyScannerSystem : SharedBodyScannerSystem
         if (!TryComp<OperatingTableComponent>(args.Sink, out var table) || !TryComp<StrapComponent>(args.Sink, out var strap))
             return;
 
-        ent.Comp.TableEntity = GetNetEntity(args.Sink);
+        ent.Comp.TableEntity = args.Sink;
         
         // Why one? Because operating table don't have more than one slot, and also Health Analyzer works only with one target.
         if (TryComp<HealthAnalyzerComponent>(ent.Owner, out var analyzer) && strap.BuckledEntities.Count == 1)
@@ -53,11 +53,10 @@ public sealed partial class BodyScannerSystem : SharedBodyScannerSystem
     
     private void OnPortDisconnected(Entity<BodyScannerComponent> ent, ref PortDisconnectedEvent args)
     {
-        var tableNetEntity = ent.Comp.TableEntity;
-        if (args.Port != ent.Comp.LinkingPort || tableNetEntity == null)
+        var tableEntityUid = ent.Comp.TableEntity;
+        if (args.Port != ent.Comp.LinkingPort || tableEntityUid == null)
             return;
-        
-        var tableEntityUid = GetEntity(tableNetEntity);
+
         if (TryComp<OperatingTableComponent>(tableEntityUid, out var table))
         {
             table.Scanner = null;

--- a/Content.Shared/_Starlight/Medical/Surgery/Components/_Tools.cs
+++ b/Content.Shared/_Starlight/Medical/Surgery/Components/_Tools.cs
@@ -27,7 +27,7 @@ public sealed partial class SurgeryToolComponent : Component
 [AutoGenerateComponentState]
 public sealed partial class OperatingTableComponent : Component
 {
-    [ViewVariables, AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public EntityUid? Scanner;
 }
 
@@ -36,7 +36,7 @@ public sealed partial class OperatingTableComponent : Component
 public sealed partial class BodyScannerComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public NetEntity? TableEntity;
+    public EntityUid? TableEntity;
     
     /// <summary>
     /// The machine linking port


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Fixes bug when Scanner and Table variables can't be saved in map(because one of it don't have [DataField] and another uses NetEntity)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Fix

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

No Content

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rinary
- fix: Fixed bug when premapped and linked body scanner/table sink can't be saved.