### PR TITLE
Medical Belt for Surgeons

### DIFF
--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Medical/surgeon.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Medical/surgeon.yml
@@ -19,5 +19,6 @@
   id: SurgeonGear
   equipment:
     ears: ClothingHeadsetMedical
+    belt: ClothingBeltMedicalFilled
   inhand:
     - ClothingBackpackDuffelSurgeryFilled


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Gives surgeon a filled medical belt because its needed.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Surgeons already have the customization they needed but now they to have them feel fully like a part of medical they need their medical belt. (Also for some reason certain maps don't have clothing vendors.)

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="813" height="125" alt="Capture" src="https://github.com/user-attachments/assets/5be5a800-1517-4011-991a-529100ffaa92" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AthenaAI
- add: Added Medical Belt to Surgeon's spawning loadout
