### PR TITLE
Fixed Vampire Logic

### DIFF
--- a/Content.Server/Vampire/VampireSystem.Abilities.cs
+++ b/Content.Server/Vampire/VampireSystem.Abilities.cs
@@ -678,7 +678,7 @@ public sealed partial class VampireSystem
         if (!_interaction.InRangeUnobstructed(vampire.Owner, target, popup: true))
             return false;
 
-        if (_ingestion.HasMouthAvailable(vampire, target))
+        if (!_ingestion.HasMouthAvailable(vampire, target))
             return false;
 
         if (_rotting.IsRotten(target))
@@ -712,7 +712,7 @@ public sealed partial class VampireSystem
         if (!HasComp<VampireFangsExtendedComponent>(entity))
             return;
 
-        if (_ingestion.HasMouthAvailable(entity, entity))
+        if (!_ingestion.HasMouthAvailable(entity, entity))
             return;
 
         if (_rotting.IsRotten(args.Target!.Value))

--- a/Content.Server/Vampire/VampireSystem.cs
+++ b/Content.Server/Vampire/VampireSystem.cs
@@ -184,7 +184,7 @@ public sealed partial class VampireSystem : EntitySystem
 
     private void OnExamined(EntityUid uid, VampireComponent component, ExaminedEvent args)
     {
-        if (HasComp<VampireFangsExtendedComponent>(uid) && args.IsInDetailsRange && !_ingestion.HasMouthAvailable(args.Examiner, uid))
+        if (HasComp<VampireFangsExtendedComponent>(uid) && args.IsInDetailsRange && _ingestion.HasMouthAvailable(args.Examiner, uid))
             args.AddMarkup($"{Loc.GetString("vampire-fangs-extended-examine")}{Environment.NewLine}");
     }
     private bool AddBloodEssence(Entity<VampireComponent> vampire, FixedPoint2 quantity)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Previously, vampires were unable to drink blood unless they were wearing a helmet. They would also not show the glint of their sharp teeth on inspect. This was due to a mistake in the boolean logic that this PR fixes. The check was changed from "_food.IsMouthBlocked" to "_ingestion.HasMouthAvailable" but the logic was not inverted properly.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Vampires cannot currently drink blood in the way that was intended, which causes lots of issues for people who roll this antagonist.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: rustdevelopment
- fix: Fixed vampire blood draining.