### PR TITLE
1984 - TC in the Security vendor.

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/security.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/security.yml
@@ -110,3 +110,19 @@
     stock: 4
   - !type:BuyerAccessCondition
     access: Brigmedic
+
+- type: listing
+  id: TCSyndie
+  productEntity: Telecrystal5
+  cost:
+    NTCredit: 1984
+  categories:
+  - SLSecurity
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 4
+  - !type:BuyerAntagCondition
+    whitelist:
+    - Thief
+    - Traitor
+    - TraitorSleeper


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Traitor and thief can now buy 4 packs of 5 telecrystals each for just 1984 credits, in the Security vendor.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- add: Traitor and thief can now buy 4 packs of 5 telecrystals each for just 1984 credits, in the Security vendor.