### PR TITLE
Resomi are not spiders.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/resomi.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/resomi.yml
@@ -3,11 +3,3 @@
   name: Urist McRaptor
   parent: BaseMobResomi
   id: MobResomi
-  components:
-  - type: Respirator
-    damage:
-      types:
-        Asphyxiation: 1.5 # This makes space and crit more lethal to arachnids.
-    damageRecovery:
-      types:
-        Asphyxiation: -0.5


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes the 1.5x asphyx damage from Resomi, which is _very clearly_ copied from arachnids.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I dunno about you but ion't think birds is spiders

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- remove: Birds _isn't_ spiders
- remove: Resomi no longer take 1.5x asphyx
