### PR TITLE
Added missing magazines and ammo box recipes to emagged lathes

### DIFF
--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
@@ -19,6 +19,7 @@
   - MagazineBoxLightRiflePractice
   - MagazineBoxMagnumPractice
   - MagazineBoxPistolPractice
+  - MagazineBoxCaselessRiflePractice
   - MagazineBoxRiflePractice
   - WeaponDisablerPractice
   - WeaponLaserCarbinePractice
@@ -38,6 +39,8 @@
   - MagazineBoxMagnumHP
   - MagazineBoxMagnumFMJ
 # Pistol
+  - MagazineBoxCaselessRifle
+  - MagazineBoxCaselessRifleRubber
   - MagazineBoxPistolSP
   - MagazineBoxPistolHP
   - MagazineBoxPistolFMJ
@@ -62,13 +65,20 @@
   - MagazineLightRifleSP
   - MagazineLightRifleHP
   - MagazineLightRifleFMJ
+  - MagazineLightRifleMaxim
+  - SpeedLoaderLightRifle
   - MagazineLightRifleEmpty
 # Magnum
   - SpeedLoaderMagnumSP
   - SpeedLoaderMagnumHP
   - SpeedLoaderMagnumFMJ
+  - MagazineMagnum
+  - MagazineMagnumRifleSP
+  - MagazineMagnumEmpty
   - SpeedLoaderMagnumEmpty
 # Pistol
+  - MagazinePistolCaselessRifle
+  - MagazineCaselessRifleRubber
   - MagazinePistolSP
   - MagazinePistolHP
   - MagazinePistolFMJ
@@ -84,6 +94,8 @@
   - MagazinePistolSubMachineGunEmpty
   - MagazinePistolSubMachineGunTopMounted
   - MagazinePistolSubMachineGunTopMountedEmpty
+  - MagazinePistolSubMachineGunUzi
+  - MagazinePistolSubMachineGunPPSH
 # Rifle
   - MagazineRifleSP
   - MagazineRifleHP

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/light-rifle.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/light-rifle.yml
@@ -125,6 +125,20 @@
     Steel: 1312
     Uranium: 1312
 
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineLightRifleMaxim
+  result: MagazineLightRifleMaxim
+  materials:
+    Steel: 350
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: SpeedLoaderLightRifle
+  result: SpeedLoaderLightRifle
+  materials:
+    Steel: 200
+
 ############ BOXES ############
 
 - type: latheRecipe

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/magnum.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/magnum.yml
@@ -17,6 +17,13 @@
     Steel: 50
 
 - type: latheRecipe
+  parent: BaseEmptyAmmoRecipe
+  id: MagazineMagnumEmpty
+  result: MagazineMagnumEmpty
+  materials:
+    Steel: 50
+
+- type: latheRecipe
   parent: BaseAmmoRecipe
   id: SpeedLoaderMagnumSP
   result: SpeedLoaderMagnumSP
@@ -69,6 +76,20 @@
     Steel: 110
     Uranium: 110
     Plastic: 150
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineMagnum
+  result: MagazineMagnum
+  materials:
+    Steel: 200
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineMagnumRifleSP
+  result: MagazineMagnumRifleSP
+  materials:
+    Steel: 250
 
 ############ BOXES ############
 

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/pistol.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/pistol.yml
@@ -7,6 +7,46 @@
   materials:
     Plastic: 5
     Steel: 5
+############ MAGAZINES (.25 CASELESS) ############
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazinePistolCaselessRifle
+  result: MagazinePistolCaselessRifle
+  materials:
+    Steel: 150
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineCaselessRifleRubber
+  result: MagazineCaselessRifleRubber
+  materials:
+    Steel: 100
+    Plastic: 20
+
+############ BOXES (.25 CASELESS) ############
+
+- type: latheRecipe
+  parent: BaseAmmoBoxRecipe
+  id: MagazineBoxCaselessRifle
+  result: MagazineBoxCaselessRifle
+  materials:
+    Steel: 450
+
+- type: latheRecipe
+  parent: BaseAmmoBoxRecipe
+  id: MagazineBoxCaselessRifleRubber
+  result: MagazineBoxCaselessRifleRubber
+  materials:
+    Steel: 230
+    Plastic: 60
+
+- type: latheRecipe
+  parent: BaseAmmoBoxRecipe
+  id: MagazineBoxCaselessRiflePractice
+  result: MagazineBoxCaselessRiflePractice
+  materials:
+    Steel: 100
 
 ############ MAGAZINES (.35) ############
 

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/smg.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/smg.yml
@@ -63,3 +63,17 @@
   result: MagazinePistolSubMachineGunTopMounted
   materials:
     Steel: 300
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazinePistolSubMachineGunUzi
+  result: MagazinePistolSubMachineGunUzi
+  materials:
+    Steel: 300
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazinePistolSubMachineGunPPSH
+  result: MagazinePistolSubMachineGunPPSH
+  materials:
+    Steel: 350


### PR DESCRIPTION
Added missing ammo magazine and ammo box recipes to emagged lathes and ordinary secfabs.

## Short description

Added new emagged autolathe recipes 
- Pitbull mag
- Type Uzi mag
- Mosin speedloader
- Caseless mags and boxes
- PPSH mag
- Pan mag for the rev LMG
- Magnum mags for the Jungle Hawk


## Why we need to add this

I believe it was not intentional to leave out these recipes as they were newly added guns. Adding these new emagged autolathes recipes will makes these weapons more viable to use as you can just print out new fresh mags instead of ammo boxes. It is also impossible to get extra mags for the rev weapons as well.


## Media (Video/Screenshots)

https://github.com/user-attachments/assets/47a04eaa-7bbb-4fed-ad44-8b6df2aba9f3

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: rylandsuper
- add: Added emagged lathe & secfab mag recipes for nukie, rev, and traitor weapons.
