### PR TITLE
Uzi Magazine Fix

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -879,7 +879,7 @@
       
 - type: entity
   id: MagazinePistolSubMachineGunUzi
-  name: Uzi magazine (.35 auto rubber)
+  name: Uzi magazine (.35 auto)
   parent: BaseMagazinePistolSubMachineGun
   components:
   - type: BallisticAmmoProvider


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes the "rubber" part from the uzi magazine's name as the bullets are not, infact, rubber
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
fix
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.-->

:cl: PubliclyExecutedPig
- fix: The Syndicate no longer mis-labells their magazines as rubber.

