### PR TITLE
Allow staff to use more ghost themes

### DIFF
--- a/Content.Server/_Starlight/GhostTheme/GhostThemeSystem.cs
+++ b/Content.Server/_Starlight/GhostTheme/GhostThemeSystem.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.EUI;
@@ -93,6 +94,12 @@ public sealed class GhostThemeSystem : EntitySystem
             {
                 if (_nulllinkPlayerRoles.IsAnyRole(session, roleReq.Roles))
                     AvailableThemes.Add(ghostTheme.ID);
+                // surely there is a better way to get the role id but whatever
+                else if (_prototypeManager.TryIndex(new ProtoId<RoleRequirementPrototype>("StaffRolesReq"), out var staffReq))
+                {
+                    if (roleReq.StaffOverrideable && _nulllinkPlayerRoles.IsAnyRole(session, staffReq.Roles))
+                        AvailableThemes.Add(ghostTheme.ID);
+                }
                 continue;
             }
             AvailableThemes.Add(ghostTheme.ID);

--- a/Content.Server/_Starlight/GhostTheme/GhostThemeSystem.cs
+++ b/Content.Server/_Starlight/GhostTheme/GhostThemeSystem.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.EUI;

--- a/Content.Shared/_NullLink/RoleRequirementPrototype.cs
+++ b/Content.Shared/_NullLink/RoleRequirementPrototype.cs
@@ -22,4 +22,7 @@ public sealed partial class RoleRequirementPrototype : IPrototype
 
     [DataField(required: true)]
     public string RolesLoc = default!;
+
+    [DataField]
+    public bool StaffOverrideable; // Does having staff override the requirement or not
 }

--- a/Resources/Prototypes/_NullLink/RolesReq/ghost_themes.yml
+++ b/Resources/Prototypes/_NullLink/RolesReq/ghost_themes.yml
@@ -5,6 +5,7 @@
   - 1294130153651306516 # BetaTester
   discord: roles-req-discord-starlight
   rolesLoc: roles-req-tester-roles
+  staffOverrideable: True
 
 - type: roleRequirementPrototype
   id: MentorRolesReq
@@ -12,6 +13,7 @@
   - 1294132218918207639 # Mentor
   discord: roles-req-discord-starlight
   rolesLoc: roles-req-mentor-roles
+  staffOverrideable: True
 
 - type: roleRequirementPrototype
   id: GoldEventWinnerReq


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Add ability having staff to override role requirements for other ghost themes.

I am pretty sure I handled getting the role ID pretty good but if there's a better way to do it than instantiating a new `ProtoID` please do let me know. I would like to not hardcode the ID.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Imho makes sense for staff to have access to all of the ghost themes within reason, no personal themes, patron themes, or event themes are unlocked to staff by this. Mentor and alfa/beta tester themes are.
Also I just want to be able to be a cat lmao

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- tweak: Staff can now use mentor and tester ghost themes.