### PR TITLE
chat sanitisation

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -978,7 +978,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     }
 
     // ReSharper disable once InconsistentNaming
-    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool punctuate = false, bool capitalizeTheWordI = true)
+    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool punctuate = false, bool capitalizeTheWordI = true, bool noDisallowedCharacters = true)
     {
         var newMessage = SanitizeMessageReplaceWords(message.Trim());
 
@@ -993,6 +993,8 @@ public sealed partial class ChatSystem : SharedChatSystem
             newMessage = SanitizeMessageCapitalizeTheWordI(newMessage, "i");
         if (punctuate)
             newMessage = SanitizeMessagePeriod(newMessage);
+        if (noDisallowedCharacters) // Starlight
+            newMessage = SanitizeMessageOfEvilCharacters(newMessage); // Starlight
 
         return prefix + newMessage;
     }

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -978,7 +978,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     }
 
     // ReSharper disable once InconsistentNaming
-    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool punctuate = false, bool capitalizeTheWordI = true, bool noDisallowedCharacters = true)
+    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool punctuate = false, bool capitalizeTheWordI = true, bool noDisallowedCharacters = true) // Starlight
     {
         var newMessage = SanitizeMessageReplaceWords(message.Trim());
 

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -33,9 +33,9 @@ public abstract class SharedChatSystem : EntitySystem
     public const int WhisperMuffledRange = 5; // how far whisper goes at all, in world units
     public const string DefaultAnnouncementSound = "/Audio/Announcements/announce.ogg";
 
-    public static readonly char[] ICDisallowedCharacters = ['[', ']', '\\'];
+    public static readonly char[] ICDisallowedCharacters = ['[', ']', '\\']; // Starlight
 
-public static readonly ProtoId<RadioChannelPrototype> CommonChannel = "Common";
+    public static readonly ProtoId<RadioChannelPrototype> CommonChannel = "Common";
 
     public static readonly string DefaultChannelPrefix = $"{RadioChannelPrefix}{DefaultChannelKey}";
     public static readonly ProtoId<SpeechVerbPrototype> DefaultSpeechVerb = "Default";

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -33,7 +33,9 @@ public abstract class SharedChatSystem : EntitySystem
     public const int WhisperMuffledRange = 5; // how far whisper goes at all, in world units
     public const string DefaultAnnouncementSound = "/Audio/Announcements/announce.ogg";
 
-    public static readonly ProtoId<RadioChannelPrototype> CommonChannel = "Common";
+    public static readonly char[] ICDisallowedCharacters = ['[', ']', '\\'];
+
+public static readonly ProtoId<RadioChannelPrototype> CommonChannel = "Common";
 
     public static readonly string DefaultChannelPrefix = $"{RadioChannelPrefix}{DefaultChannelKey}";
     public static readonly ProtoId<SpeechVerbPrototype> DefaultSpeechVerb = "Default";
@@ -241,6 +243,19 @@ public abstract class SharedChatSystem : EntitySystem
         message = OopsConcat(char.ToUpper(message[0]).ToString(), message.Remove(0, 1));
         return message;
     }
+
+    // Starlight start
+    public string SanitizeMessageOfEvilCharacters(string message)
+    {
+        
+        foreach (char c in ICDisallowedCharacters)
+        {
+            message = message.Replace($"{c}", "");
+        }
+
+        return message;
+    }
+    // Starlight end
 
     private static string OopsConcat(string a, string b)
     {


### PR DESCRIPTION
This acts after emote/radio detection, so no interaction with that realm (including text emotes like :/)
Given that there was a push a while back to kill netspeak, it might be worth inverting this to make unicode 1984, so that it only allows english alphanumeric and punctuation, would stop raider ascii art, lenny faces and the like

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
