### PR TITLE
Fix zombie animals not having an attack

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -207,6 +207,10 @@ public sealed partial class ZombieSystem
             Dirty(target, pryComp);
         }
 
+        //starlight start
+        if(!melee.Damage.AnyPositive()) melee.Damage = zombiecomp.MinimumDamageOnBite;
+        //starlight end
+
         Dirty(target, melee);
 
         //The zombie gets the assigned damage weaknesses and strengths

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -151,6 +151,20 @@ public sealed partial class ZombieComponent : Component
         }
     };
 
+    // starlight
+    /// <summary>
+    /// What bite damage should be assigned to this mob if it previously had a 0 damage attack (mice, moproaches, etc)
+    /// </summary>
+    [DataField]
+    public DamageSpecifier MinimumDamageOnBite = new()
+    {
+        DamageDict = new()
+        {
+            { "Slash", 10 },
+            { "Structural", 5 }
+        }
+    };
+
     /// <summary>
     ///     Starlight, this just makes zombies always attack at the same speed as a base human (and also the first C# code I did eheee :3)
     /// </summary>


### PR DESCRIPTION
## Short description
Adds a default (reduced, 10 slash 5 structural) damage attack to zombies whose original form had a 0 damage attack (mice, moproaches, etc)

## Why we need to add this
- lost ability, 0 damage per bites makes mouse/moproach zombie animal ghost roles useless and totally unable to infect anyone
- reported as a bug in discord
- complaints about zeds getting curbedstomped consistently, this brings back some of the population that previously couldn't attack


## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- fix: Fixed zombie mice, moproaches from being unable to attack
