### PR TITLE
Fix clown being unable to fire honk mech guns

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/special.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/special.yml
@@ -14,6 +14,7 @@
     angleDecay: 16
     fireRate: 0.5
     selectedMode: SemiAuto
+    clumsyProof: true # Starlight
     availableModes:
       - SemiAuto
     soundGunshot:
@@ -44,6 +45,7 @@
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto
+    clumsyProof: true # Starlight
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/grenade_launcher.ogg
     soundEmpty:


### PR DESCRIPTION
## Short description
What it says on the tin

## Why we need to add this
clowns able to use their god given mech

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- fix: Fix clown being unable to fire honk mech "guns"
