### PR TITLE
Abductor Can no longer Teleport crit/dead targets

### DIFF
--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
@@ -5,6 +5,7 @@ using Content.Shared.Actions.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.Effects;
 using Content.Shared.Inventory;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Starlight.Antags.Abductor;
@@ -24,6 +25,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     [Dependency] private readonly PullingSystem _pullingSystem = default!;
     [Dependency] private readonly InventorySystem _inv = default!;
     [Dependency] private readonly StarlightActionsSystem _starlightActions = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
     
     private static readonly EntProtoId<InstantActionComponent> _gizmoMark = "ActionGizmoMark";
     private static readonly EntProtoId<InstantActionComponent> _sendYourself = "ActionSendYourself";
@@ -79,6 +81,8 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
 
     private void OnReturn(AbductorReturnToShipEvent ev)
     {
+        if (_mobState.IsIncapacitated(ev.Performer)) # if crit/dead don't telport
+            return;
         AbductorAgentComponent? agentComp = null;
         if (!TryComp<AbductorScientistComponent>(ev.Performer, out var scientistComp) && !TryComp<AbductorAgentComponent>(ev.Performer, out agentComp))
             EnsureComp<AbductorScientistComponent>(ev.Performer, out scientistComp);
@@ -189,6 +193,8 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     
     private void OnDoAfterSendYourself(EntityUid ent, AbductorSendYourselfDoAfterEvent args)
     {
+        if (_mobState.IsIncapacitated(ent)) # If crit/dead don't telport
+            return;
         _color.RaiseEffect(Color.FromHex("#BA0099"), new List<EntityUid>(1) { ent }, Filter.Pvs(ent, entityManager: EntityManager));
         if (_pullingSystem.IsPulling(ent))
         {

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
@@ -81,7 +81,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
 
     private void OnReturn(AbductorReturnToShipEvent ev)
     {
-        if (_mobState.IsIncapacitated(ev.Performer)) # if crit/dead don't telport
+        if (_mobState.IsIncapacitated(ev.Performer)) // if crit/dead don't telport
             return;
         AbductorAgentComponent? agentComp = null;
         if (!TryComp<AbductorScientistComponent>(ev.Performer, out var scientistComp) && !TryComp<AbductorAgentComponent>(ev.Performer, out agentComp))
@@ -193,7 +193,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     
     private void OnDoAfterSendYourself(EntityUid ent, AbductorSendYourselfDoAfterEvent args)
     {
-        if (_mobState.IsIncapacitated(ent)) # If crit/dead don't telport
+        if (_mobState.IsIncapacitated(ent)) // If crit/dead don't telport
             return;
         _color.RaiseEffect(Color.FromHex("#BA0099"), new List<EntityUid>(1) { ent }, Filter.Pvs(ent, entityManager: EntityManager));
         if (_pullingSystem.IsPulling(ent))

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
@@ -181,16 +181,13 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         }
         if (!HasComp<AbductorComponent>(victim))
         {
+            if (_mobState.IsIncapacitated(victim)) // If crit/dead don't teleport
+                return;
             var dispenser = GetEntity(args.Dispencer);
             if (TryComp<VendingMachineComponent>(dispenser, out var vendingComp))
             {
                 _vending.RestockRandom(dispenser, vendingComp);
             }
-        }
-        else
-        {
-            if (_mobState.IsIncapacitated(victim)) // If crit/dead don't teleport
-                return;
         }
         
         _xformSys.SetCoordinates(victim, GetCoordinates(args.TargetCoordinates));

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
@@ -45,6 +45,11 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         args.Progress = AbductProgress(ent, _number.GetTarget(ent.Owner));
     }
 
+    private void ConsolePopup(EntityUid actor, string text)
+    {
+        _popup.PopupCursor(text, actor);
+    }
+
     private float AbductProgress(Entity<AbductConditionComponent> ent, int target)
     {
         AbductorScientistComponent? scientistComp = null;
@@ -161,6 +166,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         };
         _doAfter.TryStartDoAfter(doAfter);
     }
+
     private void OnDoAfterAttract(Entity<AbductorComponent> ent, ref AbductorAttractDoAfterEvent args)
     {
         if (args.Handled || args.Cancelled)
@@ -183,7 +189,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         {
             if (_mobState.IsIncapacitated(victim)) // If crit/dead don't teleport
             {
-                ConsolePopup(args.Actor, Loc.GetString("abductor-console-target-status-bad"));
+                // ConsolePopup(args.Actor, Loc.GetString("abductor-console-target-status-bad"));
                 return;
             }
             var dispenser = GetEntity(args.Dispencer);

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
@@ -182,7 +182,10 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         if (!HasComp<AbductorComponent>(victim))
         {
             if (_mobState.IsIncapacitated(victim)) // If crit/dead don't teleport
+            {
+                ConsolePopup(args.Actor, Loc.GetString("abductor-console-target-status-bad"));
                 return;
+            }
             var dispenser = GetEntity(args.Dispencer);
             if (TryComp<VendingMachineComponent>(dispenser, out var vendingComp))
             {

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
@@ -45,11 +45,6 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         args.Progress = AbductProgress(ent, _number.GetTarget(ent.Owner));
     }
 
-    private void ConsolePopup(EntityUid actor, string text)
-    {
-        _popup.PopupCursor(text, actor);
-    }
-
     private float AbductProgress(Entity<AbductConditionComponent> ent, int target)
     {
         AbductorScientistComponent? scientistComp = null;
@@ -166,7 +161,6 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         };
         _doAfter.TryStartDoAfter(doAfter);
     }
-
     private void OnDoAfterAttract(Entity<AbductorComponent> ent, ref AbductorAttractDoAfterEvent args)
     {
         if (args.Handled || args.Cancelled)
@@ -187,15 +181,10 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         }
         if (!HasComp<AbductorComponent>(victim))
         {
-            if (_mobState.IsIncapacitated(victim)) // If crit/dead don't teleport
-            {
-                // ConsolePopup(args.Actor, Loc.GetString("abductor-console-target-status-bad"));
-                return;
-            }
             var dispenser = GetEntity(args.Dispencer);
             if (TryComp<VendingMachineComponent>(dispenser, out var vendingComp))
             {
-                _vending.RestockRandom(dispenser, vendingComp);
+                _vending.RestockRandom(dispenser,vendingComp);
             }
         }
         

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
@@ -179,14 +179,18 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
             if (!TryComp<PullableComponent>(victim, out var pullableComp)
                 || !_pullingSystem.TryStopPull(victim, pullableComp)) return;
         }
-        
         if (!HasComp<AbductorComponent>(victim))
         {
             var dispenser = GetEntity(args.Dispencer);
             if (TryComp<VendingMachineComponent>(dispenser, out var vendingComp))
             {
-                _vending.RestockRandom(dispenser,vendingComp);
+                _vending.RestockRandom(dispenser, vendingComp);
             }
+        }
+        else
+        {
+            if (_mobState.IsIncapacitated(victim)) // If crit/dead don't teleport
+                return;
         }
         
         _xformSys.SetCoordinates(victim, GetCoordinates(args.TargetCoordinates));

--- a/Resources/Locale/en-US/_Starlight/abductor/abductor-console.ftl
+++ b/Resources/Locale/en-US/_Starlight/abductor/abductor-console.ftl
@@ -1,0 +1,2 @@
+# Status Message
+abductor-console-target-status-bad = Target is not healthy enough for teleport.


### PR DESCRIPTION
## Short description
Abductor can no longer teleport crit/dead targets, including each other.

## Why we need to add this
Constant be aggressive, get crit, port back, get healed by other abductor, also putting a stop to raiding morgue and medbay. Want to abduct the dead? better heal them first.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Trep_Maul
- tweak: Abductors can no longer teleport while crit/dead
- tweak: Abductors can no longer abduct someone who is crit/dead
