### PR TITLE
Fixed omnitools for airlocks and similar applications, specifically

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Tools/tools.yml
@@ -454,6 +454,7 @@
             - Prying
           useSound:
             path: /Audio/Items/crowbar.ogg
+        - type: Prying
         - type: MeleeWeapon
           wideAnimationRotation: -135
           soundHit:
@@ -707,6 +708,7 @@
             - Prying
           useSound:
             path: /Audio/Items/crowbar.ogg
+        - type: Prying
         - type: MeleeWeapon
           wideAnimationRotation: -135
           soundHit:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixing omnitool crowbars... again.

## Why we need to add this
My original fix of omnitool crowbars worked on everything *but* airlocks, this is now fixed. Most things tun off the tool component with the prying quality... except when you actually pry open doors, those use the prying component >_<

## Media (Video/Screenshots)
<img width="161" height="128" alt="image" src="https://github.com/user-attachments/assets/fa43ac34-0efe-439b-b08f-228a2195f4bf" />
<img width="177" height="72" alt="image" src="https://github.com/user-attachments/assets/06e2be6f-0dfe-445f-a186-da1a5c064af2" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Omnitool crowbars also work on unpowered airlocks now.
