### PR TITLE
Update Resomi to have ammonia based blood + Fix Avali

### DIFF
--- a/Resources/Locale/en-US/_Starlight/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_Starlight/reagents/meta/biological.ftl
@@ -3,3 +3,6 @@ reagent-desc-abductor-blood = The blood of a supreme creature, something above l
 
 reagent-name-avali-blood = diluted ammonia blood
 reagent-desc-avali-blood = Smells like piss.
+
+reagent-name-resomi-blood = diluted ammonia blood
+reagent-desc-resomi-blood = Smells like piss.

--- a/Resources/Locale/en-US/_Starlight/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_Starlight/reagents/meta/medicine.ftl
@@ -1,2 +1,2 @@
 reagent-name-amoxla = Amoxla
-reagent-desc-amoxla = Ammonia-based chem that treats airloss and bloodloss in Avali, and acts like a somewhat strong poison in other species.
+reagent-desc-amoxla = Ammonia-based chem that treats airloss and bloodloss in Avali and Resomi, and acts like a somewhat strong poison in other species.

--- a/Resources/Locale/en-US/_Starlight/reagents/meta/physical-desc.ftl
+++ b/Resources/Locale/en-US/_Starlight/reagents/meta/physical-desc.ftl
@@ -1,3 +1,5 @@
 reagent-physical-desc-abductor = abducted
 
 reagent-physical-desc-avali = non-ferrous
+
+reagent-physical-desc-resomi = non-ferrous

--- a/Resources/Locale/en-US/metabolism/metabolizer-types.ftl
+++ b/Resources/Locale/en-US/metabolism/metabolizer-types.ftl
@@ -13,4 +13,5 @@ metabolizer-type-arachnid = Arachnid
 # Starlight
 metabolizer-type-vampire = Vampire
 metabolizer-type-avali = Avali
+metabolizer-type-resomi = Resomi
 metabolizer-type-budget-cyber = Budget Cyber

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -24,10 +24,10 @@ reagent-desc-dermaline = An advanced chemical that is more effective at treating
 
 # Starlight Start
 reagent-name-dexalin = dexalin
-reagent-desc-dexalin = Used for treating minor oxygen deprivation and bloodloss, mildly toxic to Avali. A required reagent for dexalin plus.
+reagent-desc-dexalin = Used for treating minor oxygen deprivation and bloodloss, mildly toxic to Avali and Resomi. A required reagent for dexalin plus.
 
 reagent-name-dexalin-plus = dexalin plus
-reagent-desc-dexalin-plus = Used in treatment of extreme cases of oxygen deprivation and bloodloss, toxic to Avali. Flushes heartbreaker toxin out of the blood stream.
+reagent-desc-dexalin-plus = Used in treatment of extreme cases of oxygen deprivation and bloodloss, toxic to Avali and Resomi. Flushes heartbreaker toxin out of the blood stream.
 # Starlight End
 
 reagent-name-epinephrine = epinephrine
@@ -110,7 +110,7 @@ reagent-desc-sigynate = A thick pink syrup useful for neutralizing acids and soo
 
 # Starlight Start
 reagent-name-saline = saline
-reagent-desc-saline = A mixture of salt and water, highly toxic to Avali. Commonly used to treat dehydration or low fluid presence in blood.
+reagent-desc-saline = A mixture of salt and water, highly toxic to Avali and Resomi. Commonly used to treat dehydration or low fluid presence in blood.
 #Starlight End
 
 reagent-name-lacerinol = lacerinol

--- a/Resources/Prototypes/Body/Organs/resomi.yml
+++ b/Resources/Prototypes/Body/Organs/resomi.yml
@@ -9,3 +9,16 @@
     - type: NightVision
     - type: FlashModifier
       modifier: 2
+      
+- type: entity # Starlight
+  id: OrganResomiHeart
+  parent: OrganHumanHeart
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Metabolizer
+    maxReagents: 2
+    metabolizerTypes: [Resomi]
+    groups:
+    - id: Medicine
+    - id: Poison
+    - id: Narcotic

--- a/Resources/Prototypes/Body/Parts/resomi.yml
+++ b/Resources/Prototypes/Body/Parts/resomi.yml
@@ -9,7 +9,7 @@
       reagents:
       - ReagentId: Fat
         Quantity: 3
-      - ReagentId: Blood
+      - ReagentId: AmmoniaBlood # Starlight
         Quantity: 10
 
 - type: entity
@@ -25,7 +25,7 @@
       reagents:
       - ReagentId: Fat
         Quantity: 10
-      - ReagentId: Blood
+      - ReagentId: AmmoniaBlood # Starlight
         Quantity: 20
 
 
@@ -42,7 +42,7 @@
       reagents:
       - ReagentId: Fat
         Quantity: 5
-      - ReagentId: Blood
+      - ReagentId: AmmoniaBlood # Starlight
         Quantity: 10
 
 - type: entity

--- a/Resources/Prototypes/Body/Prototypes/resomi.yml
+++ b/Resources/Prototypes/Body/Prototypes/resomi.yml
@@ -20,7 +20,7 @@
       - right leg
       - left leg
       organs:
-        heart: OrganHumanHeart
+        heart: OrganResomiHeart # Starlight
         lungs: OrganHumanLungs
         stomach: OrganHumanStomach
         liver: OrganHumanLiver

--- a/Resources/Prototypes/Chemistry/metabolizer_types.yml
+++ b/Resources/Prototypes/Chemistry/metabolizer_types.yml
@@ -29,6 +29,10 @@
   id: Avali
   name: metabolizer-type-avali
 
+- type: metabolizerType #🌟Starlight🌟
+  id: Resomi
+  name: metabolizer-type-resomi
+
 - type: metabolizerType
   id: Vox
   name: metabolizer-type-vox

--- a/Resources/Prototypes/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/resomi.yml
@@ -35,6 +35,8 @@
         color: "#C048C2"
       Burn:
         sprite: Mobs/Effects/Resomi/burn_damage.rsi
+  - type: Bloodstream # Starlight
+    bloodReagent: ResomiBlood
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Resomi_minor_burning

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -218,6 +218,9 @@
         - !type:OrganType
           type: Avali
           shouldHave: false
+        - !type:OrganType
+          type: Resomi
+          shouldHave: false
         damage:
           types:
             Caustic: 1
@@ -227,6 +230,14 @@
         conditions:
         - !type:OrganType
           type: Avali
+          shouldHave: true
+        damage:
+          types:
+            Asphyxiation: -1
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Resomi
           shouldHave: true
         damage:
           types:

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -165,6 +165,11 @@
         - !type:OrganType # Starlight
           type: Avali
           shouldHave: true
+        damage:
+          types:
+            Poison: 2
+      - !type:HealthChange
+        conditions:
         - !type:OrganType # Starlight
           type: Resomi
           shouldHave: true

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -162,8 +162,11 @@
             Poison: 0.1
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Starlight
           type: Avali
+          shouldHave: true
+        - !type:OrganType # Starlight
+          type: Resomi
           shouldHave: true
         damage:
           types:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -293,7 +293,7 @@
           shouldHave: true
         damage:
           types:
-            Poison: 1.5 #Avali blood is ammonia based, so chems made to treat normal bloodloss poison them instead (Lethal Dose: 20u)
+            Poison: 1.5 #Resomi blood is ammonia based, so chems made to treat normal bloodloss poison them instead (Lethal Dose: 20u)
             Asphyxiation: 1 
             Bloodloss: 1
 
@@ -352,7 +352,7 @@
           shouldHave: true
         damage:
           types:
-            Poison: 2.5 #Avali blood is ammonia based, so chems made to treat normal bloodloss poison them instead. Dex+ is worse. (Lethal Dose: 15u)
+            Poison: 2.5 #Resomi blood is ammonia based, so chems made to treat normal bloodloss poison them instead. Dex+ is worse. (Lethal Dose: 15u)
             Asphyxiation: 1.5
             Bloodloss: 1
 

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -257,6 +257,13 @@
     Medicine:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType #starliight
+          type: Avali
+          shouldHave: false
+        - !type:OrganType
+          type: Resomi
+          shouldHave: false
         damage:
           types:
             Asphyxiation: -1
@@ -269,6 +276,26 @@
           types:
             Asphyxiation: 3
             Cold: 1
+      - !type:HealthChange #Starlight
+        conditions:
+        - !type:OrganType
+          type: Avali
+          shouldHave: true
+        damage:
+          types:
+            Poison: 1.5 #Avali blood is ammonia based, so chems made to treat normal bloodloss poison them instead (Lethal Dose: 20u)
+            Asphyxiation: 1 
+            Bloodloss: 1
+      - !type:HealthChange #Starlight
+        conditions:
+        - !type:OrganType
+          type: Resomi
+          shouldHave: true
+        damage:
+          types:
+            Poison: 1.5 #Avali blood is ammonia based, so chems made to treat normal bloodloss poison them instead (Lethal Dose: 20u)
+            Asphyxiation: 1 
+            Bloodloss: 1
 
 - type: reagent
   id: DexalinPlus
@@ -282,6 +309,13 @@
     Medicine:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType #starliight
+          type: Avali
+          shouldHave: false
+        - !type:OrganType
+          type: Resomi
+          shouldHave: false
         damage:
           types:
             Asphyxiation: -3.5
@@ -301,6 +335,26 @@
           types:
             Asphyxiation: 5
             Cold: 3
+      - !type:HealthChange #Starlight
+        conditions:
+        - !type:OrganType
+          type: Avali
+          shouldHave: true
+        damage:
+          types:
+            Poison: 2.5 #Avali blood is ammonia based, so chems made to treat normal bloodloss poison them instead. Dex+ is worse. (Lethal Dose: 15u)
+            Asphyxiation: 1.5
+            Bloodloss: 1
+      - !type:HealthChange #Starlight
+        conditions:
+        - !type:OrganType
+          type: Resomi
+          shouldHave: true
+        damage:
+          types:
+            Poison: 2.5 #Avali blood is ammonia based, so chems made to treat normal bloodloss poison them instead. Dex+ is worse. (Lethal Dose: 15u)
+            Asphyxiation: 1.5
+            Bloodloss: 1
 
 # this ones a doozy
 - type: reagent
@@ -683,8 +737,49 @@
       effects:
         - !type:SatiateThirst
           factor: 6
+    Medicine: #Starlight
+      effects:
         - !type:ModifyBloodLevel
+          conditions:
+          - !type:OrganType
+           type: Avali
+           shouldHave: false
+          - !type:OrganType
+           type: Resomi
+           shouldHave: false
           amount: 6
+        - !type:ModifyBleedAmount
+          conditions:
+          - !type:OrganType
+           type: Avali
+           shouldHave: true
+          amount: 2
+        - !type:ModifyBleedAmount
+          conditions:
+          - !type:OrganType
+           type: Resomi
+           shouldHave: true
+          amount: 2
+        - !type:HealthChange
+          conditions:
+          - !type:OrganType
+           type: Avali
+           shouldHave: true
+          damage:
+            types:
+              Poison: 12 #This is on par with giving someone the wrong blood-type (very lethal) / (Lethal Dose: 10u, VERY FAST ACTING)
+              Caustic: 2 #Split to prevent 15u RRing someone, as caustic can be healed with topicals.
+              Slash: 1 #Allows it to heal bleeding.
+        - !type:HealthChange
+          conditions:
+          - !type:OrganType
+           type: Resomi
+           shouldHave: true
+          damage:
+            types:
+              Poison: 12 #This is on par with giving someone the wrong blood-type (very lethal) / (Lethal Dose: 10u, VERY FAST ACTING)
+              Caustic: 2 #Split to prevent 15u RRing someone, as caustic can be healed with topicals.
+              Slash: 1 #Allows it to heal bleeding.
 
 - type: reagent
   id: Siderlac
@@ -1117,10 +1212,30 @@
       effects:
       - !type:SatiateThirst
         factor: 3
+    Medicine:  # Starlight
+      effects:
+      #If vampire
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Vampire
+        damage:
+          types:
+            Heat: 2
+      - !type:Emote
+        conditions:
+        - !type:OrganType
+          type: Vampire
+        emote: Scream
+        probability: 0.3
+      #If not vampire
       - !type:HealthChange
         conditions:
         - !type:TotalDamage
           max: 50
+        - !type:OrganType
+          type: Vampire
+          shouldHave: false
         damage:
           types:
             Blunt: -0.2
@@ -1130,6 +1245,15 @@
             Cold: -0.2
 
   reactiveEffects:
+    Unholy: # Starlight
+      methods: [ Touch ]
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Heat: 5
+        - !type:Emote
+          emote: Scream
     Extinguish:
       methods: [ Touch ]
       effects:

--- a/Resources/Prototypes/_StarLight/Reagents/biological.yml
+++ b/Resources/Prototypes/_StarLight/Reagents/biological.yml
@@ -19,3 +19,14 @@
   color: "#6C3BAA"
   recognizable: true
   physicalDesc: reagent-physical-desc-avali
+
+- type: reagent
+  parent: Blood
+  id: ResomiBlood
+  name: reagent-name-resomi-blood
+  group: Biological
+  desc: reagent-desc-resomi-blood
+  flavor: beer
+  color: "#6C3BAA"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-resomi

--- a/Resources/Prototypes/_StarLight/Reagents/medicine.yml
+++ b/Resources/Prototypes/_StarLight/Reagents/medicine.yml
@@ -49,6 +49,15 @@
           types:
             Asphyxiation: -3.5
             Bloodloss: -3
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Resomi
+          shouldHave: true
+        damage:
+          types:
+            Asphyxiation: -3.5
+            Bloodloss: -3
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold
@@ -69,6 +78,9 @@
         - !type:OrganType
           type: Avali
           shouldHave: false
+        - !type:OrganType
+          type: Resomi
+          shouldHave: false
         damage:
           types:
             Poison: 1.5 #Ammonia is toxic injected directly into bloodstream
@@ -78,5 +90,11 @@
         conditions:
         - !type:OrganType
           type: Avali
+          shouldHave: true
+        amount: 3
+      - !type:ModifyBloodLevel
+        conditions:
+        - !type:OrganType
+          type: Resomi
           shouldHave: true
         amount: 3

--- a/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
@@ -4,6 +4,9 @@
   <Box>
     <GuideEntityEmbed Entity="MobResomi" Caption=""/>
   </Box>
+
+  [color=#ffa500]Warning! This species is not recommended for new players due to major gameplay changes![/color]
+
   small, upright, raptor-like creatures with four ears.
   Their thin tail is still strong enough to pull things without needing their hands for assistance.
 

--- a/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Resomi.xml
@@ -39,6 +39,8 @@
   ## Health
   Resomi have lower health due to their small stature, falling into a critical state at [color=#ffa500]85[/color] points of damage and dying at [color=#ffa500]170[/color] points of damage.
   Resomi also prefer colder temperatures compared to humans, being roughly akin to Moths.
+  Resomi heal airloss from [color=cyan]Ammonia[/color] and [color=cyan]Amoxla[/color], 
+  but [color=red]Saline[/color], [color=red]Dex[/color], and [color=red]Dex+[/color] are lethal to them. Remember to remind doctors about this!
   
   ## Claw attack
   Resomi are able to slash at others with their claws.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR gives Resomi Ammonia based blood, and also fixes Avali not getting their poisoning from saline, dex, dexp

## Why we need to add this
Resomi is a species related to Avali, it should have the same blood as Avali. And share its biology.
Avali losing its saline and dex weakness seems like an upstream merge issue.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- add: Resomi is now hurt by Saline, Dexalin and Dexalin Plus the same as Avali.
- add: Resomi is healed by Ammonia and Amoxla the same as Avali.
- tweak: Resomi now has Ammonia based blood.
- fix: Avali is now correctly harmed by Saline, Dexalin and Dexalin Plus again. 
- fix: Vampires not being damaged by holy water.
