### PR TITLE
Traitor Quality of Life

### DIFF
--- a/Resources/Locale/en-US/_Starlight/catalog/uplink.ftl
+++ b/Resources/Locale/en-US/_Starlight/catalog/uplink.ftl
@@ -1,0 +1,2 @@
+uplink-clothing-outer-armor-basic-name = Armor Vest
+uplink-clothing-outer-armor-basic-desc = Doesn't out you as a Traitor instantly, but isn't as good as a Web Vest

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1692,9 +1692,9 @@
   productEntity: ClothingOuterVestWeb
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 3 #SL / Rebalanced pricing: Armor Vest 2, Web Vest 3, Elite Web vest 4
   cost:
-    Telecrystal: 5
+    Telecrystal: 4 #SL / Rebalanced pricing: Armor Vest 3, Web Vest 4, Elite Web vest 5
   categories:
   - UplinkWearables
 
@@ -1705,9 +1705,9 @@
   productEntity: ClothingOuterVestWebElite
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 4 #SL / Rebalanced pricing: Armor Vest 2, Web Vest 3, Elite Web vest 4
   cost:
-    Telecrystal: 5
+    Telecrystal: 5 #SL / Rebalanced pricing: Armor Vest 3, Web Vest 4, Elite Web vest 5
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -411,7 +411,7 @@
         maxVol: 3
 
 - type: entity
-  parent: [BaseBrandedLighter, BaseSyndicateContraband]
+  parent: [BaseBrandedLighter] #SL Edit: Non Contra
   id: CybersunFlippo
   name: CyberSun Flippo
   description: "A Sleek black and magenta flippo lighter, bearing the logo and iconography of CyberSun Industries."
@@ -431,7 +431,7 @@
     color: magenta
 
 - type: entity
-  parent: [BaseBrandedLighter, BaseSyndicateContraband]
+  parent: [BaseBrandedLighter] #SL Edit: Non Contra
   id: InterdyneFlippo
   name: Interdyne Flippo
   description: "A deep blue flippo lighter, decorated with the logo of Interdyne Pharmaceuticals' 'Gene Clean' clinics. Become the master of your own cigarette."
@@ -551,7 +551,7 @@
     color: green
 
 - type: entity
-  parent: [BaseBrandedLighter, BaseSyndicateContraband]
+  parent: [BaseBrandedLighter] #SL Edit: Non Contra
   id: WaffleCoFlippo
   name: Waffle Co. flippo
   description: "A robust mass produced lighter. The Waffle Co. logo turns the spark wheel when pushed up, minimising risk of lighter burns for even the most inept user."
@@ -619,7 +619,7 @@
   parent: [BaseBrandedLighter]
   id: DonkcoLighter
   name: Donk Co. flippo
-  description: "The flippo of choice for the seasoned traitor. A Breaded novelty lighter made by Donk Co. Somehow edible while lit."
+  description: "The flippo of choice for terrible cooks. A Breaded novelty lighter made by Donk Co. Somehow edible while lit." #SL Edit: decription edit to remove 'traitor' reference
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/donkco.rsi

--- a/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
@@ -379,3 +379,16 @@
     Telecrystal: 5
   categories:
   - UplinkWearables
+
+- type: listing
+  id: UplinkClothingOuterArmorBasic
+  name: uplink-clothing-outer-armor-basic-name
+  description: uplink-clothing-outer-armor-basic-desc
+  productEntity: ClothingOuterArmorBasic
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 2
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkWearables

--- a/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
@@ -387,8 +387,8 @@
   productEntity: ClothingOuterArmorBasic
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 2 #SL / Rebalanced pricing: Armor Vest 2, Web Vest 3, Elite Web vest 4
   cost:
-    Telecrystal: 4
+    Telecrystal: 3 #SL / Rebalanced pricing: Armor Vest 3, Web Vest 4, Elite Web vest 5
   categories:
   - UplinkWearables


### PR DESCRIPTION
## Short description
Makes certain corporate lighters no longer contra, to match our lore. Also adds the armor vest to Traitor Uplinks and rebalances the pricing of the web vest and elite web vest to make sense. I did not change their armor values, but I will list them here so my reasoning makes more sense:
- Armor Vest - 30% blunt/slash/pierce resist, 20% heat resist, 10% explosion resist - 3tc / 2tc on discount - Major Contra
- Web Vest - 40% blunt/slash resist, 70% pierce resist, 10% heat/explosion resist, 45% stamina resist - 4tc / 3tc on discount - Syndie Contra
- Elite Web Vest - 50% blunt/slash/radiation/caustic/explosion resist, 30% piercing resist, 70% heat resist, 65% stamina resist, 85% fire resist - 5tc / 4tc on discount - Syndie Contra

## Why we need to add this
Rebalances the costs of wearables to make more sense. Prior, Web Vest and Elite Web Vest were 5tc each, despite Elite getting vastle more resistances of must higher value. Now, it is staggered in a tier system.
- Armor Vest is weakest and cheapest and while still major contra does not out you as traitor.
- Web Vest is the middleground in price and resistances, and outs you as traitor.
- Elite Web Vest is the strongest and most expensive, and outs you as traitor.

Hopefully this will give Traitors more flexibility, being able to purchase an armor item that doesn't get them thrown in Genpop for 30 minutes.

## Media (Video/Screenshots)
<img width="370" height="244" alt="image" src="https://github.com/user-attachments/assets/1c8f24e7-b1f1-4a47-8c1c-0d580b26478f" />
<img width="407" height="248" alt="image" src="https://github.com/user-attachments/assets/ab8de6d3-9794-4b5b-bee2-254748c3f3ca" />
<img width="386" height="312" alt="image" src="https://github.com/user-attachments/assets/06fd86ad-54c6-4065-9c54-932dc7975fc5" />


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added the Armor Vest to the Traitor Uplink for 3tc
- tweak: Changed the Web Vest price from 5tc to 4tc. The Elite Web Vest is still 5tc
- tweak: Changed some corporate branded lighters to be non-contra

