### PR TITLE
Raffle by default

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/MakeGhostRoleWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/MakeGhostRoleWindow.xaml.cs
@@ -69,17 +69,30 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
                 _prototypeManager.EnumeratePrototypes<GhostRoleRaffleSettingsPrototype>();
 
             var idx = 0;
+            var raffleDefault = -1; //Starlight raffle default
             foreach (var raffleProto in raffleProtos)
             {
                 _rafflePrototypes.Add(raffleProto);
                 var s = raffleProto.Settings;
                 var label =
                     $"{raffleProto.ID} (initial {s.InitialDuration}s, max {s.MaxDuration}s, join adds {s.JoinExtendsDurationBy}s)";
+                #region Starlight raffle by default
+                if (raffleProto.Default)
+                    raffleDefault = idx;
+                #endregion
                 RaffleButton.AddItem(label, idx++);
             }
 
             MakeButton.OnPressed += OnMakeButtonPressed;
             RaffleButton.OnItemSelected += OnRaffleButtonItemSelected;
+
+            #region Starlight raffle by default
+            if (raffleDefault != -1)
+            {
+                RaffleButton.Select(raffleDefault);
+                OnRaffleButtonItemSelected(new OptionButton.ItemSelectedEventArgs(raffleDefault, RaffleButton));
+            }
+            #endregion
         }
 
         private void OnRaffleDurationChanged(ValueChangedEventArgs args)

--- a/Content.Shared/Ghost/Roles/Raffles/GhostRoleRaffleSettingsPrototype.cs
+++ b/Content.Shared/Ghost/Roles/Raffles/GhostRoleRaffleSettingsPrototype.cs
@@ -18,4 +18,12 @@ public sealed partial class GhostRoleRaffleSettingsPrototype : IPrototype
     /// <seealso cref="GhostRoleRaffleSettings"/>
     [DataField(required: true)]
     public GhostRoleRaffleSettings Settings { get; private set; } = new();
+
+    #region Starlight
+    /// <summary>
+    /// Is this the default when using the MakeGhostRole admin verb?
+    /// </summary>
+    [DataField]
+    public bool Default = false;
+    #endregion
 }

--- a/Resources/Prototypes/GhostRoleRaffles/settings.yml
+++ b/Resources/Prototypes/GhostRoleRaffles/settings.yml
@@ -5,6 +5,7 @@
     initialDuration: 30
     joinExtendsDurationBy: 10
     maxDuration: 90
+  default: true #Starlight raffle by default
 
 # for roles that don't matter too much or are available plentifully (e.g. space carp)
 - type: ghostRoleRaffleSettings


### PR DESCRIPTION
## Short description
makes it so debug make ghost role uses the default raffle config instead of defaulting to off.

## Why we need to add this
if you want a specific person in a body you `setmind`. if you want a "whoever wants it" you *should* raffle it off.

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: Debug make ghost role now raffles by default.
