### PR TITLE
implicitroof

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -105,7 +105,10 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
             return;
 
         EnsureComp<ShuttleComponent>(ev.EntityUid);
-        EnsureComp<ImplicitRoofComponent>(ev.EntityUid);
+        if (HasComp<RoofComponent>(ev.EntityUid))   // 🌟Starlight🌟 Wont add imp roof on grids with no roof, since it bugs lighting on those grids
+        {
+            EnsureComp<ImplicitRoofComponent>(ev.EntityUid);
+        }
     }
 
     private void OnShuttleStartup(EntityUid uid, ShuttleComponent component, ComponentStartup args)

--- a/Resources/Maps/_Starlight/Stations/Cork.yml
+++ b/Resources/Maps/_Starlight/Stations/Cork.yml
@@ -1,6 +1,19 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Map
+  engineVersion: 266.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 09/06/2025 13:50:12
+  entityCount: 7242
+maps:
+- 1
+grids:
+- 2
+- 5654
+- 7133
+orphans: []
+nullspace: []
 tilemap:
   0: Space
   7: FloorAsteroidSand
@@ -4061,7 +4074,6 @@ entities:
     - type: FTLDestination
     - type: GravityShake
       shakeTimes: 10
-    - type: ImplicitRoof
   - uid: 5
     components:
     - type: MetaData
@@ -6565,7 +6577,6 @@ entities:
     - type: NavMap
     - type: GravityShake
       shakeTimes: 10
-    - type: ImplicitRoof
   - uid: 7133
     components:
     - type: MetaData
@@ -6734,6 +6745,8 @@ entities:
       - 3169
       - 3187
       - 3171
+    - type: Fixtures
+      fixtures: {}
   - uid: 23
     components:
     - type: Transform
@@ -6749,6 +6762,8 @@ entities:
       - 3172
       - 3173
       - 105
+    - type: Fixtures
+      fixtures: {}
   - uid: 24
     components:
     - type: Transform
@@ -6767,6 +6782,8 @@ entities:
       - 3213
       - 114
       - 3184
+    - type: Fixtures
+      fixtures: {}
   - uid: 25
     components:
     - type: Transform
@@ -6790,6 +6807,8 @@ entities:
       - 3207
       - 3179
       - 3223
+    - type: Fixtures
+      fixtures: {}
   - uid: 26
     components:
     - type: Transform
@@ -6814,6 +6833,8 @@ entities:
       - 3185
       - 3225
       - 3224
+    - type: Fixtures
+      fixtures: {}
   - uid: 27
     components:
     - type: Transform
@@ -6828,6 +6849,8 @@ entities:
       - 3199
       - 109
       - 3200
+    - type: Fixtures
+      fixtures: {}
   - uid: 28
     components:
     - type: Transform
@@ -6843,6 +6866,8 @@ entities:
       - 3219
       - 3217
       - 3141
+    - type: Fixtures
+      fixtures: {}
   - uid: 29
     components:
     - type: Transform
@@ -6859,6 +6884,8 @@ entities:
       - 111
       - 3182
       - 3222
+    - type: Fixtures
+      fixtures: {}
   - uid: 30
     components:
     - type: Transform
@@ -6878,6 +6905,8 @@ entities:
       - 113
       - 2354
       - 2353
+    - type: Fixtures
+      fixtures: {}
   - uid: 31
     components:
     - type: Transform
@@ -6897,6 +6926,8 @@ entities:
       - 3158
       - 3159
       - 3197
+    - type: Fixtures
+      fixtures: {}
 - proto: Airlock
   entities:
   - uid: 32
@@ -7810,17 +7841,23 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -21.5,23.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 134
     components:
     - type: Transform
       pos: 10.5,42.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -53.5,19.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: APCHighCapacity
   entities:
   - uid: 136
@@ -7829,74 +7866,100 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 18.5,4.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,15.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,6.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 139
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,14.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 140
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 141
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-10.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 142
     components:
     - type: Transform
       pos: -12.5,5.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 143
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-9.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-8.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 145
     components:
     - type: Transform
       pos: -16.5,-1.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 5672
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 7151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-0.5
       parent: 7133
+    - type: Fixtures
+      fixtures: {}
   - uid: 7152
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 7133
+    - type: Fixtures
+      fixtures: {}
 - proto: APCHyperCapacity
   entities:
   - uid: 146
@@ -7905,12 +7968,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -27.5,5.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 5673
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: APCSuperCapacity
   entities:
   - uid: 147
@@ -7919,6 +7986,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 17.5,-4.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: APECircuitboard
   entities:
   - uid: 148
@@ -8870,6 +8939,8 @@ entities:
     - type: Transform
       pos: -5.5,16.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: Bucket
   entities:
   - uid: 329
@@ -18730,6 +18801,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -19.5,1.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: ClockworkGrille
   entities:
   - uid: 1810
@@ -19099,6 +19172,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 8.5,-17.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: ClosetWallGreen
   entities:
   - uid: 1798
@@ -19138,6 +19213,8 @@ entities:
           - 1799
           - 1802
           - 1804
+    - type: Fixtures
+      fixtures: {}
 - proto: ClosetWallMaintenanceFilledRandom
   entities:
   - uid: 1855
@@ -19145,6 +19222,8 @@ entities:
     - type: Transform
       pos: -24.5,3.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: ClothingBeltUtilityEngineering
   entities:
   - uid: 1856
@@ -20944,11 +21023,15 @@ entities:
       rot: 3.141592653589793 rad
       pos: 12.5,12.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 2032
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: DeskBell
   entities:
   - uid: 2033
@@ -22608,6 +22691,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -18.4584,11.452088
       parent: 2
+    missingComponents:
+    - ActiveListener
 - proto: ExGrenade
   entities:
   - uid: 6099
@@ -22640,6 +22725,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 25.5,-11.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 2265
@@ -22647,46 +22734,62 @@ entities:
     - type: Transform
       pos: 9.5,10.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 2266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,13.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 2267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 2268
     components:
     - type: Transform
       pos: 20.5,-3.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 2269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,5.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 2270
     components:
     - type: Transform
       pos: -18.5,3.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 2271
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-18.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 2272
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-2.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: FatExtractor
   entities:
   - uid: 2273
@@ -22990,6 +23093,8 @@ entities:
       - 2357
       - 2356
       - 2355
+    - type: Fixtures
+      fixtures: {}
   - uid: 2325
     components:
     - type: Transform
@@ -23008,6 +23113,8 @@ entities:
       - 2369
       - 2370
       - 2368
+    - type: Fixtures
+      fixtures: {}
   - uid: 2326
     components:
     - type: Transform
@@ -23027,6 +23134,8 @@ entities:
       - 2371
       - 2372
       - 108
+    - type: Fixtures
+      fixtures: {}
   - uid: 2327
     components:
     - type: Transform
@@ -23043,6 +23152,8 @@ entities:
       - 2382
       - 2342
       - 2341
+    - type: Fixtures
+      fixtures: {}
   - uid: 2328
     components:
     - type: Transform
@@ -23056,6 +23167,8 @@ entities:
       - 2385
       - 2388
       - 110
+    - type: Fixtures
+      fixtures: {}
   - uid: 2329
     components:
     - type: Transform
@@ -23069,6 +23182,8 @@ entities:
       - 112
       - 2391
       - 2392
+    - type: Fixtures
+      fixtures: {}
   - uid: 2330
     components:
     - type: Transform
@@ -23086,6 +23201,8 @@ entities:
       - 2400
       - 2404
       - 115
+    - type: Fixtures
+      fixtures: {}
   - uid: 2331
     components:
     - type: Transform
@@ -23099,6 +23216,8 @@ entities:
       - 2412
       - 116
       - 2418
+    - type: Fixtures
+      fixtures: {}
   - uid: 2332
     components:
     - type: Transform
@@ -23118,6 +23237,8 @@ entities:
       - 2350
       - 2352
       - 118
+    - type: Fixtures
+      fixtures: {}
   - uid: 2333
     components:
     - type: Transform
@@ -23136,6 +23257,8 @@ entities:
       - 118
       - 2410
       - 2411
+    - type: Fixtures
+      fixtures: {}
   - uid: 2334
     components:
     - type: Transform
@@ -23152,6 +23275,8 @@ entities:
       - 2370
       - 2369
       - 106
+    - type: Fixtures
+      fixtures: {}
   - uid: 2335
     components:
     - type: Transform
@@ -23169,6 +23294,8 @@ entities:
       - 2403
       - 2398
       - 2396
+    - type: Fixtures
+      fixtures: {}
 - proto: FireAxeCabinetFilled
   entities:
   - uid: 2336
@@ -23176,6 +23303,8 @@ entities:
     - type: Transform
       pos: 21.5,3.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: FireBombEmpty
   entities:
   - uid: 6103
@@ -24834,6 +24963,8 @@ entities:
     - type: Transform
       pos: 23.5,-3.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: GasCanisterBrokenBase
   entities:
   - uid: 6200
@@ -32357,40 +32488,54 @@ entities:
     - type: Transform
       pos: 11.5,-8.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-2.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6263
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6264
     components:
     - type: Transform
       pos: 13.5,-0.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6265
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-6.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,3.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6267
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,9.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: JanitorialTrolley
   entities:
   - uid: 3402
@@ -32596,6 +32741,8 @@ entities:
         1952:
         - - Pressed
           - Forward
+    - type: Fixtures
+      fixtures: {}
   - uid: 3424
     components:
     - type: MetaData
@@ -32612,6 +32759,8 @@ entities:
         1952:
         - - Pressed
           - Off
+    - type: Fixtures
+      fixtures: {}
 - proto: LockableButtonCaptain
   entities:
   - uid: 3425
@@ -32636,6 +32785,8 @@ entities:
         7162:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
   - uid: 3427
@@ -32643,6 +32794,8 @@ entities:
     - type: Transform
       pos: 22.5,0.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -32680,6 +32833,8 @@ entities:
     - type: Transform
       pos: 2.5,-14.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerBSOFilled
   entities:
   - uid: 298
@@ -32687,6 +32842,8 @@ entities:
     - type: Transform
       pos: 0.5,-0.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -32723,6 +32880,8 @@ entities:
     - type: Transform
       pos: -2.5,-0.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -32760,6 +32919,8 @@ entities:
     - type: Transform
       pos: 2.5,9.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -32797,6 +32958,8 @@ entities:
     - type: Transform
       pos: 19.5,5.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -32833,6 +32996,8 @@ entities:
     - type: Transform
       pos: 1.5,15.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -32869,6 +33034,8 @@ entities:
     - type: Transform
       pos: -14.5,9.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerEngineerFilledHardsuit
   entities:
   - uid: 300
@@ -32876,16 +33043,22 @@ entities:
     - type: Transform
       pos: 14.5,0.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
   - uid: 301
     components:
     - type: Transform
       pos: 16.5,0.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
   - uid: 328
     components:
     - type: Transform
       pos: 15.5,0.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerEvidence
   entities:
   - uid: 3439
@@ -32893,16 +33066,22 @@ entities:
     - type: Transform
       pos: -4.5,8.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
   - uid: 3440
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
   - uid: 3441
     components:
     - type: Transform
       pos: -7.5,16.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerFreezer
   entities:
   - uid: 259
@@ -32976,6 +33155,8 @@ entities:
     - type: Transform
       pos: 8.5,-1.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -33012,6 +33193,8 @@ entities:
     - type: Transform
       pos: -12.5,14.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -33037,6 +33220,8 @@ entities:
     - type: Transform
       pos: 8.5,17.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerMedicineFilled
   entities:
   - uid: 3446
@@ -33044,6 +33229,8 @@ entities:
     - type: Transform
       pos: 3.5,15.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -33079,6 +33266,8 @@ entities:
     - type: Transform
       pos: 7.5,17.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerMiningSpecialistFilled
   entities:
   - uid: 2534
@@ -33086,11 +33275,15 @@ entities:
     - type: Transform
       pos: 25.5,7.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
   - uid: 2535
     components:
     - type: Transform
       pos: 24.5,7.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerParamedicFilled
   entities:
   - uid: 3450
@@ -33098,6 +33291,8 @@ entities:
     - type: Transform
       pos: 6.5,17.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerPrisoner
   entities:
   - uid: 1732
@@ -33105,6 +33300,8 @@ entities:
     - type: Transform
       pos: -4.5,23.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerPrisoner2
   entities:
   - uid: 1660
@@ -33112,6 +33309,8 @@ entities:
     - type: Transform
       pos: -4.5,22.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerQuarterMasterFilled
   entities:
   - uid: 3451
@@ -33119,6 +33318,8 @@ entities:
     - type: Transform
       pos: 17.5,8.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -33155,6 +33356,8 @@ entities:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerResearchDirectorFilledHardsuit
   entities:
   - uid: 3453
@@ -33162,6 +33365,8 @@ entities:
     - type: Transform
       pos: 18.5,-2.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -33198,6 +33403,8 @@ entities:
     - type: Transform
       pos: 21.5,13.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -33232,11 +33439,15 @@ entities:
     - type: Transform
       pos: 22.5,13.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
   - uid: 3458
     components:
     - type: Transform
       pos: 23.5,13.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: EntityStorage
       air:
         volume: 200
@@ -33273,16 +33484,22 @@ entities:
     - type: Transform
       pos: -8.5,10.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
   - uid: 576
     components:
     - type: Transform
       pos: -6.5,10.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
   - uid: 577
     components:
     - type: Transform
       pos: -7.5,10.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: LockerSyndicate
   entities:
   - uid: 6098
@@ -33326,6 +33543,8 @@ entities:
     - type: Transform
       pos: -18.5,13.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
     - type: Lock
       locked: False
     - type: Fixtures
@@ -33340,7 +33559,7 @@ entities:
             - -0.25,0.48
           mask:
           - Impassable
-          - TableLayer
+          - MidImpassable
           - LowImpassable
           layer:
           - BulletImpassable
@@ -33378,11 +33597,15 @@ entities:
     - type: Transform
       pos: 0.5,13.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 3465
     components:
     - type: Transform
       pos: -11.5,-0.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: LockerWardenFilledHardsuit
   entities:
   - uid: 3466
@@ -33390,6 +33613,8 @@ entities:
     - type: Transform
       pos: -7.5,21.5
       parent: 2
+    - type: WiresPanelSecurity
+      wiresAccessible: True
 - proto: Log
   entities:
   - uid: 3467
@@ -33789,11 +34014,15 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -12.5,6.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 6295
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: ModularGrenade
   entities:
   - uid: 6296
@@ -33942,6 +34171,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -19.5,6.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: Paper
   entities:
   - uid: 3434
@@ -34468,6 +34699,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 8.5,-16.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandBeachStarYamamoto
   entities:
   - uid: 3618
@@ -34476,12 +34709,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: 8.5,41.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 6308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-5.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandClown
   entities:
   - uid: 3619
@@ -34490,6 +34727,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -17.5,7.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandDonutCorp
   entities:
   - uid: 3620
@@ -34498,6 +34737,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -8.5,9.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandFreeDrone
   entities:
   - uid: 6309
@@ -34506,6 +34747,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,7.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandLustyExomorph
   entities:
   - uid: 6310
@@ -34514,6 +34757,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,-7.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandNuclearDeviceInformational
   entities:
   - uid: 3621
@@ -34521,12 +34766,16 @@ entities:
     - type: Transform
       pos: 6.5,2.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 6311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,4.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandPunchShit
   entities:
   - uid: 6312
@@ -34535,6 +34784,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 14.5,-7.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandShamblersJuice
   entities:
   - uid: 6313
@@ -34543,6 +34794,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 12.5,-9.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandTools
   entities:
   - uid: 3622
@@ -34551,6 +34804,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -16.5,2.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterContrabandUnreadableAnnouncement
   entities:
   - uid: 6314
@@ -34562,6 +34817,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -0.5,-5.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterLegitHighClassMartini
   entities:
   - uid: 3623
@@ -34569,6 +34826,8 @@ entities:
     - type: Transform
       pos: 1.5,-14.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterLegitMime
   entities:
   - uid: 3624
@@ -34577,6 +34836,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -19.5,0.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterLegitNanotrasenLogo
   entities:
   - uid: 3625
@@ -34585,6 +34846,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterLegitScience
   entities:
   - uid: 6315
@@ -34593,6 +34856,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,-7.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: PottedPlant14
   entities:
   - uid: 3626
@@ -38759,12 +39024,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: -14.5,-29.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 2692
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-29.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: Screwdriver
   entities:
   - uid: 6391
@@ -39018,6 +39287,8 @@ entities:
         4231:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
   - uid: 4233
     components:
     - type: MetaData
@@ -39040,6 +39311,8 @@ entities:
         277:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
   - uid: 6399
     components:
     - type: Transform
@@ -39051,6 +39324,8 @@ entities:
         5658:
         - - Pressed
           - DoorBolt
+    - type: Fixtures
+      fixtures: {}
   - uid: 6400
     components:
     - type: Transform
@@ -39062,6 +39337,8 @@ entities:
         5657:
         - - Pressed
           - DoorBolt
+    - type: Fixtures
+      fixtures: {}
   - uid: 6401
     components:
     - type: Transform
@@ -39073,6 +39350,8 @@ entities:
         5656:
         - - Pressed
           - DoorBolt
+    - type: Fixtures
+      fixtures: {}
 - proto: SignalButtonDirectional
   entities:
   - uid: 4234
@@ -39095,6 +39374,8 @@ entities:
         271:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
   - uid: 6402
     components:
     - type: Transform
@@ -39121,6 +39402,8 @@ entities:
         5693:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
 - proto: SignArmory
   entities:
   - uid: 6403
@@ -39129,6 +39412,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 12.5,5.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: SignBar
   entities:
   - uid: 4235
@@ -39137,6 +39422,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,-11.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignBridge
   entities:
   - uid: 4236
@@ -39145,6 +39432,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,-5.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignCargoDock
   entities:
   - uid: 4237
@@ -39153,6 +39442,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 9.5,6.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignChapel
   entities:
   - uid: 4238
@@ -39160,6 +39451,8 @@ entities:
     - type: Transform
       pos: -46.5,19.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignChem
   entities:
   - uid: 4239
@@ -39168,6 +39461,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 6.5,10.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignCryogenicsMed
   entities:
   - uid: 4240
@@ -39175,11 +39470,15 @@ entities:
     - type: Transform
       pos: -7.5,-5.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4241
     components:
     - type: Transform
       pos: 8.5,18.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignDangerMed
   entities:
   - uid: 6404
@@ -39187,6 +39486,8 @@ entities:
     - type: Transform
       pos: 2.5,7.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: SignDirectionalEvac
   entities:
   - uid: 4243
@@ -39194,6 +39495,8 @@ entities:
     - type: Transform
       pos: -14.5,-9.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignDirectionalLibrary
   entities:
   - uid: 4244
@@ -39202,6 +39505,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -14.5,24.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignDisposalSpace
   entities:
   - uid: 4245
@@ -39209,6 +39514,8 @@ entities:
     - type: Transform
       pos: -29.5,0.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignEngineering
   entities:
   - uid: 4248
@@ -39217,11 +39524,15 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 12.5,0.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 6405
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: SignEVA
   entities:
   - uid: 4249
@@ -39229,6 +39540,8 @@ entities:
     - type: Transform
       pos: 4.5,-16.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignFlammableMed
   entities:
   - uid: 4250
@@ -39236,6 +39549,8 @@ entities:
     - type: Transform
       pos: 25.5,-9.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignGenpop
   entities:
   - uid: 225
@@ -39244,6 +39559,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -0.5,15.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignHead
   entities:
   - uid: 4251
@@ -39252,30 +39569,40 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -11.5,12.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4252
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,15.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4253
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,9.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4254
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,4.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4255
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-3.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignLibrary
   entities:
   - uid: 4256
@@ -39283,6 +39610,8 @@ entities:
     - type: Transform
       pos: -22.5,23.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignMedical
   entities:
   - uid: 4257
@@ -39291,6 +39620,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 6.5,6.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignMorgue
   entities:
   - uid: 4258
@@ -39299,6 +39630,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 7.5,18.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignPsychology
   entities:
   - uid: 4259
@@ -39307,6 +39640,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -7.5,-0.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignRadiationMed
   entities:
   - uid: 4260
@@ -39315,6 +39650,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 29.5,-1.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignScience
   entities:
   - uid: 4261
@@ -39323,6 +39660,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 12.5,-6.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignSecureMed
   entities:
   - uid: 6406
@@ -39330,16 +39669,22 @@ entities:
     - type: Transform
       pos: 8.5,8.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6407
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6408
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: SignTelecomms
   entities:
   - uid: 4263
@@ -39348,6 +39693,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SilverOre
   entities:
   - uid: 6409
@@ -40271,22 +40618,30 @@ entities:
     - type: Transform
       pos: -10.5,-5.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4416
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-0.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4417
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4418
     components:
     - type: Transform
       pos: -16.5,4.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: StationMapAssembly
   entities:
   - uid: 6420
@@ -40294,11 +40649,15 @@ entities:
     - type: Transform
       pos: 8.5,-3.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6421
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: SteelBench
   entities:
   - uid: 4419
@@ -41068,26 +41427,36 @@ entities:
     - type: Transform
       pos: -18.5,9.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 6433
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6434
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6435
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
   - uid: 6436
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 5654
+    - type: Fixtures
+      fixtures: {}
 - proto: Table
   entities:
   - uid: 228
@@ -42064,6 +42433,18 @@ entities:
     components:
     - type: Transform
       parent: 3326
+    - type: Tool
+      useSound: !type:SoundPathSpecifier
+        params:
+          variation: null
+          playOffsetSeconds: 0
+          loop: False
+          referenceDistance: 1
+          rolloffFactor: 1
+          maxDistance: 15
+          pitch: 1
+          volume: 0
+        path: /Audio/Items/Culinary/chop.ogg
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -43466,18 +43847,24 @@ entities:
     - type: Transform
       pos: -3.5,-5.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4741
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4742
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,8.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: WallPlastitanium
   entities:
   - uid: 6498


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Description
Removes autoadding of problematic components that bricks maplighting on event maps and non roof maps.

Wizard know about this problem, but still didnt release a fix, so removing it until then

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.


