### PR TITLE
xenoborgis can now unlock anything.

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/borgi_chassis.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/borgi_chassis.yml
@@ -268,9 +268,6 @@
       raffle:
         settings: default
     - type: GhostTakeoverAvailable
-    - type: SiliconLawProvider
-      laws: ShadowFactoryBorgiLawset
-      subverted: true
     - type: ContainerFill
       containers:
         borg_brain:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/borgi_chassis.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/borgi_chassis.yml
@@ -231,6 +231,8 @@
             32:
               sprite: Mobs/Pets/displacements.rsi
               state: corgi_head_displacement
+    - type: LockingWhitelist
+      blacklist: #N/A you are the 2nd in command. if the mothership put you in this spot you are TRUSTED
 
 - type: entity
   parent: XenoBorgiChassis


### PR DESCRIPTION
## Short description
xenoborgis can now unlock the robotics console and other xenoborgs as a *true* 2nd in command.
also removes a redundant component from the "initial spawn" variant

## Why we need to add this
kinda hard to be a 2nd in command when you cant really do anything.

## Media (Video/Screenshots)
<img width="271" height="143" alt="image" src="https://github.com/user-attachments/assets/e785f258-b301-485a-b782-d480e722e480" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- fix: Xenoborgis can now properly do their 2nd in command duty (by unlocking robotics consoles and other xenoborgs)
