### PR TITLE
Welding Protection for Engineering Hardsuits + RD

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -426,6 +426,9 @@
     tags:
     - CorgiWearable
     - WhitelistChameleon
+  - type: ComponentToggler # Starlight begin
+    components:
+    - type: EyeProtection # Starlight end
 
 #Chief Medical Officer's Hardsuit
 - type: entity
@@ -468,6 +471,9 @@
     tags:
     - CorgiWearable
     - WhitelistChameleon
+  - type: ComponentToggler # Starlight begin
+    components:
+      - type: EyeProtection # Starlight end
 
 #Head of Security's hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -64,6 +64,9 @@
     tags:
     - CorgiWearable
     - WhitelistChameleon
+  - type: ComponentToggler # Starlight begin
+    components:
+      - type: EyeProtection # Starlight end
 
 #Engineering Hardsuit
 - type: entity
@@ -119,6 +122,9 @@
     tags:
     - CorgiWearable
     - WhitelistChameleon
+  - type: ComponentToggler # Starlight begin
+    components:
+      - type: EyeProtection # Starlight end
 
 #Spationaut Hardsuit
 - type: entity
@@ -819,6 +825,9 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+  - type: ComponentToggler # Starlight begin
+    components:
+      - type: EyeProtection # Starlight end
 
 #ERT Medical Hardsuit
 - type: entity


### PR DESCRIPTION
## Short description
CE, RD, Engi, Atmosian, and ERT Engi hardsuits did not offer welding protection when the helmet is on. Out of any hardsuits, these seem like ones that should definitely have protection offered.

## Why we need to add this
QOL for engineering

## Media (Video/Screenshots)
WIP

## Checks

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: biteless-dot
- tweak: Gave welding protection to the CE, RD, Engi, ERT Engi, and Atmos hardsuits helmets.
