### PR TITLE
Make InputMoverComponent only be present on entities with active players

### DIFF
--- a/Content.Shared/_Starlight/CCVar/StarlightCCVar.Physics.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVar.Physics.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.Configuration;
+
+namespace Content.Shared.Starlight.CCVar;
+
+public sealed partial class StarlightCCVars
+{
+    // Taken from https://github.com/RMC-14/RMC-14
+    public static readonly CVarDef<bool> PhysicsActiveInputMoverEnabled =
+        CVarDef.Create("physics.active_input_mover_enabled", true, CVar.REPLICATED | CVar.SERVER);
+}

--- a/Content.Shared/_Starlight/Input/ActiveInputMoverComponent.cs
+++ b/Content.Shared/_Starlight/Input/ActiveInputMoverComponent.cs
@@ -1,0 +1,8 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.Input;
+
+// Taken from https://github.com/RMC-14/RMC-14
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(StarlightInputSystem))]
+public sealed partial class ActiveInputMoverComponent : Component;

--- a/Content.Shared/_Starlight/Input/StarlightInputSystem.cs
+++ b/Content.Shared/_Starlight/Input/StarlightInputSystem.cs
@@ -17,11 +17,13 @@ public sealed class StarlightInputSystem : EntitySystem
 
     private EntityQuery<ActiveNPCComponent> _activeNpcQuery;
     private EntityQuery<ActorComponent> _actorQuery;
+    private EntityQuery<MovementRelayTargetComponent> _movementRelayTargetQuery;
 
     public override void Initialize()
     {
         _activeNpcQuery = GetEntityQuery<ActiveNPCComponent>();
         _actorQuery = GetEntityQuery<ActorComponent>();
+        _movementRelayTargetQuery = GetEntityQuery<MovementRelayTargetComponent>();
 
         SubscribeLocalEvent<ActiveInputMoverComponent, MapInitEvent>(OnActiveChanged);
         SubscribeLocalEvent<ActiveInputMoverComponent, PlayerAttachedEvent>(OnActiveChanged);
@@ -29,6 +31,9 @@ public sealed class StarlightInputSystem : EntitySystem
 
         SubscribeLocalEvent<ActiveNPCComponent, MapInitEvent>(OnActiveChanged);
         SubscribeLocalEvent<ActiveNPCComponent, ComponentRemove>(OnActiveChanged);
+
+        SubscribeLocalEvent<MovementRelayTargetComponent, ComponentRemove>(OnActiveChanged);
+        SubscribeLocalEvent<MovementRelayTargetComponent, MapInitEvent>(OnActiveChanged);
 
         Subs.CVar(_config, StarlightCCVars.PhysicsActiveInputMoverEnabled, v => _activeInputMoverEnabled = v, true);
     }
@@ -49,6 +54,8 @@ public sealed class StarlightInputSystem : EntitySystem
 
     private bool ShouldBeActive(EntityUid ent)
     {
-        return _actorQuery.HasComp(ent) || _activeNpcQuery.HasComp(ent);
+        return _actorQuery.HasComp(ent) ||
+               _activeNpcQuery.HasComp(ent) ||
+               _movementRelayTargetQuery.CompOrNull(ent)?.Source != null;
     }
 }

--- a/Content.Shared/_Starlight/Input/StarlightInputSystem.cs
+++ b/Content.Shared/_Starlight/Input/StarlightInputSystem.cs
@@ -1,0 +1,54 @@
+﻿using Content.Shared.Movement.Components;
+using Content.Shared.NPC;
+using Content.Shared.Starlight.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._Starlight.Input;
+
+// Taken from https://github.com/RMC-14/RMC-14
+public sealed class StarlightInputSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private bool _activeInputMoverEnabled;
+
+    private EntityQuery<ActiveNPCComponent> _activeNpcQuery;
+    private EntityQuery<ActorComponent> _actorQuery;
+
+    public override void Initialize()
+    {
+        _activeNpcQuery = GetEntityQuery<ActiveNPCComponent>();
+        _actorQuery = GetEntityQuery<ActorComponent>();
+
+        SubscribeLocalEvent<ActiveInputMoverComponent, MapInitEvent>(OnActiveChanged);
+        SubscribeLocalEvent<ActiveInputMoverComponent, PlayerAttachedEvent>(OnActiveChanged);
+        SubscribeLocalEvent<ActiveInputMoverComponent, PlayerDetachedEvent>(OnActiveChanged);
+
+        SubscribeLocalEvent<ActiveNPCComponent, MapInitEvent>(OnActiveChanged);
+        SubscribeLocalEvent<ActiveNPCComponent, ComponentRemove>(OnActiveChanged);
+
+        Subs.CVar(_config, StarlightCCVars.PhysicsActiveInputMoverEnabled, v => _activeInputMoverEnabled = v, true);
+    }
+
+    private void OnActiveChanged<TComp, TEvent>(Entity<TComp> ent, ref TEvent args) where TComp : IComponent?
+    {
+        if (!_activeInputMoverEnabled)
+            return;
+
+        if (_timing.ApplyingState || TerminatingOrDeleted(ent))
+            return;
+
+        if (ShouldBeActive(ent))
+            EnsureComp<InputMoverComponent>(ent);
+        else
+            RemCompDeferred<InputMoverComponent>(ent);
+    }
+
+    private bool ShouldBeActive(EntityUid ent)
+    {
+        return _actorQuery.HasComp(ent) || _activeNpcQuery.HasComp(ent);
+    }
+}

--- a/Resources/Prototypes/Body/Organs/base.yml
+++ b/Resources/Prototypes/Body/Organs/base.yml
@@ -35,6 +35,7 @@
     entries:
       Burger: Brain
       Taco: Brain
+  - type: ActiveInputMover # Starlight
 
 - type: entity
   id: BaseOrganEyes

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -72,6 +72,7 @@
     radius: 6
     castShadows: false
     enabled: false
+  - type: ActiveInputMover # Starlight
 
 # proto for player ghosts specifically
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -224,6 +224,7 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
+  - type: ActiveInputMover # Starlight
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -176,6 +176,7 @@
     enabled: false
     drawRate: 1
     delay: 3
+  - type: ActiveInputMover
 
 # Ripley MK-I
 - type: entity


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Ported from RMC14 and Afterlight, I coded it for both.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
On Afterlight, 10.8% of all entity system tick time is in SharedMoverController.TryUpdateRelative, this cuts the amount of input mover components present down in around half, since brains are always present as an entity, but now they won't get the component unless a player is actively controlling it
This also works for leftover ghosts since bugs with those are common
It accounts for NPCs and mechs, and won't remove their input mover component if they are active

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/c6f8be56-f62e-4020-9f85-3516015122cf

New round without it active, goes from 16 input movers to 24, with one player online
<img width="302" height="61" alt="image" src="https://github.com/user-attachments/assets/9bf14a8f-8ff1-4ac4-8fca-281565d4e342" />

Accounting for mechs, goes down to 12
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/017d27c0-7632-45e4-8414-552d0791ffbb" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: DrSmugleaf
- tweak: Improved performance specially during high player counts and long rounds.