### PR TITLE
readds patch packs, and adds craft for them

### DIFF
--- a/Resources/Locale/en-US/_Starlight/lathe/recipes.ftl
+++ b/Resources/Locale/en-US/_Starlight/lathe/recipes.ftl
@@ -1,0 +1,1 @@
+lathe-recipe-PatchPack-name = patch pack (empty)

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -95,6 +95,8 @@
     - id: BoxBeaker
       prob: 0.3
     - id: BoxPillCanister
+    - id: PatchPack # Starlight
+    - id: PatchPack # Starlight
     - id: BoxBottle
     - id: BoxVial
     - id: PlasmaChemistryVial

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -496,6 +496,7 @@
     - RollerBedsStatic
     - MedicalClothingStatic
     - EmptyMedkitsStatic
+    - StarlightMedicalStatic # Starlight
     dynamicPacks:
     - StarlightSurgeryDynamic
     - StarlightCyberlimbDynamic

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/bandaid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/bandaid.yml
@@ -108,7 +108,7 @@
   name: patch pack
   id: PatchPack
   parent: BaseStorageItem
-  description: Storage of multiple patches efficiently.
+  description: Stores multiple patches efficiently.
   components:
   - type: Item
     size: Tiny

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/medical.yml
@@ -1,3 +1,10 @@
+## Static Recipes
+
+- type: latheRecipePack
+  id: StarlightMedicalStatic
+  recipes:
+    - PatchPack # Starlight
+
 ## Dynamic recipes
 
 - type: latheRecipePack

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/medical.yml
@@ -339,3 +339,11 @@
     Plastic: 150
     Steel: 50
     Glass: 150
+
+- type: latheRecipe
+  id: PatchPack
+  result: PatchPack
+  completetime: 2
+  materials:
+    Plastic: 200
+  name: lathe-recipe-PatchPack-name


### PR DESCRIPTION
## Short description
Chemist's roundstart patch packs were seemingly accidentally nuked during an upstream merge. Readding at request of chem players

## Why we need to add this
Discord suggestion thread: https://discord.com/channels/1272545509562777621/1414586437046898730

Basically re-adds patch packs to the game:
* Adds a craft for patch packs, costing 2 plastic. Available roundstart
* Chemist lockers start with 2 patch packs in them.

 Currently the only place they exist is on one map. This PR lets you craft them now at an equivalent cost to the other medical storage items, to hopefully make these alternative medicines relevant again.

## Media (Video/Screenshots)
<img width="460" height="72" alt="image" src="https://github.com/user-attachments/assets/749b276f-87f1-4c56-97df-dacf7bf799fc" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: biteless-dot
- tweak: Re-adds 2 empty patch packs to chemist locker spawns
- add: Adds a craft for patch packs - costs 2 plastic and is available roundstart