### PR TITLE
Make Closet Skeletons Free Agents Again

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -54,24 +54,6 @@
   - type: GhostRole
     name: ghost-role-information-closet-skeleton-name
     description: ghost-role-information-closet-skeleton-description
-    rules: ghost-role-information-nonantagonist-rules
-    # mindRoles:
-    # - MindRoleGhostRoleFreeAgent
-    raffle:
-      settings: default
-  - type: GhostTakeoverAvailable
-  - type: Loadout
-    prototypes: [LimitedAssistantGear]
-  - type: RandomHumanoidAppearance
-
-- type: entity
-  parent: MobSkeletonPerson
-  id: MobSkeletonClosetFreeAgent
-  name: closet skeleton
-  components:
-  - type: GhostRole
-    name: ghost-role-information-closet-skeleton-name
-    description: ghost-role-information-closet-skeleton-description
     rules: ghost-role-information-freeagent-rules
     mindRoles:
     - MindRoleGhostRoleFreeAgent


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Changing the ruleset of the closet skeleton back to "Free Agent"

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This was discussed in the discord and was an overwhelmingly supported change, with 21 for and 4 against at the time of writing this. https://discord.com/channels/1272545509562777621/1400908878040006706

The fun of closet skeletons was found in their status as loose cannons. They were made to be crew aligned over concerns about them causing too much chaos. I think that if we can rarely have chaotic wizards, then I don't see why the already rare role of closet skeleton couldn't be chaotic as well especially since they have less tools at their disposal. They are immediately identifiable and security would keep tabs on them regardless of what they were doing. There are many chaotic and destructive antagonists like nuclear operatives and zombies. Most rounds either seem to be complete chaos, or there is nothing happening at all. I believe we need more rounds that are somewhere in between where players can get creative with what they do. Free agents are perfect for helping spice up what would otherwise be a quiet shift.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="502" height="501" alt="FreeAgent" src="https://github.com/user-attachments/assets/5c5a0c2f-6aad-4a2a-8310-a04e21b5f847" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
- Added back the free agent rule status to closet skeletons
- Removed the separate redundant closet skeleton free agent entity