### PR TITLE
HoS gun nerf

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -404,7 +404,7 @@
     availableModes:
     - SemiAuto
     - FullAuto #Just allows people to hold down left click
-  - type: Battery 
+  - type: Battery
     maxCharge: 1500 # ~2:30 minutes for recharge
     startingCharge: 1500
   - type: HitscanBatteryAmmoProvider
@@ -810,12 +810,12 @@
       steps: 5
       zeroVisible: true
     - type: Appearance
-    
+
 - type: entity
   name: proto-5x energy gun
   parent: [BaseWeaponBattery, BaseGrandTheftContraband]
   id: WeaponEnergySMG
-  description: A one-of-a-kind prototype energy sub-machine gun. It offers high energy firepower and a powerful self recharge.
+  description: A one-of-a-kind prototype energy sub-machine gun. It offers high energy firepower.
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Battery/energy_smg.rsi
@@ -833,7 +833,7 @@
   - type: Clothing
     sprite: _Starlight/Objects/Weapons/Guns/Battery/energy_smg.rsi
   - type: Gun
-    fireRate: 4.5
+    fireRate: 1.75
     selectedMode: FullAuto
     availableModes:
     - FullAuto
@@ -861,15 +861,10 @@
     - HighRiskItem
   #- type: StealTarget
     #stealGroup: WeaponEnergyShotgun
-  #- type: GunRequiresWield #remove when inaccuracy on spreads is fixed
+  - type: GunRequiresWield
   - type: Battery
     maxCharge: 1500
     startingCharge: 1500
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 100
-    autoRechargePause: true
-    autoRechargePauseTime: 10
 
 - type: entity
   name: pulse cannon

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -833,7 +833,7 @@
   - type: Clothing
     sprite: _Starlight/Objects/Weapons/Guns/Battery/energy_smg.rsi
   - type: Gun
-    fireRate: 1.75
+    fireRate: 2.5
     selectedMode: FullAuto
     availableModes:
     - FullAuto

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -861,7 +861,7 @@
     - HighRiskItem
   #- type: StealTarget
     #stealGroup: WeaponEnergyShotgun
-  - type: GunRequiresWield
+  #- type: GunRequiresWield
   - type: Battery
     maxCharge: 1500
     startingCharge: 1500


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Halves the firerate of the HoS gun and removes autorecharge.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The HoS gun really, _really_ needs a nerf.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- tweak: Halved firerate of Proto-5X (HoS energy gun)
- remove: Proto-5X no longer self recharges.
