### PR TITLE
Elite suit rebalance

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1782,22 +1782,21 @@
       tags:
       - NukeOpsUplink
 
-# Starlight
-# - type: listing
-#   id: UplinkHardsuitSyndieElite
-#   name: uplink-hardsuit-syndieelite-name
-#   description: uplink-hardsuit-syndieelite-desc
-#   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
-#   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
-#   cost:
-#     Telecrystal: 12
-#   categories:
-#   - UplinkWearables
-#   conditions:
-#   - !type:StoreWhitelistCondition
-#     whitelist:
-#       tags:
-#       - NukeOpsUplink
+- type: listing
+  id: UplinkHardsuitSyndieElite
+  name: uplink-hardsuit-syndieelite-name
+  description: uplink-hardsuit-syndieelite-desc
+  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
+  productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
+  cost:
+    Telecrystal: 12
+  categories:
+  - UplinkWearables
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
 
 - type: listing
   id: UplinkClothingOuterHardsuitJuggernaut

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1789,7 +1789,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   cost:
-    Telecrystal: 8
+    Telecrystal: 8 # Starlight-edit
   categories:
   - UplinkWearables
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1782,21 +1782,22 @@
       tags:
       - NukeOpsUplink
 
-- type: listing
-  id: UplinkHardsuitSyndieElite
-  name: uplink-hardsuit-syndieelite-name
-  description: uplink-hardsuit-syndieelite-desc
-  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
-  productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
-  cost:
-    Telecrystal: 12
-  categories:
-  - UplinkWearables
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
+# Starlight
+# - type: listing
+#   id: UplinkHardsuitSyndieElite
+#   name: uplink-hardsuit-syndieelite-name
+#   description: uplink-hardsuit-syndieelite-desc
+#   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
+#   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
+#   cost:
+#     Telecrystal: 12
+#   categories:
+#   - UplinkWearables
+#   conditions:
+#   - !type:StoreWhitelistCondition
+#     whitelist:
+#       tags:
+#       - NukeOpsUplink
 
 - type: listing
   id: UplinkClothingOuterHardsuitJuggernaut

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1789,7 +1789,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   cost:
-    Telecrystal: 12
+    Telecrystal: 8
   categories:
   - UplinkWearables
   conditions:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -727,7 +727,7 @@
         Heat: 0.1 # SL EDIT
         Radiation: 0.01
         Caustic: 0.5
-      staminaModifier: 0.2
+    staminaModifier: 0.2
   - type: Item
     size: Huge
   # Starlight removal

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -721,10 +721,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.60 #SL EDIT
-        Slash: 0.60 #SL EDIT
-        Piercing: 0.60 #SL EDIT
-        Heat: 0.15 # SL EDIT
+        Blunt: 0.50 #SL EDIT
+        Slash: 0.50 #SL EDIT
+        Piercing: 0.50 #SL EDIT
+        Heat: 0.1 # SL EDIT
         Radiation: 0.01
         Caustic: 0.5
       staminaModifier: 0.2

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -727,10 +727,10 @@
         Heat: 0.15 # SL EDIT
         Radiation: 0.01
         Caustic: 0.5
-  # Starlight removal
-  #   staminaModifier: 0.2
+      staminaModifier: 0.2
   - type: Item
     size: Huge
+  # Starlight removal
   # - type: ClothingSpeedModifier
   #   walkModifier: 0.9
   #   sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -729,8 +729,8 @@
         Caustic: 0.5
   # Starlight removal
   #   staminaModifier: 0.2
-  # - type: Item
-  #   size: Huge
+  - type: Item
+    size: Huge
   # - type: ClothingSpeedModifier
   #   walkModifier: 0.9
   #   sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -232,7 +232,7 @@
     heatingCoefficient: 0.001
     coolingCoefficient: 0.001
   - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHelmetHardsuitMaxim  
+    clothingPrototype: ClothingHeadHelmetHardsuitMaxim
   - type: ContainerContainer
     containers:
       cell_slot: !type:ContainerSlot
@@ -721,19 +721,20 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.70 #SL EDIT
-        Slash: 0.70 #SL EDIT
-        Piercing: 0.60 #SL EDIT
-        Heat: 0.2
+        Blunt: 0.60 #SL EDIT
+        Slash: 0.60 #SL EDIT
+        Piercing: 0.55 #SL EDIT
+        Heat: 0.15 # SL EDIT
         Radiation: 0.01
         Caustic: 0.5
-    staminaModifier: 0.2
-  - type: Item
-    size: Huge
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
-  - type: HeldSpeedModifier
+  # Starlight removal
+  #   staminaModifier: 0.2
+  # - type: Item
+  #   size: Huge
+  # - type: ClothingSpeedModifier
+  #   walkModifier: 0.9
+  #   sprintModifier: 0.9
+  # - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
   - type: Tag

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -723,7 +723,7 @@
       coefficients:
         Blunt: 0.60 #SL EDIT
         Slash: 0.60 #SL EDIT
-        Piercing: 0.55 #SL EDIT
+        Piercing: 0.60 #SL EDIT
         Heat: 0.15 # SL EDIT
         Radiation: 0.01
         Caustic: 0.5


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Rebalances the elite suit to be less "objectively worse than bloodred".

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The current elite suit has worse blunt, slash, and piercing resistance than the normal blood-red.
To make up for this, it now has 50/50/50 resistance for all three - same as regular nukeops hardsuit, 90% heat resistance (from 80%), and most importantly does not slow you down. Additionally, it has been repriced from 12 to 8 TC because the _jugsuit_ was 12. This should probably not cost the same lmao

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- tweak: Elite suit now has the same blunt, pierce, and slash resistances as bloodred
- tweak: Elite suit no longer costs the same as a jugsuit
- add: Elite suit no longer slows you down