### PR TITLE
Switch entity pickup eligibility to mass-based system

### DIFF
--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -194,6 +194,12 @@ public sealed partial class SpeciesPrototype : IPrototype
     public int StandardDensity = 110;
     //starlight end
 
+    /// <summary>
+    ///     Multiplier applied to this species' mass to determine how heavy a carried entity may be.
+    /// </summary>
+    [DataField("carryWeightMultiplier")]
+    public float CarryWeightMultiplier { get; private set; } = 0.75f;
+
     /// Starlight
     /// <summary>
     ///     How many points species get for installing cybernetics at roundstart

--- a/Content.Shared/_Starlight/Restrict/RestrictNestingCarrierComponent.cs
+++ b/Content.Shared/_Starlight/Restrict/RestrictNestingCarrierComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Starlight.Restrict;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RestrictNestingCarrierComponent : Component
+{
+    /// <summary>
+    ///     Optional override for how much weight this entity can carry relative to its own mass.
+    ///     If absent or null, the species' <see cref="SpeciesPrototype.CarryWeightMultiplier"/> (or the default) is used.
+    ///     Only entities that need a custom multiplier require this component.
+    /// </summary>
+    [DataField("carryWeightMultiplier")]
+    public float? CarryWeightMultiplier;
+}

--- a/Content.Shared/_Starlight/Restrict/RestrictNestingItemComponent.cs
+++ b/Content.Shared/_Starlight/Restrict/RestrictNestingItemComponent.cs
@@ -13,12 +13,4 @@ public sealed partial class RestrictNestingItemComponent : Component
     /// </summary>
     [DataField]
     public TimeSpan DoAfter = TimeSpan.FromSeconds(5.0);
-
-    /// <summary>
-    ///     Maximum fraction of the user's mass that this entity can be and still be
-    ///     eligible to be picked up. For example, a value of <c>0.75f</c> means the
-    ///     target must weigh less than or equal to 75% of the user's mass.
-    /// </summary>
-    [DataField]
-    public float MaxMassRatio = 0.75f;
 }

--- a/Content.Shared/_Starlight/Restrict/RestrictNestingItemComponent.cs
+++ b/Content.Shared/_Starlight/Restrict/RestrictNestingItemComponent.cs
@@ -4,10 +4,21 @@ using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Starlight.Restrict;
+
 [RegisterComponent, NetworkedComponent]
 public sealed partial class RestrictNestingItemComponent : Component
 {
-    //doafter time
+    /// <summary>
+    ///     How long it takes to pick up an entity with this component.
+    /// </summary>
     [DataField]
     public TimeSpan DoAfter = TimeSpan.FromSeconds(5.0);
+
+    /// <summary>
+    ///     Maximum fraction of the user's mass that this entity can be and still be
+    ///     eligible to be picked up. For example, a value of <c>0.75f</c> means the
+    ///     target must weigh less than or equal to 75% of the user's mass.
+    /// </summary>
+    [DataField]
+    public float MaxMassRatio = 0.75f;
 }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1269,7 +1269,7 @@
 - type: entity
   name: genetic ancestor
   id: MobBaseAncestor
-  parent: [SimpleMobBase, StripableInventoryBase]
+  parent: [SimpleMobBase, StripableInventoryBase, BaseSpeciesPickupable]
   description: The genetic bipedal ancestor of... Uh... Something. Yeah, there's definitely something on the station that descended from whatever this is.
   abstract: true
   components:
@@ -1396,7 +1396,7 @@
 - type: entity
   name: monkey
   id: MobMonkey
-  parent: [MobBaseAncestor, BaseSpeciesPickupable]
+  parent: [MobBaseAncestor]
   description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
   components:
   - type: NameIdentifier
@@ -1490,7 +1490,7 @@
 - type: entity
   name: kobold
   id: MobBaseKobold
-  parent: [MobBaseAncestor, BaseSpeciesPickupable]
+  parent: [MobBaseAncestor]
   description: Cousins to the sentient race of lizard people, kobolds blend in with their natural habitat and are as nasty as monkeys; ready to pull out your hair and stab you to death.
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
@@ -4,7 +4,7 @@
 - type: entity
   name: scurret
   id: MobBaseScurret
-  parent: [ MobBaseAncestor, BaseSpeciesPickupable ] #Starlight - give the scurret uppies.
+  parent: [ MobBaseAncestor ] #Starlight - give the scurret uppies.
   abstract: true
   components:
   # Starlight-start: Languages

--- a/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/scurret.yml
@@ -4,7 +4,7 @@
 - type: entity
   name: scurret
   id: MobBaseScurret
-  parent: [ MobBaseAncestor ] #Starlight - give the scurret uppies.
+  parent: [ MobBaseAncestor ] #Starlight
   abstract: true
   components:
   # Starlight-start: Languages

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -6,6 +6,7 @@
   - MobPolymorphable
   - MobCombat
   - StripableInventoryBase
+  - BaseSpeciesPickupable # enables carrying this species if mass ratio allows
   id: BaseMobSpecies
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/resomi.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: Urist McRaptor
-  parent: [BaseMobSpeciesOrganic, BaseSpeciesPickupable]
+  parent: [BaseMobSpeciesOrganic]
   id: BaseMobResomi
   abstract: true
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McAvali
-  parent: [ BaseMobSpeciesOrganic, BaseSpeciesPickupable ]
+  parent: [ BaseMobSpeciesOrganic ]
   id: BaseMobAvali
   abstract: true
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/base.yml
@@ -10,7 +10,6 @@
     - 0, 0, 6, 4
   - type: RestrictNestingItem
     # Allow pickup only if the carrier is at least ~33% heavier
-    maxMassRatio: 0.75
   - type: MultiHandedItem
   - type: CanEscapeInventory
     baseResistTime: 2

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/base.yml
@@ -9,7 +9,6 @@
     shape:
     - 0, 0, 6, 4
   - type: RestrictNestingItem
-    # Allow pickup only if the carrier is at least ~33% heavier
   - type: MultiHandedItem
   - type: CanEscapeInventory
     baseResistTime: 2

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/base.yml
@@ -9,6 +9,8 @@
     shape:
     - 0, 0, 6, 4
   - type: RestrictNestingItem
+    # Allow pickup only if the carrier is at least ~33% heavier
+    maxMassRatio: 0.75
   - type: MultiHandedItem
   - type: CanEscapeInventory
     baseResistTime: 2

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: [BaseMobSpeciesOrganic, BaseSpeciesPickupable]
+  parent: [BaseMobSpeciesOrganic]
   id: BaseMobFelionoid
   abstract: true
   components:


### PR DESCRIPTION
## Short description
**Summary of Change: Mass-Based Pickup System**

The codebase was refactored to replace the previous hardcoded approach for determining which entities can be picked up with a flexible, mass-based system:

- **Species and Carrier Multipliers:** Entities now use a `CarryWeightMultiplier` defined in their species prototype or an optional override via the new `RestrictNestingCarrierComponent`. This multiplier determines how heavy a carried entity may be relative to the carrier's own mass.
- **Removal of Hardcoded Pickupable Parent:** The `BaseSpeciesPickupable` parent and its associated logic were removed from individual species and mob definitions. Instead, pickup eligibility is now calculated dynamically based on mass and multipliers.
- **System Logic Update:** The pickup system (`SharedRestrictNestingItemSystem`) now checks mass limits using the carrier's multiplier, falling back to a default if none is specified.
- **Prototype Cleanup:** YAML prototypes were updated to remove direct references to `BaseSpeciesPickupable` and the obsolete `maxMassRatio` field.

**Result:**  
Pickup eligibility is now determined by the carrier's mass and configurable multipliers, allowing for more nuanced and scalable gameplay rules.



### NOTE:

Currently the value of 0.75 is fairly arbitrary and chosen based on more or less realistic values.

> Firefighter studies on “victim carries” show that most trained responders can handle 60–80% of their bodyweight briefly, but fatigue sets in within seconds to minutes.
> 
> The average untrained person might only sustain 30–50% of their bodyweight in a front carry.

This also allows for species-based carry-weight multipliers. Dwarves for instance are usually short but strong, and could reasonably be argued to carry more than the average human. But I kept that out of this PR.

Future potential additions:
- Whether a picked-up entity is one or two-handed is determined by mass and/or bulkiness, using this system. This would allow for instance picking up resomi with one hand instead of two, if the carrying entity is large enough
- Species-based multipliers
- Tie visual size-scale to actual mass <-- This is what I'd like to work on next, to make this PR more impactful.

## Why we need to add this
This should make the ability to pick someone up or not more 'natural' and not require hardcoded configurations.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/01c8f9f7-dcac-40cd-b06a-dd8a9c4f20ab

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
