### PR TITLE
Decreases Translator's Power Consumption

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/translators.yml
@@ -32,7 +32,7 @@
   components:
   - type: ItemToggle
   - type: PowerCellDraw
-    drawRate: 1
+    drawRate: 0.6 # 10 min with low-cap / 20 min with med-cap / 30 min with high-cap power cells
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/translators.yml
@@ -47,6 +47,6 @@
 - type: entity
   categories: [ HideSpawnMenu ]
   id: TranslatorForeigner
-  parent: [ PowerCellSlotHighItem, TranslatorPoweredBase ]
+  parent: [ PowerCellSlotMediumItem, TranslatorPoweredBase ]
   name: foreigner's translator
   description: A special-issue translator that helps foreigner's speak and understand this station's primary language.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- Decreases the power consumption of Translator devices
- Changes the round-start battery in a Translator device to be a medium-capacity power cell

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Players enjoy the Foreigner trait but find they have to charge their Translation device a little too frequently.
- High-capacity power cells currently last 18 minutes
- Medium-capacity power cells currently last 12 minutes
- Low-capacity power cells currently last 6 minutes

This PR drops the power consumption rate from `1` to `0.6`, which is the same as Borgs.
- High-capacity power cells will now last 30 minutes
- Medium-capacity power cells will now last 20 minutes
- Low-capacity power cells will now last 10 minutes

Also, players with the Foreigner trait will now round-start with a medium-capacity power cell in their Translator device instead. This makes getting a high-capacity cell (through Science or through Maints Diving) feel like a nice upgrade.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="546" height="607" alt="image" src="https://github.com/user-attachments/assets/37ee56ad-45b4-4c9d-9bf5-a204dde68303" />
<img width="636" height="145" alt="image" src="https://github.com/user-attachments/assets/57253f6f-fa3a-49df-aad9-9c87eea88c2f" />



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- tweak: Reduced the Translator's power draw by 40%
- tweak: Foreigner's Translator devices start with a medium-capacity power cell instead of high-capacity