### PR TITLE
Adds a Ticket Machine to Barratry

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Barratry.yml
+++ b/Resources/Maps/_Starlight/Stations/Barratry.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 09/06/2025 20:50:38
-  entityCount: 15657
+  time: 09/12/2025 21:01:14
+  entityCount: 15658
 maps:
 - 5005
 grids:
@@ -81998,11 +81998,6 @@ entities:
     - type: Transform
       pos: -57.5,60.5
       parent: 1
-  - uid: 7393
-    components:
-    - type: Transform
-      pos: -44.5,-13.5
-      parent: 1
   - uid: 8025
     components:
     - type: Transform
@@ -83853,6 +83848,11 @@ entities:
     components:
     - type: Transform
       pos: -16.5,8.5
+      parent: 1
+  - uid: 15440
+    components:
+    - type: Transform
+      pos: -45.5,-13.5
       parent: 1
   - uid: 15782
     components:
@@ -86969,6 +86969,13 @@ entities:
       parent: 1
     - type: StockLimitedProcessing
       processingListings: {}
+- proto: SLVendingMachineSalvage
+  entities:
+  - uid: 7393
+    components:
+    - type: Transform
+      pos: -44.5,-13.5
+      parent: 1
 - proto: SLVendingMachineSecurity
   entities:
   - uid: 14339


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a ticket machine to Barratry's Salvage Bay. It didn't have one before.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Ticket machines encourage Salvage to mine the minerals that we all crave.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1066" height="668" alt="image" src="https://github.com/user-attachments/assets/30bbd647-4657-4e8a-b8f8-0c229163a34a" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- add: (Barratry) Ticket Machine to Salvage