### PR TITLE
Removes Mail Technician playtime requirements

### DIFF
--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mailman.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mailman.yml
@@ -3,10 +3,6 @@
   name: job-name-mailtech
   description: job-description-mailtech
   playTimeTracker: JobMailTech
-  requirements:
-    - !type:DepartmentTimeRequirement
-      department: Cargo
-      time: 18000 # 5 hours
   startingGear: MailTechGear
   icon: "JobIconMailTech"
   supervisors: job-supervisors-qm


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- Cargo Technician doesn't have a playtime requirement. 
- Mail Technician requires 5 hours of Cargo Department playtime.
- This PR removes the playtime requirement on Mail Technician 

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Relevant Discord Thread: https://discord.com/channels/1272545509562777621/1416651051574231141

There's not a strong reason why Mail Technician should be locked behind playtime (e.g. locked behind playing Cargo Technician for 5 hours). Mail Technician is a really simple, easy job that's great for new players. You can also do 100% of what a Mail Technician does _as_ a Cargo Technician.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1367" height="423" alt="image" src="https://github.com/user-attachments/assets/1107d213-f9f1-4eec-a22c-2d639f6d5f7d" />
fig. 1 - I can choose Mail Technician with zero playtime requirements.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- remove: Mail Technician is no longer locked behind Cargo Department playtime (previously required 5 hours)