### PR TITLE
Proto-5x Slight Rebalance

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -867,7 +867,7 @@
     startingCharge: 1500
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 100
+    autoRechargeRate: 80
     autoRechargePause: true
     autoRechargePauseTime: 10
 

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -180,7 +180,7 @@
     - state: omnilaser
       shader: unshaded
   - type: StaminaDamageOnCollide
-    damage: 12
+    damage: 15
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Buffs the disabler mode of the proto-5x to 15 stamina damage a shot from 12, and to compensate cuts the recharge rate by 20% (from 100 -> 80)
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
After spectating many many rounds, speaking to 2 HoS players and being a HoS player myself, I have come to the conclusion that the disabler mode is a bit weak. The gun is meant to be the code green/blue firearm, with a decent lethal and great non-lethal, whilst the WT550 can fill in for code red. Right now the disabler mode is kind of difficult and annoying to use because of how many shots you have to hit, so I changed that. The lethal mode, contrary to how some people portray it, is not overpowered as the time to kill is actually quite low. It is more of a suppressive tool you use whilst the WT550 is out of ammo. So instead of nerfing the damage to compensate, I've lowered the recharge rate just slightly to make it less offensive and more of a "fuck off im reloading" tool. Essay over
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.-->

:cl: PubliclyExecutedPig
- tweak: Proto-5x disabler mode stamina damage buffed to 15 from 12 (1.6 second time to stun now)
- tweak: Proto-5x now recharges 1.6 shots a second down from 2 shots a second
