### PR TITLE
Fix: add construction recipes for Uranium & Reinforced Uranium Directional Windows

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -531,6 +531,7 @@
   placementMode: SnapgridCenter
   canRotate: false
 
+
 - type: construction
   id: UraniumWindowDiagonal
   name: construction-recipe-uranium-window-diagonal
@@ -559,6 +560,32 @@
   objectType: Structure
   placementMode: SnapgridCenter
 
+- type: construction
+  id: UraniumWindowDirectional
+  graph: WindowDirectional
+  startNode: start
+  targetNode: uraniumWindowDirectional
+  category: construction-category-structures
+  canBuildInImpassable: true
+  conditions:
+    - !type:EmptyOrWindowValidInTile
+    - !type:NoWindowsInTile
+  objectType: Structure
+  placementMode: SnapgridCenter
+
+- type: construction
+  id: UraniumReinforcedWindowDirectional
+  graph: WindowDirectional
+  startNode: start
+  targetNode: uraniumReinforcedWindowDirectional
+  category: construction-category-structures
+  canBuildInImpassable: true
+  conditions:
+    - !type:EmptyOrWindowValidInTile
+    - !type:NoWindowsInTile
+  objectType: Structure
+  placementMode: SnapgridCenter
+  
 - type: construction
   id: Firelock
   graph: Firelock


### PR DESCRIPTION
## Short description
Fixes issue #1278 where players are unable to construct Uranium and Reinforced Uranium Directional Windows by adding the items to the constructs.yml.

(Recreated PR due to pulling from forked master branch. Fixed by creating new branch and moving commit)

## Why we need to add this
While these items are on the salvage ship, players are unable to construct them. This could be prudent if the salvage ship is to be reconstructed. Overall, this PR fixes the issue outlined in stated issue #1278.

## Media (Video/Screenshots)
<img width="574" height="466" alt="Shot-2025-09-16-141710" src="https://github.com/user-attachments/assets/9e6b1b36-0664-4784-86a2-d907ede4b263" />
<img width="317" height="168" alt="Shot-2025-09-16-144347" src="https://github.com/user-attachments/assets/11db5be2-dfc9-453a-9256-7350b5675640" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: 0xRai
- fix: Players can now construct Uranium Directional Windows and Reinforced Uranium Directional Windows.
