### PR TITLE
MT-7 Introduction

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -26,7 +26,7 @@
   id: FillLockerWarden
   table: !type:AllSelector
     children:
-    - id: WeaponEnergyShotgun #Starlight
+    - id: WeaponEnergyMagnumGun #Starlight
     - id: ClothingEyesHudSecurity #Starlight
     - id: ClothingHeadsetSecurityWarden #Starlight
     - id: FlashlightSeclite

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/security.yml
@@ -125,7 +125,7 @@
       - id: FlashlightSeclite
         amount: 2
       - id: WeaponEnergyShotgun
-      -id: WeaponEnergyMagnumGun
+      - id: WeaponEnergyMagnumGun
       - id: WeaponDisabler
         amount: 2
       - id: ClothingBeltSecurityFilled

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/security.yml
@@ -125,6 +125,7 @@
       - id: FlashlightSeclite
         amount: 2
       - id: WeaponEnergyShotgun
+      -id: WeaponEnergyMagnumGun
       - id: WeaponDisabler
         amount: 2
       - id: ClothingBeltSecurityFilled


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds MT-7 to replace eshotgun in small wardens locker, and just adds it to  the double locker
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
MT-7 introduction 
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.-->

:cl: PubliclyExecutedPig, ScarletLightweaver
- tweak: MT-7 now spawns in the warden's locker instead of the Energy Shotgun
- tweak: In warden double lockers, the MT-7 spawns in addition to the Energy Shotgun

