### PR TITLE
A buff for the 5 least popular species.

### DIFF
--- a/Resources/Prototypes/Actions/diona.yml
+++ b/Resources/Prototypes/Actions/diona.yml
@@ -18,7 +18,7 @@
   description: Reform back into a whole Diona.
   components:
   - type: Action
-    useDelay: 600 # Once every 10 minutes. Keep them dead for a fair bit before reforming
+    useDelay: 300 # Once every 5 minutes. Keep them dead for a fair bit before reforming
     icon:
       sprite: Mobs/Species/Diona/parts.rsi
       state: full

--- a/Resources/Prototypes/Actions/diona.yml
+++ b/Resources/Prototypes/Actions/diona.yml
@@ -18,7 +18,7 @@
   description: Reform back into a whole Diona.
   components:
   - type: Action
-    useDelay: 300 # Once every 5 minutes. Keep them dead for a fair bit before reforming
+    useDelay: 300 # Starlight - Once every 5 minutes. Keep them dead for a fair bit before reforming
     icon:
       sprite: Mobs/Species/Diona/parts.rsi
       state: full

--- a/Resources/Prototypes/Body/Organs/vox.yml
+++ b/Resources/Prototypes/Body/Organs/vox.yml
@@ -37,7 +37,8 @@
   components:
   - type: Metabolizer
     metabolizerTypes: [Vox]
-  - type: OrganDamage
+  # Starlight start
+  - type: OrganDamage 
     damage:
       types:
         Poison: 280
@@ -45,6 +46,7 @@
         Bloodloss: 40
         Caustic: 40
         Radiation: 60
+  # Starlight end
 
 - type: entity
   parent: OrganHumanHeart

--- a/Resources/Prototypes/Body/Organs/vox.yml
+++ b/Resources/Prototypes/Body/Organs/vox.yml
@@ -37,6 +37,14 @@
   components:
   - type: Metabolizer
     metabolizerTypes: [Vox]
+  - type: OrganDamage
+    damage:
+      types:
+        Poison: 280
+        Cellular: 40
+        Bloodloss: 40
+        Caustic: 40
+        Radiation: 60
 
 - type: entity
   parent: OrganHumanHeart

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -13,6 +13,7 @@
     understands:
     - GalacticCommon
     - Chittin
+  - type: IgnoreSpiderWeb
   # Starlight-end
   - type: Absorbable
   - type: Body

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -13,6 +13,11 @@
     understands:
     - GalacticCommon
     - SolCommon
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      110: Critical
+      220: Dead
   # Starlight-end
   - type: Absorbable
   - type: Hunger

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -68,7 +68,7 @@
     animation: WeaponArcClaw
     damage:
       types:
-        Slash: 5 # Reduce?
+        Slash: 6
   - type: Sprite # Need to redefine the whole order to draw the tail over their gas tank
     layers:
     - map: [ "enum.HumanoidVisualLayers.Chest" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -45,7 +45,7 @@
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
     allowedStates:
     - Alive
-    damageCap: 20
+    damageCap: 25
     damage:
       types:
         Heat: -0.07

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -45,7 +45,7 @@
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
     allowedStates:
     - Alive
-    damageCap: 25
+    damageCap: 25 # Starlight
     damage:
       types:
         Heat: -0.07
@@ -68,7 +68,7 @@
     animation: WeaponArcClaw
     damage:
       types:
-        Slash: 6
+        Slash: 6 # Starlight
   - type: Sprite # Need to redefine the whole order to draw the tail over their gas tank
     layers:
     - map: [ "enum.HumanoidVisualLayers.Chest" ]

--- a/Resources/Prototypes/_StarLight/Body/Parts/cyclorite.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/cyclorite.yml
@@ -110,7 +110,7 @@
       sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
       state: "l_leg"
     - type: MovementBodyPart
-      sprintSpeed : 3.825
+      sprintSpeed : 4.05
       maxDensity: 111
       
 - type: entity
@@ -125,7 +125,7 @@
       sprite: _Starlight/Mobs/Species/Cyclorite/parts.rsi
       state: "r_leg"
     - type: MovementBodyPart
-      sprintSpeed : 3.825
+      sprintSpeed : 4.05
       maxDensity: 111
 
 - type: entity

--- a/Resources/ServerInfo/Guidebook/Mobs/Cyclorite.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Cyclorite.xml
@@ -15,6 +15,6 @@ These intelligent inhabitants of the Abyss are emotionally reserved and have a s
   - They take [color=#ffa500]50% more poison damage[/color] than a comparable human.
   - They take [color=#ffa500]15% less blunt damage[/color] and [color=#ffa500]25% less slash damage[/color] than a comparable human.
   - Due to their size, they stretch external clothing to such an extent that they can fit two tanks on their back.
-  - Their eyes are less sensitive to red colors but provide better vision in the dark (shader still in development)."
+  - Their eyes are less sensitive to red colors but provide better vision in the dark."
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
@@ -31,7 +31,7 @@
   with the player taking control of the Brain Nymph.
   It can talk but has no hands or inventory, and can't do much.
 
-  After 10 minutes, a Nymph can reform into a whole Diona. This will be a new randomised body with a random name,
+  After 5 minutes, a Nymph can reform into a whole Diona. This will be a new randomised body with a random name,
   and there will be little to no evidence beyond their word about who they were before.
 
 

--- a/Resources/ServerInfo/Guidebook/Mobs/Dwarf.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Dwarf.xml
@@ -6,6 +6,6 @@
   </Box>
 
   Dwarves are similar to humans in most respect, but tolerate alcohol better and are healed by it.
-
+  Dwarves are tougher than humans, they have 10% more health.
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Vox.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Vox.xml
@@ -17,7 +17,7 @@
   In addition to regular foods, Vox can also eat various snack packaging, banana peels, eggshells, and raw meat without any ill effects. They also like to drink welding fuel.
 
   Vox [color=#1e90ff]slowly recover from low levels of poison damage[/color] on their own,
-  so long as they are careful not to exceed 20 poison damage.
+  so long as they are careful not to exceed 25 poison damage.
   This allows them to endure breathing station air for up to thirty seconds at a time without lasting damage,
   letting them quickly eat, drink, take oral medication, and so on.
   A thirty second oxygen exposure takes them two minutes to recover from.

--- a/Resources/Textures/_Starlight/Mobs/Species/Cyclorite/parts.rsi/meta.json
+++ b/Resources/Textures/_Starlight/Mobs/Species/Cyclorite/parts.rsi/meta.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "license": "Custom",
+  "license": "CC-BY-SA-4.0",
   "copyright": "Darkrell - 🌟Starlight🌟",
   "size": {
     "x": 32,

--- a/Resources/Textures/_Starlight/Mobs/Species/Felionoid/parts.rsi/meta.json
+++ b/Resources/Textures/_Starlight/Mobs/Species/Felionoid/parts.rsi/meta.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "license": "Custom",
+  "license": "CC-BY-SA-4.0",
   "copyright": "Darkrell",
   "size": {
     "x": 32,


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- tweak: A diona can restore its body in 5 minutes instead of 10.
- tweak: The liver of vox now absorbs much more damage. When removed from the body, it takes on 280 toxins. Don’t forget that if you restore a vox this way by transplanting a human liver, it will just be normal.
- tweak: Vox can now regenerate up to 25 damage instead of the base 20.
- tweak: Vox claws now deal 6 damage instead of 5.
- tweak: Cyclorites are now 10% slower instead of 15%.
- tweak: Dwarves now go into crit at 110 damage and die at 220.
- add: Arachnids are no longer slowed down when walking on webs.
