### PR TITLE
Restock Price Fixes

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -12,7 +12,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockBoozeFilled
-  cost: 3500
+  cost: 3000 #SL EDIT
   category: cargoproduct-category-name-service
   group: market
 
@@ -22,7 +22,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockChefvendFilled
-  cost: 750 # Starlight-edit
+  cost: 850 # Starlight-edit
   category: cargoproduct-category-name-service
   group: market
 
@@ -32,7 +32,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 4010 # Starlight-edit
+  cost: 4025 # Starlight-edit
   category: cargoproduct-category-name-service
   group: market
 
@@ -42,7 +42,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockAutoDrobeFilled
-  cost: 4010 # Starlight-edit
+  cost: 4000 # Starlight-edit
   category: cargoproduct-category-name-service
   group: market
 
@@ -92,7 +92,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockHotDrinksFilled
-  cost: 1200
+  cost: 1000 #SL EDIT
   category: cargoproduct-category-name-service
   group: market
 
@@ -102,7 +102,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockMedicalFilled
-  cost: 1750
+  cost: 1800 #SL EDIT
   category: cargoproduct-category-name-medical
   group: market
 
@@ -122,7 +122,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockNutriMaxFilled
-  cost: 2400
+  cost: 2000 #SL EDIT
   category: cargoproduct-category-name-hydroponics
   group: market
 
@@ -142,7 +142,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockRobustSoftdrinksFilled
-  cost: 1200
+  cost: 1000 #SL EDIT
   category: cargoproduct-category-name-service
   group: market
 
@@ -172,7 +172,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockSeedsFilled
-  cost: 3600
+  cost: 3650 #SL EDIT
   category: cargoproduct-category-name-hydroponics
   group: market
 
@@ -192,7 +192,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockVendomatFilled
-  cost: 1200
+  cost: 1000 #SL EDIT
   category: cargoproduct-category-name-service
   group: market
 
@@ -212,7 +212,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockTankDispenserFilled
-  cost: 1000
+  cost: 1100
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -222,7 +222,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockHappyHonkFilled
-  cost: 2100
+  cost: 3000 #SL EDIT
   category: cargoproduct-category-name-service
   group: market
 
@@ -242,7 +242,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockChangFilled
-  cost: 1200
+  cost: 1000 #SL EDIT
   category: cargoproduct-category-name-service
   group: market
 
@@ -252,7 +252,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockDiscountDansFilled
-  cost: 1200
+  cost: 1000 #SL EDIT
   category: cargoproduct-category-name-service
   group: market
 
@@ -262,6 +262,6 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockDonutFilled
-  cost: 1200
+  cost: 1000 #SL EDIT
   category: cargoproduct-category-name-service
   group: market

--- a/Resources/Prototypes/_StarLight/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_StarLight/Voice/speech_emote_sounds.yml
@@ -1,104 +1,320 @@
 - type: emoteSounds
-  id: MaleThaven
+  id: MaleFelionoid
+  params:
+    variation: 0.125
   sounds:
     Scream:
-      collection: MaleScreams
+      collection: FelionoidScreams
     Laugh:
       collection: MaleLaugh
     Sneeze:
       collection: MaleSneezes
     Cough:
       collection: MaleCoughs
-    CatMeow:
-      collection: CatMeows
-    CatHisses:
-      collection: CatHisses
-    MonkeyScreeches:
-      collection: MonkeyScreeches
-    RobotBeep:
-      collection: RobotBeeps
-    Yawn:
-      collection: MaleYawn
-    Snore:
-      collection: Snores
-    Sigh:
-      collection: MaleSigh
-    Honk:
-      collection: BikeHorn
     Crying:
       collection: MaleCry
     Whistle:
       collection: Whistles
-    Weh:
-      collection: Weh
+    Sigh:
+      collection: MaleSigh
+    Yawn:
+      collection: MaleYawn
+    Snore:
+      collection: Snores
+    Mew:
+      collection: FelionoidMews
+    Hisses:
+      collection: FelionoidHisses
+    Meow:
+      collection: FelionoidMeows
+    Purr:
+      collection: FelionoidPurrs
+    Growl:
+      collection: FelionoidGrowls
+    Trill:
+      collection: FelionoidTrills
     Gasp:
       collection: MaleGasp
     DefaultDeathgasp:
       collection: MaleDeathGasp
-  params:
-    variation: 0.05
-    pitch: 1.25
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
 
 - type: emoteSounds
-  id: FemaleThaven
+  id: FemaleFelionoid
+  params:
+    variation: 0.125
   sounds:
     Scream:
-      collection: FemaleScreams
+      collection: FelionoidScreams
     Laugh:
       collection: FemaleLaugh
     Sneeze:
       collection: FemaleSneezes
     Cough:
       collection: FemaleCoughs
-    CatMeow:
-      collection: CatMeows
-    CatHisses:
-      collection: CatHisses
-    MonkeyScreeches:
-      collection: MonkeyScreeches
-    RobotBeep:
-      collection: RobotBeeps
+    Crying:
+      collection: FemaleCry
+    Sigh:
+      collection: FemaleSigh
+    Yawn:
+      collection: FemaleYawn
+    Snore:
+      collection: Snores
+    Whistle:
+      collection: Whistles
+    Mew:
+      collection: FelionoidMews
+    Hisses:
+      collection: FelionoidHisses
+    Meow:
+      collection: FelionoidMeows
+    Purr:
+      collection: FelionoidPurrs
+    Growl:
+      collection: FelionoidGrowls
+    Trill:
+      collection: FelionoidTrills
+    Gasp:
+      collection: FemaleGasp
+    DefaultDeathgasp:
+      collection: FemaleDeathGasp
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+
+- type: emoteSounds
+  id: MaleCyclorite
+  params:
+    variation: 0.125
+  sounds:
+    Scream:
+      collection: CycloriteScreams
+    Laugh:
+      collection: CycloriteLaugh
+    Sneeze:
+      collection: CycloriteCough
+    Cough:
+      collection: CycloriteCough
+    Crying:
+      collection: CycloriteScreams
+    Whistle:
+      collection: CycloriteWhistle
+    Yawn:
+      collection: CycloriteYawn
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+
+- type: emoteSounds
+  id: FemaleCyclorite
+  params:
+    variation: 0.125
+  sounds:
+    Scream:
+      collection: CycloriteScreams
+    Laugh:
+      collection: CycloriteLaugh
+    Sneeze:
+      collection: CycloriteCough
+    Cough:
+      collection: CycloriteCough
+    Crying:
+      collection: CycloriteScreams
+    Whistle:
+      collection: CycloriteWhistle
+    Yawn:
+      collection: CycloriteYawn
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+
+# Avali Sounds
+- type: emoteSounds
+  id: MaleAvali
+  params:
+    variation: 0.125
+  sounds:
+    Scream:
+      path: /Audio/_Starlight/Effects/avali_scream.ogg
+    Laugh:
+      path: /Audio/_Starlight/Voice/Avali/avali_laugh.ogg
+    Sneeze:
+      collection: MaleSneezes
+    Cough:
+      collection: MaleCoughs
+    Yawn:
+      collection: MaleYawn
+    Snore:
+      collection: Snores
+    Sigh:
+      collection: MaleSigh
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+    Gasp:
+      collection: MaleGasp
+    DefaultDeathgasp:
+      collection: MaleDeathGasp
+    Hisses:
+      collection: FelionoidHisses
+    Purr:
+      collection: FelionoidPurrs
+    Growl:
+      collection: FelionoidGrowls
+    Trill:
+      collection: FelionoidTrills
+    Scree:
+      collection: ResomiScrees
+    Call:
+      collection: ResomiCalls
+    Squawk:
+      collection: ResomiSquawk
+    Crying:
+      path: /Audio/_Starlight/Voice/Avali/avali_cry.ogg
+    Honk:
+      collection: BikeHorn
+    Whistle:
+      path: /Audio/Voice/Resomi/resomi_whistle.ogg
+    Chirp:
+      collection: ResomiChirp
+
+- type: emoteSounds
+  id: FemaleAvali
+  params:
+    variation: 0.125
+  sounds:
+    Scream:
+      path: /Audio/_Starlight/Effects/avali_scream.ogg
+    Laugh:
+      path: /Audio/_Starlight/Voice/Avali/avali_laugh.ogg
+    Sneeze:
+      collection: FemaleSneezes
+    Cough:
+      collection: FemaleCoughs
     Yawn:
       collection: FemaleYawn
     Snore:
       collection: Snores
     Sigh:
       collection: FemaleSigh
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+    Gasp:
+      collection: FemaleGasp
+    DefaultDeathgasp:
+      collection: FemaleDeathGasp
+    Hisses:
+      collection: FelionoidHisses
+    Purr:
+      collection: FelionoidPurrs
+    Growl:
+      collection: FelionoidGrowls
+    Trill:
+      collection: FelionoidTrills
+    Scree:
+      collection: ResomiScrees
+    Call:
+      collection: ResomiCalls
+    Squawk:
+      collection: ResomiSquawk
+    Crying:
+      path: /Audio/_Starlight/Voice/Avali/avali_cry.ogg
     Honk:
       collection: BikeHorn
+    Whistle:
+      path: /Audio/Voice/Resomi/resomi_whistle.ogg
+    Chirp:
+      collection: ResomiChirp
+
+- type: emoteSounds
+  id: MaleShadekin
+  params:
+    variation: 0.125
+  sounds:
+    Scream:
+      collection: ShadekinMaleScreams
+    Laugh:
+      collection: MaleLaugh
+    Sneeze:
+      collection: MaleSneezes
+    Cough:
+      collection: MaleCoughs
+    Yawn:
+      collection: MaleYawn
+    Snore:
+      collection: Snores
+    Sigh:
+      collection: MaleSigh
+    Crying:
+      collection: MaleCry
+    Whistle:
+      collection: Whistles
+    Weh:
+      collection: Weh
+    Hew:
+      collection: Hew
+    Gasp:
+      collection: MaleGasp
+    DefaultDeathgasp:
+      collection: MaleDeathGasp
+    Mar:
+      path: /Audio/_Starlight/Voice/Shadekin/mar.ogg
+    Wurble:
+      path: /Audio/_Starlight/Voice/Shadekin/wurble.ogg
+    Hisses:
+      collection: FelionoidHisses
+    Purr:
+      collection: FelionoidPurrs
+    Growl:
+      collection: FelionoidGrowls
+
+- type: emoteSounds
+  id: FemaleShadekin
+  params:
+    variation: 0.125
+  sounds:
+    Scream:
+      collection: ShadekinFemaleScreams
+    Laugh:
+      collection: FemaleLaugh
+    Sneeze:
+      collection: FemaleSneezes
+    Cough:
+      collection: FemaleCoughs
+    Yawn:
+      collection: FemaleYawn
+    Snore:
+      collection: Snores
+    Sigh:
+      collection: FemaleSigh
     Crying:
       collection: FemaleCry
     Whistle:
       collection: Whistles
     Weh:
       collection: Weh
+    Hew:
+      collection: Hew
     Gasp:
       collection: FemaleGasp
     DefaultDeathgasp:
       collection: FemaleDeathGasp
-  params:
-    variation: 0.05
-    pitch: 1.25
-
-- type: emoteSounds
-  id: UnisexThaven
-  sounds:
-    CatMeow:
-      collection: CatMeows
-    CatHisses:
-      collection: CatHisses
-    MonkeyScreeches:
-      collection: MonkeyScreeches
-    RobotBeep:
-      collection: RobotBeeps
-    Snore:
-      collection: Snores
-    Honk:
-      collection: BikeHorn
-    Whistle:
-      collection: Whistles
-    Weh:
-      collection: Weh
-  params:
-    variation: 0.05
-    pitch: 1.25
+    Mar:
+      path: /Audio/_Starlight/Voice/Shadekin/mar.ogg
+    Wurble:
+      path: /Audio/_Starlight/Voice/Shadekin/wurble.ogg
+    Hisses:
+      collection: FelionoidHisses
+    Purr:
+      collection: FelionoidPurrs
+    Growl:
+      collection: FelionoidGrowls

--- a/Resources/Prototypes/_StarLight/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_StarLight/Voice/speech_emote_sounds.yml
@@ -1,320 +1,104 @@
 - type: emoteSounds
-  id: MaleFelionoid
-  params:
-    variation: 0.125
+  id: MaleThaven
   sounds:
     Scream:
-      collection: FelionoidScreams
+      collection: MaleScreams
     Laugh:
       collection: MaleLaugh
     Sneeze:
       collection: MaleSneezes
     Cough:
       collection: MaleCoughs
-    Crying:
-      collection: MaleCry
-    Whistle:
-      collection: Whistles
-    Sigh:
-      collection: MaleSigh
-    Yawn:
-      collection: MaleYawn
-    Snore:
-      collection: Snores
-    Mew:
-      collection: FelionoidMews
-    Hisses:
-      collection: FelionoidHisses
-    Meow:
-      collection: FelionoidMeows
-    Purr:
-      collection: FelionoidPurrs
-    Growl:
-      collection: FelionoidGrowls
-    Trill:
-      collection: FelionoidTrills
-    Gasp:
-      collection: MaleGasp
-    DefaultDeathgasp:
-      collection: MaleDeathGasp
-    Weh:
-      collection: Weh
-    Hew:
-      collection: Hew
-
-- type: emoteSounds
-  id: FemaleFelionoid
-  params:
-    variation: 0.125
-  sounds:
-    Scream:
-      collection: FelionoidScreams
-    Laugh:
-      collection: FemaleLaugh
-    Sneeze:
-      collection: FemaleSneezes
-    Cough:
-      collection: FemaleCoughs
-    Crying:
-      collection: FemaleCry
-    Sigh:
-      collection: FemaleSigh
-    Yawn:
-      collection: FemaleYawn
-    Snore:
-      collection: Snores
-    Whistle:
-      collection: Whistles
-    Mew:
-      collection: FelionoidMews
-    Hisses:
-      collection: FelionoidHisses
-    Meow:
-      collection: FelionoidMeows
-    Purr:
-      collection: FelionoidPurrs
-    Growl:
-      collection: FelionoidGrowls
-    Trill:
-      collection: FelionoidTrills
-    Gasp:
-      collection: FemaleGasp
-    DefaultDeathgasp:
-      collection: FemaleDeathGasp
-    Weh:
-      collection: Weh
-    Hew:
-      collection: Hew
-
-- type: emoteSounds
-  id: MaleCyclorite
-  params:
-    variation: 0.125
-  sounds:
-    Scream:
-      collection: CycloriteScreams
-    Laugh:
-      collection: CycloriteLaugh
-    Sneeze:
-      collection: CycloriteCough
-    Cough:
-      collection: CycloriteCough
-    Crying:
-      collection: CycloriteScreams
-    Whistle:
-      collection: CycloriteWhistle
-    Yawn:
-      collection: CycloriteYawn
-    Weh:
-      collection: Weh
-    Hew:
-      collection: Hew
-
-- type: emoteSounds
-  id: FemaleCyclorite
-  params:
-    variation: 0.125
-  sounds:
-    Scream:
-      collection: CycloriteScreams
-    Laugh:
-      collection: CycloriteLaugh
-    Sneeze:
-      collection: CycloriteCough
-    Cough:
-      collection: CycloriteCough
-    Crying:
-      collection: CycloriteScreams
-    Whistle:
-      collection: CycloriteWhistle
-    Yawn:
-      collection: CycloriteYawn
-    Weh:
-      collection: Weh
-    Hew:
-      collection: Hew
-
-# Avali Sounds
-- type: emoteSounds
-  id: MaleAvali
-  params:
-    variation: 0.125
-  sounds:
-    Scream:
-      path: /Audio/_Starlight/Effects/avali_scream.ogg
-    Laugh:
-      path: /Audio/_Starlight/Voice/Avali/avali_laugh.ogg
-    Sneeze:
-      collection: MaleSneezes
-    Cough:
-      collection: MaleCoughs
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
     Yawn:
       collection: MaleYawn
     Snore:
       collection: Snores
     Sigh:
       collection: MaleSigh
-    Weh:
-      collection: Weh
-    Hew:
-      collection: Hew
-    Gasp:
-      collection: MaleGasp
-    DefaultDeathgasp:
-      collection: MaleDeathGasp
-    Hisses:
-      collection: FelionoidHisses
-    Purr:
-      collection: FelionoidPurrs
-    Growl:
-      collection: FelionoidGrowls
-    Trill:
-      collection: FelionoidTrills
-    Scree:
-      collection: ResomiScrees
-    Call:
-      collection: ResomiCalls
-    Squawk:
-      collection: ResomiSquawk
-    Crying:
-      path: /Audio/_Starlight/Voice/Avali/avali_cry.ogg
     Honk:
       collection: BikeHorn
-    Whistle:
-      path: /Audio/Voice/Resomi/resomi_whistle.ogg
-    Chirp:
-      collection: ResomiChirp
-
-- type: emoteSounds
-  id: FemaleAvali
-  params:
-    variation: 0.125
-  sounds:
-    Scream:
-      path: /Audio/_Starlight/Effects/avali_scream.ogg
-    Laugh:
-      path: /Audio/_Starlight/Voice/Avali/avali_laugh.ogg
-    Sneeze:
-      collection: FemaleSneezes
-    Cough:
-      collection: FemaleCoughs
-    Yawn:
-      collection: FemaleYawn
-    Snore:
-      collection: Snores
-    Sigh:
-      collection: FemaleSigh
-    Weh:
-      collection: Weh
-    Hew:
-      collection: Hew
-    Gasp:
-      collection: FemaleGasp
-    DefaultDeathgasp:
-      collection: FemaleDeathGasp
-    Hisses:
-      collection: FelionoidHisses
-    Purr:
-      collection: FelionoidPurrs
-    Growl:
-      collection: FelionoidGrowls
-    Trill:
-      collection: FelionoidTrills
-    Scree:
-      collection: ResomiScrees
-    Call:
-      collection: ResomiCalls
-    Squawk:
-      collection: ResomiSquawk
-    Crying:
-      path: /Audio/_Starlight/Voice/Avali/avali_cry.ogg
-    Honk:
-      collection: BikeHorn
-    Whistle:
-      path: /Audio/Voice/Resomi/resomi_whistle.ogg
-    Chirp:
-      collection: ResomiChirp
-
-- type: emoteSounds
-  id: MaleShadekin
-  params:
-    variation: 0.125
-  sounds:
-    Scream:
-      collection: ShadekinMaleScreams
-    Laugh:
-      collection: MaleLaugh
-    Sneeze:
-      collection: MaleSneezes
-    Cough:
-      collection: MaleCoughs
-    Yawn:
-      collection: MaleYawn
-    Snore:
-      collection: Snores
-    Sigh:
-      collection: MaleSigh
     Crying:
       collection: MaleCry
     Whistle:
       collection: Whistles
     Weh:
       collection: Weh
-    Hew:
-      collection: Hew
     Gasp:
       collection: MaleGasp
     DefaultDeathgasp:
       collection: MaleDeathGasp
-    Mar:
-      path: /Audio/_Starlight/Voice/Shadekin/mar.ogg
-    Wurble:
-      path: /Audio/_Starlight/Voice/Shadekin/wurble.ogg
-    Hisses:
-      collection: FelionoidHisses
-    Purr:
-      collection: FelionoidPurrs
-    Growl:
-      collection: FelionoidGrowls
+  params:
+    variation: 0.05
+    pitch: 1.25
 
 - type: emoteSounds
-  id: FemaleShadekin
-  params:
-    variation: 0.125
+  id: FemaleThaven
   sounds:
     Scream:
-      collection: ShadekinFemaleScreams
+      collection: FemaleScreams
     Laugh:
       collection: FemaleLaugh
     Sneeze:
       collection: FemaleSneezes
     Cough:
       collection: FemaleCoughs
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
     Yawn:
       collection: FemaleYawn
     Snore:
       collection: Snores
     Sigh:
       collection: FemaleSigh
+    Honk:
+      collection: BikeHorn
     Crying:
       collection: FemaleCry
     Whistle:
       collection: Whistles
     Weh:
       collection: Weh
-    Hew:
-      collection: Hew
     Gasp:
       collection: FemaleGasp
     DefaultDeathgasp:
       collection: FemaleDeathGasp
-    Mar:
-      path: /Audio/_Starlight/Voice/Shadekin/mar.ogg
-    Wurble:
-      path: /Audio/_Starlight/Voice/Shadekin/wurble.ogg
-    Hisses:
-      collection: FelionoidHisses
-    Purr:
-      collection: FelionoidPurrs
-    Growl:
-      collection: FelionoidGrowls
+  params:
+    variation: 0.05
+    pitch: 1.25
+
+- type: emoteSounds
+  id: UnisexThaven
+  sounds:
+    CatMeow:
+      collection: CatMeows
+    CatHisses:
+      collection: CatHisses
+    MonkeyScreeches:
+      collection: MonkeyScreeches
+    RobotBeep:
+      collection: RobotBeeps
+    Snore:
+      collection: Snores
+    Honk:
+      collection: BikeHorn
+    Whistle:
+      collection: Whistles
+    Weh:
+      collection: Weh
+  params:
+    variation: 0.05
+    pitch: 1.25


### PR DESCRIPTION

## Short description
Fixed some restocks being worth more than their buy price from Cargo due to the stock rebalance PR. Adjusted some other restock prices to be slightly more if their sell price was very close to their buy price, or slightly less if their sell price was dramatically lower than their buy price, to make purchasing and using restocks more attractive and worthwhile.

## Why we need to add this
Fixes infinite money glitch (Quartermasters everywhere are sobbing into their gold trimmed silk sheets)

## Media (Video/Screenshots)
M/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed pricing of some restock crates to be more reasonable. If the resell price was close to the buy price, I made them cost slightly more. If the resell price was way under the buy price, I made them cost slightly less.
- fix: Fixed infinite money glitch with restock crates in cargo
