### PR TITLE
Remove destroying beam from MT-7 Magnum

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -110,6 +110,7 @@
 
 - type: hitscan
   id: RedHeavyLaser
+  name: heavy laser # Starlight
   damage:
     types:
       Heat: 28

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -297,10 +297,6 @@
       fireCost: 222
       magState: kill
       visualState: kill-unshaded
-    - proto: DestroyBeam
-      fireCost: 1000
-      magState: destroy
-      visualState: destroy-unshaded
   - type: Battery
     maxCharge: 2000
     startingCharge: 2000


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes destroying beam from the MT-7 Magnum, and adds a name for the heavy laser mode.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Currently, destroying beam is restricted to NT and CC roles, as far as I'm aware. It feels out of place and a bit unbalanced to have a soon-to-be security weapon have destroying beams. 

I was originally going to lower the number of laser shots per charge, but I decided that since it lacks the ability to quickly reload like a kinetic weapon, having slightly more damage per magazine than a standard six-shot revolver (42 more damage to be exact, when using SP on an unarmored target) is fine.

Adding a name for the heavy laser mode is a bugfix, it didn't have a name before and would just display as a blank box when picking the mode with the MT-7.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CommanderAlex365
- remove: Removed destroying beam from the MT-7 Magnum
- fix: Gave the heavy laser firing mode a name in the selection dropdown
