### PR TITLE
Buff dragon heat resistance

### DIFF
--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -57,6 +57,8 @@
     Slash: 2
     Heat: 0.2
     Bloodloss: 0
+  flatReductions:
+    Heat: 10
 
 - type: damageModifierSet
   id: DragonCarpResistances

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -54,7 +54,7 @@
   id: DragonResistances
   coefficients:
     Piercing: 0.4
-    Slash: 3
+    Slash: 4
     Heat: 0.2
     Bloodloss: 0
   flatReductions:
@@ -64,6 +64,6 @@
   id: DragonCarpResistances
   coefficients:
     Piercing: 0.65
-    Slash: 3
+    Slash: 2
     Heat: 0.6
     Bloodloss: 0

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -54,7 +54,7 @@
   id: DragonResistances
   coefficients:
     Piercing: 0.4
-    Slash: 2
+    Slash: 3
     Heat: 0.2
     Bloodloss: 0
   flatReductions:
@@ -64,6 +64,6 @@
   id: DragonCarpResistances
   coefficients:
     Piercing: 0.65
-    Slash: 2
+    Slash: 3
     Heat: 0.6
     Bloodloss: 0

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -57,8 +57,6 @@
     Slash: 4
     Heat: 0.2
     Bloodloss: 0
-  flatReductions:
-    Heat: 10
 
 - type: damageModifierSet
   id: DragonCarpResistances

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -53,7 +53,7 @@
 - type: damageModifierSet
   id: DragonResistances
   coefficients:
-    Piercing: 0.3
+    Piercing: 0.4
     Slash: 2
     Heat: 0.2
     Bloodloss: 0
@@ -61,7 +61,7 @@
 - type: damageModifierSet
   id: DragonCarpResistances
   coefficients:
-    Piercing: 0.5
+    Piercing: 0.65
     Slash: 2
     Heat: 0.6
     Bloodloss: 0

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -54,7 +54,7 @@
   id: DragonResistances
   coefficients:
     Piercing: 0.4
-    Slash: 4
+    Slash: 2
     Heat: 0.2
     Bloodloss: 0
 

--- a/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_StarLight/Damage/modifier_sets.yml
@@ -55,7 +55,7 @@
   coefficients:
     Piercing: 0.3
     Slash: 2
-    Heat: 0.5
+    Heat: 0.2
     Bloodloss: 0
 
 - type: damageModifierSet
@@ -63,5 +63,5 @@
   coefficients:
     Piercing: 0.5
     Slash: 2
-    Heat: 0.75
+    Heat: 0.6
     Bloodloss: 0


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
The dragon needs quite a bit more heat resistance; as it stands you can get damaged _and set on fire by_ by your own fireballs. (I don't know if you can actually take damage from being on fire though. A cursory glance through the YAML suggests no, but I think you _can_ still get hit by the fireball itself and get damaged by that.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
See above point about being hit by your own fireballs. Additionally it's, well, a dragon - famously known for spewing fire. Makes sense that it would have very high resistance to heat. However to compensate piercing damage has been increased by 10%.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- tweak: Dragon now has 80% heat resistance (from 50%)
- tweak: Dragon now has 60% pierce resistance (from 70%)