### PR TITLE
temporary switch back to sl vulpkanin, requested changes

### DIFF
--- a/Resources/Prototypes/Body/Prototypes/vulpkanin.yml
+++ b/Resources/Prototypes/Body/Prototypes/vulpkanin.yml
@@ -18,9 +18,9 @@
       - right leg
       - left leg
       organs:
-        heart: OrganAnimalHeart
+        heart: OrganVulpkaninHeart # starlight - temp vulpkanin revert
         lungs: OrganHumanLungs
-        stomach: OrganAnimalStomach
+        stomach: OrganVulpkaninStomach # starlight - temp vulpkanin revert
         liver: OrganAnimalLiver
         kidneys: OrganHumanKidneys
     right arm:

--- a/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
@@ -44,16 +44,18 @@
       types:
         Piercing: 2
         Slash: 3
-  - type: Temperature # Same as moth temperatures until below is solved.
-    heatDamageThreshold: 320 # TODO: 315 when there is a way to make the temperature alert not blink to the side of the screen and disappear when you "sweat" at 39C.
-    coldDamageThreshold: 230 # TODO: 220 when the above is solved.
-    specificHeat: 44
-    coldDamage:
-      types:
-        Cold: 0.05 # Per second, scales with temperature & other constants
-    heatDamage:
-      types:
-        Heat: 2.5 # Per second, scales with temperature & other constants
+  # starlight start - temp vulpkanin revert
+  # - type: Temperature # Same as moth temperatures until below is solved.
+  #   heatDamageThreshold: 320 # TODO: 315 when there is a way to make the temperature alert not blink to the side of the screen and disappear when you "sweat" at 39C.
+  #   coldDamageThreshold: 230 # TODO: 220 when the above is solved.
+  #   specificHeat: 44
+  #   coldDamage:
+  #     types:
+  #       Cold: 0.05 # Per second, scales with temperature & other constants
+  #   heatDamage:
+  #     types:
+  #       Heat: 2.5 # Per second, scales with temperature & other constants
+  # starlight end
     # Starlight start
     # - type: Wagging TODO: Add back once we have animated tails again. Were removed due to the sprite rework, causing all of them to not fit anymore.
     #   action: ActionToggleWaggingVulpkanin
@@ -63,16 +65,18 @@
   - type: TemperatureProtection
     heatingCoefficient: 1.2
     coolingCoefficient: 0.3
-  - type: JumpAbility
-    action: ActionVulpkaninGravityJump
-    canCollide: true
-    jumpDistance: 3
-    jumpSound:
-      path: /Audio/Weapons/punchmiss.ogg
-      params:
-        pitch: 1.33
-        volume: -5
-        variation: 0.05
+  # STARLIGHT START
+  # - type: JumpAbility
+  #   action: ActionVulpkaninGravityJump
+  #   canCollide: true
+  #   jumpDistance: 3
+  #   jumpSound:
+  #     path: /Audio/Weapons/punchmiss.ogg
+  #     params:
+  #       pitch: 1.33
+  #       volume: -5
+  #       variation: 0.05
+  # STARLIGHT END
   - type: InteractionPopup # Crucial detail.
     successChance: 1
     interactSuccessString: petting-success-soft-floofy-vulp
@@ -165,6 +169,38 @@
             sprite: _Starlight/Mobs/Species/Vulpkanin/displacement.rsi
             state: shoes
   # Starlight end
+  # starlight start - temp vulpkanin revert
+  - type: Hunger # on 1.5x more
+    thresholds:
+      Overfed: 250
+      Okay: 200
+      Peckish: 150
+      Starving: 100
+      Dead: 0
+    baseDecayRate: 0.02
+  - type: Thirst # on 1.5x more
+    thresholds:
+      OverHydrated: 650
+      Okay: 500
+      Thirsty: 350
+      Parched: 200
+      Dead: 0
+    baseDecayRate: 0.15
+  - type: Temperature # Ported over from CD. Afterall, it does make sense that something with fur can handle more cold/less heat. Basegame Moths, apparently, have similar resistances.
+    heatDamageThreshold: 325
+    coldDamageThreshold: 230
+    currentTemperature: 310.15
+    specificHeat: 46
+    coldDamage:
+      types:
+        Cold : 0.05 #per second, scales with temperature & other constants
+    heatDamage:
+      types:
+        Heat : 1.75 #per second, scales with temperature & other constants
+  - type: ContentEye
+    targetZoom: "1.125, 1.125"
+    maxZoom: "1.125, 1.125"
+  # starlight end
 
 - type: entity
   parent: [BaseSpeciesDummy]

--- a/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
@@ -177,7 +177,7 @@
       Peckish: 150
       Starving: 100
       Dead: 0
-    baseDecayRate: 0.02
+    baseDecayRate: 0.018
   - type: Thirst # on 1.5x more
     thresholds:
       OverHydrated: 650
@@ -185,7 +185,7 @@
       Thirsty: 350
       Parched: 200
       Dead: 0
-    baseDecayRate: 0.15
+    baseDecayRate: 0.125
   - type: Temperature # Ported over from CD. Afterall, it does make sense that something with fur can handle more cold/less heat. Basegame Moths, apparently, have similar resistances.
     heatDamageThreshold: 325
     coldDamageThreshold: 230

--- a/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
@@ -16,8 +16,8 @@
     - Fox # "vaguely canidae"
     - Dog # "vaguely canidae"
   #Starlight
-  - type: Hunger
-  - type: Thirst
+#  - type: Hunger # starlight
+#  - type: Thirst # starlight
   - type: MessyDrinker
     spillChance: 0.33
   - type: Icon

--- a/Resources/Prototypes/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Species/vulpkanin.yml
@@ -11,6 +11,15 @@
   maleFirstNames: names_vulpkanin_male
   femaleFirstNames: names_vulpkanin_female
   lastNames: names_vulpkanin_last
+  skinColoration: Hues # Starlight
+  # starlight start
+  minHeight: 0.9
+  defaultHeight: 1
+  maxHeight: 1.2
+  standardSize: 170
+  standardWeight: 75
+  standardDensity: 110
+  # starlight end
 
 - type: speciesBaseSprites
   id: MobVulpkaninSprites

--- a/Resources/Prototypes/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Species/vulpkanin.yml
@@ -7,11 +7,10 @@
   defaultSkinTone: "#5a3f2d"
   markingLimits: MobVulpkaninMarkingLimits
   dollPrototype: MobVulpkaninDummy
-  skinColoration: VulpkaninColors
+  skinColoration: Hues # Starlight
   maleFirstNames: names_vulpkanin_male
   femaleFirstNames: names_vulpkanin_female
   lastNames: names_vulpkanin_last
-  skinColoration: Hues # Starlight
   # starlight start
   minHeight: 0.9
   defaultHeight: 1


### PR DESCRIPTION
## Short description
Temporarily switches back to starlight vulpkanin stats

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- tweak: Temporarily switch back to starlight vulpkanin stats
