### PR TITLE
Early launch reactivate

### DIFF
--- a/Content.Shared/Shuttles/Systems/SharedEmergencyShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedEmergencyShuttleSystem.cs
@@ -28,7 +28,9 @@ public abstract class SharedEmergencyShuttleSystem : EntitySystem
         if (_emergencyEarlyLaunchAllowed)
             return;
 
-        args.Cancel();
-        Popup.PopupClient(Loc.GetString("emergency-shuttle-console-no-early-launches"), ent, args.User);
+        // Starlight edit: Start Early launch system enabled
+        // args.Cancel();
+        // Popup.PopupClient(Loc.GetString("emergency-shuttle-console-no-early-launches"), ent, args.User); 
+        // Starlight edit: End
     }
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Reactivates early evac launch
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Wizden disabled this. I think its a very neat feature and worse case scenario we can make it against the rules for command to try early evac without valid reason
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="459" height="136" alt="image" src="https://github.com/user-attachments/assets/362896d1-941d-4ff9-a526-a17e26c16178" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- tweak: Re-enable early evac launch