### PR TITLE
[HOTFIX] Actually fixes Laser Carbines

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -279,7 +279,7 @@
   - type: PacifismAllowedGun
   - type: HitscanBatteryAmmoProvider
     proto: RedLaserPractice
-    fireCost: 30 
+    fireCost: 30 # Starlight
 
 
 #- type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -53,13 +53,18 @@
   - type: Appearance
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
-  - type: Gun
+  - type: Gun #Starlight - Start
+    fireRate: 2
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
+    - FullAuto #Just allows people to hold down left click
+  - type: Battery 
+    maxCharge: 1500 # ~1:30 minutes for recharge
+    startingCharge: 1500
   - type: HitscanBatteryAmmoProvider
     proto: RedLaser
-    fireCost: 62.5
+    fireCost: 30 #Starlight - End
   - type: StaticPrice
     price: 420
 
@@ -272,18 +277,10 @@
     steps: 5
     zeroVisible: true
   - type: PacifismAllowedGun
-  - type: Gun #Starlight - Start
-    fireRate: 2
-    selectedMode: SemiAuto
-    availableModes:
-    - SemiAuto
-    - FullAuto #Just allows people to hold down left click
-  - type: Battery 
-    maxCharge: 1500 # ~1:30 minutes for recharge
-    startingCharge: 1500
   - type: HitscanBatteryAmmoProvider
-    proto: RedLaserPractice # Starlight
-    fireCost: 30 #Starlight - End
+    proto: RedLaserPractice
+    fireCost: 30 
+
 
 #- type: entity
 #  name: pulse pistol


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Actually fixes the carbines by moving the starlight changes to the abstract laser.

## Why we need to add this
The previous PR simply swapped the proto the practice rifle used, however didn't realize what got us into this god damn mess. At some point Wizden swapped the locations of the laser carbine and the practice carbine in their files, then made an abstract base laser rifle. Because the protos got swapped, this deleted our custom laser code without creating a merge conflict. This PR moves our custom laser code to the abstract laser, causing both laser rifles to have the correct magazines.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RoadTrain
- fix: Actually fixes the laser carbine by moving our code to the abstract laser.
