### PR TITLE
[Fixes] Terror spiders tier 3

### DIFF
--- a/Content.Server/_Starlight/Antags/Actions/EMPScreamSystem.cs
+++ b/Content.Server/_Starlight/Antags/Actions/EMPScreamSystem.cs
@@ -29,10 +29,11 @@ public sealed partial class EMPScreamSystem : EntitySystem
 
     private void OnEMPScream(EMPScreamEvent ev)
     {
-        if (ev.Handled || !_chargesSystem.TryUseCharge(ev.Action.Owner))
+        if (ev.Handled)
             return;
 
         ev.Handled = true;
+
         var uid = ev.Performer;
 
         ScreamEffect(uid, ev.Power, ev.ScreamSound);

--- a/Content.Server/_Starlight/Antags/Actions/EMPScreamSystem.cs
+++ b/Content.Server/_Starlight/Antags/Actions/EMPScreamSystem.cs
@@ -29,7 +29,7 @@ public sealed partial class EMPScreamSystem : EntitySystem
 
     private void OnEMPScream(EMPScreamEvent ev)
     {
-        if (ev.Handled || _chargesSystem.GetCurrentCharges(ev.Action.Owner) == 0)
+        if (ev.Handled || !_chargesSystem.TryUseCharge(ev.Action.Owner))
             return;
 
         ev.Handled = true;

--- a/Content.Server/_Starlight/NPC/HTN/PrimitiveTasks/Operators/JumpOperator.cs
+++ b/Content.Server/_Starlight/NPC/HTN/PrimitiveTasks/Operators/JumpOperator.cs
@@ -3,6 +3,7 @@ using Content.Server.NPC;
 using Content.Server.NPC.HTN;
 using Content.Server.NPC.HTN.PrimitiveTasks;
 using Content.Shared._Starlight.Actions.Jump;
+using Content.Shared.Throwing;
 using Robust.Shared.Map;
 
 namespace Content.Server._Starlight.NPC.HTN.PrimitiveTasks.Operators;
@@ -59,7 +60,10 @@ public sealed partial class JumpOperator : HTNOperator, IHtnConditionalShutdown
     {
         var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
         if (!_entManager.TryGetComponent<JumpComponent>(owner, out var jump))
-            return HTNOperatorStatus.Failed;
+            return HTNOperatorStatus.Finished; // If we can't jump, we finish this.
+
+        if (_entManager.TryGetComponent<ThrownItemComponent>(owner, out var thrown) && !thrown.Landed)
+            return HTNOperatorStatus.Continuing;
 
         return HTNOperatorStatus.Finished;
     }

--- a/Content.Shared/_Starlight/Actions/Jump/JumpComponent.cs
+++ b/Content.Shared/_Starlight/Actions/Jump/JumpComponent.cs
@@ -21,7 +21,13 @@ public sealed partial class JumpComponent : Component
     public bool KnockdownTargetOnCollision = false;
 
     [DataField]
+    public float KnockdownTargetDuration = 1f;
+
+    [DataField]
     public bool KnockdownSelfOnCollision = false;
+
+    [DataField]
+    public float KnockdownSelfDuration = 1f;
 
     [DataField]
     public float Cooldown = 30f;

--- a/Content.Shared/_Starlight/Actions/Jump/SharedJumpSystem.cs
+++ b/Content.Shared/_Starlight/Actions/Jump/SharedJumpSystem.cs
@@ -40,10 +40,10 @@ public abstract class SharedJumpSystem : EntitySystem
     private void OnThrowCollide(EntityUid uid, JumpComponent component, ref ThrowDoHitEvent args)
     {
         if (component.KnockdownSelfOnCollision)
-            _stun.TryKnockdown(uid, TimeSpan.FromSeconds(2), true);
+            _stun.TryKnockdown(uid, TimeSpan.FromSeconds(component.KnockdownSelfDuration), true);
 
         if (component.KnockdownTargetOnCollision)
-            _stun.TryKnockdown(args.Target, TimeSpan.FromSeconds(2), true);
+            _stun.TryKnockdown(args.Target, TimeSpan.FromSeconds(component.KnockdownTargetDuration), true);
     }
 
     private void OnGetItemActions(Entity<JumpComponent> ent, ref GetItemActionsEvent args)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Fixed some bugs from terror spiders tier 3:

- [x] Fixed jumping on entities... Without jumping, now they work.
- [x] Fixed cooldown on emp scream.
- [ ] Fixed evolution.
- [x] Reduced knockdown on black terror from two seconds to one.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Fixes critical but small bug with NPC's

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

no content

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rinary
- fix: Fixed emp scream cooldown for purple terror.
- fix: Fixed npc's with jumping task, now they work.(Hostile)
- tweak: Changed black terror jump knockdown duration from 2 seconds to 1 seconds.