### PR TITLE
Water Cup Rebuffed - Added Water Bottle Craft

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -99,7 +99,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 5 # One sip at a time. No rushing at the water cooler
+        maxVol: 15 # One sip at a time. No rushing at the water cooler - I REBUKE YOUR HERESY OF ONE SIP ONLY (Starlight)
   - type: Item
     size: Tiny
   - type: Sprite

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -13,3 +13,17 @@
   - type: Icon
     sprite: _Starlight/Objects/Consumable/Drinks/dragan_special.rsi
     state: icon
+
+- type: entity
+  parent: DrinkWaterBottleFull
+  id: DrinkWaterBottleEmpty
+  name: water bottle
+  description: Simple clean water of unknown origin. You think that maybe you dont want to know it.
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+  - type: Construction
+    graph: DrinkWaterBottleEmpty
+    node: waterbottle

--- a/Resources/Prototypes/_StarLight/Recipes/Crafting/Graphs/misc.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Crafting/Graphs/misc.yml
@@ -1,0 +1,13 @@
+﻿- type: constructionGraph
+  id: DrinkWaterBottleEmpty
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: waterbottle
+      steps:
+      - material: Plastic
+        amount: 1
+        doAfter: 3
+  - node: waterbottle
+    entity: DrinkWaterBottleEmpty

--- a/Resources/Prototypes/_StarLight/Recipes/Crafting/Graphs/misc.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Crafting/Graphs/misc.yml
@@ -8,6 +8,6 @@
       steps:
       - material: Plastic
         amount: 1
-        doAfter: 3
+        doAfter: 20
   - node: waterbottle
     entity: DrinkWaterBottleEmpty

--- a/Resources/Prototypes/_StarLight/Recipes/Crafting/misc.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Crafting/misc.yml
@@ -1,0 +1,7 @@
+﻿- type: construction
+  id: DrinkWaterBottleEmpty
+  graph: DrinkWaterBottleEmpty
+  startNode: start
+  targetNode: waterbottle
+  category: construction-category-misc
+  objectType: Item


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Unnerfed the random decrease of Water Cup capacity max of 5u of water by bringing it back to 15u. https://discord.com/channels/1272545509562777621/1418881051580829727

Added new Plastic Water Bottle craft - Just in case you somehow lose it or have it blown up in a random explosion, you can recraft it, at the cost of one plastic and a decent chunk of time trying to hand mold plastic into a bottle. :) https://discord.com/channels/1272545509562777621/1418463373208588288

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
For some reason someone decided to nerf the already underused water cup (I  forgot this existed really) to only hold 5u of water. Everyone already has a bunch of stuff that holds more fluid in it anyways so no reason it needs to be nerfed...

Water Bottle is only found in survival kits but they don't do so well when you get hit with an explosion. Now they can be crafted for just one plastic but with a long crafting time of 20 seconds. Shouldn't effect balance much as there are many sources of fluid containers already in and around the station. Vending machines carry explosion proof cans that hold the same amount of water. Bar hands out glasses constantly which they're lucky when people don't just run off with them. 
So overall I don't think having a backup craft of water bottles is overly bad, but if the powers that be don't agree I can remove it again.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="190" height="60" alt="image" src="https://github.com/user-attachments/assets/295d8f11-61e3-4dcb-8635-f1b3c3eb761e" />

https://github.com/user-attachments/assets/8c161439-7361-44f3-b322-f6eb904665f3

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: CorruptOmega
- tweak: Water Cup now holds 15u again. They are small but 5u is silly.
- add: Water Bottle can now be crafted by hand. Have fun molding plastic into a bottle for a good chunk of time!
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
