### PR TITLE
Thaven tweaks

### DIFF
--- a/Content.Server/_Starlight/Thaven/ThavenMoodsCommands.cs
+++ b/Content.Server/_Starlight/Thaven/ThavenMoodsCommands.cs
@@ -1,0 +1,164 @@
+using System.Linq;
+using Content.Server.Administration;
+using Content.Server.Database;
+using Content.Server.Preferences.Managers;
+using Content.Shared._Starlight.Thaven;
+using Content.Shared._Starlight.Thaven.Components;
+using Content.Shared.Administration;
+using Content.Shared.Dataset;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server._Starlight.Thaven;
+
+[AdminCommand(AdminFlags.Admin)]
+internal sealed class ThavenSharedMoodsCommand : LocalizedCommands
+{
+    [Dependency] private readonly IEntitySystemManager _entman = default!;
+    private ThavenMoodsSystem? _moods;
+    public override string Command => "thavenshared";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        _moods ??= _entman.GetEntitySystem<ThavenMoodsSystem>();
+        var moods = _moods.SharedMoods;
+        foreach (var mood in moods)
+        {
+            shell.WriteLine($"{mood.GetLocName()}: {mood.GetLocDesc()}");
+        }
+    }
+}
+
+[AdminCommand(AdminFlags.Admin)]
+internal sealed class ThavenRerollMoodsCommand : LocalizedCommands
+{
+    [Dependency] private readonly IEntitySystemManager _entman = default!;
+    private ThavenMoodsSystem? _moods;
+    public override string Command => "thavenreollshared";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        _moods ??= _entman.GetEntitySystem<ThavenMoodsSystem>();
+        _moods.NewSharedMoods();
+    }
+}
+
+[ToolshedCommand(Name = "moods"), AdminCommand(AdminFlags.Admin)]
+public sealed class AdminMoodsCommand : ToolshedCommand
+{
+    private ThavenMoodsSystem? _moods;
+
+    [CommandImplementation("addproto")]
+    public EntityUid AddMoodProto(
+        [PipedArgument] EntityUid input,
+        [CommandArgument] ProtoId<ThavenMoodPrototype> mood
+    )
+    {
+        _moods ??= GetSys<ThavenMoodsSystem>();
+
+        if (TryComp<ThavenMoodsComponent>(input, out var moodsComponent))
+        {
+            _moods.TryAddMood((input, moodsComponent), mood);
+        }
+
+        return input;
+    }
+
+    [CommandImplementation("addproto")]
+    public IEnumerable<EntityUid> AddMoodProto(
+        [PipedArgument] IEnumerable<EntityUid> input,
+        [CommandArgument] ProtoId<ThavenMoodPrototype> language
+    ) => input.Select(x => AddMoodProto(x, language));
+
+    [CommandImplementation("adddataset")]
+    public EntityUid AddMoodDataset(
+        [PipedArgument] EntityUid input,
+        [CommandArgument] ProtoId<DatasetPrototype> dataset
+    )
+    {
+        _moods ??= GetSys<ThavenMoodsSystem>();
+
+        if (TryComp<ThavenMoodsComponent>(input, out var moodsComponent))
+        {
+            var ent = (input, moodsComponent);
+            if (_moods.TryPick(dataset, out var proto, _moods.GetActiveMoods(ent)))
+                _moods.TryAddMood(ent, proto, true, false);
+        }
+
+        return input;
+    }
+
+    [CommandImplementation("adddataset")]
+    public IEnumerable<EntityUid> AddMoodDataset(
+        [PipedArgument] IEnumerable<EntityUid> input,
+        [CommandArgument] ProtoId<DatasetPrototype> dataset
+    ) => input.Select(x => AddMoodDataset(x, dataset));
+
+    [CommandImplementation("addraw")]
+    public EntityUid AddMoodRaw(
+        [PipedArgument] EntityUid input,
+        [CommandArgument] string title,
+        [CommandArgument] string description
+    )
+    {
+        _moods ??= GetSys<ThavenMoodsSystem>();
+
+        if (TryComp<ThavenMoodsComponent>(input, out var moodsComponent))
+        {
+            var ent = (input, moodsComponent);
+            var mood = new ThavenMood();
+            mood.MoodName = title;
+            mood.MoodDesc = description;
+            _moods.AddMood(ent, mood);
+        }
+
+        return input;
+    }
+
+    [CommandImplementation("addraw")]
+    public IEnumerable<EntityUid> AddMoodDataset(
+        [PipedArgument] IEnumerable<EntityUid> input,
+        [CommandArgument] string title,
+        [CommandArgument] string description
+    ) => input.Select(x => AddMoodRaw(x, title, description));
+
+    [CommandImplementation("ensure")]
+    public EntityUid EnsureMood(
+        [PipedArgument] EntityUid input
+    )
+    {
+        _moods ??= GetSys<ThavenMoodsSystem>();
+
+        if (!EntityManager.EnsureComponent<ThavenMoodsComponent>(input, out var moods))
+            _moods.NotifyMoodChange((input, moods));
+
+        return input;
+    }
+
+    [CommandImplementation("ensure")]
+    public IEnumerable<EntityUid> EnsureMood(
+        [PipedArgument] IEnumerable<EntityUid> input
+    ) => input.Select(x => EnsureMood(x));
+
+    [CommandImplementation("rm")]
+    public EntityUid RemoveMood(
+    [PipedArgument] EntityUid input,
+
+    [CommandArgument] int index = 0
+    )
+    {
+        _moods ??= GetSys<ThavenMoodsSystem>();
+
+        if (TryComp<ThavenMoodsComponent>(input, out var moods))
+            _moods.RemoveMood((input, moods), index);
+
+        return input;
+    }
+
+    [CommandImplementation("rm")]
+    public IEnumerable<EntityUid> RemoveMood(
+        [PipedArgument] IEnumerable<EntityUid> input,
+        [CommandArgument] int index = 0
+    ) => input.Select(x => RemoveMood(x, index));
+}

--- a/Content.Shared/_Starlight/Thaven/SharedThavenMoodSystem.cs
+++ b/Content.Shared/_Starlight/Thaven/SharedThavenMoodSystem.cs
@@ -1,10 +1,17 @@
 using Content.Shared.Emag.Systems;
 using Content.Shared._Starlight.Thaven.Components;
+using Robust.Shared.Prototypes;
+using Content.Shared.Dataset;
 
 namespace Content.Shared._Starlight.Thaven;
 
 public abstract class SharedThavenMoodSystem : EntitySystem
 {
+    
+    public static readonly ProtoId<DatasetPrototype> YesAndDataset = "ThavenMoodsYesAnd";  
+    public static readonly ProtoId<DatasetPrototype> NoAndDataset = "ThavenMoodsNoAnd";
+    public static readonly ProtoId<DatasetPrototype> WildcardDataset = "ThavenMoodsWildcard";
+
     [Dependency] private readonly EmagSystem _emag = default!;
     public override void Initialize()
     {
@@ -18,11 +25,13 @@ public abstract class SharedThavenMoodSystem : EntitySystem
         if (!_emag.CompareFlag(args.Type, EmagType.Interaction))
             return;
 
-        if (_emag.CheckFlag(ent, EmagType.Interaction))
-            return;
+        // allow repeated-emagging of thaven
+        // if (_emag.CheckFlag(ent, EmagType.Interaction))
+        //     return;
 
-        if (ent.Owner == args.UserUid)
-            return;
+        // allow self-emagging of thaven
+        // if (ent.Owner == args.UserUid)
+        //     return;
 
         args.Handled = true;
     }

--- a/Content.Shared/_Starlight/Thaven/ThavenMoodsComponent.cs
+++ b/Content.Shared/_Starlight/Thaven/ThavenMoodsComponent.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Actions;
+using Content.Shared.Dataset;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._Starlight.Thaven.Components;
@@ -35,6 +37,18 @@ public sealed partial class ThavenMoodsComponent : Component
 
     [DataField(serverOnly: true)]
     public EntityUid? Action;
+
+    /// <summary>
+    /// will grab 1 mood from each of these datasets on round start/map init
+    /// </summary>
+    [DataField(serverOnly: true)]
+    public List<ProtoId<DatasetPrototype>> MoodDatasets =  new() { SharedThavenMoodSystem.YesAndDataset, SharedThavenMoodSystem.NoAndDataset };
+
+    /// <summary>
+    /// what dataset will the "wildcard" mood be pulled from
+    /// </summary>
+    [DataField(serverOnly: true)]
+    public ProtoId<DatasetPrototype> Wildcard = SharedThavenMoodSystem.WildcardDataset;
 }
 
 public sealed partial class ToggleMoodsScreenEvent : InstantActionEvent;

--- a/Resources/Locale/en-US/_Starlight/thavens/commands.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/commands.ftl
@@ -1,0 +1,8 @@
+command-description-moods-addproto = Adds a mood from a ThavenMood prototype.
+command-description-moods-adddataset = Adds a mood picked from a Dataset of ThavenMood prototypes.
+command-description-moods-addraw = Adds a mood that was manually typed.
+command-description-moods-ensure = Ensures the input entity has the ThavenMoodsComponent. and informs them of such.
+command-description-moods-rm = Removes a mood specified by the index of said mood.
+
+cmd-thavenshared-desc = Prints the shared thaven mood(s) to the console.
+cmd-thavenreollshared-desc = Rerolls the shared mood(s) between all thaves and tells them their moods have changes.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
tweaks thaven emagging, adds some minor VV, allows added moods to be controlled via the component instead of the system meaning it can be pointed to other datasets. and finally toolsheds and bql for managing moods.

## Why we need to add this
Helps to alleviate admin burden and makes managing them for events easier

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: Thaven can now self-emag
- tweak: Thaven can now be emagged repeatedly.