### PR TITLE
yes the cane is a cane

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cane_nt.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cane_nt.yml
@@ -69,3 +69,4 @@
     solution: battery
   - type: DrawableSolution
     solution: battery
+  - type: MobilityAid


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
the NTrep's cane is now usable as a cane

## Why we need to add this
upstream trait allowed you to become crippled and need a cane. NTRep's cane cant be used as a cane to support yourself. now it can.

## Media (Video/Screenshots)
N/A (what am I supposed to show? walking faster?)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- fix: Nanotransen Rep's cane can now be used as a mobility aid
