### PR TITLE
sign a paper if you have a pen.

### DIFF
--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -327,7 +327,8 @@ public sealed class PaperSystem : EntitySystem
             {
                 TrySign(uid, user);
             },
-            Text = Loc.GetString("paper-component-verb-sign")
+            Text = Loc.GetString("paper-component-verb-sign"),
+            Priority = 4
             // Icon = Don't have an icon yet. Todo for later.
         };
         args.Verbs.Add(verb);


### PR DESCRIPTION
## Short description
Papers are now signed with alt-click if you are holding a pen instead of trying to eat

## Why we need to add this
the ammount of papers I have eaten instead of signing. is too many.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: walksanatora
- fix: Alt-Click now signs papers again.