### PR TITLE
Makes cloth wraps (clothing item) use barefoot sounds

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Shoes/clothwarps.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Shoes/clothwarps.yml
@@ -37,6 +37,11 @@
     fiberMaterial: fibers-cloth
     fiberColor: fibers-white
   - type: ProtectedFromStepTriggers
+  - type: FootstepModifier
+    footstepSoundCollection:
+      collection: BarestepHard
+      params:
+        volume: -6 # bit quieter than barefeet
   - type: Tag
     tags:
     - ClothMade


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a `FootstepModifier` component to cloth wraps clothing item (`ClothingClothWrap`) to make it use the `BarestepHard` soundset with a very small volume param modifier of `-6`. 

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Cloth wraps aren't hard-soled shoes, so they shouldn't sound like hard-soled shoes when you walk around.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/52fe7103-704b-4d28-a106-d6ee2920a16f

fig. 1 - regular shoes compared to the updated cloth wraps


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- tweak: Cloth wraps now use the barefoot footsteps (no longer sound like hard-soled shoes when walking)