### PR TITLE
Dominator Access Taser & Laser on Orange & Psi Alert

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -194,6 +194,8 @@
         - yellow
         - red
         - gamma
+        - psi
+        - orange
     - proto: RedLaserBeam
       fireCost: 66.6
       magState: lethal
@@ -204,6 +206,8 @@
         - yellow
         - red
         - gamma
+        - psi
+        - orange
 
 - type: entity
   name: X-01 multiphase energy gun


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Changes the Dominator modes so that you can change to taser and laser modes during Orange and Psi Alert levels.

## Why we need to add this
Orange Alert implies that the station is being torn to shreds as is, so Security having access to taser and laser could help depending on the circumstances under which the tesla or singularly was loosed.

Psi Alert, for the time being, implies Xenoborg presence. Rather self-explanatory.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/5577a20f-3fd0-414b-a596-42eda07b68f6

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Bukkataro
- add: Taser & Laser for Dominator on Orange Alert.
- add: Taser & Laser for Dominator on Psi Alert.
