### PR TITLE
Adds N2 canisters to job lockerfills, alongside the existing O2 canisters

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/emergency.yml
@@ -33,6 +33,8 @@
         amount: 2
       - id: OxygenTankFilled
         amount: 2
+      - id: EmergencyNitrogenTankFilled # Starlight - vox gang
+        amount: 2
 
 - type: entity
   id: CrateEmergencyInternals

--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -3,6 +3,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingShoesBootsMag
     - id: ClothingOuterHardsuitSpatio
     - id: ClothingMaskGasExplorer

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -166,6 +166,7 @@
     children:
     - id: ClothingOuterHardsuitAtmos
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingMaskBreath
 
 - type: entity
@@ -209,6 +210,7 @@
     children:
     - id: ClothingOuterHardsuitEngineering
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingShoesBootsMag
     - id: ClothingMaskBreath
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -84,6 +84,7 @@
     - id: ClothingMaskGasCaptain
     - id: JetpackCaptainFilled
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
 
 # No laser locker, used when the antique laser is placed in the special display crate
 - type: entity
@@ -195,6 +196,7 @@
     - id: ClothingShoesBootsMagAdv
     - id: JetpackVoidFilled
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
 
 # No hardsuit locker
 - type: entity
@@ -256,6 +258,7 @@
     - id: ClothingMaskBreathMedical
     - id: ClothingOuterHardsuitMedical
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
 
 # No hardsuit locker
 - type: entity
@@ -310,6 +313,7 @@
     - id: ClothingMaskBreath
     - id: ClothingOuterHardsuitRd
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
 
 # No hardsuit locker
 - type: entity
@@ -373,6 +377,7 @@
     - id: ClothingOuterHardsuitSecurityRed
     - id: JetpackSecurityFilled
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingShoesBootsMagSec
 
 # No hardsuit locker

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -109,6 +109,8 @@
       children:
       - id: EmergencyOxygenTankFilled
       - id: OxygenTankFilled
+      - id: EmergencyNitrogenTankFilled # Starlight - vox gang
+      - id: NitrogenTankFilled # Starlight - vox gang
     - id: CrowbarRed
     - !type:GroupSelector
       children:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -55,6 +55,7 @@
     children:
     - id: ClothingOuterHardsuitWarden
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingMaskBreath
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -15,6 +15,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingOuterHardsuitEVA
     - id: ClothingHeadHelmetEVA
     - id: ClothingMaskBreath
@@ -35,6 +36,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingOuterHardsuitEVA
     - id: ClothingHeadHelmetEVALarge
     - id: ClothingMaskBreath
@@ -55,6 +57,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingOuterSuitEmergency
     - id: ClothingMaskBreath
 
@@ -74,6 +77,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingOuterHardsuitEVAPrisoner
     - id: ClothingHeadHelmetEVALarge
     - id: ClothingMaskBreath
@@ -94,6 +98,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingOuterEVASuitSyndicate
     - id: ClothingHeadHelmetSyndicate
     - id: ClothingMaskGasSyndicate
@@ -114,6 +119,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingOuterHardsuitPirateEVA
     - id: ClothingMaskGas
 
@@ -182,6 +188,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingOuterHardsuitSecurity
     - id: ClothingMaskBreath
     - id: ClothingShoesBootsMagSec
@@ -293,6 +300,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingOuterHardsuitSyndie
     - id: ClothingShoesBootsMagSyndie
     - id: ClothingMaskGasSyndicate
@@ -313,6 +321,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingOuterHardsuitPirateCap
     - id: ClothingMaskGas
 
@@ -332,6 +341,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingMaskBreath
     # TODO: Gone until reworked to have no space protection
     #- id: ClothingOuterHardsuitWizard

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/suit_storage.yml
@@ -6,6 +6,7 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        - id: NitrogenTankFilled
         - id: ClothingOuterHardsuitBlueshield
         - id: ClothingMaskBreath
         - id: ClothingShoesBootsMagBSO


### PR DESCRIPTION
## Short description
Adds N2 canisters to all jobs lockerfills alongside existing O2 canisters, to help the Vox employees feel less left out <3

## Why we need to add this
Vox did not have easy access to N2 in lockers where atmospheric canisters would be expected for them. Also adds to a few crates that were already providing oxygen canisters.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- add: Adds N2 canister spawns to all job lockerfills alongside existing O2 canister spawns
