### PR TITLE
HOTFIX fixes for salvage rework

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1449,7 +1449,7 @@
     energy: 1.6
     color: "#b89f25"
   - type: AccessReader
-    access: [["Salvage"]]
+    access: [["Salvage"],["Mining"]]
   - type: GuideHelp
     guides:
     - Salvage

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Ears/headsets.yml
@@ -88,6 +88,8 @@
     containers:
       key_slots:
       - EncryptionKeyExpedition
+      - EncryptionKeyCargo
+      - EncryptionKeyCommon
   - type: Sprite
     sprite: Clothing/Ears/Headsets/mining.rsi
   - type: Clothing


### PR DESCRIPTION

## Short description
fixes miners missing access for salvage vender (forgot about that)
fixes salv lead headset missing cargo+common encryption keys

## Why we need to add this

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- fix: Fixed missing radio channels in salv lead headset
- fix: Fixed miners not having access to salvage vendor for getting roundstart PKAs etc
