### PR TITLE
HOTFIX. Chem Bags can no longer take Patch packs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
@@ -31,5 +31,4 @@
         - Bottle
         - Syringe
         - Dropper
-        - PatchPack
   - type: Dumpable


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Stops patch packs fitting in chem bags
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Letting them fit in chem bags lets the chem bag fit 100 patches.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="466" height="227" alt="image" src="https://github.com/user-attachments/assets/4d26f503-77ea-435c-b03a-50d60ebd3c94" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Chemistry Bags can no longer take patch packs.