### PR TITLE
Paddy gets basic Lethals, actually.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -94,7 +94,7 @@
   - type: AmmoCounter
   # region starlight
   - type: Tag
-    taags:
+    tags:
     - PaddyMech
   # end region
 
@@ -149,7 +149,7 @@
   - type: AmmoCounter
   # region starlight
   - type: Tag
-    taags:
+    tags:
     - PaddyMech
   # end region
 
@@ -177,7 +177,7 @@
   - type: AmmoCounter
   # region starlight
   - type: Tag
-    taags:
+    tags:
     - PaddyMech
   # end region
 
@@ -205,7 +205,7 @@
   - type: AmmoCounter
   # region starlight
   - type: Tag
-    taags:
+    tags:
     - PaddyMech
   # end region
 
@@ -414,6 +414,6 @@
   - type: AmmoCounter
   # region starlight
   - type: Tag
-    taags:
+    tags:
     - PaddyMech
   # end region

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -92,6 +92,11 @@
     fireCost: 80
   - type: Appearance
   - type: AmmoCounter
+  # region starlight
+  - type: Tag
+    taags:
+    - PaddyMech
+  # end region
 
 - type: entity
   id: WeaponMechCombatTeslaCannon
@@ -142,6 +147,11 @@
     fireCost: 60
   - type: Appearance
   - type: AmmoCounter
+  # region starlight
+  - type: Tag
+    taags:
+    - PaddyMech
+  # end region
 
 - type: entity
   id: WeaponMechCombatTaser
@@ -165,6 +175,11 @@
     fireCost: 40
   - type: Appearance
   - type: AmmoCounter
+  # region starlight
+  - type: Tag
+    taags:
+    - PaddyMech
+  # end region
 
 - type: entity
   id: WeaponMechCombatShotgun
@@ -188,6 +203,11 @@
     fireCost: 100
   - type: Appearance
   - type: AmmoCounter
+  # region starlight
+  - type: Tag
+    taags:
+    - PaddyMech
+  # end region
 
 - type: entity
   id: WeaponMechCombatShotgunIncendiary
@@ -392,3 +412,8 @@
     fireCost: 60
   - type: Appearance
   - type: AmmoCounter
+  # region starlight
+  - type: Tag
+    taags:
+    - PaddyMech
+  # end region

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -142,9 +142,6 @@
     fireCost: 60
   - type: Appearance
   - type: AmmoCounter
-  - type: Tag
-    tags:
-    - NonlethalMech
 
 - type: entity
   id: WeaponMechCombatTaser
@@ -168,9 +165,6 @@
     fireCost: 40
   - type: Appearance
   - type: AmmoCounter
-  - type: Tag
-    tags:
-    - NonlethalMech
 
 - type: entity
   id: WeaponMechCombatShotgun
@@ -242,7 +236,7 @@
     fireCost: 20
   - type: Appearance
   - type: AmmoCounter
-
+  
 - type: entity
   id: WeaponMechCombatIon
   name: Mk.IV Ion Heavy Cannon
@@ -271,7 +265,7 @@
   - type: Battery
     maxCharge: 400
     startingCharge: 400
-
+    
 - type: entity
   id: WeaponMechCombatAMLG90
   name: AMLG90
@@ -298,7 +292,7 @@
     fireCost: 20
   - type: Appearance
   - type: AmmoCounter
-
+  
 - type: entity
   id: WeaponMechCombatXray
   name: S-1 X-Ray Projector
@@ -398,6 +392,3 @@
     fireCost: 60
   - type: Appearance
   - type: AmmoCounter
-  - type: Tag
-    tags:
-    - NonlethalMech

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
@@ -18,3 +18,8 @@
       types:
         Structural: 35
         Piercing: 15
+  # region starlight
+  - type: Tag
+    taags:
+    - PaddyMech
+  # end region

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Melee/combat.yml
@@ -20,6 +20,6 @@
         Piercing: 15
   # region starlight
   - type: Tag
-    taags:
+    tags:
     - PaddyMech
   # end region

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -7,6 +7,7 @@
     equipmentWhitelist:
       tags:
       - CombatMech
+      - PaddyMech
 
 - type: entity
   id: IndustrialMech
@@ -325,7 +326,7 @@
   - type: Mech
     equipmentWhitelist:
       tags:
-      - CombatMech
+      - PaddyMech
       - IndustrialMech
     baseState: base
     openState: base-open

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -7,7 +7,6 @@
     equipmentWhitelist:
       tags:
       - CombatMech
-      - NonlethalMech
 
 - type: entity
   id: IndustrialMech
@@ -38,7 +37,7 @@
     equipmentWhitelist:
       tags:
       - SmallMech
-
+      
 - type: entity
   id: NanotrasenMech
   abstract: true
@@ -50,7 +49,7 @@
       path: /Audio/Mecha/lowpowernano.ogg
     nominalSound:
       path: /Audio/Mecha/nominalnano.ogg
-
+      
 - type: entity
   id: SyndieMech
   abstract: true
@@ -302,7 +301,7 @@
       - PowerCellHigh
       mech-gas-tank-slot:
       - MechAirTankFilled
-
+      
 # Paddy
 - type: entity
   id: MechPaddy
@@ -326,7 +325,7 @@
   - type: Mech
     equipmentWhitelist:
       tags:
-      - NonlethalMech
+      - CombatMech
       - IndustrialMech
     baseState: base
     openState: base-open
@@ -364,7 +363,7 @@
       - PowerCellHigh
       mech-gas-tank-slot:
       - MechAirTankFilled
-
+      
 - type: entity
   id: MechPaddyFilled
   parent: MechPaddyBattery

--- a/Resources/Prototypes/_StarLight/tags.yml
+++ b/Resources/Prototypes/_StarLight/tags.yml
@@ -133,6 +133,9 @@
   id: ModularBarrel
 
 - type: Tag
+  id: PaddyMech
+
+- type: Tag
   id: OmniCyberEyes
 
 - type: Tag

--- a/Resources/Prototypes/_StarLight/tags.yml
+++ b/Resources/Prototypes/_StarLight/tags.yml
@@ -133,9 +133,6 @@
   id: ModularBarrel
 
 - type: Tag
-  id: NonlethalMech
-
-- type: Tag
   id: OmniCyberEyes
 
 - type: Tag


### PR DESCRIPTION
## Short description
Gives Paddy access to basic lethals again.

## Why we need to add this
After a discussion following the merge of ss14Starlight/space-station-14#1773 it was decided that Paddy gets to keep access to basic lethals. Advanced lethals remain locked to the Gygax/Durand: Paddy being able to shoot missiles was admittedly a _LITTLE_ goofy.

## Media (Video/Screenshots)
## Checks
* [x]  I do not require assistance to complete the PR.
* [x]  Before posting/requesting review of a PR, I have verified that the changes work.
* [x]  I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
* [x]  I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog** 
:cl: RoadTrain
- tweak: The Paddy can use basic lethals.