### PR TITLE
Add insulated gloves and t-ray scanners to atmos lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -159,6 +159,8 @@
     - id: RCD
     - id: RCDAmmo
     - id: AirGrenade
+    - id: trayScanner # Starlight: Add t-ray scanner to atmos lockers
+    - id: ClothingHandsGlovesColorYellow # Starlight: Add insulated gloves to atmos lockers
 
 - type: entityTable
   id: FillAtmosphericsHardsuit


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

Adds insulated gloves and t-ray scanners to atmospheric technician lockers.

## Why we need to add this

Engineers get these by default, but atmospheric technicians don't currently. The result is that atmos techs can't actually gear up in one go, they instead either go raid a Station Engineer's lockers for insuls/t-rays, or have to find a vending machine to find them.

This regularly results in atmos techs going out to do repairs and getting shocked, after forgetting to find insuls outside of their locker, and then having to go back and forth between Engineering and the repair job to actually get it done. It's just pain for no gain.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/5001c6c4-2664-4c15-a09f-348d6b061e88


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: Added insulated gloves and t-ray scanners to Atmospheric Technician lockers

