### PR TITLE
Fix Air Alarms not warning about dangerously low Oxygen levels

### DIFF
--- a/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
+++ b/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
@@ -34,11 +34,11 @@
 - type: alarmThreshold
   id: stationOxygen
   lowerBound: !type:AlarmThresholdSetting
-    threshold: 0.10
+    threshold: 0.17 # Starlight: Was 0.10, now 0.17. Danger triggers <=17% oxygenation.
   upperBound: !type:AlarmThresholdSetting
     threshold: 0.3
   lowerWarnAround: !type:AlarmThresholdSetting
-    threshold: 1.5
+    threshold: 1.179 # Starlight: Was 1.5x, now 1.179x. Warning triggers <=20% oxygenation.
   upperWarnAround: !type:AlarmThresholdSetting
     threshold: 0.8
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

Reduces Air Alarm tolerance to low Oxygen levels, from the previous Warning at <15% and Danger <10%, to Warning <=20% and Danger <=17%.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Currently Air Alarms don't even enter Warning state while oxygen-breathers are literally suffocating:

<img width="1281" height="799" alt="evrNtR2eJQ" src="https://github.com/user-attachments/assets/ce6362af-0621-4b77-93ff-041fa48b87d8" />

This also results in people complaining and Atmos Techs not being able to find the location on the Atmospherics alerts console, to great annoyance of atmos players.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="1180" height="290" alt="image" src="https://github.com/user-attachments/assets/1755fc8d-53e0-4655-a775-6292613b7ab4" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: Air Alarms now actually warn about dangerously low oxygen levels
