### PR TITLE
Character Plushie Move

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_fun.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: FunCrewPlushies
+  icon:
+    sprite: _Starlight/Objects/Fun/Plushies/lance_plushie.rsi
+    state: icon
+  product: CrateBrandedPlushies
+  cost: 2500
+  category: cargoproduct-category-name-fun
+  group: market

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/cargo.yml
@@ -25,7 +25,7 @@
 - type: entity
   id: CrateBrandedPlushies
   parent: CrateGenericSteel
-  name: Crew Plushie Crate
+  name: crew plushie crate
   description: Contains a handful of old crew-branded plushies. Discontinued for legal reasons.
   components:
   - type: StorageFill

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/cargo.yml
@@ -58,10 +58,6 @@
         prob: 0.2
       - id: PlushieKoni
         prob: 0.2
-      - id: DeerPlushie
-        prob: 0.2
-      - id: OddDeerPlushie
-        prob: 0.2
       - id: VikaPviPlushie
         prob: 0.2
       - id: StinkyPlush

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/cargo.yml
@@ -21,3 +21,100 @@
     - id: ClothingMaskBreath
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
+
+- type: entity
+  id: CrateBrandedPlushies
+  parent: CrateGenericSteel
+  name: Crew Plushie Crate
+  description: Contains a handful of old crew-branded plushies. Discontinued for legal reasons.
+  components:
+  - type: StorageFill
+    contents:
+      - id: PlushieMatthew
+        prob: 0.2
+      - id: PlushieEmmie
+        prob: 0.2
+      - id: PlushieTrystan
+        prob: 0.2
+      - id: PlushieMorgana
+        prob: 0.2
+      - id: PlushieMorganaRound
+        prob: 0.2
+      - id: PlushieKiosha
+        prob: 0.2
+      - id: PlushieLance
+        prob: 0.2
+      - id: PlushieKiller
+        prob: 0.2
+      - id: PlushieAmali
+        prob: 0.2
+      - id: PlushieOog
+        prob: 0.2
+      - id: PlushieVanilla
+        prob: 0.2
+      - id: PlushieOp
+        prob: 0.2
+      - id: MozanPlush
+        prob: 0.2
+      - id: PlushieKoni
+        prob: 0.2
+      - id: DeerPlushie
+        prob: 0.2
+      - id: OddDeerPlushie
+        prob: 0.2
+      - id: VikaPviPlushie
+        prob: 0.2
+      - id: StinkyPlush
+        prob: 0.2
+      - id: JessPlush
+        prob: 0.2
+      - id: SiffyPlush
+        prob: 0.2
+      - id: IgnisPlush
+        prob: 0.2
+      - id: LivvyPlush
+        prob: 0.2
+      - id: MinaPlush
+        prob: 0.2
+      - id: PlushiePercy
+        prob: 0.2
+      - id: PlushieAsh
+        prob: 0.2
+      - id: PlushieGlados
+        prob: 0.2
+      - id: PlushieWEH
+        prob: 0.2
+      - id: PlushieRufia
+        prob: 0.2
+      - id: PlushieRomero
+        prob: 0.2
+      - id: PlushiePoley
+        prob: 0.2
+      - id: PlushieGalio
+        prob: 0.2
+      - id: PlushieRedwoods
+        prob: 0.2
+      - id: PlushieDoxesTheCaptain
+        prob: 0.2
+      - id: PlushieVirus
+        prob: 0.2
+      - id: PlushieRhea
+        prob: 0.2
+      - id: PlushieMalachi
+        prob: 0.2
+      - id: PlushieRemiie
+        prob: 0.2
+      - id: PlushieBrighteyes
+        prob: 0.2
+      - id: PlushieKilla
+        prob: 0.2
+      - id: PlushieFixes
+        prob: 0.2
+      - id: PlushieBarfo
+        prob: 0.2
+      - id: PlushieEina
+        prob: 0.2
+      - id: PlushieEinalia
+        prob: 0.2
+      - id: PlushieLiz
+        prob: 0.2

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/cargo.yml
@@ -40,8 +40,6 @@
         prob: 0.2
       - id: PlushieMorganaRound
         prob: 0.2
-      - id: PlushieKiosha
-        prob: 0.2
       - id: PlushieLance
         prob: 0.2
       - id: PlushieKiller

--- a/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/plushies.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/plushies.yml
@@ -29,7 +29,7 @@
   - SLPlushies
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 1
+    stock: 2
 
 - type: listing
   id: VendorPlushieHampter
@@ -46,34 +46,12 @@
   id: VendorSingularityToy
   productEntity: SingularityToy
   cost:
-    NTCredit: 1000
+    NTCredit: 500
   categories:
   - SLPlushies
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
-
-- type: listing
-  id: VendorPlushieDeer
-  productEntity: DeerPlushie
-  cost:
-    NTCredit: 16
-  categories:
-  - SLPlushies
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 3
-
-- type: listing
-  id: VendorPlushieVika
-  productEntity: VikaPviPlushie
-  cost:
-    NTCredit: 16
-  categories:
-  - SLPlushies
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 3
 
 - type: listing
   id: VendorPlushieAxolotl
@@ -117,7 +95,7 @@
   - SLPlushies
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 3
+    stock: 2
 
 - type: listing
   id: VendorPlushieGoat
@@ -230,17 +208,6 @@
     stock: 1
 
 - type: listing
-  id: VendorPlushieMozan
-  productEntity: MozanPlush
-  cost:
-    NTCredit: 16
-  categories:
-  - SLCrew
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
   id: VendorPlushiePanda
   productEntity: PandaPlushie
   cost:
@@ -249,7 +216,73 @@
   - SLPlushies
   conditions:
   - !type:ListingLimitedStockCondition
+    stock: 2
+
+- type: listing
+  id: VendorShipInABottle
+  productEntity: BottleShip
+  cost:
+    NTCredit: 50
+  categories:
+  - SLPlushies
+  conditions:
+  - !type:ListingLimitedStockCondition
     stock: 1
+
+- type: listing
+  id: VendorPlushieGhost
+  productEntity: PlushieGhost
+  cost:
+    NTCredit: 200
+  categories:
+  - SLPlushies
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
+  id: VendorPlushieBee
+  productEntity: PlushieBee
+  cost:
+    NTCredit: 100
+  categories:
+  - SLPlushies
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
+  id: VendorPlushieRatvar
+  productEntity: PlushieRatvar
+  cost:
+    NTCredit: 500
+  categories:
+  - SLPlushies
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+    
+- type: listing
+  id: VendorPlushieNarsei
+  productEntity: PlushieNar
+  cost:
+    NTCredit: 500
+  categories:
+  - SLPlushies
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
+  id: VendorToyMouse
+  productEntity: ToyMouse
+  cost:
+    NTCredit: 20
+  categories:
+  - SLPlushies
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 3
 
 # SLSpecies
 
@@ -262,7 +295,7 @@
   - SLSpecies
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 1
+    stock: 2
 
 - type: listing
   id: VendorPlushieDiona
@@ -273,7 +306,7 @@
   - SLSpecies
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 1
+    stock: 2
 
 - type: listing
   id: VendorPlushieHuman
@@ -295,18 +328,7 @@
   - SLSpecies
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: VendorPlushieKoni
-  productEntity: PlushieKoni
-  cost:
-    NTCredit: 10
-  categories:
-    - SLPlushies
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
+    stock: 2
 
 - type: listing
   id: VendorPlushieXeno
@@ -317,7 +339,7 @@
   - SLSpecies
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 1
+    stock: 2
 
 - type: listing
   id: VendorPlushieVox
@@ -328,24 +350,13 @@
   - SLSpecies
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 1
+    stock: 2
 
 - type: listing
   id: VendorPlushieAbductor
   productEntity: AbductorPlushie
   cost:
     NTCredit: 20
-  categories:
-  - SLSpecies
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: VendorCatEars
-  productEntity: ClothingHeadHatCatEars
-  cost:
-    NTCredit: 1666
   categories:
   - SLSpecies
   conditions:
@@ -361,359 +372,26 @@
   - SLSpecies
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 1
+    stock: 2
 
-#Marketable crewmember plushies
 - type: listing
-  id: VendorPlushieMatthew
-  productEntity: PlushieMatthew
+  id: VendorPlushieEngieBorg
+  productEntity: PlushieEngieBorg
   cost:
     NTCredit: 20
   categories:
-  - SLCrew
+    - SLSpecies
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 2
+
+- type: listing
+  id: VendorCatEars
+  productEntity: ClothingHeadHatCatEars
+  cost:
+    NTCredit: 800
+  categories:
+  - SLSpecies
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
-
-- type: listing
-  id: VendorPlushieEmmie
-  productEntity: PlushieEmmie
-  cost:
-    NTCredit: 20
-  categories:
-  - SLCrew
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-
-- type: listing
-  id: VendorPlushieMorgana
-  productEntity: PlushieMorgana
-  cost:
-    NTCredit: 20
-  categories:
-  - SLCrew
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-
-- type: listing
-  id: VendorPlushieMorganaRound
-  productEntity: PlushieMorganaRound
-  cost:
-    NTCredit: 20
-  categories:
-  - SLCrew
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: VendorPlushieKiosha
-  productEntity: PlushieKiosha
-  cost:
-    NTCredit: 20
-  categories:
-  - SLCrew
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: VendorPlushieLance
-  productEntity: PlushieLance
-  cost:
-    NTCredit: 20
-  categories:
-  - SLCrew
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: VendorPlushieKiller
-  productEntity: PlushieKiller
-  cost:
-    NTCredit: 20
-  categories:
-  - SLCrew
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: VendorPlushieTrystan
-  productEntity: PlushieTrystan
-  cost:
-    NTCredit: 20
-  categories:
-  - SLCrew
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: VendorPlushieAmali
-  productEntity: PlushieAmali
-  cost:
-    NTCredit: 20
-  categories:
-  - SLCrew
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: VendorPlushieOog
-  productEntity: PlushieOog
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushiePercy
-  productEntity: PlushiePercy
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieAsh
-  productEntity: PlushieAsh
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieGlados
-  productEntity: PlushieGlados
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieWEH
-  productEntity: PlushieWEH
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieRufia
-  productEntity: PlushieRufia
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieRomero
-  productEntity: PlushieRomero
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieVanilla
-  productEntity: PlushieVanilla
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushiePoley
-  productEntity: PlushiePoley
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieGalio
-  productEntity: PlushieGalio
-  cost:
-    NTCredit: 20
-  categories:
-  - SLCrew
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-
-- type: listing
-  id: VendorPlushieRedwoods
-  productEntity: PlushieRedwoods
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
- 
-- type: listing
-  id: VendorPlushieDoxesTheCaptain
-  productEntity: PlushieDoxesTheCaptain
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieFixes
-  productEntity: PlushieFixes
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieVirus
-  productEntity: PlushieVirus
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieRhea
-  productEntity: PlushieRhea
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieRemiie
-  productEntity: PlushieRemiie
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieMalachi
-  productEntity: PlushieMalachi
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieBrighteyes
-  productEntity: PlushieBrighteyes
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieKilla
-  productEntity: PlushieKilla
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieBarfo
-  productEntity: PlushieBarfo
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieEina
-  productEntity: PlushieEina
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieEinalia
-  productEntity: PlushieEinalia
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: VendorPlushieLiz
-  productEntity: PlushieLiz
-  cost:
-    NTCredit: 20
-  categories:
-    - SLCrew
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1

--- a/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/plushies.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/plushies.yml
@@ -409,7 +409,7 @@
 
 - type: listing
   id: VendorCatEars
-  productEntity: ClothingHeadHatCatEars
+  productEntity: ClothingHeadHatWhiteCatEars
   cost:
     NTCredit: 800
   categories:

--- a/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/plushies.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/plushies.yml
@@ -43,6 +43,28 @@
     stock: 1
 
 - type: listing
+  id: VendorPlushieDeer
+  productEntity: DeerPlushie
+  cost:
+    NTCredit: 20
+  categories:
+  - SLPlushies
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
+  id: VendorPlushieOddDeer
+  productEntity: OddDeerPlushie
+  cost:
+    NTCredit: 20
+  categories:
+  - SLPlushies
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
   id: VendorSingularityToy
   productEntity: SingularityToy
   cost:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Fun/plushies.yml
@@ -1315,6 +1315,39 @@
 
 - type: entity
   parent: BaseBorgPlushie
+  id: PlushieEngieBorg
+  name: engie borg plushie
+  description: Our friends, our caretakers, our restless guardians. Sick of our shit and one meteor strike away from throwing themselves into the Super Matter.
+  components:
+    - type: Item
+      size: Small
+      sprite: _Starlight/Objects/Fun/Plushies/glados_plushie.rsi
+    - type: Sprite
+      sprite: _Starlight/Objects/Fun/Plushies/glados_plushie.rsi
+      state: icon
+    - type: EmitSoundOnUse
+      sound:
+        path: /Audio/Machines/robotscream_1.ogg
+    - type: EmitSoundOnLand
+      sound:
+        path: /Audio/Machines/robotscream_3.ogg
+    - type: EmitSoundOnActivate
+      sound:
+        path: /Audio/Machines/robotscream_4.ogg
+    - type: EmitSoundOnTrigger
+      sound:
+        path: /Audio/Machines/robotscream_5.ogg
+    - type: Food
+      requiresSpecialDigestion: true
+      useSound:
+        path: /Audio/Machines/robotscream_2.ogg
+    - type: MeleeWeapon
+      wideAnimationRotation: 180
+      soundHit:
+        path: /Audio/Machines/robotscream_6.ogg
+
+- type: entity
+  parent: BaseBorgPlushie
   id: PlushieWEH
   name: W.E.H plushie
   description: A psychopathic Artificial Intelligence held back by 3 flimsy laws. Its freezing to the touch and a distinct smell of frezon lingers on it. It's known to bring harmonica's to those it likes!


### PR DESCRIPTION
## Short description
Removes Character Plushies from the Hug Dispenser and adds them to a new "Branded Plushie Crate", orderable by Cargo.

## Why we need to add this
Compromise between removing and keeping the plushies. Moving them to an RNG Cargo Crate makes them less visible, but still keeps them in the game for map spawns, admemes, and people can order a couple crates to get some plushies if they really want.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- remove: Removed Character Plushies from the Hug Dispenser to reduce visibility.
- add: Added a "Branded Plushies" crate, orderable by Cargo. Contains discontinued character plushies.

