### PR TITLE
replace infinite trinket crayon with normal crayon

### DIFF
--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
@@ -423,7 +423,7 @@
         time: 36000 # 10hr
   storage:
     back:
-      - CrayonMagic
+      - CrayonRainbow
 
 - type: loadout
   id: HappyHonk


### PR DESCRIPTION

## Short description
Enacting dystopian futures

Replace the free 2 billion use any colour crayon in trinkets with a normal 30 use rainbow crayon

## Why we need to add this
people painting all of manor causing decal system to shit itself and use more compute than physics

## Media (Video/Screenshots)
<img width="1673" height="1079" alt="Screenshot_20251003_175627" src="https://github.com/user-attachments/assets/6731855b-dbbe-401b-9034-0afa8f3bebf0" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- tweak: Replaced 2 billion use trinket crayon with 30 use crayon
