### PR TITLE
Make Air Alarms less tolerant to cold

### DIFF
--- a/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
+++ b/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
@@ -12,11 +12,11 @@
   upperBound: !type:AlarmThresholdSetting
     threshold: 393.15 # T20C + 200
   lowerBound: !type:AlarmThresholdSetting
-    threshold: 193.15 # T20C - 100
+    threshold: 233.15 # T20C - 100 # Starlight: Was -80C. Changed to -40C.
   upperWarnAround: !type:AlarmThresholdSetting
     threshold: 0.8
   lowerWarnAround: !type:AlarmThresholdSetting
-    threshold: 1.1
+    threshold: 1.1286 # Starlight: Was -60C. Changed to -10C (when uninsulated reptilians start taking damage).
 
 - type: alarmThreshold
   id: stationPressure


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

Reduce Air Alarm tolerance to cold, from -60C warning and -80C danger, to -10C as warning and -40C as danger.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

In short: Un-insulated players actively take cold damage before air alarms even enter Warning state.

Mostly for atmos techs, but reptilian players are also positively affected. People get cold warnings on their HUD pretty early, and from my testing un-insulated reptilians start taking damage if idle in a -10C room. Previously the air alarms didn't even react until **-60C**!

For the atmos techs: If the air alarms are all green and happy while people start taking cold damage, it's truly a pain to actually determine where the problem is.

I feel like there might be good reasons for the current settings, so please let me know if you disagree or have important things to take into consideration.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Changes
<img width="791" height="669" alt="image" src="https://github.com/user-attachments/assets/9329b852-7de4-455d-82c1-92b3a4980caf" />

### Demonstration of reptilians taking damage at -10C

https://github.com/user-attachments/assets/ab310046-2ff2-481d-98a3-ed282bd54a2e


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: Air alarms now react to cold sooner
