### PR TITLE
Increase Air Alarm tolerance for high Oxygen levels

### DIFF
--- a/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
+++ b/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
@@ -36,11 +36,11 @@
   lowerBound: !type:AlarmThresholdSetting
     threshold: 0.10
   upperBound: !type:AlarmThresholdSetting
-    threshold: 0.7 # Starlight: Was 30% o2, now 70% o2. Excluding Vox, zero species are negatively affected until >85%.
+    threshold: 0.45 # Starlight: Was 30% o2, now 45% o2.
   lowerWarnAround: !type:AlarmThresholdSetting
     threshold: 1.5
   upperWarnAround: !type:AlarmThresholdSetting
-    threshold: 0.858 # Starlight: Was 0.8x, now 0.858x. Warning triggers >60.1% oxygenation.
+    threshold: 0.8 # Starlight: Was 0.8x, now 0.8x. Warning triggers >=36% oxygenation.
 
 - type: alarmThreshold
   id: stationNitrogen

--- a/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
+++ b/Resources/Prototypes/Atmospherics/Thresholds/airalarms.yml
@@ -36,11 +36,11 @@
   lowerBound: !type:AlarmThresholdSetting
     threshold: 0.10
   upperBound: !type:AlarmThresholdSetting
-    threshold: 0.3
+    threshold: 0.7 # Starlight: Was 30% o2, now 70% o2. Excluding Vox, zero species are negatively affected until >85%.
   lowerWarnAround: !type:AlarmThresholdSetting
     threshold: 1.5
   upperWarnAround: !type:AlarmThresholdSetting
-    threshold: 0.8
+    threshold: 0.858 # Starlight: Was 0.8x, now 0.858x. Warning triggers >60.1% oxygenation.
 
 - type: alarmThreshold
   id: stationNitrogen


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Fixes Air Alarms entering Warning or Danger state from higher oxygenation levels despite posing no significant threat.

- Significantly increase warn/danger thresholds for **high** oxygen levels
  - Zero races (ex. Vox) negatively affected by high oxygen levels, yet cause of a lot of false positives
  - Danger was >=30%, changed to >=45%
  - Warning was >=24%, changed to >=36%

## Why we need to add this

As an atmos main, quite frequently the air alarm console is lighting up showing the Warning or Danger sprite for situations that are entirely unimportant and not dangerous in the least. (This PR is part of several to tweak Air Alarms to be more sensible in real-world scenarios).

Most common I've seen is higher oxygen percentages caused by opening of oxygen tanks or cans. Prior to this PR, every few shifts you would see anywhere from 1 to 10 air alarms in Warning state for completely harmless but slightly-higher-than-normal (e.g.: 34%) oxygen levels. From my testing anywhere below 80% oxygen in the atmosphere is completely harmless to every race (excluding Vox ofcourse).

This 'boy who cried wolf' effect makes it basically impossible to tell if the atmospherics need attention without manually clicking through every single warning/danger Air Alarm. It's quite miserable if you want to actually do your job.

Of course, you can suppress an individual air alarm entirely, but this makes it impossible to see if it it's still a false positive or an actual atmospheric emergency.

## Media (Video/Screenshots)

<img width="1200" height="323" alt="image" src="https://github.com/user-attachments/assets/9bf9dc6b-e8b2-4229-93dd-a31e873e623c" />

<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: Increased Air Alarm tolerances for high oxygen levels

