### PR TITLE
Moppies

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -482,7 +482,7 @@
 
 - type: entity
   name: mothroach
-  parent: MobCockroach
+  parent: SimpleMobBase
   id: MobMothroach
   description: This is the adorable by-product of multiple attempts at genetically mixing mothpeople with cockroaches.
   components:
@@ -494,6 +494,11 @@
     - Moffic
     - Mothroach
   # Starlight-end
+  - type: VentCrawler
+  - type: HTN
+    constantlyReplan: false
+    rootTask:
+      task: MouseCompound
   - type: GhostRole
     makeSentient: true
     allowSpeech: true
@@ -523,6 +528,7 @@
     insertingState: inserting_mothroach
   - type: MothAccent
   - type: Sprite
+    drawdepth: SmallMobs
     sprite: Mobs/Animals/mothroach/mothroach.rsi
     layers:
     - map: ["enum.DamageStateVisualLayers.Base", "movement"]
@@ -551,6 +557,7 @@
         Base: mothroach_dead
       Dead:
         Base: mothroach_dead
+  - type: MobState
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -567,6 +574,7 @@
     damageModifierSet: Moth
   - type: Bloodstream
     bloodReagent: InsectBlood
+    bloodMaxVolume: 50
   - type: Respirator
     damage:
       types:
@@ -575,12 +583,34 @@
       types:
         Asphyxiation: -0.5
   - type: CombatMode
+  - type: MeleeWeapon
+    soundHit:
+      path: /Audio/Effects/bite.ogg
+    damage:
+      types:
+        Piercing: 0
+  - type: Food
+    requireDead: true
+    transferAmount: 2
+  - type: FlavorProfile
+    flavors:
+    - horrible
+    - terrible
+    - chewy
+  - type: Hunger
+    baseDecayRate: 0.25
+  - type: Extractable
+    grindableSolutionName: food
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        reagents:
+        - ReagentId: Slime
+          Quantity: 5
   - type: Butcherable
     spawned:
     - id: FoodMeatSlime
       amount: 2
-  - type: Extractable
-    grindableSolutionName: food
   - type: ZombieAccentOverride
     accent: zombieMoth
   - type: Vocal
@@ -591,6 +621,7 @@
     wilhelmProbability: 0.001
   - type: MobPrice
     price: 150
+  - type: BadFood
   - type: Tag
     tags:
     - Trash
@@ -3938,3 +3969,4 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
+

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -504,8 +504,8 @@
       fixtures:
         fix1:
           shape: !type:PhysShapeCircle
-            radius: 0.2
-          density: 120
+            radius: 0.3
+          density: 180
           mask:
             - SmallMobMask
           layer:
@@ -532,7 +532,7 @@
         movement:
           state: mothroach
     - type: Item
-      size: Normal
+      size: Small
     - type: Clothing
       quickEquip: false
       sprite: Mobs/Animals/mothroach/mothroach.rsi
@@ -549,14 +549,21 @@
         Dead:
           Base: mothroach_dead
     - type: MobState
+    - type: Deathgasp
+    - type: MobStateActions
+      actions:
+        Critical:
+          - ActionCritSuccumb
+          - ActionCritFakeDeath
+          - ActionCritLastWords
     - type: MobThresholds
       thresholds:
         0: Alive
-        40: Critical
-        60: Dead
+        55: Critical
+        90: Dead
     - type: MovementSpeedModifier
-      baseWalkSpeed: 2.5
-      baseSprintSpeed: 4
+      baseWalkSpeed: 2.4
+      baseSprintSpeed: 4.2
       weightlessAcceleration: 1.5
       weightlessFriction: 1
       baseWeightlessModifier: 1
@@ -565,7 +572,7 @@
       damageModifierSet: Moth
     - type: Bloodstream
       bloodReagent: InsectBlood
-      bloodMaxVolume: 50
+      bloodMaxVolume: 120
     - type: Respirator
       damage:
         types:
@@ -573,35 +580,56 @@
       damageRecovery:
         types:
           Asphyxiation: -0.5
+    - type: Barotrauma
+      damage:
+        types:
+          Blunt: 0.08
     - type: CombatMode
     - type: MeleeWeapon
       soundHit:
         path: /Audio/Effects/bite.ogg
+      angle: 0
+      animation: WeaponArcBite
       damage:
         types:
-          Piercing: 0
+          Piercing: 1
+    - type: InteractionPopup
+      successChance: 0.8
+      interactDelay: 1.2
+      interactSuccessString: petting-success-soft-floofy
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/fox_squeak.ogg
     - type: Food
       requireDead: true
-      transferAmount: 2
+      transferAmount: 4
     - type: FlavorProfile
       flavors:
         - horrible
         - terrible
         - chewy
     - type: Hunger
-      baseDecayRate: 0.25
+      baseDecayRate: 0.3
     - type: Extractable
       grindableSolutionName: food
     - type: SolutionContainerManager
       solutions:
         food:
+          maxVol: 120
           reagents:
+            - ReagentId: Nutriment
+              Quantity: 12
+            - ReagentId: Protein
+              Quantity: 6
+            - ReagentId: InsectBlood
+              Quantity: 90
             - ReagentId: Slime
-              Quantity: 5
+              Quantity: 8
     - type: Butcherable
       spawned:
         - id: FoodMeatSlime
-          amount: 2
+          amount: 3
     - type: ZombieAccentOverride
       accent: zombieMoth
     - type: Vocal
@@ -618,7 +646,10 @@
         - Trash
         - CannotSuicide
         - VimPilot
+        - ChefPilot
+        - Meat
     - type: CanEscapeInventory
+      baseResistTime: 4
     - type: NpcFactionMember
       factions:
         - Mouse
@@ -630,7 +661,7 @@
       thresholds:
         - trigger: !type:DamageTypeTrigger
             damageType: Blunt
-            damage: 60
+            damage: 90
           behaviors:
             - !type:GibBehavior
               recursive: false

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1,202 +1,197 @@
 - type: entity
   name: bat
-  parent: [ SimpleMobBase, FlyingMobBase, MobCombat ]
+  parent: [SimpleMobBase, FlyingMobBase, MobCombat]
   id: MobBat
   description: Some cultures find them terrifying, others crunchy on the teeth.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Bat
-    understands:
-    - Bat
-    - GalacticCommon
-  # Starlight-end
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 3
-    baseSprintSpeed : 6
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: bat
-      sprite: Mobs/Animals/bat.rsi
-  - type: Speech
-    speechSounds: Squeak
-    speechVerb: SmallMob
-    allowedEmotes: ['Squeak']
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.25
-        density: 10
-        mask:
-        - FlyingMobMask
-        layer:
-        - FlyingMobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: bat
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 1
-  - type: InteractionPopup
-    successChance: 0.2
-    interactSuccessString: petting-success-soft-floofy
-    interactFailureString: petting-failure-bat
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/fox_squeak.ogg
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-organic
-  - type: Bloodstream
-    bloodMaxVolume: 50
-  - type: MeleeWeapon
-    soundHit:
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Bat
+      understands:
+        - Bat
+        - GalacticCommon
+    # Starlight-end
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 3
+      baseSprintSpeed: 6
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: bat
+          sprite: Mobs/Animals/bat.rsi
+    - type: Speech
+      speechSounds: Squeak
+      speechVerb: SmallMob
+      allowedEmotes: ["Squeak"]
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.25
+          density: 10
+          mask:
+            - FlyingMobMask
+          layer:
+            - FlyingMobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: bat
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 1
+    - type: InteractionPopup
+      successChance: 0.2
+      interactSuccessString: petting-success-soft-floofy
+      interactFailureString: petting-failure-bat
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/fox_squeak.ogg
+    - type: SentienceTarget
+      flavorKind: station-event-random-sentience-flavor-organic
+    - type: Bloodstream
+      bloodMaxVolume: 50
+    - type: MeleeWeapon
+      soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
-    animation: WeaponArcBite
-    damage:
-      types:
-        Piercing: 5
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      30: Critical
-      60: Dead
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 120
-      behaviors:
-      - !type:GibBehavior
-        recursive: false
-  - type: Tag
-    tags:
-    - VimPilot
+      angle: 0
+      animation: WeaponArcBite
+      damage:
+        types:
+          Piercing: 5
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        30: Critical
+        60: Dead
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTypeTrigger
+            damageType: Blunt
+            damage: 120
+          behaviors:
+            - !type:GibBehavior
+              recursive: false
+    - type: Tag
+      tags:
+        - VimPilot
 
 - type: entity
   name: bee
-  parent: [ SimpleMobBase, FlyingMobBase ]
+  parent: [SimpleMobBase, FlyingMobBase]
   id: MobBee
   description: Nice to have, but you can't build a civilization on a foundation of honey alone.
   components:
-  - type: CombatMode
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 3
-    baseSprintSpeed : 7
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: 0
-      sprite: Mobs/Animals/bee.rsi
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.1
-        density: 30
-        mask:
-        - FlyingMobMask
-        layer:
-        - FlyingMobLayer
-  - type: MobState
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      10: Dead
-  - type: Stamina
-    critThreshold: 10
-    animationThreshold: 1
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: 0
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Extractable
-    grindableSolutionName: food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: GroundBee
-          Quantity: 1
-  - type: Butcherable
-    spawned:
-    - id: null # Should give nothing when you butcher it so we set the item id it needs to spawn to null
-  - type: Item
-    size: Tiny
-  - type: Tag
-    tags:
-    - Bee
-    - Trash
-  - type: Bloodstream
-    bloodReagent: InsectBlood
-    bloodMaxVolume: 0.1
-  - type: MobPrice
-    price: 50
-  - type: NPCRetaliation
-  - type: FactionException
-  - type: NpcFactionMember
-    factions:
-    - Passive
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
-  - type: ZombieImmune
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 20
-      behaviors:
-      - !type:GibBehavior
-        recursive: false
+    - type: CombatMode
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 3
+      baseSprintSpeed: 7
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: 0
+          sprite: Mobs/Animals/bee.rsi
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.1
+          density: 30
+          mask:
+            - FlyingMobMask
+          layer:
+            - FlyingMobLayer
+    - type: MobState
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        10: Dead
+    - type: Stamina
+      critThreshold: 10
+      animationThreshold: 1
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: 0
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Extractable
+      grindableSolutionName: food
+    - type: SolutionContainerManager
+      solutions:
+        food:
+          reagents:
+            - ReagentId: GroundBee
+              Quantity: 1
+    - type: Butcherable
+      spawned:
+        - id: null # Should give nothing when you butcher it so we set the item id it needs to spawn to null
+    - type: Item
+      size: Tiny
+    - type: Tag
+      tags:
+        - Bee
+        - Trash
+    - type: Bloodstream
+      bloodReagent: InsectBlood
+      bloodMaxVolume: 0.1
+    - type: MobPrice
+      price: 50
+    - type: NPCRetaliation
+    - type: FactionException
+    - type: NpcFactionMember
+      factions:
+        - Passive
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound
+    - type: ZombieImmune
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTypeTrigger
+            damageType: Blunt
+            damage: 20
+          behaviors:
+            - !type:GibBehavior
+              recursive: false
 
 - type: entity
   name: bee
   suffix: Angry
-  parent: [ MobBee, MobCombat ]
+  parent: [MobBee, MobCombat]
   id: MobAngryBee
   description: How nice a bee. Oh no, it looks angry and wants my pizza.
   components:
-  - type: CombatMode
-  - type: MeleeWeapon
-    angle: 0
-    animation: WeaponArcBite
-    damage:
-      types:
-        Poison: 2
-        Piercing: 1
-  - type: InputMover
-  - type: MobMover
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
-  - type: NpcFactionMember
-    factions:
-    - SimpleHostile
-  - type: Bloodstream
-    bloodMaxVolume: 0.1
-  - type: ZombieImmune
-
+    - type: CombatMode
+    - type: MeleeWeapon
+      angle: 0
+      animation: WeaponArcBite
+      damage:
+        types:
+          Poison: 2
+          Piercing: 1
+    - type: InputMover
+    - type: MobMover
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound
+    - type: NpcFactionMember
+      factions:
+        - SimpleHostile
+    - type: Bloodstream
+      bloodMaxVolume: 0.1
+    - type: ZombieImmune
 
 - type: entity
   name: chicken
@@ -204,154 +199,153 @@
   id: MobChicken
   description: Comes before an egg, and IS a dinosaur!
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Chicken
-    understands:
-    - Chicken
-  # Starlight-end
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: chicken-0
-      sprite: Mobs/Animals/chicken.rsi
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: chicken-moving-0
-    noMovementLayers:
-      movement:
-        state: chicken-0
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 8
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Speech
-    speechVerb: SmallMob
-    speechSounds: Cluck
-  - type: Tag
-    tags:
-    - DoorBumpOpener
-    - Chicken
-    - VimPilot
-  - type: Reproductive
-    breedChance: 0.05
-    birthPopup: reproductive-laid-egg-popup
-    makeOffspringInfant: false
-    partnerWhitelist:
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Chicken
+      understands:
+        - Chicken
+    # Starlight-end
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: chicken-0
+          sprite: Mobs/Animals/chicken.rsi
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: chicken-moving-0
+      noMovementLayers:
+        movement:
+          state: chicken-0
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 8
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Speech
+      speechVerb: SmallMob
+      speechSounds: Cluck
+    - type: Tag
       tags:
-      - Chicken
-    offspring:
-    - id: FoodEggChickenFertilized
-      maxAmount: 3
-  - type: ReproductivePartner
-  - type: Appearance
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: chicken-0
-      Critical:
-        Base: dead-0
-      Dead:
-        Base: dead-0
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatChicken
-      amount: 1
-  - type: InteractionPopup
-    successChance: 0.8
-    interactSuccessString: petting-success-bird
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/chicken_cluck_happy.ogg
-  - type: Bloodstream
-    bloodMaxVolume: 100
-  - type: EggLayer
-    eggSpawn:
-    - id: FoodEgg
-  - type: ExaminableHunger
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-organic
-  - type: NpcFactionMember
-    factions:
-    - Passive
+        - DoorBumpOpener
+        - Chicken
+        - VimPilot
+    - type: Reproductive
+      breedChance: 0.05
+      birthPopup: reproductive-laid-egg-popup
+      makeOffspringInfant: false
+      partnerWhitelist:
+        tags:
+          - Chicken
+      offspring:
+        - id: FoodEggChickenFertilized
+          maxAmount: 3
+    - type: ReproductivePartner
+    - type: Appearance
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: chicken-0
+        Critical:
+          Base: dead-0
+        Dead:
+          Base: dead-0
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatChicken
+          amount: 1
+    - type: InteractionPopup
+      successChance: 0.8
+      interactSuccessString: petting-success-bird
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/chicken_cluck_happy.ogg
+    - type: Bloodstream
+      bloodMaxVolume: 100
+    - type: EggLayer
+      eggSpawn:
+        - id: FoodEgg
+    - type: ExaminableHunger
+    - type: SentienceTarget
+      flavorKind: station-event-random-sentience-flavor-organic
+    - type: NpcFactionMember
+      factions:
+        - Passive
 
 - type: entity
   parent: MobChicken
   id: MobChicken1
   components:
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: chicken-1
-      sprite: Mobs/Animals/chicken.rsi
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: chicken-moving-1
-    noMovementLayers:
-      movement:
-        state: chicken-1
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: chicken-1
-      Critical:
-        Base: dead-1
-      Dead:
-        Base: dead-1
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: chicken-1
+          sprite: Mobs/Animals/chicken.rsi
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: chicken-moving-1
+      noMovementLayers:
+        movement:
+          state: chicken-1
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: chicken-1
+        Critical:
+          Base: dead-1
+        Dead:
+          Base: dead-1
 
 - type: entity
   parent: MobChicken
   id: MobChicken2
   components:
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: chicken-2
-      sprite: Mobs/Animals/chicken.rsi
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: chicken-moving-2
-    noMovementLayers:
-      movement:
-        state: chicken-2
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: chicken-2
-      Critical:
-        Base: dead-2
-      Dead:
-        Base: dead-2
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: chicken-2
+          sprite: Mobs/Animals/chicken.rsi
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: chicken-moving-2
+      noMovementLayers:
+        movement:
+          state: chicken-2
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: chicken-2
+        Critical:
+          Base: dead-2
+        Dead:
+          Base: dead-2
 
 - type: entity
   id: FoodEggChickenFertilized
   parent: FoodEgg
   suffix: Fertilized, Chicken
   components:
-  - type: Timer
-  - type: TimedSpawner
-    prototypes:
-    - MobChicken
-    - MobChicken1
-    - MobChicken2
-    intervalSeconds: 20
-    minimumEntitiesSpawned: 1
-    maximumEntitiesSpawned: 1
-  - type: TimedDespawn #delete the egg after the chicken spawns
-    lifetime: 21
+    - type: Timer
+    - type: TimedSpawner
+      prototypes:
+        - MobChicken
+        - MobChicken1
+        - MobChicken2
+      intervalSeconds: 20
+      minimumEntitiesSpawned: 1
+      maximumEntitiesSpawned: 1
+    - type: TimedDespawn #delete the egg after the chicken spawns
+      lifetime: 21
 
 - type: entity # TODO: figure out how to make these guys gib when stepped on
   name: cockroach
@@ -359,94 +353,92 @@
   id: MobCockroach
   description: This station is just crawling with bugs.
   components:
-  - type: VentCrawler
-  - type: Sprite
-    drawdepth: SmallMobs
-    sprite: Mobs/Animals/cockroach.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: cockroach
-  - type: Item
-    size: Tiny
-  - type: HTN
-    constantlyReplan: false
-    rootTask:
-      task: MouseCompound
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.2
-        density: 100
-        mask:
-        - SmallMobMask
-        layer:
-        - SmallMobLayer
-  - type: MobState
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      1: Dead
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
-    baseSprintSpeed : 5
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: cockroach
-      Critical:
-        Base: cockroach_dead
-      Dead:
-        Base: cockroach_dead
-  - type: Bloodstream
-    bloodReagent: InsectBlood
-    bloodMaxVolume: 20
-  - type: Food
-  - type: FlavorProfile
-    flavors:
-    - horrible
-    - terrible
-    - chewy
-  - type: Hunger
-    baseDecayRate: 0.25
-  - type: Extractable
-    grindableSolutionName: food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: Slime
-          Quantity: 5
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatSlime
-  - type: Damageable
-    damageContainer: Biological
-    damageModifierSet: Cockroach
-  - type: Tag
-    tags:
-    - Trash
-    - VimPilot
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 10
-      behaviors:
-      - !type:GibBehavior
-        recursive: false
-  - type: NonSpreaderZombie
-  - type: MeleeWeapon
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    angle: 0
-    animation: WeaponArcBite
-    damage:
-      types:
-        Piercing: 0
+    - type: VentCrawler
+    - type: Sprite
+      drawdepth: SmallMobs
+      sprite: Mobs/Animals/cockroach.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: cockroach
+    - type: Item
+      size: Tiny
+    - type: HTN
+      constantlyReplan: false
+      rootTask:
+        task: MouseCompound
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.2
+          density: 100
+          mask:
+            - SmallMobMask
+          layer:
+            - SmallMobLayer
+    - type: MobState
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        1: Dead
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 2.5
+      baseSprintSpeed: 5
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: cockroach
+        Critical:
+          Base: cockroach_dead
+        Dead:
+          Base: cockroach_dead
+    - type: Bloodstream
+      bloodReagent: InsectBlood
+      bloodMaxVolume: 20
+    - type: Food
+    - type: FlavorProfile
+      flavors:
+        - horrible
+        - terrible
+        - chewy
+    - type: Hunger
+      baseDecayRate: 0.25
+    - type: Extractable
+      grindableSolutionName: food
+    - type: SolutionContainerManager
+      solutions:
+        food:
+          reagents:
+            - ReagentId: Slime
+              Quantity: 5
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatSlime
+    - type: Damageable
+      damageContainer: Biological
+      damageModifierSet: Cockroach
+    - type: Tag
+      tags:
+        - Trash
+        - VimPilot
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTypeTrigger
+            damageType: Blunt
+            damage: 10
+          behaviors:
+            - !type:GibBehavior
+              recursive: false
+    - type: NonSpreaderZombie
+    - type: MeleeWeapon
+      soundHit:
+        path: /Audio/Effects/bite.ogg
+      angle: 0
+      animation: WeaponArcBite
+      damage:
+        types:
+          Piercing: 0
 
 - type: entity
   name: glockroach
@@ -455,30 +447,30 @@
   id: MobGlockroach
   description: This station is just crawling with bu- OH GOD THAT COCKROACH HAS A GUN!!!
   components:
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: glockroach
-  - type: Gun
-    fireRate: 2
-    useKey: false
-    selectedMode: SemiAuto
-    availableModes:
-      - SemiAuto
-    soundGunshot: /Audio/Weapons/Guns/Gunshots/pistol.ogg
-  - type: BallisticAmmoProvider
-    proto: CartridgeCaselessRifle
-    capacity: 500
-  - type: CombatMode
-  - type: HTN
-    rootTask:
-      task: GlockroachCompound
-  - type: NpcFactionMember
-    factions:
-    - SimpleHostile
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatSlime
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: glockroach
+    - type: Gun
+      fireRate: 2
+      useKey: false
+      selectedMode: SemiAuto
+      availableModes:
+        - SemiAuto
+      soundGunshot: /Audio/Weapons/Guns/Gunshots/pistol.ogg
+    - type: BallisticAmmoProvider
+      proto: CartridgeCaselessRifle
+      capacity: 500
+    - type: CombatMode
+    - type: HTN
+      rootTask:
+        task: GlockroachCompound
+    - type: NpcFactionMember
+      factions:
+        - SimpleHostile
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatSlime
 
 - type: entity
   name: mothroach
@@ -486,203 +478,200 @@
   id: MobMothroach
   description: This is the adorable by-product of multiple attempts at genetically mixing mothpeople with cockroaches.
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Mothroach
-    understands:
-    - Moffic
-    - Mothroach
-  # Starlight-end
-  - type: VentCrawler
-  - type: HTN
-    constantlyReplan: false
-    rootTask:
-      task: MouseCompound
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: ghost-role-information-mothroach-name
-    description: ghost-role-information-mothroach-description
-    rules: ghost-role-information-freeagent-rules
-    mindRoles:
-    - MindRoleGhostRoleFreeAgentHarmless
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.2
-        density: 120
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Mothroach
+      understands:
+        - Moffic
+        - Mothroach
+    # Starlight-end
+    - type: VentCrawler
+    - type: HTN
+      constantlyReplan: false
+      rootTask:
+        task: MouseCompound
+    - type: GhostRole
+      makeSentient: true
+      allowSpeech: true
+      allowMovement: true
+      name: ghost-role-information-mothroach-name
+      description: ghost-role-information-mothroach-description
+      rules: ghost-role-information-freeagent-rules
+      mindRoles:
+        - MindRoleGhostRoleFreeAgentHarmless
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.2
+          density: 120
+          mask:
+            - SmallMobMask
+          layer:
+            - SmallMobLayer
+    - type: GhostTakeoverAvailable
+    - type: Speech
+      speechVerb: Moth
+      speechSounds: Squeak
+      allowedEmotes: ["Chitter", "Squeak"]
+    - type: FaxableObject
+      insertingState: inserting_mothroach
+    - type: MothAccent
+    - type: Sprite
+      drawdepth: SmallMobs
+      sprite: Mobs/Animals/mothroach/mothroach.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: mothroach
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: mothroach-moving
+      noMovementLayers:
+        movement:
+          state: mothroach
+    - type: Item
+      size: Normal
+    - type: Clothing
+      quickEquip: false
+      sprite: Mobs/Animals/mothroach/mothroach.rsi
+      equippedPrefix: 0
+      slots:
+        - HEAD
+    - type: Appearance
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: mothroach
+        Critical:
+          Base: mothroach_dead
+        Dead:
+          Base: mothroach_dead
+    - type: MobState
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        40: Critical
+        60: Dead
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 2.5
+      baseSprintSpeed: 4
+      weightlessAcceleration: 1.5
+      weightlessFriction: 1
+      baseWeightlessModifier: 1
+    - type: Damageable
+      damageContainer: Biological
+      damageModifierSet: Moth
+    - type: Bloodstream
+      bloodReagent: InsectBlood
+      bloodMaxVolume: 50
+    - type: Respirator
+      damage:
+        types:
+          Asphyxiation: 0.5
+      damageRecovery:
+        types:
+          Asphyxiation: -0.5
+    - type: CombatMode
+    - type: MeleeWeapon
+      soundHit:
+        path: /Audio/Effects/bite.ogg
+      damage:
+        types:
+          Piercing: 0
+    - type: Food
+      requireDead: true
+      transferAmount: 2
+    - type: FlavorProfile
+      flavors:
+        - horrible
+        - terrible
+        - chewy
+    - type: Hunger
+      baseDecayRate: 0.25
+    - type: Extractable
+      grindableSolutionName: food
+    - type: SolutionContainerManager
+      solutions:
+        food:
+          reagents:
+            - ReagentId: Slime
+              Quantity: 5
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatSlime
+          amount: 2
+    - type: ZombieAccentOverride
+      accent: zombieMoth
+    - type: Vocal
+      sounds:
+        Male: UnisexMoth
+        Female: UnisexMoth
+        Unsexed: UnisexMoth
+      wilhelmProbability: 0.001
+    - type: MobPrice
+      price: 150
+    - type: BadFood
+    - type: Tag
+      tags:
+        - Trash
+        - CannotSuicide
+        - VimPilot
+    - type: CanEscapeInventory
+    - type: NpcFactionMember
+      factions:
+        - Mouse
+    - type: Body
+      prototype: Mothroach
+    - type: TypingIndicator
+      proto: moth
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTypeTrigger
+            damageType: Blunt
+            damage: 60
+          behaviors:
+            - !type:GibBehavior
+              recursive: false
+    - type: FireVisuals
+      sprite: Mobs/Effects/onfire.rsi
+      normalState: Mouse_burning
+    - type: Strippable
+    - type: UserInterface
+      interfaces:
+        enum.StrippingUiKey.Key:
+          type: StrippableBoundUserInterface
+    - type: InventorySlots
+    - type: Inventory
+      speciesId: hamster
+      templateId: hamster
+      displacements:
+        head:
+          sizeMaps:
+            32:
+              sprite: Mobs/Animals/mothroach/displacement.rsi
+              state: head
         mask:
-        - SmallMobMask
-        layer:
-        - SmallMobLayer
-  - type: GhostTakeoverAvailable
-  - type: Speech
-    speechVerb: Moth
-    speechSounds: Squeak
-    allowedEmotes: ['Chitter', 'Squeak']
-  - type: FaxableObject
-    insertingState: inserting_mothroach
-  - type: MothAccent
-  - type: Sprite
-    drawdepth: SmallMobs
-    sprite: Mobs/Animals/mothroach/mothroach.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: mothroach
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: mothroach-moving
-    noMovementLayers:
-      movement:
-        state: mothroach
-  - type: Item
-    size: Normal
-  - type: Clothing
-    quickEquip: false
-    sprite: Mobs/Animals/mothroach/mothroach.rsi
-    equippedPrefix: 0
-    slots:
-    - HEAD
-  - type: Appearance
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: mothroach
-      Critical:
-        Base: mothroach_dead
-      Dead:
-        Base: mothroach_dead
-  - type: MobState
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      40: Critical
-      60: Dead
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
-    baseSprintSpeed : 4
-    weightlessAcceleration: 1.5
-    weightlessFriction: 1
-    baseWeightlessModifier: 1
-  - type: Damageable
-    damageContainer: Biological
-    damageModifierSet: Moth
-  - type: Bloodstream
-    bloodReagent: InsectBlood
-    bloodMaxVolume: 50
-  - type: Respirator
-    damage:
-      types:
-        Asphyxiation: 0.5
-    damageRecovery:
-      types:
-        Asphyxiation: -0.5
-  - type: CombatMode
-  - type: MeleeWeapon
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    damage:
-      types:
-        Piercing: 0
-  - type: Food
-    requireDead: true
-    transferAmount: 2
-  - type: FlavorProfile
-    flavors:
-    - horrible
-    - terrible
-    - chewy
-  - type: Hunger
-    baseDecayRate: 0.25
-  - type: Extractable
-    grindableSolutionName: food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: Slime
-          Quantity: 5
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatSlime
-      amount: 2
-  - type: ZombieAccentOverride
-    accent: zombieMoth
-  - type: Vocal
-    sounds:
-      Male: UnisexMoth
-      Female: UnisexMoth
-      Unsexed: UnisexMoth
-    wilhelmProbability: 0.001
-  - type: MobPrice
-    price: 150
-  - type: BadFood
-  - type: Tag
-    tags:
-    - Trash
-    - CannotSuicide
-    - VimPilot
-  - type: CanEscapeInventory
-  - type: NpcFactionMember
-    factions:
-    - Mouse
-  - type: Body
-    prototype: Mothroach
-  - type: TypingIndicator
-    proto: moth
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 60
-      behaviors:
-      - !type:GibBehavior
-        recursive: false
-  - type: FireVisuals
-    sprite: Mobs/Effects/onfire.rsi
-    normalState: Mouse_burning
-  - type: Strippable
-  - type: UserInterface
-    interfaces:
-      enum.StrippingUiKey.Key:
-        type: StrippableBoundUserInterface
-  - type: InventorySlots
-  - type: Inventory
-    speciesId: hamster
-    templateId: hamster
-    displacements:
-      head:
-        sizeMaps:
-          32:
-            sprite: Mobs/Animals/mothroach/displacement.rsi
-            state: head
-      mask:
-        sizeMaps:
-          32:
-            sprite: Mobs/Animals/mothroach/displacement.rsi
-            state: mask
-      suitstorage:
-        sizeMaps:
-          32:
-            sprite: Mobs/Animals/mothroach/displacement.rsi
-            state: suitstorage
-      eyes:
-        sizeMaps:
-          32:
-            sprite: Mobs/Animals/mothroach/displacement.rsi
-            state: eyes
-      neck:
-        sizeMaps:
-          32:
-            sprite: Mobs/Animals/mothroach/displacement.rsi
-            state: neck
-
+          sizeMaps:
+            32:
+              sprite: Mobs/Animals/mothroach/displacement.rsi
+              state: mask
+        suitstorage:
+          sizeMaps:
+            32:
+              sprite: Mobs/Animals/mothroach/displacement.rsi
+              state: suitstorage
+        eyes:
+          sizeMaps:
+            32:
+              sprite: Mobs/Animals/mothroach/displacement.rsi
+              state: eyes
+        neck:
+          sizeMaps:
+            32:
+              sprite: Mobs/Animals/mothroach/displacement.rsi
+              state: neck
 
 # Note that the mallard duck is actually a male drake mallard, with the brown duck being the female variant of the same species, however ss14 lacks sex specific textures
 # The white duck is more akin to a pekin or call duck.
@@ -693,77 +682,76 @@
   id: MobDuckMallard
   description: An adorable mallard duck, it's fluffy and soft!
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Duck
-    understands:
-    - Duck
-  # Starlight-end
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: duck-0
-    sprite: Mobs/Animals/duck.rsi
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 5 #They actually are pretty light, I looked it up
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Tag
-    tags:
-    - DoorBumpOpener
-    - Duck
-    - VimPilot
-  - type: Reproductive
-    breedChance: 0.05
-    birthPopup: reproductive-laid-egg-popup
-    makeOffspringInfant: false
-    partnerWhitelist:
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Duck
+      understands:
+        - Duck
+    # Starlight-end
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: duck-0
+      sprite: Mobs/Animals/duck.rsi
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 5 #They actually are pretty light, I looked it up
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Tag
       tags:
-      - Duck
-    offspring:
-    - id: FoodEggDuckFertilized
-      maxAmount: 3
-  - type: ReproductivePartner
-  - type: Appearance
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: duck-0
-      Critical:
-        Base: dead-0
-      Dead:
-        Base: dead-0
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatDuck
-      amount: 1
-  - type: InteractionPopup
-    successChance: 0.9
-    interactSuccessString: petting-success-bird
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/duck_quack_happy.ogg
-  - type: Bloodstream
-    bloodMaxVolume: 100
-  - type: EggLayer
-    eggSpawn:
-    - id: FoodEgg
-  - type: ExaminableHunger
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-organic
-  - type: NpcFactionMember
-    factions:
-    - Passive
+        - DoorBumpOpener
+        - Duck
+        - VimPilot
+    - type: Reproductive
+      breedChance: 0.05
+      birthPopup: reproductive-laid-egg-popup
+      makeOffspringInfant: false
+      partnerWhitelist:
+        tags:
+          - Duck
+      offspring:
+        - id: FoodEggDuckFertilized
+          maxAmount: 3
+    - type: ReproductivePartner
+    - type: Appearance
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: duck-0
+        Critical:
+          Base: dead-0
+        Dead:
+          Base: dead-0
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatDuck
+          amount: 1
+    - type: InteractionPopup
+      successChance: 0.9
+      interactSuccessString: petting-success-bird
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/duck_quack_happy.ogg
+    - type: Bloodstream
+      bloodMaxVolume: 100
+    - type: EggLayer
+      eggSpawn:
+        - id: FoodEgg
+    - type: ExaminableHunger
+    - type: SentienceTarget
+      flavorKind: station-event-random-sentience-flavor-organic
+    - type: NpcFactionMember
+      factions:
+        - Passive
 
 - type: entity
   name: white duck #Quack
@@ -771,18 +759,18 @@
   id: MobDuckWhite
   description: An adorable white duck, it's fluffy and soft!
   components:
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: duck-1
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: duck-1
-      Critical:
-        Base: dead-1
-      Dead:
-        Base: dead-1
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: duck-1
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: duck-1
+        Critical:
+          Base: dead-1
+        Dead:
+          Base: dead-1
 
 - type: entity
   name: brown duck #Quack
@@ -790,18 +778,18 @@
   id: MobDuckBrown
   description: An adorable brown duck, it's fluffy and soft!
   components:
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: duck-2
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: duck-2
-      Critical:
-        Base: dead-2
-      Dead:
-        Base: dead-2
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: duck-2
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: duck-2
+        Critical:
+          Base: dead-2
+        Dead:
+          Base: dead-2
 
 - type: entity
   id: FoodEggDuckFertilized
@@ -811,9 +799,9 @@
     - type: Timer
     - type: TimedSpawner
       prototypes:
-      - MobDuckMallard
-      - MobDuckWhite
-      - MobDuckBrown
+        - MobDuckMallard
+        - MobDuckWhite
+        - MobDuckBrown
       intervalSeconds: 20
       minimumEntitiesSpawned: 1
       maximumEntitiesSpawned: 1
@@ -822,78 +810,76 @@
 
 - type: entity
   name: butterfly
-  parent: [ SimpleMobBase, FlyingMobBase ]
+  parent: [SimpleMobBase, FlyingMobBase]
   id: MobButterfly
   description: Despite popular misconceptions, it's not actually made of butter.
   components:
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 3
-    baseSprintSpeed : 6
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: butterfly
-      sprite: Mobs/Animals/butterfly.rsi
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.2
-        density: 7.5
-        mask:
-        - FlyingMobMask
-        layer:
-        - FlyingMobLayer
-  - type: MobState
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      10: Dead
-  - type: RandomSprite
-    available:
-      - enum.DamageStateVisualLayers.Base:
-          butterfly: Rainbow
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: butterfly
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Extractable
-    grindableSolutionName: food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 1
-  - type: Butcherable
-    spawned:
-    - id: null # Should give nothing when you butcher it so we set the item id it needs to spawn to null
-  - type: Item
-    size: Tiny
-  - type: Tag
-    tags:
-    - Trash
-  - type: Bloodstream
-    bloodReagent: InsectBlood
-    bloodMaxVolume: 0.1
-  - type: MobPrice
-    price: 50
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 20
-      behaviors:
-      - !type:GibBehavior
-        recursive: false
-  - type: ZombieImmune
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 3
+      baseSprintSpeed: 6
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: butterfly
+          sprite: Mobs/Animals/butterfly.rsi
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.2
+          density: 7.5
+          mask:
+            - FlyingMobMask
+          layer:
+            - FlyingMobLayer
+    - type: MobState
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        10: Dead
+    - type: RandomSprite
+      available:
+        - enum.DamageStateVisualLayers.Base:
+            butterfly: Rainbow
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: butterfly
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Extractable
+      grindableSolutionName: food
+    - type: SolutionContainerManager
+      solutions:
+        food:
+          reagents:
+            - ReagentId: UncookedAnimalProteins
+              Quantity: 1
+    - type: Butcherable
+      spawned:
+        - id: null # Should give nothing when you butcher it so we set the item id it needs to spawn to null
+    - type: Item
+      size: Tiny
+    - type: Tag
+      tags:
+        - Trash
+    - type: Bloodstream
+      bloodReagent: InsectBlood
+      bloodMaxVolume: 0.1
+    - type: MobPrice
+      price: 50
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTypeTrigger
+            damageType: Blunt
+            damage: 20
+          behaviors:
+            - !type:GibBehavior
+              recursive: false
+    - type: ZombieImmune
 
 - type: entity
   name: cow
@@ -901,84 +887,83 @@
   id: MobCow
   description: Moo.
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: cow
-      sprite: Mobs/Animals/cow.rsi
-  - type: Tag
-    tags:
-    - DoorBumpOpener
-    - Cow
-  - type: Reproductive
-    partnerWhitelist:
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: cow
+          sprite: Mobs/Animals/cow.rsi
+    - type: Tag
       tags:
-      - Cow
-    offspring:
-    - id: MobCow
-  - type: ReproductivePartner
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.40
-        density: 400
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: cow
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: SolutionContainerManager
-    solutions:
-      udder:
-        maxVol: 250
-        reagents:
-        - ReagentId: Milk
-          Quantity: 30
-  - type: Udder
-    reagentId: Milk
-    quantityPerUpdate: 25
-    growthDelay: 30
-  - type: ExaminableHunger
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 5
-  - type: Grammar
-    attributes:
-      gender: female # Here because of UdderComponent
-  - type: InteractionPopup
-    successChance: 0.7
-    interactDelay: 2 # Avoids overlapping SFX due to spam - these SFX are a little longer than the typical 1 second.
-    interactSuccessString: petting-success-soft-floofy
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/cow_moo.ogg
-  - type: Perishable
-    molsPerSecondPerUnitMass: 0.0015
-  - type: NpcFactionMember
-    factions:
-    - Passive
-  - type: Body
-    prototype: AnimalRuminant
-  - type: HTN
-    rootTask:
-      task: RuminantCompound
-  - type: GuideHelp
-    guides:
-    - Chef
-    - FoodRecipes
+        - DoorBumpOpener
+        - Cow
+    - type: Reproductive
+      partnerWhitelist:
+        tags:
+          - Cow
+      offspring:
+        - id: MobCow
+    - type: ReproductivePartner
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.40
+          density: 400
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: cow
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: SolutionContainerManager
+      solutions:
+        udder:
+          maxVol: 250
+          reagents:
+            - ReagentId: Milk
+              Quantity: 30
+    - type: Udder
+      reagentId: Milk
+      quantityPerUpdate: 25
+      growthDelay: 30
+    - type: ExaminableHunger
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 5
+    - type: Grammar
+      attributes:
+        gender: female # Here because of UdderComponent
+    - type: InteractionPopup
+      successChance: 0.7
+      interactDelay: 2 # Avoids overlapping SFX due to spam - these SFX are a little longer than the typical 1 second.
+      interactSuccessString: petting-success-soft-floofy
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/cow_moo.ogg
+    - type: Perishable
+      molsPerSecondPerUnitMass: 0.0015
+    - type: NpcFactionMember
+      factions:
+        - Passive
+    - type: Body
+      prototype: AnimalRuminant
+    - type: HTN
+      rootTask:
+        task: RuminantCompound
+    - type: GuideHelp
+      guides:
+        - Chef
+        - FoodRecipes
 
 - type: entity
   name: crab
@@ -986,68 +971,67 @@
   id: MobCrab
   description: A folk legend goes around that his claw snaps spacemen out of existence over distasteful remarks. Be polite and tolerant for your own safety.
   components:
-  - type: VentCrawler
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: crab
-      sprite: Mobs/Animals/crab.rsi
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: crab-moving
-    noMovementLayers:
-      movement:
-        state: crab
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 5
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Speech
-    speechVerb: Arachnid
-    speechSounds: Arachnid
-    allowedEmotes: ['Click', 'Chitter']
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: crab
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatCrab
-      amount: 2
-  - type: InteractionPopup
-    successChance: 0.5
-    interactSuccessString: petting-success-crab
-    interactFailureString: petting-failure-crab
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Voice/Arachnid/arachnid_chitter.ogg
-  - type: ReplacementAccent
-    accent: crab
-  - type: Bloodstream
-    bloodMaxVolume: 50
-    bloodReagent: CopperBlood
-  - type: Tag
-    tags:
-    - VimPilot
-  - type: HTN
-    rootTask:
-      task: RuminantCompound
-  - type: Body
-    prototype: AnimalHemocyanin
+    - type: VentCrawler
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: crab
+          sprite: Mobs/Animals/crab.rsi
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: crab-moving
+      noMovementLayers:
+        movement:
+          state: crab
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 5
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Speech
+      speechVerb: Arachnid
+      speechSounds: Arachnid
+      allowedEmotes: ["Click", "Chitter"]
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: crab
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatCrab
+          amount: 2
+    - type: InteractionPopup
+      successChance: 0.5
+      interactSuccessString: petting-success-crab
+      interactFailureString: petting-failure-crab
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Voice/Arachnid/arachnid_chitter.ogg
+    - type: ReplacementAccent
+      accent: crab
+    - type: Bloodstream
+      bloodMaxVolume: 50
+      bloodReagent: CopperBlood
+    - type: Tag
+      tags:
+        - VimPilot
+    - type: HTN
+      rootTask:
+        task: RuminantCompound
+    - type: Body
+      prototype: AnimalHemocyanin
 
 - type: entity
   name: goat
@@ -1055,102 +1039,101 @@
   id: MobGoat
   description: Her spine consists of long sharp segments, no wonder she is so grumpy.
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: goat
-      sprite: Mobs/Animals/goat.rsi
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 150
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Tag
-    tags:
-    # let moths eat wool directly
-    - ClothMade
-    - DoorBumpOpener
-    - Goat
-  - type: Reproductive
-    partnerWhitelist:
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: goat
+          sprite: Mobs/Animals/goat.rsi
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 150
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Tag
       tags:
-      - Goat
-    offspring:
-    - id: MobGoat
-  - type: ReproductivePartner
-  - type: Appearance
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: goat
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: SolutionContainerManager
-    solutions:
-      udder:
-        maxVol: 250
-        reagents:
-        - ReagentId: MilkGoat
-          Quantity: 30
-      wool:
-        maxVol: 250
-  - type: Udder
-    reagentId: MilkGoat
-    quantityPerUpdate: 25
-    growthDelay: 20
-  - type: ExaminableHunger
-  - type: Wooly
-  - type: Edible
-    destroyOnEmpty: false
-    solution: wool
-    requiresSpecialDigestion: true
-    requireDead: false
-  - type: FlavorProfile
-    flavors:
-    - fiber
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 4
-  - type: Grammar
-    attributes:
-      gender: female # Here because of UdderComponent
-  - type: Speech
-    speechSounds: Goat
-    speechVerb: Goat
-  - type: Vocal
-    sounds:
-      Female: Goat
-      Male: Goat
-      Unsexed: Goat
-  - type: BleatingAccent
-  - type: InteractionPopup
-    successChance: 0.2
-    interactSuccessString: petting-success-goat
-    interactFailureString: petting-failure-goat
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/goat_bah.ogg
-  - type: NpcFactionMember
-    factions:
-    - Passive
-  - type: Body
-    prototype: AnimalRuminant
-  - type: NPCRetaliation
-    attackMemoryLength: 5
-  - type: FactionException
-  - type: HTN
-    rootTask:
-      task: RuminantHostileCompound
+        # let moths eat wool directly
+        - ClothMade
+        - DoorBumpOpener
+        - Goat
+    - type: Reproductive
+      partnerWhitelist:
+        tags:
+          - Goat
+      offspring:
+        - id: MobGoat
+    - type: ReproductivePartner
+    - type: Appearance
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: goat
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: SolutionContainerManager
+      solutions:
+        udder:
+          maxVol: 250
+          reagents:
+            - ReagentId: MilkGoat
+              Quantity: 30
+        wool:
+          maxVol: 250
+    - type: Udder
+      reagentId: MilkGoat
+      quantityPerUpdate: 25
+      growthDelay: 20
+    - type: ExaminableHunger
+    - type: Wooly
+    - type: Edible
+      destroyOnEmpty: false
+      solution: wool
+      requiresSpecialDigestion: true
+      requireDead: false
+    - type: FlavorProfile
+      flavors:
+        - fiber
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 4
+    - type: Grammar
+      attributes:
+        gender: female # Here because of UdderComponent
+    - type: Speech
+      speechSounds: Goat
+      speechVerb: Goat
+    - type: Vocal
+      sounds:
+        Female: Goat
+        Male: Goat
+        Unsexed: Goat
+    - type: BleatingAccent
+    - type: InteractionPopup
+      successChance: 0.2
+      interactSuccessString: petting-success-goat
+      interactFailureString: petting-failure-goat
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/goat_bah.ogg
+    - type: NpcFactionMember
+      factions:
+        - Passive
+    - type: Body
+      prototype: AnimalRuminant
+    - type: NPCRetaliation
+      attackMemoryLength: 5
+    - type: FactionException
+    - type: HTN
+      rootTask:
+        task: RuminantHostileCompound
 
 # Note that we gotta make this bitch vomit someday when you feed it anthrax or sumthin. Needs to be a small item thief too and aggressive if attacked.
 - type: entity
@@ -1159,142 +1142,140 @@
   id: MobGoose
   description: Its stomach and mind are an enigma beyond human comprehension.
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: goose
-      sprite: Mobs/Animals/goose.rsi
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 25
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: goose
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatChicken
-      amount: 2
-  - type: InteractionPopup # TODO: Make it so there's a separate chance to make certain animals outright hostile towards you.
-    successChance: 0.1 # Yeah, good luck with that.
-    interactSuccessString: petting-success-goose
-    interactFailureString: petting-failure-goose
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/goose_honk.ogg
-  - type: Bloodstream
-    bloodMaxVolume: 100
-  - type: NpcFactionMember
-    factions:
-    - Passive
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: goose
+          sprite: Mobs/Animals/goose.rsi
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 25
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: goose
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatChicken
+          amount: 2
+    - type: InteractionPopup # TODO: Make it so there's a separate chance to make certain animals outright hostile towards you.
+      successChance: 0.1 # Yeah, good luck with that.
+      interactSuccessString: petting-success-goose
+      interactFailureString: petting-failure-goose
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/goose_honk.ogg
+    - type: Bloodstream
+      bloodMaxVolume: 100
+    - type: NpcFactionMember
+      factions:
+        - Passive
 
 - type: entity
   name: kangaroo
   parent:
-  - SimpleMobBase
-  - MobCombat
-  - StripableInventoryBase
+    - SimpleMobBase
+    - MobCombat
+    - StripableInventoryBase
   id: MobKangaroo
   description: A large marsupial herbivore. It has powerful hind legs, with nails that resemble long claws.
   components:
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 3.5
-    baseSprintSpeed: 4.5
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-      - map: ["enum.DamageStateVisualLayers.Base"]
-        state: kangaroo
-        sprite: Mobs/Animals/kangaroo.rsi
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 130
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Physics
-  - type: Inventory
-    speciesId: kangaroo
-    templateId: kangaroo
-  - type: ReplacementAccent
-    accent: kangaroo
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: kangaroo
-      # SKIPPY NO!
-      Critical:
-        Base: kangaroo-crit
-      Dead:
-        Base: kangaroo-dead
-  - type: Tag
-    tags:
-    - DoorBumpOpener
-    - FootstepSound
-  - type: GhostRole
-    prob: 0.25
-    name: ghost-role-information-kangaroo-name
-    description: ghost-role-information-kangaroo-description
-    rules: ghost-role-information-nonantagonist-rules
-  - type: GhostTakeoverAvailable
-  - type: Vocal
-    sounds:
-      Unsexed: Kangaroo
-  - type: Puller
-    needsHands: false
-  - type: StaminaDamageOnHit
-    damage: 8 #Stam damage values seem a bit higher than regular damage because of the decay, etc
-    # This needs to be moved to boxinggloves
-    #knockdownSound: /Audio/Weapons/boxingbell.ogg
-  - type: MeleeWeapon
-    attackRate: 1.5
-    damage:
-      types:
-        Blunt: 0.4
-    soundHit:
-      collection: BoxingHit
-    animation: WeaponArcFist
-  - type: NPCRetaliation
-    attackMemoryLength: 10
-  - type: FactionException
-  - type: NpcFactionMember
-    factions:
-    - Passive
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 3.5
+      baseSprintSpeed: 4.5
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: kangaroo
+          sprite: Mobs/Animals/kangaroo.rsi
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 130
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Physics
+    - type: Inventory
+      speciesId: kangaroo
+      templateId: kangaroo
+    - type: ReplacementAccent
+      accent: kangaroo
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: kangaroo
+        # SKIPPY NO!
+        Critical:
+          Base: kangaroo-crit
+        Dead:
+          Base: kangaroo-dead
+    - type: Tag
+      tags:
+        - DoorBumpOpener
+        - FootstepSound
+    - type: GhostRole
+      prob: 0.25
+      name: ghost-role-information-kangaroo-name
+      description: ghost-role-information-kangaroo-description
+      rules: ghost-role-information-nonantagonist-rules
+    - type: GhostTakeoverAvailable
+    - type: Vocal
+      sounds:
+        Unsexed: Kangaroo
+    - type: Puller
+      needsHands: false
+    - type: StaminaDamageOnHit
+      damage: 8 #Stam damage values seem a bit higher than regular damage because of the decay, etc
+      # This needs to be moved to boxinggloves
+      #knockdownSound: /Audio/Weapons/boxingbell.ogg
+    - type: MeleeWeapon
+      attackRate: 1.5
+      damage:
+        types:
+          Blunt: 0.4
+      soundHit:
+        collection: BoxingHit
+      animation: WeaponArcFist
+    - type: NPCRetaliation
+      attackMemoryLength: 10
+    - type: FactionException
+    - type: NpcFactionMember
+      factions:
+        - Passive
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound
 
 - type: entity
   name: boxing kangaroo
   parent: MobKangaroo
   id: MobBoxingKangaroo
   components:
-  - type: Loadout
-    prototypes: [ BoxingKangarooGear ]
-  - type: NpcFactionMember
-    factions:
-    - SimpleHostile
+    - type: Loadout
+      prototypes: [BoxingKangarooGear]
+    - type: NpcFactionMember
+      factions:
+        - SimpleHostile
 
 - type: entity
   name: genetic ancestor
@@ -1303,125 +1284,122 @@
   description: The genetic bipedal ancestor of... Uh... Something. Yeah, there's definitely something on the station that descended from whatever this is.
   abstract: true
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Ancestor
-    understands:
-    - Ancestor
-  # Starlight-end
-  - type: VentCrawler # Starlight-edit: Vent Crawl
-  - type: CombatMode
-  - type: Inventory
-    templateId: monkey
-    speciesId: monkey
-  - type: Deathgasp
-    prototype: MonkeyDeathgasp
-  - type: Cuffable
-  - type: RotationVisuals
-    defaultRotation: 90
-    horizontalRotation: 90
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 80
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Stripping
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: monkey
-      sprite: Mobs/Animals/monkey.rsi
-    - map: [ "jumpsuit" ]
-    - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
-      color: "#ffffff"
-      sprite: Objects/Misc/handcuffs.rsi
-      state: body-overlay-2
-      visible: false
-    - map: [ "ears" ]
-    - map: [ "id" ]
-    - map: [ "outerClothing" ]
-    - map: [ "mask" ]
-    - map: [ "head" ]
-    - map: [ "clownedon" ]
-      sprite: "Effects/creampie.rsi"
-      state: "creampie_human"
-      visible: false
-  - type: Hands
-  - type: ComplexInteraction
-  - type: GenericVisualizer
-    visuals:
-      enum.CreamPiedVisuals.Creamed:
-        clownedon:
-          True: {visible: true}
-          False: {visible: false}
-  - type: Body
-    prototype: Primate
-    requiredLegs: 1 # TODO: More than 1 leg
-  - type: CreamPied
-  - type: FireVisuals
-    sprite: Mobs/Effects/onfire.rsi
-    normalState: Monkey_burning
-  - type: InteractionPopup
-    successChance: 0.9
-    interactSuccessString: petting-success-monkey
-    interactFailureString: petting-failure-monkey
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/ferret_happy.ogg
-    interactFailureSound:
-      path: /Audio/Items/wirecutter.ogg
-  - type: MeleeWeapon
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    angle: 30
-    animation: WeaponArcBite
-    damage:
-      types:
-        Blunt: 3
-        Piercing: 3
-  - type: Butcherable
-    butcheringType: Spike
-    spawned:
-    - id: FoodMeat
-      amount: 3
-  - type: Puller
-    needsHands: false
-  - type: CanHostGuardian
-  - type: NPCRetaliation
-    attackMemoryLength: 10
-  - type: FactionException
-  - type: NpcFactionMember
-    factions:
-      - Passive
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
-  - type: IdExaminable
-  - type: Tag
-    tags:
-    - VimPilot
-    - DoorBumpOpener
-    - AnomalyHost
-  - type: Reactive
-    groups:
-      Flammable: [ Touch ]
-      Extinguish: [ Touch ]
-    reactions:
-    - reagents: [ Water, SpaceCleaner ]
-      methods: [ Touch ]
-      effects:
-      - !type:WashCreamPieReaction
-  - type: Crawler
-
-
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Ancestor
+      understands:
+        - Ancestor
+    # Starlight-end
+    - type: VentCrawler # Starlight-edit: Vent Crawl
+    - type: CombatMode
+    - type: Inventory
+      templateId: monkey
+      speciesId: monkey
+    - type: Deathgasp
+      prototype: MonkeyDeathgasp
+    - type: Cuffable
+    - type: RotationVisuals
+      defaultRotation: 90
+      horizontalRotation: 90
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 80
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Stripping
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: monkey
+          sprite: Mobs/Animals/monkey.rsi
+        - map: ["jumpsuit"]
+        - map: ["enum.HumanoidVisualLayers.Handcuffs"]
+          color: "#ffffff"
+          sprite: Objects/Misc/handcuffs.rsi
+          state: body-overlay-2
+          visible: false
+        - map: ["ears"]
+        - map: ["id"]
+        - map: ["outerClothing"]
+        - map: ["mask"]
+        - map: ["head"]
+        - map: ["clownedon"]
+          sprite: "Effects/creampie.rsi"
+          state: "creampie_human"
+          visible: false
+    - type: Hands
+    - type: ComplexInteraction
+    - type: GenericVisualizer
+      visuals:
+        enum.CreamPiedVisuals.Creamed:
+          clownedon:
+            True: { visible: true }
+            False: { visible: false }
+    - type: Body
+      prototype: Primate
+      requiredLegs: 1 # TODO: More than 1 leg
+    - type: CreamPied
+    - type: FireVisuals
+      sprite: Mobs/Effects/onfire.rsi
+      normalState: Monkey_burning
+    - type: InteractionPopup
+      successChance: 0.9
+      interactSuccessString: petting-success-monkey
+      interactFailureString: petting-failure-monkey
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/ferret_happy.ogg
+      interactFailureSound:
+        path: /Audio/Items/wirecutter.ogg
+    - type: MeleeWeapon
+      soundHit:
+        path: /Audio/Effects/bite.ogg
+      angle: 30
+      animation: WeaponArcBite
+      damage:
+        types:
+          Blunt: 3
+          Piercing: 3
+    - type: Butcherable
+      butcheringType: Spike
+      spawned:
+        - id: FoodMeat
+          amount: 3
+    - type: Puller
+      needsHands: false
+    - type: CanHostGuardian
+    - type: NPCRetaliation
+      attackMemoryLength: 10
+    - type: FactionException
+    - type: NpcFactionMember
+      factions:
+        - Passive
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound
+    - type: IdExaminable
+    - type: Tag
+      tags:
+        - VimPilot
+        - DoorBumpOpener
+        - AnomalyHost
+    - type: Reactive
+      groups:
+        Flammable: [Touch]
+        Extinguish: [Touch]
+      reactions:
+        - reagents: [Water, SpaceCleaner]
+          methods: [Touch]
+          effects:
+            - !type:WashCreamPieReaction
+    - type: Crawler
 
 - type: entity
   name: monkey
@@ -1429,34 +1407,33 @@
   parent: [MobBaseAncestor, BaseSpeciesPickupable]
   description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
   components:
-  - type: NameIdentifier
-    group: Monkey
-  - type: Speech
-    speechSounds: Monkey
-    speechVerb: Monkey
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-primate
-  - type: AlwaysRevolutionaryConvertible
-  - type: GhostRole
-    prob: 0.05
-    makeSentient: true
-    name: ghost-role-information-monkey-name
-    description: ghost-role-information-monkey-description
-    rules: ghost-role-information-nonantagonist-rules
-  - type: GhostTakeoverAvailable
-  - type: Clumsy
-    gunShootFailDamage:
-      types:
-        Blunt: 5
-        Piercing: 4
-      groups:
-        Burn: 3
-    catchingFailDamage:
-      types:
-        Blunt: 1
-    clumsySound:
-      path: /Audio/Animals/monkey_scream.ogg
-
+    - type: NameIdentifier
+      group: Monkey
+    - type: Speech
+      speechSounds: Monkey
+      speechVerb: Monkey
+    - type: SentienceTarget
+      flavorKind: station-event-random-sentience-flavor-primate
+    - type: AlwaysRevolutionaryConvertible
+    - type: GhostRole
+      prob: 0.05
+      makeSentient: true
+      name: ghost-role-information-monkey-name
+      description: ghost-role-information-monkey-description
+      rules: ghost-role-information-nonantagonist-rules
+    - type: GhostTakeoverAvailable
+    - type: Clumsy
+      gunShootFailDamage:
+        types:
+          Blunt: 5
+          Piercing: 4
+        groups:
+          Burn: 3
+      catchingFailDamage:
+        types:
+          Blunt: 1
+      clumsySound:
+        path: /Audio/Animals/monkey_scream.ogg
 
 - type: entity
   name: monkey
@@ -1465,40 +1442,40 @@
   description: New church of neo-darwinists actually believe that EVERY animal evolved from a monkey. Tastes like pork, and killing them is both fun and relaxing.
   suffix: syndicate base
   components:
-  # Starlight-Start
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Ancestor
-    understands:
-    - Ancestor
-    - GalacticCommon
-  # Starlight-End
-  - type: NameIdentifier
-    group: Monkey
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-primate
-  - type: Speech
-    speechSounds: Monkey
-    speechVerb: Monkey
-  - type: MonkeyAccent
-  - type: NpcFactionMember
-    factions:
-    - Syndicate
-  - type: GhostRole
-    prob: 0.05
-    makeSentient: true
-    name: ghost-role-information-monkey-name
-    description: ghost-role-information-monkey-description
-    rules: ghost-role-information-syndicate-reinforcement-rules
-    mindRoles:
-    # This is for syndicate monkeys that randomly gain sentience, thus have no summoner to team with
-    - MindRoleGhostRoleSoloAntagonist
-    raffle:
-      settings: default
-  - type: GhostTakeoverAvailable
-  - type: Loadout
-    prototypes: [SyndicateOperativeGearMonkey]
+    # Starlight-Start
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Ancestor
+      understands:
+        - Ancestor
+        - GalacticCommon
+    # Starlight-End
+    - type: NameIdentifier
+      group: Monkey
+    - type: SentienceTarget
+      flavorKind: station-event-random-sentience-flavor-primate
+    - type: Speech
+      speechSounds: Monkey
+      speechVerb: Monkey
+    - type: MonkeyAccent
+    - type: NpcFactionMember
+      factions:
+        - Syndicate
+    - type: GhostRole
+      prob: 0.05
+      makeSentient: true
+      name: ghost-role-information-monkey-name
+      description: ghost-role-information-monkey-description
+      rules: ghost-role-information-syndicate-reinforcement-rules
+      mindRoles:
+        # This is for syndicate monkeys that randomly gain sentience, thus have no summoner to team with
+        - MindRoleGhostRoleSoloAntagonist
+      raffle:
+        settings: default
+    - type: GhostTakeoverAvailable
+    - type: Loadout
+      prototypes: [SyndicateOperativeGearMonkey]
 
 - type: entity
   id: MobMonkeySyndicateAgent
@@ -1506,35 +1483,35 @@
   suffix: syndicate agent
   components:
     # make the player a traitor once its taken
-  - type: VentCrawler
-  # Starlight-Start
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Ancestor
-    understands:
-    - Ancestor
-    - GalacticCommon
-  # Starlight-End
-  - type: AutoTraitor
-    profile: TraitorReinforcement
+    - type: VentCrawler
+    # Starlight-Start
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Ancestor
+      understands:
+        - Ancestor
+        - GalacticCommon
+    # Starlight-End
+    - type: AutoTraitor
+      profile: TraitorReinforcement
 
 - type: entity
   id: MobMonkeySyndicateAgentNukeops # Reinforcement exclusive to nukeops uplink
   parent: MobBaseSyndicateMonkey
   suffix: NukeOps
   components:
-  - type: VentCrawler
-  # Starlight-Start
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Ancestor
-    understands:
-    - Ancestor
-    - GalacticCommon
-  # Starlight-End
-  - type: NukeOperative
+    - type: VentCrawler
+    # Starlight-Start
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Ancestor
+      understands:
+        - Ancestor
+        - GalacticCommon
+    # Starlight-End
+    - type: NukeOperative
 
 - type: entity
   name: kobold
@@ -1543,109 +1520,109 @@
   description: Cousins to the sentient race of lizard people, kobolds blend in with their natural habitat and are as nasty as monkeys; ready to pull out your hair and stab you to death.
   abstract: true
   components:
-  - type: NameIdentifier
-    group: Kobold
-  - type: LizardAccent
-  - type: Speech
-    speechSounds: Lizard
-    speechVerb: Reptilian
-    allowedEmotes: ['Thump']
-  - type: Vocal
-    sounds:
-      Male: MaleReptilian
-      Female: FemaleReptilian
-      Unsexed: MaleReptilian
-  - type: BodyEmotes
-    soundsId: ReptilianBodyEmotes
-  - type: TypingIndicator
-    proto: lizard
-  - type: InteractionPopup
-    successChance: 0.9
-    interactSuccessString: petting-success-monkey
-    interactFailureString: petting-failure-monkey
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/lizard_happy.ogg
-    interactFailureSound:
-      path: /Audio/Items/wirecutter.ogg
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      60: Critical
-      125: Dead
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 3.5
-    baseSprintSpeed: 5
-  - type: MeleeWeapon
-    soundHit:
-      collection: AlienClaw
-    angle: 30
-    animation: WeaponArcClaw
-    damage:
-      types:
-        Slash: 5
-        Piercing: 4
-  - type: Temperature
-    heatDamageThreshold: 360
-    coldDamageThreshold: 285
-    currentTemperature: 310.15
-    specificHeat: 42
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      sprite: Mobs/Animals/kobold.rsi
-      state: kobold
-    - map: [ "outline" ]
-      sprite: Mobs/Animals/kobold.rsi
-      state: outline
-    - map: [ "horns" ]
-      sprite: Mobs/Customization/reptilian_parts.rsi
-      state: horns_short
-    - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
-      color: "#ffffff"
-      sprite: Objects/Misc/handcuffs.rsi
-      state: body-overlay-2
-      visible: false
-    - map: [ "ears" ]
-    - map: [ "id" ]
-    - map: [ "mask" ]
-    - map: [ "head" ]
-    - map: [ "clownedon" ]
-      sprite: "Effects/creampie.rsi"
-      state: "creampie_human"
-      visible: false
-  - type: RandomSprite
-    getAllGroups: true
-    available:
-      - enum.DamageStateVisualLayers.Base:
-          kobold: KoboldColors
-      - horns:
-          horns_curled: KoboldHornColors
-          horns_ram: KoboldHornColors
-          horns_short: KoboldHornColors
-          horns_myrsore: KoboldHornColors
-          horns_bighorn: KoboldHornColors
-          horns_argali: KoboldHornColors
-          horns_ayrshire: KoboldHornColors
-          horns_floppy_kobold_ears: Inherit
-          horns_double: Inherit
-          horns_kobold_ears: Inherit
-  - type: Butcherable
-    butcheringType: Spike
-    spawned:
-    - id: FoodMeat
-      amount: 2
-  - type: AlwaysRevolutionaryConvertible
-  - type: GhostTakeoverAvailable
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-kobold
-  - type: GhostRole
-    prob: 0.05
-    makeSentient: true
-    name: ghost-role-information-kobold-name
-    description: ghost-role-information-kobold-description
-    rules: ghost-role-information-nonantagonist-rules
+    - type: NameIdentifier
+      group: Kobold
+    - type: LizardAccent
+    - type: Speech
+      speechSounds: Lizard
+      speechVerb: Reptilian
+      allowedEmotes: ["Thump"]
+    - type: Vocal
+      sounds:
+        Male: MaleReptilian
+        Female: FemaleReptilian
+        Unsexed: MaleReptilian
+    - type: BodyEmotes
+      soundsId: ReptilianBodyEmotes
+    - type: TypingIndicator
+      proto: lizard
+    - type: InteractionPopup
+      successChance: 0.9
+      interactSuccessString: petting-success-monkey
+      interactFailureString: petting-failure-monkey
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/lizard_happy.ogg
+      interactFailureSound:
+        path: /Audio/Items/wirecutter.ogg
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        60: Critical
+        125: Dead
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 3.5
+      baseSprintSpeed: 5
+    - type: MeleeWeapon
+      soundHit:
+        collection: AlienClaw
+      angle: 30
+      animation: WeaponArcClaw
+      damage:
+        types:
+          Slash: 5
+          Piercing: 4
+    - type: Temperature
+      heatDamageThreshold: 360
+      coldDamageThreshold: 285
+      currentTemperature: 310.15
+      specificHeat: 42
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          sprite: Mobs/Animals/kobold.rsi
+          state: kobold
+        - map: ["outline"]
+          sprite: Mobs/Animals/kobold.rsi
+          state: outline
+        - map: ["horns"]
+          sprite: Mobs/Customization/reptilian_parts.rsi
+          state: horns_short
+        - map: ["enum.HumanoidVisualLayers.Handcuffs"]
+          color: "#ffffff"
+          sprite: Objects/Misc/handcuffs.rsi
+          state: body-overlay-2
+          visible: false
+        - map: ["ears"]
+        - map: ["id"]
+        - map: ["mask"]
+        - map: ["head"]
+        - map: ["clownedon"]
+          sprite: "Effects/creampie.rsi"
+          state: "creampie_human"
+          visible: false
+    - type: RandomSprite
+      getAllGroups: true
+      available:
+        - enum.DamageStateVisualLayers.Base:
+            kobold: KoboldColors
+        - horns:
+            horns_curled: KoboldHornColors
+            horns_ram: KoboldHornColors
+            horns_short: KoboldHornColors
+            horns_myrsore: KoboldHornColors
+            horns_bighorn: KoboldHornColors
+            horns_argali: KoboldHornColors
+            horns_ayrshire: KoboldHornColors
+            horns_floppy_kobold_ears: Inherit
+            horns_double: Inherit
+            horns_kobold_ears: Inherit
+    - type: Butcherable
+      butcheringType: Spike
+      spawned:
+        - id: FoodMeat
+          amount: 2
+    - type: AlwaysRevolutionaryConvertible
+    - type: GhostTakeoverAvailable
+    - type: SentienceTarget
+      flavorKind: station-event-random-sentience-flavor-kobold
+    - type: GhostRole
+      prob: 0.05
+      makeSentient: true
+      name: ghost-role-information-kobold-name
+      description: ghost-role-information-kobold-description
+      rules: ghost-role-information-nonantagonist-rules
 
 - type: entity
   name: kobold
@@ -1653,82 +1630,82 @@
   parent: MobBaseKobold
   description: Cousins to the sentient race of lizard people, kobolds blend in with their natural habitat and are as nasty as monkeys; ready to pull out your hair and stab you to death.
   components:
-  - type: Clumsy
-    gunShootFailDamage:
-      types:
-        Blunt: 2
-        Piercing: 7
-      groups:
-        Burn: 3
-    catchingFailDamage:
-      types:
-        Blunt: 1
-    clumsySound:
-      path: /Audio/Voice/Reptilian/reptilian_scream.ogg
+    - type: Clumsy
+      gunShootFailDamage:
+        types:
+          Blunt: 2
+          Piercing: 7
+        groups:
+          Burn: 3
+      catchingFailDamage:
+        types:
+          Blunt: 1
+      clumsySound:
+        path: /Audio/Voice/Reptilian/reptilian_scream.ogg
 
 - type: entity
   id: MobBaseSyndicateKobold
   parent: MobBaseKobold
   suffix: syndicate base
   components:
-  # Starlight-Start
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Ancestor
-    understands:
-    - Ancestor
-    - GalacticCommon
-  # Starlight-End
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      100: Critical
-      200: Dead
-  - type: NpcFactionMember
-    factions:
-    - Syndicate
-  - type: Loadout
-    prototypes: [SyndicateOperativeGearMonkey]
+    # Starlight-Start
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Ancestor
+      understands:
+        - Ancestor
+        - GalacticCommon
+    # Starlight-End
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        100: Critical
+        200: Dead
+    - type: NpcFactionMember
+      factions:
+        - Syndicate
+    - type: Loadout
+      prototypes: [SyndicateOperativeGearMonkey]
 
 - type: entity
   id: MobKoboldSyndicateAgent
   parent: MobBaseSyndicateKobold
   suffix: syndicate agent
   components:
-  # Starlight-Start
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Ancestor
-    understands:
-    - Ancestor
-    - GalacticCommon
-  # Starlight-End
+    # Starlight-Start
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Ancestor
+      understands:
+        - Ancestor
+        - GalacticCommon
+    # Starlight-End
     # make the player a traitor once its taken
-  - type: AutoTraitor
-    profile: TraitorReinforcement
+    - type: AutoTraitor
+      profile: TraitorReinforcement
 
 - type: entity
   id: MobKoboldSyndicateAgentNukeops # Reinforcement exclusive to nukeops uplink
   parent: MobBaseSyndicateKobold
   suffix: NukeOps
   components:
-  # Starlight-Start
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Ancestor
-    understands:
-    - Ancestor
-    - GalacticCommon
-  # Starlight-End
-  - type: NukeOperative
+    # Starlight-Start
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Ancestor
+      understands:
+        - Ancestor
+        - GalacticCommon
+    # Starlight-End
+    - type: NukeOperative
 
 - type: entity
   name: guidebook monkey
   parent: MobMonkey
-  categories: [ HideSpawnMenu ]
+  categories: [HideSpawnMenu]
   id: MobGuidebookMonkey
   description: A hopefully helpful monkey whose only purpose in life is for you to click on. Does this count as having a monkey give you a tutorial?
   components:
@@ -1740,188 +1717,186 @@
   id: MobMouse
   description: Squeak!
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Mouse
-    understands:
-    - Mouse
-  # Starlight-end
-  - type: VentCrawler # Starlight-edit: Vent Crawl
-  - type: Body
-    prototype: Mouse
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: ghost-role-information-mouse-name
-    description: ghost-role-information-mouse-description
-    rules: ghost-role-information-freeagent-rules
-    mindRoles:
-    - MindRoleGhostRoleFreeAgentHarmless
-  - type: GhostTakeoverAvailable
-  - type: Speech
-    speechSounds: Squeak
-    speechVerb: SmallMob
-    allowedEmotes: ['Squeak']
-  - type: Sprite
-    drawdepth: SmallMobs
-    sprite: Mobs/Animals/mouse.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: mouse-0
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: mouse-moving-0
-    noMovementLayers:
-      movement:
-        state: mouse-0
-  - type: Item
-    size: Tiny
-    heldPrefix: 0
-  - type: Clothing
-    quickEquip: false
-    sprite: Mobs/Animals/mouse.rsi
-    equippedPrefix: 0
-    slots:
-    - HEAD
-  - type: NpcFactionMember
-    factions:
-      - Mouse
-  - type: HTN
-    constantlyReplan: false
-    rootTask:
-      task: MouseCompound
-  - type: Physics
-  - type: FaxableObject
-    insertingState: inserting_mouse
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.2
-        density: 100
-        mask:
-        - SmallMobMask
-        layer:
-        - SmallMobLayer
-  - type: MobState
-  - type: Deathgasp
-  - type: MobStateActions
-    actions:
-      Critical:
-      - ActionCritSuccumb
-      - ActionCritFakeDeath
-      - ActionCritLastWords
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      10: Critical
-      20: Dead
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
-    baseSprintSpeed : 5
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: mouse-0
-      Critical:
-        Base: dead-0
-      Dead:
-        Base: splat-0
-  - type: Food
-  - type: FlavorProfile
-    flavors:
-    - meaty
-  - type: Thirst
-    startingThirst: 25  # spawn with Okay thirst state
-    thresholds:
-      OverHydrated: 35
-      Okay: 25
-      Thirsty: 15
-      Parched: 10
-      Dead: 0
-    baseDecayRate: 0.04
-  - type: Hunger
-    thresholds:
-      Overfed: 35
-      Okay: 25
-      Peckish: 15
-      Starving: 10
-      Dead: 0
-    baseDecayRate: 0.5 # I'm very hungry! Give me. The cheese.
-  - type: Extractable
-    grindableSolutionName: food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 3
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatRat
-      amount: 1
-  - type: Tag
-    tags:
-    - Trash
-    - VimPilot
-    - ChefPilot
-    - Mouse
-    - Meat
-  - type: Respirator
-    damage:
-      types:
-        Asphyxiation: 0.25
-    damageRecovery:
-      types:
-        Asphyxiation: -0.25
-  - type: Barotrauma
-    damage:
-      types:
-        Blunt: 0.1
-  - type: Vocal
-    sounds:
-      Male: Mouse
-      Female: Mouse
-      Unsexed: Mouse
-    wilhelmProbability: 0.001
-  # TODO: Remove CombatMode when Prototype Composition is added
-  - type: CombatMode
-  - type: MeleeWeapon
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    angle: 0
-    animation: WeaponArcBite
-    damage:
-      types:
-        Piercing: 0
-  - type: Bloodstream
-    bloodMaxVolume: 50
-  - type: CanEscapeInventory
-  - type: MobPrice
-    price: 50
-  - type: BadFood
-  - type: NonSpreaderZombie
-  - type: FireVisuals
-    sprite: Mobs/Effects/onfire.rsi
-    normalState: Mouse_burning
-  - type: FoodSequenceElement
-    entries:
-      Taco: RatTaco
-      Burger: RatBurger
-      Skewer: RatSkewer
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 60
-      behaviors:
-      - !type:GibBehavior
-        recursive: false
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Mouse
+      understands:
+        - Mouse
+    # Starlight-end
+    - type: VentCrawler # Starlight-edit: Vent Crawl
+    - type: Body
+      prototype: Mouse
+    - type: GhostRole
+      makeSentient: true
+      allowSpeech: true
+      allowMovement: true
+      name: ghost-role-information-mouse-name
+      description: ghost-role-information-mouse-description
+      rules: ghost-role-information-freeagent-rules
+      mindRoles:
+        - MindRoleGhostRoleFreeAgentHarmless
+    - type: GhostTakeoverAvailable
+    - type: Speech
+      speechSounds: Squeak
+      speechVerb: SmallMob
+      allowedEmotes: ["Squeak"]
+    - type: Sprite
+      drawdepth: SmallMobs
+      sprite: Mobs/Animals/mouse.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: mouse-0
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: mouse-moving-0
+      noMovementLayers:
+        movement:
+          state: mouse-0
+    - type: Item
+      size: Tiny
+      heldPrefix: 0
+    - type: Clothing
+      quickEquip: false
+      sprite: Mobs/Animals/mouse.rsi
+      equippedPrefix: 0
+      slots:
+        - HEAD
+    - type: NpcFactionMember
+      factions:
+        - Mouse
+    - type: HTN
+      constantlyReplan: false
+      rootTask:
+        task: MouseCompound
+    - type: Physics
+    - type: FaxableObject
+      insertingState: inserting_mouse
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.2
+          density: 100
+          mask:
+            - SmallMobMask
+          layer:
+            - SmallMobLayer
+    - type: MobState
+    - type: Deathgasp
+    - type: MobStateActions
+      actions:
+        Critical:
+          - ActionCritSuccumb
+          - ActionCritFakeDeath
+          - ActionCritLastWords
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        10: Critical
+        20: Dead
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 2.5
+      baseSprintSpeed: 5
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: mouse-0
+        Critical:
+          Base: dead-0
+        Dead:
+          Base: splat-0
+    - type: Food
+    - type: FlavorProfile
+      flavors:
+        - meaty
+    - type: Thirst
+      startingThirst: 25 # spawn with Okay thirst state
+      thresholds:
+        OverHydrated: 35
+        Okay: 25
+        Thirsty: 15
+        Parched: 10
+        Dead: 0
+      baseDecayRate: 0.04
+    - type: Hunger
+      thresholds:
+        Overfed: 35
+        Okay: 25
+        Peckish: 15
+        Starving: 10
+        Dead: 0
+      baseDecayRate: 0.5 # I'm very hungry! Give me. The cheese.
+    - type: Extractable
+      grindableSolutionName: food
+    - type: SolutionContainerManager
+      solutions:
+        food:
+          reagents:
+            - ReagentId: UncookedAnimalProteins
+              Quantity: 3
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatRat
+          amount: 1
+    - type: Tag
+      tags:
+        - Trash
+        - VimPilot
+        - ChefPilot
+        - Mouse
+        - Meat
+    - type: Respirator
+      damage:
+        types:
+          Asphyxiation: 0.25
+      damageRecovery:
+        types:
+          Asphyxiation: -0.25
+    - type: Barotrauma
+      damage:
+        types:
+          Blunt: 0.1
+    - type: Vocal
+      sounds:
+        Male: Mouse
+        Female: Mouse
+        Unsexed: Mouse
+      wilhelmProbability: 0.001
+    # TODO: Remove CombatMode when Prototype Composition is added
+    - type: CombatMode
+    - type: MeleeWeapon
+      soundHit:
+        path: /Audio/Effects/bite.ogg
+      angle: 0
+      animation: WeaponArcBite
+      damage:
+        types:
+          Piercing: 0
+    - type: Bloodstream
+      bloodMaxVolume: 50
+    - type: CanEscapeInventory
+    - type: MobPrice
+      price: 50
+    - type: BadFood
+    - type: NonSpreaderZombie
+    - type: FireVisuals
+      sprite: Mobs/Effects/onfire.rsi
+      normalState: Mouse_burning
+    - type: FoodSequenceElement
+      entries:
+        Taco: RatTaco
+        Burger: RatBurger
+        Skewer: RatSkewer
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTypeTrigger
+            damageType: Blunt
+            damage: 60
+          behaviors:
+            - !type:GibBehavior
+              recursive: false
 
 - type: entity
   parent: MobMouse
@@ -1931,87 +1906,87 @@
   name: mouse
   description: Squeak!
   components:
-  - type: Damageable
-    damage:
-      types:
-        Bloodloss: 6
-        Asphyxiation: 4
-        Slash: 7
-        Blunt: 3
+    - type: Damageable
+      damage:
+        types:
+          Bloodloss: 6
+          Asphyxiation: 4
+          Slash: 7
+          Blunt: 3
 
 - type: entity
   parent: MobMouse
   id: MobMouseAdmeme
   suffix: Admeme
   components:
-  # allow admeme mouse to eat pills
-  - type: IgnoreBadFood
-  # intended for swarms that eat pills so only temporary
-  - type: TimedDespawn
-    lifetime: 60
-  - type: Hunger
-    baseDecayRate: 10 # always hungry
-    starvingSlowdownModifier: 1
-  - type: Thirst
-    baseDecayRate: 10 # always thirsty
+    # allow admeme mouse to eat pills
+    - type: IgnoreBadFood
+    # intended for swarms that eat pills so only temporary
+    - type: TimedDespawn
+      lifetime: 60
+    - type: Hunger
+      baseDecayRate: 10 # always hungry
+      starvingSlowdownModifier: 1
+    - type: Thirst
+      baseDecayRate: 10 # always thirsty
 
 - type: entity
   parent: MobMouse
   id: MobMouse1
   components:
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: mouse-1
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: mouse-moving-1
-    noMovementLayers:
-      movement:
-        state: mouse-1
-  - type: Clothing
-    equippedPrefix: 1
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: mouse-1
-      Critical:
-        Base: dead-1
-      Dead:
-        Base: splat-1
-  - type: Item
-    size: Tiny
-    heldPrefix: 1
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: mouse-1
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: mouse-moving-1
+      noMovementLayers:
+        movement:
+          state: mouse-1
+    - type: Clothing
+      equippedPrefix: 1
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: mouse-1
+        Critical:
+          Base: dead-1
+        Dead:
+          Base: splat-1
+    - type: Item
+      size: Tiny
+      heldPrefix: 1
 
 - type: entity
   parent: MobMouse
   id: MobMouse2
   components:
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: mouse-2
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: mouse-moving-2
-    noMovementLayers:
-      movement:
-        state: mouse-2
-  - type: Clothing
-    equippedPrefix: 2
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: mouse-2
-      Critical:
-        Base: dead-2
-      Dead:
-        Base: splat-2
-  - type: Item
-    size: Tiny
-    heldPrefix: 2
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: mouse-2
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: mouse-moving-2
+      noMovementLayers:
+        movement:
+          state: mouse-2
+    - type: Clothing
+      equippedPrefix: 2
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: mouse-2
+        Critical:
+          Base: dead-2
+        Dead:
+          Base: splat-2
+    - type: Item
+      size: Tiny
+      heldPrefix: 2
 
 - type: entity
   name: cancer mouse
@@ -2019,34 +1994,34 @@
   parent: MobMouse
   id: MobMouseCancer
   components:
-  - type: Sprite
-    color: LightGreen
-  - type: PointLight
-    color: LightGreen
-    radius: 5
-    energy: 5
-    netsync: false
-  - type: RadiationSource
-    intensity: 0.3
-  - type: Bloodstream
-    bloodReagent: UnstableMutagen
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: UncookedAnimalProteins
-          Quantity: 3
-        - ReagentId: Uranium
-          Quantity: 10
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatRat
-      amount: 1
-    - id: SheetUranium1
-      amount: 1
-  - type: Damageable
-    damageContainer: Biological
-    damageModifierSet: Zombie
+    - type: Sprite
+      color: LightGreen
+    - type: PointLight
+      color: LightGreen
+      radius: 5
+      energy: 5
+      netsync: false
+    - type: RadiationSource
+      intensity: 0.3
+    - type: Bloodstream
+      bloodReagent: UnstableMutagen
+    - type: SolutionContainerManager
+      solutions:
+        food:
+          reagents:
+            - ReagentId: UncookedAnimalProteins
+              Quantity: 3
+            - ReagentId: Uranium
+              Quantity: 10
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatRat
+          amount: 1
+        - id: SheetUranium1
+          amount: 1
+    - type: Damageable
+      damageContainer: Biological
+      damageModifierSet: Zombie
 
 - type: entity
   name: lizard #Weh
@@ -2054,55 +2029,53 @@
   id: MobLizard
   description: A harmless dragon.
   components:
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 2
-    baseSprintSpeed: 3
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: lizard
-      sprite: Mobs/Animals/lizard.rsi
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.2
-        density: 50
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: lizard
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatLizard
-      amount: 1
-  - type: InteractionPopup
-    successChance: 0.3
-    interactSuccessString: petting-success-reptile
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/lizard_happy.ogg
-  - type: Bloodstream
-    bloodMaxVolume: 150
-  - type: Damageable
-    damageContainer: Biological
-    damageModifierSet: Scale
-  - type: Tag
-    tags:
-    - VimPilot
-
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 2
+      baseSprintSpeed: 3
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: lizard
+          sprite: Mobs/Animals/lizard.rsi
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.2
+          density: 50
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: lizard
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatLizard
+          amount: 1
+    - type: InteractionPopup
+      successChance: 0.3
+      interactSuccessString: petting-success-reptile
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/lizard_happy.ogg
+    - type: Bloodstream
+      bloodMaxVolume: 150
+    - type: Damageable
+      damageContainer: Biological
+      damageModifierSet: Scale
+    - type: Tag
+      tags:
+        - VimPilot
 
 - type: entity
   name: slug
@@ -2110,47 +2083,46 @@
   id: MobSlug
   description: And they called this a lizard?
   components:
-  - type: VentCrawler
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2
-    baseSprintSpeed : 3
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: slug
-      sprite: Mobs/Animals/slug.rsi
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.2
-        density: 5
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: slug
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 1
-  - type: InteractionPopup
-    successChance: 0.3
-    interactSuccessString: petting-success-generic
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-  - type: Bloodstream
-    bloodMaxVolume: 50
+    - type: VentCrawler
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 2
+      baseSprintSpeed: 3
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: slug
+          sprite: Mobs/Animals/slug.rsi
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.2
+          density: 5
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: slug
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 1
+    - type: InteractionPopup
+      successChance: 0.3
+      interactSuccessString: petting-success-generic
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+    - type: Bloodstream
+      bloodMaxVolume: 50
 
 - type: entity
   name: frog
@@ -2158,153 +2130,150 @@
   id: MobFrog
   description: Hop hop hop. Lookin' moist.
   components:
-  - type: VentCrawler
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 3
-    baseSprintSpeed: 6
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: frog
-      sprite: Mobs/Animals/frog.rsi
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: frog-moving
-    noMovementLayers:
-      movement:
-        state: frog
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.2
-        density: 5
-        mask:
-        - SmallMobMask
-        layer:
-        - SmallMobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: frog
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 1
-  - type: InteractionPopup
-    successChance: 0.6
-    interactSuccessString: petting-success-frog
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/frog_ribbit.ogg
-  - type: Bloodstream
-    bloodMaxVolume: 50
-  - type: Tag
-    tags:
-    - VimPilot
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 60
-      behaviors:
-      - !type:GibBehavior
-        recursive: false
+    - type: VentCrawler
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 3
+      baseSprintSpeed: 6
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: frog
+          sprite: Mobs/Animals/frog.rsi
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: frog-moving
+      noMovementLayers:
+        movement:
+          state: frog
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.2
+          density: 5
+          mask:
+            - SmallMobMask
+          layer:
+            - SmallMobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: frog
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 1
+    - type: InteractionPopup
+      successChance: 0.6
+      interactSuccessString: petting-success-frog
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/frog_ribbit.ogg
+    - type: Bloodstream
+      bloodMaxVolume: 50
+    - type: Tag
+      tags:
+        - VimPilot
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTypeTrigger
+            damageType: Blunt
+            damage: 60
+          behaviors:
+            - !type:GibBehavior
+              recursive: false
 
 # Would be cool to have some functionality for the parrot to be able to sit on stuff
 - type: entity
-  parent: [ SimpleMobBase, FlyingMobBase ]
+  parent: [SimpleMobBase, FlyingMobBase]
   id: MobParrotBase
   name: parrot
   abstract: true
   description: Infiltrates your domain, spies on you, and somehow still a cool pet.
   components:
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
-    baseSprintSpeed : 6
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: parrot
-      sprite: Mobs/Animals/parrot/parrot.rsi
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.25
-        density: 10
-        mask:
-        - FlyingMobMask
-        layer:
-        - FlyingMobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: parrot
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 1
-  - type: Speech
-    speechSounds: Parrot
-    speechVerb: Parrot
-  - type: Vocal
-    sounds:
-      Unsexed: Parrot
-  - type: ActiveListener
-  - type: Vocalizer
-  - type: RadioVocalizer
-  - type: ParrotListener
-  - type: ParrotMemory
-  - type: Inventory
-    templateId: parrot
-    speciesId: parrot
-    # transparent displacement map to hide the headset. this should be an animated displacement map to follow the parrot
-    # as it bobs up and down, but this in turn needs some way to change the displacement map on inventory entities when
-    # the parrot dies, otherwise the visuals will be broken
-    displacements:
-      ears:
-        sizeMaps:
-          32:
-            sprite: Mobs/Animals/parrot/displacement.rsi
-            state: ears
-  - type: InventorySlots
-  - type: Strippable
-  - type: UserInterface
-    interfaces:
-      enum.StrippingUiKey.Key:
-        type: StrippableBoundUserInterface
-  - type: InteractionPopup
-    successChance: 0.6
-    interactSuccessString: petting-success-bird
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/parrot_raught.ogg
-  - type: Bloodstream
-    bloodMaxVolume: 50
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 2.5
+      baseSprintSpeed: 6
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: parrot
+          sprite: Mobs/Animals/parrot/parrot.rsi
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.25
+          density: 10
+          mask:
+            - FlyingMobMask
+          layer:
+            - FlyingMobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: parrot
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 1
+    - type: Speech
+      speechSounds: Parrot
+      speechVerb: Parrot
+    - type: Vocal
+      sounds:
+        Unsexed: Parrot
+    - type: ActiveListener
+    - type: Vocalizer
+    - type: RadioVocalizer
+    - type: ParrotListener
+    - type: ParrotMemory
+    - type: Inventory
+      templateId: parrot
+      speciesId: parrot
+      # transparent displacement map to hide the headset. this should be an animated displacement map to follow the parrot
+      # as it bobs up and down, but this in turn needs some way to change the displacement map on inventory entities when
+      # the parrot dies, otherwise the visuals will be broken
+      displacements:
+        ears:
+          sizeMaps:
+            32:
+              sprite: Mobs/Animals/parrot/displacement.rsi
+              state: ears
+    - type: InventorySlots
+    - type: Strippable
+    - type: UserInterface
+      interfaces:
+        enum.StrippingUiKey.Key:
+          type: StrippableBoundUserInterface
+    - type: InteractionPopup
+      successChance: 0.6
+      interactSuccessString: petting-success-bird
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/parrot_raught.ogg
+    - type: Bloodstream
+      bloodMaxVolume: 50
 
 - type: entity
   parent: MobParrotBase
   id: MobParrot
   components:
-  - type: ParrotAccent # regular parrots have a parrotaccent. Polly is special and does not
+    - type: ParrotAccent # regular parrots have a parrotaccent. Polly is special and does not
 
 - type: entity
   name: penguin
@@ -2312,305 +2281,300 @@
   id: MobPenguin
   description: Their lives are constant pain due to their inner-body knees.
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: penguin
-      sprite: Mobs/Animals/penguin.rsi
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.25
-        density: 100
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: penguin
-      Critical:
-        Base: penguin_dead
-      Dead:
-        Base: penguin_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatPenguin
-      amount: 3
-  - type: InteractionPopup
-    successChance: 0.5
-    interactSuccessString: petting-success-bird
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/penguin_squawk.ogg
-  - type: Tag
-    tags:
-    - VimPilot
-  - type: NpcFactionMember
-    factions:
-    - Passive
-  - type: Temperature
-    heatDamageThreshold: 335
-    coldDamageThreshold: 230
-    currentTemperature: 310.15
-    specificHeat: 46
-    coldDamage:
-      types:
-        Cold : 0.05 #per second, scales with temperature & other constants
-    heatDamage:
-      types:
-        Heat : 0.2 #per second, scales with temperature & other constants
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: penguin
+          sprite: Mobs/Animals/penguin.rsi
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.25
+          density: 100
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: penguin
+        Critical:
+          Base: penguin_dead
+        Dead:
+          Base: penguin_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatPenguin
+          amount: 3
+    - type: InteractionPopup
+      successChance: 0.5
+      interactSuccessString: petting-success-bird
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/penguin_squawk.ogg
+    - type: Tag
+      tags:
+        - VimPilot
+    - type: NpcFactionMember
+      factions:
+        - Passive
+    - type: Temperature
+      heatDamageThreshold: 335
+      coldDamageThreshold: 230
+      currentTemperature: 310.15
+      specificHeat: 46
+      coldDamage:
+        types:
+          Cold: 0.05 #per second, scales with temperature & other constants
+      heatDamage:
+        types:
+          Heat: 0.2 #per second, scales with temperature & other constants
 
 # TODO: Make grenade penguin voice activated like the rest of the stealth items.
 - type: entity
   name: grenade penguin
-  parent: [ MobPenguin, MobCombat, BaseSyndicateContraband ]
+  parent: [MobPenguin, MobCombat, BaseSyndicateContraband]
   id: MobGrenadePenguin
   description: A small penguin with a grenade strapped around its neck. Harvested by the Syndicate from icy shit-hole planets.
   components:
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 3
-    baseSprintSpeed: 5
-  - type: InputMover
-  - type: MobMover
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
-  - type: NpcFactionMember
-    factions:
-    - Syndicate
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: penguin
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 3
+      baseSprintSpeed: 5
+    - type: InputMover
+    - type: MobMover
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound
+    - type: NpcFactionMember
+      factions:
+        - Syndicate
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: penguin
+          sprite: Mobs/Animals/grenadepenguin.rsi
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.25
+          density: 25
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: penguin
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: MeleeWeapon
+      angle: 0
+      animation: WeaponArcBite
+      damage:
+        groups:
+          Brute: 5
+    - type: Item
+      size: Normal
       sprite: Mobs/Animals/grenadepenguin.rsi
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.25
-        density: 25
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: penguin
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: MeleeWeapon
-    angle: 0
-    animation: WeaponArcBite
-    damage:
-      groups:
-        Brute: 5
-  - type: Item
-    size: Normal
-    sprite: Mobs/Animals/grenadepenguin.rsi
-  - type: TriggerOnUse
-  - type: TimerTrigger
-    delay: 10
-    beepSound:
-      path: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg #funny sfx use
-      params:
-        volume: -2
-    beepInterval: 1
-  - type: Explosive
-    explosionType: Default
-    maxIntensity: 20
-    intensitySlope: 20
-    totalIntensity: 225
-  - type: ExplodeOnTrigger
-    keysIn:
-    - timer
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:ExplodeBehavior
+    - type: TriggerOnUse
+    - type: TimerTrigger
+      delay: 10
+      beepSound:
+        path: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg #funny sfx use
+        params:
+          volume: -2
+      beepInterval: 1
+    - type: Explosive
+      explosionType: Default
+      maxIntensity: 20
+      intensitySlope: 20
+      totalIntensity: 225
+    - type: ExplodeOnTrigger
+      keysIn:
+        - timer
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTrigger
+            damage: 50
+          behaviors:
+            - !type:ExplodeBehavior # I have included a snake_hiss.ogg sound file so if you want to use that be my guest
 
-  # I have included a snake_hiss.ogg sound file so if you want to use that be my guest
+
 - type: entity
   name: snake
   parent: SimpleMobBase
   id: MobSnake
   description: Hissss! Bites aren't poisonous.
   components:
-  - type: VentCrawler
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: snake
-      sprite: Mobs/Animals/snake.rsi
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.25
-        density: 10
-        mask:
-        - SmallMobMask
-        layer:
-        - SmallMobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: snake
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatSnake
-      amount: 1
-  - type: InteractionPopup
-    successChance: 0.6
-    interactSuccessString: petting-success-reptile
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-  - type: Bloodstream
-    bloodMaxVolume: 50
-  - type: Damageable
-    damageContainer: Biological
-    damageModifierSet: Scale
+    - type: VentCrawler
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: snake
+          sprite: Mobs/Animals/snake.rsi
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.25
+          density: 10
+          mask:
+            - SmallMobMask
+          layer:
+            - SmallMobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: snake
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatSnake
+          amount: 1
+    - type: InteractionPopup
+      successChance: 0.6
+      interactSuccessString: petting-success-reptile
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+    - type: Bloodstream
+      bloodMaxVolume: 50
+    - type: Damageable
+      damageContainer: Biological
+      damageModifierSet: Scale
 
 # Code unique spider prototypes or combine them all into one spider and get a
 # random sprite state when you spawn it.
 - type: entity
-  parent: [ SimpleMobBase, MobCombat ]
+  parent: [SimpleMobBase, MobCombat]
   id: MobSpiderBase
   abstract: true
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Chittin
-    understands:
-    - Chittin
-  # Starlight-end
-  - type: VentCrawler # Starlight-edit: Vent Crawl
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 130
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatSpider
-      amount: 2
-  - type: CombatMode
-  - type: Body
-    prototype: AnimalHemocyanin
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      90: Dead
-  - type: SolutionContainerManager
-    solutions:
-      melee:
-        maxVol: 30
-  - type: SolutionRegeneration
-    solution: melee
-    generated:
-      reagents:
-      - ReagentId: Mechanotoxin
-        Quantity: 1
-  - type: MeleeChemicalInjector
-    transferAmount: 0.75
-    solution: melee
-  - type: InteractionPopup
-    successChance: 0.5
-    interactSuccessString: petting-success-tarantula
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/snake_hiss.ogg
-  - type: NoSlip
-  - type: Spider
-  - type: IgnoreSpiderWeb
-  - type: Bloodstream
-    bloodMaxVolume: 150
-    bloodReagent: CopperBlood
-  - type: Speech
-    speechVerb: Arachnid
-    speechSounds: Arachnid
-    allowedEmotes: ['Click', 'Chitter']
-  - type: Vocal
-    sounds:
-      Male: UnisexArachnid
-      Female: UnisexArachnid
-      Unsexed: UnisexArachnid
-  - type: TypingIndicator
-    proto: spider
-  - type: Tag
-    tags:
-    - DoorBumpOpener
-    - FootstepSound
-  - type: Prying # Open door from xeno.yml.
-    pryPowered: true
-    force: true
-    speedModifier: 1.5
-    useSound:
-      path: /Audio/Items/crowbar.ogg
-  - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute from base.yml.
-    allowedStates:
-    - Alive
-    damageCap: 89
-    damage:
-      types:
-        Poison: -0.07
-      groups:
-        Brute: -0.07
-        Burn: -0.07
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Chittin
+      understands:
+        - Chittin
+    # Starlight-end
+    - type: VentCrawler # Starlight-edit: Vent Crawl
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 130
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatSpider
+          amount: 2
+    - type: CombatMode
+    - type: Body
+      prototype: AnimalHemocyanin
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        90: Dead
+    - type: SolutionContainerManager
+      solutions:
+        melee:
+          maxVol: 30
+    - type: SolutionRegeneration
+      solution: melee
+      generated:
+        reagents:
+          - ReagentId: Mechanotoxin
+            Quantity: 1
+    - type: MeleeChemicalInjector
+      transferAmount: 0.75
+      solution: melee
+    - type: InteractionPopup
+      successChance: 0.5
+      interactSuccessString: petting-success-tarantula
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/snake_hiss.ogg
+    - type: NoSlip
+    - type: Spider
+    - type: IgnoreSpiderWeb
+    - type: Bloodstream
+      bloodMaxVolume: 150
+      bloodReagent: CopperBlood
+    - type: Speech
+      speechVerb: Arachnid
+      speechSounds: Arachnid
+      allowedEmotes: ["Click", "Chitter"]
+    - type: Vocal
+      sounds:
+        Male: UnisexArachnid
+        Female: UnisexArachnid
+        Unsexed: UnisexArachnid
+    - type: TypingIndicator
+      proto: spider
+    - type: Tag
+      tags:
+        - DoorBumpOpener
+        - FootstepSound
+    - type: Prying # Open door from xeno.yml.
+      pryPowered: true
+      force: true
+      speedModifier: 1.5
+      useSound:
+        path: /Audio/Items/crowbar.ogg
+    - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute from base.yml.
+      allowedStates:
+        - Alive
+      damageCap: 89
+      damage:
+        types:
+          Poison: -0.07
+        groups:
+          Brute: -0.07
+          Burn: -0.07
 
 - type: entity
   parent: MobSpiderBase
   id: MobSpiderAngryBase
   abstract: true
   components:
-  - type: NpcFactionMember
-    factions:
-      - Xeno
-  - type: InputMover
-  - type: MobMover
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
-  - type: GhostRole
-    makeSentient: true
-    name: ghost-role-information-giant-spider-name
-    description: ghost-role-information-giant-spider-description
-    rules: ghost-role-information-giant-spider-rules
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-    raffle:
-      settings: short
-  - type: GhostTakeoverAvailable
+    - type: NpcFactionMember
+      factions:
+        - Xeno
+    - type: InputMover
+    - type: MobMover
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound
+    - type: GhostRole
+      makeSentient: true
+      name: ghost-role-information-giant-spider-name
+      description: ghost-role-information-giant-spider-description
+      rules: ghost-role-information-giant-spider-rules
+      mindRoles:
+        - MindRoleGhostRoleTeamAntagonist
+      raffle:
+        settings: short
+    - type: GhostTakeoverAvailable
 
 - type: entity
   name: tarantula
@@ -2618,41 +2582,41 @@
   id: MobGiantSpider
   description: Widely recognized to be the literal worst thing in existence.
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: tarantula
-      sprite: Mobs/Animals/spider.rsi
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: tarantula-moving
-    noMovementLayers:
-      movement:
-        state: tarantula
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: tarantula
-      Critical:
-        Base: tarantula_dead
-      Dead:
-        Base: tarantula_dead
-  - type: MeleeWeapon
-    altDisarm: false
-    angle: 0
-    animation: WeaponArcBite
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    damage:
-      types:
-        Piercing: 6
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: tarantula
+          sprite: Mobs/Animals/spider.rsi
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: tarantula-moving
+      noMovementLayers:
+        movement:
+          state: tarantula
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: tarantula
+        Critical:
+          Base: tarantula_dead
+        Dead:
+          Base: tarantula_dead
+    - type: MeleeWeapon
+      altDisarm: false
+      angle: 0
+      animation: WeaponArcBite
+      soundHit:
+        path: /Audio/Effects/bite.ogg
+      damage:
+        types:
+          Piercing: 6
 
 - type: entity
   parent:
-  - MobSpiderAngryBase
-  - MobGiantSpider
+    - MobSpiderAngryBase
+    - MobGiantSpider
   id: MobGiantSpiderAngry
 
 - type: entity
@@ -2664,9 +2628,9 @@
     - type: Sprite
       drawdepth: Mobs
       layers:
-      - map: ["enum.DamageStateVisualLayers.Base"]
-        state: clown
-        sprite: Mobs/Animals/clownspider.rsi
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: clown
+          sprite: Mobs/Animals/clownspider.rsi
     - type: Butcherable
       spawned:
         - id: MaterialBananium1
@@ -2687,11 +2651,11 @@
       webPrototype: SpiderWebClown
     - type: Tag
       tags:
-      - DoorBumpOpener
-      - FootstepSound
+        - DoorBumpOpener
+        - FootstepSound
     - type: NpcFactionMember
       factions:
-      - HonkHostile
+        - HonkHostile
     - type: MeleeWeapon
       altDisarm: false
       angle: 0
@@ -2723,51 +2687,50 @@
   id: MobPossum
   description: '"O Possum! My Possum!" -- Walt Whitman, 1865'
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Animals/possum.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: possum
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 50
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: possum
-    templateId: pet
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: possum
-      Critical:
-        Base: possum_dead
-      Dead:
-        Base: possum_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 3
-  - type: InteractionPopup
-    successChance: 0.2 # Low when undomesticated.
-    interactSuccessString: petting-success-possum # Possums don't really make much noise when they're happy. They make clicking noises as a mating call, but that is NOT the same thing!
-    interactFailureString: petting-failure-possum
-    interactFailureSound:
-      path: /Audio/Animals/cat_hiss.ogg # This sound effect is intended for generic hissing. For easy reference it's named after the animal it came from IRL.
-  - type: Grammar
-    attributes:
-      gender: epicene
-  - type: Tag
-    tags:
-    - VimPilot
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Animals/possum.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: possum
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 50
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: possum
+      templateId: pet
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: possum
+        Critical:
+          Base: possum_dead
+        Dead:
+          Base: possum_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 3
+    - type: InteractionPopup
+      successChance: 0.2 # Low when undomesticated.
+      interactSuccessString: petting-success-possum # Possums don't really make much noise when they're happy. They make clicking noises as a mating call, but that is NOT the same thing!
+      interactFailureString: petting-failure-possum
+      interactFailureSound:
+        path: /Audio/Animals/cat_hiss.ogg # This sound effect is intended for generic hissing. For easy reference it's named after the animal it came from IRL.
+    - type: Grammar
+      attributes:
+        gender: epicene
+    - type: Tag
+      tags:
+        - VimPilot
 
 - type: entity
   name: possum
@@ -2775,20 +2738,20 @@
   suffix: Old sprite
   id: MobPossumOld
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Animals/possum_old.rsi
-    layers:
-    - map: [ "enum.DamageStateVisualLayers.Base" ]
-      state: possum_old
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: possum_old
-      Critical:
-        Base: possum_dead_old
-      Dead:
-        Base: possum_dead_old
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Animals/possum_old.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: possum_old
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: possum_old
+        Critical:
+          Base: possum_dead_old
+        Dead:
+          Base: possum_dead_old
 
 - type: entity
   name: raccoon
@@ -2796,52 +2759,51 @@
   id: MobRaccoon
   description: Trash panda!
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Animals/raccoon.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: raccoon
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 50
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: possum #close enough
-    templateId: pet
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: raccoon
-      Critical:
-        Base: raccoon_dead
-      Dead:
-        Base: raccoon_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 3
-  - type: InteractionPopup
-    successChance: 0.2 # Low when undomesticated.
-    interactSuccessString: petting-success-soft-floofy
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/raccoon_chatter.ogg
-  - type: Grammar
-    attributes:
-      gender: epicene
-  - type: Tag
-    tags:
-    - VimPilot
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Animals/raccoon.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: raccoon
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 50
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: possum #close enough
+      templateId: pet
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: raccoon
+        Critical:
+          Base: raccoon_dead
+        Dead:
+          Base: raccoon_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 3
+    - type: InteractionPopup
+      successChance: 0.2 # Low when undomesticated.
+      interactSuccessString: petting-success-soft-floofy
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/raccoon_chatter.ogg
+    - type: Grammar
+      attributes:
+        gender: epicene
+    - type: Tag
+      tags:
+        - VimPilot
 
 - type: entity
   name: fox
@@ -2849,86 +2811,85 @@
   id: MobFox
   description: They're a fox.
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Fox
-    understands:
-    - Fox
-    - Canilunzt
-  # Starlight-end
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Animals/fox.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: fox
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: fox-moving
-    noMovementLayers:
-      movement:
-        state: fox
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 50 #They actually are pretty light, I looked it up
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: fox
-    templateId: pet
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: fox
-      Critical:
-        Base: fox_dead
-      Dead:
-        Base: fox_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 3
-  - type: InteractionPopup
-    successChance: 0.5
-    interactSuccessString: petting-success-soft-floofy
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      collection: Fox
-  - type: Grammar
-    attributes:
-      gender: epicene
-  - type: Bloodstream
-    bloodMaxVolume: 100
-  - type: MeleeWeapon
-    angle: 0
-    animation: WeaponArcBite
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    damage:
-      types:
-        Piercing: 8
-  - type: NpcFactionMember
-    factions:
-    - Passive
-  - type: NPCRetaliation
-    attackMemoryLength: 10
-  - type: HTN
-    rootTask:
-      task: RuminantHostileCompound
-  - type: MessyDrinker
-  - type: Tag
-    tags:
-    - VimPilot
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Fox
+      understands:
+        - Fox
+        - Canilunzt
+    # Starlight-end
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Animals/fox.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: fox
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: fox-moving
+      noMovementLayers:
+        movement:
+          state: fox
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 50 #They actually are pretty light, I looked it up
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: fox
+      templateId: pet
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: fox
+        Critical:
+          Base: fox_dead
+        Dead:
+          Base: fox_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 3
+    - type: InteractionPopup
+      successChance: 0.5
+      interactSuccessString: petting-success-soft-floofy
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        collection: Fox
+    - type: Grammar
+      attributes:
+        gender: epicene
+    - type: Bloodstream
+      bloodMaxVolume: 100
+    - type: MeleeWeapon
+      angle: 0
+      animation: WeaponArcBite
+      soundHit:
+        path: /Audio/Effects/bite.ogg
+      damage:
+        types:
+          Piercing: 8
+    - type: NpcFactionMember
+      factions:
+        - Passive
+    - type: NPCRetaliation
+      attackMemoryLength: 10
+    - type: HTN
+      rootTask:
+        task: RuminantHostileCompound
+    - type: MessyDrinker
+    - type: Tag
+      tags:
+        - VimPilot
 
 - type: entity
   abstract: true
@@ -2937,142 +2898,141 @@
   name: corgi
   description: Finally, a space corgi!
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/corgi.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: corgi
-  - type: Physics
-  - type: Speech
-    speechVerb: Canine
-    speechSounds: Dog
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 50
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: dog
-    templateId: pet
-  - type: InteractionPopup
-    interactSuccessString: petting-success-dog
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/small_dog_bark_happy.ogg
-  - type: Grammar
-    attributes:
-      gender: epicene
-  - type: MobPrice
-    price: 200
-  - type: MessyDrinker
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/corgi.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: corgi
+    - type: Physics
+    - type: Speech
+      speechVerb: Canine
+      speechSounds: Dog
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 50
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: dog
+      templateId: pet
+    - type: InteractionPopup
+      interactSuccessString: petting-success-dog
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/small_dog_bark_happy.ogg
+    - type: Grammar
+      attributes:
+        gender: epicene
+    - type: MobPrice
+      price: 200
+    - type: MessyDrinker
 
 - type: entity
   parent: MobCorgiBase
   id: MobCorgi
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Dog
-    understands:
-    - Dog
-    - Canilunzt
-  # Starlight-end
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: corgi
-      Critical:
-        Base: corgi_dead
-      Dead:
-        Base: corgi_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 2
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-corgi
-  - type: Tag
-    tags:
-    - VimPilot
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Dog
+      understands:
+        - Dog
+        - Canilunzt
+    # Starlight-end
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: corgi
+        Critical:
+          Base: corgi_dead
+        Dead:
+          Base: corgi_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 2
+    - type: SentienceTarget
+      flavorKind: station-event-random-sentience-flavor-corgi
+    - type: Tag
+      tags:
+        - VimPilot
 
 - type: entity
   name: corrupted corgi
-  parent: [ MobCorgi, MobCombat ]
+  parent: [MobCorgi, MobCombat]
   id: MobCorgiNarsi
   description: Ian! No!
   components:
-  # Starlight Start
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Dog
-    understands:
-    - Dog
-    - GalacticCommon
-  # Starlight End
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/corgi.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: narsian
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: narsian
-      Critical:
-        Base: narsian_dead
-      Dead:
-        Base: narsian_dead
-  - type: MeleeWeapon
-    soundHit:
+    # Starlight Start
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Dog
+      understands:
+        - Dog
+        - GalacticCommon
+    # Starlight End
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/corgi.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: narsian
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: narsian
+        Critical:
+          Base: narsian_dead
+        Dead:
+          Base: narsian_dead
+    - type: MeleeWeapon
+      soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
-    animation: WeaponArcBite
-    damage:
-      types:
-        Piercing: 5
-        Slash: 5
-  - type: InputMover
-  - type: MobMover
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
-  - type: NpcFactionMember
-    factions:
-    - SimpleHostile
-  - type: InteractionPopup
-    successChance: 0 # Override the automatic success that would normally be inherited from MobCorgi.
-    interactSuccessString: petting-success-corrupted-corgi # Normally impossible but added an easter egg just in case.
-    interactFailureString: petting-failure-corrupted-corgi
-  - type: Grammar
-    attributes:
-      gender: epicene
-  - type: Bloodstream
-    bloodReagent: DemonsBlood
-  - type: Damageable
-    damageContainer: BiologicalMetaphysical
-    damageModifierSet: Infernal
-  - type: Temperature
-    heatDamageThreshold: 4000 #They come from hell, so..
-    coldDamageThreshold: 260
-    currentTemperature: 310.15
-    coldDamage:
-      types:
-        Cold : 1 #per second, scales with temperature & other constants
-    specificHeat: 42
-    heatDamage:
-      types:
-        Heat : 1 #per second, scales with temperature & other constants
+      angle: 0
+      animation: WeaponArcBite
+      damage:
+        types:
+          Piercing: 5
+          Slash: 5
+    - type: InputMover
+    - type: MobMover
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound
+    - type: NpcFactionMember
+      factions:
+        - SimpleHostile
+    - type: InteractionPopup
+      successChance: 0 # Override the automatic success that would normally be inherited from MobCorgi.
+      interactSuccessString: petting-success-corrupted-corgi # Normally impossible but added an easter egg just in case.
+      interactFailureString: petting-failure-corrupted-corgi
+    - type: Grammar
+      attributes:
+        gender: epicene
+    - type: Bloodstream
+      bloodReagent: DemonsBlood
+    - type: Damageable
+      damageContainer: BiologicalMetaphysical
+      damageModifierSet: Infernal
+    - type: Temperature
+      heatDamageThreshold: 4000 #They come from hell, so..
+      coldDamageThreshold: 260
+      currentTemperature: 310.15
+      coldDamage:
+        types:
+          Cold: 1 #per second, scales with temperature & other constants
+      specificHeat: 42
+      heatDamage:
+        types:
+          Heat: 1 #per second, scales with temperature & other constants
 
 - type: entity
   name: corgi puppy
@@ -3080,27 +3040,27 @@
   id: MobCorgiPuppy
   description: A little corgi! Aww...
   components:
-  - type: VentCrawler
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/corgi.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: puppy
-  - type: Inventory
-    speciesId: puppy
-    templateId: pet
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: puppy
-      Critical:
-        Base: puppy_dead
-      Dead:
-        Base: puppy_dead
-  - type: Grammar
-    attributes:
-      gender: epicene
+    - type: VentCrawler
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/corgi.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: puppy
+    - type: Inventory
+      speciesId: puppy
+      templateId: pet
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: puppy
+        Critical:
+          Base: puppy_dead
+        Dead:
+          Base: puppy_dead
+    - type: Grammar
+      attributes:
+        gender: epicene
 
 - type: entity
   name: cat
@@ -3108,77 +3068,76 @@
   id: MobCat
   description: Feline pet, very funny.
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Cat
-    understands:
-    - Cat
-    - Nekomimetic
-  # Starlight-end
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/cat.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: cat
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 15
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: cat
-    templateId: pet
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: cat
-      Critical:
-        Base: cat_dead
-      Dead:
-        Base: cat_dead
-  - type: Speech
-    speechSounds: Cat
-    speechVerb: SmallMob
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 3
-  - type: InteractionPopup
-    successChance: 0.7
-    interactSuccessString: petting-success-cat
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/cat_meow.ogg
-  - type: MeleeWeapon
-    altDisarm: false
-    angle: 0
-    animation: WeaponArcBite
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    damage:
-      types:
-        Piercing: 5
-  - type: Grammar
-    attributes:
-      gender: epicene
-  - type: MobPrice
-    price: 200
-  - type: Tag
-    tags:
-    - VimPilot
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 2
-    baseSprintSpeed: 4
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Cat
+      understands:
+        - Cat
+        - Nekomimetic
+    # Starlight-end
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/cat.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: cat
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 15
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: cat
+      templateId: pet
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: cat
+        Critical:
+          Base: cat_dead
+        Dead:
+          Base: cat_dead
+    - type: Speech
+      speechSounds: Cat
+      speechVerb: SmallMob
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 3
+    - type: InteractionPopup
+      successChance: 0.7
+      interactSuccessString: petting-success-cat
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/cat_meow.ogg
+    - type: MeleeWeapon
+      altDisarm: false
+      angle: 0
+      animation: WeaponArcBite
+      soundHit:
+        path: /Audio/Effects/bite.ogg
+      damage:
+        types:
+          Piercing: 5
+    - type: Grammar
+      attributes:
+        gender: epicene
+    - type: MobPrice
+      price: 200
+    - type: Tag
+      tags:
+        - VimPilot
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 2
+      baseSprintSpeed: 4
 
 - type: entity
   name: calico cat
@@ -3186,18 +3145,18 @@
   parent: MobCat
   description: Feline pet, very funny.
   components:
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: cat2
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: cat2
-      Critical:
-        Base: cat2_dead
-      Dead:
-        Base: cat2_dead
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: cat2
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: cat2
+        Critical:
+          Base: cat2_dead
+        Dead:
+          Base: cat2_dead
 
 - type: entity
   name: syndicat
@@ -3205,60 +3164,60 @@
   parent: MobCatSpace
   description: Explosive kitten.
   components:
-# Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Cat
-    understands:
-    - Cat
-    - GalacticCommon
-# Starlight-end
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: syndicat
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: syndicat
-      Critical:
-        Base: syndicat_dead
-      Dead:
-        Base: syndicat_dead
-  - type: GhostRole
-    prob: 1
-    name: ghost-role-information-SyndiCat-name
-    allowMovement: true
-    description: ghost-role-information-SyndiCat-description
-    rules: ghost-role-information-SyndiCat-rules
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-    raffle:
-      settings: default
-  - type: GhostTakeoverAvailable
-  - type: AutoImplant
-    implants:
-    - MicroBombImplant
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
-  - type: NpcFactionMember
-    factions:
-    - Syndicate
-  - type: Access
-    tags:
-    - NuclearOperative
-    - SyndicateAgent
-  - type: MeleeWeapon
-    altDisarm: false
-    angle: 0
-    animation: WeaponArcBite
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    damage:
-      types:
-        Slash: 6
-        Piercing: 6
-        Structural: 15
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Cat
+      understands:
+        - Cat
+        - GalacticCommon
+    # Starlight-end
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: syndicat
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: syndicat
+        Critical:
+          Base: syndicat_dead
+        Dead:
+          Base: syndicat_dead
+    - type: GhostRole
+      prob: 1
+      name: ghost-role-information-SyndiCat-name
+      allowMovement: true
+      description: ghost-role-information-SyndiCat-description
+      rules: ghost-role-information-SyndiCat-rules
+      mindRoles:
+        - MindRoleGhostRoleTeamAntagonist
+      raffle:
+        settings: default
+    - type: GhostTakeoverAvailable
+    - type: AutoImplant
+      implants:
+        - MicroBombImplant
+    - type: ExplosionResistance
+      damageCoefficient: 0.2
+    - type: NpcFactionMember
+      factions:
+        - Syndicate
+    - type: Access
+      tags:
+        - NuclearOperative
+        - SyndicateAgent
+    - type: MeleeWeapon
+      altDisarm: false
+      angle: 0
+      animation: WeaponArcBite
+      soundHit:
+        path: /Audio/Effects/bite.ogg
+      damage:
+        types:
+          Slash: 6
+          Piercing: 6
+          Structural: 15
 
 - type: entity
   name: space cat
@@ -3266,37 +3225,37 @@
   parent: MobCat
   description: Feline pet, prepared for the worst.
   components:
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: spacecat
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: spacecat
-      Critical:
-        Base: spacecat_dead
-      Dead:
-        Base: spacecat_dead
-  - type: Temperature
-    heatDamageThreshold: 423
-    coldDamageThreshold: 0
-  - type: Tag
-    tags:
-      - DoorBumpOpener
-  - type: MovementAlwaysTouching
-  - type: PressureImmunity
-  - type: ProtectedFromStepTriggers
-  - type: Insulated
-  - type: InteractionPopup
-    successChance: 0.7
-    interactSuccessString: petting-success-space-cat
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/cat_meow.ogg
-  - type: Respirator #It just works?
-    minSaturation: 5.0
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: spacecat
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: spacecat
+        Critical:
+          Base: spacecat_dead
+        Dead:
+          Base: spacecat_dead
+    - type: Temperature
+      heatDamageThreshold: 423
+      coldDamageThreshold: 0
+    - type: Tag
+      tags:
+        - DoorBumpOpener
+    - type: MovementAlwaysTouching
+    - type: PressureImmunity
+    - type: ProtectedFromStepTriggers
+    - type: Insulated
+    - type: InteractionPopup
+      successChance: 0.7
+      interactSuccessString: petting-success-space-cat
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/cat_meow.ogg
+    - type: Respirator #It just works?
+      minSaturation: 5.0
 
 - type: entity
   name: caracal cat
@@ -3304,19 +3263,19 @@
   parent: MobCat
   description: Hilarious.
   components:
-  - type: Sprite
-    sprite: Mobs/Pets/caracal.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: caracal_flop
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: caracal_flop
-      Critical:
-        Base: caracal_dead
-      Dead:
-        Base: caracal_dead
+    - type: Sprite
+      sprite: Mobs/Pets/caracal.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: caracal_flop
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: caracal_flop
+        Critical:
+          Base: caracal_dead
+        Dead:
+          Base: caracal_dead
 
 - type: entity
   name: kitten
@@ -3324,32 +3283,32 @@
   id: MobCatKitten
   description: Small and fluffy.
   components:
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: kitten
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: kitten
-      Critical:
-        Base: kitten_dead
-      Dead:
-        Base: kitten_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 1
-  - type: MobPrice
-    price: 100
-  - type: MeleeWeapon
-    damage:
-      types:
-        Piercing: 3
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      25: Dead
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: kitten
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: kitten
+        Critical:
+          Base: kitten_dead
+        Dead:
+          Base: kitten_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 1
+    - type: MobPrice
+      price: 100
+    - type: MeleeWeapon
+      damage:
+        types:
+          Piercing: 3
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        25: Dead
 
 - type: entity
   name: sloth
@@ -3357,56 +3316,55 @@
   id: MobSloth
   description: Very slow animal. For people with low energy.
   components:
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 0.5
-    baseSprintSpeed : 1
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/sloth.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: sloth
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 15
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: sloth
-    templateId: pet
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: sloth
-      Critical:
-        Base: sloth_dead
-      Dead:
-        Base: sloth_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 3
-  - type: InteractionPopup
-    successChance: 0.9
-    interactSuccessString: petting-success-sloth
-    interactFailureString: petting-failure-sloth
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/sloth_squeak.ogg
-  - type: Grammar
-    attributes:
-      gender: epicene
-  - type: SlowAccent
-  - type: Tag
-    tags:
-    - VimPilot
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 0.5
+      baseSprintSpeed: 1
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/sloth.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: sloth
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 15
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: sloth
+      templateId: pet
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: sloth
+        Critical:
+          Base: sloth_dead
+        Dead:
+          Base: sloth_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 3
+    - type: InteractionPopup
+      successChance: 0.9
+      interactSuccessString: petting-success-sloth
+      interactFailureString: petting-failure-sloth
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/sloth_squeak.ogg
+    - type: Grammar
+      attributes:
+        gender: epicene
+    - type: SlowAccent
+    - type: Tag
+      tags:
+        - VimPilot
 
 - type: entity
   name: ferret
@@ -3414,211 +3372,208 @@
   id: MobFerret
   description: Just a silly little guy!
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/ferret.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: ferret
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 5
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: fox #close enough
-    templateId: pet
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: ferret
-      Critical:
-        Base: ferret_dead
-      Dead:
-        Base: ferret_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 3
-  - type: InteractionPopup
-    successChance: 0.8
-    interactDelay: 1.5 # Avoids overlapping SFX due to spam - these SFX are a little longer than the typical 1 second.
-    interactSuccessString: petting-success-soft-floofy
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/ferret_happy.ogg
-  - type: Grammar
-    attributes:
-      gender: epicene
-  - type: Tag
-    tags:
-    - VimPilot
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/ferret.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: ferret
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 5
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: fox #close enough
+      templateId: pet
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: ferret
+        Critical:
+          Base: ferret_dead
+        Dead:
+          Base: ferret_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 3
+    - type: InteractionPopup
+      successChance: 0.8
+      interactDelay: 1.5 # Avoids overlapping SFX due to spam - these SFX are a little longer than the typical 1 second.
+      interactSuccessString: petting-success-soft-floofy
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/ferret_happy.ogg
+    - type: Grammar
+      attributes:
+        gender: epicene
+    - type: Tag
+      tags:
+        - VimPilot
 
 - type: entity
   name: hamster
-  parent: [ SimpleMobBase, MobCombat, StripableInventoryBase]
+  parent: [SimpleMobBase, MobCombat, StripableInventoryBase]
   id: MobHamster
   description: A cute, fluffy, robust hamster.
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Mouse
-    understands:
-    - Mouse
-  # Starlight-end
-  - type: VentCrawler # Starlight-edit: Vent Crawl
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: ghost-role-information-hamster-name
-    description: ghost-role-information-hamster-description
-    rules: ghost-role-information-nonantagonist-rules
-  - type: GhostTakeoverAvailable
-  - type: Speech
-    speechVerb: SmallMob
-    speechSounds: Squeak
-    allowedEmotes: ['Squeak']
-  - type: Sprite
-    drawdepth: SmallMobs
-    sprite: Mobs/Animals/hamster.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: hamster-0
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: hamster-moving-0
-    noMovementLayers:
-      movement:
-        state: hamster-0
-  - type: Item
-    size: Tiny
-  - type: Physics
-  - type: FaxableObject
-    insertingState: inserting_hamster
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.2
-        density: 120
-        mask:
-        - SmallMobMask
-        layer:
-        - SmallMobLayer
-  - type: MobState
-  - type: Deathgasp
-  - type: MobStateActions
-    actions:
-      Critical:
-      - ActionCritSuccumb
-      - ActionCritFakeDeath
-      - ActionCritLastWords
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      40: Critical
-      60: Dead
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
-    baseSprintSpeed : 4
-  - type: Inventory
-    speciesId: hamster
-    templateId: hamster
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: hamster-0
-      Critical:
-        Base: dead-0
-      Dead:
-        Base: splat-0
-  - type: Food
-  - type: FlavorProfile
-    flavors:
-    - meaty
-  - type: Hunger
-    baseDecayRate: 0.3
-  - type: Extractable
-    grindableSolutionName: food
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
-        - ReagentId: Blood
-          Quantity: 55
-        - ReagentId: Fat
-          Quantity: 5
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 1
-  - type: Tag
-    tags:
-    - VimPilot
-    - ChefPilot
-    - Trash
-    - Hamster
-    - Meat
-  - type: Respirator
-    damage:
-      types:
-        Asphyxiation: 0.25
-    damageRecovery:
-      types:
-        Asphyxiation: -0.25
-  - type: Barotrauma
-    damage:
-      types:
-        Blunt: 0.1
-  - type: CombatMode
-  - type: MeleeWeapon
-    soundHit:
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Mouse
+      understands:
+        - Mouse
+    # Starlight-end
+    - type: VentCrawler # Starlight-edit: Vent Crawl
+    - type: GhostRole
+      makeSentient: true
+      allowSpeech: true
+      allowMovement: true
+      name: ghost-role-information-hamster-name
+      description: ghost-role-information-hamster-description
+      rules: ghost-role-information-nonantagonist-rules
+    - type: GhostTakeoverAvailable
+    - type: Speech
+      speechVerb: SmallMob
+      speechSounds: Squeak
+      allowedEmotes: ["Squeak"]
+    - type: Sprite
+      drawdepth: SmallMobs
+      sprite: Mobs/Animals/hamster.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: hamster-0
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: hamster-moving-0
+      noMovementLayers:
+        movement:
+          state: hamster-0
+    - type: Item
+      size: Tiny
+    - type: Physics
+    - type: FaxableObject
+      insertingState: inserting_hamster
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.2
+          density: 120
+          mask:
+            - SmallMobMask
+          layer:
+            - SmallMobLayer
+    - type: MobState
+    - type: Deathgasp
+    - type: MobStateActions
+      actions:
+        Critical:
+          - ActionCritSuccumb
+          - ActionCritFakeDeath
+          - ActionCritLastWords
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        40: Critical
+        60: Dead
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 2.5
+      baseSprintSpeed: 4
+    - type: Inventory
+      speciesId: hamster
+      templateId: hamster
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: hamster-0
+        Critical:
+          Base: dead-0
+        Dead:
+          Base: splat-0
+    - type: Food
+    - type: FlavorProfile
+      flavors:
+        - meaty
+    - type: Hunger
+      baseDecayRate: 0.3
+    - type: Extractable
+      grindableSolutionName: food
+    - type: SolutionContainerManager
+      solutions:
+        food:
+          reagents:
+            - ReagentId: Nutriment
+              Quantity: 10
+            - ReagentId: Blood
+              Quantity: 55
+            - ReagentId: Fat
+              Quantity: 5
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 1
+    - type: Tag
+      tags:
+        - VimPilot
+        - ChefPilot
+        - Trash
+        - Hamster
+        - Meat
+    - type: Respirator
+      damage:
+        types:
+          Asphyxiation: 0.25
+      damageRecovery:
+        types:
+          Asphyxiation: -0.25
+    - type: Barotrauma
+      damage:
+        types:
+          Blunt: 0.1
+    - type: CombatMode
+    - type: MeleeWeapon
+      soundHit:
         path: /Audio/Effects/bite.ogg
-    angle: 0
-    animation: WeaponArcBite
-    damage:
-      types:
-        Piercing: 2
-  - type: InteractionPopup
-    successChance: 0.4
-    interactSuccessString: petting-success-hamster
-    interactFailureString: petting-failure-hamster
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/fox_squeak.ogg
-  - type: Bloodstream
-    bloodMaxVolume: 60
-  - type: CanEscapeInventory
-    baseResistTime: 3
-  - type: MobPrice
-    price: 60
-  - type: NonSpreaderZombie
-  - type: FireVisuals
-    sprite: Mobs/Effects/onfire.rsi
-    normalState: Mouse_burning
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 120
-      behaviors:
-      - !type:GibBehavior
-        recursive: false
+      angle: 0
+      animation: WeaponArcBite
+      damage:
+        types:
+          Piercing: 2
+    - type: InteractionPopup
+      successChance: 0.4
+      interactSuccessString: petting-success-hamster
+      interactFailureString: petting-failure-hamster
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/fox_squeak.ogg
+    - type: Bloodstream
+      bloodMaxVolume: 60
+    - type: CanEscapeInventory
+      baseResistTime: 3
+    - type: MobPrice
+      price: 60
+    - type: NonSpreaderZombie
+    - type: FireVisuals
+      sprite: Mobs/Effects/onfire.rsi
+      normalState: Mouse_burning
+    - type: Destructible
+      thresholds:
+        - trigger: !type:DamageTypeTrigger
+            damageType: Blunt
+            damage: 120
+          behaviors:
+            - !type:GibBehavior
+              recursive: false
 
 - type: entity
   name: pig
@@ -3626,75 +3581,74 @@
   id: MobPig
   description: Oink.
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Pig
-    understands:
-    - Pig
-  # Starlight-end
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: pig
-      sprite: Mobs/Animals/pig.rsi
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 250
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: pig
-    templateId: pet
-  - type: Tag
-    tags:
-    - DoorBumpOpener
-    - Pig
-    - VimPilot
-  - type: Reproductive
-    partnerWhitelist:
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Pig
+      understands:
+        - Pig
+    # Starlight-end
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: pig
+          sprite: Mobs/Animals/pig.rsi
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 250
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: pig
+      templateId: pet
+    - type: Tag
       tags:
-      - Pig
-    offspring:
-    - id: MobPig
-  - type: ReproductivePartner
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: pig
-      Critical:
-        Base: dead
-      Dead:
-        Base: dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatBacon
-      amount: 6
-  - type: Grammar
-    attributes:
-      gender: epicene
-  - type: InteractionPopup
-    successChance: 0.7
-    interactSuccessString: petting-success-pig
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/pig_oink.ogg
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-organic
-  - type: NpcFactionMember
-    factions:
-    - Passive
-  - type: HTN
-    rootTask:
-      task: RuminantCompound
+        - DoorBumpOpener
+        - Pig
+        - VimPilot
+    - type: Reproductive
+      partnerWhitelist:
+        tags:
+          - Pig
+      offspring:
+        - id: MobPig
+    - type: ReproductivePartner
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: pig
+        Critical:
+          Base: dead
+        Dead:
+          Base: dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatBacon
+          amount: 6
+    - type: Grammar
+      attributes:
+        gender: epicene
+    - type: InteractionPopup
+      successChance: 0.7
+      interactSuccessString: petting-success-pig
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/pig_oink.ogg
+    - type: SentienceTarget
+      flavorKind: station-event-random-sentience-flavor-organic
+    - type: NpcFactionMember
+      factions:
+        - Passive
+    - type: HTN
+      rootTask:
+        task: RuminantCompound
 
 - type: entity
   name: diona nymph
@@ -3703,193 +3657,191 @@
   description: It's like a cat, only.... branch-ier.
   components:
     # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Sylvan
-    understands:
-    - Sylvan
-  # Starlight-end
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: nymph
-      sprite: Mobs/Animals/nymph.rsi
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 100 # High, because wood is heavy.
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: cat
-    templateId: pet
-  - type: Bloodstream
-    bloodReagent: Sap
-    bloodMaxVolume: 60
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: nymph
-      Critical:
-        Base: nymph_sleep
-      Dead:
-        Base: nymph_dead
-  - type: Butcherable
-    spawned:
-    - id: MaterialWoodPlank1
-      amount: 2
-  - type: InteractionPopup
-    successChance: 0.7
-    interactSuccessString: petting-success-nymph
-    interactFailureString: petting-failure-nymph
-    interactSuccessSound:
-      path: /Audio/Animals/nymph_chirp.ogg
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      30: Critical
-      60: Dead
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
-    baseSprintSpeed : 4.5
-  - type: Grammar
-    attributes:
-      gender: epicene
-  - type: Speech
-    speechVerb: Plant
-    speechSounds: Alto
-    allowedEmotes: ['Chirp']
-  - type: Vocal
-    sounds:
-      Male: UnisexDiona
-      Female: UnisexDiona
-      Unsexed: UnisexDiona
-  - type: Tag
-    tags:
-    - DoorBumpOpener
-    - VimPilot
-  - type: Emoting
-  - type: BodyEmotes
-    soundsId: Nymph
-  - type: Reform
-    actionPrototype: DionaReformAction
-    reformTime: 10
-    popupText: diona-reform-attempt
-    reformPrototype: MobDionaReformed
+    - type: LanguageKnowledge
+      speaks:
+        - Sylvan
+      understands:
+        - Sylvan
+    # Starlight-end
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: nymph
+          sprite: Mobs/Animals/nymph.rsi
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 100 # High, because wood is heavy.
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: cat
+      templateId: pet
+    - type: Bloodstream
+      bloodReagent: Sap
+      bloodMaxVolume: 60
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: nymph
+        Critical:
+          Base: nymph_sleep
+        Dead:
+          Base: nymph_dead
+    - type: Butcherable
+      spawned:
+        - id: MaterialWoodPlank1
+          amount: 2
+    - type: InteractionPopup
+      successChance: 0.7
+      interactSuccessString: petting-success-nymph
+      interactFailureString: petting-failure-nymph
+      interactSuccessSound:
+        path: /Audio/Animals/nymph_chirp.ogg
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        30: Critical
+        60: Dead
+    - type: MovementSpeedModifier
+      baseWalkSpeed: 2.5
+      baseSprintSpeed: 4.5
+    - type: Grammar
+      attributes:
+        gender: epicene
+    - type: Speech
+      speechVerb: Plant
+      speechSounds: Alto
+      allowedEmotes: ["Chirp"]
+    - type: Vocal
+      sounds:
+        Male: UnisexDiona
+        Female: UnisexDiona
+        Unsexed: UnisexDiona
+    - type: Tag
+      tags:
+        - DoorBumpOpener
+        - VimPilot
+    - type: Emoting
+    - type: BodyEmotes
+      soundsId: Nymph
+    - type: Reform
+      actionPrototype: DionaReformAction
+      reformTime: 10
+      popupText: diona-reform-attempt
+      reformPrototype: MobDionaReformed
 
 - type: entity
   parent: MobDionaNymph
   id: MobDionaNymphAccent # No talky. For non-brain & wild nymphs
   suffix: Accent
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Sylvan
-    understands:
-    - Sylvan
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Sylvan
+      understands:
+        - Sylvan
   # Starlight-end
 
 - type: entity
   name: reindeer buck
-  parent: [ SimpleMobBase, MobCombat ]
+  parent: [SimpleMobBase, MobCombat]
   id: MobReindeerBuck
   description: You think it can pull a sleigh?
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: reindeer_buck
-      sprite: Mobs/Animals/reindeer_buck.rsi
-#  - type: SpriteMovement  # One day when this shit isnt broken as hell. For now they hoppity hop.
-#    movementLayers:
-#      movement:
-#        state: reindeer_buck
-#    noMovementLayers:
-#      movement:
-#        state: reindeer_buck_still
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.48
-        density: 200
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: reindeer_buck
-      Critical:
-        Base: reindeer_buck_dead
-      Dead:
-        Base: reindeer_buck_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 4
-  - type: Bloodstream
-    bloodMaxVolume: 300
-    # Horns though
-  - type: MeleeWeapon
-    damage:
-      types:
-        Piercing: 22
-    animation: WeaponArcFist
-  - type: NPCRetaliation
-  - type: FactionException
-  - type: NpcFactionMember
-    factions:
-    - Passive
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
-  - type: Puller
-    needsHands: false
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: reindeer_buck
+          sprite: Mobs/Animals/reindeer_buck.rsi
+    #  - type: SpriteMovement  # One day when this shit isnt broken as hell. For now they hoppity hop.
+    #    movementLayers:
+    #      movement:
+    #        state: reindeer_buck
+    #    noMovementLayers:
+    #      movement:
+    #        state: reindeer_buck_still
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.48
+          density: 200
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: reindeer_buck
+        Critical:
+          Base: reindeer_buck_dead
+        Dead:
+          Base: reindeer_buck_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 4
+    - type: Bloodstream
+      bloodMaxVolume: 300
+      # Horns though
+    - type: MeleeWeapon
+      damage:
+        types:
+          Piercing: 22
+      animation: WeaponArcFist
+    - type: NPCRetaliation
+    - type: FactionException
+    - type: NpcFactionMember
+      factions:
+        - Passive
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound
+    - type: Puller
+      needsHands: false
 
 - type: entity
   name: reindeer doe
   parent: MobReindeerBuck
   id: MobReindeerDoe
   components:
-  - type: MeleeWeapon
-    damage:
-      types:
-        Blunt: 15
-    animation: WeaponArcFist
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: reindeer_doe
-      sprite: Mobs/Animals/reindeer_doe.rsi
-#  - type: SpriteMovement  # One day when this shit isnt broken as hell. For now they hoppity hop.
-#    movementLayers:
-#      movement:
-#        state: reindeer_doe
-#    noMovementLayers:
-#      movement:
-#        state: reindeer_doe_still
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: reindeer_doe
-      Critical:
-        Base: reindeer_doe_dead
-      Dead:
-        Base: reindeer_doe_dead
+    - type: MeleeWeapon
+      damage:
+        types:
+          Blunt: 15
+      animation: WeaponArcFist
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: reindeer_doe
+          sprite: Mobs/Animals/reindeer_doe.rsi
+    #  - type: SpriteMovement  # One day when this shit isnt broken as hell. For now they hoppity hop.
+    #    movementLayers:
+    #      movement:
+    #        state: reindeer_doe
+    #    noMovementLayers:
+    #      movement:
+    #        state: reindeer_doe_still
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: reindeer_doe
+        Critical:
+          Base: reindeer_doe_dead
+        Dead:
+          Base: reindeer_doe_dead
 
 - type: entity
   parent: MobCorgiBase
@@ -3897,76 +3849,75 @@
   name: smart corgi
   description: An unusually smart dog.
   components:
-  # Use corgi sprite, need to add handcuff layer
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Dog
-    - GalacticCommon
-    understands:
-    - Dog
-    - GalacticCommon
-    - Canilunzt
-  # Starlight-end
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: corgi
-    - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
-      color: "#ffffff"
-      sprite: Objects/Misc/handcuffs.rsi # Would do a custom dog handcuff sprite but unfortunately handcuffs have their overlay baked-in to the cuff itself so this is mostly filler
-      state: body-overlay-2
-      visible: false
-  - type: UserInterface
-    interfaces:
-      enum.StrippingUiKey.Key:
-        type: StrippableBoundUserInterface
-      enum.StorageUiKey.Key:
-        type: StorageBoundUserInterface
-  # Custom inventory template
-  - type: Inventory
-    speciesId: dog
-    templateId: SmartCorgi
-    displacements:
-      belt:
-        sizeMaps:
-          32:
-            sprite: Mobs/Pets/displacements.rsi
-            state: corgi_belt_displacement
-      ears:
-        sizeMaps:
-          32:
-            sprite: Mobs/Pets/displacements.rsi
-            state: corgi_belt_displacement
-      head:
-        sizeMaps:
-          32:
-            sprite: Mobs/Pets/displacements.rsi
-            state: corgi_head_displacement
-  - type: Hands # HANDS!
-  - type: Puller
-  - type: Cuffable # bad dog!
-  - type: BlockWriting # dogs can't write, paws unwieldy; mouth-writing is a myth
-  - type: Stripping
-  - type: ComplexInteraction
-  # Implement custom borgi body type
-  - type: Body
-    prototype: SmartCorgi
-  - type: RotationVisuals
-    defaultRotation: 90
-    horizontalRotation: 180
-  - type: Grammar
-    attributes:
-      gender: epicene # Gender neutral
-      proper: true
-  - type: Tag
-    tags:
-    - VimPilot
-    - CanPilot
-    - DoorBumpOpener
-  - type: StatusIcon # marks them as crew
-    bounds: -0.5,-0.5,0.5,0.5
-  - type: NpcFactionMember
-    factions:
-    - NanoTrasen
-
+    # Use corgi sprite, need to add handcuff layer
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Dog
+        - GalacticCommon
+      understands:
+        - Dog
+        - GalacticCommon
+        - Canilunzt
+    # Starlight-end
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: corgi
+        - map: ["enum.HumanoidVisualLayers.Handcuffs"]
+          color: "#ffffff"
+          sprite: Objects/Misc/handcuffs.rsi # Would do a custom dog handcuff sprite but unfortunately handcuffs have their overlay baked-in to the cuff itself so this is mostly filler
+          state: body-overlay-2
+          visible: false
+    - type: UserInterface
+      interfaces:
+        enum.StrippingUiKey.Key:
+          type: StrippableBoundUserInterface
+        enum.StorageUiKey.Key:
+          type: StorageBoundUserInterface
+    # Custom inventory template
+    - type: Inventory
+      speciesId: dog
+      templateId: SmartCorgi
+      displacements:
+        belt:
+          sizeMaps:
+            32:
+              sprite: Mobs/Pets/displacements.rsi
+              state: corgi_belt_displacement
+        ears:
+          sizeMaps:
+            32:
+              sprite: Mobs/Pets/displacements.rsi
+              state: corgi_belt_displacement
+        head:
+          sizeMaps:
+            32:
+              sprite: Mobs/Pets/displacements.rsi
+              state: corgi_head_displacement
+    - type: Hands # HANDS!
+    - type: Puller
+    - type: Cuffable # bad dog!
+    - type: BlockWriting # dogs can't write, paws unwieldy; mouth-writing is a myth
+    - type: Stripping
+    - type: ComplexInteraction
+    # Implement custom borgi body type
+    - type: Body
+      prototype: SmartCorgi
+    - type: RotationVisuals
+      defaultRotation: 90
+      horizontalRotation: 180
+    - type: Grammar
+      attributes:
+        gender: epicene # Gender neutral
+        proper: true
+    - type: Tag
+      tags:
+        - VimPilot
+        - CanPilot
+        - DoorBumpOpener
+    - type: StatusIcon # marks them as crew
+      bounds: -0.5,-0.5,0.5,0.5
+    - type: NpcFactionMember
+      factions:
+        - NanoTrasen

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -626,6 +626,8 @@
               Quantity: 90
             - ReagentId: Slime
               Quantity: 8
+        absorbed:
+          maxVol: 50
     - type: Butcherable
       spawned:
         - id: FoodMeatSlime

--- a/Resources/Prototypes/Entities/Mobs/NPCs/moproach.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/moproach.yml
@@ -27,13 +27,14 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      45: Critical
-      65: Dead
+      60: Critical
+      95: Dead
   - type: Food
     requireDead: true
-    transferAmount: 2
+    transferAmount: 4
   - type: MovementSpeedModifier
-    baseSprintSpeed : 5 # extra speed for that moppin'!
+    baseWalkSpeed: 2.6
+    baseSprintSpeed: 5 # extra speed for that moppin'!
   - type: NoSlip
   - type: HTN
     rootTask:
@@ -58,14 +59,26 @@
       absorbed:
         maxVol: 50
       food:
+        maxVol: 140
         reagents:
-        - ReagentId: Slime
-          Quantity: 5
+          - ReagentId: Nutriment
+            Quantity: 12
+          - ReagentId: Protein
+            Quantity: 6
+          - ReagentId: InsectBlood
+            Quantity: 90
+          - ReagentId: Slime
+            Quantity: 8
   - type: DrainableSolution
     solution: drainBuffer
   - type: InteractionPopup
+    successChance: 0.9
+    interactDelay: 1
     interactSuccessString: petting-success-cleanbot
     interactFailureString: petting-failure-cleanbot
+    interactSuccessSpawn: EffectHearts
+    interactSuccessSound:
+      path: /Audio/Ambience/Objects/periodic_beep.ogg
 
 - type: entity
   parent: MobMoproach

--- a/Resources/Prototypes/Entities/Mobs/NPCs/moproach.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/moproach.yml
@@ -29,8 +29,12 @@
       0: Alive
       45: Critical
       65: Dead
+  - type: Food
+    requireDead: true
+    transferAmount: 2
   - type: MovementSpeedModifier
     baseSprintSpeed : 5 # extra speed for that moppin'!
+  - type: NoSlip
   - type: HTN
     rootTask:
       task: MoproachCompound
@@ -111,3 +115,4 @@
   components:
   - type: Paper
     content: book-text-moproach
+

--- a/Resources/Prototypes/Entities/Mobs/NPCs/moproach.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/moproach.yml
@@ -29,9 +29,6 @@
       0: Alive
       60: Critical
       95: Dead
-  - type: Food
-    requireDead: true
-    transferAmount: 4
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.6
     baseSprintSpeed: 5 # extra speed for that moppin'!
@@ -54,21 +51,6 @@
     preserve:
       - Water
     quantity: 10
-  - type: SolutionContainerManager
-    solutions:
-      absorbed:
-        maxVol: 50
-      food:
-        maxVol: 140
-        reagents:
-          - ReagentId: Nutriment
-            Quantity: 12
-          - ReagentId: Protein
-            Quantity: 6
-          - ReagentId: InsectBlood
-            Quantity: 90
-          - ReagentId: Slime
-            Quantity: 8
   - type: DrainableSolution
     solution: drainBuffer
   - type: InteractionPopup

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -7,59 +7,59 @@
   id: MobCorgiIan
   description: Favorite pet corgi.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Dog
-    understands:
-    - Dog
-    - GalacticCommon
-    - Canilunzt
-  # Starlight-end
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/corgi.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: ian
-  - type: Inventory
-    speciesId: dog
-    templateId: petAdvanced
-    displacements:
-      head:
-        sizeMaps:
-          32:
-            sprite: Mobs/Pets/displacements.rsi
-            state: corgi_head_displacement
-      eyes:
-        sizeMaps:
-          32:
-            sprite: Mobs/Pets/displacements.rsi
-            state: corgi_eyes_displacement
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: ian
-      Critical:
-        Base: ian_dead
-      Dead:
-        Base: ian_dead
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatCorgi
-      amount: 2
-    - id: MaterialHideCorgi
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
-  - type: StealTarget
-    stealGroup: AnimalIan
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Dog
+      understands:
+        - Dog
+        - GalacticCommon
+        - Canilunzt
+    # Starlight-end
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/corgi.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: ian
+    - type: Inventory
+      speciesId: dog
+      templateId: petAdvanced
+      displacements:
+        head:
+          sizeMaps:
+            32:
+              sprite: Mobs/Pets/displacements.rsi
+              state: corgi_head_displacement
+        eyes:
+          sizeMaps:
+            32:
+              sprite: Mobs/Pets/displacements.rsi
+              state: corgi_eyes_displacement
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: ian
+        Critical:
+          Base: ian_dead
+        Dead:
+          Base: ian_dead
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatCorgi
+          amount: 2
+        - id: MaterialHideCorgi
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
+    - type: StealTarget
+      stealGroup: AnimalIan
 
 - type: entity
   name: Old Ian
@@ -67,34 +67,34 @@
   id: MobCorgiIanOld
   description: Still the favorite pet corgi. Love his wheels.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Dog
-    understands:
-    - Dog
-    - GalacticCommon
-    - Canilunzt
-  # Starlight-end
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: old_ian
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: old_ian
-      Critical:
-        Base: old_ian_dead
-      Dead:
-        Base: old_ian_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatCorgi
-      amount: 2
-    - id: SheetSteel1
-    - id: MaterialHideCorgi
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Dog
+      understands:
+        - Dog
+        - GalacticCommon
+        - Canilunzt
+    # Starlight-end
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: old_ian
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: old_ian
+        Critical:
+          Base: old_ian_dead
+        Dead:
+          Base: old_ian_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatCorgi
+          amount: 2
+        - id: SheetSteel1
+        - id: MaterialHideCorgi
 
 - type: entity
   name: Lisa
@@ -102,46 +102,46 @@
   id: MobCorgiLisa
   description: Ian's favorite corgi.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Dog
-    understands:
-    - Dog
-    - GalacticCommon
-    - Canilunzt
-  # Starlight-end
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: lisa
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: lisa
-      Critical:
-        Base: lisa_dead
-      Dead:
-        Base: lisa_dead
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: female
-  - type: Inventory
-    speciesId: dog
-    templateId: petAdvanced
-    displacements:
-      head:
-        sizeMaps:
-          32:
-            sprite: Mobs/Pets/displacements.rsi
-            state: lisa_head_displacement
-      eyes:
-        sizeMaps:
-          32:
-            sprite: Mobs/Pets/displacements.rsi
-            state: corgi_eyes_displacement
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Dog
+      understands:
+        - Dog
+        - GalacticCommon
+        - Canilunzt
+    # Starlight-end
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: lisa
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: lisa
+        Critical:
+          Base: lisa_dead
+        Dead:
+          Base: lisa_dead
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: female
+    - type: Inventory
+      speciesId: dog
+      templateId: petAdvanced
+      displacements:
+        head:
+          sizeMaps:
+            32:
+              sprite: Mobs/Pets/displacements.rsi
+              state: lisa_head_displacement
+        eyes:
+          sizeMaps:
+            32:
+              sprite: Mobs/Pets/displacements.rsi
+              state: corgi_eyes_displacement
 
 - type: entity
   name: real mouse
@@ -149,32 +149,32 @@
   id: MobCorgiMouse
   description: It's 100% a real hungry mouse.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Dog
-    understands:
-    - Dog
-    - GalacticCommon
-    - Canilunzt
-  # Starlight-end
-  - type: Sprite
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: real_mouse
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: real_mouse
-      Critical:
-        Base: real_mouse_dead
-      Dead:
-        Base: real_mouse_dead
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: female
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Dog
+      understands:
+        - Dog
+        - GalacticCommon
+        - Canilunzt
+    # Starlight-end
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: real_mouse
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: real_mouse
+        Critical:
+          Base: real_mouse_dead
+        Dead:
+          Base: real_mouse_dead
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: female
 
 - type: entity
   name: Puppy Ian
@@ -182,27 +182,27 @@
   id: MobCorgiIanPup
   description: Favourite puppy corgi. Awww.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Dog
-    understands:
-    - Dog
-    - GalacticCommon
-    - Canilunzt
-  # Starlight-end
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-  - type: Butcherable # A puppy? You monster...
-    spawned:
-    - id: FoodMeatCorgi
-      amount: 2
-    - id: MaterialHideCorgi
-  - type: StealTarget
-    stealGroup: AnimalIan
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Dog
+      understands:
+        - Dog
+        - GalacticCommon
+        - Canilunzt
+    # Starlight-end
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    - type: Butcherable # A puppy? You monster...
+      spawned:
+        - id: FoodMeatCorgi
+          amount: 2
+        - id: MaterialHideCorgi
+    - type: StealTarget
+      stealGroup: AnimalIan
 
 - type: entity
   name: Runtime
@@ -210,36 +210,36 @@
   id: MobCatRuntime
   description: Professional mouse hunter. Escape artist.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Cat
-    understands:
-    - Cat
-    - GalacticCommon
-    - Nekomimetic
-  # Starlight-end
-  - type: NpcFactionMember
-    factions:
-      - PetsNT
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: female
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
-  - type: StealTarget
-    stealGroup: AnimalNamedCat
-  #region Starlight
-  - type: Butcherable
-    spawned:
-      - id: ClothingHandsCatPawsBlack
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Cat
+      understands:
+        - Cat
+        - GalacticCommon
+        - Nekomimetic
+    # Starlight-end
+    - type: NpcFactionMember
+      factions:
+        - PetsNT
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: female
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
+    - type: StealTarget
+      stealGroup: AnimalNamedCat
+    #region Starlight
+    - type: Butcherable
+      spawned:
+        - id: ClothingHandsCatPawsBlack
   #endregion Starlight
 
 - type: entity
@@ -248,33 +248,33 @@
   parent: MobCatCalico
   description: Ask nicely, and maybe they'll give you one of their spare lives.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Cat
-    understands:
-    - Cat
-    - GalacticCommon
-    - Nekomimetic
-  # Starlight-end
-  - type: NpcFactionMember
-    factions:
-      - PetsNT
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
-  - type: StealTarget
-    stealGroup: AnimalNamedCat
-  #region Starlight
-  - type: Butcherable
-    spawned:
-      - id: ClothingHandsCatPawsBrown
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Cat
+      understands:
+        - Cat
+        - GalacticCommon
+        - Nekomimetic
+    # Starlight-end
+    - type: NpcFactionMember
+      factions:
+        - PetsNT
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
+    - type: StealTarget
+      stealGroup: AnimalNamedCat
+    #region Starlight
+    - type: Butcherable
+      spawned:
+        - id: ClothingHandsCatPawsBrown
   #endregion Starlight
 
 - type: entity
@@ -283,41 +283,40 @@
   parent: MobCatCaracal
   description: He out here.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Cat
-    understands:
-    - Cat
-    - GalacticCommon
-    - Nekomimetic
-  # Starlight-end
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 40
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Grammar
-    attributes:
-      gender: male
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
-  - type: StealTarget
-    stealGroup: AnimalNamedCat
-    #region Starlight
-  - type: Butcherable
-    spawned:
-      - id: ClothingHandsCatPawsBrown
-    #endregion Starlight
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Cat
+      understands:
+        - Cat
+        - GalacticCommon
+        - Nekomimetic
+    # Starlight-end
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 40
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Grammar
+      attributes:
+        gender: male
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
+    - type: StealTarget
+      stealGroup: AnimalNamedCat
+      #region Starlight
+    - type: Butcherable
+      spawned:
+        - id: ClothingHandsCatPawsBrown
+      #endregion Starlight
 
 - type: entity
   name: Bandito
@@ -325,14 +324,14 @@
   id: MobBandito
   description: Just a silly little guy!
   components:
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
 
 - type: entity
   name: Bingus
@@ -340,67 +339,66 @@
   id: MobBingus
   description: Bingus my beloved...
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Cat
-    understands:
-    - Cat
-    - GalacticCommon
-    - Nekomimetic
-  # Starlight-end
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/bingus.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: bingus
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 12
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: cat
-    templateId: pet
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: bingus
-      Critical:
-        Base: bingus_dead
-      Dead:
-        Base: bingus_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 2
-    - id: ClothingHandsCatPawsWhite # Starlight
-  - type: InteractionPopup
-    successChance: 0.9
-    interactSuccessString: petting-success-bingus
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/cat_meow.ogg
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: epicene
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
-  - type: StealTarget
-    stealGroup: AnimalNamedCat
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Cat
+      understands:
+        - Cat
+        - GalacticCommon
+        - Nekomimetic
+    # Starlight-end
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/bingus.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: bingus
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 12
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: cat
+      templateId: pet
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: bingus
+        Critical:
+          Base: bingus_dead
+        Dead:
+          Base: bingus_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 2
+        - id: ClothingHandsCatPawsWhite # Starlight
+    - type: InteractionPopup
+      successChance: 0.9
+      interactSuccessString: petting-success-bingus
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/cat_meow.ogg
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: epicene
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
+    - type: StealTarget
+      stealGroup: AnimalNamedCat
 
 - type: entity
   name: McGriff
@@ -408,83 +406,82 @@
   id: MobMcGriff
   description: This dog can tell something smells around here, and that something is CRIME!
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Dog
-    understands:
-    - Dog
-    - GalacticCommon
-    - Canilunzt
-  # Starlight-end
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/mcgriff.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: mcgriff
-    - map: [ "head" ]
-    - map: [ "eyes" ]
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 20
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: puppy
-    templateId: petAdvanced
-    displacements:
-      head:
-        sizeMaps:
-          32:
-            sprite: Mobs/Pets/displacements.rsi
-            state: mcgriff_head_displacement
-      eyes:
-        sizeMaps:
-          32:
-            sprite: Mobs/Pets/displacements.rsi
-            state: mcgriff_eyes_displacement
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: mcgriff
-      Critical:
-        Base: mcgriff_dead
-      Dead:
-        Base: mcgriff_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 2
-  - type: InteractionPopup
-    successChance: 0.5
-    interactSuccessString: petting-success-dog
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/small_dog_bark_happy.ogg
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-  - type: Speech
-    speechVerb: Canine
-    speechSounds: Dog
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
-  - type: StealTarget
-    stealGroup: AnimalMcGriff
-  - type: MessyDrinker
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Dog
+      understands:
+        - Dog
+        - GalacticCommon
+        - Canilunzt
+    # Starlight-end
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/mcgriff.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: mcgriff
+        - map: ["head"]
+        - map: ["eyes"]
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 20
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: puppy
+      templateId: petAdvanced
+      displacements:
+        head:
+          sizeMaps:
+            32:
+              sprite: Mobs/Pets/displacements.rsi
+              state: mcgriff_head_displacement
+        eyes:
+          sizeMaps:
+            32:
+              sprite: Mobs/Pets/displacements.rsi
+              state: mcgriff_eyes_displacement
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: mcgriff
+        Critical:
+          Base: mcgriff_dead
+        Dead:
+          Base: mcgriff_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 2
+    - type: InteractionPopup
+      successChance: 0.5
+      interactSuccessString: petting-success-dog
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/small_dog_bark_happy.ogg
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    - type: Speech
+      speechVerb: Canine
+      speechSounds: Dog
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
+    - type: StealTarget
+      stealGroup: AnimalMcGriff
+    - type: MessyDrinker
 
 - type: entity
   name: Paperwork
@@ -492,33 +489,33 @@
   id: MobPaperwork
   description: Took up a new job sorting books in the library after he got transferred from Space Station 13. He seems to be just as slow at this.
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/paperwork.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: paperwork
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: paperwork
-      Critical:
-        Base: paperwork_dead
-      Dead:
-        Base: paperwork_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 3
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: petting-success-sloth
-    interactFailureString: petting-failure-sloth
-    interactSuccessSpawn: EffectHearts
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/paperwork.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: paperwork
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: paperwork
+        Critical:
+          Base: paperwork_dead
+        Dead:
+          Base: paperwork_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 3
+    - type: InteractionPopup
+      successChance: 1
+      interactSuccessString: petting-success-sloth
+      interactFailureString: petting-failure-sloth
+      interactSuccessSpawn: EffectHearts
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
 
 - type: entity
   name: Walter
@@ -526,70 +523,69 @@
   id: MobWalter
   description: He likes chems and treats. Walter.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Dog
-    understands:
-    - Dog
-    - GalacticCommon
-    - Canilunzt
-  # Starlight-end
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Pets/walter.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base"]
-      state: walter
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.35
-        density: 50
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
-  - type: Inventory
-    speciesId: dog
-    templateId: pet
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: walter
-      Critical:
-        Base: walter_dead
-      Dead:
-        Base: walter_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 3
-  - type: InteractionPopup
-    successChance: 0.7
-    interactSuccessString: petting-success-dog
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/small_dog_bark_happy.ogg
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
-  - type: StealTarget
-    stealGroup: AnimalWalter
-  - type: Speech
-    speechVerb: Canine
-    speechSounds: Dog
-  - type: MessyDrinker
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Dog
+      understands:
+        - Dog
+        - GalacticCommon
+        - Canilunzt
+    # Starlight-end
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Pets/walter.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: walter
+    - type: Physics
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape: !type:PhysShapeCircle
+            radius: 0.35
+          density: 50
+          mask:
+            - MobMask
+          layer:
+            - MobLayer
+    - type: Inventory
+      speciesId: dog
+      templateId: pet
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: walter
+        Critical:
+          Base: walter_dead
+        Dead:
+          Base: walter_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 3
+    - type: InteractionPopup
+      successChance: 0.7
+      interactSuccessString: petting-success-dog
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/small_dog_bark_happy.ogg
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
+    - type: StealTarget
+      stealGroup: AnimalWalter
+    - type: Speech
+      speechVerb: Canine
+      speechSounds: Dog
+    - type: MessyDrinker
 
 - type: entity
   name: Morty
@@ -597,23 +593,23 @@
   id: MobPossumMorty
   description: The station's resident Didelphis virginiana. A sensitive but resilient kind of guy.
   components:
-  - type: InteractionPopup
-    successChance: 1.0 # Hey, c'mon, this is Morty we're talking about here.
-    interactSuccessString: petting-success-possum
-    interactFailureString: petting-failure-possum
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/snake_hiss.ogg
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
-  - type: StealTarget
-    stealGroup: AnimalMorty
+    - type: InteractionPopup
+      successChance: 1.0 # Hey, c'mon, this is Morty we're talking about here.
+      interactSuccessString: petting-success-possum
+      interactFailureString: petting-failure-possum
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/snake_hiss.ogg
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
+    - type: StealTarget
+      stealGroup: AnimalMorty
 
 - type: entity
   name: Morty
@@ -621,18 +617,18 @@
   id: MobPossumMortyOld
   suffix: Old sprite
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Animals/possum_old.rsi
-    layers:
-    - map: [ "enum.DamageStateVisualLayers.Base" ]
-      state: possum_old
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: possum_old
-      Dead:
-        Base: possum_dead_old
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Animals/possum_old.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: possum_old
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: possum_old
+        Dead:
+          Base: possum_dead_old
 
 - type: entity
   name: Poppy # the Safety Possum
@@ -640,22 +636,22 @@
   id: MobPossumPoppy
   description: It's an opossum, a small scavenging marsupial. It's wearing appropriate personal protective equipment.
   components:
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: female
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Animals/possum.rsi
-    layers:
-    - map: [ "enum.DamageStateVisualLayers.Base" ]
-      state: poppy
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: poppy
-      Dead:
-        Base: poppy_dead
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: female
+    - type: Sprite
+      drawdepth: Mobs
+      sprite: Mobs/Animals/possum.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: poppy
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: poppy
+        Dead:
+          Base: poppy_dead
 
 - type: entity
   name: Morticia
@@ -663,21 +659,21 @@
   id: MobRaccoonMorticia
   description: A powerful creature of the night. Her eyeshadow is always on point.
   components:
-  - type: InteractionPopup
-    successChance: 0.7
-    interactSuccessString: petting-success-raccoon
-    interactFailureString: petting-failure-raccoon
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/raccoon_chatter.ogg
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: female
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
+    - type: InteractionPopup
+      successChance: 0.7
+      interactSuccessString: petting-success-raccoon
+      interactFailureString: petting-failure-raccoon
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/raccoon_chatter.ogg
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: female
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
 
 - type: entity
   name: Alexander
@@ -685,30 +681,30 @@
   id: MobAlexander
   description: Chef's finest colleague.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Pig
-    understands:
-    - Pig
-    - GalacticCommon
-  # Starlight-end
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: petting-success-pig
-    interactFailureString: petting-failure-pig
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/pig_oink.ogg
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Pig
+      understands:
+        - Pig
+        - GalacticCommon
+    # Starlight-end
+    - type: InteractionPopup
+      successChance: 1
+      interactSuccessString: petting-success-pig
+      interactFailureString: petting-failure-pig
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/pig_oink.ogg
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
 
 - type: entity
   name: Renault
@@ -716,39 +712,39 @@
   id: MobFoxRenault
   description: The captain's trustworthy fox.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Fox
-    understands:
-    - Fox
-    - GalacticCommon
-    - Canilunzt
-  # Starlight-end
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: petting-success-soft-floofy
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      collection: Fox
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 3
-    - id: Telecrystal5
-      amount: 1
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: female
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
-  - type: StealTarget
-    stealGroup: AnimalRenault
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Fox
+      understands:
+        - Fox
+        - GalacticCommon
+        - Canilunzt
+    # Starlight-end
+    - type: InteractionPopup
+      successChance: 1
+      interactSuccessString: petting-success-soft-floofy
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        collection: Fox
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 3
+        - id: Telecrystal5
+          amount: 1
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: female
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
+    - type: StealTarget
+      stealGroup: AnimalRenault
 
 - type: entity
   name: Hamlet
@@ -756,77 +752,77 @@
   id: MobHamsterHamlet
   description: A grumpy, cute and fluffy hamster.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Mouse
-    understands:
-    - Mouse
-    - GalacticCommon
-  # Starlight-end
-  - type: Sprite
-    drawdepth: SmallMobs
-    sprite: Mobs/Pets/hamlet.rsi
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: hamster-0
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: hamster-moving-0
-    noMovementLayers:
-      movement:
-        state: hamster-0
-  - type: GhostRole
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: ghost-role-information-hamlet-name
-    description: ghost-role-information-hamlet-description
-    rules: ghost-role-information-nonantagonist-rules
-  - type: GhostTakeoverAvailable
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: petting-success-hamster
-    interactFailureString: petting-failure-hamster
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/fox_squeak.ogg
-  - type: Butcherable
-    spawned:
-    - id: FoodMeat
-      amount: 1
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - Hamster
-    - VimPilot
-    - ChefPilot
-  - type: FlavorProfile
-    flavors:
-    - meaty
-    - sadness
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Mouse
+      understands:
+        - Mouse
+        - GalacticCommon
+    # Starlight-end
+    - type: Sprite
+      drawdepth: SmallMobs
+      sprite: Mobs/Pets/hamlet.rsi
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: hamster-0
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: hamster-moving-0
+      noMovementLayers:
+        movement:
+          state: hamster-0
+    - type: GhostRole
+      makeSentient: true
+      allowSpeech: true
+      allowMovement: true
+      name: ghost-role-information-hamlet-name
+      description: ghost-role-information-hamlet-description
+      rules: ghost-role-information-nonantagonist-rules
+    - type: GhostTakeoverAvailable
+    - type: InteractionPopup
+      successChance: 1
+      interactSuccessString: petting-success-hamster
+      interactFailureString: petting-failure-hamster
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/fox_squeak.ogg
+    - type: Butcherable
+      spawned:
+        - id: FoodMeat
+          amount: 1
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - Hamster
+        - VimPilot
+        - ChefPilot
+    - type: FlavorProfile
+      flavors:
+        - meaty
+        - sadness
 
 - type: entity
   parent: MobHamsterHamlet
   id: MobHamsterHamletSlippery
   suffix: Slippery
   components:
-  - type: Slippery
-  - type: StepTrigger
-    requiredTriggeredSpeed: 1
-  - type: TriggerOnStepTrigger
-  - type: GibOnTrigger
-  - type: EmitSoundOnTrigger
-    sound:
-      path: "/Audio/Animals/mouse_squeak.ogg"
-    positional: true
-    predicted: true
+    - type: Slippery
+    - type: StepTrigger
+      requiredTriggeredSpeed: 1
+    - type: TriggerOnStepTrigger
+    - type: GibOnTrigger
+    - type: EmitSoundOnTrigger
+      sound:
+        path: "/Audio/Animals/mouse_squeak.ogg"
+      positional: true
+      predicted: true
 
 - type: entity
   name: Shiva
@@ -834,75 +830,75 @@
   id: MobSpiderShiva
   description: The first defender of the station.
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Chittin
-    understands:
-    - Chittin
-    - GalacticCommon
-  # Starlight-end
-  - type: InteractionPopup
-    successChance: 0.5 # spider is mean
-    interactSuccessString: petting-success-tarantula
-    interactFailureString: petting-failure-hamster
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/snake_hiss.ogg
-  - type: NpcFactionMember
-    factions:
-      - PetsNT
-  - type: Sprite
-    drawdepth: Mobs
-    layers:
-    - map: ["enum.DamageStateVisualLayers.Base", "movement"]
-      state: shiva
-      sprite: Mobs/Pets/shiva.rsi
-  - type: SpriteMovement
-    movementLayers:
-      movement:
-        state: shiva-moving
-    noMovementLayers:
-      movement:
-        state: shiva
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
-  - type: Physics
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: shiva
-      Dead:
-        Base: shiva_dead
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      150: Dead
-  - type: MeleeWeapon
-    angle: 0
-    animation: WeaponArcBite
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    damage:
-      types:
-        Piercing: 8
-        Poison: 8
-  - type: Spider
-    spawnsWebsAsNonPlayer: false
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: female
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - VimPilot
-    - DoorBumpOpener
-    - FootstepSound
-  - type: StealTarget
-    stealGroup: AnimalShiva
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Chittin
+      understands:
+        - Chittin
+        - GalacticCommon
+    # Starlight-end
+    - type: InteractionPopup
+      successChance: 0.5 # spider is mean
+      interactSuccessString: petting-success-tarantula
+      interactFailureString: petting-failure-hamster
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/snake_hiss.ogg
+    - type: NpcFactionMember
+      factions:
+        - PetsNT
+    - type: Sprite
+      drawdepth: Mobs
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base", "movement"]
+          state: shiva
+          sprite: Mobs/Pets/shiva.rsi
+    - type: SpriteMovement
+      movementLayers:
+        movement:
+          state: shiva-moving
+      noMovementLayers:
+        movement:
+          state: shiva
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound
+    - type: Physics
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: shiva
+        Dead:
+          Base: shiva_dead
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        150: Dead
+    - type: MeleeWeapon
+      angle: 0
+      animation: WeaponArcBite
+      soundHit:
+        path: /Audio/Effects/bite.ogg
+      damage:
+        types:
+          Piercing: 8
+          Poison: 8
+    - type: Spider
+      spawnsWebsAsNonPlayer: false
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: female
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - VimPilot
+        - DoorBumpOpener
+        - FootstepSound
+    - type: StealTarget
+      stealGroup: AnimalShiva
 
 - type: entity
   name: Willow
@@ -910,30 +906,30 @@
   id: MobKangarooWillow
   description: Willow the boxing kangaroo.
   components:
-  - type: InteractionPopup
-    successChance: 0.8
-    interactSuccessString: petting-success-kangaroo
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/kangaroo_grunt.ogg
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: female
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - DoorBumpOpener
-    - FootstepSound
-  - type: GhostRole
-    prob: 0.25
-    name: ghost-role-information-willow-name
-    description: ghost-role-information-willow-description
-    rules: ghost-role-information-nonantagonist-rules
-  - type: GhostTakeoverAvailable
-  - type: Loadout
-    prototypes: [ BoxingKangarooGear ]
+    - type: InteractionPopup
+      successChance: 0.8
+      interactSuccessString: petting-success-kangaroo
+      interactFailureString: petting-failure-generic
+      interactSuccessSpawn: EffectHearts
+      interactSuccessSound:
+        path: /Audio/Animals/kangaroo_grunt.ogg
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: female
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - DoorBumpOpener
+        - FootstepSound
+    - type: GhostRole
+      prob: 0.25
+      name: ghost-role-information-willow-name
+      description: ghost-role-information-willow-description
+      rules: ghost-role-information-nonantagonist-rules
+    - type: GhostTakeoverAvailable
+    - type: Loadout
+      prototypes: [BoxingKangarooGear]
 
 - type: entity
   name: Smile
@@ -941,88 +937,87 @@
   parent: [MobAdultSlimes, StripableInventoryBase]
   description: This masterpiece has gone through thousands of experiments. But it is the sweetest creature in the world. Smile Slime!
   components:
-  # Starlight-start: Languages
-  - type: LanguageSpeaker
-  - type: LanguageKnowledge
-    speaks:
-    - Bubblish
-    understands:
-    - GalacticCommon
-    - Bubblish
-  # Starlight-end
-  - type: Sprite
-    layers:
-    - map: [ "enum.DamageStateVisualLayers.Base" ]
-      state: rainbow_baby_slime
-    - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
-      state: aslime-_3
-      shader: unshaded
-    - map: [ "head" ]
-  - type: Inventory
-    speciesId: slime
-    templateId: head
-    displacements:
-      head:
-        sizeMaps:
-          32:
-            sprite: Mobs/Pets/Smile/smile_displacement.rsi
-            state: head
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      200: Dead
-  - type: FootstepModifier
-    footstepSoundCollection:
-      collection: FootstepSlime
-  - type: Tag
-    tags:
-    - FootstepSound
-    - DoorBumpOpener
-    - CannotSuicide
-    - VimPilot
-  - type: DamageStateVisuals
-    states:
-      Alive:
-        Base: rainbow_baby_slime
-        BaseUnshaded: aslime-_3
-      Dead:
-        Base: rainbow_baby_slime_dead
-  - type: Butcherable
-    spawned:
-    - id: FoodMeatSlime
-      amount: 1
-    - id: MaterialSmileExtract
-      amount: 1
-  - type: Damageable
-    damageModifierSet: SlimePet
-  - type: Bloodstream
-    bloodlossHealDamage:
-      types:
-        Bloodloss:
-          -0.8
-  - type: Temperature
-    heatDamageThreshold: 800
-    coldDamageThreshold: 0
-  - type: MeleeWeapon
-    damage:
-      types:
-        Blunt: 1
-        Caustic: 1
-  - type: MultiHandedItem
-  - type: Item
-    sprite: Mobs/Pets/Smile/smile.rsi
-    size: Huge
-  - type: MobPrice
-    price: 3000 # it is a truly valuable creature
-  - type: GhostRole
-    name: ghost-role-information-smile-name
-    description: ghost-role-information-smile-description
-    rules: ghost-role-information-nonantagonist-rules
-    raffle: null
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: female
+    # Starlight-start: Languages
+    - type: LanguageSpeaker
+    - type: LanguageKnowledge
+      speaks:
+        - Bubblish
+      understands:
+        - GalacticCommon
+        - Bubblish
+    # Starlight-end
+    - type: Sprite
+      layers:
+        - map: ["enum.DamageStateVisualLayers.Base"]
+          state: rainbow_baby_slime
+        - map: ["enum.DamageStateVisualLayers.BaseUnshaded"]
+          state: aslime-_3
+          shader: unshaded
+        - map: ["head"]
+    - type: Inventory
+      speciesId: slime
+      templateId: head
+      displacements:
+        head:
+          sizeMaps:
+            32:
+              sprite: Mobs/Pets/Smile/smile_displacement.rsi
+              state: head
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        200: Dead
+    - type: FootstepModifier
+      footstepSoundCollection:
+        collection: FootstepSlime
+    - type: Tag
+      tags:
+        - FootstepSound
+        - DoorBumpOpener
+        - CannotSuicide
+        - VimPilot
+    - type: DamageStateVisuals
+      states:
+        Alive:
+          Base: rainbow_baby_slime
+          BaseUnshaded: aslime-_3
+        Dead:
+          Base: rainbow_baby_slime_dead
+    - type: Butcherable
+      spawned:
+        - id: FoodMeatSlime
+          amount: 1
+        - id: MaterialSmileExtract
+          amount: 1
+    - type: Damageable
+      damageModifierSet: SlimePet
+    - type: Bloodstream
+      bloodlossHealDamage:
+        types:
+          Bloodloss: -0.8
+    - type: Temperature
+      heatDamageThreshold: 800
+      coldDamageThreshold: 0
+    - type: MeleeWeapon
+      damage:
+        types:
+          Blunt: 1
+          Caustic: 1
+    - type: MultiHandedItem
+    - type: Item
+      sprite: Mobs/Pets/Smile/smile.rsi
+      size: Huge
+    - type: MobPrice
+      price: 3000 # it is a truly valuable creature
+    - type: GhostRole
+      name: ghost-role-information-smile-name
+      description: ghost-role-information-smile-description
+      rules: ghost-role-information-nonantagonist-rules
+      raffle: null
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: female
 
 - type: entity
   name: Pun Pun
@@ -1030,46 +1025,46 @@
   id: MobMonkeyPunpun
   description: A prominent representative of monkeys with unlimited access to alcohol.
   components:
-  # Starlight-start: Languages
-  - type: LanguageKnowledge
-    speaks:
-    - Ancestor
-    understands:
-    - Ancestor
-    - GalacticCommon
-  # Starlight-end
-  - type: GhostRole
-    prob: 1
-    makeSentient: true
-    allowSpeech: true
-    allowMovement: true
-    name: ghost-role-information-punpun-name
-    description: ghost-role-information-punpun-description
-    rules: ghost-role-information-nonantagonist-rules
-    requirements:
-    - !type:RoleTimeRequirement
-      role: JobBartender
-      time: 7200 # 2h STARLIGHT
-  - type: GhostTakeoverAvailable
-  - type: Butcherable
-    butcheringType: Spike
-    spawned:
-    - id: FoodMeat
-      amount: 3
-    - id: DrinkTequilaBottleFull
-      amount: 1
-  - type: Tag
-    tags:
-    - CannotSuicide
-    - DoorBumpOpener
-    - VimPilot
-    - AnomalyHost
-  - type: Loadout
-    prototypes: [ MobMonkeyGear ]
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
+    # Starlight-start: Languages
+    - type: LanguageKnowledge
+      speaks:
+        - Ancestor
+      understands:
+        - Ancestor
+        - GalacticCommon
+    # Starlight-end
+    - type: GhostRole
+      prob: 1
+      makeSentient: true
+      allowSpeech: true
+      allowMovement: true
+      name: ghost-role-information-punpun-name
+      description: ghost-role-information-punpun-description
+      rules: ghost-role-information-nonantagonist-rules
+      requirements:
+        - !type:RoleTimeRequirement
+          role: JobBartender
+          time: 7200 # 2h STARLIGHT
+    - type: GhostTakeoverAvailable
+    - type: Butcherable
+      butcheringType: Spike
+      spawned:
+        - id: FoodMeat
+          amount: 3
+        - id: DrinkTequilaBottleFull
+          amount: 1
+    - type: Tag
+      tags:
+        - CannotSuicide
+        - DoorBumpOpener
+        - VimPilot
+        - AnomalyHost
+    - type: Loadout
+      prototypes: [MobMonkeyGear]
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
 
 - type: entity
   name: Tropico
@@ -1077,26 +1072,26 @@
   id: MobCrabAtmos
   description: The noble and stalwart defender of Atmosia. Viva!
   components:
-#  - type: GhostRole
-#    prob: 1
-#    makeSentient: true
-#    allowSpeech: true
-#    allowMovement: true
-#    name: ghost-role-information-tropico-name
-#    description: ghost-role-information-tropico-description
-#    rules: ghost-role-information-nonantagonist-rules
-#  - type: GhostTakeoverAvailable
-  - type: Tag
-    tags:
-    - VimPilot
-    - CannotSuicide
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-#  - type: AlwaysRevolutionaryConvertible
-  - type: StealTarget
-    stealGroup: AnimalTropico
+    #  - type: GhostRole
+    #    prob: 1
+    #    makeSentient: true
+    #    allowSpeech: true
+    #    allowMovement: true
+    #    name: ghost-role-information-tropico-name
+    #    description: ghost-role-information-tropico-description
+    #    rules: ghost-role-information-nonantagonist-rules
+    #  - type: GhostTakeoverAvailable
+    - type: Tag
+      tags:
+        - VimPilot
+        - CannotSuicide
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    #  - type: AlwaysRevolutionaryConvertible
+    - type: StealTarget
+      stealGroup: AnimalTropico
 
 - type: entity
   name: Polly the parrot
@@ -1104,14 +1099,13 @@
   id: MobPollyParrot
   description: An expert in quantum cracker theory
   components:
-  - type: Vocalizer
-    maxVocalizeInterval: 240 # polly is chattier
-  - type: RadioVocalizer
-    radioAttemptChance: 0.8 # polly wants to share with the world
-  - type: Grammar
-    attributes:
-      proper: true
-      gender: male
-  - type: Loadout
-    prototypes: [ MobPollyGear ]
-
+    - type: Vocalizer
+      maxVocalizeInterval: 240 # polly is chattier
+    - type: RadioVocalizer
+      radioAttemptChance: 0.8 # polly wants to share with the world
+    - type: Grammar
+      attributes:
+        proper: true
+        gender: male
+    - type: Loadout
+      prototypes: [MobPollyGear]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

- Rebuilt the mothroach prototype and filled in the bespoke stats so they’re bigger, pick‑up‑able, and only edible once dead.
- Let the moproach inherit those shared behaviours while keeping the janitorial tweaks (mop absorption, cleanbot petting feedback) instead of re‑declaring the same data.
- Made moproaches non-slippable - poor critters now stop constantly slipping on their own puddles.

## Why we need to add this
- Mothroaches now behave like other station pets rather than cockroaches: they can be loved, carried, eaten post-mortem, and drop more appropriate resources, with blood volume and damage thresholds scaled up to their size.
- Refactoring the moproach to rely on the parent prototype removes duplicate solution/food blocks, making future adjustments to mothroaches automatically flow down to their mop-wearing counterparts.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: aneyeforsecrets
- tweak: Mothroaches are now sizeable station pets - carryable, only edible when dead, and loaded with extra insect blood and butcher yields.
- tweak: Moproaches inherit the new mothroach behaviour while keeping their janitorial perks and heart-sparkling pet reactions.
- tweak: Moproaches no longer slip on their own puddles.