### PR TITLE
boom no more RR

### DIFF
--- a/Content.Shared/_Starlight/Silicons/Borgs/StationAIShuntSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/Borgs/StationAIShuntSystem.cs
@@ -1,14 +1,17 @@
 using Content.Shared._Starlight.Polymorph.Components;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
+using Content.Shared.Chat;
 using Content.Shared.Follower;
 using Content.Shared.Follower.Components;
 using Content.Shared.Mind;
+using Content.Shared.Popups;
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.Silicons.Laws;
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Silicons.StationAi;
 using Content.Shared.Verbs;
+using Robust.Shared.Network;
 using Robust.Shared.Utility;
 
 namespace Content.Shared._Starlight.Silicons.Borgs;
@@ -21,6 +24,10 @@ public sealed class StationAIShuntSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedSiliconLawSystem _siliconLaw = default!;
     [Dependency] private readonly FollowerSystem _follower = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly INetManager _net = default!;
+
+
     public override void Initialize()
     {
         base.Initialize();
@@ -51,10 +58,21 @@ public sealed class StationAIShuntSystem : EntitySystem
                 return; //Chassis has no posibrian so cant shunt into it.
             if (!TryComp<StationAIShuntComponent>(brain, out var brainShunt))
                 return; //Chassis brain is not able to be shunted into so obviously we cant.
+            if (brainShunt.Return != null)
+            {
+                if (_net.IsServer) //only send on server cause client is confused somehow?
+                    _popup.PopupEntity(Loc.GetString("shunt-target-occupied"), target, uid, PopupType.Large);
+                return; //Chassis is allready inhabited.
+            }
             brainShunt.Return = uid;
             brainShunt.ReturnAction = _actionSystem.AddAction(brain.Value, shuntable.UnshuntAction.Id);
         }
-
+        if (shunt.Return != null)
+        {
+            if (_net.IsServer) //only send on server cause client is confused somehow?
+                _popup.PopupEntity(Loc.GetString("shunt-target-occupied"), target, uid, PopupType.Large);
+            return; //target is allready inhabited.
+        }
         shunt.Return = uid;
         _mindSystem.TransferTo(mindId, target);
         shunt.ReturnAction = _actionSystem.AddAction(target, shuntable.UnshuntAction.Id);

--- a/Resources/Locale/en-US/_Starlight/borg/shunt.ftl
+++ b/Resources/Locale/en-US/_Starlight/borg/shunt.ftl
@@ -1,0 +1,1 @@
+shunt-target-occupied = A AI is allready using that body.


### PR DESCRIPTION
## Short description
Station AIs trying to shunt into the same body no longer RR's the person in the body.

## Why we need to add this
I can see all the future ahelps

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walsanator
- fix: Fixed station-AI able to RR other AIs by shunting into the same chassis as them
