### PR TITLE
Expressly ban abductor validhunting

### DIFF
--- a/Resources/ServerInfo/Guidebook/Antagonist/Abductors.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Abductors.xml
@@ -8,6 +8,7 @@
   Its important to note: Abductors, unlike most antagonists are [color=red]NOT set on killing people[/color] and are exclusively interested in completing their experiments.
   
   Abductors must make every attempt to leave no trace and avoid detection while doing their task. Whether it be abductions or retrieval of emergency supplies.
+  Similarly, abductors must never intervene in events on the station if at all avoidable, even if this means the end of the experiment, as otherwise said experiment's impurity would make it useless for the mothership's research.
 
   Abductors do not possess the ability to speak and therefore communicate through more... mime-like methods.
   They do however have a hivemind: "+q"


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Added an extra line to the abductor guidebook explicitly forbidding intervening on behalf of the station against things like dragons and nukies.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It is not intended behaviour for abductors to "preserve" the experiment actively through, essentially, validhunting. However, this is not explicitly clear, leading to some misunderstandings with abductors saving the station to prevent harm to their test subjects. This is now explicitly forbidden.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- tweak: Abductors are now expressly forbidden from defending the station
