### PR TITLE
Make addhand command work as expected when the target entity doesn't already have hands.

### DIFF
--- a/Content.Server/Body/Commands/AddHandCommand.cs
+++ b/Content.Server/Body/Commands/AddHandCommand.cs
@@ -6,6 +6,7 @@ using Content.Shared.Administration;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
 using Content.Shared.Hands.Components;
+using Content.Shared.Interaction.Components;
 using Robust.Shared.Console;
 using Robust.Shared.Prototypes;
 
@@ -112,6 +113,10 @@ namespace Content.Server.Body.Commands
                     shell.WriteLine(Help);
                     return;
             }
+
+            // STARLIGHT PRETTY MUCH ALWAYS WANTS THESE
+            _entManager.EnsureComponent<HandsComponent>(entity);
+            _entManager.EnsureComponent<ComplexInteractionComponent>(entity);
 
             if (!_entManager.TryGetComponent(entity, out BodyComponent? body) || body.RootContainer.ContainedEntity == null)
             {


### PR DESCRIPTION
## Short description
Makes sure hands and complexinteraction components exist before adding hands to an entity.

## Why we need to add this
command didn't work as expected if an entity didn't already have hands

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Trep_Maul
- tweak: addhand command works as expected with entities without hands.