### PR TITLE
add mining/salvlead access to missing jobs + Magi/IAA changes

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -11,6 +11,7 @@
   - Maintenance
   extendedAccess:
   - Salvage
+  - Mining # Starlight
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: BoxingDay

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -16,6 +16,8 @@
   - Salvage
   - Maintenance
   - External
+  extendedAccess:
+  - Mining # Starlight
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -53,6 +53,8 @@
   - Brigmedic # Starlight
   - Surgery # Starlight
   - Paramedic # Starlight
+  - Mining # Starlight
+  - SalvageLead # Starlight
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
@@ -17,6 +17,8 @@
   - Mining
   - Maintenance
   - External
+  extendedAccess:
+  - Salvage
 
 - type: startingGear
   id: MiningSpecialistGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/salvage_lead.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/salvage_lead.yml
@@ -17,6 +17,8 @@
   - SalvageLead
   - Maintenance
   - External
+  extendedAccess:
+  - Mining
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Law/Magistrate.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Law/Magistrate.yml
@@ -20,26 +20,11 @@
   setPreference: true
   access:
   - Magistrate
-  - Bar
-  - Kitchen
-  - Hydroponics
-  - Janitor
-  - Theatre
-  - Chapel
   - Lawyer
   - Brig
   - Security
-  - Medical
-  - Research
-  - Engineering
-  - Cargo
-  - Salvage
-  - Mining
-  - SalvageLead
   - Command
   - Maintenance
-  extendedAccess:
-  - Hydroponics
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Law/Magistrate.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Law/Magistrate.yml
@@ -34,6 +34,8 @@
   - Engineering
   - Cargo
   - Salvage
+  - Mining
+  - SalvageLead
   - Command
   - Maintenance
   extendedAccess:

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Law/iaa.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Law/iaa.yml
@@ -17,10 +17,8 @@
   canBeAntag: false
   displayWeight: 40
   access:
-  - Service
   - Brig
   - Maintenance
-  - External
   - Lawyer
   special:
   - !type:AddImplantSpecial

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
@@ -45,6 +45,8 @@
     - BlueShield
     - Surgery
     - Paramedic
+    - Mining
+    - SalvageLead
   special:
     - !type:AddImplantSpecial
       implants: [MindShieldImplant]

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
@@ -33,6 +33,8 @@
     - Robotics
     - Detective
     - Salvage
+    - Mining
+    - SalvageLead
     - Security
     - Brig
     - Cargo


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
anyone that got salvage access outside of cargo also gets mining access now

NTR/BSO/Magistrate were missing the new mining+salvlead access
ive also added mining onto the extendedAccesses for cargotech, alongside salv

also updates magistrate and IAA to reduce scope to just law and surrounding accesses per convo with Shades/Grape/Lily on discord [link](https://discord.com/channels/1272545509562777621/1356838103670849710/1425284051689803966)

## Why we need to add this
consistency + reduce law dpt access. if they want access they can request it

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- fix: NT jobs have mining and salvage lead access now
- add: Gives the cargo jobs extended access to mining/salvage now
- tweak: Reduces Magistrate access to security+command+law
- tweak: Reduces IAA access to brig+law
