### PR TITLE
Add vending machine circuit boards and construction

### DIFF
--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
@@ -201,7 +201,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
 
     protected virtual void OnMapInit(EntityUid uid, VendingMachineComponent component, MapInitEvent args)
     {
-        RestockInventoryFromPrototype(uid, component, component.InitialStockQuality);
+        RestockInventoryFromPrototype(uid, component, component.InitialStockQuality, true); // Starlight-edit: added last parameter
     }
 
     protected virtual void EjectItem(EntityUid uid, VendingMachineComponent? vendComponent = null, bool forceEject = false) { }
@@ -367,7 +367,8 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
     }
 
     public void RestockInventoryFromPrototype(EntityUid uid,
-        VendingMachineComponent? component = null, float restockQuality = 1f)
+        VendingMachineComponent? component = null, float restockQuality = 1f,
+	bool initialRestock = false) // Starlight-edit: added last parameter
     {
         if (!Resolve(uid, ref component))
         {
@@ -376,6 +377,9 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
 
         if (!PrototypeManager.TryIndex(component.PackPrototypeId, out VendingMachineInventoryPrototype? packPrototype))
             return;
+
+        if (initialRestock && HasComp<EmptyVendingMachineComponent>(component.Owner)) // Starlight
+            return; // Starlight
 
         AddInventoryFromPrototype(uid, packPrototype.StartingInventory, InventoryType.Regular, component, restockQuality);
         AddInventoryFromPrototype(uid, packPrototype.EmaggedInventory, InventoryType.Emagged, component, restockQuality);

--- a/Content.Shared/_Starlight/VendingMachines/EmptyVendingMachineComponent.cs
+++ b/Content.Shared/_Starlight/VendingMachines/EmptyVendingMachineComponent.cs
@@ -1,0 +1,11 @@
+
+namespace Content.Shared.VendingMachines
+{
+    /// <summary>
+    /// Indicates that a given vending machine should not get stocked on MapInit (e.g. when constructed)
+    /// </summary>
+    [RegisterComponent]
+    public sealed partial class EmptyVendingMachineComponent : Component
+    {
+    }
+}

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -264,6 +264,7 @@
     - CargoBoardsStatic
     - MedicalBoardsStatic
     - EngineeringBoardsStatic
+    - StarlightVendorBoards # Starlight
     dynamicPacks:
     - EngineeringBoards
     - CargoBoards
@@ -280,6 +281,7 @@
     - StarlightSecurityBoards
     emagStaticPacks: # Starlight
     - StarlightDangerousLawboards # Starlight
+    - StarlightSyndicateVendorBoards # Starlight
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -2,7 +2,7 @@
 
 - type: entity
   id: VendingMachine
-  parent: BaseMachinePowered
+  parent: [BaseMachinePowered, ConstructibleMachine] # Starlight-edit: Add ConstructableMachine
   name: vending machine
   description: Just add capitalism!
   abstract: true
@@ -55,6 +55,8 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalGlassBreak
+      - !type:ChangeConstructionNodeBehavior # Starlight-edit: Vending machine circuitboards
+        node: machineFrame # Starlight-edit: Vending machine circuitboards
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
@@ -146,6 +148,8 @@
         layer:
         - MachineLayer
         density: 190
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineCondimentsCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: CondimentVendAds
   - type: SpeakOnUIClosed
@@ -165,6 +169,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineAmmoCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: CondimentVendAds
   - type: SpeakOnUIClosed
@@ -194,6 +200,8 @@
     normalState: normal-unshaded
     denyState: deny-unshaded
     loopDeny: false
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineBoozeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: BoozeOMatAds
   - type: SpeakOnUIClosed
@@ -229,6 +237,8 @@
     normalState: normal-unshaded
     denyState: deny-unshaded
     loopDeny: false
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineBoozeSyndicateCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: BruiseOMatAds
   - type: SpeakOnUIClosed
@@ -264,6 +274,8 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineCartCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/cart.rsi
     layers:
@@ -294,6 +306,8 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineChefvendCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: ChefvendAds
   - type: SpeakOnUIClosed
@@ -330,6 +344,8 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineCigsCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: CigaretteMachineAds
   - type: SpeakOnUIClosed
@@ -357,6 +373,8 @@
     brokenState: broken
     normalState: normal-unshaded
     denyState: deny-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineClothingCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: ClothesMateAds
   - type: SpeakOnUIClosed
@@ -388,6 +406,8 @@
     brokenState: broken
     normalState: normal-unshaded
     denyState: deny-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineWinterCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: ClothesMateAds
   - type: SpeakOnUIClosed
@@ -426,6 +446,8 @@
     ejectDelay: 5
     soundVend: /Audio/Machines/machine_vend_hot_drink.ogg
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineCoffeeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: HotDrinksMachineAds
   - type: SpeakOnUIClosed
@@ -465,6 +487,8 @@
     denyState: deny-unshaded
     ejectDelay: 1.9
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineColaCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: RobustSoftdrinksAds
   - type: SpeakOnUIClosed
@@ -489,6 +513,8 @@
   id: VendingMachineColaBlack
   suffix: Black
   components:
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineColaBlackCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/cola-black.rsi
     layers:
@@ -510,6 +536,8 @@
   name: Space Cola Vendor
   description: It vends cola, in space.
   components:
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineColaRedCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/cola-red.rsi
     layers:
@@ -533,6 +561,8 @@
   components:
   - type: VendingMachine
     pack: SpaceUpInventory
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSpaceUpCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/spaceup.rsi
     layers:
@@ -555,6 +585,8 @@
   components:
   - type: VendingMachine
     pack: SodaInventory
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSodaCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/soda.rsi
     layers:
@@ -578,6 +610,8 @@
   components:
   - type: VendingMachine
     pack: StarkistInventory
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineStarkistCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/starkist.rsi
     layers:
@@ -610,6 +644,8 @@
     denyState: deny-unshaded
     ejectDelay: 1.9
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineShamblersJuiceCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: RobustSoftdrinksAds
   - type: Sprite
@@ -644,6 +680,8 @@
     denyState: deny-unshaded
     ejectDelay: 1.9
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachinePwrGameCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: RobustSoftdrinksAds
   - type: SpeakOnUIClosed
@@ -680,6 +718,8 @@
     denyState: deny-unshaded
     ejectDelay: 1.9
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineDrGibbCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: DrGibbAds
   - type: SpeakOnUIClosed
@@ -726,6 +766,8 @@
     denyState: deny-unshaded
     ejectDelay: 1.9
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSmiteCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: SmiteAds
   - type: SpeakOnUIClosed
@@ -748,6 +790,8 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineDinnerwareCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: DinnerwareAds
   - type: SpeakOnUIClosed
@@ -814,6 +858,8 @@
     brokenState: broken
     normalState: normal-unshaded
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineDiscountCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: DiscountDansAds
   - type: SpeakOnUIClosed
@@ -847,6 +893,8 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineEngivendCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/engivend.rsi
     layers:
@@ -910,6 +958,8 @@
     pack: NanoMedPlusInventory
     offState: off
     showPrices: false  # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineMedicalCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     layers:
     - state: "off"
@@ -936,6 +986,8 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineNutriCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: NutriMaxAds
   - type: SpeakOnUIClosed
@@ -971,6 +1023,8 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSecCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: SecTechAds
   - type: SpeakOnUIClosed
@@ -1011,6 +1065,8 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSeedsUnlockedCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: MegaSeedAds
   - type: SpeakOnUIClosed
@@ -1035,6 +1091,8 @@
   id: VendingMachineSeeds
   suffix: Hydroponics
   components:
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSeedsCircuitboard # Starlight-edit: Vending Machine boards
   - type: AccessReader
     access: [["Hydroponics"]]
 
@@ -1054,6 +1112,8 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSnackCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: GetmoreChocolateCorpAds
   - type: SpeakOnUIClosed
@@ -1088,6 +1148,8 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSustenanceCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/sustenance.rsi
     layers:
@@ -1108,6 +1170,8 @@
   id: VendingMachineSnackBlue
   suffix: Blue
   components:
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSnackBlueCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/snack-blue.rsi
     layers:
@@ -1128,6 +1192,8 @@
   id: VendingMachineSnackOrange
   suffix: Orange
   components:
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSnackOrangeCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/snack-orange.rsi
     layers:
@@ -1148,6 +1214,8 @@
   id: VendingMachineSnackGreen
   suffix: Green
   components:
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSnackGreenCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/snack-green.rsi
     layers:
@@ -1168,6 +1236,8 @@
   id: VendingMachineSnackTeal
   suffix: Teal
   components:
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSnackTealCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/snack-teal.rsi
     layers:
@@ -1199,6 +1269,8 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSovietSodaCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: BodaAds
   - type: SpeakOnUIClosed
@@ -1233,6 +1305,8 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     screenState: screen
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineTheaterCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: AutoDrobeAds
   - type: SpeakOnUIClosed
@@ -1268,6 +1342,8 @@
     normalState: normal-unshaded
     ejectState: eject-unshaded
     denyState: deny-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineVendomatCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: VendomatAds
   - type: SpeakOnUIClosed
@@ -1301,6 +1377,8 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineRoboticsCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: VendomatAds
   - type: SpeakOnUIClosed
@@ -1339,6 +1417,8 @@
     ejectState: eject-unshaded
     denyState: deny-unshaded
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineYouToolCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/youtool.rsi
     layers:
@@ -1368,6 +1448,8 @@
     ejectState: eject-unshaded
     ejectDelay: 1.8
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineGamesCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: GoodCleanFunAds
   - type: SpeakOnUIClosed
@@ -1401,6 +1483,8 @@
     brokenState: broken
     normalState: normal-unshaded
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineChangCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: ChangAds
   - type: SpeakOnUIClosed
@@ -1433,6 +1517,8 @@
     brokenState: broken
     normalState: normal-unshaded
     denyState: deny-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSalvageCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/mining.rsi
     layers:
@@ -1467,6 +1553,8 @@
     brokenState: broken
     normalState: normal-unshaded
     initialStockQuality: 0.33
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineDonutCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: DonutAds
   - type: SpeakOnUIClosed
@@ -1521,6 +1609,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineHydrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: HyDrobeAds
   - type: SpeakOnUIClosed
@@ -1553,6 +1643,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineLawDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: LawDrobeAds
   - type: SpeakOnUIClosed
@@ -1581,6 +1673,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSecDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: SecDrobeAds
   - type: SpeakOnUIClosed
@@ -1614,6 +1708,8 @@
     showPrices: false # Starlight-edit: Vending Machines Prices
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingBarDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: BarDrobeAds
   - type: SpeakOnUIClosed
@@ -1642,6 +1738,8 @@
     brokenState: broken
     normalState: normal-unshaded
     denyState: deny-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineChapelCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/chapdrobe.rsi
     layers:
@@ -1670,6 +1768,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineCargoDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: CargoDrobeAds
   - type: SpeakOnUIClosed
@@ -1702,6 +1802,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineMediDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: MediDrobeAds
   - type: SpeakOnUIClosed
@@ -1730,6 +1832,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineChemDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: ChemDrobeAds
   - type: SpeakOnUIClosed
@@ -1758,6 +1862,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineCuraDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: CuraDrobeAds
   - type: SpeakOnUIClosed
@@ -1786,6 +1892,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineAtmosDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: AtmosDrobeAds
   - type: SpeakOnUIClosed
@@ -1818,6 +1926,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineEngiDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: EngiDrobeAds
   - type: SpeakOnUIClosed
@@ -1850,6 +1960,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineChefDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: ChefDrobeAds
   - type: SpeakOnUIClosed
@@ -1878,6 +1990,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineDetDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: DetDrobeAds
   - type: SpeakOnUIClosed
@@ -1906,6 +2020,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineJaniDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: JaniDrobeAds
   - type: SpeakOnUIClosed
@@ -1938,6 +2054,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSciDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: SciDrobeAds
   - type: SpeakOnUIClosed
@@ -1967,6 +2085,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineSyndieDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: SyndieDrobeAds
   - type: SpeakOnUIClosed
@@ -1999,6 +2119,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineRoboDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: RoboDrobeAds
   - type: SpeakOnUIClosed
@@ -2027,6 +2149,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineGeneDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: GeneDrobeAds
   - type: SpeakOnUIClosed
@@ -2055,6 +2179,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineViroDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: ViroDrobeAds
   - type: SpeakOnUIClosed
@@ -2084,6 +2210,8 @@
     offState: off
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineCentDrobeCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/centdrobe.rsi
     layers:
@@ -2119,6 +2247,8 @@
     soundVend: /Audio/Items/bikehorn.ogg
     initialStockQuality: 1.0 # Nobody knows how Honk does it, but their vending machines always seem well-stocked...
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineHappyHonkCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/happyhonk.rsi
     layers:
@@ -2154,6 +2284,8 @@
     showPrices: false # Starlight-start: Vending Machines Prices
     brokenState: broken
     normalState: normal-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachinePrideCircuitboard # Starlight-edit: Vending Machine boards
   - type: DatasetVocalizer
     dataset: PrideDrobeAds
   - type: SpeakOnUIClosed
@@ -2186,6 +2318,8 @@
   - type: VendingMachine
     showPrices: false # Starlight-edit: Vending Machines Prices
     pack: TankDispenserEVAInventory
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineTankDispenserEVACircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/tankdispenser.rsi #TODO add visualiser for remaining tanks as layers
     state: dispenser
@@ -2200,6 +2334,8 @@
   - type: VendingMachine
     showPrices: false # Starlight-edit: Vending Machines Prices
     pack: TankDispenserEngineeringInventory
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineTankDispenserEngineeringCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/tankdispenser.rsi #TODO add visualiser for remaining tanks as layers
     layers:
@@ -2220,6 +2356,8 @@
     normalState: normal
     denyState: deny
     ejectDelay: 2
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineChemicalsCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/chemvend.rsi
     layers:
@@ -2250,6 +2388,8 @@
     normalState: normal
     denyState: deny
     ejectDelay: 2
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineChemicalsSyndicateCircuitboard # Starlight-edit: Vending Machine boards
   - type: AccessReader
     access: [["SyndicateAgent"]]
 
@@ -2267,6 +2407,8 @@
     brokenState: broken
     normalState: normal-unshaded
     denyState: deny-unshaded
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineWallMedicalCivilianCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     sprite: Structures/Machines/VendingMachines/wallmed.rsi
     layers:
@@ -2294,6 +2436,8 @@
     pack: NanoMedInventory
     offState: off
     showPrices: false # Starlight-edit: Vending Machines Prices
+  - type: Machine # Starlight-edit: Vending Machine boards
+    board: VendingMachineWallMedicalCircuitboard # Starlight-edit: Vending Machine boards
   - type: Sprite
     layers:
     - state: "off"

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -97,3 +97,1018 @@
   - type: Construction
     graph: AssortedForgeParts
     node: finish
+
+- type: entity
+  id: VendingMachineCondimentsCircuitboard
+  parent: BaseMachineCircuitboard
+  name: condiment station circuitboard
+  description: A machine printed circuit board for a condiment station machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineCondimentsEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineAmmoCircuitboard
+  parent: BaseMachineCircuitboard
+  name: liberation station circuitboard
+  description: A machine printed circuit board for a liberation station machine
+  components:
+    - type: Sprite
+      state: security
+    - type: MachineBoard
+      prototype: VendingMachineAmmoEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineBoozeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Booze-O-Mat circuitboard
+  description: A machine printed circuit board for a Booze-O-Mat machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineBoozeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineBoozeSyndicateCircuitboard
+  parent: [BaseMachineCircuitboard, BaseMinorContraband]
+  name: Bruise-O-Mat circuitboard
+  description: A machine printed circuit board for a Bruise-O-Mat machine
+  components:
+    - type: Sprite
+      state: cpu_syndicate
+    - type: MachineBoard
+      prototype: VendingMachineBoozeSyndicateEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineCartCircuitboard
+  parent: BaseMachineCircuitboard
+  name: PTech circuitboard
+  description: A machine printed circuit board for a PTech machine
+  components:
+    - type: Sprite
+      state: command
+    - type: MachineBoard
+      prototype: VendingMachineCartEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineChefvendCircuitboard
+  parent: BaseMachineCircuitboard
+  name: ChefVend circuitboard
+  description: A machine printed circuit board for a ChefVend machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineChefvendEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineCigsCircuitboard
+  parent: BaseMachineCircuitboard
+  name: ShadyCigs Deluxe circuitboard
+  description: A machine printed circuit board for a ShadyCigs Deluxe machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineCigsEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineClothingCircuitboard
+  parent: BaseMachineCircuitboard
+  name: ClothesMate circuitboard
+  description: A machine printed circuit board for a ClothesMate machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineClothingEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineWinterCircuitboard
+  parent: BaseMachineCircuitboard
+  name: WinterDrobe circuitboard
+  description: A machine printed circuit board for a WinterDrobe machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineWinterEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineCoffeeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Solar's Best Hot Drinks circuitboard
+  description: A machine printed circuit board for a Solar's Best Hot Drinks machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineCoffeeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineColaCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Robust Softdrinks (cola) circuitboard
+  description: A machine printed circuit board for a Robust Softdrinks machine serving cola
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineColaEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineColaBlackCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Robust Softdrinks (cola, black) circuitboard
+  description: A machine printed circuit board for a Robust Softdrinks machine serving cola, colored black
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineColaBlackEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineColaRedCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Space Cola Vendor circuitboard
+  description: A machine printed circuit board for a Space Cola Vendor machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineColaRedEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSodaCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Robust Softdrinks (soda) circuitboard
+  description: A machine printed circuit board for a Robust Softdrinks machine serving soda
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineSodaEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSpaceUpCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Space-Up! Vendor circuitboard
+  description: A machine printed circuit board for a Space-Up! Vendor machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineSpaceUpEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineStarkistCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Star-kist Vendor circuitboard
+  description: A machine printed circuit board for a Star-kist Vendor machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineStarkistEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineShamblersJuiceCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Shambler's Juice Vendor circuitboard
+  description: A machine printed circuit board for a Shambler's Juice Vendor machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineShamblersJuiceEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachinePwrGameCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Pwr Game Vendor circuitboard
+  description: A machine printed circuit board for a Pwr Game Vendor machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachinePwrGameEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineDrGibbCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Dr. Gibb Vendor circuitboard
+  description: A machine printed circuit board for a Dr. Gibb Vendor machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineDrGibbEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSmiteCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Smite Vendor circuitboard
+  description: A machine printed circuit board for a Smite Vendor machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineSmiteEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineDinnerwareCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Plasteel Chef's Dinnerware Vendor circuitboard
+  description: A machine printed circuit board for a Plasteel Chef's Dinnerware Vendor machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineDinnerwareEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineDiscountCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Discount Dan's circuitboard
+  description: A machine printed circuit board for a Discount Dan's machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineDiscountEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineEngivendCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Engi-Vend circuitboard
+  description: A machine printed circuit board for a Engi-Vend machine
+  components:
+    - type: Sprite
+      state: engineering
+    - type: MachineBoard
+      prototype: VendingMachineEngivendEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineMedicalCircuitboard
+  parent: BaseMachineCircuitboard
+  name: NanoMed Plus circuitboard
+  description: A machine printed circuit board for a NanoMed Plus machine
+  components:
+    - type: Sprite
+      state: medical
+    - type: MachineBoard
+      prototype: VendingMachineMedicalEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineNutriCircuitboard
+  parent: BaseMachineCircuitboard
+  name: NutriMax circuitboard
+  description: A machine printed circuit board for a NutriMax machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineNutriEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSecCircuitboard
+  parent: BaseMachineCircuitboard
+  name: SecTech circuitboard
+  description: A machine printed circuit board for a SecTech machine
+  components:
+    - type: Sprite
+      state: security
+    - type: MachineBoard
+      prototype: VendingMachineSecEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSeedsUnlockedCircuitboard
+  parent: BaseMachineCircuitboard
+  name: MegaSeed Servitor (unlocked) circuitboard
+  description: A machine printed circuit board for a MegaSeed Servitor machine, set to public access
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineSeedsUnlockedEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSeedsCircuitboard
+  parent: BaseMachineCircuitboard
+  name: MegaSeed Servitor circuitboard
+  description: A machine printed circuit board for a MegaSeed Servitor machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineSeedsEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSnackCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Getmore Chocolate Corp circuitboard
+  description: A machine printed circuit board for a Getmore Chocolate Corp machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineSnackEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSustenanceCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Sustenance Vendor circuitboard
+  description: A machine printed circuit board for a Sustenance Vendor machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineSustenanceEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSnackBlueCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Sustenance Vendor (blue) circuitboard
+  description: A machine printed circuit board for a Sustenance Vendor machine, in blue
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineSnackBlueEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSnackOrangeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Sustenance Vendor (orange) circuitboard
+  description: A machine printed circuit board for a Sustenance Vendor machine, in orange
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineSnackOrangeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSnackGreenCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Sustenance Vendor (green) circuitboard
+  description: A machine printed circuit board for a Sustenance Vendor machine, in green
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineSnackGreenEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSnackTealCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Sustenance Vendor (teal) circuitboard
+  description: A machine printed circuit board for a Sustenance Vendor machine, in teal
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineSnackTealEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSovietSodaCircuitboard
+  parent: BaseMachineCircuitboard
+  name: BODA circuitboard
+  description: A machine printed circuit board for a BODA machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineSovietSodaEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineTheaterCircuitboard
+  parent: BaseMachineCircuitboard
+  name: AutoDrobe circuitboard
+  description: A machine printed circuit board for a AutoDrobe machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineTheaterEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineVendomatCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Vendomat circuitboard
+  description: A machine printed circuit board for a Vendomat machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineVendomatEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineRoboticsCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Robotech Deluxe circuitboard
+  description: A machine printed circuit board for a Robotech Deluxe machine
+  components:
+    - type: Sprite
+      state: science
+    - type: MachineBoard
+      prototype: VendingMachineRoboticsEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineYouToolCircuitboard
+  parent: BaseMachineCircuitboard
+  name: YouTool circuitboard
+  description: A machine printed circuit board for a YouTool machine
+  components:
+    - type: Sprite
+      state: engineering
+    - type: MachineBoard
+      prototype: VendingMachineYouToolEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineGamesCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Good Clean Fun circuitboard
+  description: A machine printed circuit board for a Good Clean Fun machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineGamesEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineChangCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Mr. Chang circuitboard
+  description: A machine printed circuit board for a Mr. Chang machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachineChangEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSalvageCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Salvage Vendor circuitboard
+  description: A machine printed circuit board for a Salvage Vendor machine
+  components:
+    - type: Sprite
+      state: supply
+    - type: MachineBoard
+      prototype: VendingMachineSalvageEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineDonutCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Monkin' Donuts circuitboard
+  description: A machine printed circuit board for a Monkin' Donuts machine
+  components:
+    - type: Sprite
+      state: security
+    - type: MachineBoard
+      prototype: VendingMachineDonutEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineHydrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: HyDrobe circuitboard
+  description: A machine printed circuit board for a HyDrobe machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineHydrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineLawDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: LawDrobe circuitboard
+  description: A machine printed circuit board for a LawDrobe machine
+  components:
+    - type: Sprite
+      state: security
+    - type: MachineBoard
+      prototype: VendingMachineLawDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSecDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: SecDrobe circuitboard
+  description: A machine printed circuit board for a SecDrobe machine
+  components:
+    - type: Sprite
+      state: security
+    - type: MachineBoard
+      prototype: VendingMachineSecDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingBarDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: BarDrobe circuitboard
+  description: A machine printed circuit board for a BarDrobe machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingBarDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineChapelCircuitboard
+  parent: BaseMachineCircuitboard
+  name: PietyVend circuitboard
+  description: A machine printed circuit board for a PietyVend machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineChapelEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineCargoDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: CargoDrobe circuitboard
+  description: A machine printed circuit board for a CargoDrobe machine
+  components:
+    - type: Sprite
+      state: supply
+    - type: MachineBoard
+      prototype: VendingMachineCargoDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineMediDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: MediDrobe circuitboard
+  description: A machine printed circuit board for a MediDrobe machine
+  components:
+    - type: Sprite
+      state: medical
+    - type: MachineBoard
+      prototype: VendingMachineMediDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineChemDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: ChemDrobe circuitboard
+  description: A machine printed circuit board for a ChemDrobe machine
+  components:
+    - type: Sprite
+      state: medical
+    - type: MachineBoard
+      prototype: VendingMachineChemDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineCuraDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: CuraDrobe circuitboard
+  description: A machine printed circuit board for a CuraDrobe machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineCuraDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineAtmosDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: AtmosDrobe circuitboard
+  description: A machine printed circuit board for a AtmosDrobe machine
+  components:
+    - type: Sprite
+      state: engineering
+    - type: MachineBoard
+      prototype: VendingMachineAtmosDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineEngiDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: EngiDrobe circuitboard
+  description: A machine printed circuit board for a EngiDrobe machine
+  components:
+    - type: Sprite
+      state: engineering
+    - type: MachineBoard
+      prototype: VendingMachineEngiDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineChefDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: ChefDrobe circuitboard
+  description: A machine printed circuit board for a ChefDrobe machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineChefDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineDetDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: DetDrobe circuitboard
+  description: A machine printed circuit board for a DetDrobe machine
+  components:
+    - type: Sprite
+      state: security
+    - type: MachineBoard
+      prototype: VendingMachineDetDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineJaniDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: JaniDrobe circuitboard
+  description: A machine printed circuit board for a JaniDrobe machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineJaniDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSciDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: SciDrobe circuitboard
+  description: A machine printed circuit board for a SciDrobe machine
+  components:
+    - type: Sprite
+      state: science
+    - type: MachineBoard
+      prototype: VendingMachineSciDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineSyndieDrobeCircuitboard
+  parent: [BaseMachineCircuitboard, BaseMinorContraband]
+  name: SyndieDrobe circuitboard
+  description: A machine printed circuit board for a SyndieDrobe machine
+  components:
+    - type: Sprite
+      state: cpu_syndicate
+    - type: MachineBoard
+      prototype: VendingMachineSyndieDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineRoboDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: RoboDrobe circuitboard
+  description: A machine printed circuit board for a RoboDrobe machine
+  components:
+    - type: Sprite
+      state: science
+    - type: MachineBoard
+      prototype: VendingMachineRoboDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineGeneDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: GeneDrobe circuitboard
+  description: A machine printed circuit board for a GeneDrobe machine
+  components:
+    - type: Sprite
+      state: medical
+    - type: MachineBoard
+      prototype: VendingMachineGeneDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineViroDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: ViroDrobe circuitboard
+  description: A machine printed circuit board for a ViroDrobe machine
+  components:
+    - type: Sprite
+      state: medical
+    - type: MachineBoard
+      prototype: VendingMachineViroDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineCentDrobeCircuitboard
+  parent: BaseMachineCircuitboard
+  name: CentDrobe circuitboard
+  description: A machine printed circuit board for a CentDrobe machine
+  components:
+    - type: Sprite
+      state: command
+    - type: MachineBoard
+      prototype: VendingMachineCentDrobeEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineHappyHonkCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Happy Honk Dispenser circuitboard
+  description: A machine printed circuit board for a Happy Honk Dispenser machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineHappyHonkEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachinePrideCircuitboard
+  parent: BaseMachineCircuitboard
+  name: Pride-O-Mat circuitboard
+  description: A machine printed circuit board for a Pride-O-Mat machine
+  components:
+    - type: MachineBoard
+      prototype: VendingMachinePrideEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineTankDispenserEVACircuitboard
+  parent: BaseMachineCircuitboard
+  name: gas tank dispenser circuitboard
+  description: A machine printed circuit board for a gas tank dispenser machine
+  components:
+    - type: Sprite
+      state: service
+    - type: MachineBoard
+      prototype: VendingMachineTankDispenserEVAEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineTankDispenserEngineeringCircuitboard
+  parent: BaseMachineCircuitboard
+  name: gas tank dispenser (with plasma) circuitboard
+  description: A machine printed circuit board for a gas tank dispenser (with plasma) machine
+  components:
+    - type: Sprite
+      state: engineering
+    - type: MachineBoard
+      prototype: VendingMachineTankDispenserEngineeringEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineChemicalsCircuitboard
+  parent: BaseMachineCircuitboard
+  name: ChemVend circuitboard
+  description: A machine printed circuit board for a ChemVend machine
+  components:
+    - type: Sprite
+      state: medical
+    - type: MachineBoard
+      prototype: VendingMachineChemicalsEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineChemicalsSyndicateCircuitboard
+  parent: [BaseMachineCircuitboard, BaseMinorContraband]
+  name: SyndieJuice circuitboard
+  description: A machine printed circuit board for a SyndieJuice machine
+  components:
+    - type: Sprite
+      state: cpu_syndicate
+    - type: MachineBoard
+      prototype: VendingMachineChemicalsSyndicateEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineWallMedicalCivilianCircuitboard
+  parent: BaseMachineCircuitboard
+  name: NanoMed band-aid circuitboard
+  description: A machine printed circuit board for a NanoMed band-aid machine
+  components:
+    - type: Sprite
+      state: medical
+    - type: MachineBoard
+      prototype: VendingMachineWallMedicalCivilianEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2
+
+- type: entity
+  id: VendingMachineWallMedicalCircuitboard
+  parent: BaseMachineCircuitboard
+  name: NanoMed circuitboard
+  description: A machine printed circuit board for a NanoMed machine
+  components:
+    - type: Sprite
+      state: medical
+    - type: MachineBoard
+      prototype: VendingMachineWallMedicalEmpty
+      stackRequirements:
+        Steel: 5
+        Manipulator: 1
+        Glass: 2

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Machines/vending_machines.yml
@@ -241,3 +241,515 @@
     - type: WirelessNetworkConnection
       range: 200
     - type: AbductorDispencer
+
+- type: entity
+  parent: VendingMachineCondiments
+  id: VendingMachineCondimentsEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineAmmo
+  id: VendingMachineAmmoEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineBooze
+  id: VendingMachineBoozeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineBoozeSyndicate
+  id: VendingMachineBoozeSyndicateEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineCart
+  id: VendingMachineCartEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineChefvend
+  id: VendingMachineChefvendEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineCigs
+  id: VendingMachineCigsEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineClothing
+  id: VendingMachineClothingEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineWinter
+  id: VendingMachineWinterEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineCoffee
+  id: VendingMachineCoffeeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineCola
+  id: VendingMachineColaEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineColaBlack
+  id: VendingMachineColaBlackEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineColaRed
+  id: VendingMachineColaRedEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSpaceUp
+  id: VendingMachineSpaceUpEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSoda
+  id: VendingMachineSodaEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineStarkist
+  id: VendingMachineStarkistEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineShamblersJuice
+  id: VendingMachineShamblersJuiceEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachinePwrGame
+  id: VendingMachinePwrGameEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineDrGibb
+  id: VendingMachineDrGibbEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSmite
+  id: VendingMachineSmiteEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineDinnerware
+  id: VendingMachineDinnerwareEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineMagivend
+  id: VendingMachineMagivendEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineDiscount
+  id: VendingMachineDiscountEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineEngivend
+  id: VendingMachineEngivendEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineMedicalBase
+  id: VendingMachineMedicalBaseEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineMedical
+  id: VendingMachineMedicalEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineNutri
+  id: VendingMachineNutriEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSec
+  id: VendingMachineSecEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSeedsUnlocked
+  id: VendingMachineSeedsUnlockedEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSeeds
+  id: VendingMachineSeedsEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSnack
+  id: VendingMachineSnackEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSustenance
+  id: VendingMachineSustenanceEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSnackBlue
+  id: VendingMachineSnackBlueEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSnackOrange
+  id: VendingMachineSnackOrangeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSnackGreen
+  id: VendingMachineSnackGreenEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSnackTeal
+  id: VendingMachineSnackTealEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSovietSoda
+  id: VendingMachineSovietSodaEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineTheater
+  id: VendingMachineTheaterEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineVendomat
+  id: VendingMachineVendomatEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineRobotics
+  id: VendingMachineRoboticsEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineYouTool
+  id: VendingMachineYouToolEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineGames
+  id: VendingMachineGamesEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineChang
+  id: VendingMachineChangEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSalvage
+  id: VendingMachineSalvageEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineDonut
+  id: VendingMachineDonutEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineHydrobe
+  id: VendingMachineHydrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineLawDrobe
+  id: VendingMachineLawDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSecDrobe
+  id: VendingMachineSecDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingBarDrobe
+  id: VendingBarDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineChapel
+  id: VendingMachineChapelEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineCargoDrobe
+  id: VendingMachineCargoDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineMediDrobe
+  id: VendingMachineMediDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineChemDrobe
+  id: VendingMachineChemDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineCuraDrobe
+  id: VendingMachineCuraDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineAtmosDrobe
+  id: VendingMachineAtmosDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineEngiDrobe
+  id: VendingMachineEngiDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineChefDrobe
+  id: VendingMachineChefDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineDetDrobe
+  id: VendingMachineDetDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineJaniDrobe
+  id: VendingMachineJaniDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSciDrobe
+  id: VendingMachineSciDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineSyndieDrobe
+  id: VendingMachineSyndieDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineRoboDrobe
+  id: VendingMachineRoboDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineGeneDrobe
+  id: VendingMachineGeneDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineViroDrobe
+  id: VendingMachineViroDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineCentDrobe
+  id: VendingMachineCentDrobeEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineHappyHonk
+  id: VendingMachineHappyHonkEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachinePride
+  id: VendingMachinePrideEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineTankDispenserEVA
+  id: VendingMachineTankDispenserEVAEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineTankDispenserEngineering
+  id: VendingMachineTankDispenserEngineeringEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineChemicals
+  id: VendingMachineChemicalsEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineChemicalsSyndicate
+  id: VendingMachineChemicalsSyndicateEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineWallMedicalCivilian
+  id: VendingMachineWallMedicalCivilianEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+
+- type: entity
+  parent: VendingMachineWallMedical
+  id: VendingMachineWallMedicalEmpty
+  suffix: Empty
+  components:
+    - type: EmptyVendingMachine
+

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
@@ -111,3 +111,80 @@
   id: StarlightDangerousLawboards
   recipes:
     - OverlordCircuitBoard
+
+- type: latheRecipePack
+  id: StarlightVendorBoards
+  recipes:
+    - VendingMachineCondimentsCircuitboard
+    - VendingMachineAmmoCircuitboard
+    - VendingMachineBoozeCircuitboard
+    - VendingMachineCartCircuitboard
+    - VendingMachineChefvendCircuitboard
+    - VendingMachineCigsCircuitboard
+    - VendingMachineClothingCircuitboard
+    - VendingMachineWinterCircuitboard
+    - VendingMachineCoffeeCircuitboard
+    - VendingMachineColaBlackCircuitboard
+    - VendingMachineColaRedCircuitboard
+    - VendingMachineSpaceUpCircuitboard
+    - VendingMachineStarkistCircuitboard
+    - VendingMachineShamblersJuiceCircuitboard
+    - VendingMachinePwrGameCircuitboard
+    - VendingMachineDrGibbCircuitboard
+    - VendingMachineSmiteCircuitboard
+    - VendingMachineDinnerwareCircuitboard
+    - VendingMachineDiscountCircuitboard
+    - VendingMachineEngivendCircuitboard
+    - VendingMachineMedicalCircuitboard
+    - VendingMachineNutriCircuitboard
+    - VendingMachineSecCircuitboard
+    - VendingMachineSeedsUnlockedCircuitboard
+    - VendingMachineSeedsCircuitboard
+    - VendingMachineSnackCircuitboard
+    - VendingMachineSustenanceCircuitboard
+    - VendingMachineSnackBlueCircuitboard
+    - VendingMachineSnackOrangeCircuitboard
+    - VendingMachineSnackGreenCircuitboard
+    - VendingMachineSnackTealCircuitboard
+    - VendingMachineSovietSodaCircuitboard
+    - VendingMachineTheaterCircuitboard
+    - VendingMachineVendomatCircuitboard
+    - VendingMachineRoboticsCircuitboard
+    - VendingMachineYouToolCircuitboard
+    - VendingMachineGamesCircuitboard
+    - VendingMachineChangCircuitboard
+    - VendingMachineSalvageCircuitboard
+    - VendingMachineDonutCircuitboard
+    - VendingMachineHydrobeCircuitboard
+    - VendingMachineLawDrobeCircuitboard
+    - VendingMachineSecDrobeCircuitboard
+    - VendingBarDrobeCircuitboard
+    - VendingMachineChapelCircuitboard
+    - VendingMachineCargoDrobeCircuitboard
+    - VendingMachineMediDrobeCircuitboard
+    - VendingMachineChemDrobeCircuitboard
+    - VendingMachineCuraDrobeCircuitboard
+    - VendingMachineAtmosDrobeCircuitboard
+    - VendingMachineEngiDrobeCircuitboard
+    - VendingMachineChefDrobeCircuitboard
+    - VendingMachineDetDrobeCircuitboard
+    - VendingMachineJaniDrobeCircuitboard
+    - VendingMachineSciDrobeCircuitboard
+    - VendingMachineRoboDrobeCircuitboard
+    - VendingMachineGeneDrobeCircuitboard
+    - VendingMachineViroDrobeCircuitboard
+    - VendingMachineCentDrobeCircuitboard
+    - VendingMachineHappyHonkCircuitboard
+    - VendingMachinePrideCircuitboard
+    - VendingMachineTankDispenserEVACircuitboard
+    - VendingMachineTankDispenserEngineeringCircuitboard
+    - VendingMachineChemicalsCircuitboard
+
+
+# Contraband Vendor Boards (Emag only)
+- type: latheRecipePack
+  id: StarlightSyndicateVendorBoards
+  recipes:
+    - VendingMachineBoozeSyndicateCircuitboard
+    - VendingMachineSyndieDrobeCircuitboard
+    - VendingMachineChemicalsSyndicateCircuitboard

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/misc.yml
@@ -5,3 +5,540 @@
   materials:
      Steel: 100
      Glass: 900
+
+- type: latheRecipe
+  id: VendingMachineCondimentsCircuitboard
+  result: VendingMachineCondimentsCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineAmmoCircuitboard
+  result: VendingMachineAmmoCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineBoozeCircuitboard
+  result: VendingMachineBoozeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineBoozeSyndicateCircuitboard
+  result: VendingMachineBoozeSyndicateCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineCartCircuitboard
+  result: VendingMachineCartCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineChefvendCircuitboard
+  result: VendingMachineChefvendCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineCigsCircuitboard
+  result: VendingMachineCigsCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineClothingCircuitboard
+  result: VendingMachineClothingCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineWinterCircuitboard
+  result: VendingMachineWinterCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineCoffeeCircuitboard
+  result: VendingMachineCoffeeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineColaBlackCircuitboard
+  result: VendingMachineColaBlackCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineColaRedCircuitboard
+  result: VendingMachineColaRedCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSpaceUpCircuitboard
+  result: VendingMachineSpaceUpCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineStarkistCircuitboard
+  result: VendingMachineStarkistCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineShamblersJuiceCircuitboard
+  result: VendingMachineShamblersJuiceCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachinePwrGameCircuitboard
+  result: VendingMachinePwrGameCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineDrGibbCircuitboard
+  result: VendingMachineDrGibbCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSmiteCircuitboard
+  result: VendingMachineSmiteCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineDinnerwareCircuitboard
+  result: VendingMachineDinnerwareCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineDiscountCircuitboard
+  result: VendingMachineDiscountCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineEngivendCircuitboard
+  result: VendingMachineEngivendCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineMedicalCircuitboard
+  result: VendingMachineMedicalCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineNutriCircuitboard
+  result: VendingMachineNutriCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSecCircuitboard
+  result: VendingMachineSecCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSeedsUnlockedCircuitboard
+  result: VendingMachineSeedsUnlockedCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSeedsCircuitboard
+  result: VendingMachineSeedsCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSnackCircuitboard
+  result: VendingMachineSnackCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSustenanceCircuitboard
+  result: VendingMachineSustenanceCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSnackBlueCircuitboard
+  result: VendingMachineSnackBlueCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSnackOrangeCircuitboard
+  result: VendingMachineSnackOrangeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSnackGreenCircuitboard
+  result: VendingMachineSnackGreenCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSnackTealCircuitboard
+  result: VendingMachineSnackTealCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSovietSodaCircuitboard
+  result: VendingMachineSovietSodaCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineTheaterCircuitboard
+  result: VendingMachineTheaterCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineVendomatCircuitboard
+  result: VendingMachineVendomatCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineRoboticsCircuitboard
+  result: VendingMachineRoboticsCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineYouToolCircuitboard
+  result: VendingMachineYouToolCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineGamesCircuitboard
+  result: VendingMachineGamesCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineChangCircuitboard
+  result: VendingMachineChangCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSalvageCircuitboard
+  result: VendingMachineSalvageCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineDonutCircuitboard
+  result: VendingMachineDonutCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineHydrobeCircuitboard
+  result: VendingMachineHydrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineLawDrobeCircuitboard
+  result: VendingMachineLawDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSecDrobeCircuitboard
+  result: VendingMachineSecDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSyndieDrobeCircuitboard
+  result: VendingMachineSyndieDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingBarDrobeCircuitboard
+  result: VendingBarDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineChapelCircuitboard
+  result: VendingMachineChapelCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineCargoDrobeCircuitboard
+  result: VendingMachineCargoDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineMediDrobeCircuitboard
+  result: VendingMachineMediDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineChemDrobeCircuitboard
+  result: VendingMachineChemDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineCuraDrobeCircuitboard
+  result: VendingMachineCuraDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineAtmosDrobeCircuitboard
+  result: VendingMachineAtmosDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineEngiDrobeCircuitboard
+  result: VendingMachineEngiDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineChefDrobeCircuitboard
+  result: VendingMachineChefDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineDetDrobeCircuitboard
+  result: VendingMachineDetDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineJaniDrobeCircuitboard
+  result: VendingMachineJaniDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineSciDrobeCircuitboard
+  result: VendingMachineSciDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineRoboDrobeCircuitboard
+  result: VendingMachineRoboDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineGeneDrobeCircuitboard
+  result: VendingMachineGeneDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineViroDrobeCircuitboard
+  result: VendingMachineViroDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineCentDrobeCircuitboard
+  result: VendingMachineCentDrobeCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineHappyHonkCircuitboard
+  result: VendingMachineHappyHonkCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachinePrideCircuitboard
+  result: VendingMachinePrideCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineTankDispenserEVACircuitboard
+  result: VendingMachineTankDispenserEVACircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineTankDispenserEngineeringCircuitboard
+  result: VendingMachineTankDispenserEngineeringCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineChemicalsCircuitboard
+  result: VendingMachineChemicalsCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+
+- type: latheRecipe
+  id: VendingMachineChemicalsSyndicateCircuitboard
+  result: VendingMachineChemicalsSyndicateCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500
+


### PR DESCRIPTION
## Short description
This adds the ability to construct vending machines, reducing the need for admin intervention in the case that a crucial machine gets destroyed early in the round. Some machines don't have restock crates, but the majority of important ones do.

If a vending machine is constructed, it starts with an empty inventory; if destroyed, it spews some inventory as is currently the case, and then sets down a machineframe that can be rebuilt into the machine (depending on the level of damage done). When rebuilt, the lost inventory remains lost.

As a side effect, this PR adds empty variants of vending machines, so when appropriate mappers can place those into their maps.

## Why we need to add this
Currently replacing a destroyed vending machine requires luck and high interaction with and cooperation from Salvage, or admin intervention. It doesn't make sense that vending machines would be more restricted than many of the things we _can_ print circuit boards for already.

Discussed in https://discord.com/channels/1272545509562777621/1424897810972545064.

## Media (Video/Screenshots)
No real visual changes - you touch the machine frame, and the vending machine appears. Hit it enough, and the reverse happens.

## Checks

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Penguinwizzard
- add: Vending machines can now be constructed, and vending machine circuit boards are now imprintable.