### PR TITLE
Small species knockback consistency

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -10,13 +10,16 @@
     - Abductor
     messages:
     - abductor-gun-restricted-1
-  - type: KnockbackByUserTag
+  - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
         knockback: 0.01
         staminaMultiplier: 100
       Avali:
-        knockback: 0.01 # Bigger bird, more sturdy bones.. or something.
+        knockback: 0.005 # half of what resomi take
+        staminaMultiplier: 100
+      Felionoid:
+        knockback: 0.005 # half of what resomi take
         staminaMultiplier: 100
   - type: Sprite
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -10,13 +10,16 @@
     - Abductor
     messages:
     - abductor-gun-restricted-1
-  - type: KnockbackByUserTag
+  - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
         knockback: 0.02
         staminaMultiplier: 100
       Avali:
-        knockback: 0.01 # Bigger bird, more sturdy bones.. or something.
+        knockback: 0.01 # half of what resomi take
+        staminaMultiplier: 100
+      Felionoid:
+        knockback: 0.01 #half of what resomi take
         staminaMultiplier: 100
   - type: Sprite
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -10,16 +10,16 @@
     - Abductor
     messages:
     - abductor-gun-restricted-1
-  - type: KnockbackByUserTag
+  - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
         knockback: 10
         staminaMultiplier: 8
       Avali:
-        knockback: 3 # Bigger bird, more sturdy bones.. or something.
+        knockback: 5 # half of what resomi take
         staminaMultiplier: 8
       Felionoid:
-        knockback: 5 #half of what resomi take
+        knockback: 5 # half of what resomi take
         staminaMultiplier: 8
   - type: Sprite
   - type: Clothing
@@ -126,14 +126,14 @@
   id: WeaponLauncherRocket
   description: A modified ancient rocket-propelled grenade launcher.
   components:
-  - type: KnockbackByUserTag
+  - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
         knockback: -5
-      Felionoid:
-        knockback: -2.5 #half of what resomi take
       Avali:
-        knockback: -1.5
+        knockback: -2.5 # half of what resomi take
+      Felionoid:
+        knockback: -2.5 # half of what resomi take
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/rocket.rsi
     layers:
@@ -167,13 +167,16 @@
   id: WeaponLauncherMultipleRocket
   description: A modified ancient rocket-propelled grenade launcher.
   components:
-  - type: KnockbackByUserTag
+  - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
         knockback: 10
         staminaMultiplier: 8
+      Avali:
+        knockback: 5 # half of what resomi take
+        staminaMultiplier: 8
       Felionoid:
-        knockback: 5 #half of what resomi take
+        knockback: 5 # half of what resomi take
         staminaMultiplier: 8
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/rocket.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -10,12 +10,14 @@
     - Abductor
     messages:
     - abductor-gun-restricted-1
-  - type: KnockbackByUserTag
+  - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
         knockback: 0.1
       Avali:
         knockback: 0.05 # Bigger bird, more sturdy bones.. or something.
+      Felionoid:
+        knockback: 0.05 #half of what resomi take
   - type: Sprite
   - type: Item
     size: Huge
@@ -306,9 +308,13 @@
   id: WeaponRifleFoam
   description: A premium foam rifle of the highest quality. Its plastic feels rugged, and its mechanisms sturdy.
   components:
-  - type: KnockbackByUserTag
+  - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
+        knockback: 0
+      Avali:
+        knockback: 0
+      Felionoid:
         knockback: 0
   - type: Sprite
     sprite: Objects/Fun/Foam/foam_rifle.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -10,13 +10,13 @@
     - Abductor
     messages:
     - abductor-gun-restricted-1
-  - type: KnockbackByUserTag
+  - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
         knockback: 3
         staminaMultiplier: 20
       Avali:
-        knockback: 1 # Bigger bird, more sturdy bones.. or something.
+        knockback: 1 # half of what resomi take
         staminaMultiplier: 20
       Felionoid:
         knockback: 1.5 #half of what resomi take

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -10,13 +10,13 @@
     - Abductor
     messages:
     - abductor-gun-restricted-1
-  - type: KnockbackByUserTag
+  - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
         knockback: 4
         staminaMultiplier: 15
       Avali:
-        knockback: 1 # Bigger bird, more sturdy bones.. or something.
+        knockback: 2 # half of what resomi take
         staminaMultiplier: 15
       Felionoid:
         knockback: 2 #half of what resomi take
@@ -61,12 +61,14 @@
   id: WeaponSniperMosin
   description: A weapon of the masses, a true relic. The Kardashev-Mosin has served in nearly every armed conflict since its creation 670 years ago. The bolt-action design of the rifle remains virtually identical to its original design, whether used for hunting, sniping, or endless trench warfare. Uses .45 magnum ammo.
   components:
-  - type: KnockbackByUserTag
+  - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
         knockback: 2
+      Avali:
+        knockback: 1 # half of what resomi take
       Felionoid:
-        knockback: 1 #half of what resomi take
+        knockback: 1 # half of what resomi take
   - type: BallisticAmmoProvider # Starlight
     capacity: 10
     proto: CartridgeMagnumSP

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -23,8 +23,10 @@
     doestContain:
       Resomi:
         knockback: 1.5
+      Avali:
+        knockback: 0.75 # half of what resomi take
       Felionoid:
-        knockback: 0.5
+        knockback: 0.75 # half of what resomi take
   - type: BallisticAmmoProvider
     whitelist:
       tags:

--- a/Resources/ServerInfo/Guidebook/Mobs/Felionoid.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Felionoid.xml
@@ -4,13 +4,24 @@
   <Box>
     <GuideEntityEmbed Entity="MobFelionoid" Caption=""/>
   </Box>
+  
+  A smaller feline species that is light on their feet.
+  
+  ## Racial Features
+  Their unarmed claw attacks deal [color=red]3[/color] points of Slash damage with a hit rate that is [color=yellow]2[/color] times faster than humans.
 
-  [color=#ffa500]Caution! This species has a severely limiting game mechanic and is not recommended for new players. [/color]
+  Additionally, Felionoids can run [color=lightgreen]25%[/color] faster than humans but are more vulnerable:
+  - They fall into a critical state at [color=red]75[/color] points of damage.
+  - They die at [color=red]150[/color] points of damage.
 
-  Their unarmed claw attacks deal 3 points of Slash damage with a hit rate that is 2 times faster than humans.
+  ## Weapon Knockback
+  Felionoids will find that large caliber weapons will push them around. They receive [color=yellow]Stun Damage[/color] for every shot fired from a large caliber weapon.
+  
+  In general, the weapons that will give you knockback are [color=yellow]Rifles, Sniper Rifles, Shotguns, LMGs, HMGs, and Grenade Launchers.[/color]
 
-  Additionally, Felionoids can run 1.3 times faster than humans but are more vulnerable:
-  - They fall into a critical state at 75 points of damage.
-  - They die at 150 points of damage.
+  Look out especially on Rocket launchers, as since they are recoilless, you will actually get [color=red]pulled forward with the rocket[/color] for a short distance.
+  - The safest weapons to use that will give you no knockback are [color=green]Pistols and SMGs[/color].
+  - No slips can help mitigate some of the knockback from firing weapons, but not all of it!
+  - Also keep in mind that any stamina resistance you have DOES work to reduce the stamina damage from these weapons.
 
 </Document>


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- Avali and Felionoids now take **exactly half** of the stamina damage from firing guns that Resomi take consistently. Before it was kinda all over the place.
- **Felionoids actually take stamina damage from Rifles and LMGs now,** consistent with other small species. Before they only took stamina damage from Shotguns, Launchers, Snipers, etc.
- Updated the Felionoid guidebook entry, adding the nice text colors that other guidebook entries have.
- Updated the Felionoid guidebook entry to actually mention they take stamina damage. It wasn't listed before.
- Updated the Felionoid guidebook to list the actually correct speed bonus -- it's a 25% speed bonus in game, not 30%.

Also added a bunch of Starlight comments that were just, like, not there before.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Consistency, and I'm faaaairly sure that Felionoids not taking stamina damage from Rifles / LMGs is either an oversight or something that got messed up in an upstream merge.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="609" height="784" alt="image" src="https://github.com/user-attachments/assets/952f8ef4-6135-4e25-b885-97117438c9ba" />

fig. 1 - Updated guidebook entry for Felionoids.

https://github.com/user-attachments/assets/ced73183-8bb2-459e-8afc-cbc956a1d65c

fig. 2 - Stamina damage demonstrated in-game. Felionoids on the live branch do already take stamina damage from shotguns, but you can see here that the Felionoid is taking stamina damage from firing the AKMS (they didn't before this PR).


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- tweak: Felionoids and Avali now take exactly half the stamina damage from large firearms that Resomi do (instead of like, close-ish to half)
- fix: Avali now take half the stamina damage from snipers that Resomi do (instead of full damage)
- fix: Felionoids' guidebook entry now mentions they take stamina damage from firearms
- fix: Felionoids' guidebook entry now lists the correct speedbonus (25%, was mistakenly listed as 30% before)
- fix: Felionoids actually take stamina damage from Rifles and LMGs now