### PR TITLE
Mute trait now gives you sign language

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -61,7 +61,12 @@
     components:
       - BorgChassis
   components:
-    - type: Muted
+  - type: Muted
+  - type: LanguageSpeaker # Starlight start
+  languagesSpoken:
+    - Sign
+  languagesUnderstood:
+    - Sign # Starlight end
 
 - type: trait
   id: Paracusia


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Picking the Mute trait now gives you sign language for free.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
There's no real reason you should be forced to spend a language point to communicate in sign if you're mute.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- add: Mute trait now gives you sign language
