### PR TITLE
(Lobster) Removes window underneath a windoor in Botany

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Lobster.yml
+++ b/Resources/Maps/_Starlight/Stations/Lobster.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 266.0.0
+  engineVersion: 267.1.0
   forkId: ""
   forkVersion: ""
-  time: 09/29/2025 23:34:49
-  entityCount: 23859
+  time: 10/10/2025 07:12:09
+  entityCount: 23858
 maps:
 - 1
 grids:
@@ -5744,8 +5744,7 @@ entities:
           0,0:
             0: 65423
           0,1:
-            0: 46895
-            2: 16384
+            0: 63279
           0,2:
             0: 10103
           0,3:
@@ -5768,7 +5767,7 @@ entities:
           2,-4:
             0: 12279
           2,-3:
-            1: 21855
+            1: 23903
           2,-2:
             1: 15
             0: 65280
@@ -5777,7 +5776,7 @@ entities:
           2,-5:
             0: 30711
           2,0:
-            0: 62719
+            0: 64255
           3,-4:
             0: 61424
           3,-2:
@@ -5789,16 +5788,16 @@ entities:
           3,-3:
             0: 61166
           3,0:
-            0: 28863
+            0: 28927
           4,-1:
-            0: 64743
+            0: 60647
             1: 8
           0,4:
             0: 56607
           1,1:
-            0: 32525
+            0: 63245
           1,2:
-            0: 26495
+            0: 30583
           1,3:
             0: 65535
           1,4:
@@ -5806,7 +5805,7 @@ entities:
           2,1:
             0: 65535
           2,2:
-            0: 65535
+            0: 61695
           2,3:
             0: 65535
           2,4:
@@ -5814,13 +5813,13 @@ entities:
           3,1:
             0: 30583
           3,2:
-            0: 15283
+            0: 14515
           3,3:
             0: 65535
           3,4:
             0: 64497
           4,0:
-            0: 56543
+            0: 56559
           4,1:
             0: 49117
             1: 16384
@@ -6901,9 +6900,9 @@ entities:
             1: 3
             0: 8
           9,8:
-            0: 4367
+            0: 13071
           9,9:
-            0: 4369
+            0: 13107
           9,10:
             0: 1
           9,7:
@@ -6935,31 +6934,31 @@ entities:
             0: 4497
             1: 17472
           10,4:
-            3: 5
+            2: 5
             1: 3840
           10,5:
             0: 36863
           10,6:
             0: 48051
           10,3:
-            3: 20480
+            2: 20480
             0: 255
           11,4:
-            3: 3
+            2: 3
             1: 3840
-            4: 8
+            3: 8
           11,5:
             0: 65535
           11,6:
             0: 65531
           11,3:
-            3: 12288
-            4: 32768
+            2: 12288
+            3: 32768
             0: 255
           12,4:
-            4: 1
+            3: 1
             1: 3840
-            3: 12
+            2: 12
           12,6:
             0: 65535
           12,7:
@@ -6998,8 +6997,8 @@ entities:
             0: 65535
           12,3:
             0: 255
-            4: 4096
-            3: 49152
+            3: 4096
+            2: 49152
           12,5:
             0: 3822
           13,5:
@@ -7009,15 +7008,15 @@ entities:
           13,7:
             0: 56719
           13,4:
-            3: 238
+            2: 238
             1: 57344
           13,8:
             0: 221
           13,3:
-            3: 57344
+            2: 57344
             0: 255
           14,4:
-            3: 3
+            2: 3
             0: 60928
             1: 8
           14,5:
@@ -7068,7 +7067,7 @@ entities:
             0: 3822
           13,-1:
             0: 57344
-            5: 238
+            4: 238
           14,0:
             0: 57906
             1: 3276
@@ -7080,7 +7079,7 @@ entities:
             1: 8
           14,-1:
             0: 60620
-            5: 19
+            4: 19
           15,0:
             0: 56797
           15,2:
@@ -7294,7 +7293,7 @@ entities:
             0: 39935
             1: 25600
           13,-2:
-            5: 65256
+            4: 65256
           13,-5:
             0: 65535
           14,-4:
@@ -7304,7 +7303,7 @@ entities:
             0: 52479
             1: 13056
           14,-2:
-            5: 4368
+            4: 4368
             0: 52428
           14,-5:
             0: 65535
@@ -8010,11 +8009,6 @@ entities:
           moles:
             Oxygen: 21.824879
             Nitrogen: 82.10312
-        - volume: 2500
-          temperature: 293.14975
-          moles:
-            Oxygen: 20.078888
-            Nitrogen: 75.53487
         - volume: 2500
           temperature: 293.15
           moles: {}
@@ -8849,7 +8843,6 @@ entities:
   - uid: 74
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 2
   - uid: 75
@@ -8900,25 +8893,21 @@ entities:
   - uid: 84
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-32.5
       parent: 2
   - uid: 85
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,-21.5
       parent: 2
   - uid: 86
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-17.5
       parent: 2
   - uid: 87
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,-28.5
       parent: 2
   - uid: 88
@@ -8968,7 +8957,6 @@ entities:
   - uid: 96
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,5.5
       parent: 2
 - proto: AirlockAssemblyGlass
@@ -9030,13 +9018,11 @@ entities:
   - uid: 106
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 34.5,-1.5
       parent: 2
   - uid: 107
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 34.5,-7.5
       parent: 2
   - uid: 108
@@ -9064,7 +9050,7 @@ entities:
       pos: -1.5,5.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -4102.819
+      secondsUntilStateChange: -4156.13
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9091,7 +9077,6 @@ entities:
   - uid: 115
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,2.5
       parent: 2
   - uid: 116
@@ -9102,7 +9087,6 @@ entities:
   - uid: 117
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 75.5,-21.5
       parent: 2
 - proto: AirlockCaptainLocked
@@ -9120,7 +9104,6 @@ entities:
   - uid: 120
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,46.5
       parent: 2
 - proto: AirlockCargoGlass
@@ -9162,13 +9145,11 @@ entities:
   - uid: 127
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,25.5
       parent: 2
   - uid: 128
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,17.5
       parent: 2
   - uid: 129
@@ -9186,13 +9167,11 @@ entities:
   - uid: 131
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -67.5,19.5
       parent: 2
   - uid: 132
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,15.5
       parent: 2
 - proto: AirlockChemistryLocked
@@ -9207,13 +9186,11 @@ entities:
   - uid: 134
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 37.5,32.5
       parent: 2
   - uid: 135
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 40.5,28.5
       parent: 2
 - proto: AirlockChiefMedicalOfficerGlassLocked
@@ -9306,7 +9283,7 @@ entities:
       pos: 67.5,48.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -40923.15
+      secondsUntilStateChange: -40976.46
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9316,19 +9293,16 @@ entities:
   - uid: 152
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,38.5
       parent: 2
   - uid: 153
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,38.5
       parent: 2
   - uid: 154
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,4.5
       parent: 2
 - proto: AirlockDetectiveLocked
@@ -9440,7 +9414,6 @@ entities:
   - uid: 174
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,-9.5
       parent: 2
   - uid: 175
@@ -9471,25 +9444,21 @@ entities:
   - uid: 179
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 45.5,-35.5
       parent: 2
   - uid: 180
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 59.5,-35.5
       parent: 2
   - uid: 181
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-50.5
       parent: 2
   - uid: 182
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,-50.5
       parent: 2
 - proto: AirlockExternalAtmosphericsLocked
@@ -9769,7 +9738,7 @@ entities:
       pos: 87.5,-23.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -92063.336
+      secondsUntilStateChange: -92116.65
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9839,7 +9808,6 @@ entities:
   - uid: 239
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,42.5
       parent: 2
   - uid: 240
@@ -10071,7 +10039,6 @@ entities:
   - uid: 280
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,34.5
       parent: 2
   - uid: 281
@@ -10082,13 +10049,11 @@ entities:
   - uid: 282
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,8.5
       parent: 2
   - uid: 283
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-36.5
       parent: 2
   - uid: 284
@@ -10109,7 +10074,6 @@ entities:
   - uid: 287
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 69.5,-26.5
       parent: 2
   - uid: 288
@@ -10125,7 +10089,6 @@ entities:
   - uid: 290
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,23.5
       parent: 2
   - uid: 291
@@ -10151,31 +10114,26 @@ entities:
   - uid: 295
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -49.5,13.5
       parent: 2
   - uid: 296
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 35.5,-37.5
       parent: 2
   - uid: 297
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,-39.5
       parent: 2
   - uid: 298
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 66.5,-38.5
       parent: 2
   - uid: 299
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 69.5,-39.5
       parent: 2
 - proto: AirlockHeadOfPersonnelLocked
@@ -10224,7 +10182,6 @@ entities:
   - uid: 306
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-17.5
       parent: 2
 - proto: AirlockKitchenLocked
@@ -10232,7 +10189,6 @@ entities:
   - uid: 307
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 50.5,-7.5
       parent: 2
 - proto: AirlockLawyerLocked
@@ -10240,13 +10196,11 @@ entities:
   - uid: 308
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,7.5
       parent: 2
   - uid: 309
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,6.5
       parent: 2
 - proto: AirlockMaintCargoLocked
@@ -10261,7 +10215,6 @@ entities:
   - uid: 311
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,28.5
       parent: 2
 - proto: AirlockMaintCommandLocked
@@ -10276,7 +10229,6 @@ entities:
   - uid: 313
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-6.5
       parent: 2
 - proto: AirlockMaintEngiLocked
@@ -10284,7 +10236,6 @@ entities:
   - uid: 314
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,21.5
       parent: 2
 - proto: AirlockMaintJanitorLocked
@@ -10299,7 +10250,6 @@ entities:
   - uid: 316
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,-8.5
       parent: 2
   - uid: 317
@@ -10312,13 +10262,11 @@ entities:
   - uid: 318
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,0.5
       parent: 2
   - uid: 319
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -46.5,-4.5
       parent: 2
 - proto: AirlockMaintRnDLocked
@@ -10326,7 +10274,6 @@ entities:
   - uid: 320
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,34.5
       parent: 2
 - proto: AirlockMaintSecLocked
@@ -10414,13 +10361,11 @@ entities:
   - uid: 334
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,-4.5
       parent: 2
   - uid: 335
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -41.5,11.5
       parent: 2
   - uid: 336
@@ -10433,7 +10378,6 @@ entities:
   - uid: 337
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -43.5,9.5
       parent: 2
 - proto: AirlockMedicalScienceLocked
@@ -10453,7 +10397,6 @@ entities:
   - uid: 340
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,21.5
       parent: 2
 - proto: AirlockResearchDirectorGlassLocked
@@ -10556,7 +10499,6 @@ entities:
   - uid: 356
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,24.5
       parent: 2
 - proto: AirlockSecurityGlassLocked
@@ -10589,7 +10531,6 @@ entities:
   - uid: 361
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-1.5
       parent: 2
   - uid: 362
@@ -10602,19 +10543,16 @@ entities:
   - uid: 363
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 82.5,-42.5
       parent: 2
   - uid: 364
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 81.5,-42.5
       parent: 2
   - uid: 365
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 84.5,-43.5
       parent: 2
 - proto: AirlockTheatreGlassLocked
@@ -48312,55 +48250,46 @@ entities:
   - uid: 7685
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-16.5
       parent: 2
   - uid: 7686
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-15.5
       parent: 2
   - uid: 7687
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-16.5
       parent: 2
   - uid: 7688
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-15.5
       parent: 2
   - uid: 7689
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-19.5
       parent: 2
   - uid: 7690
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,-20.5
       parent: 2
   - uid: 7691
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,4.5
       parent: 2
   - uid: 7692
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,4.5
       parent: 2
   - uid: 7693
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,4.5
       parent: 2
   - uid: 7694
@@ -48425,19 +48354,16 @@ entities:
   - uid: 7705
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,36.5
       parent: 2
   - uid: 7706
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,36.5
       parent: 2
   - uid: 7707
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,36.5
       parent: 2
   - uid: 7708
@@ -48518,25 +48444,21 @@ entities:
   - uid: 7723
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,49.5
       parent: 2
   - uid: 7724
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,49.5
       parent: 2
   - uid: 7725
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,49.5
       parent: 2
   - uid: 7726
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,49.5
       parent: 2
   - uid: 7727
@@ -48759,19 +48681,16 @@ entities:
   - uid: 7766
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,3.5
       parent: 2
   - uid: 7767
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,3.5
       parent: 2
   - uid: 7768
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,3.5
       parent: 2
   - uid: 7769
@@ -48884,61 +48803,51 @@ entities:
   - uid: 7790
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,19.5
       parent: 2
   - uid: 7791
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,19.5
       parent: 2
   - uid: 7792
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,19.5
       parent: 2
   - uid: 7793
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,22.5
       parent: 2
   - uid: 7794
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,22.5
       parent: 2
   - uid: 7795
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,22.5
       parent: 2
   - uid: 7796
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 35.5,30.5
       parent: 2
   - uid: 7797
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 35.5,31.5
       parent: 2
   - uid: 7798
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 34.5,30.5
       parent: 2
   - uid: 7799
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 34.5,31.5
       parent: 2
   - uid: 7800
@@ -48998,91 +48907,76 @@ entities:
   - uid: 7810
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,32.5
       parent: 2
   - uid: 7811
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,24.5
       parent: 2
   - uid: 7812
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,31.5
       parent: 2
   - uid: 7813
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,30.5
       parent: 2
   - uid: 7814
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,30.5
       parent: 2
   - uid: 7815
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,29.5
       parent: 2
   - uid: 7816
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,29.5
       parent: 2
   - uid: 7817
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,32.5
       parent: 2
   - uid: 7818
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,25.5
       parent: 2
   - uid: 7819
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,24.5
       parent: 2
   - uid: 7820
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,24.5
       parent: 2
   - uid: 7821
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,24.5
       parent: 2
   - uid: 7822
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,25.5
       parent: 2
   - uid: 7823
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,24.5
       parent: 2
   - uid: 7824
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,31.5
       parent: 2
   - uid: 7825
@@ -75848,19 +75742,16 @@ entities:
   - uid: 12473
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 69.5,-26.5
       parent: 2
   - uid: 12474
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 72.5,-27.5
       parent: 2
   - uid: 12475
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,-35.5
       parent: 2
     - type: DeviceNetwork
@@ -75869,7 +75760,6 @@ entities:
   - uid: 12476
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 59.5,-35.5
       parent: 2
     - type: DeviceNetwork
@@ -75878,7 +75768,6 @@ entities:
   - uid: 12477
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-25.5
       parent: 2
     - type: DeviceNetwork
@@ -75887,7 +75776,6 @@ entities:
   - uid: 12478
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-24.5
       parent: 2
     - type: DeviceNetwork
@@ -75896,7 +75784,6 @@ entities:
   - uid: 12479
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 45.5,-12.5
       parent: 2
     - type: DeviceNetwork
@@ -76093,7 +75980,6 @@ entities:
   - uid: 12505
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,17.5
       parent: 2
   - uid: 12506
@@ -76330,7 +76216,6 @@ entities:
   - uid: 12535
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,9.5
       parent: 2
     - type: DeviceNetwork
@@ -76339,7 +76224,6 @@ entities:
   - uid: 12536
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -48.5,11.5
       parent: 2
   - uid: 12537
@@ -76378,13 +76262,11 @@ entities:
   - uid: 12541
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -42.5,28.5
       parent: 2
   - uid: 12542
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -42.5,34.5
       parent: 2
     - type: DeviceNetwork
@@ -76520,7 +76402,6 @@ entities:
   - uid: 12557
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,32.5
       parent: 2
     - type: DeviceNetwork
@@ -76542,13 +76423,11 @@ entities:
   - uid: 12560
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,24.5
       parent: 2
   - uid: 12561
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,24.5
       parent: 2
   - uid: 12562
@@ -77393,7 +77272,6 @@ entities:
   - uid: 12674
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -49.5,28.5
       parent: 2
     - type: DeviceNetwork
@@ -77402,7 +77280,6 @@ entities:
   - uid: 12675
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -49.5,29.5
       parent: 2
     - type: DeviceNetwork
@@ -77411,7 +77288,6 @@ entities:
   - uid: 12676
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -47.5,33.5
       parent: 2
     - type: DeviceNetwork
@@ -77421,7 +77297,6 @@ entities:
   - uid: 12677
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -46.5,33.5
       parent: 2
     - type: DeviceNetwork
@@ -77431,7 +77306,6 @@ entities:
   - uid: 12678
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -48.5,40.5
       parent: 2
     - type: DeviceNetwork
@@ -95449,7 +95323,6 @@ entities:
   - uid: 15074
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,42.5
       parent: 2
   - uid: 15075
@@ -95505,13 +95378,11 @@ entities:
   - uid: 15085
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,38.5
       parent: 2
   - uid: 15086
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,35.5
       parent: 2
   - uid: 15087
@@ -95527,13 +95398,11 @@ entities:
   - uid: 15089
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,42.5
       parent: 2
   - uid: 15090
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,43.5
       parent: 2
   - uid: 15091
@@ -95574,7 +95443,6 @@ entities:
   - uid: 15098
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,42.5
       parent: 2
   - uid: 15099
@@ -95585,7 +95453,6 @@ entities:
   - uid: 15100
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,45.5
       parent: 2
   - uid: 15101
@@ -95661,7 +95528,6 @@ entities:
   - uid: 15115
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,42.5
       parent: 2
   - uid: 15116
@@ -95682,31 +95548,26 @@ entities:
   - uid: 15119
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,33.5
       parent: 2
   - uid: 15120
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,31.5
       parent: 2
   - uid: 15121
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,30.5
       parent: 2
   - uid: 15122
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,28.5
       parent: 2
   - uid: 15123
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,29.5
       parent: 2
   - uid: 15124
@@ -95887,49 +95748,41 @@ entities:
   - uid: 15159
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-3.5
       parent: 2
   - uid: 15160
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-1.5
       parent: 2
   - uid: 15161
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-1.5
       parent: 2
   - uid: 15162
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 2
   - uid: 15163
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-1.5
       parent: 2
   - uid: 15164
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 2
   - uid: 15165
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 2
   - uid: 15166
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,0.5
       parent: 2
   - uid: 15167
@@ -95970,13 +95823,11 @@ entities:
   - uid: 15174
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-12.5
       parent: 2
   - uid: 15175
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-12.5
       parent: 2
   - uid: 15176
@@ -96142,55 +95993,46 @@ entities:
   - uid: 15208
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,10.5
       parent: 2
   - uid: 15209
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,6.5
       parent: 2
   - uid: 15210
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,5.5
       parent: 2
   - uid: 15211
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,4.5
       parent: 2
   - uid: 15212
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,3.5
       parent: 2
   - uid: 15213
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,2.5
       parent: 2
   - uid: 15214
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,1.5
       parent: 2
   - uid: 15215
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,5.5
       parent: 2
   - uid: 15216
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,1.5
       parent: 2
   - uid: 15217
@@ -96241,13 +96083,11 @@ entities:
   - uid: 15226
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -39.5,-2.5
       parent: 2
   - uid: 15227
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -39.5,0.5
       parent: 2
   - uid: 15228
@@ -96258,13 +96098,11 @@ entities:
   - uid: 15229
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,10.5
       parent: 2
   - uid: 15230
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,9.5
       parent: 2
   - uid: 15231
@@ -96280,49 +96118,41 @@ entities:
   - uid: 15233
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,1.5
       parent: 2
   - uid: 15234
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,-0.5
       parent: 2
   - uid: 15235
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,3.5
       parent: 2
   - uid: 15236
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,5.5
       parent: 2
   - uid: 15237
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -54.5,2.5
       parent: 2
   - uid: 15238
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,2.5
       parent: 2
   - uid: 15239
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,-0.5
       parent: 2
   - uid: 15240
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,0.5
       parent: 2
   - uid: 15241
@@ -96528,19 +96358,16 @@ entities:
   - uid: 15281
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -61.5,34.5
       parent: 2
   - uid: 15282
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -64.5,34.5
       parent: 2
   - uid: 15283
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,34.5
       parent: 2
   - uid: 15284
@@ -96556,19 +96383,16 @@ entities:
   - uid: 15286
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -54.5,25.5
       parent: 2
   - uid: 15287
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -53.5,25.5
       parent: 2
   - uid: 15288
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -52.5,25.5
       parent: 2
   - uid: 15289
@@ -96629,79 +96453,66 @@ entities:
   - uid: 15300
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,44.5
       parent: 2
   - uid: 15301
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,45.5
       parent: 2
   - uid: 15302
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,46.5
       parent: 2
   - uid: 15303
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,47.5
       parent: 2
   - uid: 15304
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -62.5,48.5
       parent: 2
   - uid: 15305
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -61.5,48.5
       parent: 2
   - uid: 15306
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -60.5,48.5
       parent: 2
   - uid: 15307
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -59.5,48.5
       parent: 2
   - uid: 15308
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -58.5,48.5
       parent: 2
   - uid: 15309
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,47.5
       parent: 2
   - uid: 15310
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,46.5
       parent: 2
   - uid: 15311
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,45.5
       parent: 2
   - uid: 15312
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,44.5
       parent: 2
   - uid: 15313
@@ -96772,7 +96583,6 @@ entities:
   - uid: 15326
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,39.5
       parent: 2
   - uid: 15327
@@ -96813,25 +96623,21 @@ entities:
   - uid: 15334
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,16.5
       parent: 2
   - uid: 15335
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,16.5
       parent: 2
   - uid: 15336
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,16.5
       parent: 2
   - uid: 15337
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,16.5
       parent: 2
   - uid: 15338
@@ -96847,7 +96653,6 @@ entities:
   - uid: 15340
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,38.5
       parent: 2
   - uid: 15341
@@ -96913,25 +96718,21 @@ entities:
   - uid: 15353
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,16.5
       parent: 2
   - uid: 15354
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,16.5
       parent: 2
   - uid: 15355
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,16.5
       parent: 2
   - uid: 15356
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,40.5
       parent: 2
   - uid: 15357
@@ -96947,7 +96748,6 @@ entities:
   - uid: 15359
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,40.5
       parent: 2
   - uid: 15361
@@ -97353,7 +97153,6 @@ entities:
   - uid: 15441
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-33.5
       parent: 2
   - uid: 15442
@@ -97364,31 +97163,26 @@ entities:
   - uid: 15443
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-34.5
       parent: 2
   - uid: 15444
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-34.5
       parent: 2
   - uid: 15445
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-34.5
       parent: 2
   - uid: 15446
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,-33.5
       parent: 2
   - uid: 15447
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-33.5
       parent: 2
   - uid: 15448
@@ -97639,7 +97433,6 @@ entities:
   - uid: 15497
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 55.5,-21.5
       parent: 2
   - uid: 15498
@@ -97670,37 +97463,31 @@ entities:
   - uid: 15503
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,1.5
       parent: 2
   - uid: 15504
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,-0.5
       parent: 2
   - uid: 15505
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,0.5
       parent: 2
   - uid: 15506
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,3.5
       parent: 2
   - uid: 15507
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,2.5
       parent: 2
   - uid: 15508
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 75.5,-3.5
       parent: 2
   - uid: 15509
@@ -97736,193 +97523,161 @@ entities:
   - uid: 15515
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 76.5,-3.5
       parent: 2
   - uid: 15516
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 77.5,-21.5
       parent: 2
   - uid: 15517
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 78.5,-21.5
       parent: 2
   - uid: 15518
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 78.5,-22.5
       parent: 2
   - uid: 15519
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 78.5,-26.5
       parent: 2
   - uid: 15520
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 78.5,-27.5
       parent: 2
   - uid: 15521
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 78.5,-28.5
       parent: 2
   - uid: 15522
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 78.5,-29.5
       parent: 2
   - uid: 15523
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 77.5,-29.5
       parent: 2
   - uid: 15524
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 67.5,-5.5
       parent: 2
   - uid: 15525
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 77.5,-3.5
       parent: 2
   - uid: 15526
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,-5.5
       parent: 2
   - uid: 15527
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 68.5,-5.5
       parent: 2
   - uid: 15528
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 70.5,-5.5
       parent: 2
   - uid: 15529
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 69.5,-5.5
       parent: 2
   - uid: 15530
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 72.5,-5.5
       parent: 2
   - uid: 15531
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 71.5,-5.5
       parent: 2
   - uid: 15532
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 74.5,-5.5
       parent: 2
   - uid: 15533
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 75.5,-5.5
       parent: 2
   - uid: 15534
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 67.5,-3.5
       parent: 2
   - uid: 15535
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 70.5,-3.5
       parent: 2
   - uid: 15536
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,-3.5
       parent: 2
   - uid: 15537
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 72.5,-3.5
       parent: 2
   - uid: 15538
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 71.5,-3.5
       parent: 2
   - uid: 15539
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 74.5,-3.5
       parent: 2
   - uid: 15540
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 78.5,-3.5
       parent: 2
   - uid: 15541
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 79.5,-3.5
       parent: 2
   - uid: 15542
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 80.5,-3.5
       parent: 2
   - uid: 15543
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 82.5,-3.5
       parent: 2
   - uid: 15544
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 83.5,-3.5
       parent: 2
   - uid: 15545
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 84.5,-3.5
       parent: 2
   - uid: 15546
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 81.5,-3.5
       parent: 2
   - uid: 15547
@@ -99518,13 +99273,11 @@ entities:
   - uid: 15865
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 67.5,-34.5
       parent: 2
   - uid: 15866
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 68.5,-32.5
       parent: 2
   - uid: 15867
@@ -99685,7 +99438,6 @@ entities:
   - uid: 15898
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 67.5,-33.5
       parent: 2
   - uid: 15899
@@ -100011,25 +99763,21 @@ entities:
   - uid: 15963
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-6.5
       parent: 2
   - uid: 15964
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-7.5
       parent: 2
   - uid: 15965
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -54.5,-7.5
       parent: 2
   - uid: 15966
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -54.5,-8.5
       parent: 2
   - uid: 15967
@@ -100305,7 +100053,6 @@ entities:
   - uid: 16021
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,54.5
       parent: 2
   - uid: 16022
@@ -100406,445 +100153,371 @@ entities:
   - uid: 16041
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,54.5
       parent: 2
   - uid: 16042
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -62.5,54.5
       parent: 2
   - uid: 16043
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -58.5,54.5
       parent: 2
   - uid: 16044
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -56.5,54.5
       parent: 2
   - uid: 16045
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,53.5
       parent: 2
   - uid: 16046
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,53.5
       parent: 2
   - uid: 16047
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,52.5
       parent: 2
   - uid: 16048
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,51.5
       parent: 2
   - uid: 16049
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,53.5
       parent: 2
   - uid: 16050
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,50.5
       parent: 2
   - uid: 16051
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,50.5
       parent: 2
   - uid: 16052
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,48.5
       parent: 2
   - uid: 16053
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,49.5
       parent: 2
   - uid: 16054
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,48.5
       parent: 2
   - uid: 16055
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,47.5
       parent: 2
   - uid: 16056
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,45.5
       parent: 2
   - uid: 16057
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,44.5
       parent: 2
   - uid: 16058
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,42.5
       parent: 2
   - uid: 16059
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,43.5
       parent: 2
   - uid: 16060
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -70.5,53.5
       parent: 2
   - uid: 16061
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -71.5,53.5
       parent: 2
   - uid: 16062
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -72.5,53.5
       parent: 2
   - uid: 16063
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -72.5,52.5
       parent: 2
   - uid: 16064
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -73.5,52.5
       parent: 2
   - uid: 16065
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -73.5,51.5
       parent: 2
   - uid: 16066
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -74.5,48.5
       parent: 2
   - uid: 16067
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -75.5,47.5
       parent: 2
   - uid: 16068
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -75.5,43.5
       parent: 2
   - uid: 16069
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -74.5,42.5
       parent: 2
   - uid: 16070
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -74.5,40.5
       parent: 2
   - uid: 16071
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -74.5,39.5
       parent: 2
   - uid: 16072
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -74.5,41.5
       parent: 2
   - uid: 16073
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -73.5,39.5
       parent: 2
   - uid: 16074
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -73.5,38.5
       parent: 2
   - uid: 16075
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -72.5,38.5
       parent: 2
   - uid: 16076
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -72.5,37.5
       parent: 2
   - uid: 16077
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -72.5,36.5
       parent: 2
   - uid: 16078
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -72.5,35.5
       parent: 2
   - uid: 16079
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -72.5,34.5
       parent: 2
   - uid: 16080
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -70.5,49.5
       parent: 2
   - uid: 16081
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -70.5,50.5
       parent: 2
   - uid: 16082
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -70.5,52.5
       parent: 2
   - uid: 16083
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,50.5
       parent: 2
   - uid: 16084
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,51.5
       parent: 2
   - uid: 16085
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,49.5
       parent: 2
   - uid: 16086
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,52.5
       parent: 2
   - uid: 16087
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -51.5,50.5
       parent: 2
   - uid: 16088
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -51.5,51.5
       parent: 2
   - uid: 16089
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -51.5,52.5
       parent: 2
   - uid: 16090
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -51.5,53.5
       parent: 2
   - uid: 16091
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,50.5
       parent: 2
   - uid: 16092
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,51.5
       parent: 2
   - uid: 16093
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,52.5
       parent: 2
   - uid: 16094
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,53.5
       parent: 2
   - uid: 16095
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,50.5
       parent: 2
   - uid: 16096
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,52.5
       parent: 2
   - uid: 16097
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,53.5
       parent: 2
   - uid: 16098
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -71.5,38.5
       parent: 2
   - uid: 16099
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -73.5,42.5
       parent: 2
   - uid: 16100
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -72.5,42.5
       parent: 2
   - uid: 16101
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -71.5,42.5
       parent: 2
   - uid: 16102
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,46.5
       parent: 2
   - uid: 16103
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,46.5
       parent: 2
   - uid: 16104
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,46.5
       parent: 2
   - uid: 16105
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,39.5
       parent: 2
   - uid: 16106
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,39.5
       parent: 2
   - uid: 16107
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,39.5
       parent: 2
   - uid: 16108
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,39.5
       parent: 2
   - uid: 16109
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,39.5
       parent: 2
   - uid: 16110
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,39.5
       parent: 2
   - uid: 16111
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,32.5
       parent: 2
   - uid: 16112
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,31.5
       parent: 2
   - uid: 16113
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,20.5
       parent: 2
   - uid: 16114
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,18.5
       parent: 2
   - uid: 16115
@@ -100865,7 +100538,6 @@ entities:
   - uid: 16118
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,-6.5
       parent: 2
   - uid: 16119
@@ -100906,13 +100578,11 @@ entities:
   - uid: 16126
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,11.5
       parent: 2
   - uid: 16127
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,11.5
       parent: 2
   - uid: 16128
@@ -101198,7 +100868,6 @@ entities:
   - uid: 16184
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-30.5
       parent: 2
   - uid: 16185
@@ -101510,115 +101179,96 @@ entities:
   - uid: 16240
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 49.5,-46.5
       parent: 2
   - uid: 16241
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 48.5,-46.5
       parent: 2
   - uid: 16242
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,-50.5
       parent: 2
   - uid: 16243
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,-51.5
       parent: 2
   - uid: 16244
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,-49.5
       parent: 2
   - uid: 16245
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,-50.5
       parent: 2
   - uid: 16246
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-47.5
       parent: 2
   - uid: 16247
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-46.5
       parent: 2
   - uid: 16248
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-45.5
       parent: 2
   - uid: 16249
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-44.5
       parent: 2
   - uid: 16250
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-50.5
       parent: 2
   - uid: 16251
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,-49.5
       parent: 2
   - uid: 16252
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 81.5,-39.5
       parent: 2
   - uid: 16253
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 82.5,-39.5
       parent: 2
   - uid: 16254
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-48.5
       parent: 2
   - uid: 16255
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-49.5
       parent: 2
   - uid: 16256
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,-51.5
       parent: 2
   - uid: 16257
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-49.5
       parent: 2
   - uid: 16258
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-48.5
       parent: 2
   - uid: 16259
@@ -101839,25 +101489,21 @@ entities:
   - uid: 16302
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 67.5,-49.5
       parent: 2
   - uid: 16303
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 67.5,-47.5
       parent: 2
   - uid: 16304
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 67.5,-50.5
       parent: 2
   - uid: 16305
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 67.5,-51.5
       parent: 2
   - uid: 16306
@@ -102028,7 +101674,6 @@ entities:
   - uid: 16339
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 67.5,-32.5
       parent: 2
   - uid: 16340
@@ -102549,19 +102194,16 @@ entities:
   - uid: 16443
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,35.5
       parent: 2
   - uid: 16444
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,36.5
       parent: 2
   - uid: 16445
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,37.5
       parent: 2
   - uid: 18659
@@ -115478,7 +115120,6 @@ entities:
   - uid: 18472
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,40.5
       parent: 2
     - type: DeltaPressure
@@ -115486,7 +115127,6 @@ entities:
   - uid: 18473
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -47.5,40.5
       parent: 2
     - type: DeltaPressure
@@ -115508,7 +115148,6 @@ entities:
   - uid: 18476
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -53.5,25.5
       parent: 2
     - type: DeltaPressure
@@ -115516,7 +115155,6 @@ entities:
   - uid: 18477
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -52.5,25.5
       parent: 2
     - type: DeltaPressure
@@ -115524,7 +115162,6 @@ entities:
   - uid: 18478
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -54.5,25.5
       parent: 2
     - type: DeltaPressure
@@ -115783,7 +115420,6 @@ entities:
   - uid: 18514
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,2.5
       parent: 2
     - type: DeltaPressure
@@ -115791,7 +115427,6 @@ entities:
   - uid: 18515
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,1.5
       parent: 2
     - type: DeltaPressure
@@ -115799,7 +115434,6 @@ entities:
   - uid: 18516
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,-0.5
       parent: 2
     - type: DeltaPressure
@@ -115856,7 +115490,6 @@ entities:
   - uid: 18524
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-30.5
       parent: 2
     - type: DeltaPressure
@@ -115871,7 +115504,6 @@ entities:
   - uid: 18526
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,42.5
       parent: 2
     - type: DeltaPressure
@@ -115991,7 +115623,6 @@ entities:
   - uid: 18543
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,43.5
       parent: 2
     - type: DeltaPressure
@@ -116013,7 +115644,6 @@ entities:
   - uid: 18546
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,42.5
       parent: 2
     - type: DeltaPressure
@@ -116042,7 +115672,6 @@ entities:
   - uid: 18550
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,45.5
       parent: 2
     - type: DeltaPressure
@@ -116050,7 +115679,6 @@ entities:
   - uid: 18551
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,42.5
       parent: 2
     - type: DeltaPressure
@@ -116058,7 +115686,6 @@ entities:
   - uid: 18552
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,42.5
       parent: 2
     - type: DeltaPressure
@@ -116073,7 +115700,6 @@ entities:
   - uid: 18554
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,35.5
       parent: 2
     - type: DeltaPressure
@@ -116123,7 +115749,6 @@ entities:
   - uid: 18561
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,33.5
       parent: 2
     - type: DeltaPressure
@@ -116145,7 +115770,6 @@ entities:
   - uid: 18564
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,28.5
       parent: 2
     - type: DeltaPressure
@@ -116153,7 +115777,6 @@ entities:
   - uid: 18565
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,29.5
       parent: 2
     - type: DeltaPressure
@@ -116161,7 +115784,6 @@ entities:
   - uid: 18566
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,30.5
       parent: 2
     - type: DeltaPressure
@@ -116169,7 +115791,6 @@ entities:
   - uid: 18567
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,31.5
       parent: 2
     - type: DeltaPressure
@@ -116352,7 +115973,6 @@ entities:
   - uid: 18593
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 2
     - type: DeltaPressure
@@ -116360,7 +115980,6 @@ entities:
   - uid: 18594
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-3.5
       parent: 2
     - type: DeltaPressure
@@ -116368,7 +115987,6 @@ entities:
   - uid: 18595
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-1.5
       parent: 2
     - type: DeltaPressure
@@ -116376,7 +115994,6 @@ entities:
   - uid: 18596
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-1.5
       parent: 2
     - type: DeltaPressure
@@ -116384,7 +116001,6 @@ entities:
   - uid: 18597
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 2
     - type: DeltaPressure
@@ -116392,7 +116008,6 @@ entities:
   - uid: 18598
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-1.5
       parent: 2
     - type: DeltaPressure
@@ -116400,7 +116015,6 @@ entities:
   - uid: 18599
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-1.5
       parent: 2
     - type: DeltaPressure
@@ -116457,7 +116071,6 @@ entities:
   - uid: 18607
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-12.5
       parent: 2
     - type: DeltaPressure
@@ -116465,7 +116078,6 @@ entities:
   - uid: 18608
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-12.5
       parent: 2
     - type: DeltaPressure
@@ -116473,7 +116085,6 @@ entities:
   - uid: 18609
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-12.5
       parent: 2
     - type: DeltaPressure
@@ -116488,7 +116099,6 @@ entities:
   - uid: 18611
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,6.5
       parent: 2
     - type: DeltaPressure
@@ -116496,7 +116106,6 @@ entities:
   - uid: 18612
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,10.5
       parent: 2
     - type: DeltaPressure
@@ -116511,7 +116120,6 @@ entities:
   - uid: 18614
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,4.5
       parent: 2
     - type: DeltaPressure
@@ -116519,7 +116127,6 @@ entities:
   - uid: 18615
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,5.5
       parent: 2
     - type: DeltaPressure
@@ -116527,7 +116134,6 @@ entities:
   - uid: 18616
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,5.5
       parent: 2
     - type: DeltaPressure
@@ -116535,7 +116141,6 @@ entities:
   - uid: 18617
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,3.5
       parent: 2
     - type: DeltaPressure
@@ -116543,7 +116148,6 @@ entities:
   - uid: 18618
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,2.5
       parent: 2
     - type: DeltaPressure
@@ -116551,7 +116155,6 @@ entities:
   - uid: 18619
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,1.5
       parent: 2
     - type: DeltaPressure
@@ -116559,7 +116162,6 @@ entities:
   - uid: 18620
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,1.5
       parent: 2
     - type: DeltaPressure
@@ -116574,7 +116176,6 @@ entities:
   - uid: 18622
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,10.5
       parent: 2
     - type: DeltaPressure
@@ -116589,7 +116190,6 @@ entities:
   - uid: 18624
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,9.5
       parent: 2
     - type: DeltaPressure
@@ -116618,7 +116218,6 @@ entities:
   - uid: 18628
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -35.5,11.5
       parent: 2
     - type: DeltaPressure
@@ -116647,7 +116246,6 @@ entities:
   - uid: 18632
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -39.5,-2.5
       parent: 2
     - type: DeltaPressure
@@ -116655,7 +116253,6 @@ entities:
   - uid: 18633
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -39.5,0.5
       parent: 2
     - type: DeltaPressure
@@ -116691,7 +116288,6 @@ entities:
   - uid: 18638
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,2.5
       parent: 2
     - type: DeltaPressure
@@ -116699,7 +116295,6 @@ entities:
   - uid: 18639
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,-0.5
       parent: 2
     - type: DeltaPressure
@@ -116714,7 +116309,6 @@ entities:
   - uid: 18641
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,1.5
       parent: 2
     - type: DeltaPressure
@@ -116722,7 +116316,6 @@ entities:
   - uid: 18642
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,0.5
       parent: 2
     - type: DeltaPressure
@@ -116758,7 +116351,6 @@ entities:
   - uid: 18647
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,3.5
       parent: 2
     - type: DeltaPressure
@@ -116766,7 +116358,6 @@ entities:
   - uid: 18648
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,5.5
       parent: 2
     - type: DeltaPressure
@@ -116774,7 +116365,6 @@ entities:
   - uid: 18649
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -54.5,2.5
       parent: 2
     - type: DeltaPressure
@@ -116782,7 +116372,6 @@ entities:
   - uid: 18650
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,0.5
       parent: 2
     - type: DeltaPressure
@@ -116790,7 +116379,6 @@ entities:
   - uid: 18651
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,-0.5
       parent: 2
     - type: DeltaPressure
@@ -116798,7 +116386,6 @@ entities:
   - uid: 18652
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,40.5
       parent: 2
     - type: DeltaPressure
@@ -116848,7 +116435,6 @@ entities:
   - uid: 18660
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,40.5
       parent: 2
     - type: DeltaPressure
@@ -116856,7 +116442,6 @@ entities:
   - uid: 18661
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,39.5
       parent: 2
     - type: DeltaPressure
@@ -116864,7 +116449,6 @@ entities:
   - uid: 18662
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,38.5
       parent: 2
     - type: DeltaPressure
@@ -116907,7 +116491,6 @@ entities:
   - uid: 18668
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,34.5
       parent: 2
     - type: DeltaPressure
@@ -116915,7 +116498,6 @@ entities:
   - uid: 18669
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -61.5,34.5
       parent: 2
     - type: DeltaPressure
@@ -116923,7 +116505,6 @@ entities:
   - uid: 18670
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -64.5,34.5
       parent: 2
     - type: DeltaPressure
@@ -116959,7 +116540,6 @@ entities:
   - uid: 18675
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,44.5
       parent: 2
     - type: DeltaPressure
@@ -116967,7 +116547,6 @@ entities:
   - uid: 18676
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,46.5
       parent: 2
     - type: DeltaPressure
@@ -116975,7 +116554,6 @@ entities:
   - uid: 18677
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,40.5
       parent: 2
     - type: DeltaPressure
@@ -116983,7 +116561,6 @@ entities:
   - uid: 18678
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -58.5,40.5
       parent: 2
     - type: DeltaPressure
@@ -116991,7 +116568,6 @@ entities:
   - uid: 18679
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -58.5,41.5
       parent: 2
     - type: DeltaPressure
@@ -116999,7 +116575,6 @@ entities:
   - uid: 18680
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -59.5,41.5
       parent: 2
     - type: DeltaPressure
@@ -117007,7 +116582,6 @@ entities:
   - uid: 18681
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -61.5,41.5
       parent: 2
     - type: DeltaPressure
@@ -117015,7 +116589,6 @@ entities:
   - uid: 18682
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -62.5,41.5
       parent: 2
     - type: DeltaPressure
@@ -117023,7 +116596,6 @@ entities:
   - uid: 18683
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -62.5,40.5
       parent: 2
     - type: DeltaPressure
@@ -117031,7 +116603,6 @@ entities:
   - uid: 18684
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,40.5
       parent: 2
     - type: DeltaPressure
@@ -117081,7 +116652,6 @@ entities:
   - uid: 18691
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,22.5
       parent: 2
     - type: DeltaPressure
@@ -117089,7 +116659,6 @@ entities:
   - uid: 18692
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,20.5
       parent: 2
     - type: DeltaPressure
@@ -117097,7 +116666,6 @@ entities:
   - uid: 18693
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,16.5
       parent: 2
     - type: DeltaPressure
@@ -117105,7 +116673,6 @@ entities:
   - uid: 18694
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,16.5
       parent: 2
     - type: DeltaPressure
@@ -117113,7 +116680,6 @@ entities:
   - uid: 18695
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,16.5
       parent: 2
     - type: DeltaPressure
@@ -117121,7 +116687,6 @@ entities:
   - uid: 18696
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,16.5
       parent: 2
     - type: DeltaPressure
@@ -117213,7 +116778,6 @@ entities:
   - uid: 18709
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,16.5
       parent: 2
     - type: DeltaPressure
@@ -117221,7 +116785,6 @@ entities:
   - uid: 18710
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,16.5
       parent: 2
     - type: DeltaPressure
@@ -117229,7 +116792,6 @@ entities:
   - uid: 18711
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,16.5
       parent: 2
     - type: DeltaPressure
@@ -117258,7 +116820,6 @@ entities:
   - uid: 18715
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,35.5
       parent: 2
     - type: DeltaPressure
@@ -117875,7 +117436,6 @@ entities:
   - uid: 18803
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 87.5,-16.5
       parent: 2
     - type: DeltaPressure
@@ -117883,7 +117443,6 @@ entities:
   - uid: 18804
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 87.5,-24.5
       parent: 2
     - type: DeltaPressure
@@ -117891,7 +117450,6 @@ entities:
   - uid: 18805
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,-27.5
       parent: 2
     - type: DeltaPressure
@@ -117899,7 +117457,6 @@ entities:
   - uid: 18806
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,-22.5
       parent: 2
     - type: DeltaPressure
@@ -117907,7 +117464,6 @@ entities:
   - uid: 18807
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 77.5,-29.5
       parent: 2
     - type: DeltaPressure
@@ -117915,7 +117471,6 @@ entities:
   - uid: 18808
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,-28.5
       parent: 2
     - type: DeltaPressure
@@ -117923,7 +117478,6 @@ entities:
   - uid: 18809
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,-29.5
       parent: 2
     - type: DeltaPressure
@@ -117931,7 +117485,6 @@ entities:
   - uid: 18810
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,-21.5
       parent: 2
     - type: DeltaPressure
@@ -117939,7 +117492,6 @@ entities:
   - uid: 18811
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 77.5,-21.5
       parent: 2
     - type: DeltaPressure
@@ -117947,7 +117499,6 @@ entities:
   - uid: 18812
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,-26.5
       parent: 2
     - type: DeltaPressure
@@ -117955,7 +117506,6 @@ entities:
   - uid: 18813
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 39.5,10.5
       parent: 2
     - type: DeltaPressure
@@ -118012,7 +117562,6 @@ entities:
   - uid: 18821
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,12.5
       parent: 2
     - type: DeltaPressure
@@ -118020,7 +117569,6 @@ entities:
   - uid: 18822
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,12.5
       parent: 2
     - type: DeltaPressure
@@ -118070,7 +117618,6 @@ entities:
   - uid: 18829
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 48.5,20.5
       parent: 2
     - type: DeltaPressure
@@ -118078,7 +117625,6 @@ entities:
   - uid: 18830
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 48.5,22.5
       parent: 2
     - type: DeltaPressure
@@ -118086,7 +117632,6 @@ entities:
   - uid: 18831
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 48.5,21.5
       parent: 2
     - type: DeltaPressure
@@ -118171,7 +117716,6 @@ entities:
   - uid: 18843
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 46.5,24.5
       parent: 2
     - type: DeltaPressure
@@ -118179,7 +117723,6 @@ entities:
   - uid: 18844
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,18.5
       parent: 2
     - type: DeltaPressure
@@ -118187,7 +117730,6 @@ entities:
   - uid: 18845
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,17.5
       parent: 2
     - type: DeltaPressure
@@ -118195,7 +117737,6 @@ entities:
   - uid: 18846
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,20.5
       parent: 2
     - type: DeltaPressure
@@ -118203,7 +117744,6 @@ entities:
   - uid: 18847
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,19.5
       parent: 2
     - type: DeltaPressure
@@ -118211,7 +117751,6 @@ entities:
   - uid: 18848
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 78.5,16.5
       parent: 2
     - type: DeltaPressure
@@ -118226,7 +117765,6 @@ entities:
   - uid: 18850
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,17.5
       parent: 2
     - type: DeltaPressure
@@ -118234,7 +117772,6 @@ entities:
   - uid: 18851
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,17.5
       parent: 2
     - type: DeltaPressure
@@ -118242,7 +117779,6 @@ entities:
   - uid: 18852
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,17.5
       parent: 2
     - type: DeltaPressure
@@ -118250,7 +117786,6 @@ entities:
   - uid: 18853
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,17.5
       parent: 2
     - type: DeltaPressure
@@ -118307,7 +117842,6 @@ entities:
   - uid: 18861
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-23.5
       parent: 2
     - type: DeltaPressure
@@ -118315,7 +117849,6 @@ entities:
   - uid: 18862
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,-23.5
       parent: 2
     - type: DeltaPressure
@@ -118323,7 +117856,6 @@ entities:
   - uid: 18863
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-23.5
       parent: 2
     - type: DeltaPressure
@@ -118331,7 +117863,6 @@ entities:
   - uid: 18864
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-22.5
       parent: 2
     - type: DeltaPressure
@@ -118339,7 +117870,6 @@ entities:
   - uid: 18865
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-21.5
       parent: 2
     - type: DeltaPressure
@@ -118347,7 +117877,6 @@ entities:
   - uid: 18866
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,-23.5
       parent: 2
     - type: DeltaPressure
@@ -118355,7 +117884,6 @@ entities:
   - uid: 18867
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,-23.5
       parent: 2
     - type: DeltaPressure
@@ -118363,7 +117891,6 @@ entities:
   - uid: 18868
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-23.5
       parent: 2
     - type: DeltaPressure
@@ -118371,7 +117898,6 @@ entities:
   - uid: 18869
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-22.5
       parent: 2
     - type: DeltaPressure
@@ -118379,7 +117905,6 @@ entities:
   - uid: 18870
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-21.5
       parent: 2
     - type: DeltaPressure
@@ -118387,7 +117912,6 @@ entities:
   - uid: 18871
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-20.5
       parent: 2
     - type: DeltaPressure
@@ -118395,7 +117919,6 @@ entities:
   - uid: 18872
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -22.5,-20.5
       parent: 2
     - type: DeltaPressure
@@ -118403,7 +117926,6 @@ entities:
   - uid: 18873
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-20.5
       parent: 2
     - type: DeltaPressure
@@ -118411,7 +117933,6 @@ entities:
   - uid: 18874
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-20.5
       parent: 2
     - type: DeltaPressure
@@ -118496,7 +118017,6 @@ entities:
   - uid: 18886
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,39.5
       parent: 2
     - type: DeltaPressure
@@ -118504,7 +118024,6 @@ entities:
   - uid: 18887
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,39.5
       parent: 2
     - type: DeltaPressure
@@ -118512,7 +118031,6 @@ entities:
   - uid: 18888
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,39.5
       parent: 2
     - type: DeltaPressure
@@ -118520,7 +118038,6 @@ entities:
   - uid: 18889
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -37.5,39.5
       parent: 2
     - type: DeltaPressure
@@ -118528,7 +118045,6 @@ entities:
   - uid: 18890
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,39.5
       parent: 2
     - type: DeltaPressure
@@ -118536,7 +118052,6 @@ entities:
   - uid: 18891
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -34.5,39.5
       parent: 2
     - type: DeltaPressure
@@ -118677,7 +118192,6 @@ entities:
   - uid: 18911
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 39.5,33.5
       parent: 2
     - type: DeltaPressure
@@ -118685,7 +118199,6 @@ entities:
   - uid: 18912
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,35.5
       parent: 2
     - type: DeltaPressure
@@ -118693,7 +118206,6 @@ entities:
   - uid: 18913
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,36.5
       parent: 2
     - type: DeltaPressure
@@ -118701,7 +118213,6 @@ entities:
   - uid: 18914
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,37.5
       parent: 2
     - type: DeltaPressure
@@ -122827,13 +122338,11 @@ entities:
   - uid: 19462
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,-10.5
       parent: 2
   - uid: 19463
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -38.5,-11.5
       parent: 2
 - proto: SpawnMobGoat
@@ -126845,7 +126354,6 @@ entities:
   - uid: 19997
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,45.5
       parent: 2
   - uid: 19998
@@ -126856,25 +126364,21 @@ entities:
   - uid: 19999
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,45.5
       parent: 2
   - uid: 20000
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-6.5
       parent: 2
   - uid: 20001
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,41.5
       parent: 2
   - uid: 20002
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-5.5
       parent: 2
   - uid: 20003
@@ -126890,7 +126394,6 @@ entities:
   - uid: 20005
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,10.5
       parent: 2
   - uid: 20006
@@ -126936,7 +126439,6 @@ entities:
   - uid: 20014
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,0.5
       parent: 2
   - uid: 20015
@@ -126952,7 +126454,6 @@ entities:
   - uid: 20017
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,2.5
       parent: 2
   - uid: 20018
@@ -126973,7 +126474,6 @@ entities:
   - uid: 20021
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -54.5,-1.5
       parent: 2
   - uid: 20022
@@ -126984,7 +126484,6 @@ entities:
   - uid: 20023
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -51.5,5.5
       parent: 2
   - uid: 20024
@@ -127020,13 +126519,11 @@ entities:
   - uid: 20030
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,27.5
       parent: 2
   - uid: 20031
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,28.5
       parent: 2
   - uid: 20032
@@ -127047,13 +126544,11 @@ entities:
   - uid: 20035
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -62.5,27.5
       parent: 2
   - uid: 20036
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -61.5,27.5
       parent: 2
   - uid: 20037
@@ -127089,13 +126584,11 @@ entities:
   - uid: 20043
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,28.5
       parent: 2
   - uid: 20044
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,28.5
       parent: 2
   - uid: 20045
@@ -127106,25 +126599,21 @@ entities:
   - uid: 20046
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,28.5
       parent: 2
   - uid: 20047
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,26.5
       parent: 2
   - uid: 20048
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,26.5
       parent: 2
   - uid: 20049
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,26.5
       parent: 2
   - uid: 20050
@@ -127135,7 +126624,6 @@ entities:
   - uid: 20051
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,22.5
       parent: 2
   - uid: 20052
@@ -127161,103 +126649,86 @@ entities:
   - uid: 20056
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,-33.5
       parent: 2
   - uid: 20057
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,-32.5
       parent: 2
   - uid: 20058
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,-32.5
       parent: 2
   - uid: 20059
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,-29.5
       parent: 2
   - uid: 20060
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,-28.5
       parent: 2
   - uid: 20061
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,-28.5
       parent: 2
   - uid: 20062
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-28.5
       parent: 2
   - uid: 20063
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 47.5,-4.5
       parent: 2
   - uid: 20064
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 49.5,-3.5
       parent: 2
   - uid: 20065
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 47.5,-3.5
       parent: 2
   - uid: 20066
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 47.5,-2.5
       parent: 2
   - uid: 20067
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 49.5,-1.5
       parent: 2
   - uid: 20068
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 47.5,-1.5
       parent: 2
   - uid: 20069
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 48.5,-3.5
       parent: 2
   - uid: 20070
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 48.5,-2.5
       parent: 2
   - uid: 20071
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 49.5,-2.5
       parent: 2
   - uid: 20072
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 49.5,-4.5
       parent: 2
   - uid: 20073
@@ -127303,7 +126774,6 @@ entities:
   - uid: 20081
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 74.5,-22.5
       parent: 2
   - uid: 20082
@@ -127334,7 +126804,6 @@ entities:
   - uid: 20087
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,27.5
       parent: 2
   - uid: 20088
@@ -127355,25 +126824,21 @@ entities:
   - uid: 20091
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,-15.5
       parent: 2
   - uid: 20092
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-15.5
       parent: 2
   - uid: 20093
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 50.5,0.5
       parent: 2
   - uid: 20094
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-0.5
       parent: 2
   - uid: 20095
@@ -127389,7 +126854,6 @@ entities:
   - uid: 20097
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-22.5
       parent: 2
   - uid: 20098
@@ -127415,19 +126879,16 @@ entities:
   - uid: 20102
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -77.5,-3.5
       parent: 2
   - uid: 20103
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -77.5,-2.5
       parent: 2
   - uid: 20104
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -77.5,-1.5
       parent: 2
   - uid: 20105
@@ -127478,13 +126939,11 @@ entities:
   - uid: 20114
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,35.5
       parent: 2
   - uid: 20115
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 37.5,37.5
       parent: 2
 - proto: TableCarpet
@@ -127589,19 +127048,16 @@ entities:
   - uid: 20134
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,-7.5
       parent: 2
   - uid: 20135
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-2.5
       parent: 2
   - uid: 20136
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-5.5
       parent: 2
   - uid: 20137
@@ -127612,7 +127068,6 @@ entities:
   - uid: 20138
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-3.5
       parent: 2
   - uid: 20139
@@ -127643,13 +127098,11 @@ entities:
   - uid: 20144
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 36.5,-1.5
       parent: 2
   - uid: 20145
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 37.5,-1.5
       parent: 2
   - uid: 20146
@@ -127660,31 +127113,26 @@ entities:
   - uid: 20147
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-7.5
       parent: 2
   - uid: 20148
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-6.5
       parent: 2
   - uid: 20149
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-4.5
       parent: 2
   - uid: 20150
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,-1.5
       parent: 2
   - uid: 20151
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,-1.5
       parent: 2
   - uid: 20152
@@ -127852,13 +127300,11 @@ entities:
   - uid: 20181
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 85.5,-40.5
       parent: 2
   - uid: 20182
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 85.5,-39.5
       parent: 2
 - proto: TablePlasmaGlass
@@ -127928,13 +127374,11 @@ entities:
   - uid: 20195
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,9.5
       parent: 2
   - uid: 20196
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,9.5
       parent: 2
   - uid: 20197
@@ -127965,25 +127409,21 @@ entities:
   - uid: 20202
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,55.5
       parent: 2
   - uid: 20203
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,55.5
       parent: 2
   - uid: 20204
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,54.5
       parent: 2
   - uid: 20205
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,54.5
       parent: 2
   - uid: 20206
@@ -127999,19 +127439,16 @@ entities:
   - uid: 20208
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,32.5
       parent: 2
   - uid: 20209
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,50.5
       parent: 2
   - uid: 20210
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,51.5
       parent: 2
   - uid: 20211
@@ -128052,7 +127489,6 @@ entities:
   - uid: 20218
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,11.5
       parent: 2
   - uid: 20219
@@ -128083,19 +127519,16 @@ entities:
   - uid: 20224
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,-13.5
       parent: 2
   - uid: 20225
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-13.5
       parent: 2
   - uid: 20226
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-13.5
       parent: 2
   - uid: 20227
@@ -128121,19 +127554,16 @@ entities:
   - uid: 20231
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,7.5
       parent: 2
   - uid: 20232
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,9.5
       parent: 2
   - uid: 20233
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,7.5
       parent: 2
   - uid: 20234
@@ -128159,61 +127589,51 @@ entities:
   - uid: 20238
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -33.5,-0.5
       parent: 2
   - uid: 20239
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -33.5,-1.5
       parent: 2
   - uid: 20240
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,-9.5
       parent: 2
   - uid: 20241
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-9.5
       parent: 2
   - uid: 20242
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-8.5
       parent: 2
   - uid: 20243
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-10.5
       parent: 2
   - uid: 20244
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,24.5
       parent: 2
   - uid: 20245
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,24.5
       parent: 2
   - uid: 20246
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,23.5
       parent: 2
   - uid: 20247
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,23.5
       parent: 2
   - uid: 20248
@@ -128289,7 +127709,6 @@ entities:
   - uid: 20262
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-2.5
       parent: 2
   - uid: 20263
@@ -128325,7 +127744,6 @@ entities:
   - uid: 20269
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-2.5
       parent: 2
   - uid: 20270
@@ -128351,7 +127769,6 @@ entities:
   - uid: 20274
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-3.5
       parent: 2
   - uid: 20275
@@ -128442,7 +127859,6 @@ entities:
   - uid: 20292
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-4.5
       parent: 2
   - uid: 20293
@@ -128488,25 +127904,21 @@ entities:
   - uid: 20301
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,12.5
       parent: 2
   - uid: 20302
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,12.5
       parent: 2
   - uid: 20303
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,12.5
       parent: 2
   - uid: 20304
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -66.5,12.5
       parent: 2
   - uid: 20305
@@ -128542,25 +127954,21 @@ entities:
   - uid: 20311
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,10.5
       parent: 2
   - uid: 20312
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,10.5
       parent: 2
   - uid: 20313
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,9.5
       parent: 2
   - uid: 20314
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,10.5
       parent: 2
 - proto: TableReinforcedGlass
@@ -128568,61 +127976,51 @@ entities:
   - uid: 20315
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,48.5
       parent: 2
   - uid: 20316
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,47.5
       parent: 2
   - uid: 20317
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,30.5
       parent: 2
   - uid: 20318
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,29.5
       parent: 2
   - uid: 20319
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,33.5
       parent: 2
   - uid: 20320
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,25.5
       parent: 2
   - uid: 20321
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,9.5
       parent: 2
   - uid: 20322
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,7.5
       parent: 2
   - uid: 20323
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,3.5
       parent: 2
   - uid: 20324
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,8.5
       parent: 2
   - uid: 20325
@@ -128660,19 +128058,16 @@ entities:
   - uid: 20331
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,36.5
       parent: 2
   - uid: 20332
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,36.5
       parent: 2
   - uid: 20333
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,41.5
       parent: 2
   - uid: 20334
@@ -129733,7 +129128,6 @@ entities:
   - uid: 20527
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,6.5
       parent: 2
     - type: DeltaPressure
@@ -129741,7 +129135,6 @@ entities:
   - uid: 20528
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,6.5
       parent: 2
     - type: DeltaPressure
@@ -129749,7 +129142,6 @@ entities:
   - uid: 20529
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,6.5
       parent: 2
     - type: DeltaPressure
@@ -129799,7 +129191,6 @@ entities:
   - uid: 20536
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,8.5
       parent: 2
     - type: DeltaPressure
@@ -129807,7 +129198,6 @@ entities:
   - uid: 20537
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,10.5
       parent: 2
     - type: DeltaPressure
@@ -131120,217 +130510,181 @@ entities:
   - uid: 20695
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-62.5
       parent: 2
   - uid: 20696
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,-60.5
       parent: 2
   - uid: 20697
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-63.5
       parent: 2
   - uid: 20698
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,-61.5
       parent: 2
   - uid: 20699
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-61.5
       parent: 2
   - uid: 20700
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-62.5
       parent: 2
   - uid: 20701
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,-62.5
       parent: 2
   - uid: 20702
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-62.5
       parent: 2
   - uid: 20703
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-61.5
       parent: 2
   - uid: 20704
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -0.5,-63.5
       parent: 2
   - uid: 20705
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-64.5
       parent: 2
   - uid: 20706
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-63.5
       parent: 2
   - uid: 20707
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-63.5
       parent: 2
   - uid: 20708
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-64.5
       parent: 2
   - uid: 20709
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-64.5
       parent: 2
   - uid: 20710
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,-65.5
       parent: 2
   - uid: 20711
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-64.5
       parent: 2
   - uid: 20712
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 6.5,-65.5
       parent: 2
   - uid: 20713
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 3.5,-64.5
       parent: 2
   - uid: 20714
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-65.5
       parent: 2
   - uid: 20715
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,-65.5
       parent: 2
   - uid: 20716
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,-65.5
       parent: 2
   - uid: 20717
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-65.5
       parent: 2
   - uid: 20718
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-65.5
       parent: 2
   - uid: 20719
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-64.5
       parent: 2
   - uid: 20720
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-64.5
       parent: 2
   - uid: 20721
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-63.5
       parent: 2
   - uid: 20722
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-64.5
       parent: 2
   - uid: 20723
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,-60.5
       parent: 2
   - uid: 20724
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,-60.5
       parent: 2
   - uid: 20725
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-63.5
       parent: 2
   - uid: 20726
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-63.5
       parent: 2
   - uid: 20727
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-62.5
       parent: 2
   - uid: 20728
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-62.5
       parent: 2
   - uid: 20729
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,-61.5
       parent: 2
   - uid: 20730
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,-61.5
       parent: 2
 - proto: WallCobblebrick
@@ -131419,31 +130773,26 @@ entities:
   - uid: 20746
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,33.5
       parent: 2
   - uid: 20747
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,38.5
       parent: 2
   - uid: 20748
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,34.5
       parent: 2
   - uid: 20749
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,39.5
       parent: 2
   - uid: 20750
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,39.5
       parent: 2
   - uid: 20751
@@ -131454,7 +130803,6 @@ entities:
   - uid: 20752
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,37.5
       parent: 2
   - uid: 20753
@@ -131465,7 +130813,6 @@ entities:
   - uid: 20754
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,27.5
       parent: 2
   - uid: 20755
@@ -131476,7 +130823,6 @@ entities:
   - uid: 20756
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,27.5
       parent: 2
   - uid: 20757
@@ -131492,37 +130838,31 @@ entities:
   - uid: 20759
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,40.5
       parent: 2
   - uid: 20760
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,42.5
       parent: 2
   - uid: 20761
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,42.5
       parent: 2
   - uid: 20762
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,51.5
       parent: 2
   - uid: 20763
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,34.5
       parent: 2
   - uid: 20764
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,41.5
       parent: 2
   - uid: 20765
@@ -131533,19 +130873,16 @@ entities:
   - uid: 20766
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 58.5,-35.5
       parent: 2
   - uid: 20767
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,38.5
       parent: 2
   - uid: 20768
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,31.5
       parent: 2
   - uid: 20769
@@ -131556,43 +130893,36 @@ entities:
   - uid: 20770
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,36.5
       parent: 2
   - uid: 20771
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,39.5
       parent: 2
   - uid: 20772
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,33.5
       parent: 2
   - uid: 20773
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,33.5
       parent: 2
   - uid: 20774
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,42.5
       parent: 2
   - uid: 20775
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,35.5
       parent: 2
   - uid: 20776
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,44.5
       parent: 2
   - uid: 20777
@@ -131603,7 +130933,6 @@ entities:
   - uid: 20778
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -31.5,42.5
       parent: 2
   - uid: 20779
@@ -131619,43 +130948,36 @@ entities:
   - uid: 20781
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,41.5
       parent: 2
   - uid: 20782
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,40.5
       parent: 2
   - uid: 20783
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,35.5
       parent: 2
   - uid: 20784
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,34.5
       parent: 2
   - uid: 20785
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,39.5
       parent: 2
   - uid: 20786
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,38.5
       parent: 2
   - uid: 20787
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,37.5
       parent: 2
   - uid: 20788
@@ -131666,25 +130988,21 @@ entities:
   - uid: 20789
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,51.5
       parent: 2
   - uid: 20790
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,23.5
       parent: 2
   - uid: 20791
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,38.5
       parent: 2
   - uid: 20792
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -14.5,38.5
       parent: 2
   - uid: 20793
@@ -131700,55 +131018,46 @@ entities:
   - uid: 20795
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,37.5
       parent: 2
   - uid: 20796
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,35.5
       parent: 2
   - uid: 20797
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,33.5
       parent: 2
   - uid: 20798
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,33.5
       parent: 2
   - uid: 20799
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,32.5
       parent: 2
   - uid: 20800
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,31.5
       parent: 2
   - uid: 20801
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,29.5
       parent: 2
   - uid: 20802
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,28.5
       parent: 2
   - uid: 20803
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,35.5
       parent: 2
   - uid: 20804
@@ -131774,37 +131083,31 @@ entities:
   - uid: 20808
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,38.5
       parent: 2
   - uid: 20809
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,38.5
       parent: 2
   - uid: 20810
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,33.5
       parent: 2
   - uid: 20811
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,33.5
       parent: 2
   - uid: 20812
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,54.5
       parent: 2
   - uid: 20813
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,55.5
       parent: 2
   - uid: 20814
@@ -131815,43 +131118,36 @@ entities:
   - uid: 20815
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,52.5
       parent: 2
   - uid: 20816
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,42.5
       parent: 2
   - uid: 20817
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,42.5
       parent: 2
   - uid: 20818
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,42.5
       parent: 2
   - uid: 20819
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,42.5
       parent: 2
   - uid: 20820
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,42.5
       parent: 2
   - uid: 20821
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,33.5
       parent: 2
   - uid: 20822
@@ -131862,19 +131158,16 @@ entities:
   - uid: 20823
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -27.5,33.5
       parent: 2
   - uid: 20824
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,42.5
       parent: 2
   - uid: 20825
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,34.5
       parent: 2
   - uid: 20826
@@ -131885,7 +131178,6 @@ entities:
   - uid: 20827
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,33.5
       parent: 2
   - uid: 20828
@@ -131896,13 +131188,11 @@ entities:
   - uid: 20829
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -27.5,27.5
       parent: 2
   - uid: 20830
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,33.5
       parent: 2
   - uid: 20831
@@ -131913,31 +131203,26 @@ entities:
   - uid: 20832
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,33.5
       parent: 2
   - uid: 20833
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,33.5
       parent: 2
   - uid: 20834
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,30.5
       parent: 2
   - uid: 20835
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,29.5
       parent: 2
   - uid: 20836
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,32.5
       parent: 2
   - uid: 20837
@@ -131948,13 +131233,11 @@ entities:
   - uid: 20838
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,45.5
       parent: 2
   - uid: 20839
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,43.5
       parent: 2
   - uid: 20840
@@ -131965,37 +131248,31 @@ entities:
   - uid: 20841
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,35.5
       parent: 2
   - uid: 20842
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,42.5
       parent: 2
   - uid: 20843
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,42.5
       parent: 2
   - uid: 20844
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,42.5
       parent: 2
   - uid: 20845
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,40.5
       parent: 2
   - uid: 20846
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,39.5
       parent: 2
   - uid: 20847
@@ -132006,13 +131283,11 @@ entities:
   - uid: 20848
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,36.5
       parent: 2
   - uid: 20849
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,36.5
       parent: 2
   - uid: 20850
@@ -132023,31 +131298,26 @@ entities:
   - uid: 20851
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,28.5
       parent: 2
   - uid: 20852
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,42.5
       parent: 2
   - uid: 20853
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,46.5
       parent: 2
   - uid: 20854
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,38.5
       parent: 2
   - uid: 20855
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,34.5
       parent: 2
   - uid: 20856
@@ -132188,91 +131458,76 @@ entities:
   - uid: 20883
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,51.5
       parent: 2
   - uid: 20884
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,51.5
       parent: 2
   - uid: 20885
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,51.5
       parent: 2
   - uid: 20886
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,46.5
       parent: 2
   - uid: 20887
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,54.5
       parent: 2
   - uid: 20888
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,55.5
       parent: 2
   - uid: 20889
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,27.5
       parent: 2
   - uid: 20890
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,42.5
       parent: 2
   - uid: 20891
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,27.5
       parent: 2
   - uid: 20892
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,27.5
       parent: 2
   - uid: 20893
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,35.5
       parent: 2
   - uid: 20894
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,35.5
       parent: 2
   - uid: 20895
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,36.5
       parent: 2
   - uid: 20896
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,36.5
       parent: 2
   - uid: 20897
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,34.5
       parent: 2
   - uid: 20898
@@ -132283,7 +131538,6 @@ entities:
   - uid: 20899
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,39.5
       parent: 2
   - uid: 20900
@@ -132299,7 +131553,6 @@ entities:
   - uid: 20902
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,37.5
       parent: 2
   - uid: 20903
@@ -132315,13 +131568,11 @@ entities:
   - uid: 20905
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,42.5
       parent: 2
   - uid: 20906
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,38.5
       parent: 2
   - uid: 20907
@@ -132332,13 +131583,11 @@ entities:
   - uid: 20908
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,38.5
       parent: 2
   - uid: 20909
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 0.5,34.5
       parent: 2
   - uid: 20910
@@ -132349,13 +131598,11 @@ entities:
   - uid: 20911
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,33.5
       parent: 2
   - uid: 20912
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,34.5
       parent: 2
   - uid: 20913
@@ -132371,7 +131618,6 @@ entities:
   - uid: 20915
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,41.5
       parent: 2
   - uid: 20916
@@ -132382,37 +131628,31 @@ entities:
   - uid: 20917
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,37.5
       parent: 2
   - uid: 20918
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,34.5
       parent: 2
   - uid: 20919
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,27.5
       parent: 2
   - uid: 20920
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,34.5
       parent: 2
   - uid: 20921
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,34.5
       parent: 2
   - uid: 20922
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,42.5
       parent: 2
   - uid: 20923
@@ -132428,7 +131668,6 @@ entities:
   - uid: 20925
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,42.5
       parent: 2
   - uid: 20926
@@ -132439,13 +131678,11 @@ entities:
   - uid: 20927
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,46.5
       parent: 2
   - uid: 20928
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 4.5,46.5
       parent: 2
   - uid: 20929
@@ -132456,7 +131693,6 @@ entities:
   - uid: 20930
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,34.5
       parent: 2
   - uid: 20931
@@ -132467,175 +131703,146 @@ entities:
   - uid: 20932
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,27.5
       parent: 2
   - uid: 20933
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,23.5
       parent: 2
   - uid: 20934
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,24.5
       parent: 2
   - uid: 20935
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,25.5
       parent: 2
   - uid: 20936
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,26.5
       parent: 2
   - uid: 20937
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,22.5
       parent: 2
   - uid: 20938
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,22.5
       parent: 2
   - uid: 20939
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,22.5
       parent: 2
   - uid: 20940
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,22.5
       parent: 2
   - uid: 20941
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,22.5
       parent: 2
   - uid: 20942
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,23.5
       parent: 2
   - uid: 20943
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,22.5
       parent: 2
   - uid: 20944
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,24.5
       parent: 2
   - uid: 20945
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,25.5
       parent: 2
   - uid: 20946
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,26.5
       parent: 2
   - uid: 20947
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,27.5
       parent: 2
   - uid: 20948
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,27.5
       parent: 2
   - uid: 20949
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,28.5
       parent: 2
   - uid: 20950
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,29.5
       parent: 2
   - uid: 20951
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,30.5
       parent: 2
   - uid: 20952
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,31.5
       parent: 2
   - uid: 20953
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,32.5
       parent: 2
   - uid: 20954
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,27.5
       parent: 2
   - uid: 20955
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,27.5
       parent: 2
   - uid: 20956
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,27.5
       parent: 2
   - uid: 20957
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,27.5
       parent: 2
   - uid: 20958
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,27.5
       parent: 2
   - uid: 20959
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,22.5
       parent: 2
   - uid: 20960
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,22.5
       parent: 2
   - uid: 20961
@@ -132706,7 +131913,6 @@ entities:
   - uid: 20974
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,5.5
       parent: 2
   - uid: 20975
@@ -132747,13 +131953,11 @@ entities:
   - uid: 20982
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,4.5
       parent: 2
   - uid: 20983
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,2.5
       parent: 2
   - uid: 20984
@@ -132774,49 +131978,41 @@ entities:
   - uid: 20987
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,2.5
       parent: 2
   - uid: 20988
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,3.5
       parent: 2
   - uid: 20989
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,2.5
       parent: 2
   - uid: 20990
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,2.5
       parent: 2
   - uid: 20991
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,2.5
       parent: 2
   - uid: 20992
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,2.5
       parent: 2
   - uid: 20993
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,2.5
       parent: 2
   - uid: 20994
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,2.5
       parent: 2
   - uid: 20995
@@ -132932,7 +132128,6 @@ entities:
   - uid: 21017
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,6.5
       parent: 2
   - uid: 21018
@@ -132993,7 +132188,6 @@ entities:
   - uid: 21029
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,3.5
       parent: 2
   - uid: 21030
@@ -133009,37 +132203,31 @@ entities:
   - uid: 21032
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,4.5
       parent: 2
   - uid: 21033
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,2.5
       parent: 2
   - uid: 21034
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,2.5
       parent: 2
   - uid: 21035
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 2
   - uid: 21036
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,2.5
       parent: 2
   - uid: 21037
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,2.5
       parent: 2
   - uid: 21038
@@ -133065,31 +132253,26 @@ entities:
   - uid: 21042
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,8.5
       parent: 2
   - uid: 21043
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,7.5
       parent: 2
   - uid: 21044
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,9.5
       parent: 2
   - uid: 21045
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,10.5
       parent: 2
   - uid: 21046
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,8.5
       parent: 2
   - uid: 21047
@@ -133105,13 +132288,11 @@ entities:
   - uid: 21049
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,2.5
       parent: 2
   - uid: 21050
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,2.5
       parent: 2
   - uid: 21051
@@ -133137,37 +132318,31 @@ entities:
   - uid: 21055
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,-6.5
       parent: 2
   - uid: 21056
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -6.5,-6.5
       parent: 2
   - uid: 21057
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -7.5,-6.5
       parent: 2
   - uid: 21058
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,-6.5
       parent: 2
   - uid: 21059
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -9.5,-6.5
       parent: 2
   - uid: 21060
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,-6.5
       parent: 2
   - uid: 21061
@@ -133198,7 +132373,6 @@ entities:
   - uid: 21066
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-6.5
       parent: 2
   - uid: 21067
@@ -133214,121 +132388,101 @@ entities:
   - uid: 21069
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-12.5
       parent: 2
   - uid: 21070
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-12.5
       parent: 2
   - uid: 21071
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,-14.5
       parent: 2
   - uid: 21072
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,-14.5
       parent: 2
   - uid: 21073
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 2.5,-14.5
       parent: 2
   - uid: 21074
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,-14.5
       parent: 2
   - uid: 21075
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-14.5
       parent: 2
   - uid: 21076
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-13.5
       parent: 2
   - uid: 21077
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-12.5
       parent: 2
   - uid: 21078
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-12.5
       parent: 2
   - uid: 21079
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-12.5
       parent: 2
   - uid: 21080
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-12.5
       parent: 2
   - uid: 21081
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-12.5
       parent: 2
   - uid: 21082
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-12.5
       parent: 2
   - uid: 21083
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-12.5
       parent: 2
   - uid: 21084
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-11.5
       parent: 2
   - uid: 21085
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-10.5
       parent: 2
   - uid: 21086
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-9.5
       parent: 2
   - uid: 21087
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-7.5
       parent: 2
   - uid: 21088
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-8.5
       parent: 2
   - uid: 21089
@@ -133344,55 +132498,46 @@ entities:
   - uid: 21091
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-14.5
       parent: 2
   - uid: 21092
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-15.5
       parent: 2
   - uid: 21093
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,-16.5
       parent: 2
   - uid: 21094
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-16.5
       parent: 2
   - uid: 21095
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-17.5
       parent: 2
   - uid: 21096
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-17.5
       parent: 2
   - uid: 21097
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-17.5
       parent: 2
   - uid: 21098
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,-17.5
       parent: 2
   - uid: 21099
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-17.5
       parent: 2
   - uid: 21100
@@ -133493,19 +132638,16 @@ entities:
   - uid: 21119
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 2
   - uid: 21120
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -6.5,-9.5
       parent: 2
   - uid: 21121
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-9.5
       parent: 2
   - uid: 21122
@@ -133716,7 +132858,6 @@ entities:
   - uid: 21163
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,11.5
       parent: 2
   - uid: 21164
@@ -133727,7 +132868,6 @@ entities:
   - uid: 21165
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,5.5
       parent: 2
   - uid: 21166
@@ -133798,49 +132938,41 @@ entities:
   - uid: 21179
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -43.5,11.5
       parent: 2
   - uid: 21180
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,11.5
       parent: 2
   - uid: 21181
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,11.5
       parent: 2
   - uid: 21182
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,11.5
       parent: 2
   - uid: 21183
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,11.5
       parent: 2
   - uid: 21184
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,11.5
       parent: 2
   - uid: 21185
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,11.5
       parent: 2
   - uid: 21186
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,11.5
       parent: 2
   - uid: 21187
@@ -133851,103 +132983,86 @@ entities:
   - uid: 21188
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,11.5
       parent: 2
   - uid: 21189
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,11.5
       parent: 2
   - uid: 21190
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,2.5
       parent: 2
   - uid: 21191
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,2.5
       parent: 2
   - uid: 21192
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,2.5
       parent: 2
   - uid: 21193
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,2.5
       parent: 2
   - uid: 21194
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,-2.5
       parent: 2
   - uid: 21195
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,-3.5
       parent: 2
   - uid: 21196
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,1.5
       parent: 2
   - uid: 21197
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,11.5
       parent: 2
   - uid: 21198
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,-2.5
       parent: 2
   - uid: 21199
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,-3.5
       parent: 2
   - uid: 21200
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,-1.5
       parent: 2
   - uid: 21201
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,-3.5
       parent: 2
   - uid: 21202
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,-3.5
       parent: 2
   - uid: 21203
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,-3.5
       parent: 2
   - uid: 21204
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,-3.5
       parent: 2
   - uid: 21205
@@ -133973,49 +133088,41 @@ entities:
   - uid: 21209
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,25.5
       parent: 2
   - uid: 21210
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -56.5,25.5
       parent: 2
   - uid: 21211
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,27.5
       parent: 2
   - uid: 21212
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,26.5
       parent: 2
   - uid: 21213
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -49.5,27.5
       parent: 2
   - uid: 21214
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -49.5,26.5
       parent: 2
   - uid: 21215
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -50.5,25.5
       parent: 2
   - uid: 21216
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 34.5,37.5
       parent: 2
   - uid: 21217
@@ -134026,13 +133133,11 @@ entities:
   - uid: 21218
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,39.5
       parent: 2
   - uid: 21219
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 38.5,34.5
       parent: 2
   - uid: 21220
@@ -134068,49 +133173,41 @@ entities:
   - uid: 21226
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,34.5
       parent: 2
   - uid: 21227
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,33.5
       parent: 2
   - uid: 21228
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -54.5,33.5
       parent: 2
   - uid: 21229
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -53.5,33.5
       parent: 2
   - uid: 21230
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -52.5,33.5
       parent: 2
   - uid: 21231
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -51.5,33.5
       parent: 2
   - uid: 21232
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -50.5,33.5
       parent: 2
   - uid: 21233
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -49.5,33.5
       parent: 2
   - uid: 21234
@@ -134361,91 +133458,76 @@ entities:
   - uid: 21283
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -49.5,32.5
       parent: 2
   - uid: 21284
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -49.5,31.5
       parent: 2
   - uid: 21285
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -62.5,43.5
       parent: 2
   - uid: 21286
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -62.5,44.5
       parent: 2
   - uid: 21287
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -62.5,45.5
       parent: 2
   - uid: 21288
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -62.5,46.5
       parent: 2
   - uid: 21289
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,43.5
       parent: 2
   - uid: 21290
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,44.5
       parent: 2
   - uid: 21291
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,45.5
       parent: 2
   - uid: 21292
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,46.5
       parent: 2
   - uid: 21293
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,39.5
       parent: 2
   - uid: 21294
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,35.5
       parent: 2
   - uid: 21295
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,40.5
       parent: 2
   - uid: 21296
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,40.5
       parent: 2
   - uid: 21297
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -56.5,40.5
       parent: 2
   - uid: 21298
@@ -134481,13 +133563,11 @@ entities:
   - uid: 21304
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 70.5,21.5
       parent: 2
   - uid: 21305
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 69.5,21.5
       parent: 2
   - uid: 21306
@@ -134548,7 +133628,6 @@ entities:
   - uid: 21317
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,16.5
       parent: 2
   - uid: 21318
@@ -134574,7 +133653,6 @@ entities:
   - uid: 21322
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,37.5
       parent: 2
   - uid: 21323
@@ -134630,247 +133708,206 @@ entities:
   - uid: 21333
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,23.5
       parent: 2
   - uid: 21334
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,23.5
       parent: 2
   - uid: 21335
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,20.5
       parent: 2
   - uid: 21336
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,19.5
       parent: 2
   - uid: 21337
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,18.5
       parent: 2
   - uid: 21338
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,17.5
       parent: 2
   - uid: 21339
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,16.5
       parent: 2
   - uid: 21340
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 26.5,16.5
       parent: 2
   - uid: 21341
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 22.5,16.5
       parent: 2
   - uid: 21342
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,23.5
       parent: 2
   - uid: 21343
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,23.5
       parent: 2
   - uid: 21344
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,23.5
       parent: 2
   - uid: 21345
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,22.5
       parent: 2
   - uid: 21346
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,21.5
       parent: 2
   - uid: 21347
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,20.5
       parent: 2
   - uid: 21348
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,19.5
       parent: 2
   - uid: 21349
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,18.5
       parent: 2
   - uid: 21350
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,18.5
       parent: 2
   - uid: 21351
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,18.5
       parent: 2
   - uid: 21352
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,18.5
       parent: 2
   - uid: 21353
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,22.5
       parent: 2
   - uid: 21354
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,27.5
       parent: 2
   - uid: 21355
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 26.5,37.5
       parent: 2
   - uid: 21356
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,37.5
       parent: 2
   - uid: 21357
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,37.5
       parent: 2
   - uid: 21358
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,28.5
       parent: 2
   - uid: 21359
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,33.5
       parent: 2
   - uid: 21360
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,31.5
       parent: 2
   - uid: 21361
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,35.5
       parent: 2
   - uid: 21362
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,27.5
       parent: 2
   - uid: 21363
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,27.5
       parent: 2
   - uid: 21364
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,27.5
       parent: 2
   - uid: 21365
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,27.5
       parent: 2
   - uid: 21366
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 32.5,27.5
       parent: 2
   - uid: 21367
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,27.5
       parent: 2
   - uid: 21368
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,28.5
       parent: 2
   - uid: 21369
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,29.5
       parent: 2
   - uid: 21370
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,30.5
       parent: 2
   - uid: 21371
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,31.5
       parent: 2
   - uid: 21372
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,32.5
       parent: 2
   - uid: 21373
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,33.5
       parent: 2
   - uid: 21374
@@ -134886,37 +133923,31 @@ entities:
   - uid: 21376
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,36.5
       parent: 2
   - uid: 21377
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 33.5,37.5
       parent: 2
   - uid: 21378
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 31.5,37.5
       parent: 2
   - uid: 21379
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 30.5,37.5
       parent: 2
   - uid: 21380
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,37.5
       parent: 2
   - uid: 21381
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,37.5
       parent: 2
   - uid: 21382
@@ -135107,91 +134138,76 @@ entities:
   - uid: 21419
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,-42.5
       parent: 2
   - uid: 21420
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,-42.5
       parent: 2
   - uid: 21421
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-42.5
       parent: 2
   - uid: 21422
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-42.5
       parent: 2
   - uid: 21423
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-42.5
       parent: 2
   - uid: 21424
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-42.5
       parent: 2
   - uid: 21425
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-42.5
       parent: 2
   - uid: 21426
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-41.5
       parent: 2
   - uid: 21427
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-40.5
       parent: 2
   - uid: 21428
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-39.5
       parent: 2
   - uid: 21429
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-38.5
       parent: 2
   - uid: 21430
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-37.5
       parent: 2
   - uid: 21431
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-36.5
       parent: 2
   - uid: 21432
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-35.5
       parent: 2
   - uid: 21433
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-34.5
       parent: 2
   - uid: 21434
@@ -135577,7 +134593,6 @@ entities:
   - uid: 21510
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,19.5
       parent: 2
   - uid: 21511
@@ -135593,79 +134608,66 @@ entities:
   - uid: 21513
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,20.5
       parent: 2
   - uid: 21514
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,21.5
       parent: 2
   - uid: 21515
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,22.5
       parent: 2
   - uid: 21516
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,25.5
       parent: 2
   - uid: 21517
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,24.5
       parent: 2
   - uid: 21518
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,18.5
       parent: 2
   - uid: 21519
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,17.5
       parent: 2
   - uid: 21520
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,16.5
       parent: 2
   - uid: 21521
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,15.5
       parent: 2
   - uid: 21522
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,26.5
       parent: 2
   - uid: 21523
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 48.5,-35.5
       parent: 2
   - uid: 21524
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 76.5,-5.5
       parent: 2
   - uid: 21525
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 43.5,-35.5
       parent: 2
   - uid: 21526
@@ -135831,7 +134833,6 @@ entities:
   - uid: 21558
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 42.5,-35.5
       parent: 2
   - uid: 21559
@@ -136042,7 +135043,6 @@ entities:
   - uid: 21600
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,2.5
       parent: 2
   - uid: 21601
@@ -136123,13 +135123,11 @@ entities:
   - uid: 21616
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 41.5,-35.5
       parent: 2
   - uid: 21617
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 47.5,-35.5
       parent: 2
   - uid: 21618
@@ -136190,19 +135188,16 @@ entities:
   - uid: 21629
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 44.5,-35.5
       parent: 2
   - uid: 21630
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 49.5,-35.5
       parent: 2
   - uid: 21631
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 50.5,-35.5
       parent: 2
   - uid: 21632
@@ -136303,7 +135298,6 @@ entities:
   - uid: 21651
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 42.5,32.5
       parent: 2
   - uid: 21652
@@ -136319,19 +135313,16 @@ entities:
   - uid: 21654
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 42.5,31.5
       parent: 2
   - uid: 21655
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 36.5,28.5
       parent: 2
   - uid: 21656
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 35.5,28.5
       parent: 2
   - uid: 21657
@@ -136367,7 +135358,6 @@ entities:
   - uid: 21663
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,21.5
       parent: 2
   - uid: 21664
@@ -136378,13 +135368,11 @@ entities:
   - uid: 21665
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 42.5,30.5
       parent: 2
   - uid: 21666
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 42.5,29.5
       parent: 2
   - uid: 21667
@@ -136475,7 +135463,6 @@ entities:
   - uid: 21684
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 48.5,23.5
       parent: 2
   - uid: 21685
@@ -136486,7 +135473,6 @@ entities:
   - uid: 21686
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 52.5,23.5
       parent: 2
   - uid: 21687
@@ -136602,7 +135588,6 @@ entities:
   - uid: 21709
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 51.5,-35.5
       parent: 2
   - uid: 21710
@@ -137373,7 +136358,6 @@ entities:
   - uid: 21863
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,18.5
       parent: 2
   - uid: 21864
@@ -137384,19 +136368,16 @@ entities:
   - uid: 21865
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,17.5
       parent: 2
   - uid: 21866
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,21.5
       parent: 2
   - uid: 21867
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,19.5
       parent: 2
   - uid: 21868
@@ -137432,7 +136413,6 @@ entities:
   - uid: 21874
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,20.5
       parent: 2
   - uid: 21875
@@ -137458,37 +136438,31 @@ entities:
   - uid: 21879
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,21.5
       parent: 2
   - uid: 21880
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,21.5
       parent: 2
   - uid: 21881
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,18.5
       parent: 2
   - uid: 21882
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,19.5
       parent: 2
   - uid: 21883
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -5.5,18.5
       parent: 2
   - uid: 21884
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 52.5,-35.5
       parent: 2
   - uid: 21885
@@ -137534,55 +136508,46 @@ entities:
   - uid: 21893
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,-35.5
       parent: 2
   - uid: 21894
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 55.5,-35.5
       parent: 2
   - uid: 21895
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 56.5,-35.5
       parent: 2
   - uid: 21896
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 54.5,-35.5
       parent: 2
   - uid: 21897
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 53.5,-35.5
       parent: 2
   - uid: 21898
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 57.5,-35.5
       parent: 2
   - uid: 21899
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 60.5,-35.5
       parent: 2
   - uid: 21900
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 61.5,-35.5
       parent: 2
   - uid: 21901
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 63.5,-35.5
       parent: 2
   - uid: 21902
@@ -137718,61 +136683,51 @@ entities:
   - uid: 21928
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 75.5,25.5
       parent: 2
   - uid: 21929
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 74.5,25.5
       parent: 2
   - uid: 21930
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 72.5,25.5
       parent: 2
   - uid: 21931
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 73.5,25.5
       parent: 2
   - uid: 21932
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 75.5,11.5
       parent: 2
   - uid: 21933
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 74.5,11.5
       parent: 2
   - uid: 21934
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 73.5,11.5
       parent: 2
   - uid: 21935
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 72.5,11.5
       parent: 2
   - uid: 21936
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 77.5,25.5
       parent: 2
   - uid: 21937
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 77.5,11.5
       parent: 2
   - uid: 21938
@@ -138218,25 +137173,21 @@ entities:
   - uid: 22026
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 64.5,-35.5
       parent: 2
   - uid: 22027
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 66.5,-35.5
       parent: 2
   - uid: 22028
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 62.5,-35.5
       parent: 2
   - uid: 22029
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 65.5,-35.5
       parent: 2
   - uid: 22030
@@ -138247,7 +137198,6 @@ entities:
   - uid: 22031
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 72.5,-35.5
       parent: 2
   - uid: 22032
@@ -138303,25 +137253,21 @@ entities:
   - uid: 22042
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-17.5
       parent: 2
   - uid: 22043
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 71.5,-35.5
       parent: 2
   - uid: 22044
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,-34.5
       parent: 2
   - uid: 22045
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 72.5,-34.5
       parent: 2
   - uid: 22046
@@ -138332,73 +137278,61 @@ entities:
   - uid: 22047
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,-30.5
       parent: 2
   - uid: 22048
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,-31.5
       parent: 2
   - uid: 22049
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,-33.5
       parent: 2
   - uid: 22050
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-20.5
       parent: 2
   - uid: 22051
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-9.5
       parent: 2
   - uid: 22052
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-9.5
       parent: 2
   - uid: 22053
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-10.5
       parent: 2
   - uid: 22054
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-11.5
       parent: 2
   - uid: 22055
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-12.5
       parent: 2
   - uid: 22056
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-13.5
       parent: 2
   - uid: 22057
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-13.5
       parent: 2
   - uid: 22058
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-13.5
       parent: 2
   - uid: 22059
@@ -138454,7 +137388,6 @@ entities:
   - uid: 22069
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,-32.5
       parent: 2
   - uid: 22070
@@ -138485,19 +137418,16 @@ entities:
   - uid: 22075
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-23.5
       parent: 2
   - uid: 22076
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-23.5
       parent: 2
   - uid: 22077
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-20.5
       parent: 2
   - uid: 22078
@@ -138538,7 +137468,6 @@ entities:
   - uid: 22085
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-23.5
       parent: 2
   - uid: 22086
@@ -138554,121 +137483,101 @@ entities:
   - uid: 22088
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-17.5
       parent: 2
   - uid: 22089
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-18.5
       parent: 2
   - uid: 22090
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-19.5
       parent: 2
   - uid: 22091
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-20.5
       parent: 2
   - uid: 22092
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-21.5
       parent: 2
   - uid: 22093
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-21.5
       parent: 2
   - uid: 22094
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-23.5
       parent: 2
   - uid: 22095
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-22.5
       parent: 2
   - uid: 22096
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-22.5
       parent: 2
   - uid: 22097
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-21.5
       parent: 2
   - uid: 22098
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-21.5
       parent: 2
   - uid: 22099
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-21.5
       parent: 2
   - uid: 22100
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-20.5
       parent: 2
   - uid: 22101
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-19.5
       parent: 2
   - uid: 22102
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-17.5
       parent: 2
   - uid: 22103
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-18.5
       parent: 2
   - uid: 22104
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,24.5
       parent: 2
   - uid: 22105
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,26.5
       parent: 2
   - uid: 22106
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,25.5
       parent: 2
   - uid: 22107
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,-18.5
       parent: 2
   - uid: 22108
@@ -138764,115 +137673,96 @@ entities:
   - uid: 22126
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,26.5
       parent: 2
   - uid: 22127
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,24.5
       parent: 2
   - uid: 22128
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,25.5
       parent: 2
   - uid: 22129
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,24.5
       parent: 2
   - uid: 22130
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -76.5,10.5
       parent: 2
   - uid: 22131
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -72.5,8.5
       parent: 2
   - uid: 22132
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -73.5,8.5
       parent: 2
   - uid: 22133
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -74.5,8.5
       parent: 2
   - uid: 22134
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -75.5,8.5
       parent: 2
   - uid: 22135
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -75.5,9.5
       parent: 2
   - uid: 22136
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -75.5,12.5
       parent: 2
   - uid: 22137
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -75.5,10.5
       parent: 2
   - uid: 22138
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -75.5,13.5
       parent: 2
   - uid: 22139
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -75.5,14.5
       parent: 2
   - uid: 22140
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -75.5,15.5
       parent: 2
   - uid: 22141
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -76.5,12.5
       parent: 2
   - uid: 22142
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -74.5,15.5
       parent: 2
   - uid: 22143
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -70.5,15.5
       parent: 2
   - uid: 22144
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-34.5
       parent: 2
   - uid: 22145
@@ -138933,37 +137823,31 @@ entities:
   - uid: 22156
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 71.5,-36.5
       parent: 2
   - uid: 22157
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 71.5,-37.5
       parent: 2
   - uid: 22158
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 71.5,-38.5
       parent: 2
   - uid: 22159
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 72.5,-39.5
       parent: 2
   - uid: 22160
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 72.5,-38.5
       parent: 2
   - uid: 22161
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,-39.5
       parent: 2
   - uid: 22162
@@ -138989,103 +137873,86 @@ entities:
   - uid: 22166
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 67.5,-46.5
       parent: 2
   - uid: 22167
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 68.5,-46.5
       parent: 2
   - uid: 22168
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 69.5,-46.5
       parent: 2
   - uid: 22169
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 69.5,-45.5
       parent: 2
   - uid: 22170
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 70.5,-45.5
       parent: 2
   - uid: 22171
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 71.5,-45.5
       parent: 2
   - uid: 22172
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 73.5,-42.5
       parent: 2
   - uid: 22173
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 72.5,-42.5
       parent: 2
   - uid: 22174
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 72.5,-43.5
       parent: 2
   - uid: 22175
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 72.5,-44.5
       parent: 2
   - uid: 22176
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 71.5,-44.5
       parent: 2
   - uid: 22177
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 81.5,-45.5
       parent: 2
   - uid: 22178
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 83.5,-45.5
       parent: 2
   - uid: 22179
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 81.5,-46.5
       parent: 2
   - uid: 22180
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 81.5,-48.5
       parent: 2
   - uid: 22181
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 81.5,-47.5
       parent: 2
   - uid: 22182
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 84.5,-45.5
       parent: 2
   - uid: 22183
@@ -139131,7 +137998,6 @@ entities:
   - uid: 22191
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,25.5
       parent: 2
   - uid: 22192
@@ -139147,7 +138013,6 @@ entities:
   - uid: 22194
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,9.5
       parent: 2
 - proto: WallReinforcedDiagonal
@@ -140949,37 +139814,31 @@ entities:
   - uid: 22552
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,46.5
       parent: 2
   - uid: 22553
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,47.5
       parent: 2
   - uid: 22554
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,47.5
       parent: 2
   - uid: 22555
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,50.5
       parent: 2
   - uid: 22556
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -10.5,46.5
       parent: 2
   - uid: 22557
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,50.5
       parent: 2
   - uid: 22558
@@ -141075,19 +139934,16 @@ entities:
   - uid: 22576
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,2.5
       parent: 2
   - uid: 22577
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,4.5
       parent: 2
   - uid: 22578
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,5.5
       parent: 2
   - uid: 22579
@@ -141098,13 +139954,11 @@ entities:
   - uid: 22580
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,1.5
       parent: 2
   - uid: 22581
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,3.5
       parent: 2
   - uid: 22582
@@ -141275,37 +140129,31 @@ entities:
   - uid: 22615
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,22.5
       parent: 2
   - uid: 22616
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,18.5
       parent: 2
   - uid: 22617
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,19.5
       parent: 2
   - uid: 22618
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,17.5
       parent: 2
   - uid: 22619
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,5.5
       parent: 2
   - uid: 22620
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,1.5
       parent: 2
   - uid: 22621
@@ -141321,7 +140169,6 @@ entities:
   - uid: 22623
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-7.5
       parent: 2
   - uid: 22624
@@ -141347,7 +140194,6 @@ entities:
   - uid: 22628
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -43.5,-4.5
       parent: 2
   - uid: 22629
@@ -141358,205 +140204,171 @@ entities:
   - uid: 22630
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -31.5,-7.5
       parent: 2
   - uid: 22631
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-7.5
       parent: 2
   - uid: 22632
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -33.5,-7.5
       parent: 2
   - uid: 22633
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,-7.5
       parent: 2
   - uid: 22634
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -34.5,-7.5
       parent: 2
   - uid: 22635
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,-7.5
       parent: 2
   - uid: 22636
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-7.5
       parent: 2
   - uid: 22637
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -37.5,-7.5
       parent: 2
   - uid: 22638
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-7.5
       parent: 2
   - uid: 22639
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-5.5
       parent: 2
   - uid: 22640
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-6.5
       parent: 2
   - uid: 22641
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,-6.5
       parent: 2
   - uid: 22642
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,-7.5
       parent: 2
   - uid: 22643
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-4.5
       parent: 2
   - uid: 22644
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,-5.5
       parent: 2
   - uid: 22645
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-1.5
       parent: 2
   - uid: 22646
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-3.5
       parent: 2
   - uid: 22647
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-2.5
       parent: 2
   - uid: 22648
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,-4.5
       parent: 2
   - uid: 22649
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,-6.5
       parent: 2
   - uid: 22650
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,-5.5
       parent: 2
   - uid: 22651
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -35.5,-4.5
       parent: 2
   - uid: 22652
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,24.5
       parent: 2
   - uid: 22653
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,-9.5
       parent: 2
   - uid: 22654
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-9.5
       parent: 2
   - uid: 22655
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-6.5
       parent: 2
   - uid: 22656
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,-10.5
       parent: 2
   - uid: 22657
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,1.5
       parent: 2
   - uid: 22658
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,6.5
       parent: 2
   - uid: 22659
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,-3.5
       parent: 2
   - uid: 22660
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,-4.5
       parent: 2
   - uid: 22661
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,-4.5
       parent: 2
   - uid: 22662
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -43.5,7.5
       parent: 2
   - uid: 22663
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,6.5
       parent: 2
   - uid: 22664
@@ -141567,13 +140379,11 @@ entities:
   - uid: 22665
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,10.5
       parent: 2
   - uid: 22666
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,8.5
       parent: 2
   - uid: 22667
@@ -141584,253 +140394,211 @@ entities:
   - uid: 22668
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,7.5
       parent: 2
   - uid: 22669
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,9.5
       parent: 2
   - uid: 22670
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -53.5,6.5
       parent: 2
   - uid: 22671
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,6.5
       parent: 2
   - uid: 22672
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -54.5,6.5
       parent: 2
   - uid: 22673
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,6.5
       parent: 2
   - uid: 22674
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,2.5
       parent: 2
   - uid: 22675
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,2.5
       parent: 2
   - uid: 22676
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,2.5
       parent: 2
   - uid: 22677
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -53.5,2.5
       parent: 2
   - uid: 22678
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,6.5
       parent: 2
   - uid: 22679
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,6.5
       parent: 2
   - uid: 22680
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,6.5
       parent: 2
   - uid: 22681
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,6.5
       parent: 2
   - uid: 22682
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,6.5
       parent: 2
   - uid: 22683
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,6.5
       parent: 2
   - uid: 22684
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,6.5
       parent: 2
   - uid: 22685
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -43.5,6.5
       parent: 2
   - uid: 22686
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,6.5
       parent: 2
   - uid: 22687
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,-2.5
       parent: 2
   - uid: 22688
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,-6.5
       parent: 2
   - uid: 22689
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,-5.5
       parent: 2
   - uid: 22690
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,-7.5
       parent: 2
   - uid: 22691
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,-11.5
       parent: 2
   - uid: 22692
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,-8.5
       parent: 2
   - uid: 22693
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,-9.5
       parent: 2
   - uid: 22694
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -53.5,-1.5
       parent: 2
   - uid: 22695
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-1.5
       parent: 2
   - uid: 22696
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-2.5
       parent: 2
   - uid: 22697
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,-2.5
       parent: 2
   - uid: 22698
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,-2.5
       parent: 2
   - uid: 22699
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -54.5,-2.5
       parent: 2
   - uid: 22700
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -53.5,-2.5
       parent: 2
   - uid: 22701
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,-6.5
       parent: 2
   - uid: 22702
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -47.5,-12.5
       parent: 2
   - uid: 22703
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -46.5,-12.5
       parent: 2
   - uid: 22704
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,-12.5
       parent: 2
   - uid: 22705
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,-13.5
       parent: 2
   - uid: 22706
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-13.5
       parent: 2
   - uid: 22707
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,-13.5
       parent: 2
   - uid: 22708
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-13.5
       parent: 2
   - uid: 22709
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,-13.5
       parent: 2
   - uid: 22710
@@ -141841,19 +140609,16 @@ entities:
   - uid: 22711
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -43.5,-13.5
       parent: 2
   - uid: 22712
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,-12.5
       parent: 2
   - uid: 22713
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,21.5
       parent: 2
   - uid: 22714
@@ -141869,7 +140634,6 @@ entities:
   - uid: 22716
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,16.5
       parent: 2
   - uid: 22717
@@ -141880,7 +140644,6 @@ entities:
   - uid: 22718
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,22.5
       parent: 2
   - uid: 22719
@@ -141896,403 +140659,336 @@ entities:
   - uid: 22721
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,14.5
       parent: 2
   - uid: 22722
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,14.5
       parent: 2
   - uid: 22723
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,14.5
       parent: 2
   - uid: 22724
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -53.5,14.5
       parent: 2
   - uid: 22725
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,14.5
       parent: 2
   - uid: 22726
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -54.5,14.5
       parent: 2
   - uid: 22727
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,12.5
       parent: 2
   - uid: 22728
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,12.5
       parent: 2
   - uid: 22729
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,12.5
       parent: 2
   - uid: 22730
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,14.5
       parent: 2
   - uid: 22731
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,13.5
       parent: 2
   - uid: 22732
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,22.5
       parent: 2
   - uid: 22733
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,22.5
       parent: 2
   - uid: 22734
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,22.5
       parent: 2
   - uid: 22735
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -53.5,22.5
       parent: 2
   - uid: 22736
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -54.5,22.5
       parent: 2
   - uid: 22737
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,22.5
       parent: 2
   - uid: 22738
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,22.5
       parent: 2
   - uid: 22739
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,12.5
       parent: 2
   - uid: 22740
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -59.5,12.5
       parent: 2
   - uid: 22741
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,23.5
       parent: 2
   - uid: 22742
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,24.5
       parent: 2
   - uid: 22743
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,24.5
       parent: 2
   - uid: 22744
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,24.5
       parent: 2
   - uid: 22745
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,24.5
       parent: 2
   - uid: 22746
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,20.5
       parent: 2
   - uid: 22747
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -59.5,24.5
       parent: 2
   - uid: 22748
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -60.5,24.5
       parent: 2
   - uid: 22749
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -60.5,23.5
       parent: 2
   - uid: 22750
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -61.5,23.5
       parent: 2
   - uid: 22751
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -62.5,23.5
       parent: 2
   - uid: 22752
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,23.5
       parent: 2
   - uid: 22753
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -60.5,13.5
       parent: 2
   - uid: 22754
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -61.5,13.5
       parent: 2
   - uid: 22755
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -60.5,12.5
       parent: 2
   - uid: 22756
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -62.5,13.5
       parent: 2
   - uid: 22757
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -63.5,14.5
       parent: 2
   - uid: 22758
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -63.5,13.5
       parent: 2
   - uid: 22759
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -66.5,19.5
       parent: 2
   - uid: 22760
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,19.5
       parent: 2
   - uid: 22761
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,19.5
       parent: 2
   - uid: 22762
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,19.5
       parent: 2
   - uid: 22763
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,25.5
       parent: 2
   - uid: 22764
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -66.5,25.5
       parent: 2
   - uid: 22765
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,25.5
       parent: 2
   - uid: 22766
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,25.5
       parent: 2
   - uid: 22767
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,25.5
       parent: 2
   - uid: 22768
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -67.5,25.5
       parent: 2
   - uid: 22769
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -63.5,24.5
       parent: 2
   - uid: 22770
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,14.5
       parent: 2
   - uid: 22771
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,13.5
       parent: 2
   - uid: 22772
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,13.5
       parent: 2
   - uid: 22773
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -65.5,13.5
       parent: 2
   - uid: 22774
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -66.5,13.5
       parent: 2
   - uid: 22775
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -67.5,13.5
       parent: 2
   - uid: 22776
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,13.5
       parent: 2
   - uid: 22777
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -62.5,25.5
       parent: 2
   - uid: 22778
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -61.5,25.5
       parent: 2
   - uid: 22779
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -60.5,25.5
       parent: 2
   - uid: 22780
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -59.5,25.5
       parent: 2
   - uid: 22781
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,25.5
       parent: 2
   - uid: 22782
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,25.5
       parent: 2
   - uid: 22783
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,25.5
       parent: 2
   - uid: 22784
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,24.5
       parent: 2
   - uid: 22785
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -49.5,23.5
       parent: 2
   - uid: 22786
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,-34.5
       parent: 2
   - uid: 22787
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,-34.5
       parent: 2
   - uid: 22788
@@ -142313,67 +141009,56 @@ entities:
   - uid: 22791
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -57.5,30.5
       parent: 2
   - uid: 22792
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -57.5,32.5
       parent: 2
   - uid: 22793
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -48.5,33.5
       parent: 2
   - uid: 22794
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,33.5
       parent: 2
   - uid: 22795
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,25.5
       parent: 2
   - uid: 22796
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,24.5
       parent: 2
   - uid: 22797
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,24.5
       parent: 2
   - uid: 22798
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -46.5,24.5
       parent: 2
   - uid: 22799
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -48.5,24.5
       parent: 2
   - uid: 22800
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -49.5,30.5
       parent: 2
   - uid: 22801
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -57.5,31.5
       parent: 2
   - uid: 22802
@@ -142389,43 +141074,36 @@ entities:
   - uid: 22804
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,17.5
       parent: 2
   - uid: 22805
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,17.5
       parent: 2
   - uid: 22806
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,17.5
       parent: 2
   - uid: 22807
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,17.5
       parent: 2
   - uid: 22808
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,17.5
       parent: 2
   - uid: 22809
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,17.5
       parent: 2
   - uid: 22810
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 42.5,24.5
       parent: 2
   - uid: 22811
@@ -142451,7 +141129,6 @@ entities:
   - uid: 22815
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,23.5
       parent: 2
   - uid: 22816
@@ -142522,25 +141199,21 @@ entities:
   - uid: 22829
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,18.5
       parent: 2
   - uid: 22830
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,16.5
       parent: 2
   - uid: 22831
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,16.5
       parent: 2
   - uid: 22832
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,23.5
       parent: 2
   - uid: 22833
@@ -142616,37 +141289,31 @@ entities:
   - uid: 22847
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,36.5
       parent: 2
   - uid: 22848
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,35.5
       parent: 2
   - uid: 22849
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,34.5
       parent: 2
   - uid: 22850
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,33.5
       parent: 2
   - uid: 22851
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,32.5
       parent: 2
   - uid: 22852
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,-8.5
       parent: 2
   - uid: 22853
@@ -142657,7 +141324,6 @@ entities:
   - uid: 22854
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,-8.5
       parent: 2
   - uid: 22855
@@ -142703,7 +141369,6 @@ entities:
   - uid: 22863
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-33.5
       parent: 2
   - uid: 22864
@@ -142784,7 +141449,6 @@ entities:
   - uid: 22879
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-33.5
       parent: 2
   - uid: 22880
@@ -142945,7 +141609,6 @@ entities:
   - uid: 22911
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-24.5
       parent: 2
   - uid: 22912
@@ -143331,31 +141994,26 @@ entities:
   - uid: 22988
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,4.5
       parent: 2
   - uid: 22989
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,2.5
       parent: 2
   - uid: 22990
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,1.5
       parent: 2
   - uid: 22991
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,1.5
       parent: 2
   - uid: 22992
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 46.5,1.5
       parent: 2
   - uid: 22993
@@ -143366,31 +142024,26 @@ entities:
   - uid: 22994
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 48.5,1.5
       parent: 2
   - uid: 22995
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 48.5,2.5
       parent: 2
   - uid: 22996
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 48.5,3.5
       parent: 2
   - uid: 22997
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 43.5,-1.5
       parent: 2
   - uid: 22998
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-1.5
       parent: 2
   - uid: 22999
@@ -143416,13 +142069,11 @@ entities:
   - uid: 23003
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-17.5
       parent: 2
   - uid: 23004
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 45.5,1.5
       parent: 2
   - uid: 23005
@@ -143658,19 +142309,16 @@ entities:
   - uid: 23051
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,-3.5
       parent: 2
   - uid: 23052
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,-5.5
       parent: 2
   - uid: 23053
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 51.5,-7.5
       parent: 2
   - uid: 23054
@@ -143681,31 +142329,26 @@ entities:
   - uid: 23055
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,-7.5
       parent: 2
   - uid: 23056
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,-6.5
       parent: 2
   - uid: 23057
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,0.5
       parent: 2
   - uid: 23058
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,1.5
       parent: 2
   - uid: 23059
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 52.5,-2.5
       parent: 2
   - uid: 23060
@@ -143801,13 +142444,11 @@ entities:
   - uid: 23078
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 68.5,-28.5
       parent: 2
   - uid: 23079
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 67.5,-35.5
       parent: 2
   - uid: 23080
@@ -143928,19 +142569,16 @@ entities:
   - uid: 23103
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 61.5,-7.5
       parent: 2
   - uid: 23104
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 64.5,-7.5
       parent: 2
   - uid: 23105
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 65.5,-7.5
       parent: 2
   - uid: 23106
@@ -144076,7 +142714,6 @@ entities:
   - uid: 23132
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-1.5
       parent: 2
   - uid: 23133
@@ -144087,7 +142724,6 @@ entities:
   - uid: 23134
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -42.5,39.5
       parent: 2
   - uid: 23135
@@ -144103,7 +142739,6 @@ entities:
   - uid: 23137
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -42.5,38.5
       parent: 2
   - uid: 23138
@@ -144119,79 +142754,66 @@ entities:
   - uid: 23140
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -42.5,37.5
       parent: 2
   - uid: 23141
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 42.5,27.5
       parent: 2
   - uid: 23142
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -42.5,36.5
       parent: 2
   - uid: 23143
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -42.5,35.5
       parent: 2
   - uid: 23144
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-15.5
       parent: 2
   - uid: 23145
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-15.5
       parent: 2
   - uid: 23146
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-15.5
       parent: 2
   - uid: 23147
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-15.5
       parent: 2
   - uid: 23148
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-19.5
       parent: 2
   - uid: 23149
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-17.5
       parent: 2
   - uid: 23150
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-16.5
       parent: 2
   - uid: 23151
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-15.5
       parent: 2
   - uid: 23152
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,0.5
       parent: 2
   - uid: 23153
@@ -144267,25 +142889,21 @@ entities:
   - uid: 23167
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,25.5
       parent: 2
   - uid: 23168
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,26.5
       parent: 2
   - uid: 23169
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,26.5
       parent: 2
   - uid: 23170
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,26.5
       parent: 2
   - uid: 23171
@@ -144356,7 +142974,6 @@ entities:
   - uid: 23184
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,31.5
       parent: 2
   - uid: 23185
@@ -144367,7 +142984,6 @@ entities:
   - uid: 23186
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -34.5,-11.5
       parent: 2
   - uid: 23187
@@ -144423,163 +143039,136 @@ entities:
   - uid: 23197
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,-11.5
       parent: 2
   - uid: 23198
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -32.5,-11.5
       parent: 2
   - uid: 23199
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,-11.5
       parent: 2
   - uid: 23200
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -33.5,-11.5
       parent: 2
   - uid: 23201
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -30.5,-11.5
       parent: 2
   - uid: 23202
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -34.5,-10.5
       parent: 2
   - uid: 23203
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-11.5
       parent: 2
   - uid: 23204
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-17.5
       parent: 2
   - uid: 23205
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -33.5,-17.5
       parent: 2
   - uid: 23206
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -32.5,-17.5
       parent: 2
   - uid: 23207
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -31.5,-17.5
       parent: 2
   - uid: 23208
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -30.5,-17.5
       parent: 2
   - uid: 23209
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-17.5
       parent: 2
   - uid: 23210
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,-11.5
       parent: 2
   - uid: 23211
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-11.5
       parent: 2
   - uid: 23212
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,-11.5
       parent: 2
   - uid: 23213
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,-11.5
       parent: 2
   - uid: 23214
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-11.5
       parent: 2
   - uid: 23215
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,-10.5
       parent: 2
   - uid: 23216
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-10.5
       parent: 2
   - uid: 23217
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-9.5
       parent: 2
   - uid: 23218
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -27.5,-9.5
       parent: 2
   - uid: 23219
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-9.5
       parent: 2
   - uid: 23220
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,-15.5
       parent: 2
   - uid: 23221
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,-12.5
       parent: 2
   - uid: 23222
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,-9.5
       parent: 2
   - uid: 23223
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 44.5,-0.5
       parent: 2
   - uid: 23224
@@ -144595,43 +143184,36 @@ entities:
   - uid: 23226
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,-16.5
       parent: 2
   - uid: 23227
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-16.5
       parent: 2
   - uid: 23228
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-18.5
       parent: 2
   - uid: 23229
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-19.5
       parent: 2
   - uid: 23230
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-17.5
       parent: 2
   - uid: 23231
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-20.5
       parent: 2
   - uid: 23232
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,-21.5
       parent: 2
   - uid: 23233
@@ -144697,25 +143279,21 @@ entities:
   - uid: 23245
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-19.5
       parent: 2
   - uid: 23246
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-20.5
       parent: 2
   - uid: 23247
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-21.5
       parent: 2
   - uid: 23248
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-18.5
       parent: 2
   - uid: 23249
@@ -144746,7 +143324,6 @@ entities:
   - uid: 23254
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-22.5
       parent: 2
   - uid: 23255
@@ -144782,13 +143359,11 @@ entities:
   - uid: 23261
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,-16.5
       parent: 2
   - uid: 23262
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-16.5
       parent: 2
   - uid: 23263
@@ -144804,19 +143379,16 @@ entities:
   - uid: 23265
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-11.5
       parent: 2
   - uid: 23266
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-11.5
       parent: 2
   - uid: 23267
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -22.5,-11.5
       parent: 2
   - uid: 23268
@@ -144872,85 +143444,71 @@ entities:
   - uid: 23278
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,-8.5
       parent: 2
   - uid: 23279
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,-8.5
       parent: 2
   - uid: 23280
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -53.5,-8.5
       parent: 2
   - uid: 23281
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,-5.5
       parent: 2
   - uid: 23282
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,29.5
       parent: 2
   - uid: 23283
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,30.5
       parent: 2
   - uid: 23284
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,30.5
       parent: 2
   - uid: 23285
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,30.5
       parent: 2
   - uid: 23286
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,30.5
       parent: 2
   - uid: 23287
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,26.5
       parent: 2
   - uid: 23288
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,26.5
       parent: 2
   - uid: 23289
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,26.5
       parent: 2
   - uid: 23290
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,21.5
       parent: 2
   - uid: 23291
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,21.5
       parent: 2
   - uid: 23292
@@ -144961,55 +143519,46 @@ entities:
   - uid: 23293
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -49.5,12.5
       parent: 2
   - uid: 23294
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -60.5,9.5
       parent: 2
   - uid: 23295
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -67.5,9.5
       parent: 2
   - uid: 23296
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -71.5,9.5
       parent: 2
   - uid: 23297
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -71.5,8.5
       parent: 2
   - uid: 23298
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -69.5,12.5
       parent: 2
   - uid: 23299
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -71.5,12.5
       parent: 2
   - uid: 23300
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -70.5,12.5
       parent: 2
   - uid: 23301
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -71.5,10.5
       parent: 2
   - uid: 23302
@@ -145045,7 +143594,6 @@ entities:
   - uid: 23308
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,-38.5
       parent: 2
   - uid: 23309
@@ -145056,7 +143604,6 @@ entities:
   - uid: 23310
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 32.5,-40.5
       parent: 2
   - uid: 23311
@@ -145204,91 +143751,76 @@ entities:
   - uid: 23339
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,36.5
       parent: 2
   - uid: 23340
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,13.5
       parent: 2
   - uid: 23341
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -59.5,13.5
       parent: 2
   - uid: 23342
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -59.5,23.5
       parent: 2
   - uid: 23343
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,13.5
       parent: 2
   - uid: 23344
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,20.5
       parent: 2
   - uid: 23345
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,16.5
       parent: 2
   - uid: 23346
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,23.5
       parent: 2
   - uid: 23347
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,13.5
       parent: 2
   - uid: 23348
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -56.5,23.5
       parent: 2
   - uid: 23349
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -58.5,23.5
       parent: 2
   - uid: 23350
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 33.5,-1.5
       parent: 2
   - uid: 23351
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 35.5,-1.5
       parent: 2
   - uid: 23352
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 35.5,-7.5
       parent: 2
   - uid: 23353
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 33.5,-7.5
       parent: 2
   - uid: 23354
@@ -146804,7 +145336,6 @@ entities:
   - uid: 23560
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-27.5
       parent: 2
     - type: DeltaPressure
@@ -146812,7 +145343,6 @@ entities:
   - uid: 23561
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-26.5
       parent: 2
     - type: DeltaPressure
@@ -146820,7 +145350,6 @@ entities:
   - uid: 23562
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-25.5
       parent: 2
     - type: DeltaPressure
@@ -146828,7 +145357,6 @@ entities:
   - uid: 23563
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-25.5
       parent: 2
     - type: DeltaPressure
@@ -146843,7 +145371,6 @@ entities:
   - uid: 23565
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-34.5
       parent: 2
     - type: DeltaPressure
@@ -146851,7 +145378,6 @@ entities:
   - uid: 23566
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-34.5
       parent: 2
     - type: DeltaPressure
@@ -146859,7 +145385,6 @@ entities:
   - uid: 23567
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-34.5
       parent: 2
     - type: DeltaPressure
@@ -146895,7 +145420,6 @@ entities:
   - uid: 23572
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-26.5
       parent: 2
     - type: DeltaPressure
@@ -146903,7 +145427,6 @@ entities:
   - uid: 23573
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-27.5
       parent: 2
     - type: DeltaPressure
@@ -146953,7 +145476,6 @@ entities:
   - uid: 23580
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-33.5
       parent: 2
     - type: DeltaPressure
@@ -146961,7 +145483,6 @@ entities:
   - uid: 23581
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,-33.5
       parent: 2
     - type: DeltaPressure
@@ -146969,7 +145490,6 @@ entities:
   - uid: 23582
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-33.5
       parent: 2
     - type: DeltaPressure
@@ -147047,7 +145567,6 @@ entities:
   - uid: 23593
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 55.5,-21.5
       parent: 2
     - type: DeltaPressure
@@ -147055,7 +145574,6 @@ entities:
   - uid: 23594
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 56.5,0.5
       parent: 2
     - type: DeltaPressure
@@ -147063,7 +145581,6 @@ entities:
   - uid: 23595
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 56.5,2.5
       parent: 2
     - type: DeltaPressure
@@ -147071,7 +145588,6 @@ entities:
   - uid: 23596
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 56.5,-0.5
       parent: 2
     - type: DeltaPressure
@@ -147121,7 +145637,6 @@ entities:
   - uid: 23603
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-30.5
       parent: 2
     - type: DeltaPressure
@@ -147129,7 +145644,6 @@ entities:
   - uid: 23604
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,-30.5
       parent: 2
     - type: DeltaPressure
@@ -147137,7 +145651,6 @@ entities:
   - uid: 23605
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-6.5
       parent: 2
     - type: DeltaPressure
@@ -147145,7 +145658,6 @@ entities:
   - uid: 23606
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-7.5
       parent: 2
     - type: DeltaPressure
@@ -147153,7 +145665,6 @@ entities:
   - uid: 23607
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -54.5,-7.5
       parent: 2
     - type: DeltaPressure
@@ -147161,7 +145672,6 @@ entities:
   - uid: 23608
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -54.5,-8.5
       parent: 2
     - type: DeltaPressure
@@ -147169,7 +145679,6 @@ entities:
   - uid: 23609
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,8.5
       parent: 2
     - type: DeltaPressure
@@ -148293,14 +146802,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 65.5,-1.5
-      parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 23754
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 64.5,-1.5
       parent: 2
     - type: DeltaPressure
       gridUid: 2


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
There's a directional window underneath one of the windoors in Botany on Lobster. This PR removes it.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Botanists would bonk into the door only to find a window blocking their way.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="844" height="626" alt="image" src="https://github.com/user-attachments/assets/39a96073-dcde-48c7-a5c2-c63b7c8d7b6b" />

fig. 1 - This is the window that was removed. You can see it's under the windoor.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- fix: (Lobster) Windoor in the north section Botany had a window accidentally placed under it
