### PR TITLE
Fix missing locale entry

### DIFF
--- a/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/en-US/interaction/interaction-popup-component.ftl
@@ -101,6 +101,11 @@ hugging-success-generic = You hug {THE($target)}.
 hugging-success-generic-others = { CAPITALIZE(THE($user)) } hugs {THE($target)}.
 hugging-success-generic-target = { CAPITALIZE(THE($user)) } hugs you.
 
+## STARLIGHT - vulpkanin
+petting-success-soft-floofy-vulp = You pet { THE($target) } on {POSS-ADJ($target)} soft floofy head.
+petting-success-soft-floofy-vulp-others = { CAPITALIZE(THE($user)) } pets {THE($target)} on {POSS-ADJ($target)} soft floofy head.
+## STARLIGHT END
+
 ## Other
 
 petting-success-tesla = You pet {THE($target)}, violating the laws of nature and physics.


### PR DESCRIPTION

## Short description
Fixes #1858 

## Why we need to add this
Re adds missing locale entry for vulpkanin petting that was lost in an upstream (as they removed the feature due to player concern)

It is worth raising the question of whether we should be reverting the change too, there was a previous dev decision made that all hugs should be standard until the interact intent or whatever system is made, but this made its way into upstream regardless

Either way this is a small fix, if decided I can also just shift this into a "remove custom interact popup" change

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.=
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- fix: Fix Vulpkanin hugging
