### PR TITLE
Sci Research Additions: Cloning Systems and Point Defense Weaponry

### DIFF
--- a/Resources/Locale/en-US/_Starlight/research/technologies.ftl
+++ b/Resources/Locale/en-US/_Starlight/research/technologies.ftl
@@ -19,3 +19,7 @@ research-technology-scan-gate = Scan Gates Technology
 
 research-technology-lawboards = AI Lawboards
 research-technology-lawboards-description = Advanced AI lawboard circuitry for programming silicon entities with various behavioral directives.
+
+research-technology-cloning = Cloning Systems
+
+research-technology-point-defense = Point Defense Weaponry

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -89,3 +89,4 @@
   - TelecomServerCircuitboard
   - SMESAdvancedMachineCircuitboard
   - HolopadMachineCircuitboard
+  - WeaponTurretPointDefenseMachineCircuitboard #Starlight

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -104,3 +104,6 @@
   - StasisBedMachineCircuitboard
   - CryoPodMachineCircuitboard
   - BiomassReclaimerMachineCircuitboard
+  - CloningConsoleComputerCircuitboard #Starlight
+  - CloningPodMachineCircuitboard #Starlight
+  - MedicalScannerMachineCircuitboard #Starlight

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/electronics.yml
@@ -52,3 +52,23 @@
   parent: BaseSilverCircuitboardRecipe
   id: DurandTargetingElectronics
   result: DurandTargetingElectronics
+
+- type: latheRecipe
+  parent: BaseSilverCircuitboardRecipe
+  id: WeaponTurretPointDefenseMachineCircuitboard
+  result: WeaponTurretPointDefenseMachineCircuitboard
+
+- type: latheRecipe
+  parent: BaseSilverCircuitboardRecipe
+  id: CloningConsoleComputerCircuitboard
+  result: CloningConsoleComputerCircuitboard
+
+- type: latheRecipe
+  parent: BaseSilverCircuitboardRecipe
+  id: CloningPodMachineCircuitboard
+  result: CloningPodMachineCircuitboard
+
+- type: latheRecipe
+  parent: BaseSilverCircuitboardRecipe
+  id: MedicalScannerMachineCircuitboard
+  result: MedicalScannerMachineCircuitboard

--- a/Resources/Prototypes/_StarLight/Research/industrial.yml
+++ b/Resources/Prototypes/_StarLight/Research/industrial.yml
@@ -62,8 +62,6 @@
   radioChannels:
   - Supply
 
-# Tier 3
-
 - type: technology
   id: PointDefenseWeaponry
   name: research-technology-point-defense
@@ -71,7 +69,7 @@
     sprite: _Starlight/Objects/Weapons/Guns/Turrets/pointdefense.rsi
     state: base
   discipline: Industrial
-  tier: 3
+  tier: 2
   cost: 10000
   recipeUnlocks:
   - WeaponTurretPointDefenseMachineCircuitboard

--- a/Resources/Prototypes/_StarLight/Research/industrial.yml
+++ b/Resources/Prototypes/_StarLight/Research/industrial.yml
@@ -61,3 +61,19 @@
   - RipleyAPLU
   radioChannels:
   - Supply
+
+# Tier 3
+
+- type: technology
+  id: PointDefenseWeaponry
+  name: research-technology-point-defense
+  icon:
+    sprite: _Starlight/Objects/Weapons/Guns/Turrets/pointdefense.rsi
+    state: base
+  discipline: Industrial
+  tier: 3
+  cost: 10000
+  recipeUnlocks:
+  - WeaponTurretPointDefenseMachineCircuitboard
+  radioChannels:
+  - Engineering

--- a/Resources/Prototypes/_StarLight/Research/medical.yml
+++ b/Resources/Prototypes/_StarLight/Research/medical.yml
@@ -223,3 +223,19 @@
   - MiniSyringe
   radioChannels:
   - Medical
+
+- type: technology
+  id: CloningSystems
+  name: research-technology-cloning
+  icon:
+    sprite: Structures/Machines/cloning.rsi
+    state: pod_0
+  discipline: Biochemical
+  tier: 3
+  cost: 25000
+  recipeUnlocks:
+  - CloningConsoleComputerCircuitboard 
+  - CloningPodMachineCircuitboard 
+  - MedicalScannerMachineCircuitboard
+  radioChannels:
+  - Medical


### PR DESCRIPTION
## Short description
Adds 2 new Science Researches: Cloning Systems and Point Defense Weaponry

## Why we need to add this
**Cloning Systems:** (Tier 3, 25000 points) Cloning has always existed but has been kept functionally unobtainable by being locked behind RNG with Salvage Loot. Adding it as an extremely expensive Tier 3 Research allows it to see more use by removing the RNG element, but keeps it rare by making it expensive. In theory, it should only be worth the cost on very calm and long shifts, or shifts that have a real _need_ for cloning (Zombie rounds where Zombies got rolled early and Evac/CBURN isn't needed).

It has been discussed, and agreed on repeatedly for the last 10 months, that it should be made an unlock, but nobody ever actually did it. We have Teach a Lesson (kill once) and Prevent from Reaching CentComm objectives for antagonists, which means that this shouldn't affect antag gameplay much either. If you only need to kill them once, there is no impact, and if you need them to stay dead then gibbing or throwing them into space is already the only real safe way to ensure that. Rot also makes cloning less likely to work.


**Point Defense Weaponry:** (Tier 2, 10000 points) Gamemodes with frequent Meteor Events have always been frustrating for players, especially Engineers. They cause a mass amount of spacing (Arrivals and spacing, two great tastes that taste great together), often loose the Tesla or Singularity. Part of why I think it is so frustrating is due to there being no current counterplay for it. You can add layers of extra walls in some areas like the engine, but short of replacing every exterior window on the station with a wall you can't do much for 99% of the station.

Making this an unlock that Engineers can print boards for to set up turrets in sensitive areas gives them a way that still requires work and for them to do their jobs, but in a more productive way. They can fix the issue more long-term instead of just pushing it back perpetually.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added 'Cloning Systems' as a Tier 3 Medical Research for 25000 points. Grants the station access to the Cloning Console, Cloning Pod, and Medical Scanner boards more consistently rather than relying on RNG, but makes it still very expensive. Allows for revival of Zombified Crew on rounds where Zombies wipe early and CBURN/EVAC isn't needed.
- add: Added 'Point Defense Weaponry' as a Tier 2 Industrial Research for 10000 points. Grants the station access to Point Defense Batteries, which can be built in sensitive areas (outside Tesla/Singulo, Bridge, Arrivals, Evac) to automatically shoot down meteors. Gives Engineers counterplay to meteors that still requires them to engage with their job.
