### PR TITLE
faster skates and stam damage

### DIFF
--- a/Content.Shared/_Starlight/Clothing/AddTagsOnClothingEquipComponent.cs
+++ b/Content.Shared/_Starlight/Clothing/AddTagsOnClothingEquipComponent.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Tag;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Clothing.Components;
+
+/// <summary>
+/// Adds the given tags when the item is equipped.
+/// Will remove the tags (if they didn't already exist) when the clothing is removed.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class AddTagsOnClothingEquipComponent : Component
+{
+    /// <summary>
+    /// A list of tags to add to the entity that equips clothing with this component
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<ProtoId<TagPrototype>> TagsToAdd = [];
+
+    /// <summary>
+    /// If true, will remove all the tags that were added when the item was equipped.
+    /// If false, will not remove any tags when the clothing is unequipped.
+    /// </summary>
+    [DataField]
+    public bool RemoveTagsOnUnequip = true;
+
+    /// <summary>
+    /// Tags that were added to the equipped entity. These will be removed when the clothing is unequipped.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<ProtoId<TagPrototype>> AddedTags = [];
+}

--- a/Content.Shared/_Starlight/Clothing/AddTagsOnClothingEquipSystem.cs
+++ b/Content.Shared/_Starlight/Clothing/AddTagsOnClothingEquipSystem.cs
@@ -1,0 +1,41 @@
+using Content.Shared.Clothing.Components;
+using Content.Shared.Tag;
+
+namespace Content.Shared.Clothing.EntitySystems;
+
+public sealed class AddTagsOnClothingEquipSystem : EntitySystem
+{
+    [Dependency] private readonly TagSystem _tag = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AddTagsOnClothingEquipComponent, ClothingGotEquippedEvent>(OnClothingEquip);
+        SubscribeLocalEvent<AddTagsOnClothingEquipComponent, ClothingGotUnequippedEvent>(OnClothingUnequip);
+    }
+    
+    private void OnClothingEquip(Entity<AddTagsOnClothingEquipComponent> ent, ref ClothingGotEquippedEvent args)
+    {
+        // This is not perfect, if the tag already exists but is temporary this will skip it.
+        foreach (var tag in ent.Comp.TagsToAdd)
+        {
+            if (_tag.AddTag(args.Wearer, tag))
+                ent.Comp.AddedTags.Add(tag);
+        }
+
+        Dirty(ent);
+    }
+    
+    private void OnClothingUnequip(Entity<AddTagsOnClothingEquipComponent> ent, ref ClothingGotUnequippedEvent args)
+    {
+        if (ent.Comp.AddedTags.Count == 0 || !ent.Comp.RemoveTagsOnUnequip)
+            return;
+
+        // Remove all added tags - just assume they are all still there. If not then too bad!
+        _tag.RemoveTags(args.Wearer, ent.Comp.AddedTags);
+        ent.Comp.AddedTags.Clear();
+
+        Dirty(ent);
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -282,14 +282,14 @@
   - type: Item
     sprite: Clothing/Shoes/Specific/skates.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.5
-    sprintModifier: 1.5
+    walkModifier: 1.5 #starlight
+    sprintModifier: 1.5 #starlight
   - type: Skates
   - type: FootstepModifier
     footstepSoundCollection:
       collection: FootstepSkates
       params:
         variation: 0.08
-  - type: AddTagsOnClothingEquip
+  - type: AddTagsOnClothingEquip #starlight
     tagsToAdd:
       - Skating

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -282,11 +282,15 @@
   - type: Item
     sprite: Clothing/Shoes/Specific/skates.rsi
   - type: ClothingSpeedModifier
-    walkModifier: 1.1
-    sprintModifier: 1.1
+    walkModifier: 1.5
+    sprintModifier: 1.5
   - type: Skates
   - type: FootstepModifier
     footstepSoundCollection:
       collection: FootstepSkates
       params:
         variation: 0.08
+  - type: AddTagsOnClothingEquip
+    tagsToAdd:
+      - Skating
+    removeOnUnequip: true

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -293,4 +293,3 @@
   - type: AddTagsOnClothingEquip
     tagsToAdd:
       - Skating
-    removeOnUnequip: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -12,6 +12,9 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
+      Skating:
+        knockback: 0.5
+        staminaMultiplier: 100
       Resomi:
         knockback: 0.01
         staminaMultiplier: 100

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -12,6 +12,9 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
+      Skating:
+        knockback: 0.5
+        staminaMultiplier: 100
       Resomi:
         knockback: 0.02
         staminaMultiplier: 100

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -12,6 +12,9 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
+      Skating:
+        knockback: 5
+        staminaMultiplier: 20
       Resomi:
         knockback: 10
         staminaMultiplier: 8
@@ -128,6 +131,8 @@
   components:
   - type: KnockbackByUserTag
     doestContain:
+      Skating:
+        knockback: -2.5
       Resomi:
         knockback: -5
       Felionoid:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -12,6 +12,9 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
+      Skating:
+        knockback: 1.0
+        staminaMultiplier: 100
       Resomi:
         knockback: 0.1
       Avali:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -12,6 +12,9 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
+      Skating:
+        knockback: 2
+        staminaMultiplier: 50
       Resomi:
         knockback: 3
         staminaMultiplier: 20

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -12,6 +12,9 @@
     - abductor-gun-restricted-1
   - type: KnockbackByUserTag
     doestContain:
+      Skating:
+        knockback: 2.0
+        staminaMultiplier: 50
       Resomi:
         knockback: 4
         staminaMultiplier: 15

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -21,6 +21,9 @@
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
   - type: KnockbackByUserTag
     doestContain:
+      Skating:
+        knockback: 1.0
+        staminaMultiplier: 100
       Resomi:
         knockback: 1.5
       Felionoid:

--- a/Resources/Prototypes/_StarLight/tags.yml
+++ b/Resources/Prototypes/_StarLight/tags.yml
@@ -172,6 +172,9 @@
   id: ShowWires
 
 - type: Tag
+  id: Skating
+  
+- type: Tag
   id: SovietDungeon
 
 - type: Tag


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
roller skates are rarely used. the 1.1 mod to movement speed is nothing compared to the amount of damage you take from them. with these changes, the crew can slam their faces into walls much faster while hopefully giving more reason to use them if you're good enough, and while not impacting combat balance (hopefully).

## Why we need to add this
make skates awesome 

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/28633a8a-d4b0-431e-8b1a-379e811cb699

## Checks

<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: OrksAreDaBest, Gensy, Happyrobot33
- tweak: roller skates are now much faster
- tweak: firing weapons while skating now deals knockback and stamina damage
- fix: Knockback system now adds all knockback sources together
