### PR TITLE
Add wrecks to pool of Kessler objects

### DIFF
--- a/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
+++ b/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
@@ -1,0 +1,40 @@
+﻿using Content.Server.StationEvents.Events;
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(WreckSwarmSystem)), AutoGenerateComponentPause]
+public sealed partial class WreckSwarmComponent : Component
+{
+    [DataField]
+    public float Velocity = 20f;
+
+    /// <summary>
+    /// The announcement played when a meteor swarm begins.
+    /// </summary>
+    [DataField]
+    public LocId? Announcement = "station-event-incoming-wreck-announcement";
+
+    [DataField]
+    public SoundSpecifier? AnnouncementSound = new SoundPathSpecifier("/Audio/Announcements/meteors.ogg")
+    {
+        Params = new()
+        {
+            Volume = -4
+        }
+    };
+
+    /// <summary>
+    /// The size of wreck this should select from, mapping to <see cref="SalvageMapPrototype.SizeString"/>.
+    /// </summary>
+    [DataField]
+    public LocId? SizeFilter;
+
+    /// <summary>
+    /// The fixed grid that should be spawned in this case; overrides SizeFilter-based selection.
+    /// </summary>
+    [DataField]
+    public ResPath? FixedGrid;
+}

--- a/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
+++ b/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
@@ -1,0 +1,144 @@
+using System.Numerics;
+using System.Linq;
+using Content.Server.Chat.Systems;
+using Content.Server.GameTicking.Rules;
+using Content.Server.Station.Systems;
+using Content.Server.StationEvents.Components;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Random.Helpers;
+using Content.Shared.Salvage;
+using Robust.Server.Audio;
+using Robust.Shared.Audio;
+using Robust.Shared.EntitySerialization.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Utility;
+
+namespace Content.Server.StationEvents.Events;
+
+public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent>
+{
+    private readonly List<SalvageMapPrototype> _salvageMaps = new();
+
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly StationSystem _station = default!;
+    [Dependency] private readonly MapLoaderSystem _loader = default!;
+    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    protected override void Added(EntityUid uid, WreckSwarmComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    {
+        base.Added(uid, component, gameRule, args);
+    }
+
+    protected override void ActiveTick(EntityUid uid, WreckSwarmComponent component, GameRuleComponent gameRule, float frameTime)
+    {
+        if (_station.GetStations().Count == 0)
+        {
+            ForceEndSelf(uid, gameRule);
+            return;
+        }
+
+        var station = RobustRandom.Pick(_station.GetStations());
+        if (_station.GetLargestGrid(station) is not { } grid)
+        {
+            ForceEndSelf(uid, gameRule);
+            return;
+        }
+
+        var mapId = Transform(grid).MapID;
+        var playableArea = _physics.GetWorldAABB(grid);
+
+        var minimumDistance = (playableArea.TopRight - playableArea.Center).Length() + 50f;
+        var maximumDistance = minimumDistance + 100f;
+
+        var center = playableArea.Center;
+
+        var mapResource = SelectGrid(component);
+
+        var angle = RobustRandom.NextAngle();
+        var spawnAngle = RobustRandom.NextAngle();
+
+        var offset = angle.RotateVec(new Vector2((maximumDistance - minimumDistance) * RobustRandom.NextFloat() + minimumDistance, 0));
+
+        var spawnPosition = new MapCoordinates(center + offset, mapId);
+
+        var wreckMap = _mapSystem.CreateMap();
+        var wreckMapXform = Transform(wreckMap);
+        if (
+                !_loader.TryLoadGrid(wreckMapXform.MapID, mapResource, out _)
+                || wreckMapXform.ChildCount == 0
+                || !_mapSystem.TryGetMap(spawnPosition.MapId, out var spawnUid)
+           )
+        {
+            // We couldn't load it, or it loaded empty - blame it on CC
+            Announce(Loc.GetString("station-event-incoming-wreck-swarm-spawn-failed"), null);
+
+            _mapSystem.DeleteMap(wreckMapXform.MapID);
+
+            // Don't try to re-run
+            ForceEndSelf(uid, gameRule);
+            return;
+        }
+
+        var mapChildren = wreckMapXform.ChildEnumerator;
+
+        // It worked, move it into position and cleanup values.
+        while (mapChildren.MoveNext(out var mapChild))
+        {
+            var wreckXForm = Comp<TransformComponent>(mapChild);
+            var localPos = wreckXForm.LocalPosition;
+
+            _transform.SetParent(mapChild, wreckXForm, spawnUid.Value);
+            _transform.SetWorldPositionRotation(mapChild, spawnPosition.Position + localPos, spawnAngle, wreckXForm);
+
+            // We're using SetLinearVelocity because the map spawns in as if it's already moving
+            var physics = Comp<PhysicsComponent>(mapChild);
+            _physics.SetLinearVelocity(mapChild, -offset.Normalized() * component.Velocity, body: physics);
+        }
+
+        _mapSystem.DeleteMap(wreckMapXform.MapID);
+
+        if (component.Announcement is { } locId)
+            Announce(Loc.GetString(locId), component.AnnouncementSound);
+
+        // Done processing, don't recur on next tick
+        ForceEndSelf(uid, gameRule);
+    }
+
+    protected ResPath SelectGrid(WreckSwarmComponent component) {
+        if (component.FixedGrid is not null) {
+            return (ResPath)component.FixedGrid;
+        } else {
+            // Salvage map seed
+            _salvageMaps.Clear();
+            if (component.SizeFilter is not null) {
+                _salvageMaps.AddRange(_proto.EnumeratePrototypes<SalvageMapPrototype>().Where((x) => x.SizeString.CompareTo((LocId)(component.SizeFilter)) == 0));
+            } else {
+                _salvageMaps.AddRange(_proto.EnumeratePrototypes<SalvageMapPrototype>());
+            }
+            _salvageMaps.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
+            var map = RobustRandom.Pick(_salvageMaps);
+
+            return map.MapPath;
+        }
+    }
+
+    protected void Announce(string announcement, SoundSpecifier? sound) {
+        // Let the players know (but we don't want to send to players who aren't in game (i.e. in the lobby))
+        Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
+
+        _chat.DispatchFilteredAnnouncement(allPlayersInGame, announcement, playSound: false, colorOverride: Color.Gold);
+
+        if (sound is not null) {
+            _audio.PlayGlobal(sound, allPlayersInGame, true);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Starlight/station-events/events/wreck-swarm.ftl
+++ b/Resources/Locale/en-US/_Starlight/station-events/events/wreck-swarm.ftl
@@ -1,0 +1,5 @@
+﻿station-event-incoming-wreck-swarm-spawn-failed = The station was about to collide with a wreck, but it was interesting enough that we bluespaced it to loot ourselves at CentCom.
+
+station-event-incoming-wreck-announcement = The station is colliding with a wreck moving at significant speed. Please inform engineering of any damage.
+station-event-incoming-wreck-large-announcement = The station is colliding with a large wreck moving at significant speed. Please panic appropriately.
+station-event-incoming-wreck-barratry-announcement = The megawreck Barratry is on a collision course with the station. Please panic inappropriately.

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -38,6 +38,8 @@
     - id: GameRulePotatoSwarm
     - id: GameRuleFunSwarm
     - id: ImmovableRodSpawn
+    - !type:NestedSelector # Starlight-edit: Kessler Wrecks
+        tableId: WreckSwarmEventsTable # Starlight-edit: Kessler Wrecks
 
 - type: weightedRandomEntity
   id: MeteorSpawnAsteroidWallTable

--- a/Resources/Prototypes/_StarLight/GameRules/wreckswarms.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/wreckswarms.yml
@@ -1,0 +1,56 @@
+# Event Tables
+
+- type: entityTable
+  id: WreckSwarmEventsTable
+  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+    children:
+    - id: GameRuleSmallWreckSwarmSpawn
+    - id: GameRuleMediumWreckSwarmSpawn
+    - id: GameRuleLargeWreckSwarmSpawn
+
+- type: entity
+  parent: BaseGameRule
+  id: GameRuleWreckSwarmSpawn
+  abstract: true
+  components:
+  - type: GameRule
+  - type: StationEvent
+    reoccurrenceDelay: 1
+    earliestStart: 12
+    minimumPlayers: 25
+  - type: WreckSwarm
+
+- type: entity
+  parent: GameRuleWreckSwarmSpawn
+  id: GameRuleSmallWreckSwarmSpawn
+  components:
+  - type: StationEvent
+    weight: 20
+    earliestStart: 5
+    minimumPlayers: 10
+  - type: WreckSwarm
+    sizeFilter: salvage-map-wreck-size-small
+
+- type: entity
+  parent: GameRuleWreckSwarmSpawn
+  id: GameRuleMediumWreckSwarmSpawn
+  components:
+  - type: StationEvent
+    weight: 20
+    earliestStart: 15
+    minimumPlayers: 30
+  - type: WreckSwarm
+    sizeFilter: salvage-map-wreck-size-medium
+
+- type: entity
+  parent: GameRuleWreckSwarmSpawn
+  id: GameRuleLargeWreckSwarmSpawn
+  components:
+  - type: StationEvent
+    weight: 10
+    earliestStart: 30
+    minimumPlayers: 50
+  - type: WreckSwarm
+    announcement: station-event-incoming-wreck-large-announcement
+    announcementSound: /Audio/Announcements/attention.ogg
+    sizeFilter: salvage-map-wreck-size-large


### PR DESCRIPTION
## Short description
This slightly increases the variety of objects that can get thrown at the station in the Kessler game mode by adding salvage wrecks to the pool.

## Why we need to add this
Right now there's not a ton of variety in the impacts caused by Kessler-mode meteor impacts (modulo the humorous ones); by adding salvage wrecks, we improve the variety, add some more complexity (as mobs and artifacts can spawn on these wrecks), and improve the rewards for dealing with it well (as loot and artifacts can spawn on these wrecks).

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/23b6e88f-d493-45a2-a0e5-71f9ce518be9



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Penguinwizzard
- add: Added some more variety to Kessler
