### PR TITLE
Update custom organ description for StarLight species

### DIFF
--- a/Resources/Prototypes/Body/Organs/resomi.yml
+++ b/Resources/Prototypes/Body/Organs/resomi.yml
@@ -2,6 +2,7 @@
   id: OrganResomiEyes
   parent: OrganHumanEyes
   name: eyes
+  suffix: Resomi
   description: "Resomi eyes have great nightvision for hunting prey in maintenance tunnels."
   components:
   - type: FunctionalOrgan
@@ -13,7 +14,7 @@
 - type: entity # Starlight
   id: OrganResomiHeart
   parent: OrganHumanHeart
-  categories: [ HideSpawnMenu ]
+  suffix: Resomi
   description: "The heart of a resomi."
   components:
   - type: Metabolizer

--- a/Resources/Prototypes/Body/Organs/resomi.yml
+++ b/Resources/Prototypes/Body/Organs/resomi.yml
@@ -1,8 +1,8 @@
 - type: entity
   id: OrganResomiEyes
   parent: OrganHumanEyes
-  name: eye
-  description: "I see you!"
+  name: eyes
+  description: "Resomi eyes have great nightvision for hunting prey in maintenance tunnels."
   components:
   - type: FunctionalOrgan
     comps: 
@@ -14,6 +14,7 @@
   id: OrganResomiHeart
   parent: OrganHumanHeart
   categories: [ HideSpawnMenu ]
+  description: "The heart of a resomi."
   components:
   - type: Metabolizer
     maxReagents: 2

--- a/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
@@ -1,8 +1,8 @@
 - type: entity
   id: OrganAvaliStomach
   parent: OrganAnimalStomach
-  categories: [ HideSpawnMenu ]
-  description: "The stomach of an avali, on closer inspection, actually consists of two stomachs." 
+  suffix: Avali
+  description: "The stomach of an avali, on closer inspection, actually consists of two stomachs."
   components:
   - type: Stomach
     specialDigestible:
@@ -25,7 +25,7 @@
 - type: entity
   id: OrganAvaliHeart
   parent: OrganHumanHeart
-  categories: [ HideSpawnMenu ]
+  suffix: Avali
   description: "The heart of an avali."
   components:
   - type: Metabolizer
@@ -39,6 +39,7 @@
 - type: entity
   id: OrganAvaliLiver
   parent: OrganHumanLiver
+  suffix: Avali
   categories: [ HideSpawnMenu ]
   components:
   - type: Metabolizer # The liver metabolizes certain chemicals only, like alcohol.
@@ -52,11 +53,13 @@
 - type: entity
   id: OrganAvaliKidneys
   parent: OrganHumanKidneys
+  suffix: Avali
   categories: [ HideSpawnMenu ]
 #Placeholder until sprited
 
 - type: entity
   id: OrganAvaliLungs
   parent: OrganHumanLungs
+  suffix: Avali
   categories: [ HideSpawnMenu ]
 #Placeholder until sprited

--- a/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/avali.yml
@@ -2,6 +2,7 @@
   id: OrganAvaliStomach
   parent: OrganAnimalStomach
   categories: [ HideSpawnMenu ]
+  description: "The stomach of an avali, on closer inspection, actually consists of two stomachs." 
   components:
   - type: Stomach
     specialDigestible:
@@ -25,6 +26,7 @@
   id: OrganAvaliHeart
   parent: OrganHumanHeart
   categories: [ HideSpawnMenu ]
+  description: "The heart of an avali."
   components:
   - type: Metabolizer
     maxReagents: 2

--- a/Resources/Prototypes/_StarLight/Body/Organs/cyclorite.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/cyclorite.yml
@@ -30,6 +30,7 @@
 - type: entity
   id: BaseCycloriteOrgan
   parent: BaseCycloriteOrganUnGibbable
+  suffix: Cyclorite
   abstract: true
   components:
   - type: Gibbable

--- a/Resources/Prototypes/_StarLight/Body/Organs/cyclorite.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/cyclorite.yml
@@ -47,7 +47,7 @@
   id: OrganCycloriteEye
   parent: [BaseCycloriteOrgan, BaseOrganEyes]
   name: eye
-  description: "I see you!"
+  description: "Cyclorites see the world slightly differently."
   components:
   - type: Sprite
     layers:
@@ -82,7 +82,7 @@
   id: OrganCycloriteLungs
   parent: [BaseCycloriteOrgan, BaseOrganLungs]
   name: lungs
-  description: "Filters oxygen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier."
+  description: "Cyclorite lungs filter nitrogen from the atmosphere to breathe."
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_StarLight/Body/Organs/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/shadekin.yml
@@ -1,6 +1,7 @@
 - type: entity
   id: OrganShadekinBrain
   parent: OrganHumanBrain
+  description: "The source of incredible, unending intelligence. Mar."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi
@@ -9,6 +10,7 @@
 - type: entity
   id: OrganShadekinEyes
   parent: OrganHumanEyes
+  description: "Eyes of a BlackEye shadekin that can never see their home reality again."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi

--- a/Resources/Prototypes/_StarLight/Body/Organs/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/shadekin.yml
@@ -10,6 +10,7 @@
 - type: entity
   id: OrganShadekinEyes
   parent: OrganHumanEyes
+  suffix: Shadekin
   description: "Eyes of a BlackEye shadekin that can never see their home reality again."
   components:
   - type: Sprite
@@ -26,6 +27,7 @@
 - type: entity
   id: OrganShadekinTongue
   parent: OrganHumanTongue
+  suffix: Shadekin
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi
@@ -35,6 +37,7 @@
 - type: entity
   id: OrganShadekinAppendix
   parent: OrganHumanAppendix
+  suffix: Shadekin
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi
@@ -45,6 +48,7 @@
 - type: entity
   id: OrganShadekinHeart
   parent: OrganHumanHeart
+  suffix: Shadekin
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi
@@ -53,6 +57,7 @@
 - type: entity
   id: OrganShadekinStomach
   parent: OrganHumanStomach
+  suffix: Shadekin
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi
@@ -70,6 +75,7 @@
 - type: entity
   id: OrganShadekinLiver
   parent: OrganHumanLiver
+  suffix: Shadekin
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi
@@ -78,6 +84,7 @@
 - type: entity
   id: OrganShadekinKidneys
   parent: OrganHumanKidneys
+  suffix: Shadekin
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi


### PR DESCRIPTION
## Short description
Updates the description / examine text of several organs for species that are not upstream.

Also adds suffixes to these organs to make them easier to find for admins in the entity spawner, and unhides some of these from the entity spawner.

## Why we need to add this
Makes it easier to distinguish organs, some with quirks, for a few species.

It is important to be able to identify Avali and Resomi hearts since these have Dexalin and Saline as a poison. In addition, the Cyclorite lungs incorrectly identified Oxygen instead of Nitrogen as the breathable gas.

## Media (Video/Screenshots)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/40aa30a1-5c91-4607-82ec-d92d62f9a676" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8c32c573-6686-4243-a7cb-1f2bff9cb6ba" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.