### PR TITLE
Adds LMG tag to ERT hardsuits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1009,6 +1009,10 @@
     staminaModifier: 0.1
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTLeader
+  - type: Tag
+    tags:
+    - Hardsuit
+    - RequiredForLmgTag # Starlight
 
 #ERT Chaplain Hardsuit
 - type: entity
@@ -1071,6 +1075,7 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
+    - RequiredForLmgTag # Starlight
 
 #ERT Janitor Hardsuit
 - type: entity
@@ -1125,6 +1130,10 @@
     walkModifier: 1.0
     sprintModifier: 1.0
   - type: HeldSpeedModifier
+  - type: Tag
+    tags:
+    - Hardsuit
+    - RequiredForLmgTag # Starlight
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes the ERT hardsuits by allowing them to use the LMG (adds tag `RequiredForLmgTag`)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The LMG is mapped in ERT shuttles. However their hardsuits cannot actually use it.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- fix: ERT can now properly use the LMG.