### PR TITLE
Force the L6 SAW to require either a Syndicate hardsuit or the Experimental Security Hardsuit.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -670,6 +670,7 @@
     - WhitelistChameleon
     - CorgiWearable
     - ScurretWearable
+    - RequiredForL6Tag # Starlight
   - type: StaticPrice
     price: 5000
 
@@ -692,6 +693,7 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
+    - RequiredForL6Tag # Starlight
 
 #Syndicate Elite Hardsuit
 - type: entity
@@ -741,6 +743,7 @@
     - CorgiWearable
     - Hardsuit
     - WhitelistChameleon
+    - RequiredForL6Tag # Starlight
 
 #Syndicate Commander Hardsuit
 - type: entity
@@ -783,6 +786,7 @@
     - CorgiWearable
     - Hardsuit
     - WhitelistChameleon
+    - RequiredForL6Tag # Starlight
 
 
 #Cybersun Juggernaut Hardsuit
@@ -838,6 +842,7 @@
     - Hardsuit
     - WhitelistChameleon
     - RequiredForLmgTag #Starlight
+    - RequiredForL6Tag # Starlight
 
 #Wizard Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -78,7 +78,7 @@
   - type: UseDelay
     delay: 1
   - type: RestrictByEquippedTag # Starlight start
-    requiredTag: "RequiredForLmgTag"
+    requiredTag: "RequiredForL6Tag"
     denialMessage: "lmg-restricted-to-hardsuit-message" # Starlight end
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -77,6 +77,9 @@
     price: 500
   - type: UseDelay
     delay: 1
+  - type: RestrictByEquippedTag # Starlight start
+    requiredTag: "RequiredForLmgTag"
+    denialMessage: "lmg-restricted-to-hardsuit-message" # Starlight end
 
 - type: entity
   name: L6 SAW

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -106,7 +106,7 @@
   parent: [ ClothingOuterHardsuitBase, BaseSalvageContraband ]
   id: ClothingOuterHardsuitMercenary
   name: mercenary hardsuit
-  description: It's a hardsuit. It could stop a bullet. It's sealed with top of the line duct tape. 
+  description: It's a hardsuit. It could stop a bullet. It's sealed with top of the line duct tape.
   components:
     - type: Sprite
       sprite: _Starlight/Clothing/OuterClothing/Hardsuits/mercenary.rsi
@@ -253,8 +253,8 @@
             - PowerCell
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitInfiltration
-    
-    
+
+
 #CCNT Consortium medics
 - type: entity
   parent: [ BaseCentcommContraband, ClothingOuterHardsuitSyndieMedic ] #sl Change
@@ -412,6 +412,7 @@
   - type: Tag
     tags:
       - RequiredForLmgTag
+      - RequiredForL6Tag
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityExperimental
 

--- a/Resources/Prototypes/_StarLight/tags.yml
+++ b/Resources/Prototypes/_StarLight/tags.yml
@@ -50,7 +50,7 @@
 
 - type: Tag
   id: ClownKudzu
-  
+
 - type: Tag
   id: CyberHandItem
 
@@ -152,6 +152,9 @@
 
 - type: Tag
   id: PrototypeVibroblade
+
+- type: Tag
+  id: RequiredForL6Tag
 
 - type: Tag
   id: RequiredForLmgTag


### PR DESCRIPTION

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
See title.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
So that John Nukeop can't get disarmed by Dave Cadet and have their gun stolen.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- add: The L6 SAW now requires a Syndicate or Experimental Security hardsuit to use.
