### PR TITLE
Ploop! fixes and improvements.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/grenade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/grenade.yml
@@ -12,7 +12,7 @@
     whitelist:
       tags:
         - Grenade
-    capacity: 5
+    capacity: 6 # starlight change: 5 -> 6 to fit the hydra
     soundRack:
       path: /Audio/Weapons/Guns/Bolt/lmg_bolt_closed.ogg
       params:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -916,7 +916,11 @@
   - type: EmitSoundOnTrigger
     sound: /Audio/Items/smoke_grenade_smoke.ogg
     positional: true
-  # - type: ExplodeOnTrigger # Starlight start
+  - type: Projectile # Starlight start
+    damage:
+      types:
+        Blunt: 0 # Cleanades shouldn't do damage
+  # - type: ExplodeOnTrigger
   # - type: Explosive
   #   explosionType: Default
   #   totalIntensity: 0.01 # a little pop

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -906,8 +906,8 @@
     layers:
     - state: cleanade
   - type: SmokeOnTrigger
-    duration: 3.5
-    spreadAmount: 30
+    duration: 6
+    spreadAmount: 45
     smokePrototype: Foam
     solution:
       reagents:
@@ -916,13 +916,13 @@
   - type: EmitSoundOnTrigger
     sound: /Audio/Items/smoke_grenade_smoke.ogg
     positional: true
-  - type: ExplodeOnTrigger
-  - type: Explosive
-    explosionType: Default
-    totalIntensity: 0.01 # a little pop
-    intensitySlope: 1
-    maxIntensity: 0.01
-    tileBreakScale: 0.01
+  # - type: ExplodeOnTrigger # Starlight start
+  # - type: Explosive
+  #   explosionType: Default
+  #   totalIntensity: 0.01 # a little pop
+  #   intensitySlope: 1
+  #   maxIntensity: 0.01
+  #   tileBreakScale: 0.01 # Starlight end
 
 - type: entity
   id: BulletGrenadeEMP
@@ -1277,7 +1277,7 @@
     damage:
       types:
         Heat: 20
-        
+
 - type: entity
   name: destroying bolt
   id: BulletLaserDestroy

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -196,10 +196,6 @@
   name: evil cleanade grenade round
   categories: [ HideSpawnMenu ]
   components:
-  - type: Sprite
-    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
-    layers:
-    - state: cleanade
   - type: SmokeOnTrigger
     duration: 6
     spreadAmount: 45
@@ -208,13 +204,3 @@
       reagents:
       - ReagentId: SyndicateSpaceCleaner
         Quantity: 30
-  - type: EmitSoundOnTrigger
-    sound: /Audio/Items/smoke_grenade_smoke.ogg
-    positional: true
-  - type: ExplodeOnTrigger
-  - type: Explosive
-    explosionType: Default
-    totalIntensity: 0.01 # a little pop
-    intensitySlope: 1
-    maxIntensity: 0.01
-    tileBreakScale: 0.01


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
After testing #1893 on Delta, a few issues have come to mind:

- Default cleanade rounds do not last as long as I'd like. Syndicate ones were fine, though.
- Cleanade rounds inherited BaseBulletTrigger's 7 blunt on hit. This has been removed.
- Both types explode slightly, which should be removed for parity with normal cleanades.
- I forgot to update the actual ammo container for the grenade magazines. Whoops.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix, and a mild improvement to cleanade grenades (not the throwable ones).

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- fix: Grenade magazines now *actually* have six rounds.
- tweak: Cleanade rounds no longer explode.
- tweak: Cleanade rounds now last slightly longer.
- tweak: Cleanade rounds no longer hurt you.