### PR TITLE
ore bags can transfer contents to ore boxes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -58,6 +58,11 @@
     whitelist:
       tags:
       - Ore
+  - type: MaterialStorage # Starlight
+    ignoreColor: true
+    whitelist:
+      tags:
+        - Ore
   - type: UserInterface
     interfaces:
       enum.StorageUiKey.Key:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
extending #1936, allowing ore boxes to do this too

## Why we need to add this
QOL

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- add: Ore bags can now right-click "Transfer Contents" onto ore boxes for rapid transfer of ores