### PR TITLE
Fixes jumpskirt time requirements

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -79,6 +79,11 @@
     jumpsuit: ClothingUniformJumpsuitMedicalDoctor
 
 - type: loadout
+  id: MedicalDoctorJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtMedicalDoctor
+
+- type: loadout
   id: SeniorPhysicianJumpsuit
   effects:
   - !type:GroupLoadoutEffect

--- a/Resources/Prototypes/Loadouts/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Wildcards/reporter.yml
@@ -5,6 +5,6 @@
     jumpsuit: ClothingUniformJumpsuitReporter
 
 - type: loadout
-  id: JournalistJumpsuit
+  id: ReporterJumpskirt
   equipment:
-    jumpsuit: ClothingUniformJumpsuitJournalist
+    jumpsuit: ClothingUniformJumpskirtReporter

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1599,8 +1599,8 @@
   name: loadout-group-reporter-jumpsuit
   loadouts:
   - ReporterJumpsuit
-  - JournalistJumpsuit
   - ReporterJumpskirt
+  - JournalistJumpsuit
   - JournalistJumpskirt
 
 - type: loadoutGroup

--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -29,11 +29,3 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorPhysician
-
-- type: loadout
-  id: MedicalDoctorJumpskirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtMedicalDoctor
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorPhysician

--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/Wildcards/reporter.yml
@@ -7,11 +7,11 @@
       role: JobReporter
       time: 216000 #60 hrs
 
-# Jumpskirt
+# Journalist
 - type: loadout
-  id: ReporterJumpskirt
+  id: JournalistJumpsuit
   equipment:
-    jumpsuit: ClothingUniformJumpskirtReporter
+    jumpsuit: ClothingUniformJumpsuitJournalist
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorReporter


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Closes #1955 

Both of Reporter's skirts were locked behind 60 hours of playtime (seniority).
This shouldn't be the case, all other roles have a skirts available from the get-go without a playtime requirement.
<img width="881" height="300" alt="image" src="https://github.com/user-attachments/assets/9e3a2216-83a0-4493-9d78-859d07f7bbb6" />

Also, the Medical Doctor jumpskirt erroneously requires 60 hours of playtime as well.
This affects Surgeon in addition to Medical Doctor.
<img width="1012" height="229" alt="image" src="https://github.com/user-attachments/assets/cc9c9df8-3fa2-47a9-a972-fa77a296e77f" />



## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Consistency with all other roles. Let the people have their skirts.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="1003" height="354" alt="image" src="https://github.com/user-attachments/assets/e64ab5af-809c-4864-af7a-3b87fc4dde7c" />

fig. 1 - The "journalist" variants of the reporter clothes are now locked behind seniority, rather than both skirts.

<img width="1005" height="331" alt="image" src="https://github.com/user-attachments/assets/c69e6034-c2bd-4fad-a311-87e75c0e1d69" />

fig. 2 - The Medical Doctor's jumpskirt is no longer locked behind seniority. The "senior physician" items still are, as intended.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- tweak: Reporter's "Journalist Suit" is now locked behind seniority playtime (60h)
- fix: Reporter's "Reporter Jumpskirt" is no longer locked behind seniority playtime
- fix: Medical Doctor & Surgeon's "Medical Doctor Jumpskirt" is no longer locked behind seniority playtime