### PR TITLE
Allow removal of reagents from automenders to avoid bricking them

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/mender.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/mender.yml
@@ -20,6 +20,10 @@
         maxVol: 35
   - type: RefillableSolution
     solution: injector
+  - type: DrawableSolution
+    solution: injector
+  - type: DrainableSolution
+    solution: injector
   - type: Appearance
   - type: SolutionContainerVisuals
     maxFillLevels: 3


### PR DESCRIPTION
## Short description
Allowed automenders to have their reagents removed.

## Why we need to add this
If you add the incorrect reagent to an automender, it bricks it. It says 'not enough reagent' to work, you cannot add new reagent, and removing it isn't possible either. This allows the removal of the incorrect reagents, preventing the behavior.

This is particularly bad for bots with the advanced chem module: They cannot drop or replace the automenders. Once bricked, only replacing the entire module (not putting it out and back in) helps.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: aneyeforsecrets
- tweak: Automenders can now have their reagents removed.
