### PR TITLE
Self surgery

### DIFF
--- a/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.cs
@@ -101,7 +101,7 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
             _ui.IsUiOpen(user, SurgeryUIKey.Key, user) ||
             !HasComp<SurgeryTargetComponent>(args.Target)) return;
 
-        if (user == args.Target)
+        if (user == args.Target && !HasComp<CanPerformSurgeryOnSelfComponent>(user))
         {
             _popup.PopupEntity("You can't perform surgery on yourself!", user, user);
             return;

--- a/Content.Shared/_Starlight/Medical/Surgery/Components/CanPerformSurgeryOnSelfComponent.cs
+++ b/Content.Shared/_Starlight/Medical/Surgery/Components/CanPerformSurgeryOnSelfComponent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Shared.Starlight.Medical.Surgery;
+
+[RegisterComponent]
+public sealed partial class CanPerformSurgeryOnSelfComponent : Component {}

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Medical/surgeon.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Medical/surgeon.yml
@@ -23,9 +23,6 @@
     - !type:AddComponentSpecial
       components:
         - type: CanPerformSurgeryOnSelf
-          conditions:
-            - !type:PlayerCountCondition
-              max: 25
 
 - type: startingGear
   id: SurgeonGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Medical/surgeon.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Medical/surgeon.yml
@@ -23,6 +23,9 @@
     - !type:AddComponentSpecial
       components:
         - type: CanPerformSurgeryOnSelf
+          conditions:
+            - !type:PlayerCountCondition
+              max: 25
 
 - type: startingGear
   id: SurgeonGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Medical/surgeon.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Medical/surgeon.yml
@@ -19,6 +19,10 @@
   - Paramedic
   - Surgery
   - Chemistry
+  special:
+    - !type:AddComponentSpecial
+      components:
+        - type: CanPerformSurgeryOnSelf
 
 - type: startingGear
   id: SurgeonGear


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? --> adds a component that allows the attached entity to operate on themselves (and pre attached it to surgeons only, because surely a highly trained surgeon would now the basics of operating on themselves)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. --> adds a useful component that could be attached to admeme things for example, and attached it to the surgeon job prototype because it would be useful, and (speaking from experience here) remove the need for the surgeon to harass other medical crew/the CMO to install cybernetics on them

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: penguinwizzard, stickycheZ101
- add: added a component that allows self surgery
- tweak: surgeons can now operate on themselves, at a much greater cost to their health