### PR TITLE
Revert huge L6C nerf.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1310,45 +1310,17 @@
   name: L6C ROW cyborg module
   description: A weapons module that comes with a L6C.
   components:
-    - type: Sprite
-      layers:
-      - state: syndicate
-      - state: icon-syndicate
-    - type: ItemBorgModule
-      hands:
-      # starlight start: cyborgs l6 actually use ammo
-      - item: WeaponLightMachineGunL6
-        hand:
-          emptyRepresentative: WeaponLightMachineGunL6
-          emptyLabel: borg-slot-l6-empty
-          whitelist:
-            tags:
-            - L6Saw
-      - hand:
-          emptyRepresentative: WeaponLightMachineGunL6
-          emptyLabel: borg-slot-l6-empty
-          whitelist:
-            tags:
-            - L6Saw
-      - item: MagazineLightRifleBoxSP
-        hand:
-          emptyRepresentative: MagazineLightRifleBoxSP
-          emptyLabel: borg-slot-light-box-empty
-          whitelist:
-            tags:
-            - MagazineLightRifleBox
-      - item: MagazineBoxLightRifleSP
-        hand:
-          emptyRepresentative: MagazineBoxLightRifleSP
-          emptyLabel: borg-slot-light-ammo-box-empty
-          whitelist:
-            tags:
-            - MagazineBoxLightRifle
-      - item: PinpointerSyndicateNuclear
-      # Starlight end
-    - type: BorgModuleIcon
-      icon: { sprite: Interface/Actions/actions_borg.rsi, state: syndicate-l6c-module }
-      
+  - type: Sprite
+    layers:
+    - state: syndicate
+    - state: icon-syndicate
+  - type: ItemBorgModule
+    hands:
+    - item: WeaponLightMachineGunL6C
+    - item: PinpointerSyndicateNuclear
+  - type: BorgModuleIcon
+    icon: { sprite: Interface/Actions/actions_borg.rsi, state: syndicate-l6c-module }
+
 - type: entity
   parent: [ BaseBorgModule, BaseProviderBorgModule, BaseSyndicateContraband ] #Starlight c20 printing
   id: BorgModuleC20r


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Reverts the _massive_ L6C nerf in #1560.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The PR provided zero reasoning for the nerf whatsoever. Additionally it made the module _completely useless_ as ammo boxes store only 60 bullets...

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- tweak: Un-nerfed L6C.