### PR TITLE
L6 SAW module changes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1351,6 +1351,13 @@
           whitelist:
             tags:
             - MagazineLightRifleBox
+      - item: MagazineLightRifleBoxSP
+        hand:
+          emptyRepresentative: MagazineLightRifleBoxSP
+          emptyLabel: borg-slot-light-box-empty
+          whitelist:
+            tags:
+            - MagazineLightRifleBox
       - item: PinpointerSyndicateNuclear
       # Starlight end
     - type: BorgModuleIcon

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1337,18 +1337,25 @@
           whitelist:
             tags:
             - MagazineLightRifleBox
-      - item: MagazineBoxLightRifleSP
+      - item: MagazineLightRifleBoxSP
         hand:
-          emptyRepresentative: MagazineBoxLightRifleSP
-          emptyLabel: borg-slot-light-ammo-box-empty
+          emptyRepresentative: MagazineLightRifleBoxSP
+          emptyLabel: borg-slot-light-box-empty
           whitelist:
             tags:
-            - MagazineBoxLightRifle
+            - MagazineLightRifleBox
+      - item: MagazineLightRifleBoxSP
+        hand:
+          emptyRepresentative: MagazineLightRifleBoxSP
+          emptyLabel: borg-slot-light-box-empty
+          whitelist:
+            tags:
+            - MagazineLightRifleBox
       - item: PinpointerSyndicateNuclear
       # Starlight end
     - type: BorgModuleIcon
       icon: { sprite: Interface/Actions/actions_borg.rsi, state: syndicate-l6c-module }
-      
+
 - type: entity
   parent: [ BaseBorgModule, BaseProviderBorgModule, BaseSyndicateContraband ] #Starlight c20 printing
   id: BorgModuleC20r

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -132,10 +132,11 @@
     - ServiceStatic
     - PowerCellsStatic
     - ElectronicsStatic
-  - type: EmagLatheRecipes
+  - type: EmagLatheRecipes # Starlight start
     emagStaticPacks:
     - StarlightSecurityEmagWeaponsStatic
     - StarlightSecurityAmmoStatic
+    - StarlightSecurityAmmoEmagStatic # Starlight end
   - type: BlueprintReceiver
     whitelist:
       tags:
@@ -422,10 +423,11 @@
     idleState: icon
     runningState: icon
     staticPacks:
-    - SecurityEquipmentStatic
+    - SecurityEquipmentStatic # Starlight start
     - SecurityPracticeStatic
     - StarlightSecurityAmmoStatic
-    - SecurityWeaponsStatic
+    - StarlightSecurityAmmoEmagStatic
+    - SecurityWeaponsStatic # Starlight end
     dynamicPacks:
     - SalvageSecurityBoards
     - SalvageSecurityWeapons

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
@@ -25,6 +25,11 @@
   - WeaponLaserCarbinePractice
   - WeaponFlareGunSecurity
 
+- type: latheRecipePack
+  id: StarlightSecurityAmmoEmagStatic
+  recipes:
+  - L6SawMagazine
+
 # Shared between secfab and emagged autolathe
 - type: latheRecipePack
   id: StarlightSecurityAmmoStatic
@@ -105,7 +110,7 @@
   - MagazineShotgun
   - MagazineShotgunEmpty
   - MagazineShotgunSlug
-  
+
   - SpeedLoaderMagnumBasic
   - SpeedLoaderShotgunEmpty
   - SpeedLoaderShotgunSlug

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/light-rifle.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/light-rifle.yml
@@ -30,7 +30,7 @@
   result: MagazineLightRifleHP
   materials:
     Steel: 565
-    
+
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: MagazineLightRifleFMJ
@@ -92,7 +92,7 @@
   result: LightRifleHeavyMagazineHP
   materials:
     Steel: 1412
-    
+
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: LightRifleHeavyMagazineFMJ
@@ -138,6 +138,14 @@
   result: SpeedLoaderLightRifle
   materials:
     Steel: 200
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: L6SawMagazine
+  result: MagazineLightRifleBoxSP
+  materials:
+    Steel: 1600
+
 
 ############ BOXES ############
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Changes the L6 SAW cyborg module to give the Assault Cyborg four ammo boxes, and also gives an emagged secfab or autolathe the ability to print more.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
One spare magazine and one ammo box is nowhere near enough. Darkrell suggested giving the cyborg twice the amount of the L6 SAW bundle (2 magazines), so it gets four spares. Plus, you can print more at an emagged secfab or autolathe.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="604" height="141" alt="image" src="https://github.com/user-attachments/assets/a1f8d50e-0ec4-4546-b6e7-e88dfec3b70c" />
<img width="822" height="182" alt="image" src="https://github.com/user-attachments/assets/480cd534-0026-408a-bdaa-e3fdb622f033" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- add: The L6 SAW module now comes with four magazines.
- add: You can now print L6 SAW magazines at an emagged autolathe or secfab.
