### PR TITLE
Add extra recipes to lootable tech disks

### DIFF
--- a/Resources/Locale/en-US/_Starlight/research/technologies.ftl
+++ b/Resources/Locale/en-US/_Starlight/research/technologies.ftl
@@ -23,3 +23,7 @@ research-technology-lawboards-description = Advanced AI lawboard circuitry for p
 research-technology-cloning = Cloning Systems
 
 research-technology-point-defense = Point Defense Weaponry
+
+research-technology-loot-only-1 = Loot Only Technologies Tier 1
+research-technology-loot-only-2 = Loot Only Technologies Tier 2
+research-technology-loot-only-3 = Loot Only Technologies Tier 3

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -132,7 +132,9 @@
     - ServiceStatic
     - PowerCellsStatic
     - ElectronicsStatic
-  - type: EmagLatheRecipes # Starlight start
+    dynamicPacks: # Starlight start
+    - StarlightAutolatheLootable
+  - type: EmagLatheRecipes
     emagStaticPacks:
     - StarlightSecurityEmagWeaponsStatic
     - StarlightSecurityAmmoStatic
@@ -210,6 +212,7 @@
     - Janitor
     - Instruments
     - Equipment
+    - StarlightProtolatheLootable
   - type: EmagLatheRecipes
     emagDynamicPacks:
     - StarlightSurgeryDynamic
@@ -276,6 +279,7 @@
     - ShuttleBoards
     - StarlightMechBoards
     - StarlightLawboards
+    - StarlightCircuitImprinterLootable
   - type: EmagLatheRecipes
     emagDynamicPacks:
     - StarlightSecurityBoards
@@ -395,6 +399,8 @@
     runningState: building
     staticPacks:
     - FriendlyCubesStatic
+    dynamicPacks:
+    - StarlightBiofabricatorLootable
   - type: EmagLatheRecipes
     emagStaticPacks:
     - HostileCubesStatic
@@ -441,7 +447,7 @@
     - SecurityDisablers
     - SecurityCyberLimbs
     - StarlightSecurityMechsWeapons
-#    - StarlightSecurityMechsSystems
+    - StarlightSecurityTechFabLootable
   #region Starlight secfab emagging
   - type: EmagLatheRecipes
     emagStaticPacks:
@@ -526,6 +532,7 @@
     - StarlightImplantDynamic
     - Chemistry
     - StarlightBudgetCyberOrgansDynamic
+    - StarlightMedicalTechFabLootable
   - type: Machine
     board: MedicalTechFabCircuitboard
   - type: StealTarget
@@ -566,6 +573,8 @@
     - Scarves
     - Carpets
     - Bedsheets
+    dynamicPacks:
+    - StarlightUniformPrinterLootable
   - type: EmagLatheRecipes
     emagStaticPacks:
     - ClothingCentComm

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/rehydrateable.yml
@@ -11,3 +11,13 @@
     - BaseStationBorgiChassis
     - StationBorgiChassis
     - MobCorgiSmart
+
+- type: entity
+  parent: RehydratableAnimalCube
+  id: ScurretCube
+  name: scurret cube
+  description: Just add rain!
+  components:
+  - type: Rehydratable
+    possibleSpawns:
+    - MobEmotionalSupportScurret

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/lootables.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/lootables.yml
@@ -1,0 +1,42 @@
+## Dynamic recipes
+
+- type: latheRecipePack
+  id: StarlightAutolatheLootable
+  recipes:
+  - CowToolboxFilled
+  - AstroNavCartridge
+
+- type: latheRecipePack
+  id: StarlightProtolatheLootable
+  recipes:
+  - AirGrenade
+  - RCDAmmo
+
+- type: latheRecipePack
+  id: StarlightCircuitImprinterLootable
+  recipes:
+  - WallmountGeneratorElectronics
+  - ComputerIFFCircuitboard
+
+- type: latheRecipePack
+  id: StarlightBiofabricatorLootable
+  recipes:
+  - ScurretCube
+
+- type: latheRecipePack
+  id: StarlightSecurityTechFabLootable
+  recipes:
+  - SeismicCharge
+  - C4
+  - LogProbeCartridge
+
+- type: latheRecipePack
+  id: StarlightMedicalTechFabLootable
+  recipes:
+  - MedTekCartridge
+  - DefibrillatorCompact
+
+- type: latheRecipePack
+  id: StarlightUniformPrinterLootable
+  recipes:
+  - AssistantPDA

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/special.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/special.yml
@@ -1,0 +1,111 @@
+# Recipes that initially only exist for lootable tech disks
+
+- type: latheRecipe
+  id: CowToolboxFilled
+  result: CowToolboxFilled
+  categories:
+  - Tools
+  completetime: 10
+  materials:
+    Steel: 1000
+
+- type: latheRecipe
+  parent: BaseCubeRecipe
+  id: ScurretCube
+  result: ScurretCube
+  materials:
+    Biomass: 400
+
+- type: latheRecipe
+  id: AssistantPDA
+  result: AssistantPDA
+  categories:
+  - General
+  completetime: 3
+  materials:
+    Plastic: 500
+
+- type: latheRecipe
+  id: WallmountGeneratorElectronics
+  result: WallmountGeneratorElectronics
+  categories:
+  - Engineering
+  completetime: 3
+  materials:
+    Glass: 500
+    Steel: 100
+    Silver: 100
+
+- type: latheRecipe
+  id: AstroNavCartridge
+  result: AstroNavCartridge
+  categories:
+  - General
+  completetime: 3
+  materials:
+    Plastic: 200
+    Steel: 200
+
+- type: latheRecipe
+  id: MedTekCartridge
+  result: MedTekCartridge
+  categories:
+  - Medical
+  completetime: 3
+  materials:
+    Plastic: 200
+    Steel: 200
+
+- type: latheRecipe
+  id: LogProbeCartridge
+  result: LogProbeCartridge
+  categories:
+  - General
+  completetime: 3
+  materials:
+    Plastic: 200
+    Steel: 200
+
+- type: latheRecipe
+  id: C4
+  result: C4
+  categories:
+  - Weapons
+  completetime: 3
+  materials:
+    Plastic: 3000
+    Steel: 100
+    Silver: 100
+
+- type: latheRecipe
+  id: DefibrillatorCompact
+  result: DefibrillatorCompact
+  categories:
+  - Medical
+  completetime: 5
+  materials:
+    Steel: 500
+    Plastic: 200
+    Silver: 100
+
+- type: latheRecipe
+  id: AirGrenade
+  result: AirGrenade
+  categories:
+  - Engineering
+  completetime: 8
+  materials:
+    Steel: 400
+    Plastic: 200
+    Plasma: 200
+
+- type: latheRecipe
+  id: ComputerIFFCircuitboard
+  result: ComputerIFFCircuitboard
+  categories:
+  - Engineering
+  completetime: 3
+  materials:
+    Glass: 500
+    Steel: 100
+    Silver: 100

--- a/Resources/Prototypes/_StarLight/Research/lootonly.yml
+++ b/Resources/Prototypes/_StarLight/Research/lootonly.yml
@@ -1,0 +1,63 @@
+# These research technologies are defined, but hidden;
+# the purpose is so that the recipes listed here are
+# available as random tech disk spawns, but not as true
+# research targets for sci. Tiers control frequency of
+# appearance.
+
+# Tier 1
+- type: technology
+  id: LootableTech1
+  name: Exotic Technology 1
+  icon:
+    sprite: Objects/Misc/books.rsi
+    state: icon_question
+  discipline: Experimental
+  tier: 1
+  cost: 9999999
+  hidden: true
+  recipeUnlocks:
+  - CowToolboxFilled
+  - AssistantPDA
+  - AstroNavCartridge
+  - MedTekCartridge
+  radioChannels:
+  - Binary
+
+# Tier 2
+- type: technology
+  id: LootableTech2
+  name: Exotic Technology 2
+  icon:
+    sprite: Objects/Misc/books.rsi
+    state: icon_question
+  discipline: Experimental
+  tier: 2
+  cost: 9999999
+  hidden: true
+  recipeUnlocks:
+  - SeismicCharge
+  - WallmountGeneratorElectronics
+  - LogProbeCartridge
+  - DefibrillatorCompact
+  - AirGrenade
+  - ComputerIFFCircuitboard
+  radioChannels:
+  - Binary
+
+# Tier 3
+- type: technology
+  id: LootableTech3
+  name: Exotic Technology 3
+  icon:
+    sprite: Objects/Misc/books.rsi
+    state: icon_question
+  discipline: Experimental
+  tier: 3
+  cost: 9999999
+  hidden: true
+  recipeUnlocks:
+  - ScurretCube
+  - C4
+  - RCDAmmo
+  radioChannels:
+  - Binary

--- a/Resources/Prototypes/_StarLight/Research/lootonly.yml
+++ b/Resources/Prototypes/_StarLight/Research/lootonly.yml
@@ -7,7 +7,7 @@
 # Tier 1
 - type: technology
   id: LootableTech1
-  name: Exotic Technology 1
+  name: research-technology-loot-only-1
   icon:
     sprite: Objects/Misc/books.rsi
     state: icon_question
@@ -26,7 +26,7 @@
 # Tier 2
 - type: technology
   id: LootableTech2
-  name: Exotic Technology 2
+  name: research-technology-loot-only-2
   icon:
     sprite: Objects/Misc/books.rsi
     state: icon_question
@@ -47,7 +47,7 @@
 # Tier 3
 - type: technology
   id: LootableTech3
-  name: Exotic Technology 3
+  name: research-technology-loot-only-3
   icon:
     sprite: Objects/Misc/books.rsi
     state: icon_question


### PR DESCRIPTION
## Short description
This adds some recipes to unresearchable (hidden) techs, which makes them available as salvage/mining-lootable tech disks. The intent is for these to be less consistently available, but interesting or humorous when they are found.

## Why we need to add this
This should add a very small amount of additional variety to rounds and provide more incentive for salvagers to get discovered tech disks to science, improving the number of opportunities for communication and RP.

## Table

| Machine | Loot Tier | Name | Recipe |
| ----- | ----- | ----- | ----- |
| Autolathe | T1 | cow tools | recipe added: 10 steel |
| Autolathe | T1 | AstroNav cartridge | recipe added: 2 plastic, 2 steel |
| Protolathe | T2 | Air Grenade | recipe added: 4 steel, 2 plastic, 2 plasma |
| Protolathe | T3 | RCD Ammunition | existing unused recipe: 5 steel, 2.5 plastic |
| Circuit Imprinter | T2 | Wallmount Generator Electronics | recipe added: 5 glass, 1 steel, 1 silver |
| Circuit Imprinter | T2 | IFF Computer circuitboard | recipe added: 5 glass, 1 steel, 1 silver |
| Biofabricator | T3 | Dehydrated scurret | item and recipe added: 4 biomass |
| SecFab | T2 | Seismic Charge | existing recipe: 15 plastic, 1 steel, 1 silver |
| SecFab | T2 | LogProbe Cartridge | recipe added: 2 plastic, 2 steel |
| SecFab | T3 | C4 | recipe added: 30 plastic, 1 steel, 1 silver |
| MedFab | T1 | MedTek Cartridge | recipe added: 2 plastic, 2 steel |
| MedFab | T2 | Compact defibrillator | recipe added: 5 steel, 2 plastic, 1 silver |
| Uniform Printer | T1 | Assistant PDA | recipe added: 5 plastic |


## Media (Video/Screenshots)
Here's an example of the rolls of TechnologyDiskRare, with the two new tech disks that got rolled in this sampling of 35 outlined with decals.
<img width="581" height="474" alt="Screenshot 2025-10-17 163814" src="https://github.com/user-attachments/assets/ad8658c0-1577-4ec4-8438-24415e263c38" />

## Checks

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- add: Added additional unresearchable recipes to those available as tech disks from salvage expeditions.
