### PR TITLE
Prioritize actions over follow for Aghost

### DIFF
--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -22,7 +22,6 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
-using Content.Shared.Strip.Components;
 
 namespace Content.Shared.Follower;
 

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -98,11 +98,11 @@ public sealed class FollowerSystem : EntitySystem
         if (ev.User == ev.Target || IsClientSide(ev.Target))
             return;
 
-        if (HasComp<GhostComponent>(ev.User))
+        if (TryComp<GhostComponent>(ev.User, out var ghost)) // Starlight edit
         {
             var verb = new AlternativeVerb()
             {
-                Priority = -10, // Starlight edit: Prioritize actions over follow for Aghost
+                Priority = ghost.CanGhostInteract ? -10 : 10, // Starlight edit: Prioritize actions over follow for Aghost
                 Act = () => StartFollowingEntity(ev.User, ev.Target),
                 Impact = LogImpact.Low,
                 Text = Loc.GetString("verb-follow-text"),

--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Shared.Strip.Components;
 
 namespace Content.Shared.Follower;
 
@@ -102,7 +103,7 @@ public sealed class FollowerSystem : EntitySystem
         {
             var verb = new AlternativeVerb()
             {
-                Priority = 10,
+                Priority = -10, // Starlight edit: Prioritize actions over follow for Aghost
                 Act = () => StartFollowingEntity(ev.User, ev.Target),
                 Impact = LogImpact.Low,
                 Text = Loc.GetString("verb-follow-text"),


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
lower the priority for ghost following from 10 to -10. This does not affect normal ghosts and Has Aghost's alt + M1 prioritize unlocking/locking, signing papers and other things that use it over following. Aghosts will still follow with Alt + M1 if there is no other action for it.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It feels much better this way and has gotten all positive feedback from staff.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- tweak: Aghost's now prioritize unlocking/locking or signing with Alt + M1 Instead of following.