### PR TITLE
Heavy Metal Rising: The great mech un-fuckening

### DIFF
--- a/Content.Client/Mech/MechSystem.cs
+++ b/Content.Client/Mech/MechSystem.cs
@@ -25,7 +25,7 @@ public sealed class MechSystem : SharedMechSystem
         if (args.Sprite == null)
             return;
 
-        if (!_sprite.LayerExists((uid, args.Sprite), MechVisualLayers.Base))
+        if (!_sprite.TryGetLayer((uid, args.Sprite), MechVisualLayers.Base, out var _, false))
             return;
 
         var state = component.BaseState;

--- a/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
+++ b/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
@@ -38,6 +38,9 @@ public sealed partial class MechGrabberComponent : Component
     [DataField("maxContents")]
     public int MaxContents = 10;
 
+    [DataField("CanGrabMobs")]
+    public bool CanGrabMobs = false;
+
     /// <summary>
     /// The sound played when a mech is grabbing something
     /// </summary>

--- a/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
+++ b/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
@@ -39,6 +39,12 @@ public sealed partial class MechGrabberComponent : Component
     public int MaxContents = 10;
 
     /// <summary>
+    /// Allows to grab mobs and people
+    /// </summary>
+    [DataField("CanGrabMobs")]
+    public bool CanGrabMobs = false;
+
+    /// <summary>
     /// The sound played when a mech is grabbing something
     /// </summary>
     [DataField("grabSound")]

--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -133,8 +133,8 @@ public sealed class MechGrabberSystem : EntitySystem
             return;
 
         if (TryComp<PhysicsComponent>(target, out var physics) && physics.BodyType == BodyType.Static ||
-            HasComp<WallMountComponent>(target) ||
-            HasComp<MobStateComponent>(target))
+            HasComp<WallMountComponent>(target))
+        ///    HasComp<MobStateComponent>(target))
         {
             return;
         }
@@ -153,6 +153,11 @@ public sealed class MechGrabberSystem : EntitySystem
 
         if (!_interaction.InRangeUnobstructed(args.User, target))
             return;
+
+        if (!component.CanGrabMobs && HasComp<MobStateComponent>(target))
+        {
+          return;
+        }
 
         args.Handled = true;
         component.AudioStream = _audio.PlayPvs(component.GrabSound, uid)?.Entity;

--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -132,9 +132,8 @@ public sealed class MechGrabberSystem : EntitySystem
         if (args.Target == args.User || component.DoAfter != null)
             return;
 
-        if (TryComp<PhysicsComponent>(target, out var physics) && physics.BodyType == BodyType.Static ||
-            HasComp<WallMountComponent>(target) ||
-            HasComp<MobStateComponent>(target))
+        if ((TryComp<PhysicsComponent>(target, out var physics) && physics.BodyType == BodyType.Static) ||
+            HasComp<WallMountComponent>(target))
         {
             return;
         }
@@ -153,7 +152,11 @@ public sealed class MechGrabberSystem : EntitySystem
 
         if (!_interaction.InRangeUnobstructed(args.User, target))
             return;
-
+        if (!component.CanGrabMobs && HasComp<MobStateComponent>(target))
+        {
+            return;
+        }
+        
         args.Handled = true;
         component.AudioStream = _audio.PlayPvs(component.GrabSound, uid)?.Entity;
         var doAfterArgs = new DoAfterArgs(EntityManager, args.User, component.GrabDelay, new GrabberDoAfterEvent(), uid, target: target, used: uid)

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -203,11 +203,10 @@ public abstract partial class SharedDoorSystem : EntitySystem
     #region Interactions
     protected void OnActivate(EntityUid uid, DoorComponent door, ActivateInWorldEvent args)
     {
-        if (args.Handled || !args.Complex || !door.ClickOpen)
-            return;
 
-        if (!TryToggleDoor(uid, door, args.User, predicted: true))
-            _pryingSystem.TryPry(uid, args.User, out _);
+        var pryingCapable = args.Complex || HasComp<PryingComponent>(args.User);
+        if (args.Handled || !pryingCapable || !door.ClickOpen)
+            return;
 
         args.Handled = true;
     }

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -100,7 +100,11 @@ public sealed class PryingSystem : EntitySystem
 
         // hand-prying is much slower
         var modifier = CompOrNull<PryingComponent>(user)?.SpeedModifier ?? unpoweredComp.PryModifier;
-        return StartPry(target, user, null, modifier, out id);
+        
+        // user is tool if they have a prying component
+        EntityUid? userAsTool = HasComp<PryingComponent>(user) ? user : null;
+
+        return StartPry(target, user, userAsTool, modifier, out id);
     }
 
     private bool CanPry(EntityUid target, EntityUid user, out string? message, PryingComponent? comp = null, PryUnpoweredComponent? unpoweredComp = null)

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/Ammunition.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/Ammunition.yml
@@ -1,0 +1,16 @@
+- type: entity
+  id: MechCartridge
+  abstract: true
+  components:
+    - type: HitScanCartridgeAmmo
+      deleteOnSpawn: true
+
+- type: entity
+  id: ShellShotgunMechIncendiary
+  parent: [ShellShotgunIncendiary, MechCartridge]
+
+- type: entity
+  id: ShellShotgunMech
+  parent: [ShellShotgun, MechCartridge]
+
+

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -205,7 +205,7 @@
       path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: ShellShotgunMech
-    fireCost: 50
+    fireCost: 80
   - type: Appearance
   - type: AmmoCounter
   # region starlight
@@ -233,7 +233,7 @@
       path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: ShellShotgunMechIncendiary
-    fireCost: 50
+    fireCost: 80
   - type: Appearance
   - type: AmmoCounter
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -208,11 +208,6 @@
     fireCost: 80
   - type: Appearance
   - type: AmmoCounter
-  # region starlight
-  - type: Tag
-    tags:
-    - PaddyMech
-  # end region
 
 - type: entity
   id: WeaponMechCombatShotgunIncendiary

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -55,15 +55,15 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_solaris
   - type: Gun
-    fireRate: 2
+    fireRate: 1.5
     selectedMode: FullAuto
     availableModes:
       - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
   - type: HitscanBatteryAmmoProvider
-    proto: RedLaser
-    fireCost: 20
+    proto: RedHeavyLaser
+    fireCost: 28
   - type: Appearance
   - type: AmmoCounter
 # region starlight
@@ -94,7 +94,7 @@
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
   - type: HitscanBatteryAmmoProvider
     proto: RedLaser
-    fireCost: 40
+    fireCost: 14
   - type: Appearance
   - type: AmmoCounter
   # region starlight
@@ -141,7 +141,7 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_disabler
   - type: Gun
-    fireRate: 1
+    fireRate: 1.5
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -332,7 +332,7 @@
       path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: HitscanBatteryAmmoProvider
     proto: XrayLaser
-    fireCost: 80
+    fireCost: 48
   - type: Appearance
   - type: AmmoCounter
   - type: Battery

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/Weapons/Gun/combat.yml
@@ -10,9 +10,9 @@
     state: mecha_pulse
   - type: Gun
     fireRate: 1.5
-    selectedMode: SemiAuto
+    selectedMode: FullAuto
     availableModes:
-      - SemiAuto
+      - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: HitscanBatteryAmmoProvider
@@ -32,22 +32,22 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_immolator
   - type: Gun
-    fireRate: 0.8
-    selectedMode: SemiAuto
+    fireRate: 2
+    selectedMode: FullAuto
     availableModes:
-      - SemiAuto
+      - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanBatteryAmmoProvider
-    proto: RedHeavyLaser
-    fireCost: 80
+    proto: IgnitionRedLaser
+    fireCost: 40
   - type: Appearance
   - type: AmmoCounter
 
 - type: entity
   id: WeaponMechCombatSolarisLaser
   name: CH-LC "Solaris" laser cannon
-  description: An experimental combat mounted laser cannon that causes more damage, but also has a greater cooldown than a "Firedart".
+  description: An experimental combat mounted laser cannon, with the same output as the Firedart, but boasting a much more efficient cycling system.
   suffix: Mech Weapon, Gun, Combat, Laser
   parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
@@ -55,17 +55,22 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_solaris
   - type: Gun
-    fireRate: 1
-    selectedMode: SemiAuto
+    fireRate: 2
+    selectedMode: FullAuto
     availableModes:
-      - SemiAuto
+      - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
   - type: HitscanBatteryAmmoProvider
-    proto: RedMediumLaser
-    fireCost: 120
+    proto: RedLaser
+    fireCost: 20
   - type: Appearance
   - type: AmmoCounter
+# region starlight
+  - type: Tag
+    tags:
+    - PaddyMech
+# end region
   - type: Battery
     maxCharge: 240
     startingCharge: 240
@@ -73,7 +78,7 @@
 - type: entity
   id: WeaponMechCombatFiredartLaser
   name: CH-PS "Firedart" Laser
-  description: The standard combat armament of the mechs is a combat mounted laser.
+  description: The standard combat armament of the mechs. Weak, but cheap
   suffix: Mech Weapon, Gun, Combat, Laser
   parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
@@ -81,15 +86,15 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_firedart
   - type: Gun
-    fireRate: 0.8
-    selectedMode: SemiAuto
+    fireRate: 2
+    selectedMode: FullAuto
     availableModes:
-      - SemiAuto
+      - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
   - type: HitscanBatteryAmmoProvider
     proto: RedLaser
-    fireCost: 80
+    fireCost: 40
   - type: Appearance
   - type: AmmoCounter
   # region starlight
@@ -112,9 +117,9 @@
     projectileSpeed: 3
     projectileSpeedModified: 6
     fireRate: 0.8
-    selectedMode: SemiAuto
+    selectedMode: FullAuto
     availableModes:
-      - SemiAuto
+      - FullAuto
     soundGunshot:
       path: /Audio/Effects/Lightning/lightningshock.ogg
       params:
@@ -137,14 +142,14 @@
     state: mecha_disabler
   - type: Gun
     fireRate: 1
-    selectedMode: SemiAuto
+    selectedMode: FullAuto
     availableModes:
-      - SemiAuto
+      - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisablerSmgSpread
-    fireCost: 60
+    fireCost: 30
   - type: Appearance
   - type: AmmoCounter
   # region starlight
@@ -165,9 +170,9 @@
     state: mecha_taser
   - type: Gun
     fireRate: 1
-    selectedMode: SemiAuto
+    selectedMode: FullAuto
     availableModes:
-      - SemiAuto
+      - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: HitscanBatteryAmmoProvider
@@ -184,7 +189,7 @@
 - type: entity
   id: WeaponMechCombatShotgun
   name: LBX AC 10 "Scattershot"
-  description: A mounted non-lethal taser that allows you to stun intruders.
+  description: A mounted shotgun able to dispatch targets quickly in a CQC environement.
   suffix: Mech Weapon, Gun, Combat, Shotgun
   parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
@@ -198,9 +203,9 @@
       - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
-  - type: HitscanBatteryAmmoProvider
-    proto: PelletShotgunSpreadTrace
-    fireCost: 100
+  - type: ProjectileBatteryAmmoProvider
+    proto: ShellShotgunMech
+    fireCost: 50
   - type: Appearance
   - type: AmmoCounter
   # region starlight
@@ -212,7 +217,7 @@
 - type: entity
   id: WeaponMechCombatShotgunIncendiary
   name: FNX-99 "Hades" Carbine
-  description: Mounted carbine, firing incendiary cartridges.
+  description: Mounted shotgun, refit to fire incendiary ammo.
   suffix: Mech Weapon, Gun, Combat, Shotgun, Incendiary
   parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
@@ -226,16 +231,16 @@
       - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/shotgun.ogg
-  - type: HitscanBatteryAmmoProvider
-    proto: ShellShotgunIncendiaryTrace
-    fireCost: 90
+  - type: ProjectileBatteryAmmoProvider
+    proto: ShellShotgunMechIncendiary
+    fireCost: 50
   - type: Appearance
   - type: AmmoCounter
 
 - type: entity
   id: WeaponMechCombatUltraRifle
   name: Ultra AC-2
-  description: Mounted carbine, firing incendiary cartridges.
+  description: A cheap and reliable burst rifle.
   suffix: Mech Weapon, Gun, Combat, Rifle
   parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
@@ -288,8 +293,8 @@
     
 - type: entity
   id: WeaponMechCombatAMLG90
-  name: AMLG90
-  description: Laser mounted machine gun.
+  name: AMLG-90 "Reaver"
+  description: A powerful and advanced burst-laser machine gun designed for maximum firepower.
   suffix: Mech Weapon, Gun, Combat, Laser
   parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
@@ -299,7 +304,7 @@
   - type: Gun
     fireRate: 4
     shotsPerBurst: 3
-    burstCooldown: 1.2
+    burstCooldown: 1
     selectedMode: Burst
     availableModes:
       - Burst
@@ -316,7 +321,7 @@
 - type: entity
   id: WeaponMechCombatXray
   name: S-1 X-Ray Projector
-  description: Experimental mech weapon that fires X-rays that pass through obstacles.
+  description: Experimental mech weapon that fires X-rays, causing both surface and deep radiation burns.
   suffix: Mech Weapon, Gun, Combat, X-Ray
   parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
@@ -324,15 +329,15 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_xray
   - type: Gun
-    fireRate: 1
-    selectedMode: SemiAuto
+    fireRate: 2
+    selectedMode: FullAuto
     availableModes:
-      - SemiAuto
+      - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: HitscanBatteryAmmoProvider
     proto: XrayLaser
-    fireCost: 200
+    fireCost: 80
   - type: Appearance
   - type: AmmoCounter
   - type: Battery
@@ -342,7 +347,7 @@
 - type: entity
   id: WeaponMechCombatMissileRack8
   name: SRM-8 Light Missile Rack
-  description: Launches low-explosive breaching missiles designed to explode only when striking a sturdy target.
+  description: Launches low-explosive missiles. Relatively weak but able to supress enemy positions.
   suffix: Mech Weapon, Gun, Combat, Light Missile
   parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
@@ -365,7 +370,7 @@
 - type: entity
   id: WeaponMechCombatMissileRack6
   name: BRM-6 Missile Rack
-  description: Tubes must be reloaded from the outside.
+  description: A set of heavy missiles designed to unleash utter carnage upon your foes.
   suffix: Mech Weapon, Gun, Combat, Missile
   parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:
@@ -391,7 +396,7 @@
 - type: entity
   id: WeaponMechCombatFlashbangLauncher
   name: SGL-6 Flashbang Launcher
-  description: Launches low-explosive breaching missiles designed to explode only when striking a sturdy target.
+  description: A rotary grenade launcher able to manufacture and launch flash charges at unruly crowds.
   suffix: Mech Weapon, Gun, Combat, Flashbang
   parent: [ BaseMechWeaponRange, CombatMechEquipment, BaseSecurityContraband ]
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
@@ -171,3 +171,36 @@
   - type: MechEquipmentAction
     actionId: ActionMechToggleNightVision
   - type: MechNightVision
+
+- type: entity
+  id: MechEquipmentSecGrabber
+  parent: [ BaseMechEquipment, CombatMechEquipment, BaseSecurityContraband]
+  name: Hydraulic Claw
+  description: A specialized Hydraulic claw designed for the containment of multiple subjects. Can hold up to 4 items at once.
+  components:
+  - type: Sprite
+    state: paddy_claw
+  - type: Item
+  - type: MultiHandedItem
+  - type: MechGrabber
+    maxContents: 4
+    grabDelay: 3
+    grabEnergyDelta: -10
+    CanGrabMobs: true
+  - type: UIFragment
+    ui: !type:MechGrabberUi
+  - type: ContainerContainer
+    containers:
+      item-container: !type:Container
+  - type: Tag
+    tags:
+    - PaddyMech
+
+  # 🌟Starlight-start🌟
+  - type: Retractor
+  - type: SurgeryTool
+    successRate: 0.5 # they are very much too large
+    speed: 1.5
+    startSound:
+      path: /Audio/Mecha/sound_mecha_hydraulic.ogg
+  # 🌟Starlight-end🌟

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
@@ -192,6 +192,7 @@
   - type: ContainerContainer
     containers:
       item-container: !type:Container
+  - type: ChildBlockVision
   - type: Tag
     tags:
     - PaddyMech

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mecha_equipment.yml
@@ -171,3 +171,36 @@
   - type: MechEquipmentAction
     actionId: ActionMechToggleNightVision
   - type: MechNightVision
+
+- type: entity
+  id: MechEquipmentSecGrabber
+  parent: [ BaseMechEquipment, CombatMechEquipment, BaseSecurityContraband]
+  name: Hydraulic Claw
+  description: A specialized Hydraulic claw designed for the containment of multiple subjects. Can hold up to 4 items at once.
+  components:
+  - type: Sprite
+    state: paddy_claw
+  - type: Item
+  - type: MultiHandedItem
+  - type: MechGrabber
+    maxContents: 4
+    grabDelay: 3
+    grabEnergyDelta: -10
+    CanGrabMobs: true
+  - type: UIFragment
+    ui: !type:MechGrabberUi
+  - type: ContainerContainer
+    containers:
+      item-container: !type:Container
+  - type: Tag
+    tags:
+    - PaddyMech
+
+  # 🌟Starlight-start🌟
+  - type: Retractor
+  - type: SurgeryTool
+    successRate: 0.5 # they are very much too large
+    speed: 1.5
+    startSound:
+      path: /Audio/Mecha/sound_mecha_hydraulic.ogg
+  # 🌟Starlight-end🌟  

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -376,6 +376,7 @@
     startingEquipment:
       - WeaponMechCombatDisabler
       - WeaponMechCombatFlashbangLauncher
+      - MechEquipmentSecGrabber
 
 # Clarke
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -333,6 +333,7 @@
     brokenState: base-broken
     mechToPilotDamageMultiplier: 0.60
     airtight: true
+    maxEquipmentAmount: 4
     pilotWhitelist:
       components:
         - HumanoidAppearance
@@ -340,6 +341,7 @@
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
+    bluntStaminaDamageFactor: 1.5
     damage:
       types:
         Blunt: 30 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
@@ -374,6 +376,7 @@
     startingEquipment:
       - WeaponMechCombatDisabler
       - WeaponMechCombatFlashbangLauncher
+      - MechEquipmentSecGrabber
 
 # Clarke
 - type: entity
@@ -633,11 +636,13 @@
     attackRate: 1
     damage:
       types:
-        Blunt: 25
+        Blunt: 30 #THWACK
         Structural: 180
   - type: MovementSpeedModifier
-    baseWalkSpeed: 2
-    baseSprintSpeed: 2.6
+    baseWalkSpeed: 2.4
+    baseSprintSpeed: 3.7
+  - type: Damageable
+    damageModifierSet: LightArmor
   - type: MechThrusters
   - type: PointLight
     mask: /Textures/Effects/LightMasks/cone.png
@@ -900,7 +905,7 @@
         Structural: 200
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
-    baseSprintSpeed: 3.7
+    baseSprintSpeed: 4.0
   - type: Damageable
     damageModifierSet: MediumArmorSyndi
   - type: MechThrusters

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -333,6 +333,7 @@
     brokenState: base-broken
     mechToPilotDamageMultiplier: 0.60
     airtight: true
+    maxEquipmentAmount: 4
     pilotWhitelist:
       components:
         - HumanoidAppearance
@@ -340,6 +341,7 @@
   - type: MeleeWeapon
     hidden: true
     attackRate: 1
+    bluntStaminaDamageFactor: 1.5
     damage:
       types:
         Blunt: 30 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
@@ -633,11 +635,13 @@
     attackRate: 1
     damage:
       types:
-        Blunt: 25
+        Blunt: 30
         Structural: 180
   - type: MovementSpeedModifier
-    baseWalkSpeed: 2
-    baseSprintSpeed: 2.6
+    baseWalkSpeed: 2.4
+    baseSprintSpeed: 3.7
+  - type: Damageable
+    damageModifierSet: LightArmor
   - type: MechThrusters
   - type: PointLight
     mask: /Textures/Effects/LightMasks/cone.png
@@ -900,7 +904,7 @@
         Structural: 200
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
-    baseSprintSpeed: 3.7
+    baseSprintSpeed: 4.0
   - type: Damageable
     damageModifierSet: MediumArmorSyndi
   - type: MechThrusters

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -382,7 +382,7 @@
     startingEquipment:
       - WeaponMechCombatDisabler
       - WeaponMechCombatFlashbangLauncher
-      - MechEquipmentSecGrabber
+#      - MechEquipmentSecGrabber
 
 # Clarke
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -638,6 +638,10 @@
       types:
         Blunt: 30 #THWACK
         Structural: 180
+  - type: MeleeThrowOnHit
+    speed: 20
+    distance: 5
+    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.4
     baseSprintSpeed: 3.7
@@ -697,6 +701,10 @@
       types:
         Blunt: 40
         Structural: 220
+  - type: MeleeThrowOnHit
+    speed: 20
+    distance: 8
+    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.5
     baseSprintSpeed: 2
@@ -762,6 +770,10 @@
       types:
         Blunt: 40
         Structural: 200
+  - type: MeleeThrowOnHit
+    speed: 20
+    distance: 8
+    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 1
     baseSprintSpeed: 1.5
@@ -831,6 +843,10 @@
       types:
         Blunt: 60
         Structural: 400
+  - type: MeleeThrowOnHit
+    speed: 20
+    distance: 8
+    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
     baseSprintSpeed: 3.7
@@ -903,6 +919,10 @@
       types:
         Blunt: 30
         Structural: 200
+  - type: MeleeThrowOnHit
+    speed: 20
+    distance: 5
+    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
     baseSprintSpeed: 4.0
@@ -978,6 +998,10 @@
       types:
         Blunt: 50
         Structural: 400
+  - type: MeleeThrowOnHit
+    speed: 20
+    distance: 8
+    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 1
     baseSprintSpeed: 1.5

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -179,6 +179,10 @@
     drawRate: 1
     delay: 3
   - type: ActiveInputMover
+  - type: Prying
+    pryPowered: false
+    force: false
+    useSound: /Audio/Items/jaws_pry.ogg
 
 # Ripley MK-I
 - type: entity
@@ -290,6 +294,8 @@
     graph: PaddyUpgrade
     node: start
     defaultTarget: paddy
+  - type: Prying
+    pryPowered: true
 
 - type: entity
   id: MechRipley2Battery
@@ -654,6 +660,8 @@
     radius: 6
     energy: 5
     enabled: false
+  - type: Prying
+    pryPowered: true
 
 - type: entity
   id: MechGygaxBattery
@@ -720,6 +728,8 @@
     radius: 7
     energy: 5
     enabled: false
+  - type: Prying
+    pryPowered: true
 
 - type: entity
   id: MechDurandBattery
@@ -783,6 +793,8 @@
   - type: Repairable
     fuelCost: 30
     doAfterDelay: 15
+  - type: Prying
+    pryPowered: true
 
 - type: entity
   id: MechMarauderBattery
@@ -856,6 +868,8 @@
   - type: Repairable
     fuelCost: 30
     doAfterDelay: 20
+  - type: Prying
+    pryPowered: true
 
 - type: entity
   id: MechSeraphBattery
@@ -938,6 +952,8 @@
     radius: 7
     energy: 6
     enabled: false
+  - type: Prying
+    pryPowered: true
 
 - type: entity
   id: MechGygaxSyndieBattery
@@ -1011,6 +1027,8 @@
   - type: Repairable
     fuelCost: 50
     doAfterDelay: 25
+  - type: Prying
+    pryPowered: true
 
 - type: entity
   id: MechMaulerSyndieBattery

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -350,7 +350,7 @@
     bluntStaminaDamageFactor: 1.5
     damage:
       types:
-        Blunt: 30 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Blunt: 30 #Decent for a loader, but without the high structural damage of a combat mech.
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
     baseSprintSpeed: 4
@@ -644,10 +644,6 @@
       types:
         Blunt: 30 #THWACK
         Structural: 180
-  - type: MeleeThrowOnHit
-    speed: 20
-    distance: 5
-    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.4
     baseSprintSpeed: 3.7
@@ -709,10 +705,6 @@
       types:
         Blunt: 40
         Structural: 220
-  - type: MeleeThrowOnHit
-    speed: 20
-    distance: 8
-    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.5
     baseSprintSpeed: 2
@@ -780,10 +772,6 @@
       types:
         Blunt: 40
         Structural: 200
-  - type: MeleeThrowOnHit
-    speed: 20
-    distance: 8
-    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 1
     baseSprintSpeed: 1.5
@@ -855,10 +843,6 @@
       types:
         Blunt: 60
         Structural: 400
-  - type: MeleeThrowOnHit
-    speed: 20
-    distance: 8
-    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
     baseSprintSpeed: 3.7
@@ -933,10 +917,6 @@
       types:
         Blunt: 30
         Structural: 200
-  - type: MeleeThrowOnHit
-    speed: 20
-    distance: 5
-    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
     baseSprintSpeed: 4.0
@@ -1014,10 +994,6 @@
       types:
         Blunt: 50
         Structural: 400
-  - type: MeleeThrowOnHit
-    speed: 20
-    distance: 8
-    stunTime: .5
   - type: MovementSpeedModifier
     baseWalkSpeed: 1
     baseSprintSpeed: 1.5

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -341,7 +341,6 @@
     - MechParts
     - MechEquipment
     - StarlightMechEquipment
-    - StarlightMechWeapon
     - StarlightSecurityMechs
     - StarlightMechParts
   - type: EmagLatheRecipes
@@ -440,6 +439,7 @@
     - SecurityDisablers
     - SecurityCyberLimbs
     - StarlightSecurityMechsWeapons
+    - StarlightSecurityMechsSystems
   #region Starlight secfab emagging
   - type: EmagLatheRecipes
     emagStaticPacks:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -437,6 +437,7 @@
     - SecurityDisablers
     - SecurityCyberLimbs
     - StarlightSecurityMechsWeapons
+    - StarlightSecurityMechsSystems
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -340,7 +340,6 @@
     - MechParts
     - MechEquipment
     - StarlightMechEquipment
-    - StarlightMechWeapon
     - StarlightSecurityMechs
     - StarlightMechParts
   - type: EmagLatheRecipes

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -75,6 +75,7 @@
   - WeaponDisabler
   - WeaponMechCombatDisabler
   - WeaponMechCombatFlashbangLauncher
+  - WeaponMechCombatTaser
   - CartridgePistolRubber
   - CartridgeMagnumRubber
   - CartridgeLightRifleRubber
@@ -192,6 +193,7 @@
   cost: 10000
   recipeUnlocks:
   - WeaponXrayCannon
+  - WeaponMechCombatXray
   radioChannels:
   - Security
   

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -75,6 +75,7 @@
   - WeaponDisabler
   - WeaponMechCombatDisabler
   - WeaponMechCombatFlashbangLauncher
+  - WeaponMechCombatTaser
   - CartridgePistolRubber
   - CartridgeMagnumRubber
   - CartridgeLightRifleRubber
@@ -192,6 +193,7 @@
   cost: 10000
   recipeUnlocks:
   - WeaponXrayCannon
+  - WeaponMechCombatXray
   radioChannels:
   - Security
   
@@ -260,6 +262,7 @@
   - WeaponAdvancedLaser
   - PortableRecharger
   - WeaponMechCombatImmolationGun
+  - WeaponMechCombatAMLG90
   radioChannels:
   - Security
 

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Mechs/equipment.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Mechs/equipment.yml
@@ -4,6 +4,8 @@
   name: exosuit AI control beacon
   description: A device used to transmit exosuit data. Also allows active AI units to take control of said exosuit.
   components:
+  - type: MechEquipment
+    equipmentType: Passive
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Mechs/equipment.rsi
     state: exosuit_beacon

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
@@ -65,6 +65,12 @@
     - WeaponMechCombatDisabler
     - WeaponMechCombatFlashbangLauncher
     - WeaponMechCombatMissileRack8
+    - WeaponMechCombatXray
+    - WeaponMechChainSword
+    - WeaponMechCombatIon
+    - WeaponMechCombatAMLG90
+    - WeaponMechCombatTaser
+
 
 - type: latheRecipePack
   id: StarlightSyndicateModules

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
@@ -65,6 +65,11 @@
     - WeaponMechCombatDisabler
     - WeaponMechCombatFlashbangLauncher
     - WeaponMechCombatMissileRack8
+    - WeaponMechCombatXray
+    - WeaponMechChainSword
+    - WeaponMechCombatIon
+    - WeaponMechCombatAMLG90
+    - WeaponMechCombatTaser
 
 - type: latheRecipePack
   id: StarlightSyndicateModules

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
@@ -255,6 +255,11 @@
   - WeaponMechCombatShotgun
   - WeaponMechCombatShotgunIncendiary
   - WeaponMechCombatUltraRifle
+  - WeaponMechCombatXray
+  - WeaponMechChainSword
+  - WeaponMechCombatIon
+  - WeaponMechCombatAMLG90
+  - WeaponMechCombatTaser
 
 - type: latheRecipePack
   id: StarlightSecurityMechs

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
@@ -260,7 +260,17 @@
   - WeaponMechCombatShotgun
   - WeaponMechCombatShotgunIncendiary
   - WeaponMechCombatUltraRifle
+  - WeaponMechCombatXray
+  - WeaponMechChainSword
+  - WeaponMechCombatIon
+  - WeaponMechCombatAMLG90
+  - WeaponMechCombatTaser
 
+- type: latheRecipePack
+  id: StarlightSecurityMechsSystems
+  recipes:
+  - MechEquipmentSecGrabber
+  
 - type: latheRecipePack
   id: StarlightSecurityMechs
   recipes:

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
@@ -262,6 +262,11 @@
   - WeaponMechCombatTaser
 
 - type: latheRecipePack
+  id: StarlightSecurityMechsSystems
+  recipes:
+  - MechEquipmentSecGrabber
+  
+- type: latheRecipePack
   id: StarlightSecurityMechs
   recipes:
   - GygaxHarness

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
@@ -267,6 +267,9 @@
   - WeaponMechCombatDisabler
   - WeaponMechCombatFlashbangLauncher
   - WeaponMechCombatTaser
+  - WeaponMechCombatImmolationGun
+  - WeaponMechCombatSolarisLaser
+  - WeaponMechCombatFiredartLaser
 
 - type: latheRecipePack
   id: StarlightSecurityMechsSystems

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
@@ -264,6 +264,8 @@
   - WeaponMechChainSword
   - WeaponMechCombatIon
   - WeaponMechCombatAMLG90
+  - WeaponMechCombatDisabler
+  - WeaponMechCombatFlashbangLauncher
   - WeaponMechCombatTaser
 
 - type: latheRecipePack

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security.yml
@@ -110,3 +110,61 @@
     Steel: 1500
     Glass: 750
     Silver: 150
+
+
+- type: latheRecipe
+  id: WeaponMechChainSword
+  result: WeaponMechChainSword
+  categories:
+  - Mech
+  completetime: 10
+  materials:
+    Steel: 1500
+    Glass: 750
+    Plastic: 550
+
+- type: latheRecipe
+  id: WeaponMechCombatXray
+  result: WeaponMechCombatXray
+  categories:
+  - Mech
+  completetime: 10
+  materials:
+    Steel: 2000
+    Plastic: 1000
+    Gold: 200
+    Glass: 500
+
+- type: latheRecipe
+  id: WeaponMechCombatTaser
+  result: WeaponMechCombatTaser
+  categories:
+  - Mech
+  completetime: 10
+  materials:
+    Steel: 750
+    Glass: 250
+    Plastic: 300
+
+- type: latheRecipe
+  id: WeaponMechCombatIon
+  result: WeaponMechCombatIon
+  categories:
+  - Mech
+  completetime: 10
+  materials:
+    Steel: 2000
+    Gold: 1000
+    Silver: 1000    
+
+- type: latheRecipe
+  id: WeaponMechCombatAMLG90
+  result: WeaponMechCombatAMLG90
+  categories:
+  - Mech
+  completetime: 10
+  materials:
+    Steel: 2900
+    Plastic: 1000
+    Plasma: 1000
+    Glass: 700    

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security.yml
@@ -168,3 +168,14 @@
     Plastic: 1000
     Plasma: 1000
     Glass: 700    
+
+- type: latheRecipe
+  id: MechEquipmentSecGrabber
+  result: MechEquipmentSecGrabber
+  categories:
+  - Mech
+  completetime: 3
+  materials:
+    Steel: 500
+    Glass: 250
+    Plastic: 200

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security.yml
@@ -110,3 +110,71 @@
     Steel: 1500
     Glass: 750
     Silver: 150
+
+- type: latheRecipe
+  id: WeaponMechChainSword
+  result: WeaponMechChainSword
+  categories:
+  - Mech
+  completetime: 10
+  materials:
+    Steel: 1500
+    Glass: 750
+    Plastic: 550
+
+- type: latheRecipe
+  id: WeaponMechCombatXray
+  result: WeaponMechCombatXray
+  categories:
+  - Mech
+  completetime: 10
+  materials:
+    Steel: 2000
+    Plastic: 1000
+    Gold: 200
+    Glass: 500
+
+- type: latheRecipe
+  id: WeaponMechCombatTaser
+  result: WeaponMechCombatTaser
+  categories:
+  - Mech
+  completetime: 10
+  materials:
+    Steel: 750
+    Glass: 250
+    Plastic: 300
+
+- type: latheRecipe
+  id: WeaponMechCombatIon
+  result: WeaponMechCombatIon
+  categories:
+  - Mech
+  completetime: 10
+  materials:
+    Steel: 2000
+    Gold: 1000
+    Silver: 1000    
+
+- type: latheRecipe
+  id: WeaponMechCombatAMLG90
+  result: WeaponMechCombatAMLG90
+  categories:
+  - Mech
+  completetime: 10
+  materials:
+    Steel: 2900
+    Plastic: 1000
+    Plasma: 1000
+    Glass: 700    
+
+- type: latheRecipe
+  id: MechEquipmentSecGrabber
+  result: MechEquipmentSecGrabber
+  categories:
+  - Mech
+  completetime: 3
+  materials:
+    Steel: 500
+    Glass: 250
+    Plastic: 200

--- a/Resources/Prototypes/_StarLight/Research/arsenal.yml
+++ b/Resources/Prototypes/_StarLight/Research/arsenal.yml
@@ -36,8 +36,7 @@
   - GygaxPeripheralsElectronics
   - GygaxTargetingElectronics
   - WeaponMechCombatUltraRifle
-  technologyPrerequisites:
-  - Paddy
+  - WeaponMechChainSword
   radioChannels:
   - Security
 
@@ -92,6 +91,7 @@
   recipeUnlocks:
   - WeaponIonRifle
   - WeaponIonCarbine
+  - WeaponMechCombatIon
   radioChannels:
   - Security
   

--- a/Resources/Prototypes/_StarLight/Research/arsenal.yml
+++ b/Resources/Prototypes/_StarLight/Research/arsenal.yml
@@ -10,6 +10,7 @@
   cost: 8500
   recipeUnlocks:
   - PaddyUpgradeKit
+  - MechEquipmentSecGrabber
   technologyPrerequisites:
   - Ripley2
   radioChannels:
@@ -36,8 +37,7 @@
   - GygaxPeripheralsElectronics
   - GygaxTargetingElectronics
   - WeaponMechCombatUltraRifle
-  technologyPrerequisites:
-  - Paddy
+  - WeaponMechChainSword
   radioChannels:
   - Security
 
@@ -92,6 +92,7 @@
   recipeUnlocks:
   - WeaponIonRifle
   - WeaponIonCarbine
+  - WeaponMechCombatIon
   radioChannels:
   - Security
   

--- a/Resources/Prototypes/_StarLight/Research/arsenal.yml
+++ b/Resources/Prototypes/_StarLight/Research/arsenal.yml
@@ -10,7 +10,7 @@
   cost: 8500
   recipeUnlocks:
   - PaddyUpgradeKit
-  - MechEquipmentSecGrabber
+#  - MechEquipmentSecGrabber
   technologyPrerequisites:
   - Ripley2
   radioChannels:

--- a/Resources/Prototypes/_StarLight/Research/arsenal.yml
+++ b/Resources/Prototypes/_StarLight/Research/arsenal.yml
@@ -10,6 +10,7 @@
   cost: 8500
   recipeUnlocks:
   - PaddyUpgradeKit
+  - MechEquipmentSecGrabber
   technologyPrerequisites:
   - Ripley2
   radioChannels:


### PR DESCRIPTION
(This is a draft PR, some extra stuff still needs to be added)
## Short description
Mechs have been a core of Starlight and a frontline advertisement of the server. They have in a few times been used to their great effect, despite their incredibly steep cost and rarity...

However they have been always plagued with issues, questionable balancing, and generally had fallen by the wayside, operating in their own bubble, often lacking key capabilities they should have while still using placeholder items. Missing equipements, equipement that never worked since it was added. If you can name it, mechs probably had it.

Today, I decide to stop doing one-line PRs and take a sweep across a large swathe of them.

## Why we need to add this
Mechs have had broken, missing, and flat out inconsistent things for as long as I have been playing, and looking at the roots of things, since they have been added. Being probably the N°1 user of mechs on the entire server, I can safely say some stuff just did not really work as anticipated. 

Combat mechs being flat out weaker than industrial ones, Exofab being print full weapons without an Emag, Paddy nerfs based on capabilities it didn't have, ton of equipement that could not be built or was flat out weaker than its crew side equivalent despite costing far more and being research-locked. And of course, tons of things that did not function at all and were left in that state. Not to mention the inconsistency in mapping, where some crucial equipement like the Exosuit Chainsword (one of the 2 lethal weapons paddy can equip) being present on only 2 maps. Mapping will need its own pass later on, especially considering the Roundstart Paddy is still missing from most of them.

To that, adding a lot of things that just didn't mesh well or didn't play well together, little Quality of life elements that needed to be adressed.

I could have made tons of individual PRs for each of them but it felt better and easier to maintain to pull them all into one. The detailed changelog shall be below with Media for all things that alter gameplay mechanics

## Media (Video/Screenshots) 
MECH PRYING:
https://github.com/user-attachments/assets/0827660a-255a-4fde-b48a-413de7c441d7

PADDY CLAW AND TRUNCHEON PUNCH (Claw Admeme only, needs additional work):
https://github.com/user-attachments/assets/50464c33-661a-4b1c-999e-1a25825b9fff

RESEARCH, FABS and EMAG:
https://github.com/user-attachments/assets/a5488aa8-4655-421d-b147-05b571e7a13d

FIX FOR MECH SHOTGUNS:
https://github.com/user-attachments/assets/a5d2148a-2d4b-466f-97c3-8fa7a5aad51b

IMMOLATOR CANNON IGNITION:
https://github.com/user-attachments/assets/79aaaf65-af37-44d0-9646-eb432cb5af45


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ X ] I do not require assistance to complete the PR.
- [ X ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ X ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ X ] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

### General Changes

- Mech shotguns (Scattershot, Hades) now actually function
- Existing Exosuit Taser, Ion cannon, X-Ray projector to the list of reserchable equipement under their usual crew equivalents
- Mech Combat weapons can no longer be crafted at a Exofab without Emag'ing it. The chasiss still needs to be built by science.
- Firedart, Solaris, Immolator and X-Ray updated to be of equivalent strengh as their handheld equivalents (they were weaker prior)
- Updated Item definitions to no longer be doing drugs at the back of an alley. They should now properly reflect what the item actually does
- Exosuit AI Control Beacon now under "passive equipement".
- Research for combat mechs (Gygax, Durand) no longer requires Ripley/RipleyMK2/Paddy as a tech pre-requisite (they share no components or build chain with any of them)

**Paddy**
- Added Hydraulic Claw (admeme only for now, needs additional work): a reduced inventory clamp for combat mechs, Researched with Paddy tech and equiped on roundstart Paddy (when mapped to tech). It is able to pick up and carry people.
- Paddy Module space expanded from 3 to 4 to account for the Hydraulic Claw
- Paddy Punches now have Truncheon type stamina damage, enabling "less than lethal" work

**Gygax**
- Speed increased, it now sits within Ripley MK1 and Paddy in terms of speed. The light combat mech now actually feels light
- Counts as "Lightly armored" from "unarmored".
- Unarmed Punch damage raised from 25 to 30 blunt.

**Dark Gygax**
- Speed increased, it now moves at the same speed as Paddy.


-->
:cl: CMDROverwerk
- fix: Mounted Shotguns now actually work
- fix: Mech Idle/Destroyed sprites now actually show
- add: PBT "Pacifier" Taser, MK.IV Ion Cannon, S-1 Xray Cannon are now research-able in their corresponding handheld equivalent techs
- add: Exosuit Chainsword research-able alongside Gygax
- add: AMLG-90 "Reaver" research-able in Portable-Microfusion Weaponry
- tweak: Firedart now has equivalent effectiveness as the handheld laser carbine (it was lesser before)
- tweak: Solaris now has identical effectiveness to the firedart (was even less powerful... somehow) but is far more power-efficient.
- tweak: S-1 Xray is now similar in effectiveness as its handheld counterpart
- tweak: ZFI Immolation Beam cannon now does lower damage but ignites targets (similar to the handheld version)
- tweak: Exofab can no longer fabricate combat mech weapons without being Emagged. Security Techfab can still fabricate those weapons. Exofab is still required to produce the chassis itself
- remove: Gygax/Durand research no longer need RipleyMK1/2/Paddy to research since they do not share any building chain or chassis similarity
- add: Hydraulic Claw (admeme only for now). A security module aviable in the Armory Paddy and researchable alongside its tech. A reduced cappacity clamp that can pick up people. Enables Paddy to actually assist in security work that does not involve beating someone into a pulp. 
- add: Mechs can finally pry doors and firelocks. All mechs can pry unpowered doors/firelocks. Ripley MK2/Combat mechs can jaw-pry.
- add: Paddy punches now do Stamina damage at the same rate as the Truncheon, enabling "less than lethal" work
- tweak: Gygax Received a speed boost and slight armor boost. Dark Gygax received a slight speed boost.