### PR TITLE
Fix Medical, Mining and janitor borg sprites

### DIFF
--- a/Content.Shared/Silicons/Borgs/SharedBorgSwitchableTypeSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSwitchableTypeSystem.cs
@@ -141,24 +141,26 @@ public abstract class SharedBorgSwitchableTypeSystem : EntitySystem
         }
 
         // Starlight-start: Movement sprite state
-
-        if (prototype.SpriteBodyMovementState is { } movementState)
+        if (!(TryComp<BorgSwitchableSubtypeComponent>(entity, out var subtype) && subtype.BorgSubtype != null))
         {
-            var spriteMovement = EnsureComp<SpriteMovementComponent>(entity);
-            spriteMovement.NoMovementLayers.Clear();
-            spriteMovement.NoMovementLayers["movement"] = new PrototypeLayerData
+            if (prototype.SpriteBodyMovementState is { } movementState)
             {
-                State = prototype.SpriteBodyState,
-            };
-            spriteMovement.MovementLayers.Clear();
-            spriteMovement.MovementLayers["movement"] = new PrototypeLayerData
+                var spriteMovement = EnsureComp<SpriteMovementComponent>(entity);
+                spriteMovement.NoMovementLayers.Clear();
+                spriteMovement.NoMovementLayers["movement"] = new PrototypeLayerData
+                {
+                    State = prototype.SpriteBodyState,
+                };
+                spriteMovement.MovementLayers.Clear();
+                spriteMovement.MovementLayers["movement"] = new PrototypeLayerData
+                {
+                    State = movementState,
+                };
+            }
+            else
             {
-                State = movementState,
-            };
-        }
-        else
-        {
-            RemComp<SpriteMovementComponent>(entity);
+                RemComp<SpriteMovementComponent>(entity);
+            }
         }
 
         // Starlight-end


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a guard to movement sprite state.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes Medical, Mining and Janitor borgs reverting their sprites for subtypes to the default when chosen.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Medical, Mining and Janitor borgs will no longer force you to use the default sprite.