### PR TITLE
Update deactivated stunbaton hit-sound

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -32,6 +32,8 @@
     activatedDamage:
       types:
         Blunt: 0
+    deactivatedSoundOnHit:
+      collection: GenericHit
   - type: MeleeWeapon
     wideAnimationRotation: -135
     damage:
@@ -40,6 +42,8 @@
     bluntStaminaDamageFactor: 2.0
     angle: 60
     animation: WeaponArcThrust
+    soundHit:
+      collection: GenericHit
   - type: StaminaDamageOnHit
     damage: 35
     sound: /Audio/Weapons/egloves.ogg

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -32,8 +32,8 @@
     activatedDamage:
       types:
         Blunt: 0
-    deactivatedSoundOnHit:
-      collection: GenericHit
+    deactivatedSoundOnHit: #starlight
+      collection: GenericHit #starlight
   - type: MeleeWeapon
     wideAnimationRotation: -135
     damage:
@@ -42,8 +42,8 @@
     bluntStaminaDamageFactor: 2.0
     angle: 60
     animation: WeaponArcThrust
-    soundHit:
-      collection: GenericHit
+    soundHit: #starlight
+      collection: GenericHit #starlight
   - type: StaminaDamageOnHit
     damage: 35
     sound: /Audio/Weapons/egloves.ogg


### PR DESCRIPTION
## Short description
Updates the stunbaton's deactivated hitsound to really clue the player to the fact they are being beaten in the head with a baton.

## Why we need to add this
The current 'weakhit' sound may trick newer players into thinking they aren't actually doing any damage, when in fact they are (sorta sounds like you lightly bop them with the baton). 

The new noises will serve to better indicate that you are doing actual damage.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/770e2f48-cc94-4e8e-a74b-479b8b665b61

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- tweak: The Stunbaton has a new sound when harmbatoning a player.

