### PR TITLE
Skeletons Cannot Be Implanted

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -28,7 +28,7 @@
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Tag
     tags:
-    - Unimplantable
+    - Unimplantable # _Starlight
   - type: MobState
   - type: MobThresholds
     thresholds:

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -28,7 +28,7 @@
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Tag
     tags:
-    - Skeleton
+    - Unimplantable
   - type: MobState
   - type: MobThresholds
     thresholds:

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -26,6 +26,9 @@
         color: "#555555AA"
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
+  - type: Tag
+    tags:
+    - Skeleton
   - type: MobState
   - type: MobThresholds
     thresholds:

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -19,7 +19,6 @@
       - Guardian # no holoparasite macrobomb wombo combo
       tags:
       - Unimplantable
-      - Skeleton
     currentMode: Draw
     implanterSlot:
       name: Implant

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -19,6 +19,7 @@
       - Guardian # no holoparasite macrobomb wombo combo
       tags:
       - Unimplantable
+      - Skeleton
     currentMode: Draw
     implanterSlot:
       name: Implant


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Skeletons Can No longer have an implant, Since there skeletons

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Skeletons are well Skeletons, Nothing but bone, Doesnt make sense In roleplay that you can implant bones

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- add: Unimplantable Tag To Skeletons
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
