### PR TITLE
[HOTFIX] Fixing the syndicate borgs.

### DIFF
--- a/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
@@ -42,7 +42,7 @@ uplink-syndicate-borgi-name = Syndicate Borgi
 uplink-syndicate-borgi-desc = A basic syndicate borgi
 
 uplink-syndicate-borgi-kitted-name = Kitted Syndicate Borgi
-uplink-syndicate-borgi-kitted-desc = A syndicate borgi, with assault modules
+uplink-syndicate-borgi-kitted-desc = A syndicate borgi, outfitted with an L6 module, operative module and E-sword module.
 
 uplink-syndicate-borgi-speed-name = Speed Syndicate Borgi
 uplink-syndicate-borgi-speed-desc = A syndicate borgi, with dagger modules and additional speed

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -151,8 +151,9 @@ uplink-reinforcement-radio-traitor-desc =  Radio in a reinforcement agent of ext
 uplink-reinforcement-radio-nukeops-name = Nuclear Operative Teleporter
 uplink-reinforcement-radio-nukeops-desc =  Radio in a nuclear operative of extremely questionable quality. No off button, buy this if you're ready to party. They have basic nuclear operative gear.
 
-uplink-reinforcement-radio-cyborg-assault-name = Syndicate Assault Cyborg Teleporter
-uplink-reinforcement-radio-cyborg-assault-desc =  A lean, mean killing machine with access to an Energy Sword, LMG, Cryptographic Sequencer, and a Pinpointer.
+# starlight fix the names of these to work again
+uplink-reinforcement-radio-cyborg-name = Syndicate Cyborg Teleporter
+uplink-reinforcement-radio-cyborg-desc = Radio in a syndicate cyborg which has a variety of frames to choose from (Do make sure to instruct them which one to pick!)
 
 uplink-mech-teleporter-heavy-name = Heavy Mech teleporter
 uplink-mech-teleporter-heavy-desc = Contains Cybersan heavy armored mech with integrated chainsword, Ultra AC-2, LBX AC 10 "Scattershot", BRM-6 Missile Rack and P-X Tesla Cannon.

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -550,18 +550,18 @@
 - type: entity
   id: PlayerBorgSyndicateAssaultBattery
   parent: BorgChassisSyndicateAssault
-  suffix: Battery, Module, Operative
+  suffix: Battery, Operative # Starlight
   components:
   - type: NukeOperative
   - type: ContainerFill
     containers:
       borg_brain:
         - PositronicBrain
-      borg_module:
-        - BorgModuleTool
-        - BorgModuleOperative
-        - BorgModuleL6C
-        - BorgModuleDoubleEsword
+      # borg_module: Starlight, these are switchable so no need to specify their modules
+      #   - BorgModuleTool
+      #   - BorgModuleOperative
+      #   - BorgModuleL6C
+      #   - BorgModuleDoubleEsword
   - type: ItemSlots
     slots:
       cell_slot:
@@ -584,18 +584,18 @@
 - type: entity
   id: PlayerBorgSyndicateSaboteurBattery
   parent: BorgChassisSyndicateSaboteur
-  suffix: Battery, Module, Operative
+  suffix: Battery, Operative # Starlight
   components:
   - type: NukeOperative
   - type: ContainerFill
     containers:
       borg_brain:
         - PositronicBrain
-      borg_module:
-        - BorgModuleTool
-        - BorgModuleRCD
-        - BorgModuleOperative
-        - BorgModuleSyndicateWeapon
+      # borg_module: Starlight, these are switchable so no need to specify their modules.
+      #   - BorgModuleTool
+      #   - BorgModuleRCD
+      #   - BorgModuleOperative
+      #   - BorgModuleSyndicateWeapon
   - type: ItemSlots
     slots:
       cell_slot:
@@ -618,18 +618,18 @@
 - type: entity
   id: PlayerBorgSyndicateMedicalBattery
   parent: BorgChassisSyndicateMedical
-  suffix: Battery, Module, Operative
+  suffix: Battery, Operative # Starlight
   components:
   - type: NukeOperative
   - type: ContainerFill
     containers:
       borg_brain:
         - PositronicBrain
-      borg_module:
-        - BorgModuleTool
-        - BorgModuleChemical
-        - BorgModuleTopicals
-        - BorgModuleSyndicateWeapon
+      # borg_module: Starlight, these are switchable so no need to specify their modules.
+      #   - BorgModuleTool
+      #   - BorgModuleChemical
+      #   - BorgModuleTopicals
+      #   - BorgModuleSyndicateWeapon
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
@@ -350,7 +350,7 @@
   icon: { sprite:  Objects/Fun/Balloons/corgi.rsi, state: icon }
   productEntity: SyndiBorgiKit1
   cost:
-    Telecrystal: 60
+    Telecrystal: 30
   categories:
     - UplinkAllies
   conditions:
@@ -368,7 +368,7 @@
   icon: { sprite:  Objects/Fun/Balloons/corgi.rsi, state: icon }
   productEntity: SyndiBorgiKit2
   cost:
-    Telecrystal: 50
+    Telecrystal: 30
   categories:
     - UplinkAllies
   conditions:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/borgi_chassis.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/borgi_chassis.yml
@@ -99,7 +99,7 @@
         borg_module:
         - BorgModuleOperative
         - BorgModuleL6C
-        - BorgModuleEsword
+        - BorgModuleEsword # We're not giving the double e-sword to the borgi. Buy the proper borg.
 
 - type: entity
   parent: BaseSyndicateBorgiChassis

--- a/Resources/Prototypes/_StarLight/borg_types.yml
+++ b/Resources/Prototypes/_StarLight/borg_types.yml
@@ -42,7 +42,6 @@
   dummyPrototype: BorgChassisSyndicateAssault
 
   # Functional
-  extraModuleCount: 4
   moduleWhitelist:
     tags:
     - BorgModuleGeneric
@@ -53,7 +52,7 @@
   - BorgModuleTool
   - BorgModuleOperative
   - BorgModuleL6C
-  - BorgModuleDEsword
+  - BorgModuleDoubleEsword
 
   radioChannels:
   - Syndicate
@@ -73,7 +72,6 @@
   dummyPrototype: BorgChassisSyndicateMedical
 
   # Functional
-  extraModuleCount: 4
   moduleWhitelist:
     tags:
     - BorgModuleGeneric
@@ -104,7 +102,6 @@
   dummyPrototype: BorgChassisSyndicateSaboteur
 
   # Functional
-  extraModuleCount: 4
   moduleWhitelist:
     tags:
     - BorgModuleGeneric
@@ -135,7 +132,6 @@
   dummyPrototype: BorgChassisSyndicateStealth
 
   # Functional
-  extraModuleCount: 4
   moduleWhitelist:
     tags:
     - BorgModuleGeneric

--- a/Resources/Prototypes/_StarLight/borg_types.yml
+++ b/Resources/Prototypes/_StarLight/borg_types.yml
@@ -53,7 +53,7 @@
   - BorgModuleTool
   - BorgModuleOperative
   - BorgModuleL6C
-  - BorgModuleEsword
+  - BorgModuleDEsword
 
   radioChannels:
   - Syndicate


### PR DESCRIPTION
## Short description
Fixes SEVERAL issues related to syndicate borgs which cause them to be uhh. Rather fucking broken.

## Why we need to add this
When Rinary changed syndie borgs to become switchable, he gave the assault borg the wrong sword and also didn't remove the modules from prototypes that come with them spawned in. Which uhh. Leads to some seriously fucked up borgs.
## Media (Video/Screenshots)
<img width="883" height="850" alt="image" src="https://github.com/user-attachments/assets/6a51c728-fc4b-48fd-9e96-c11a3a24e111" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Revelation
- fix: Syndicate Assault Borgs get the Double Esword once more, as intended.
- fix: Syndicate cyborgs in general don't get overloaded with modules anymore.
- fix: Syndicate cyborgs are no longer able to accept more modules than they start with.
- fix: Syndicate cyborg teleporter now works again and has a better description.
- tweak: Syndicate borgis have been brought down in price now that the L6 module got massively nerfed. They don't get the Double ESword though. Buy a proper borg for that.
