### PR TITLE
Booze, Chemical and Soda dispenser fixes

### DIFF
--- a/Content.Client/Chemistry/UI/ReagentDispenserBoundUserInterface.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserBoundUserInterface.cs
@@ -58,5 +58,17 @@ namespace Content.Client.Chemistry.UI
             var castState = (ReagentDispenserBoundUserInterfaceState) state;
             _window?.UpdateState(castState); //Update window state
         }
+
+        // Starlight start: Required for cell charging or UI flashes
+        protected override void ReceiveMessage(BoundUserInterfaceMessage message)
+        {
+            base.ReceiveMessage(message);
+
+            if (message is ReagentDispenserEnergyUpdateMessage energyUpdate)
+            {
+                _window?.UpdateEnergyDisplay(energyUpdate.EnergyAmount);
+            }
+        }
+        // Starlight end
     }
 }

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -72,8 +72,7 @@ namespace Content.Client.Chemistry.UI
             EjectButton.Disabled = castState.OutputContainer is null;
 
             // Starlight-start
-            EnergyDisplayBar.Value = castState.EnergyAmount;
-            EnergyDisplay.Text = Loc.GetString("mech-energy-display", ("amount", (int)Math.Round(castState.EnergyAmount * 100)));
+            UpdateEnergyDisplay(castState.EnergyAmount);
             // Starlight-end
 
             AmountGrid.Selected = ((int)castState.SelectedDispenseAmount).ToString();

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml.cs
@@ -79,6 +79,15 @@ namespace Content.Client.Chemistry.UI
             AmountGrid.Selected = ((int)castState.SelectedDispenseAmount).ToString();
         }
 
+        // Starlight Start
+        // Update only the energy display bar and text without refreshing the entire UI.
+        public void UpdateEnergyDisplay(float energyAmount)
+        {
+            EnergyDisplayBar.Value = energyAmount;
+            EnergyDisplay.Text = Loc.GetString("mech-energy-display", ("amount", (int)Math.Round(energyAmount * 100)));
+        }
+        // Starlight End
+
         /// <summary>
         /// Update the fill state and list of reagents held by the current reagent container, if applicable.
         /// <para>Also highlights a reagent if it's dispense button is being mouse hovered.</para>

--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -1,11 +1,8 @@
 using System.Linq;
 using Content.Server.Chemistry.Components;
 using Content.Server.Chemistry.Containers.EntitySystems;
-using Content.Server.PowerCell; // Starlight-edit
-using Content.Server.Popups; // Starlight-edit
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.EntitySystems;
-using Content.Shared.Chemistry.Reagent; // Starlight-edit
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.FixedPoint;
 using Content.Shared.Nutrition.EntitySystems;
@@ -19,7 +16,17 @@ using Robust.Shared.Prototypes;
 using Content.Shared.Labels.Components;
 using Content.Shared.Storage;
 using Content.Server.Hands.Systems;
-using Content.Shared.Destructible; // Starlight-edit: Empty container on destruct
+// Starlight Start
+using Content.Shared.PowerCell;
+using Content.Shared.Destructible;
+using Content.Shared.PowerCell.Components;
+using Content.Server.Power.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Server.PowerCell;
+using Content.Server.Popups;
+using Content.Server.Power.Components;
+using Content.Shared.UserInterface;
+// Starlight end
 
 namespace Content.Server.Chemistry.EntitySystems
 {
@@ -43,6 +50,9 @@ namespace Content.Server.Chemistry.EntitySystems
         [Dependency] private readonly PowerCellSystem _powercell = default!;
         [Dependency] private readonly SharedContainerSystem _container = default!;
         [Dependency] private readonly PopupSystem _popup = default!;
+        [Dependency] private readonly BatterySystem _battery = default!;
+        private readonly Dictionary<EntityUid, float> _uiUpdateAccumulators = new();
+        private const float UiUpdateInterval = 0.5f;
         // Starlight-end
 
         public override void Initialize()
@@ -60,18 +70,149 @@ namespace Content.Server.Chemistry.EntitySystems
             SubscribeLocalEvent<ReagentDispenserComponent, ReagentDispenserEjectContainerMessage>(OnEjectReagentMessage);
             SubscribeLocalEvent<ReagentDispenserComponent, ReagentDispenserClearContainerSolutionMessage>(OnClearContainerSolutionMessage);
 
-            SubscribeLocalEvent<ReagentDispenserComponent, DestructionEventArgs>(OnDestruction);  // Starlight-edit: Empty container on destruct
-
             SubscribeLocalEvent<ReagentDispenserComponent, MapInitEvent>(OnMapInit, before: new[] { typeof(ItemSlotsSystem) });
+            // Starlight Start
+            SubscribeLocalEvent<ReagentDispenserComponent, ComponentRemove>(OnComponentRemove);
+            SubscribeLocalEvent<ReagentDispenserComponent, PowerCellChangedEvent>(OnPowerCellChanged);
+            SubscribeLocalEvent<ReagentDispenserComponent, DestructionEventArgs>(OnDestruction);
+            SubscribeLocalEvent<ReagentDispenserComponent, PowerCellSlotEmptyEvent>(OnPowerCellSlotEmpty);
+            // Starlight End
         }
 
-        // Starlight-start: Empty container on destruct
+        // Starlight Start: Reagent Dispensers use cells
+        #region Starlight
+        private void OnComponentRemove(EntityUid uid, ReagentDispenserComponent component, ComponentRemove args)
+        {
+            _uiUpdateAccumulators.Remove(uid);
+        }
+
+        // Recharge power cell from APC power
+        public override void Update(float frameTime)
+        {
+            base.Update(frameTime);
+
+            var query = EntityQueryEnumerator<ReagentDispenserComponent, PowerCellSlotComponent, ApcPowerReceiverComponent, ActivatableUIComponent>();
+            while (query.MoveNext(out var uid, out var dispenser, out var cellSlot, out var powerReceiver, out var activatableUI))
+            {
+                if (!_powercell.TryGetBatteryFromSlot(uid, out var batteryUid, out var battery, cellSlot))
+                    continue;
+
+                float chargeRate;
+                bool isChargingOrDraining = false;
+
+                // Check if UI is open
+                var uiOpen = activatableUI.Key != null && _userInterfaceSystem.IsUiOpen(uid, activatableUI.Key);
+
+                if (powerReceiver.Powered)
+                {
+                    // Charge at 5W when connected to power
+                    chargeRate = 5f;
+                    
+                    if (_battery.IsFull(batteryUid.Value, battery))
+                        continue;
+                    
+                    isChargingOrDraining = true;
+                }
+                else if (uiOpen)
+                {
+                    // Drain at 5W when UI is open and not powered by APC
+                    chargeRate = -5f;
+                    
+                    if (battery.CurrentCharge <= 0)
+                    {
+                        // Close UI if cell is dead
+                        if (activatableUI.Key != null)
+                            _userInterfaceSystem.CloseUi(uid, activatableUI.Key);
+                        continue;
+                    }
+                    
+                    isChargingOrDraining = true;
+                }
+                else
+                {
+                    continue;
+                }
+
+                if (chargeRate > 0 && battery.CurrentCharge + (chargeRate * frameTime) > battery.MaxCharge)
+                {
+                    if (uiOpen)
+                    {
+                        if (!_uiUpdateAccumulators.ContainsKey(uid))
+                            _uiUpdateAccumulators[uid] = 0f;
+
+                        _uiUpdateAccumulators[uid] += frameTime;
+                        if (_uiUpdateAccumulators[uid] >= UiUpdateInterval)
+                        {
+                            _uiUpdateAccumulators[uid] = 0f;
+                            UpdateEnergyBar((uid, dispenser));
+                        }
+                    }
+                    continue;
+                }
+
+                _battery.ChangeCharge(batteryUid.Value, chargeRate * frameTime, battery);
+                
+                if (chargeRate < 0 && battery.CurrentCharge <= 0 && uiOpen)
+                {
+                    UpdateUiState((uid, dispenser));
+                    if (activatableUI.Key != null)
+                        _userInterfaceSystem.CloseUi(uid, activatableUI.Key);
+                }
+                // Prevent entire UI flashing when charging/draining
+                else if (isChargingOrDraining && uiOpen)
+                {
+                    if (!_uiUpdateAccumulators.ContainsKey(uid))
+                        _uiUpdateAccumulators[uid] = 0f;
+
+                    _uiUpdateAccumulators[uid] += frameTime;
+                    if (_uiUpdateAccumulators[uid] >= UiUpdateInterval)
+                    {
+                        _uiUpdateAccumulators[uid] = 0f;
+                        UpdateEnergyBar((uid, dispenser));
+                    }
+                }
+            }
+        }
+
+        private void UpdateEnergyBar(Entity<ReagentDispenserComponent> reagentDispenser)
+        {
+            if (!_powercell.TryGetBatteryFromSlot(reagentDispenser.Owner, out var battery))
+                return;
+
+            var energy = battery.CurrentCharge / battery.MaxCharge;
+            var message = new ReagentDispenserEnergyUpdateMessage(energy);
+            _userInterfaceSystem.ServerSendUiMessage(reagentDispenser.Owner, ReagentDispenserUiKey.Key, message);
+        }
         private void OnDestruction(EntityUid uid, ReagentDispenserComponent component, DestructionEventArgs args)
         {
             if (TryComp<StorageComponent>(uid, out var storage))
                 _container.EmptyContainer(storage.Container, destination: Transform(uid).Coordinates);
         }
-        // Starlight-end
+
+        private void OnPowerCellChanged(Entity<ReagentDispenserComponent> ent, ref PowerCellChangedEvent args)
+        {
+            if (!args.Ejected)
+                return;
+
+            UpdateUiState(ent);
+            
+            if (!_powercell.HasActivatableCharge(ent.Owner))
+            {
+                if (TryComp<ActivatableUIComponent>(ent.Owner, out var activatable) && activatable.Key != null)
+                    _userInterfaceSystem.CloseUi(ent.Owner, activatable.Key);
+            }
+        }
+
+        private void OnPowerCellSlotEmpty(Entity<ReagentDispenserComponent> ent, ref PowerCellSlotEmptyEvent args)
+        {
+            UpdateUiState(ent);
+
+            // Close the UI when cell is ejected
+            if (TryComp<ActivatableUIComponent>(ent.Owner, out var activatable) && activatable.Key != null)
+                _userInterfaceSystem.CloseUi(ent.Owner, activatable.Key);
+        }
+        #endregion
+        // Starlight End
 
         private void SubscribeUpdateUiState<T>(Entity<ReagentDispenserComponent> ent, ref T ev)
         {
@@ -85,7 +226,7 @@ namespace Content.Server.Chemistry.EntitySystems
 
             var inventory = GetInventory(reagentDispenser);
 
-            var energy = _powercell.TryGetBatteryFromSlot(reagentDispenser.Owner, out var battery) ? battery.CurrentCharge / battery.MaxCharge : 1f; // Starlight-edit: Energy bar
+            var energy = _powercell.TryGetBatteryFromSlot(reagentDispenser.Owner, out var battery) ? battery.CurrentCharge / battery.MaxCharge : 0f; // Starlight-edit: Energy bar
 
             var state = new ReagentDispenserBoundUserInterfaceState(outputContainerInfo, GetNetEntity(outputContainer), inventory, reagentDispenser.Comp.DispenseAmount, energy); // Starlight-edit: Energy bar
             _userInterfaceSystem.SetUiState(reagentDispenser.Owner, ReagentDispenserUiKey.Key, state);
@@ -164,18 +305,54 @@ namespace Content.Server.Chemistry.EntitySystems
             if (!TryComp<StorageComponent>(reagentDispenser.Owner, out var storage))
                 return;
 
+            // Starlight Start
+            var outputContainer = _itemSlotsSystem.GetItemOrNull(reagentDispenser, SharedReagentDispenser.OutputSlotName);
+            if (outputContainer is not { Valid: true })
+            {
+                if (TryComp<UserInterfaceComponent>(reagentDispenser.Owner, out var ui)
+                    && ui.Actors is { } actors
+                    && actors.TryGetValue(ReagentDispenserUiKey.Key, out var entities))
+                    foreach (var entity in entities)
+                        _popup.PopupCursor(Loc.GetString("reagent-dispenser-window-no-container-loaded-text"), entity);
+                
+                ClickSound(reagentDispenser);
+                return;
+            }
+
+            if (!_solutionContainerSystem.TryGetFitsInDispenser(outputContainer.Value, out var solution, out _))
+                return;
+            // Starlight End
+
             // Ensure that the reagent is something this reagent dispenser can dispense.
             var storageLocation = message.Data.StorageLocation; // Starlight-edit
             var storedContainer = storage.StoredItems.FirstOrDefault(kvp => kvp.Value == storageLocation).Key;
             if (storedContainer != EntityUid.Invalid)
             { // Starlight-edit
-                var outputContainer = _itemSlotsSystem.GetItemOrNull(reagentDispenser, SharedReagentDispenser.OutputSlotName);
-                if (outputContainer is not { Valid: true } || !_solutionContainerSystem.TryGetFitsInDispenser(outputContainer.Value, out var solution, out _))
-                    return;
-
+                // Starlight edit Start: Moved
+                // var outputContainer = _itemSlotsSystem.GetItemOrNull(reagentDispenser, SharedReagentDispenser.OutputSlotName);
+                // if (outputContainer is not { Valid: true } || !_solutionContainerSystem.TryGetFitsInDispenser(outputContainer.Value, out var solution, out _))
+                //     return;
+                // Starlight edit End
                 if (_solutionContainerSystem.TryGetDrainableSolution(storedContainer, out var src, out _) &&
-                    _solutionContainerSystem.TryGetRefillableSolution(outputContainer.Value, out var dst, out _))
+                    _solutionContainerSystem.TryGetRefillableSolution(outputContainer.Value, out var dst, out var dstSolution)) // Starlight edit
                 {
+                    // Starlight Start
+                    var transferAmount = FixedPoint2.New((int)reagentDispenser.Comp.DispenseAmount);
+                    if (dstSolution.AvailableVolume < transferAmount)
+                    {
+                        // Not enough space in container
+                        if (TryComp<UserInterfaceComponent>(reagentDispenser.Owner, out var ui)
+                            && ui.Actors is { } actors
+                            && actors.TryGetValue(ReagentDispenserUiKey.Key, out var entities))
+                            foreach (var entity in entities)
+                                _popup.PopupCursor(Loc.GetString("reagent-dispenser-component-cannot-fit-message"), entity);
+
+                        UpdateUiState(reagentDispenser);
+                        ClickSound(reagentDispenser);
+                        return;
+                    }
+                    // Starlight End
+
                     // force open container, if applicable, to avoid confusing people on why it doesn't dispense
                     _openable.SetOpen(storedContainer, true);
                     _solutionTransferSystem.Transfer(reagentDispenser,
@@ -186,22 +363,64 @@ namespace Content.Server.Chemistry.EntitySystems
             }
 
             // Starlight-start: Generatable Reagents
-            if (message.Data.ReagentID is { } reagentID && reagentDispenser.Comp.GeneratableReagents.TryGetValue(reagentID, out var powerDrain) && _powercell.HasCharge(reagentDispenser.Owner, powerDrain * (float)reagentDispenser.Comp.DispenseAmount))
+            if (message.Data.ReagentID is { } reagentID && reagentDispenser.Comp.GeneratableReagents.TryGetValue(reagentID, out var powerDrain))
             {
-                var outputContainer = _itemSlotsSystem.GetItemOrNull(reagentDispenser, SharedReagentDispenser.OutputSlotName);
-                if (outputContainer is not { Valid: true } || !_solutionContainerSystem.TryGetFitsInDispenser(outputContainer.Value, out var solution, out _))
+                if (!_solutionContainerSystem.TryGetRefillableSolution(outputContainer.Value, out var dst, out var dstSolution))
                     return;
 
-                if (_solutionContainerSystem.TryGetRefillableSolution(outputContainer.Value, out var dst, out _)
-                    && _solutionContainerSystem.TryAddReagent(dst.Value, reagentID.ToString(), FixedPoint2.New((int)reagentDispenser.Comp.DispenseAmount)))
-                    _powercell.TryUseCharge(reagentDispenser.Owner, powerDrain * (float)reagentDispenser.Comp.DispenseAmount);
+                // Check if there's enough space in the container FIRST (before checking power)
+                var amountToDispense = FixedPoint2.New((int)reagentDispenser.Comp.DispenseAmount);
+                if (dstSolution.AvailableVolume < amountToDispense)
+                {
+                    // Not enough space in container
+                    if (TryComp<UserInterfaceComponent>(reagentDispenser.Owner, out var ui)
+                        && ui.Actors is { } actors
+                        && actors.TryGetValue(ReagentDispenserUiKey.Key, out var entities))
+                        foreach (var entity in entities)
+                            _popup.PopupCursor(Loc.GetString("reagent-dispenser-component-cannot-fit-message"), entity);
+                    
+                    UpdateUiState(reagentDispenser);
+                    ClickSound(reagentDispenser);
+                    return;
+                }
+
+                // Check if there's enough power BEFORE dispensing
+                if (!_powercell.HasCharge(reagentDispenser.Owner, powerDrain * (float)reagentDispenser.Comp.DispenseAmount))
+                {
+                    if (reagentDispenser.Comp.NoEnergyPopup is { } popup
+                        && TryComp<UserInterfaceComponent>(reagentDispenser.Owner, out var ui2)
+                        && ui2.Actors is { } actors2
+                        && actors2.TryGetValue(ReagentDispenserUiKey.Key, out var entities2))
+                        foreach (var entity in entities2)
+                            _popup.PopupCursor(Loc.GetString(popup), entity);
+                    
+                    UpdateUiState(reagentDispenser);
+                    ClickSound(reagentDispenser);
+                    return;
+                }
+
+                // Try to add the reagent
+                if (!_solutionContainerSystem.TryAddReagent(dst.Value, reagentID.ToString(), amountToDispense))
+                {
+                    // Failed to add reagent (shouldn't happen since we checked space, but just in case)
+                    if (TryComp<UserInterfaceComponent>(reagentDispenser.Owner, out var ui3)
+                        && ui3.Actors is { } actors3
+                        && actors3.TryGetValue(ReagentDispenserUiKey.Key, out var entities3))
+                        foreach (var entity in entities3)
+                            _popup.PopupCursor(Loc.GetString("reagent-dispenser-component-cannot-fit-message"), entity);
+                    
+                    UpdateUiState(reagentDispenser);
+                    ClickSound(reagentDispenser);
+                    return;
+                }
+                
+                // Successfully dispensed, now use the power
+                if (!_powercell.TryUseCharge(reagentDispenser.Owner, powerDrain * (float)reagentDispenser.Comp.DispenseAmount))
+                {
+                    // This shouldn't happen since we already checked HasCharge, but log it just in case
+                    Logger.Warning($"Failed to use power charge on dispenser {ToPrettyString(reagentDispenser.Owner)} after dispensing reagent");
+                }
             }
-            else if (reagentDispenser.Comp.NoEnergyPopup is { } popup
-                && TryComp<UserInterfaceComponent>(reagentDispenser.Owner, out var ui)
-                && ui.Actors is { } actors
-                && actors.TryGetValue(ReagentDispenserUiKey.Key, out var entities))
-                foreach (var entity in entities)
-                    _popup.PopupCursor(Loc.GetString(popup), entity);
 
             UpdateUiState(reagentDispenser);
             ClickSound(reagentDispenser);

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -96,6 +96,20 @@ namespace Content.Shared.Chemistry
 
     }
 
+    // Starlight Start
+    // Required for UI to not flash while cell is charging/discharging
+    [Serializable, NetSerializable]
+    public sealed class ReagentDispenserEnergyUpdateMessage : BoundUserInterfaceMessage
+    {
+        public readonly float EnergyAmount;
+
+        public ReagentDispenserEnergyUpdateMessage(float energyAmount)
+        {
+            EnergyAmount = energyAmount;
+        }
+    }
+    // Starlight End
+
     public enum ReagentDispenserDispenseAmount
     {
         U1 = 1,

--- a/Resources/Locale/en-US/_Starlight/chemistry/components/reagent-dispenser-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/chemistry/components/reagent-dispenser-component.ftl
@@ -1,1 +1,2 @@
 reagent-dispenser-popup-no-energy = Not enough energy!
+reagent-dispenser-component-cannot-fit-message = The container can't hold that much!

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -86,6 +86,10 @@
   id: ReagentDispenserBasePowerCell
   parent: ReagentDispenserBaseUnpowered
   components:
+  - type: ApcPowerReceiver
+    needsPower: true
+    powerLoad: 5 # Draw power for charging cell
+  - type: ExtensionCableReceiver
   - type: PowerCellDraw
     drawRate: 0
     useRate: 5

--- a/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
@@ -3,7 +3,7 @@
   name: booze dispenser
   suffix: Empty
   description: A booze dispenser with a single slot for a container to be filled.
-  parent: ReagentDispenserBase
+  parent: ReagentDispenserBasePowerCell # Starlight edit: power cell booze dispenser
   components:
   - type: Rotatable
   - type: Sprite
@@ -25,6 +25,15 @@
     - Drinks
   - type: StealTarget
     stealGroup: BoozeDispenser
+  # Starlight start: Power Cell Booze dispenser
+  - type: PowerCellSlot
+    cellSlotId: cell_slot
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellMedium
+  # Starlight end
 
 - type: entity
   id: BoozeDispenser

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ReagentDispenserBase
+  parent: ReagentDispenserBasePowerCell # Starlight edit: power cell soda dispenser
   id: SodaDispenserEmpty
   name: soda dispenser
   description: A beverage dispenser with a selection of soda and several other common beverages. Has a single fill slot for containers.
@@ -23,6 +23,15 @@
     guides:
     - Bartender
     - Drinks
+  # Starlight start: Power Cell Soda dispenser
+  - type: PowerCellSlot
+    cellSlotId: cell_slot
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellMedium
+  # Starlight end
 
 - type: entity
   parent: SodaDispenserEmpty


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes a myriad of bugs with Booze, Chemical and Soda dispensers. Cells inside dispensers now charge at 5w when powered by LV (A 4th of a normal cell chargers speed) and discharge when no power is coming through LV and the UI is open at the same 5w. Open to changing the speeds, currently this is enough for a micro cell to keep the dispensers indefinitely going during a blackout.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bug fixes, Booze and soda dispensers had the Charge UI but never used cells, now they do. Cells charging inside when the dispenser is powered by LV makes sense and is a pretty requested QoL and I think 5w is balanced
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Many bugs with Chemical, Booze and Soda dispensers.
- tweak: Dispensers now work during a blackout at the cost of power to the cell inside slowly draining with the UI open.
- add: Cells inside dispensers now charge slowly at 5w when powered by LV.