### PR TITLE
Fix crash in preset vote

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -268,15 +268,15 @@ namespace Content.Server.Voting.Managers
                 GamePresetPrototype pickedPreset; //starlight
                 if (args.Winner == null)
                 {
-                    picked = (string)_random.Pick(args.Winners);
-                    pickedPreset = presets.FirstOrDefault(p => Loc.GetString(p.Value) == picked).Key; //starlight
+                    pickedPreset = (GamePresetPrototype)_random.Pick(args.Winners); //starlight
+                    picked = pickedPreset.ModeTitle; //starlight
                     _chatManager.DispatchServerAnnouncement(
                         Loc.GetString("ui-vote-gamemode-tie", ("picked", Loc.GetString(pickedPreset.ModeTitle)))); //starlight edit
                 }
                 else
                 {
-                    picked = (string)args.Winner;
-                    pickedPreset = presets.FirstOrDefault(p => Loc.GetString(p.Value) == picked).Key; //starlight
+                    pickedPreset = (GamePresetPrototype)args.Winner; //starlight
+                    picked = pickedPreset.ModeTitle; //starlight
                     _chatManager.DispatchServerAnnouncement(
                         Loc.GetString("ui-vote-gamemode-win", ("winner", Loc.GetString(pickedPreset.ModeTitle)))); //starlight edit
                 }


### PR DESCRIPTION
## Short description
It was assuming that the preset vote was for a string value; the code as currently written returns GamePresetPrototypes.

## Why we need to add this
Not crashing improves the player experience

## Media (Video/Screenshots)
N/A

## Checks
- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
