### PR TITLE
Fix dim PDA light

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -64,7 +64,8 @@
   - type: UnpoweredFlashlight
   - type: PointLight
     enabled: false
-    radius: 1.5
+    radius: 1.7
+    falloff: 3
     softness: 5
     autoRot: true
   - type: Ringer


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This fixes the PDA being dimmer due to Robust Toolbox V267.1.0 by cherry-picking the commit that Wizden used to fix it in [this PR](https://github.com/space-wizards/space-station-14/pull/40687).

## Why we need to add this
Currently it's very hard to see even the player character when using the PDA light, and this would bring it back to how it was before the RT update.

## Media (Video/Screenshots)
Current:
<img width="467" height="367" alt="image" src="https://github.com/user-attachments/assets/5116517f-6529-48de-a737-dd8cd716cf85" />

After:
<img width="467" height="367" alt="image" src="https://github.com/user-attachments/assets/13b344eb-37c2-4f4c-92ca-1b89f74e974a" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- fix: Fixed PDA light being too dim.
