### PR TITLE
Fix Gamemode Vote Spam

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -183,7 +183,7 @@
   name: nukeops-title
   description: nukeops-description
   minPlayers: 40
-  showInVote: true # 🌟Starlight🌟
+  showInVote: false # 🌟Starlight🌟
   rules:
   - Nukeops
   # - DummyNonAntagChance 🌟Starlight🌟
@@ -202,7 +202,7 @@
   name: rev-title
   description: rev-description
   minPlayers: 30
-  showInVote: true # 🌟Starlight🌟
+  showInVote: false # 🌟Starlight🌟
   rules:
   # - DummyNonAntagChance 🌟Starlight🌟
   - Revolutionary
@@ -239,7 +239,7 @@
   name: zombie-title
   description: zombie-description
   minPlayers: 50 # 🌟Starlight🌟
-  showInVote: true # 🌟Starlight🌟
+  showInVote: false # 🌟Starlight🌟
   rules:
   - Zombie
   - BasicStationEventScheduler
@@ -256,7 +256,7 @@
   name: zombieteors-title
   description: zombieteors-description
   minPlayers: 50 # 🌟Starlight🌟
-  showInVote: true # 🌟Starlight🌟
+  showInVote: false # 🌟Starlight🌟
   rules:
   - Zombie
   - BasicStationEventScheduler

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -19,14 +19,12 @@
     Nukeops: 0.05 #SL
     Traitor: 0.45 #SL
     Zombie: 0.03 #SL
-    Changeling: 0.03 #SL
+    Changeling: 0.15 #SL
     Zombieteors: 0.01 #SL
     Survival: 0.05 #SL
     KesslerSyndrome: 0.01 #SL
     Revolutionary: 0.10 #SL
-    Vampire: 0.10 #SL
     Extended: 0.10 #SL
-    Wizard: 0.02 #SL
     Traitorling: 0.01 #SL
     ShitStation: 0.01 #SL
     EventLight: 0.03 #SL

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,17 +1,16 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.15 #SL
-    Traitor: 0.30 #SL
-    Zombie: 0.10 #SL
-    Changeling: 0.05 #SL
-    Zombieteors: 0.01 #SL
-    Survival: 0.10 #SL
+    Revolutionary: 0.20 #SL
+    Nukeops: 0.20 #SL
+    Zombie: 0.15 #SL
+    Traitor: 0.15 #SL
+    Changeling: 0.15 #SL
+    Survival: 0.15 #SL
+    Extended: 0.05 #SL
+    Traitorling: 0.05 #SL
     KesslerSyndrome: 0.02 #SL
-    Revolutionary: 0.15 #SL
-    Vampire: 0.06 #SL
-    Wizard: 0.04 #SL
-    Traitorling: 0.01 #SL
+    Zombieteors: 0.02 #SL
     ShitStation: 0.01 #SL
 
 - type: weightedRandom

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,30 +1,33 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.08
-    Traitor: 0.40
-    Zombie: 0.05
-    Changeling: 0.10 #SL
-    Zombieteors: 0.01
-    Survival: 0.08
-    KesslerSyndrome: 0.02
-    Revolutionary: 0.15
-    Vampire: 0.15 #SL
-    Wizard: 0.10
-    Traitorling: 0.10 #SL
-    ShitStation: 0.10 #SL
+    Nukeops: 0.15 #SL
+    Traitor: 0.30 #SL
+    Zombie: 0.10 #SL
+    Changeling: 0.05 #SL
+    Zombieteors: 0.01 #SL
+    Survival: 0.10 #SL
+    KesslerSyndrome: 0.02 #SL
+    Revolutionary: 0.15 #SL
+    Vampire: 0.06 #SL
+    Wizard: 0.04 #SL
+    Traitorling: 0.01 #SL
+    ShitStation: 0.01 #SL
 
 - type: weightedRandom
   id: SecretLP
   weights:
-    Nukeops: 0.028818444
-    Traitor: 0.461095101
-    Zombie: 0.005763689
-    Changeling: 0.057636888 #SL
-    Zombieteors: 0.005763689
-    Survival: 0.057636888
-    KesslerSyndrome: 0.028818444
-    Revolutionary: 0.057636888
-    Vampire: 0.115273775 #SL
-    Extended: 0.152737752
-    Wizard: 0.028818444
+    Nukeops: 0.05 #SL
+    Traitor: 0.45 #SL
+    Zombie: 0.03 #SL
+    Changeling: 0.03 #SL
+    Zombieteors: 0.01 #SL
+    Survival: 0.05 #SL
+    KesslerSyndrome: 0.01 #SL
+    Revolutionary: 0.10 #SL
+    Vampire: 0.10 #SL
+    Extended: 0.10 #SL
+    Wizard: 0.02 #SL
+    Traitorling: 0.01 #SL
+    ShitStation: 0.01 #SL
+    EventLight: 0.03 #SL

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,14 +1,14 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.03
+    Nukeops: 0.08
     Traitor: 0.40
     Zombie: 0.05
     Changeling: 0.10 #SL
     Zombieteors: 0.01
-    Survival: 0.05
-    KesslerSyndrome: 0.01
-    Revolutionary: 0.10
+    Survival: 0.08
+    KesslerSyndrome: 0.02
+    Revolutionary: 0.15
     Vampire: 0.15 #SL
     Wizard: 0.10
     Traitorling: 0.10 #SL


### PR DESCRIPTION
## Short description
Removes Nuke OPs, Revolution, Zombies, and Zombeteors from the vote pool. Increases their odds of rolling in Secret to be much higher instead. Reorganized the odds of all gamemodes to be more legible.

## Why we need to add this
"We shouldn't add a band aid fix because it will just become permanent, wait for the vote cooldown" -someone, fucking 4 months ago.

We've suffered with **no** fix, 'temporary' or otherwise, because of this decission. Fuck it. If nobody can make the cooldown not a buggy mess just merge the damn temporary fix so we can actually RP on the MRP server.

**Changes to Odds:**

**Secret:** 51% 'RDM' modes (Nukies, Zombies, Revs, Survival, Extended)
- NukeOPs 2.5% to 15%
- Traitor 33.33% to 30%
- Zombie 4.17% to 10%
- Changeling 8.33% to 5%
- Zombieteors 0.83% to 1%
- Survival 4.17% 10%
- Kessler 0.83% to 2%
- Revolutionary 8.33% to 15%
- Vampire 12.5% to 6%
- Wizard 8.33% to 4%
- Traitorling 8.33% to 1%
- ShitStation 8.33% to 1%

**Lowpop Secret:** 34% 'RDM' modes (Nukies, Zombies, Revs, Survival, Extended)
- NukeOPs 2.88% to 5%
- Traitor 46.2% to 45%
- Zombie 0.576% to 3%
- Changeling 5.763% to 3%
- Zombieteors 0.576% to 1%
- Survival 5.763% to 5%
- Kessler 2.88% to 1%
- Revolutionary 5.763% to 10%
- Vampire 11.527% to 10%
- Wizard 2.88% to 2%
- Extended 15.27% to 10%
- Traitorling 0% to 1%
- ShitStation 0% to 1%
- EventLight 0% to 3%

## Media (Video/Screenshots)
![merge-my](https://github.com/user-attachments/assets/6c783088-5132-4a37-8492-cc974ce81908)


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- remove: Removed NukeOPs, Red Tide, Zombies, and Zombeteors from the vote pool
- tweak: Changed odds of every gamemode in the Secret pools. Secret averages 51% 'RDM' modes and Secret LP averages 34% 'RDM' modes (Nukies, Zombies, Revs, Survival, Extended).

