### PR TITLE
More Sentience

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -132,6 +132,8 @@
   - type: Construction
     graph: FireBot
     node: bot
+  - type: SentienceTarget #Starlight
+    flavorKind: station-event-random-sentience-flavor-mechanical #Starlight
   - type: HTN
     rootTask:
       task: FirebotCompound
@@ -284,6 +286,8 @@
   - type: Construction
     graph: CleanBot
     node: bot
+  - type: SentienceTarget #Starlight
+    flavorKind: station-event-random-sentience-flavor-mechanical #Starlight
   - type: Absorbent
     pickupAmount: 10
   - type: UseDelay
@@ -368,6 +372,8 @@
   - type: Construction
     graph: MediBot
     node: bot
+  - type: SentienceTarget #Starlight
+    flavorKind: station-event-random-sentience-flavor-mechanical #Starlight
   - type: Anchorable
   - type: InteractionPopup
     interactSuccessString: petting-success-medibot

--- a/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
@@ -110,6 +110,9 @@
     - ForceableFollow
     - PlushieGhost
     - Payload
+  - type: SentienceTarget #Starlight
+    flavorKind: station-event-random-sentience-flavor-inanimate #Starlight
+    weight: 0.01 #Starlight
 
 - type: entity
   parent: PlushieGhost
@@ -131,6 +134,9 @@
   - type: FoodSequenceElement
     entries:
       CottonBurger: RevenantPlushie
+  - type: SentienceTarget #Starlight
+    flavorKind: station-event-random-sentience-flavor-inanimate #Starlight
+    weight: 0.01 #Starlight
 
 - type: entity
   parent: BasePlushie

--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -42,3 +42,6 @@
   - type: Tag
     tags:
     - FakeNukeDisk
+  - type: SentienceTarget #Starlight
+    flavorKind: station-event-random-sentience-flavor-inanimate #Starlight
+    weight: 0.001 #Starlight

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -97,6 +97,9 @@
     ammoSlots: [ null, null, null, null, null, null ]
   - type: StealTarget
     stealGroup: OfficerHandgun
+  - type: SentienceTarget #Starlight
+    flavorKind: station-event-random-sentience-flavor-inanimate #Starlight
+    weight: 0.01 #Starlight
 
 - type: entity
   name: Mateba

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -102,7 +102,7 @@
   - type: DisarmMalus
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-inanimate
-    weight: 0.0002 # 5,000 times less likely than 1 regular animal
+    weight: 0.0005 # 5,000 times less likely than 1 regular animal
   - type: PirateAccent
     # not putting a BlockMovement component here cause that's funny.
   - type: StealTarget


### PR DESCRIPTION

## Short description
Reverts Upstream's [32383](https://github.com/space-wizards/space-station-14/pull/32383) by reenabling random sentience for the CleanBot and MediBot. Also adds random sentience to the FireBot.

Adds random sentience to a handful of extra items at low rates; Ghost Plushie, Revenant Plushie, Fake Nuke Disk, Inspector Revolver.

Slightly increased the odds of the Captain's Sword becoming sentient.

## Why we need to add this
It's fun. More sentient ghost roles for variety, and I tried to pick ones that will generate fun roleplay and scenarios.
- The MediBot, CleanBot, and FireBot are easy readds, as they were disabled to 'fix' a bug instead of fixing it.
- The Ghost and Revenant Plushies can cause fake hauntings, which is fun and gives Chaplain something to mess with.
- The Fake Nuke Disk is just funny. Imagine an Andy the Bomb scenario with it trying to get inserted into the Nuke to detonate, but it can't because it's impotent. Perfect.
- Inspector is the Detective's revolver. Detective gone nuts and started talking to his fuckin' gun I tell you what.
- Captain's Sword has such low odds of happening that I have never seen it occur naturally. This increases the chances slightly, from 0.02% to 0.05%. 

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added a chance for; MediBot, CleanBot, FireBot, Ghost Plushie, Revenant Plushie, Fake Nuke Disk, and the Inspector Revolver to become sentient with random sentience events.
- tweak: Increased the odds of Captain's Sword becoming sentient from 0.02% to 0.05%
