### PR TITLE
Social interaction fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -226,6 +226,13 @@
     - DoorBumpOpener
     - AnomalyHost
   - type: ActiveInputMover # Starlight
+  # Starlight Start: Social Interactions
+  - type: PhysicalSocialInteractionGiver
+  - type: PhysicalSocialInteractionReceiver
+    interactionPrototypes:
+    - Pet
+    - Boop
+  # Starlight End
 
 - type: entity
   save: false
@@ -296,12 +303,6 @@
   - type: FireVisuals
     alternateState: Standing
   - type: StunVisuals
-  #starlight, they can give and receive physical social interactions
-  - type: PhysicalSocialInteractionGiver
-  - type: PhysicalSocialInteractionReceiver
-    interactionPrototypes:
-    - Pet
-    - Boop
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Moves social interaction comps to a higher parent
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes shadekins and skeletons not being able to social interact either way
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Shadekin and Skeletons can now social interact either way.