### PR TITLE
NoObjectiveTargetComponent

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -1037,5 +1037,6 @@ public sealed partial class AdminVerbSystem
         ToggleOverlays = -32, // #🌟Starlight🌟
         AddRandomMood = -32, //Starlight Thaven
         AddCustomMood = -33, //Starlight Thaven
+        BlockObjectiveTargeting = -44, // Starlight
     }
 }

--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using Content.Server._Starlight.Antags;
 using Content.Server.Antag;
-using Content.Server.Chat.Managers; // SL add
+using Content.Server.Chat.Managers;
 using Content.Server.Cloning;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Medical.SuitSensors;
@@ -38,7 +38,6 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
     {
         base.Started(uid, component, gameRule, args);
         
-        // SL | not adding anything here other than this comment, i just wanna make fun of the comment below this one since it's just a straight up lie lmao
         // check if we got enough potential cloning targets, otherwise cancel the gamerule so that the ghost role does not show up
         var allHumans = _mind.GetAliveHumans();
 

--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -5,6 +5,7 @@ using Content.Server.GameTicking.Rules;
 using Content.Server.Revolutionary.Components;
 using Robust.Shared.Random;
 using System.Linq;
+using Content.Shared.Mind.Filters;
 
 namespace Content.Server.Objectives.Systems;
 
@@ -23,7 +24,17 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
 
         SubscribeLocalEvent<PickSpecificPersonComponent, ObjectiveAssignedEvent>(OnSpecificPersonAssigned);
         SubscribeLocalEvent<PickRandomPersonComponent, ObjectiveAssignedEvent>(OnRandomPersonAssigned);
+        SubscribeLocalEvent<PickRandomPersonComponent, ComponentStartup>(OnComponentStartup); // SL add
     }
+
+    // SL start
+    private void OnComponentStartup(Entity<PickRandomPersonComponent> ent, ref ComponentStartup args)
+    {
+        // inject new filter blacklisting NoObjectiveTargetComponent
+        var filter = new BodyMindFilter { Whitelist = { Components = ["NoObjectiveTarget"] }, Inverted = true };
+        ent.Comp.Filters.Add(filter);
+    }
+    // SL end
 
     private void OnSpecificPersonAssigned(Entity<PickSpecificPersonComponent> ent, ref ObjectiveAssignedEvent args)
     {

--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -24,11 +24,11 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
 
         SubscribeLocalEvent<PickSpecificPersonComponent, ObjectiveAssignedEvent>(OnSpecificPersonAssigned);
         SubscribeLocalEvent<PickRandomPersonComponent, ObjectiveAssignedEvent>(OnRandomPersonAssigned);
-        SubscribeLocalEvent<PickRandomPersonComponent, ComponentStartup>(OnComponentStartup); // SL add
+        SubscribeLocalEvent<PickRandomPersonComponent, MapInitEvent>(OnMapInit); // SL add
     }
 
     // SL start
-    private void OnComponentStartup(Entity<PickRandomPersonComponent> ent, ref ComponentStartup args)
+    private void OnMapInit(Entity<PickRandomPersonComponent> ent, ref MapInitEvent args)
     {
         // inject new filter blacklisting NoObjectiveTargetComponent
         var filter = new BodyMindFilter { Whitelist = { Components = ["NoObjectiveTarget"] }, Inverted = true };

--- a/Content.Server/_Starlight/Administration/Systems/AdminVerbSystem.Tools.cs
+++ b/Content.Server/_Starlight/Administration/Systems/AdminVerbSystem.Tools.cs
@@ -1,4 +1,6 @@
+using Content.Server._Starlight.Antags;
 using Content.Server.Administration.Systems;
+using Content.Server.Chat.Managers;
 using Content.Shared.Administration;
 using Content.Shared.Administration.Managers;
 using Content.Shared.Database;
@@ -15,6 +17,7 @@ public sealed partial class AdminVerbSystem : EntitySystem
     [Dependency] private readonly AdminTestArenaSystem _adminTestArenaSystem = default!;
     [Dependency] private readonly ISharedAdminManager _adminManager = default!;
     [Dependency] private readonly IEntityManager _entities = default!;
+    [Dependency] private readonly IChatManager _chat = default!;
     public override void Initialize()
     {
         SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddVerbs);
@@ -61,6 +64,22 @@ public sealed partial class AdminVerbSystem : EntitySystem
                 Priority = (int)TricksVerbPriorities.SendToTestArena,
             };
             args.Verbs.Add(sendToTestArena);
+
+            Verb preventObjectiveTargeting = new()
+            {
+                Text = "Prevent objective targeting",
+                Category = VerbCategory.Tricks,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/sentient.svg.192dpi.png")),
+                Act = () =>
+                {
+                    EnsureComp<NoObjectiveTargetComponent>(args.Target);
+                    _chat.SendAdminAnnouncementMessage(player, $"Added NoObjectiveTarget component to the entity! ({args.Target})");
+                },
+                Impact = LogImpact.Low,
+                Message = "Prevents this entity from being targeted by other player's objectives. Will also prevent paraclones of this player.",
+                Priority = (int)TricksVerbPriorities.BlockObjectiveTargeting
+            };
+            if (HasComp<ActorComponent>(args.Target)) args.Verbs.Add(preventObjectiveTargeting);
         }
     }
 }

--- a/Content.Server/_Starlight/Objectives/Components/NoObjectiveTargetComponent.cs
+++ b/Content.Server/_Starlight/Objectives/Components/NoObjectiveTargetComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Server._Starlight.Antags;
+
+[RegisterComponent]
+public sealed partial class NoObjectiveTargetComponent : Component
+{
+}

--- a/Resources/Locale/en-US/_Starlight/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/_Starlight/alerts/alerts.ftl
@@ -1,2 +1,3 @@
 alerts-cards-name = [color=lightblue]Challenge available[/color]
 alerts-cards-desc = You're [color=lightblue]facing a choice[/color]. Click the alert to see your available paths. If you close it, you won't see this again for the rest of the round.
+alerts-error-failed-to-spawn-ghost-role = Failed to spawn the requested ghost role. Sorry! :(


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->
## Short description
<!-- What do you propose to change with your PR? -->
Adds a new component: NoObjectiveTarget.
Prevents other player's objectives from targeting a player who has said component.
Will also prevent Paradox Clones of that player from spawning.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Can be added to a CC character or a urist in aspace to prevent Paradox Clones of them from spawning or from someone's kill objective targeting them. Also applicable to abductors and anything else you can think up.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- add: NoObjectiveTargetComponent
- tweak: ParadoxCloneRuleSystem filters entities with NoObjectiveTargetComponent from available targets.
- tweak: PickObjectiveTargetSystem adds a blacklist filter to all PickRandomPersonComponents that get added on component startup, aka all objective targets inherently blacklist this.