### PR TITLE
Fix Double PDAs for Mining and Salvage

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -25,7 +25,7 @@
 - type: startingGear
   id: SalvageSpecialistGear
   equipment:
-    id: SalvagePDA
+   # id: SalvagePDA #Starlight
     ears: ClothingHeadsetCargo
   #storage:
     #back:

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
@@ -23,7 +23,6 @@
 - type: startingGear
   id: MiningSpecialistGear
   equipment:
-    id: MiningPDA
     ears: ClothingHeadsetMining
     belt: OreBag
     #storage:

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/salvage_lead.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/salvage_lead.yml
@@ -26,7 +26,6 @@
 - type: startingGear
   id: SalvageLeadGear
   equipment:
-    id: SalvageLeadPDA
     ears: ClothingHeadsetSalvageLead
   #storage:
     #back:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fix Salvage Specialist, Mining Specialist, and Salvage Lead from starting with two PDAs

Fixes #2068.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It's a bugfix! We don't want anyone to start with two PDAs.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CommanderAlex365
- fix: Salvagers, Salvage Leads, and Miners no longer get two PDAs
