### PR TITLE
Make FMJ and HP ammunition types unobtainable

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -43,7 +43,7 @@
   - type: StorageFill
     contents:
       - id: MagazineLightRifleSP
-        amount: 3
+        amount: 3  #Starlight | increased due to hp and fmj removal
       #- id: MagazineLightRifleHP
       #  amount: 1
       #- id: MagazineLightRifleFMJ
@@ -85,7 +85,7 @@
   - type: StorageFill
     contents:
       - id: MagazinePistolSP
-        amount: 4
+        amount: 4 #Starlight | increased due to hp and fmj removal
       #- id: MagazinePistolHP
       #  amount: 1
       #- id: MagazinePistolFMJ
@@ -211,7 +211,7 @@
       #- id: MagazineRifleFMJ
       #  amount: 2
       - id: MagazineRifleSP
-        amount: 4
+        amount: 4 #Starlight | increased due to hp and fmj removal
       #- id: MagazineRifleHP
       #  amount: 1
       - id: MagazineRifleAP

--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -43,11 +43,11 @@
   - type: StorageFill
     contents:
       - id: MagazineLightRifleSP
-        amount: 1
-      - id: MagazineLightRifleHP
-        amount: 1
-      - id: MagazineLightRifleFMJ
-        amount: 1
+        amount: 3
+      #- id: MagazineLightRifleHP
+      #  amount: 1
+      #- id: MagazineLightRifleFMJ
+      #  amount: 1
       - id: MagazineLightRifleAP
         amount: 1
         
@@ -85,11 +85,11 @@
   - type: StorageFill
     contents:
       - id: MagazinePistolSP
-        amount: 2
-      - id: MagazinePistolHP
-        amount: 1
-      - id: MagazinePistolFMJ
-        amount: 1
+        amount: 4
+      #- id: MagazinePistolHP
+      #  amount: 1
+      #- id: MagazinePistolFMJ
+      # amount: 1
 
 - type: entity
   name: box of pistol .35 auto (practice) magazines
@@ -208,12 +208,12 @@
     - 0,0,2,3
   - type: StorageFill
     contents:
-      - id: MagazineRifleFMJ
-        amount: 2
+      #- id: MagazineRifleFMJ
+      #  amount: 2
       - id: MagazineRifleSP
-        amount: 1
-      - id: MagazineRifleHP
-        amount: 1
+        amount: 4
+      #- id: MagazineRifleHP
+      #  amount: 1
       - id: MagazineRifleAP
         amount: 1
         

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -70,11 +70,11 @@
     - id: WeaponPistolMk58
       amount: 2
     - id: MagazinePistolSP
-      amount: 2
-    - id: MagazinePistolHP
-      amount: 1
-    - id: MagazinePistolFMJ
-      amount: 1
+      amount: 4
+    #- id: MagazinePistolHP
+    #  amount: 1
+    #- id: MagazinePistolFMJ
+    #  amount: 1
 
 - type: entity
   id: CrateSecurityRiot

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -70,7 +70,7 @@
     - id: WeaponPistolMk58
       amount: 2
     - id: MagazinePistolSP
-      amount: 4
+      amount: 4 #Starlight | increased due to hp and fmj removal
     #- id: MagazinePistolHP
     #  amount: 1
     #- id: MagazinePistolFMJ

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -239,7 +239,7 @@
     #- id: WeaponMachinePistolMk64
       #amount: 1
     - id: MagazinePistolSP
-      amount: 8 #added four due to HP & FMJ removal
+      amount: 8 #Starlight | increased due to hp and fmj removal
     #- id: MagazinePistolHP
     #  amount: 2
     #- id: MagazinePistolFMJ
@@ -268,7 +268,7 @@
     #- id: MagazineRifleHP
     #  amount: 3
     - id: MagazineRifleSP
-      amount: 6 #added three due to HP removal
+      amount: 6 #Starlight | increased due to hp and fmj removal
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -239,11 +239,11 @@
     #- id: WeaponMachinePistolMk64
       #amount: 1
     - id: MagazinePistolSP
-      amount: 4
-    - id: MagazinePistolHP
-      amount: 2
-    - id: MagazinePistolFMJ
-      amount: 2
+      amount: 8 #added four due to HP & FMJ removal
+    #- id: MagazinePistolHP
+    #  amount: 2
+    #- id: MagazinePistolFMJ
+    #  amount: 2
     #- id: MagazinePistolHighCapacitySP
       #amount: 2
 
@@ -265,10 +265,10 @@
       amount: 1
     - id: WeaponRifleLeikha
       amount: 1
-    - id: MagazineRifleHP
-      amount: 3
+    #- id: MagazineRifleHP
+    #  amount: 3
     - id: MagazineRifleSP
-      amount: 3
+      amount: 6 #added three due to HP removal
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -526,16 +526,17 @@
   categories:
   - UplinkAmmo
 
-- type: listing
-  id: UplinkPistol9mmMagazineFMJ
-  name: uplink-pistol-magazine-name
-  description: uplink-pistol-magazine-desc
-  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: fmj }
-  productEntity: MagazinePistolFMJ
-  cost:
-    Telecrystal: 1
-  categories:
-  - UplinkAmmo
+# FMJ dead, and murdered, by my own two hands
+#- type: listing
+#  id: UplinkPistol9mmMagazineFMJ
+#  name: uplink-pistol-magazine-name
+#  description: uplink-pistol-magazine-desc
+#  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: fmj }
+#  productEntity: MagazinePistolFMJ
+#  cost:
+#    Telecrystal: 1
+#  categories:
+#  - UplinkAmmo
 
 # For the C20R
 - type: listing
@@ -601,7 +602,7 @@
   id: UplinkMosinAmmo
   name: uplink-mosin-ammo-name
   description: uplink-mosin-ammo-desc
-  productEntity: MagazineBoxLightRifleFMJ
+  productEntity: MagazineBoxLightRifleSP
   cost:
     Telecrystal: 1
   categories:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -526,7 +526,7 @@
   categories:
   - UplinkAmmo
 
-# FMJ dead, and murdered, by my own two hands
+# Starlight | FMJ dead, and murdered, by my own two hands
 #- type: listing
 #  id: UplinkPistol9mmMagazineFMJ
 #  name: uplink-pistol-magazine-name

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -217,7 +217,7 @@
           whitelistFailPopup: gun-magazine-whitelist-fail
         gun_chamber:
           name: Chamber
-          startingItem: CartridgePistolFMJ
+          startingItem: CartridgePistolSP
           priority: 1
           whitelist:
             tags:
@@ -279,7 +279,7 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgePistolFMJ
+        startingItem: CartridgePistolSP
         priority: 1
         whitelist:
           tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -217,7 +217,7 @@
           whitelistFailPopup: gun-magazine-whitelist-fail
         gun_chamber:
           name: Chamber
-          startingItem: CartridgePistolSP
+          startingItem: CartridgePistolSP #Starlight | FMJ -> SP
           priority: 1
           whitelist:
             tags:
@@ -279,7 +279,7 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgePistolSP
+        startingItem: CartridgePistolSP #Starlight | FMJ -> SP
         priority: 1
         whitelist:
           tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -44,7 +44,7 @@
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
   - type: BallisticAmmoProvider
     capacity: 10
-    proto: CartridgeLightRifleFMJ
+    proto: CartridgeLightRifleSP
     whitelist:
       tags:
       - CartridgeLightRifle

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -44,7 +44,7 @@
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
   - type: BallisticAmmoProvider
     capacity: 10
-    proto: CartridgeLightRifleSP
+    proto: CartridgeLightRifleSP #Starlight | FMJ -> SP
     whitelist:
       tags:
       - CartridgeLightRifle

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/security.yml
@@ -171,9 +171,9 @@
     - id: WeaponLightMachineGunM492
       amount: 1
     - id: LightRifleHeavyMagazineSP
-      amount: 1
-    - id: LightRifleHeavyMagazineHP
-      amount: 1
+      amount: 2 #added one due to HP removal
+    #- id: LightRifleHeavyMagazineHP
+    #  amount: 1
     - id: ClothingOuterHardsuitSecurityExperimental
       amount: 1
     - id: ClothingShoesBootsMagSec

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -123,7 +123,7 @@
       - MagazinePistolSubMachineGunTopMounted
   - type: BallisticAmmoProvider
     mayTransfer: true
-    proto: CartridgePistolFMJ
+    proto: CartridgePistolSP
     whitelist:
       tags:
       - CartridgePistol

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -123,7 +123,7 @@
       - MagazinePistolSubMachineGunTopMounted
   - type: BallisticAmmoProvider
     mayTransfer: true
-    proto: CartridgePistolSP
+    proto: CartridgePistolSP #FMJ -> SP
     whitelist:
       tags:
       - CartridgePistol

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -210,7 +210,7 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazinePistol40SP
+        startingItem: MagazinePistol40SP #FMJ -> SP
         insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
         priority: 2
@@ -220,7 +220,7 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgePistol40SP
+        startingItem: CartridgePistol40SP #FMJ -> SP
         priority: 1
         whitelist:
           tags:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -210,7 +210,7 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazinePistol40FMJ
+        startingItem: MagazinePistol40SP
         insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
         priority: 2
@@ -220,7 +220,7 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgePistol40FMJ
+        startingItem: CartridgePistol40SP
         priority: 1
         whitelist:
           tags:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -93,7 +93,7 @@
   damage:
     types:
       Piercing: 35
-  armorPenetration: -0.13
+  armorPenetration: 0 #previous value: -0.13
   pierceChance: 0.40
   derivation: 0.05
   ricochetChance: 0.30
@@ -219,7 +219,7 @@
   damage:
     types:
       Piercing: 16
-  armorPenetration: -0.13
+  armorPenetration: 0 #previous value: -0.13
   pierceChance: 0.40
   derivation: 0.2
   ricochetChance: 0.30
@@ -348,7 +348,7 @@
     sprite:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
       state: sp
-  armorPenetration: -0.5
+  armorPenetration: 0 #previous value: -0.5
   pierceChance: 0.30
   derivation: 0.15
   ricochetChance: 0.20
@@ -445,7 +445,7 @@
   damage:
     types:
       Piercing: 19
-  armorPenetration: -0.13
+  armorPenetration: 0 #previous value: -0.13
   staminaDamage: 2
   pierceChance: 0.40
   derivation: 0.05
@@ -574,7 +574,7 @@
   damage:
     types:
       Piercing: 17
-  armorPenetration: -0.13
+  armorPenetration: 0 #previous value: -0.13
   pierceChance: 0.40
   ricochetChance: 0.30
   staminaDamage: 2

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -151,7 +151,7 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazineLightRifleSP
+        startingItem: MagazineLightRifleSP #FMJ -> SP
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
@@ -161,7 +161,7 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgeLightRifleSP
+        startingItem: CartridgeLightRifleSP #FMJ -> SP
         priority: 1
         whitelist:
           tags:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -151,7 +151,7 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazineLightRifleFMJ
+        startingItem: MagazineLightRifleSP
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
@@ -161,7 +161,7 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgeLightRifleFMJ
+        startingItem: CartridgeLightRifleSP
         priority: 1
         whitelist:
           tags:
@@ -352,7 +352,7 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazineRifleFMJ
+        startingItem: MagazineRifleSP
         insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
@@ -362,7 +362,7 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgeRifleFMJ
+        startingItem: CartridgeRifleSP
         priority: 1
         whitelist:
           tags:

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
@@ -32,25 +32,25 @@
 ######################BOX#######################
 # Light Rifle
   - MagazineBoxLightRifleSP
-  - MagazineBoxLightRifleHP
-  - MagazineBoxLightRifleFMJ
+  #- MagazineBoxLightRifleHP
+  #- MagazineBoxLightRifleFMJ
 # Magnum
   - MagazineBoxMagnumSP
-  - MagazineBoxMagnumHP
-  - MagazineBoxMagnumFMJ
+  #- MagazineBoxMagnumHP
+  #- MagazineBoxMagnumFMJ
 # Pistol
   - MagazineBoxCaselessRifle
   - MagazineBoxCaselessRifleRubber
   - MagazineBoxPistolSP
-  - MagazineBoxPistolHP
-  - MagazineBoxPistolFMJ
+  #- MagazineBoxPistolHP
+  #- MagazineBoxPistolFMJ
   - MagazineBoxPistol40SP
-  - MagazineBoxPistol40HP
-  - MagazineBoxPistol40FMJ
+  #- MagazineBoxPistol40HP
+  #- MagazineBoxPistol40FMJ
 # Rifle
   - MagazineBoxRifleSP
-  - MagazineBoxRifleHP
-  - MagazineBoxRifleFMJ
+  #- MagazineBoxRifleHP
+  #- MagazineBoxRifleFMJ
 # Shotgun
   - BoxLethalshot
   - BoxShotgunSlug
@@ -58,20 +58,20 @@
 #####################MAGAZINE#######################
 # LMG
   - LightRifleHeavyMagazineSP
-  - LightRifleHeavyMagazineHP
-  - LightRifleHeavyMagazineFMJ
+  #- LightRifleHeavyMagazineHP
+  #- LightRifleHeavyMagazineFMJ
   - LightRifleHeavyMagazineEmpty
 # Light Rifle
   - MagazineLightRifleSP
-  - MagazineLightRifleHP
-  - MagazineLightRifleFMJ
+  #- MagazineLightRifleHP
+  #- MagazineLightRifleFMJ
   - MagazineLightRifleMaxim
   - SpeedLoaderLightRifle
   - MagazineLightRifleEmpty
 # Magnum
   - SpeedLoaderMagnumSP
-  - SpeedLoaderMagnumHP
-  - SpeedLoaderMagnumFMJ
+  #- SpeedLoaderMagnumHP
+  #- SpeedLoaderMagnumFMJ
   - MagazineMagnum
   - MagazineMagnumRifleSP
   - MagazineMagnumEmpty
@@ -80,17 +80,17 @@
   - MagazinePistolCaselessRifle
   - MagazineCaselessRifleRubber
   - MagazinePistolSP
-  - MagazinePistolHP
-  - MagazinePistolFMJ
+  #- MagazinePistolHP
+  #- MagazinePistolFMJ
   - MagazinePistolEmpty
   - MagazinePistol40SP
-  - MagazinePistol40HP
-  - MagazinePistol40FMJ
+  #- MagazinePistol40HP
+  #- MagazinePistol40FMJ
   - MagazinePistol40Empty
 # SMG
   - MagazinePistolSubMachineGunSP
-  - MagazinePistolSubMachineGunHP
-  - MagazinePistolSubMachineGunFMJ
+  #- MagazinePistolSubMachineGunHP
+  #- MagazinePistolSubMachineGunFMJ
   - MagazinePistolSubMachineGunEmpty
   - MagazinePistolSubMachineGunTopMounted
   - MagazinePistolSubMachineGunTopMountedEmpty
@@ -98,8 +98,8 @@
   - MagazinePistolSubMachineGunPPSH
 # Rifle
   - MagazineRifleSP
-  - MagazineRifleHP
-  - MagazineRifleFMJ
+  #- MagazineRifleHP
+  #- MagazineRifleFMJ
   - MagazineRifleEmpty
 # Shotgun
   - MagazineShotgun

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/light-rifle.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/light-rifle.yml
@@ -24,19 +24,19 @@
   materials:
     Steel: 565
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineLightRifleHP
-  result: MagazineLightRifleHP
-  materials:
-    Steel: 565
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineLightRifleHP
+#  result: MagazineLightRifleHP
+#  materials:
+#    Steel: 565
     
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineLightRifleFMJ
-  result: MagazineLightRifleFMJ
-  materials:
-    Steel: 565
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineLightRifleFMJ
+#  result: MagazineLightRifleFMJ
+#  materials:
+#    Steel: 565
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
@@ -86,19 +86,19 @@
   materials:
     Steel: 1412
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: LightRifleHeavyMagazineHP
-  result: LightRifleHeavyMagazineHP
-  materials:
-    Steel: 1412
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: LightRifleHeavyMagazineHP
+#  result: LightRifleHeavyMagazineHP
+#  materials:
+#    Steel: 1412
     
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: LightRifleHeavyMagazineFMJ
-  result: LightRifleHeavyMagazineFMJ
-  materials:
-    Steel: 1412
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: LightRifleHeavyMagazineFMJ
+#  result: LightRifleHeavyMagazineFMJ
+#  materials:
+#    Steel: 1412
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
@@ -158,19 +158,19 @@
   materials:
     Steel: 900
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineBoxLightRifleHP
-  result: MagazineBoxLightRifleHP
-  materials:
-    Steel: 900
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineBoxLightRifleHP
+#  result: MagazineBoxLightRifleHP
+#  materials:
+#    Steel: 900
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineBoxLightRifleFMJ
-  result: MagazineBoxLightRifleFMJ
-  materials:
-    Steel: 900
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineBoxLightRifleFMJ
+#  result: MagazineBoxLightRifleFMJ
+#  materials:
+#    Steel: 900
 
 - type: latheRecipe
   parent: BaseAmmoRecipe

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/magnum.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/magnum.yml
@@ -30,19 +30,19 @@
   materials:
     Steel: 190
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: SpeedLoaderMagnumHP
-  result: SpeedLoaderMagnumHP
-  materials:
-    Steel: 190
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: SpeedLoaderMagnumHP
+#  result: SpeedLoaderMagnumHP
+# materials:
+#    Steel: 190
     
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: SpeedLoaderMagnumFMJ
-  result: SpeedLoaderMagnumFMJ
-  materials:
-    Steel: 190
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: SpeedLoaderMagnumFMJ
+#  result: SpeedLoaderMagnumFMJ
+#  materials:
+#    Steel: 190
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
@@ -110,19 +110,19 @@
   materials:
     Steel: 240
     
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineBoxMagnumHP
-  result: MagazineBoxMagnumHP
-  materials:
-    Steel: 240
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineBoxMagnumHP
+#  result: MagazineBoxMagnumHP
+#  materials:
+#   Steel: 240
     
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineBoxMagnumFMJ
-  result: MagazineBoxMagnumFMJ
-  materials:
-    Steel: 240
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineBoxMagnumFMJ
+#  result: MagazineBoxMagnumFMJ
+#  materials:
+#    Steel: 240
 
 - type: latheRecipe
   parent: BaseAmmoRecipe

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/pistol.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/pistol.yml
@@ -64,19 +64,19 @@
   materials:
     Steel: 145
     
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazinePistolHP
-  result: MagazinePistolHP
-  materials:
-    Steel: 145
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazinePistolHP
+#  result: MagazinePistolHP
+#  materials:
+#    Steel: 145
     
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazinePistolFMJ
-  result: MagazinePistolFMJ
-  materials:
-    Steel: 145
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazinePistolFMJ
+#  result: MagazinePistolFMJ
+#  materials:
+#    Steel: 145
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
@@ -117,19 +117,19 @@
   materials:
     Steel: 145
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazinePistolHighCapacityFMJ
-  result: MagazinePistolHighCapacityFMJ
-  materials:
-    Steel: 145
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazinePistolHighCapacityFMJ
+#  result: MagazinePistolHighCapacityFMJ
+#  materials:
+#    Steel: 145
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazinePistolHighCapacityHP
-  result: MagazinePistolHighCapacityHP
-  materials:
-    Steel: 145
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazinePistolHighCapacityHP
+#  result: MagazinePistolHighCapacityHP
+#  materials:
+#    Steel: 145
 
 - type: latheRecipe
   parent: BaseEmptyAmmoRecipe
@@ -154,19 +154,19 @@
   materials:
     Steel: 167
     
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazinePistol40HP
-  result: MagazinePistol40HP
-  materials:
-    Steel: 167
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazinePistol40HP
+#  result: MagazinePistol40HP
+#  materials:
+#    Steel: 167
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazinePistol40FMJ
-  result: MagazinePistol40FMJ
-  materials:
-    Steel: 167
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazinePistol40FMJ
+#  result: MagazinePistol40FMJ
+#  materials:
+#    Steel: 167
     
 - type: latheRecipe
   parent: BaseAmmoRecipe
@@ -196,19 +196,19 @@
   materials:
     Steel: 600
         
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineBoxPistolHP
-  result: MagazineBoxPistolHP
-  materials:
-    Steel: 600
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineBoxPistolHP
+#  result: MagazineBoxPistolHP
+#  materials:
+#    Steel: 600
         
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineBoxPistolFMJ
-  result: MagazineBoxPistolFMJ
-  materials:
-    Steel: 600
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineBoxPistolFMJ
+#  result: MagazineBoxPistolFMJ
+#  materials:
+#    Steel: 600
     
 - type: latheRecipe
   parent: BaseAmmoRecipe
@@ -250,19 +250,19 @@
   materials:
     Steel: 334
     
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineBoxPistol40HP
-  result: MagazineBoxPistol40HP
-  materials:
-    Steel: 334
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineBoxPistol40HP
+#  result: MagazineBoxPistol40HP
+#  materials:
+#    Steel: 334
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineBoxPistol40FMJ
-  result: MagazineBoxPistol40FMJ
-  materials:
-    Steel: 334
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineBoxPistol40FMJ
+#  result: MagazineBoxPistol40FMJ
+#  materials:
+#   Steel: 334
     
 - type: latheRecipe
   parent: BaseAmmoRecipe

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/rifle.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/rifle.yml
@@ -24,19 +24,19 @@
   materials:
     Steel: 455
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineRifleHP
-  result: MagazineRifleHP
-  materials:
-    Steel: 425
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineRifleHP
+#  result: MagazineRifleHP
+#  materials:
+#    Steel: 425
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineRifleFMJ
-  result: MagazineRifleFMJ
-  materials:
-    Steel: 555
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazineRifleFMJ
+#  result: MagazineRifleFMJ
+#  materials:
+#    Steel: 555
 
 
 - type: latheRecipe

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/smg.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/smg.yml
@@ -12,19 +12,19 @@
   materials:
     Steel: 300
 
-- type: latheRecipe
-  parent: BaseEmptyAmmoRecipe
-  id: MagazinePistolSubMachineGunHP
-  result: MagazinePistolSubMachineGunHP
-  materials:
-    Steel: 300
+#- type: latheRecipe
+#  parent: BaseEmptyAmmoRecipe
+#  id: MagazinePistolSubMachineGunHP
+#  result: MagazinePistolSubMachineGunHP
+#  materials:
+#    Steel: 300
 
-- type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazinePistolSubMachineGunFMJ
-  result: MagazinePistolSubMachineGunFMJ
-  materials:
-    Steel: 300
+#- type: latheRecipe
+#  parent: BaseAmmoRecipe
+#  id: MagazinePistolSubMachineGunFMJ
+#  result: MagazinePistolSubMachineGunFMJ
+#  materials:
+#   Steel: 300
 
 - type: latheRecipe
   parent: BaseEmptyAmmoRecipe

--- a/Resources/_Starlight/migration.yml
+++ b/Resources/_Starlight/migration.yml
@@ -49,3 +49,21 @@ MagazineBoxMagnum: MagazineBoxMagnumSP
 CartridgeMagnum: CartridgeMagnumSP
 CartridgePistol: CartridgePistolSP
 CartridgeRifle: CartridgeRifleSP
+
+# 2025-10-30
+MagazineBoxPistol40HP: MagazineBoxPistol40SP
+MagazineBoxPistol40FMJ: MagazineBoxPistol40SP
+LightRifleHeavyMagazineHP: LightRifleHeavyMagazineSP
+LightRifleHeavyMagazineFMJ: LightRifleHeavyMagazineSP
+MagazinePistolHP: MagazinePistolSP
+MagazinePistolFMJ: MagazinePistolSP
+MagazinePistolHighCapacityHP: MagazinePistolHighCapacitySP
+MagazinePistolHighCapacityFMJ: MagazinePistolHighCapacitySP
+MagazinePistolSubMachineGunHP: MagazinePistolSubMachineGunSP
+MagazinePistolSubMachineGunFMJ: MagazinePistolSubMachineGunSP
+MagazinePistol40HP: MagazinePistol40SP
+MagazinePistol40FMJ: MagazinePistol40SP
+MagazineRifleHP: MagazineRifleSP
+MagazineRifleFMJ: MagazineRifleSP
+MagazineRifleM52HP: MagazineRifleM52SP
+MagazineRifleM52FMJ: MagazineRifleM52SP


### PR DESCRIPTION
## Short description
makes it so that FMJ and HP ammunition cannot be obtained without admin intervention (hopefully)

## Why we need to add this
both FMJ and HP ammution have been a pain to try and balance, it. each time it ended up with security still always wanting to use FMJ as it's simply just better than SP in most situations. and HP has made it so that any antag without any sort of armor could be killed too easly.
so i think the best way to make balancing easier on the community, along with removing the above issues is just to prevent the ammunition types from being obtained
most recent related discord thread: https://discord.com/channels/1272545509562777621/1433478572739395655

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Clone0401
- remove: HP and FMJ ammunition can nolonger be obtained without admin intervention
- tweak: SP ammo's armor pen changed from -0.13 to 0
