### PR TITLE
Hotfixing L6C module

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1318,12 +1318,6 @@
       hands:
       # starlight start: cyborgs l6 actually use ammo
       - item: WeaponLightMachineGunL6
-        hand:
-          emptyRepresentative: WeaponLightMachineGunL6
-          emptyLabel: borg-slot-l6-empty
-          whitelist:
-            tags:
-            - L6Saw
       - hand:
           emptyRepresentative: WeaponLightMachineGunL6
           emptyLabel: borg-slot-l6-empty


### PR DESCRIPTION
## Short description
Changes L6C module so you can no longer drop the weapon.

## Why we need to add this
Being able to drop the gun allows crew access to a virtually infinite amount of LMG's. This is absurd.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: R3v3l4t1on
- fix: You can no longer drop the L6 from the L6 module. No infinite LMG's for you.
