### PR TITLE
Kiloton Furniture

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
@@ -2,26 +2,27 @@
   id: DefaultStarlightMapPool
   maps:
   - StarlightBagel
-  - Barratry
+  - StarlightBarratry
   - StarlightCog
-  - Cork
+  - StarlightCork
   - StarlightExo
   - StarlightFland
   - StarlightHotel
-  - Lagan
-  - Leth
-  - Lobster
-  - Manor
+  - StarlightLagan
+  - StarlightLeth
+  - StarlightLobster
+  - StarlightManor
+  - StarlightMing
   - StarlightOasis
   - StarlightOmega
-  - Origin
-  - Orwell
+  - StarlightOrigin
+  - StarlightOrwell
   - StarlightReach
   - StarlightSaltern
-  - Starboard
+  - StarlightStarboard
   - StarlightKiloton
   - StarlightElkridge
-  - Prism
+  - StarlightPrism
   - StarlightSilica
   - StarlightCluster
   - StarlightBox

--- a/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
@@ -19,7 +19,7 @@
   - StarlightReach
   - StarlightSaltern
   - Starboard
-  - Kiloton
+  - StarlightKiloton
   - StarlightElkridge
   - Prism
   - StarlightSilica

--- a/Resources/Prototypes/_StarLight/Maps/kiloton.yml
+++ b/Resources/Prototypes/_StarLight/Maps/kiloton.yml
@@ -1,11 +1,11 @@
 - type: gameMap
-  id: Kiloton
+  id: StarlightKiloton
   mapName: 'Kiloton Station'
   mapPath: /Maps/_Starlight/Stations/Kiloton.yml
   minPlayers: 50
   maxPlayers: 200
   stations:
-    Kiloton:
+    StarlightKiloton:
       stationProto: StandardNanotrasenStation
       components:
         - type: StationNameSetup


### PR DESCRIPTION

## Short description
Adds new Furniture, Decals, and Tiles to Kiloton. Also added Roboticist and Surgery Airlocks.

## Why we need to add this
Minor update. New Furniture added.

## Media (Video/Screenshots)
<img width="693" height="617" alt="image" src="https://github.com/user-attachments/assets/9312fea5-c649-43c4-b77a-fcdb835899dc" />

Stuff like this, plus turning chairs into sofas.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: (Kiloton) Changed furniture in several areas to use new multi-tile benches, sofas, and colored comfy chairs. Also employed new Tiles and Decals in several places.
- tweak: (Kiloton) Added Roboticist and Surgery Airlocks where needed.

