### PR TITLE
Minor Guidebook Update

### DIFF
--- a/Resources/ServerInfo/Guidebook/StarlightSOP/NanoTrasenEmployeeSOP/nano-trasen-employee-sop-bso.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/NanoTrasenEmployeeSOP/nano-trasen-employee-sop-bso.xml
@@ -7,9 +7,9 @@
 
 3. The BlueShield Officer may ignore corporate law when [bold]actively[/bold] performing actions to protect their charge.
 
-4. The BlueShield Officer may not take armory weapons from the armory without a permit from the Warden, this includes the LMG.
+4. The Blueshield Officer may not take armory weapons from the armory without a permit, this includes the LMG. Armory permits may only be issued on [color=#0000ff]Blue[/color] Alert or higher.
 
-5. The BlueShield Officer is not restricted in the weapons he may carry, so long as armory weapons stay with the Warden's issued permit. However, their weapons should not be visible and must be holstered or placed in a bag or pocket on any alert level below [color=#ff0000]Code Red[/color].
+5. The BlueShield Officer is not restricted in the weapons they may carry, so long as armory weapons stay with the issued permit. However, their weapons should not be visible and must be holstered or placed in a bag or pocket on any alert level below [color=#ff0000]Red[/color].
 
 6. The BlueShield Officer should focus on protecting their charge and [bold]should not be pursuing[/bold] potential threats to the detriment of their charge.
 

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/PermitAcquisition.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/PermitAcquisition.xml
@@ -11,6 +11,7 @@
 - If the permit requires a security item that is in limited stock it my be denied until more can be obtained.
 - If the requester has already received a related permit the person reviewing can choose to deny the permit unless the old permit and contraband are turned in.
 - Significant Syndicate Permits are never approved.
+- Armory Permits are not issued below Blue Alert.
 
 3. If the request is not unreasonable, it is stamped APPROVED, as well as signed and stamped by the person reviewing it.
 


### PR DESCRIPTION
## Short description
Minor edits to BSO and Permit acquisition for parity and clarity.

## Why we need to add this
When to issue armory weapons came up a lot.

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Trep_Maul
- tweak: (Guidebook/SOP) Permit Acquisition clarifies when armory permits are allowed.
- tweak: (Guidebook/SOP) BSO clarifies when armory permits are allowed.
