### PR TITLE
Disable collective minds when crit

### DIFF
--- a/Content.Server/_Starlight/CollectiveMind/CollectiveMind.cs
+++ b/Content.Server/_Starlight/CollectiveMind/CollectiveMind.cs
@@ -32,13 +32,18 @@ public sealed partial class CollectiveMind : SharedCollectiveMindSystem
     {
         var uid = ent.Owner;
 
-        if (ent.Comp.CorruptWhenUnconscious)
+        if (ent.Comp.CorruptWhenUnconscious || !ent.Comp.UsableWhenCrit)
         {
             //we need to check if the entity is sleeping, or crit
             if (TryComp<MobStateComponent>(uid, out var mobState))
             {
                 if (mobState.CurrentState == MobState.Critical || TryComp<SleepingComponent>(uid, out _))
                 {
+                    if (!ent.Comp.UsableWhenCrit)
+                    {
+                        args.Cancel();
+                        return;
+                    }
                     args.Message = Corrupt(args.Message, ref ent.Comp);
                 }
             }

--- a/Content.Shared/_Starlight/CollectiveMind/CollectiveMindComponent.cs
+++ b/Content.Shared/_Starlight/CollectiveMind/CollectiveMindComponent.cs
@@ -11,6 +11,8 @@ public sealed partial class CollectiveMindComponent : Component
     public Dictionary<CollectiveMindPrototype, CollectiveMindMemberData> Minds = new();
     public bool CorruptWhenUnconscious = true;
     public float CorruptionChanceWhenUnconscious = 0.5f;
+
+    [DataField] public bool UsableWhenCrit = false;
 }
 
 /// <summary>

--- a/Resources/Prototypes/_StarLight/CollectiveMinds/collective_mind.yml
+++ b/Resources/Prototypes/_StarLight/CollectiveMinds/collective_mind.yml
@@ -37,7 +37,7 @@
   name: collective-mind-changeling
   keycode: 'h'
   color: "#ff75a8"
-  corruptWhenOnconscious: false
+  corruptWhenUnconscious: false
   usableWhenCrit: true
   requiredComponents:
   - Hivemind

--- a/Resources/Prototypes/_StarLight/CollectiveMinds/collective_mind.yml
+++ b/Resources/Prototypes/_StarLight/CollectiveMinds/collective_mind.yml
@@ -37,8 +37,6 @@
   name: collective-mind-changeling
   keycode: 'h'
   color: "#ff75a8"
-  corruptWhenUnconscious: false
-  usableWhenCrit: true
   requiredComponents:
   - Hivemind
 

--- a/Resources/Prototypes/_StarLight/CollectiveMinds/collective_mind.yml
+++ b/Resources/Prototypes/_StarLight/CollectiveMinds/collective_mind.yml
@@ -3,9 +3,9 @@
   name: collective-mind-dioneas
   keycode: 'd'
   color: "#15912a"
-  requiredTags: 
+  requiredTags:
   - Diona
-  
+
 - type: collectiveMind
   id: Carp
   name: collective-mind-carp
@@ -13,9 +13,9 @@
   color: "#787878"
   requiredComponents:
   - Dragon
-  requiredTags: 
+  requiredTags:
   - Carp
-  
+
 - type: collectiveMind
   id: Abductor
   name: collective-mind-abductor
@@ -23,7 +23,7 @@
   color: "#d600bd"
   requiredTags:
   - Abductor
-  
+
 - type: collectiveMind
   id: Spider
   name: collective-mind-spider
@@ -31,15 +31,17 @@
   color: "#8f6741"
   requiredComponents:
   - Spider
-  
+
 - type: collectiveMind
   id: Changeling
   name: collective-mind-changeling
   keycode: 'h'
   color: "#ff75a8"
+  corruptWhenOnconscious: false
+  usableWhenCrit: true
   requiredComponents:
   - Hivemind
-  
+
 - type: collectiveMind
   id: Cluwne
   name: collective-mind-cluwne
@@ -53,6 +55,6 @@
   name: collective-mind-nexus
   keycode: 'n'
   color: "#FF7922"
-  requiredTags: 
+  requiredTags:
   - Resomi
   - Avali


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Disables all collective minds (nexus, carp, spider, abductor etc) when critical or slept.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Collective minds have absolutely zero counterplay. The sleep/crit garbling is NOT enough, and can in and of itself serve as an indicator that a member is in danger if they have their suit sensors enabled.

# THIS IS A STOPGAP PULL! 
I intend to make further changes later down the line, for example:
- Radio jammers disabling collective minds
- 'Hivemind Implant' (for e.g. nexus) that allows non-roundstart access
- **Heavy** garbling when crit, incl. turned-to-11 bloodloss-style stuttering

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ ] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- remove: Collective minds can no longer be used while critical or asleep.