### PR TITLE
Borgs can strip

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -255,6 +255,7 @@
   - type: Crawler
   - type: Blindable
   - type: EyeProtection
+  - type: Stripping
   #endregion
 
 - type: entity


### PR DESCRIPTION
## Short description
Allows borgs to use the strip interaction.

## Why we need to add this
There's plans for this to be used in the future (but that needs some other stuff I'm not entirely sure how to add). But for now this will mainly help with emagged borgs performing steal objectives in their emagger's name.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: R3v3l4t1on
- add: Using strip as a borg will now actually work. Finally you can steal CE's magboots after murdering them.