### PR TITLE
Make survival boxes 2x2

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -17,6 +17,9 @@
     layers:
     - state: internals
     - state: emergencytank
+  - type: Item # Starlight start
+    shape:
+    - 0,0,2,2 # Starlight end
 
 - type: entity
   parent: BoxSurvival

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -41,23 +41,6 @@
   - type: Label
     currentLabel: reagent-name-nitrogen
 
-- type: entity #🌟Starlight🌟
-  parent: BoxSurvival
-  id: BoxSurvivalNonBreather
-  description: It's a box with survival supplies for those with no need to breathe.
-  suffix: Nonbreather
-  components:
-  - type: StorageFill
-    contents:
-    - id: EmergencyMedipen
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
-    - id: Flare
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: shadekin
-
 - type: entity
   parent: BoxCardboard
   id: BoxSurvivalEngineering

--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -3,7 +3,7 @@
   id: BoxSurvival
   name: survival box
   description: It's a box with basic internals inside.
-  suffix: Standard
+  # suffix: Standard # Starlight: remove suffix
   components:
   - type: StorageFill
     contents:
@@ -19,12 +19,12 @@
     - state: emergencytank
   - type: Item # Starlight start
     shape:
-    - 0,0,2,2 # Starlight end
+    - 0,0,1,1 # Starlight end
 
 - type: entity
   parent: BoxSurvival
   id: BoxSurvivalNitrogen
-  suffix: Standard N2
+  suffix: Nitrogen # Starlight: Make suffix clearer
   components:
   - type: StorageFill
     contents:
@@ -42,11 +42,11 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-  parent: BoxCardboard
+  parent: BoxSurvival # Starlight: reparent
   id: BoxSurvivalEngineering
   name: extended-capacity survival box
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
-  suffix: Extended
+  # suffix: Extended # Starlight: remove suffix
   components:
   - type: StorageFill
     contents:
@@ -64,7 +64,7 @@
 - type: entity
   parent: BoxSurvivalEngineering
   id: BoxSurvivalEngineeringNitrogen
-  suffix: Extended N2
+  suffix: Nitrogen # Starlight: Make suffix clearer
   components:
   - type: StorageFill
     contents:
@@ -81,30 +81,11 @@
   - type: Label
     currentLabel: reagent-name-nitrogen
 
-- type: entity #🌟Starlight🌟
-  parent: BoxSurvivalEngineering
-  id: BoxSurvivalEngineeringNonBreather
-  description: It's a box with survival supplies for those with no need to breathe. This one is labelled to contain double rations.
-  suffix: Extended Nonbreather
-  components:
-  - type: StorageFill
-    contents:
-    - id: EmergencyMedipen
-    - id: FoodSnackNutribrick
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
-    - id: Flare
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: shadekin
-
 - type: entity
-
-  parent: BoxCardboard
+  parent: BoxSurvivalEngineering # Starlight: reparent
   id: BoxSurvivalSecurity
-  name: survival box
-  description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
+  # name: survival box # Starlight start: reparent
+  # description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank. # Starlight end: Reparent
   suffix: Security
   components:
   - type: StorageFill
@@ -115,15 +96,15 @@
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: emergencytank
+  # - type: Sprite # Starlight start: Reparent
+  #   layers:
+  #   - state: internals
+  #   - state: emergencytank
 
 - type: entity
   parent: BoxSurvivalSecurity
   id: BoxSurvivalSecurityNitrogen
-  suffix: Security N2
+  suffix: Security, Nitrogen # Starlight: Make suffix clearer
   components:
   - type: StorageFill
     contents:
@@ -140,28 +121,10 @@
   - type: Label
     currentLabel: reagent-name-nitrogen
 
-- type: entity #🌟Starlight🌟
-  parent: BoxSurvivalSecurity
-  id: BoxSurvivalSecurityNonBreather
-  description: It's a box with survival supplies for those with no need to breathe. This one is labelled to contain double rations.
-  suffix: Security Nonbreather
-  components:
-  - type: StorageFill
-    contents:
-    - id: EmergencyMedipen
-    - id: FoodSnackNutribrick
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
-    - id: Flare
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: shadekin
-
 - type: entity
-  parent: BoxCardboard
+  parent: BoxSurvival # Starlight: reparent
   id: BoxSurvivalMedical
-  name: survival box
+  # name: survival box # Starlight: reparent
   description: It's a box with basic internals inside.
   suffix: Medical
   components:
@@ -173,15 +136,15 @@
     - id: Flare
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: emergencytank
+  # - type: Sprite # Starlight start: Reparent
+  #   layers:
+  #   - state: internals
+  #   - state: emergencytank # Starlight start: Reparent
 
 - type: entity
   parent: BoxSurvivalMedical
   id: BoxSurvivalMedicalNitrogen
-  suffix: Medical N2
+  suffix: Medical, Nitrogen # Starlight: Make suffix clearer
   components:
   - type: StorageFill
     contents:
@@ -198,26 +161,8 @@
   - type: Label
     currentLabel: reagent-name-nitrogen
 
-- type: entity #🌟Starlight🌟
-  parent: BoxSurvivalMedical
-  id: BoxSurvivalMedicalNonBreather
-  description: It's a box with survival supplies for those with no need to breathe. This one is labelled to contain double rations.
-  suffix: Medical Nonbreather
-  components:
-  - type: StorageFill
-    contents:
-    - id: EmergencyMedipen
-    - id: FoodSnackNutribrick
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
-    - id: Flare
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: shadekin
-
 - type: entity
-  parent: BoxCardboard
+  parent: BoxSurvival # Starlight: reparent
   id: BoxHug
   name: box of hugs
   description: A special box for sensitive people.
@@ -244,7 +189,7 @@
 - type: entity
   parent: BoxHug
   id: BoxHugNitrogen
-  suffix: Emergency N2
+  suffix: Emergency, Nitrogen # Starlight: Make suffix clearer
   components:
   - type: StorageFill
     contents:
@@ -257,27 +202,10 @@
   - type: Label
     currentLabel: reagent-name-nitrogen
 
-- type: entity #🌟Starlight🌟
-  parent: BoxHug
-  id: BoxHugNonBreather
-  description: A special box for sensitive people who don't need to breathe.
-  suffix: Emergency (Nonbreather)
-  components:
-  - type: StorageFill
-    contents:
-    - id: EmergencyMedipen
-    - id: Flare
-    - id: FoodSnackNutribrick
-    - id: DrinkWaterBottleFull
-  - type: Sprite
-    layers:
-    - state: box_hug
-    - state: shadekin
-
 - type: entity
   parent: BoxSurvival
   id: BoxMime
-  suffix: Mime, Emergency
+  suffix: Mime # Starluight: Make suffix clearer
   components:
   - type: StorageFill
     contents:
@@ -291,7 +219,7 @@
 - type: entity
   parent: BoxSurvivalNitrogen
   id: BoxMimeNitrogen
-  suffix: Mime, Emergency N2
+  suffix: Mime, Nitrogen # Starlight: Make suffix clearer
   components:
   - type: StorageFill
     contents:
@@ -311,7 +239,7 @@
 - type: entity
   parent: BoxSurvival
   id: BoxMimeMoth
-  suffix: Mime, Emergency moth
+  suffix: Mime, Moth # Starlight: Make suffix clearer
   components:
   - type: StorageFill
     contents:
@@ -322,27 +250,11 @@
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
 
-- type: entity #🌟Starlight🌟
-  parent: BoxSurvival
-  id: BoxMimeNonBreather
-  suffix: Mime, Emergency (Nonbreather)
-  components:
-  - type: StorageFill
-    contents:
-    - id: EmergencyMedipen
-    - id: FoodSnackNutribrick #Never 4 get. the day wizden took mime's baugettes
-    - id: DrinkWaterBottleFull
-    - id: Flare
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: shadekin
-
 - type: entity
-  parent: BoxCardboard
+  parent: BoxSurvivalEngineering # Starlight: reparent
   id: BoxSurvivalSyndicate
-  name: extended-capacity survival box
-  description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
+  # name: extended-capacity survival box # Starlight start: Reparent
+  # description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank. # Starlight end: Reparent
   suffix: Syndicate
   components:
   - type: StorageFill
@@ -352,15 +264,15 @@
     - id: EmergencyMedipen
     - id: Flare
     - id: FoodSnackNutribrick
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: extendedtank
+  # - type: Sprite # Starlight start - reparent
+  #   layers:
+  #   - state: internals
+  #   - state: extendedtank # Starlight end - reparent
 
 - type: entity
   parent: BoxSurvivalSyndicate
   id: BoxSurvivalSyndicateNitrogen
-  suffix: Syndicate N2
+  suffix: Syndicate, Nitrogen # Starlight: Make suffix clearer
   components:
   - type: StorageFill
     contents:
@@ -375,20 +287,3 @@
     - state: nitrogentank
   - type: Label
     currentLabel: reagent-name-nitrogen
-
-- type: entity #🌟Starlight🌟
-  parent: BoxSurvivalSyndicate
-  id: BoxSurvivalNonBreatherSyndicate
-  suffix: Syndicate Nonbreather
-  components:
-  - type: StorageFill
-    contents:
-    - id: EmergencyMedipen
-    - id: EmergencyMedipen
-    - id: Flare
-    - id: FoodSnackNutribrick
-    - id: FoodSnackNutribrick
-  - type: Sprite
-    layers:
-    - state: internals
-    - state: shadekin

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Boxes/emergency.yml
@@ -1,0 +1,16 @@
+- type: entity #🌟Starlight🌟
+  parent: BoxSurvival
+  id: BoxSurvivalNonBreather
+  description: It's a box with survival supplies for those with no need to breathe.
+  suffix: Nonbreather
+  components:
+  - type: StorageFill
+    contents:
+    - id: EmergencyMedipen
+    - id: FoodSnackNutribrick
+    - id: DrinkWaterBottleFull
+    - id: Flare
+  - type: Sprite
+    layers:
+    - state: internals
+    - state: shadekin

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Boxes/emergency.yml
@@ -1,4 +1,4 @@
-- type: entity #🌟Starlight🌟
+- type: entity
   parent: BoxSurvival
   id: BoxSurvivalNonBreather
   description: It's a box with survival supplies for those with no need to breathe.
@@ -10,6 +10,110 @@
     - id: FoodSnackNutribrick
     - id: DrinkWaterBottleFull
     - id: Flare
+  - type: Sprite
+    layers:
+    - state: internals
+    - state: shadekin
+
+- type: entity
+  parent: BoxSurvivalEngineering
+  id: BoxSurvivalEngineeringNonBreather
+  description: It's a box with survival supplies for those with no need to breathe. This one is labelled to contain double rations.
+  suffix: Nonbreather
+  components:
+  - type: StorageFill
+    contents:
+    - id: EmergencyMedipen
+    - id: FoodSnackNutribrick
+    - id: FoodSnackNutribrick
+    - id: DrinkWaterBottleFull
+    - id: Flare
+  - type: Sprite
+    layers:
+    - state: internals
+    - state: shadekin
+
+- type: entity
+  parent: BoxSurvivalSecurity
+  id: BoxSurvivalSecurityNonBreather
+  description: It's a box with survival supplies for those with no need to breathe. This one is labelled to contain double rations.
+  suffix: Security, Nonbreather
+  components:
+  - type: StorageFill
+    contents:
+    - id: EmergencyMedipen
+    - id: FoodSnackNutribrick
+    - id: FoodSnackNutribrick
+    - id: DrinkWaterBottleFull
+    - id: Flare
+  - type: Sprite
+    layers:
+    - state: internals
+    - state: shadekin
+
+- type: entity
+  parent: BoxSurvivalMedical
+  id: BoxSurvivalMedicalNonBreather
+  description: It's a box with survival supplies for those with no need to breathe. This one is labelled to contain double rations.
+  suffix: Medical, Nonbreather
+  components:
+  - type: StorageFill
+    contents:
+    - id: EmergencyMedipen
+    - id: FoodSnackNutribrick
+    - id: FoodSnackNutribrick
+    - id: DrinkWaterBottleFull
+    - id: Flare
+  - type: Sprite
+    layers:
+    - state: internals
+    - state: shadekin
+
+- type: entity
+  parent: BoxHug
+  id: BoxHugNonBreather
+  description: A special box for sensitive people who don't need to breathe.
+  suffix: Emergency, Nonbreather
+  components:
+  - type: StorageFill
+    contents:
+    - id: EmergencyMedipen
+    - id: Flare
+    - id: FoodSnackNutribrick
+    - id: DrinkWaterBottleFull
+  - type: Sprite
+    layers:
+    - state: box_hug
+    - state: shadekin
+
+- type: entity
+  parent: BoxSurvival
+  id: BoxMimeNonBreather
+  suffix: Mime, Nonbreather
+  components:
+  - type: StorageFill
+    contents:
+    - id: EmergencyMedipen
+    - id: FoodSnackNutribrick #Never 4 get. the day wizden took mime's baugettes ## Hey actually why can't we just. Give them back lol
+    - id: DrinkWaterBottleFull
+    - id: Flare
+  - type: Sprite
+    layers:
+    - state: internals
+    - state: shadekin
+
+- type: entity
+  parent: BoxSurvivalSyndicate
+  id: BoxSurvivalNonBreatherSyndicate
+  suffix: Syndicate Nonbreather
+  components:
+  - type: StorageFill
+    contents:
+    - id: EmergencyMedipen
+    - id: EmergencyMedipen
+    - id: Flare
+    - id: FoodSnackNutribrick
+    - id: FoodSnackNutribrick
   - type: Sprite
     layers:
     - state: internals


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Makes survival boxes 2x2 for easier fitting in satchels.
Also reparents all non-standard survival boxes onto `BoxSurvival` instead of `BoxCardboard`,
and moves shadekin/nonbreathers into starlight file.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Right now, survival boxes don't fit cleanly in satchels at all. They take up a 3x3 space, which aligns horribly with the only available 4x4 space - which can lead to dropping trinkets on the ground. This PR makes them 2x2 with a 3x3 interior.

A precedent already exists for this. The Happy Honk Meal is 4x4 inside with a 3x3 size, and is ALSO roundstart achievable.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="382" height="160" alt="image" src="https://github.com/user-attachments/assets/6e01d488-7691-4f89-9f7e-d08801c9ed14" />
<img width="394" height="189" alt="image" src="https://github.com/user-attachments/assets/2a658e9f-db5f-4956-8f3c-bd0f9ba08a5d" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- tweak: Survival boxes are now 2x2