### PR TITLE
Kills Cigarette Pack Powergaming with Hammers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -50,10 +50,12 @@
   - type: Storage
     grid:
     - 0,0,4,1
+    # 🌟Starlight - Start🌟
     whitelist:
       components:
         - Smokable
         - Welder
+    # 🌟Starlight - End🌟
   - type: StorageFill
     contents:
     - id: Cigarette

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -53,6 +53,7 @@
     whitelist:
       components:
         - Smokable
+        - Welder
   - type: StorageFill
     contents:
     - id: Cigarette

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -50,6 +50,9 @@
   - type: Storage
     grid:
     - 0,0,4,1
+    whitelist:
+      components:
+        - Smokable
   - type: StorageFill
     contents:
     - id: Cigarette

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -125,6 +125,12 @@
   - type: Storage
     grid:
     - 0,0,4,1
+    # 🌟Starlight - Start🌟
+    whitelist:
+      components:
+        - Smokable
+        - Welder
+    # 🌟Starlight - End🌟
   - type: ItemCounter
     count:
       tags: [Cigarette]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -54,7 +54,8 @@
     whitelist:
       components:
         - Smokable
-        - Welder
+        - Welder # for lighters
+        - Crayon # they're ciggie shaped
     # 🌟Starlight - End🌟
   - type: StorageFill
     contents:
@@ -129,7 +130,8 @@
     whitelist:
       components:
         - Smokable
-        - Welder
+        - Welder # for lighters
+        - Crayon # they're ciggie shaped
     # 🌟Starlight - End🌟
   - type: ItemCounter
     count:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This PR removes the ability to put items into cigarette packs that aren't smokables.

You can still put:
- Lighters in your cigarette pack.
- Spent (burn-out) cigarettes / cigars in your cigarette pack.
- Fresh cigarettes / cigars in your cigarette pack.
- Crayons in your cigarette pack (they are cigarette shaped).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Have you seen this on station before?
<img width="338" height="288" alt="image" src="https://github.com/user-attachments/assets/f4299dc9-db56-42a4-b21c-e0fb6abc8ee8" />

Random rows and piles of cigarettes left in the hallways?

<img width="215" height="134" alt="image" src="https://github.com/user-attachments/assets/8a6e29ff-cb15-4357-852d-574db28a28e0" />

People dump the cigarettes out of cigarette packs in order to stick syringes, vials, and other 1x1 objects into them. For example, it lets you cram 10 vials (300u) of chems, while only using a 1x2 inventory slot. You can carry around 10 syringes in a 1x2 inventory slot, etc.

There's other tools (e.g. combat medkits) that are _supposed to_ serve this purpose. Cigarette packs should be for cigarettes.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="201" height="266" alt="image" src="https://github.com/user-attachments/assets/680f8977-eef8-4d8b-bb2a-14662e8537b0" />

fig. 1 - Before the change (you can stick whatever 1x1 item you want in there)

<img width="176" height="164" alt="image" src="https://github.com/user-attachments/assets/8b90d296-6f98-4544-8577-6b98bfa608a2" />

fig. 2 - After the change. You can't put non-smokables in there anymore. Here I'm not allowed 

<img width="207" height="241" alt="image" src="https://github.com/user-attachments/assets/ca2af211-7816-4fe0-b900-6bae923e86d8" />

fig.3 - Random sample of what you can put in cigarette packs now.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- remove: Cigarette packs now only accept smokables and lighters.
