### PR TITLE
Remove the LMG from Heavy Weapons Safe

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/security.yml
@@ -165,16 +165,3 @@
   id: GunSafeHeavyWeapons
   name: heavy weapon safe
   description: For when talking it out just isn't enough.
-  components:
-  - type: StorageFill
-    contents:
-    - id: WeaponLightMachineGunM492
-      amount: 1
-    - id: LightRifleHeavyMagazineSP
-      amount: 1
-    - id: LightRifleHeavyMagazineHP
-      amount: 1
-    - id: ClothingOuterHardsuitSecurityExperimental
-      amount: 1
-    - id: ClothingShoesBootsMagSec
-      amount: 1


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This change has been floated around many times but has never actually been done.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Security does _not_ need a whole ass LMG. Not even ERT gets it.
This is a transparent change removing it from the safe itself.
No mapping work is required for this.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- remove: The LMG is no longer in the armoury.