### PR TITLE
Brighter Emergency Lights

### DIFF
--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -55,7 +55,7 @@
           volume: -3
       disableSelection: true
       color: DarkRed
-      emergencyLightColor: Orange
+      emergencyLightColor: '#ffba9c' #Starlight
       forceEnableEmergencyLights: true
       shuttleTime: 1200
     epsilon:
@@ -67,7 +67,7 @@
           volume: -2
       disableSelection: true
       color: DarkViolet
-      emergencyLightColor: DarkViolet
+      emergencyLightColor: '#938aff' #Starlight
       forceEnableEmergencyLights: true
       shuttleTime: 1200
     omega: # begin starlight

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -443,8 +443,8 @@
   components:
   - type: PointLight
     enabled: false
-    radius: 5
-    energy: 0.6
+    radius: 7 #Starlight
+    energy: 1 #Starlight
     offset: "0, 0.4"
     color: "#7CFC00"
     mask: /Textures/Effects/LightMasks/double_cone.png


### PR DESCRIPTION
## Short description
Adjusts the color, brightness, and range of the Delta and Epsilon Emergency Lights to be brighter.

## Why we need to add this
Emergency Lighting is a cool effect to set the doomsday mood, but it is currently super dark. Logically it doesn't make much sense for, in an emergency, all the lights to be set up to turn off anyway. That's stupid. But, it's also cool visually. This is a middle ground- emergency lights still kick on, but it's less dark so people can see slightly better.

## Media (Video/Screenshots)
<img width="1138" height="889" alt="image" src="https://github.com/user-attachments/assets/aa5bf46b-d9a7-4829-80f7-cb71818e32da" />

<img width="1138" height="889" alt="image" src="https://github.com/user-attachments/assets/bd169bfb-035f-4c60-b6df-ebff0f45b539" />


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed brightness, range, and color of Emergency Lights for Delta and Epsilon to be brighter, to improve visibility some while retaining the badass strobe lighting fights in the dark vibe. Turning the lights off in an emergency makes no sense anyway, but it is cool.

