### PR TITLE
[HOTFIX] Remove ability for borgs to unlock the AI upload console.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -112,6 +112,7 @@
       components:
       - BorgChassis
       - RoboticsConsole
+      - SiliconLawUpdater
   - type: WiresPanel
   - type: ActivatableUIRequiresPanel
   - type: NameIdentifier


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Title.

## Why we need to add this
There's no reason they should've EVER been able to do this.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: R3v3l4t1on
- fix: Cyborgs can no longer (un)lock the AI upload console.
