### PR TITLE
Sus  Update

### DIFF
--- a/Resources/Maps/_Starlight/Ruins/Salv_Sus.yml
+++ b/Resources/Maps/_Starlight/Ruins/Salv_Sus.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.1.0
   forkId: ""
   forkVersion: ""
-  time: 10/13/2025 01:03:30
-  entityCount: 2243
+  time: 11/10/2025 01:05:31
+  entityCount: 2302
 maps: []
 grids:
 - 1
@@ -920,6 +920,23 @@ entities:
     components:
     - type: Transform
       pos: -9.5,-46.5
+      parent: 1
+- proto: BarricadeBlock
+  entities:
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 7.5,-34.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: -7.5,-32.5
+      parent: 1
+  - uid: 1696
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
       parent: 1
 - proto: BedsheetMedical
   entities:
@@ -2780,6 +2797,13 @@ entities:
     components:
     - type: Transform
       pos: 6.5,-37.5
+      parent: 1
+- proto: CableApcStack10
+  entities:
+  - uid: 1742
+    components:
+    - type: Transform
+      pos: 13.398732,-18.514095
       parent: 1
 - proto: CableHV
   entities:
@@ -7346,13 +7370,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -10.5,-6.5
       parent: 1
-- proto: GyroscopeUnanchored
-  entities:
-  - uid: 2129
-    components:
-    - type: Transform
-      pos: 10.5,-6.5
-      parent: 1
 - proto: Handcuffs
   entities:
   - uid: 1604
@@ -7575,6 +7592,16 @@ entities:
       parent: 1
 - proto: MachineFrameDestroyed
   entities:
+  - uid: 441
+    components:
+    - type: Transform
+      pos: -10.5,-40.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 11.5,-42.5
+      parent: 1
   - uid: 599
     components:
     - type: Transform
@@ -7589,6 +7616,41 @@ entities:
     components:
     - type: Transform
       pos: 3.5,-24.5
+      parent: 1
+  - uid: 1740
+    components:
+    - type: Transform
+      pos: 12.5,-18.5
+      parent: 1
+  - uid: 1743
+    components:
+    - type: Transform
+      pos: 3.5,-51.5
+      parent: 1
+  - uid: 1744
+    components:
+    - type: Transform
+      pos: -1.5,-51.5
+      parent: 1
+  - uid: 1745
+    components:
+    - type: Transform
+      pos: -10.5,-47.5
+      parent: 1
+  - uid: 1746
+    components:
+    - type: Transform
+      pos: 11.5,-47.5
+      parent: 1
+  - uid: 1747
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 1749
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
       parent: 1
   - uid: 1883
     components:
@@ -9148,6 +9210,17 @@ entities:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
+  - uid: 1741
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-51.5
+      parent: 1
+  - uid: 1748
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
 - proto: SalvageCanisterSpawner
   entities:
   - uid: 1506
@@ -9586,29 +9659,21 @@ entities:
     - type: Transform
       pos: 11.5,-41.5
       parent: 1
-  - uid: 590
+- proto: SMESBasic
+  entities:
+  - uid: 431
     components:
     - type: Transform
       pos: -10.5,-42.5
       parent: 1
-- proto: SMESAdvancedEmpty
-  entities:
-  - uid: 540
+  - uid: 446
     components:
     - type: Transform
       pos: -10.5,-41.5
       parent: 1
-  - uid: 543
-    components:
-    - type: Transform
-      pos: 11.5,-42.5
-      parent: 1
-  - uid: 552
-    components:
-    - type: Transform
-      pos: -10.5,-40.5
-      parent: 1
-  - uid: 554
+- proto: SMESBasicEmpty
+  entities:
+  - uid: 445
     components:
     - type: Transform
       pos: 11.5,-40.5
@@ -9620,64 +9685,514 @@ entities:
     - type: Transform
       pos: -15.5,-24.5
       parent: 1
-- proto: SpawnMobXenoEasy
+- proto: SpawnMobSpiderSalvage
   entities:
-  - uid: 1966
+  - uid: 459
     components:
     - type: Transform
-      pos: 7.5,-16.5
+      pos: -3.5,-5.5
       parent: 1
-  - uid: 1967
+  - uid: 460
     components:
     - type: Transform
-      pos: 3.5,-13.5
+      pos: 12.5,-23.5
       parent: 1
-  - uid: 1968
+  - uid: 540
     components:
     - type: Transform
-      pos: -7.5,-24.5
+      pos: 4.5,-12.5
       parent: 1
-  - uid: 1969
+  - uid: 552
     components:
     - type: Transform
-      pos: -12.5,-20.5
+      pos: 1.5,-9.5
       parent: 1
-  - uid: 1970
+  - uid: 554
     components:
     - type: Transform
-      pos: 12.5,-24.5
+      pos: -1.5,-0.5
       parent: 1
-  - uid: 1971
+  - uid: 590
     components:
     - type: Transform
-      pos: -9.5,-9.5
+      pos: -0.5,-30.5
       parent: 1
-  - uid: 1972
+  - uid: 1695
     components:
     - type: Transform
-      pos: -0.5,0.5
+      pos: -2.5,-33.5
       parent: 1
-  - uid: 1974
+  - uid: 1738
+    components:
+    - type: Transform
+      pos: -9.5,-20.5
+      parent: 1
+  - uid: 1750
+    components:
+    - type: Transform
+      pos: -10.5,-9.5
+      parent: 1
+  - uid: 1751
+    components:
+    - type: Transform
+      pos: -8.5,-26.5
+      parent: 1
+  - uid: 1752
     components:
     - type: Transform
       pos: -7.5,-41.5
       parent: 1
+  - uid: 1753
+    components:
+    - type: Transform
+      pos: -1.5,-45.5
+      parent: 1
+  - uid: 1754
+    components:
+    - type: Transform
+      pos: 1.5,-39.5
+      parent: 1
+  - uid: 1756
+    components:
+    - type: Transform
+      pos: 7.5,-32.5
+      parent: 1
+- proto: SpiderWeb
+  entities:
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 14.5,-19.5
+      parent: 1
+  - uid: 1755
+    components:
+    - type: Transform
+      pos: 9.5,-29.5
+      parent: 1
+  - uid: 1757
+    components:
+    - type: Transform
+      pos: 8.5,-28.5
+      parent: 1
+  - uid: 1758
+    components:
+    - type: Transform
+      pos: 9.5,-28.5
+      parent: 1
+  - uid: 1759
+    components:
+    - type: Transform
+      pos: 13.5,-28.5
+      parent: 1
+  - uid: 1760
+    components:
+    - type: Transform
+      pos: 13.5,-29.5
+      parent: 1
+  - uid: 1761
+    components:
+    - type: Transform
+      pos: 2.5,-34.5
+      parent: 1
+  - uid: 1762
+    components:
+    - type: Transform
+      pos: 1.5,-34.5
+      parent: 1
+  - uid: 1763
+    components:
+    - type: Transform
+      pos: 1.5,-33.5
+      parent: 1
+  - uid: 1764
+    components:
+    - type: Transform
+      pos: 2.5,-33.5
+      parent: 1
+  - uid: 1812
+    components:
+    - type: Transform
+      pos: 0.5,-34.5
+      parent: 1
+  - uid: 1813
+    components:
+    - type: Transform
+      pos: 1.5,-35.5
+      parent: 1
+  - uid: 1814
+    components:
+    - type: Transform
+      pos: -5.5,-38.5
+      parent: 1
+  - uid: 1815
+    components:
+    - type: Transform
+      pos: -4.5,-38.5
+      parent: 1
+  - uid: 1816
+    components:
+    - type: Transform
+      pos: -5.5,-37.5
+      parent: 1
+  - uid: 1817
+    components:
+    - type: Transform
+      pos: -11.5,-44.5
+      parent: 1
+  - uid: 1966
+    components:
+    - type: Transform
+      pos: -12.5,-43.5
+      parent: 1
+  - uid: 1967
+    components:
+    - type: Transform
+      pos: -11.5,-43.5
+      parent: 1
+  - uid: 1968
+    components:
+    - type: Transform
+      pos: -7.5,-45.5
+      parent: 1
+  - uid: 1969
+    components:
+    - type: Transform
+      pos: -8.5,-45.5
+      parent: 1
+  - uid: 1970
+    components:
+    - type: Transform
+      pos: -4.5,-49.5
+      parent: 1
+  - uid: 1971
+    components:
+    - type: Transform
+      pos: -3.5,-50.5
+      parent: 1
+  - uid: 1972
+    components:
+    - type: Transform
+      pos: -4.5,-50.5
+      parent: 1
+  - uid: 1974
+    components:
+    - type: Transform
+      pos: -3.5,-49.5
+      parent: 1
   - uid: 1975
     components:
     - type: Transform
-      pos: -1.5,-46.5
+      pos: -5.5,-49.5
       parent: 1
   - uid: 1976
     components:
     - type: Transform
-      pos: 6.5,-30.5
+      pos: -0.5,-50.5
       parent: 1
-- proto: SpawnMobXenoHard
-  entities:
   - uid: 1978
     components:
     - type: Transform
-      pos: -1.5,-32.5
+      pos: -1.5,-50.5
+      parent: 1
+  - uid: 2129
+    components:
+    - type: Transform
+      pos: 6.5,-49.5
+      parent: 1
+  - uid: 2244
+    components:
+    - type: Transform
+      pos: 6.5,-48.5
+      parent: 1
+  - uid: 2245
+    components:
+    - type: Transform
+      pos: 7.5,-48.5
+      parent: 1
+  - uid: 2246
+    components:
+    - type: Transform
+      pos: 6.5,-47.5
+      parent: 1
+  - uid: 2247
+    components:
+    - type: Transform
+      pos: 5.5,-48.5
+      parent: 1
+  - uid: 2248
+    components:
+    - type: Transform
+      pos: 7.5,-44.5
+      parent: 1
+  - uid: 2249
+    components:
+    - type: Transform
+      pos: 8.5,-44.5
+      parent: 1
+  - uid: 2250
+    components:
+    - type: Transform
+      pos: 7.5,-43.5
+      parent: 1
+  - uid: 2251
+    components:
+    - type: Transform
+      pos: 6.5,-44.5
+      parent: 1
+  - uid: 2252
+    components:
+    - type: Transform
+      pos: 13.5,-39.5
+      parent: 1
+  - uid: 2253
+    components:
+    - type: Transform
+      pos: 12.5,-39.5
+      parent: 1
+  - uid: 2254
+    components:
+    - type: Transform
+      pos: 9.5,-34.5
+      parent: 1
+  - uid: 2255
+    components:
+    - type: Transform
+      pos: 9.5,-33.5
+      parent: 1
+  - uid: 2256
+    components:
+    - type: Transform
+      pos: 3.5,-28.5
+      parent: 1
+  - uid: 2257
+    components:
+    - type: Transform
+      pos: 5.5,-29.5
+      parent: 1
+  - uid: 2258
+    components:
+    - type: Transform
+      pos: -2.5,-28.5
+      parent: 1
+  - uid: 2259
+    components:
+    - type: Transform
+      pos: -10.5,-30.5
+      parent: 1
+  - uid: 2260
+    components:
+    - type: Transform
+      pos: -5.5,-28.5
+      parent: 1
+  - uid: 2261
+    components:
+    - type: Transform
+      pos: -4.5,-27.5
+      parent: 1
+  - uid: 2262
+    components:
+    - type: Transform
+      pos: -5.5,-27.5
+      parent: 1
+  - uid: 2263
+    components:
+    - type: Transform
+      pos: -6.5,-28.5
+      parent: 1
+  - uid: 2264
+    components:
+    - type: Transform
+      pos: -3.5,-17.5
+      parent: 1
+  - uid: 2265
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 1
+  - uid: 2266
+    components:
+    - type: Transform
+      pos: -4.5,-16.5
+      parent: 1
+  - uid: 2267
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 2268
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 2269
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 1
+  - uid: 2270
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 1
+  - uid: 2271
+    components:
+    - type: Transform
+      pos: 7.5,-13.5
+      parent: 1
+  - uid: 2272
+    components:
+    - type: Transform
+      pos: 7.5,-14.5
+      parent: 1
+  - uid: 2273
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 2274
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 2275
+    components:
+    - type: Transform
+      pos: -10.5,-12.5
+      parent: 1
+  - uid: 2276
+    components:
+    - type: Transform
+      pos: -11.5,-12.5
+      parent: 1
+  - uid: 2277
+    components:
+    - type: Transform
+      pos: -11.5,-11.5
+      parent: 1
+  - uid: 2278
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 2279
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 1
+  - uid: 2280
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 2281
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 2282
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 2283
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 1
+  - uid: 2284
+    components:
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 1
+  - uid: 2285
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 2286
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 2287
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 2288
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 2289
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 2290
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 2291
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 2292
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 1
+  - uid: 2293
+    components:
+    - type: Transform
+      pos: 10.5,-6.5
+      parent: 1
+  - uid: 2294
+    components:
+    - type: Transform
+      pos: 14.5,-18.5
+      parent: 1
+  - uid: 2295
+    components:
+    - type: Transform
+      pos: 12.5,-13.5
+      parent: 1
+  - uid: 2296
+    components:
+    - type: Transform
+      pos: 8.5,-18.5
+      parent: 1
+  - uid: 2297
+    components:
+    - type: Transform
+      pos: 9.5,-18.5
+      parent: 1
+  - uid: 2298
+    components:
+    - type: Transform
+      pos: 6.5,-20.5
+      parent: 1
+  - uid: 2299
+    components:
+    - type: Transform
+      pos: 2.5,-30.5
+      parent: 1
+  - uid: 2300
+    components:
+    - type: Transform
+      pos: -2.5,-38.5
+      parent: 1
+  - uid: 2301
+    components:
+    - type: Transform
+      pos: -2.5,-37.5
+      parent: 1
+  - uid: 2302
+    components:
+    - type: Transform
+      pos: 3.5,-37.5
       parent: 1
 - proto: StasisBed
   entities:
@@ -10156,40 +10671,15 @@ entities:
     - type: Transform
       pos: -12.5,-24.5
       parent: 1
-- proto: TelecomServer
+- proto: TelecomServerCircuitboard
   entities:
-  - uid: 1696
+  - uid: 1739
     components:
     - type: Transform
-      pos: 13.5,-18.5
-      parent: 1
-- proto: TelecomServerFilledCommon
-  entities:
-  - uid: 1695
-    components:
-    - type: Transform
-      pos: 12.5,-18.5
+      pos: 12.523732,-18.357845
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 205
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-51.5
-      parent: 1
-  - uid: 431
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-51.5
-      parent: 1
-  - uid: 441
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-51.5
-      parent: 1
   - uid: 442
     components:
     - type: Transform
@@ -10207,39 +10697,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-48.5
-      parent: 1
-  - uid: 445
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-47.5
-      parent: 1
-  - uid: 446
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,-49.5
-      parent: 1
-  - uid: 447
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-47.5
-      parent: 1
-  - uid: 458
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-  - uid: 459
-    components:
-    - type: Transform
-      pos: 4.5,-0.5
-      parent: 1
-  - uid: 460
-    components:
-    - type: Transform
-      pos: -4.5,-1.5
       parent: 1
   - uid: 461
     components:


### PR DESCRIPTION

## Short description
Replaced Xenos on the Sus wreck with Space Spiders. Removed the Telecomms server.

## Why we need to add this
Replaces Xenos on the Sus wreck with Space Spiders, since there is no Xenos Spawner that doesn't make them ghost roles for some reason. Removed the Telecomms server as well, to prevent the wreck from making Common Comms unsabotagable. 

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Swapped Xenos spawners for Space Spider spawners on the Sus wreck, since there is no spawner for non-ghost role Xenos. Also removed the comms server, to make it so common comms can be sabotaged still.

