### PR TITLE
enables damage/attacking while lit on every flippo in the novelty lighter box & adjusts roll chances in novelty lighter box

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/figurine_boxes.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/figurine_boxes.yml
@@ -137,7 +137,7 @@
   id: MysteryLighterBox
   name: Novelty lighter mystery box
   suffix: Filled
-  description: A box of discontinued promotional lighters, many of which have since been declared "contraband".
+  description: A box of discontinued promotional lighters. A faded and scratched label on the side reads, "May contain contraband".
   components:
   - type: Sprite
     sprite: Objects/Fun/figurines.rsi
@@ -148,27 +148,28 @@
       - id: MysteryFigureBoxTrash
       - id: CybersunFlippo
         orGroup: Lighterbox
-        weight: 0.15
+        weight: 0.15 #Starlight-edit
       - id: InterdyneFlippo
         orGroup: Lighterbox
-        weight: 0.15
+        weight: 0.15 #Starlight-edit
       - id: NanotrasenFlippo
         orGroup: Lighterbox
-        weight: 0.25
+        weight: 0.15 #Starlight-edit
       - id: WaffleCoFlippo
         orGroup: Lighterbox
-        weight: 0.35
+        weight: 0.15 #Starlight-edit
       - id: HonkCoFlippo
         orGroup: Lighterbox
+        weight: 0.15 #Starlight-edit
       - id: GorlexMatchbox
         orGroup: Lighterbox
-        weight: 0.15
+        weight: 0.05 #Starlight-edit
       - id: DonkcoLighter
         orGroup: Lighterbox
-        weight: 0.25
+        weight: 0.15 #Starlight-edit
       - id: SyndicateFlippo
         orGroup: Lighterbox
-        weight: 0.15
+        weight: 0.05 #Starlight-edit
 
 - type: entity
   parent: MysteryLighterBox

--- a/Resources/Prototypes/Entities/Objects/Fun/figurine_boxes.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/figurine_boxes.yml
@@ -137,7 +137,7 @@
   id: MysteryLighterBox
   name: Novelty lighter mystery box
   suffix: Filled
-  description: A box of discontinued promotional lighters. A faded and scratched label on the side reads, "May contain contraband".
+  description: A box of discontinued promotional lighters. A faded and scratched label on the side reads, "May contain contraband." #Starlight-edit
   components:
   - type: Sprite
     sprite: Objects/Fun/figurines.rsi

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -336,10 +336,10 @@
       - Lighters #SL
 
 - type: entity
-  parent: [BaseBrandedLighter, BaseSyndicateContraband] 
+  parent: [BaseBrandedLighter, BaseSyndicateContraband, FlippoLighter] #SL Edit: added flippolighter parent
   id: SyndicateFlippo
   name: Blood-red flippo
-  description: "A 'Valid' choice in lighters. Contains no copper."
+  description: "A 'Valid' choice in lighters. Contains no copper. Causes nasty burns if mishandled."
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/syndielighter.rsi
@@ -349,6 +349,13 @@
     fuelConsumption: 0.01 # Starlight-edit
     fuelLitCost: 0.01
     tankSafe: true
+  - type: ItemToggleMeleeWeapon #Starlight-start
+    activatedDamage:
+        types:
+            Heat: 8
+  - type: ItemToggleSize
+    activatedSize: Small
+  - type: ItemToggleHot #Starlight-end
   - type: PointLight
     enabled: false
     netsync: false
@@ -411,7 +418,7 @@
         maxVol: 3
 
 - type: entity
-  parent: [BaseBrandedLighter] #SL Edit: Non Contra
+  parent: [BaseBrandedLighter, FlippoLighter] #SL Edit: added flippolighter parent
   id: CybersunFlippo
   name: CyberSun Flippo
   description: "A Sleek black and magenta flippo lighter, bearing the logo and iconography of CyberSun Industries."
@@ -431,7 +438,7 @@
     color: magenta
 
 - type: entity
-  parent: [BaseBrandedLighter] #SL Edit: Non Contra
+  parent: [BaseBrandedLighter, FlippoLighter] #SL Edit: added flippolighter parent
   id: InterdyneFlippo
   name: Interdyne Flippo
   description: "A deep blue flippo lighter, decorated with the logo of Interdyne Pharmaceuticals' 'Gene Clean' clinics. Become the master of your own cigarette."
@@ -455,10 +462,10 @@
     color: cyan
 
 - type: entity
-  parent: [BaseBrandedLighter]
+  parent: [BaseBrandedLighter, FlippoLighter] #SL Edit: added flippolighter parent
   id: NanotrasenFlippo
   name: Nanotrasen Flippo
-  description: "A navy blue luxury flippo, generally handed out to loyal heads of staff instead of a payraise. Fueled with liquid plasma"
+  description: "A navy blue luxury flippo, generally handed out to loyal heads of staff instead of a payraise. Fueled with liquid plasma and burns a little hotter than usual."
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/nanotrasen.rsi
@@ -469,6 +476,13 @@
     fuelLitCost: 0 # Starlight-end
     fuelReagent: Plasma
     tankSafe: true
+  - type: ItemToggleMeleeWeapon #Starlight-start
+    activatedDamage:
+        types:
+            Heat: 4
+  - type: ItemToggleSize
+    activatedSize: Small 
+  - type: ItemToggleHot #Starlight-end
   - type: PointLight
     enabled: false
     netsync: false
@@ -531,7 +545,7 @@
     access: [["CentralCommand"]]
 
 - type: entity
-  parent: [BaseBrandedLighter, BaseMajorContraband]
+  parent: [BaseBrandedLighter, BaseMajorContraband, FlippoLighter] #SL Edit: added flippolighter parent
   id: SpiderclanFlippo
   name: Spider-Clan lighter
   description: "A high tech jet lighter, engineered to function even in deep space. Runs on a tiny microfusion cell."
@@ -551,7 +565,7 @@
     color: green
 
 - type: entity
-  parent: [BaseBrandedLighter] #SL Edit: Non Contra
+  parent: [BaseBrandedLighter, FlippoLighter] #SL Edit: added flippolighter parent
   id: WaffleCoFlippo
   name: Waffle Co. flippo
   description: "A robust mass produced lighter. The Waffle Co. logo turns the spark wheel when pushed up, minimising risk of lighter burns for even the most inept user."
@@ -571,7 +585,7 @@
     color: brown
 
 - type: entity
-  parent: [BaseBrandedLighter]
+  parent: [BaseBrandedLighter, FlippoLighter] #SL Edit: added flippolighter parent
   id: HonkCoFlippo
   name: Honk Co. flippo
   description: "A slippery gag lighter produced by Honk Co. hidden inside of a real banana peel."
@@ -616,7 +630,7 @@
     color: yellow
 
 - type: entity
-  parent: [BaseBrandedLighter]
+  parent: [BaseBrandedLighter, FlippoLighter] #SL Edit: added flippolighter parent
   id: DonkcoLighter
   name: Donk Co. flippo
   description: "The flippo of choice for terrible cooks. A Breaded novelty lighter made by Donk Co. Somehow edible while lit." #SL Edit: decription edit to remove 'traitor' reference


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
default flippo (and the engraved flippo) has the functionality of being able to be used as a weapon while lit. the flippos that spawn in the novelty lighter box not having them appears to be an oversight due to a missing parent tag

- adjusted roll chances to equalize all flippos at 0.15, but lowered roll chance for gorlex matches and blood-red flippo to 0.05
- added higher damage values to the nanotrasen lighter (4, from a default of 1) and the blood-red flippo (8, from a default of 1 - same as basic welder)
- updated description of nanotrasen and blood-red flippos to mention their burn potential
- changed figurine_boxes.yml description of the novelty lighter box to be more accurate to its mostly non-contraband contents


## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

1. the default flippo and engraved flippos can be used as a weapon. all the other ones cannot. this doesnt appear to be intentional, just an oversight.
2. the blood-red is technically contraband but right now has no "flair" or oomph to make it worth getting hassled by sec over. i gave it some extra burn damage (which is on-brand for the syndicate), but not enough to make it stand out outside of its place as a ligher. it's 8 burn, the same amount of damage as the basic welding tool (which lasts way longer and has more useful functions)
3. the NT lighter deals a little more heat damage (4, default is 1) on account of it using plasma as fuel. again, not as useful as most other things if you want to kill someone, but can cauterize wounds in a pinch. 
4. both the NT and blood-red now have some indication of their slightly higher burn damage on their description
5. most of the lighters you can get are no longer contraband, so i updated the description of the lighters box to say it may contain contraband, instead of saying everything in it is contra. the blood-red and gorlex matches are contraband, and both are pretty good items but on account of being illegal to carry, should be a little less common.
6. some of the lighters were weighed higher for no particular reason, as far as i could tell. maybe it was for a reason when most of them were considered contraband, but again, seemed pretty random and like it might have just been an oversight, so i put them all at 0.15.

short clip showing spawns on 10 lighters and how many hits it takes to down someone with the blood-red

https://github.com/user-attachments/assets/a02f16c0-bc79-4d09-8e37-a4959c43c961





## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: nomad.marshall
- fix: fixed novelty lighters inability to be used as a weapon while lit. they now do the same damage as the basic flippo, with two exceptions
- tweak: adjusted damage of blood-red and nanotrasen flippos to do more heat damage (8 for blood-red, 4 for NT) while lit and used as a weapon
- tweak: equalized roll chances of (most) novelty lighters. blood-red flippo and gorlex matches have the lowest chance to roll but everything else has the same chance to spawn


