### PR TITLE
Crippling HP meta

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -125,10 +125,9 @@
   parent: BulletTrace
   damage:
     types:
-      Blunt: 35
-      Piercing: 10 # +30%
+      Piercing: 45 # +30%
   staminaDamage: 10    
-  armorPenetration: -0.55
+  armorPenetration: -1.00
   pierceChance: 0.03
   derivation: 0.05
   ricochetChance: 0.15
@@ -251,9 +250,8 @@
   parent: BulletTrace
   damage:
     types:
-      Blunt: 16
-      Piercing: 5 # +30%
-  armorPenetration: -0.55
+      Piercing: 21 # +30%
+  armorPenetration: -1.00
   staminaDamage: 5
   pierceChance: 0.03
   derivation: 0.2
@@ -359,13 +357,12 @@
   staminaDamage: 20
   damage:
     types:
-      Blunt: 20
-      Piercing: 6 # +30%
+      Piercing: 26 # +30%
   bullet:
     sprite:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
       state: bullet
-  armorPenetration: -0.55
+  armorPenetration: -1.00
   pierceChance: 0.02
   derivation: 0.15
   ricochetChance: 0.10
@@ -479,10 +476,9 @@
   parent: BulletTrace
   damage:
     types:
-      Blunt: 19
-      Piercing: 6 # +30%
+      Piercing: 25 # +30%
   pierceLevel: Wood
-  armorPenetration: -0.55
+  armorPenetration: -1.00
   staminaDamage: 6
   pierceChance: 0.03
   derivation: 0.05
@@ -589,9 +585,8 @@
   parent: BulletTrace
   damage:
     types:
-      Blunt: 17
-      Piercing: 6 # +30%
-  armorPenetration: -0.55
+      Piercing: 23 # +30%
+  armorPenetration: -1.00
   staminaDamage: 5
   pierceChance: 0.03
   ricochetChance: 0.15


### PR DESCRIPTION
*currently should be in draft as I am writing a design document for it and getting video and screenshots of proof*


<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

This PR reverts HP values on all weapons, changing it to what it was before the ammo rework(+30% damage, -100% armor penetration, no damage conversion). No other parts of the rework were touched.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
As of currently, armor values are mostly favoring either pierce or slash(the latter being for improvised armor mostly, which is availiable to crew), with blunt damage protection being only on a few armor types(that being: riot and stabproof, limited to sec only; web vest, which by design should have been countering melee and heat-based weaponry, while still giving a formidable protection from firearms) 
Blunt resists as given rarely pull themselves anywhere over 30% crew-side, outside of the pointed out earlier outliers, as well as nuclear operatives armor values(helmet and gas mask were the only saving grace for an elite suit that didn't make HP outdamage SP against it, still overpowering FMJ)
Not only that - the lessened armor penetration values made it plain better against anything with less than 36.5% total armor protection, which made the issue even worse as type I vest(the one with 30% resists across the board) without helmet(with sec gas mask) were outdamaged by Hollow Points compared to Soft Point ammo.
And of course - dragon has 70% pierce resists(not armor related, and thus not affected by penetration values), whilst having 0% blunt resist. HP totally bypass this, making him less of an issue.
All of this, as well as issues covering healing the damage - made it basically better than SP along with it's gripes for a regular member without access to advanced topicals.

There has been a lot of discussion over it beforehand, as well as many discord suggestions, which lead to someone making a PR to delete ammo types altogether, which isn't ideal, if you ask me.

However the change that happened to SP with the same rework that made HP deal blunt damage - halved the armor penetration malus for it, making it, in my opinion, a formidable middle ground(for example - SP used against fully enclosed security hardsuit with a gas mask is actually equal in damage with FMJ, if not marginally better in terms of damage). Which is why i didn't tweak it's values.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ ] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
- tweak: changed damage on HP bullets from blunt+pierce mix back to pure pierce 
- tweak: changed HP bullets armor penetration values from -55% to -100%