### PR TITLE
Combat Medkit Storage Restriction

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -100,9 +100,11 @@
   parent: Medkit
   id: MedkitCombat
   components:
+  #Starlight start
   - type: Storage
     whitelist:
        tags:
+        - GlassBeaker
         - Bottle
         - Spray
         - Brutepack
@@ -120,6 +122,7 @@
         - Injector
         - Pill
         - HandLabeler
+    #Starlight end
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Medical/firstaidkits.rsi
     state: blackkit

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -100,6 +100,26 @@
   parent: Medkit
   id: MedkitCombat
   components:
+  - type: Storage
+    whitelist:
+       tags:
+        - Bottle
+        - Spray
+        - Brutepack
+        - Bloodpack
+        - Gauze
+        - Ointment
+        - CigPack
+        - PillCanister
+        - Radio
+        - DiscreteHealthAnalyzer
+        - SurgeryTool
+        - Dropper
+       components:
+        - Hypospray
+        - Injector
+        - Pill
+        - HandLabeler
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Medical/firstaidkits.rsi
     state: blackkit

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -105,6 +105,7 @@
     whitelist:
        tags:
         - GlassBeaker
+        - Patch
         - Bottle
         - Spray
         - Brutepack


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This limits what combat medkits can store to only medical items. Specifically, restricted to the same items medical belts can carry (as well as beakers and patches).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This was inspired by the recent change to cigarette packs. 

Since combat medkits only take up a 2x2 space in bags, but have 2x4 slots, I have seen non-medics making multiple combat medkits purely for the extra storage space. I have deemed this powergaming, and am now resolving the issue by restricting what items can go in combat medkits.

I am not restricting what other medkits can carry because there no space benefit (unless you're carrying one in your hand, but then it's just a worse toolbox). If someone wants to sort their inventory via medkits, I'm not stopping them.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Before
<img width="178" height="144" alt="Before Medkit Change" src="https://github.com/user-attachments/assets/104d2cf5-2a53-4a9d-827f-e21a6edf9c7b" />
After
<img width="175" height="74" alt="Restricted Medkit" src="https://github.com/user-attachments/assets/d292a4a3-d1ce-4d88-b464-7c60f91fa9a3" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: CommanderAlex365
- tweak: restricted combat medkits to only store medical items
-->
:cl: CommanderAlex365
- tweak: restricted combat medkits to only store medical items
