### PR TITLE
Salv mining tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -231,8 +231,9 @@
       coefficients:
         Blunt: 0.7 #slightly better overall protection but slightly worse than bulletproof armor against bullets seems sensible
         Slash: 0.7
-        Piercing: 0.5
+        Piercing: 0.6
         Heat: 0.9
+    staminaModifier: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.9
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -231,9 +231,9 @@
       coefficients:
         Blunt: 0.7 #slightly better overall protection but slightly worse than bulletproof armor against bullets seems sensible
         Slash: 0.7
-        Piercing: 0.6
+        Piercing: 0.6 #Starlight lowered values
         Heat: 0.9
-    staminaModifier: 0.85
+    staminaModifier: 0.85 #Starlight lowered values
   - type: ExplosionResistance
     damageCoefficient: 0.9
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -141,9 +141,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.75
+        Blunt: 0.8 #Starlight edit
+        Slash: 0.8 #Starlight edit
+        Piercing: 0.75 #Starlight edit
         Heat: 0.7
         Radiation: 0.3
         Caustic: 0.7
@@ -204,7 +204,7 @@
   parent: [ ClothingOuterHardsuitBase, BaseSalvageContraband ] #Starlight salvContra
   id: ClothingOuterHardsuitMaxim
   name: salvager maxim hardsuit
-  description: Fire. Heat. These things forge great weapons, they also forge great salvagers. 
+  description: Fire. Heat. These things forge great weapons, they also forge great salvagers. #Has built-in battery-powered energy barrier technology.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/maxim.rsi
@@ -218,18 +218,18 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.65
-        Heat: 0.6
-        Radiation: 0.3
-        Caustic: 0.8
+        Blunt: 0.65 #Starlight edit
+        Slash: 0.65 #Starlight edit
+        Piercing: 0.65 #Starlight edit
+        Heat: 0.6 #Starlight edit
+        Radiation: 0.3 #Starlight edit
+        Caustic: 0.8 #Starlight edit
   - type: ClothingSpeedModifier
-    walkModifier: 0.90
-    sprintModifier: 0.90
+    walkModifier: 0.85 #Starlight edit
+    sprintModifier: 0.85 #Starlight edit
   - type: ExplosionResistance
-    damageCoefficient: 0.4
-  - type: HeldSpeedModifier
+    damageCoefficient: 0.4 #Starlight edit
+  - type: HeldSpeedModifier #Starlight edit
   - type: TemperatureProtection
     heatingCoefficient: 0.001
     coolingCoefficient: 0.001
@@ -260,7 +260,7 @@
   #- type: UseDelay
     #delay: 10.0
 
-# maxim bubble shield was buggy, made no sense for salvs, and was on a suit with better stats than a blood red.
+#Starlight edit. maxim bubble shield was buggy, made no sense for salvs, and was on a suit with better stats than a blood red.
 
 #Security Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -141,9 +141,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8 #Starlight edit
-        Slash: 0.8 #Starlight edit
-        Piercing: 0.75 #Starlight edit
+      # region starlight: lowered values
+        Blunt: 0.8 
+        Slash: 0.8 
+        Piercing: 0.75 
+        # end region starlight
         Heat: 0.7
         Radiation: 0.3
         Caustic: 0.7
@@ -218,23 +220,26 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.65 #Starlight edit
-        Slash: 0.65 #Starlight edit
-        Piercing: 0.65 #Starlight edit
-        Heat: 0.6 #Starlight edit
-        Radiation: 0.3 #Starlight edit
-        Caustic: 0.8 #Starlight edit
+      # region starlight: maxim lowered values
+        Blunt: 0.65 
+        Slash: 0.65 
+        Piercing: 0.65 
+        Heat: 0.6 
+        Radiation: 0.3 
+        Caustic: 0.8 
   - type: ClothingSpeedModifier
-    walkModifier: 0.85 #Starlight edit
-    sprintModifier: 0.85 #Starlight edit
+    walkModifier: 0.85 
+    sprintModifier: 0.85 
   - type: ExplosionResistance
-    damageCoefficient: 0.4 #Starlight edit
-  - type: HeldSpeedModifier #Starlight edit
+    damageCoefficient: 0.4 
+    # end region starlight
+  - type: HeldSpeedModifier #Starlight addition
   - type: TemperatureProtection
     heatingCoefficient: 0.001
     coolingCoefficient: 0.001
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMaxim
+    # region starlight: bubble shield removal
   #- type: ContainerContainer
     #containers:
       #cell_slot: !type:ContainerSlot
@@ -261,6 +266,7 @@
     #delay: 10.0
 
 #Starlight edit. maxim bubble shield was buggy, made no sense for salvs, and was on a suit with better stats than a blood red.
+# end region starlight
 
 #Security Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -141,9 +141,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.6
-        Piercing: 0.65
+        Blunt: 0.8
+        Slash: 0.8
+        Piercing: 0.75
         Heat: 0.7
         Radiation: 0.3
         Caustic: 0.7
@@ -204,7 +204,7 @@
   parent: [ ClothingOuterHardsuitBase, BaseSalvageContraband ] #Starlight salvContra
   id: ClothingOuterHardsuitMaxim
   name: salvager maxim hardsuit
-  description: Fire. Heat. These things forge great weapons, they also forge great salvagers.  Has built-in battery-powered energy barrier technology.
+  description: Fire. Heat. These things forge great weapons, they also forge great salvagers. 
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/maxim.rsi
@@ -213,50 +213,54 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
   - type: Pierceable
     level: Metal
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.5
-        Heat: 0.3
-        Radiation: 0.1
+        Blunt: 0.65
+        Slash: 0.65
+        Piercing: 0.65
+        Heat: 0.6
+        Radiation: 0.3
+        Caustic: 0.8
+  - type: ClothingSpeedModifier
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: ExplosionResistance
-    damageCoefficient: 0.2
+    damageCoefficient: 0.4
+  - type: HeldSpeedModifier
   - type: TemperatureProtection
     heatingCoefficient: 0.001
     coolingCoefficient: 0.001
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMaxim
-  - type: ContainerContainer
-    containers:
-      cell_slot: !type:ContainerSlot
-      toggleable-clothing: !type:ContainerSlot
-  - type: PowerCellSlot
-    cellSlotId: cell_slot
-  - type: ItemSlots
-    slots:
-      cell_slot:
-        name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellSmall
-        whitelist:
-          tags:
-            - PowerCell
-            - PowerCellSmall
-  - type: EnergyDomeGenerator
-    damageEnergyDraw: 6
-    domePrototype: EnergyDomeSmallPink
-  - type: PowerCellDraw
-    enabled: false
-    drawRate: 8
-    useRate: 0
-  - type: UseDelay
-    delay: 10.0
+  #- type: ContainerContainer
+    #containers:
+      #cell_slot: !type:ContainerSlot
+      #toggleable-clothing: !type:ContainerSlot
+  #- type: PowerCellSlot
+    #cellSlotId: cell_slot
+  #- type: ItemSlots
+    #slots:
+      #cell_slot:
+        #name: power-cell-slot-component-slot-name-default
+        #startingItem: PowerCellSmall
+        #whitelist:
+          #tags:
+            #- PowerCell
+            #- PowerCellSmall
+  #- type: EnergyDomeGenerator
+    #damageEnergyDraw: 6
+    #domePrototype: EnergyDomeSmallPink
+  #- type: PowerCellDraw
+    #enabled: false
+    #drawRate: 8
+    #useRate: 0
+  #- type: UseDelay
+    #delay: 10.0
+
+# maxim bubble shield was buggy, made no sense for salvs, and was on a suit with better stats than a blood red.
 
 #Security Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -197,7 +197,7 @@
 
 - type: entity
   name: mk 58
-  parent: [BaseWeaponPistol, BaseSecurityContraband]
+  parent: [BaseWeaponPistol, BaseSecuritySalvageContraband]
   id: WeaponPistolMk58
   description: Designed by Nanotrasen’s Small Arms Division, the Mk58 is a conventional semi-automatic pistol with a simple recoil-operated action and excellent reliability. The standard sidearm of Nanotrasen’s station security and emergency response teams. Feeds from .35 pistol magazines.
   components:

--- a/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/mining.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/mining.yml
@@ -122,16 +122,6 @@
   - !type:BuyerAccessCondition
 
 - type: listing
-  id: VendorMiningAdvancedMineralScanner
-  productEntity: AdvancedMineralScanner
-  cost:
-    SalvageTicket: 500
-  categories:
-  - MiningEquipment
-  conditions:
-  - !type:BuyerAccessCondition
-
-- type: listing
   id: VendorMiningMassScanner
   productEntity: HandHeldMassScanner
   cost:

--- a/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/mining.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/mining.yml
@@ -122,6 +122,16 @@
   - !type:BuyerAccessCondition
 
 - type: listing
+  id: VendorMiningAdvancedMineralScanner
+  productEntity: AdvancedMineralScanner
+  cost:
+    SalvageTicket: 500
+  categories:
+  - MiningEquipment
+  conditions:
+  - !type:BuyerAccessCondition
+
+- type: listing
   id: VendorMiningMassScanner
   productEntity: HandHeldMassScanner
   cost:

--- a/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/salvage.yml
@@ -184,15 +184,25 @@
   conditions:
   - !type:BuyerAccessCondition
 
+#- type: listing
+  #id: VendorSalvageWeaponPistolDeagle
+  #productEntity: WeaponPistolDeagle
+  #cost:
+    #SalvageTicket: 300
+  #categories:
+  #- SalvageWeapons
+  #conditions:
+  #- !type:BuyerAccessCondition
+
 - type: listing
-  id: VendorSalvageWeaponPistolDeagle
-  productEntity: WeaponPistolDeagle
+  id: VendorSalvageWeaponPistolStechkin
+  productEntity: WeaponPistolStechkin
   cost:
-    SalvageTicket: 300
+    SalvageTicket: 250
   categories:
   - SalvageWeapons
   conditions:
-  - !type:BuyerAccessCondition
+  - !type:BuyerAccessCondition 
 
 - type: listing
   id: VendorSalvageWeaponShotgunCycler
@@ -235,11 +245,21 @@
   conditions:
   - !type:BuyerAccessCondition
 
+#- type: listing
+  #id: VendorSalvageMagazineMagnum
+  #productEntity: MagazineMagnum
+  #cost:
+    #SalvageTicket: 150
+  #categories:
+  #- SalvageConsumeables
+  #conditions:
+  #- !type:BuyerAccessCondition
+
 - type: listing
-  id: VendorSalvageMagazineMagnum
-  productEntity: MagazineMagnum
+  id: VendorSalvageMagazineStetchkin
+  productEntity: MagazinePistol40SP
   cost:
-    SalvageTicket: 150
+    SalvageTicket: 75
   categories:
   - SalvageConsumeables
   conditions:
@@ -420,7 +440,7 @@
   id: VendorSalvageClothingOuterVestWebMerc
   productEntity: ClothingOuterVestWebMerc
   cost:
-    SalvageTicket: 200
+    SalvageTicket: 350
   categories:
   - SalvageMercenaryEquipment
   conditions:

--- a/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/salvage.yml
@@ -195,8 +195,8 @@
   #- !type:BuyerAccessCondition
 
 - type: listing
-  id: VendorSalvageWeaponPistolStechkin
-  productEntity: WeaponPistolStechkin
+  id: VendorSalvageWeaponPistolMK58
+  productEntity: WeaponPistolMk58
   cost:
     SalvageTicket: 250
   categories:
@@ -256,8 +256,8 @@
   #- !type:BuyerAccessCondition
 
 - type: listing
-  id: VendorSalvageMagazineStetchkin
-  productEntity: MagazinePistol40SP
+  id: VendorSalvageMagazineMK58
+  productEntity: MagazinePistolSP
   cost:
     SalvageTicket: 75
   categories:

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -170,6 +170,7 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
+    - HardsuitSpatio #can now be used to make goliath hardsuit
 
 #CCNT Consortium BSOs
 - type: entity
@@ -473,16 +474,17 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.75
-        Slash: 0.75
+        Blunt: 0.65
+        Slash: 0.65
         Piercing: 0.85
         Heat: 0.65
         Cold: 0.65
         Radiation: 0.2
         Caustic: 0.6
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.85
+    sprintModifier: 0.85
+  - type: HeldSpeedModifier
   - type: TemperatureProtection
     heatingCoefficient: 0.001
     coolingCoefficient: 0.001
@@ -534,8 +536,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.85
-        Slash: 0.85
+        Blunt: 0.75
+        Slash: 0.75
         Piercing: 0.9
         Heat: 0.7
         Cold: 0.7

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -400,7 +400,7 @@
   name: immolator laser gun
   parent: [BaseWeaponBattery, BaseGunWieldable, BaseSecuritySalvageContraband]
   id: WeaponLaserImmolator
-  description: Favoured by Nanotrasen Security for being cheap and easy to use.
+  description: An irregular, unstable firearm. It remains warm to the touch long after it has finished firing.
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Battery/immolator.rsi

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -195,22 +195,23 @@
 
 - type: entity
   name: stechkin pistol
-  parent: [WeaponPistolMk58, BaseSecurityContraband]
+  parent: [BaseSecuritySalvageContraband, WeaponPistolMk58]
   id: WeaponPistolStechkin
-  description: A small, easily concealable .40 handgun. Has a threaded barrel for suppressors. Uses .40 ammo.
+  description: A small, easily concealable .40 handgun. Has a threaded barrel for suppressors. Uses .40 ammo. Likely picked off some poor, low ranking SNKVD agents corpse and resold.
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Pistols/stechkin.rsi
   - type: Clothing
     sprite: _Starlight/Objects/Weapons/Guns/Pistols/stechkin.rsi
   - type: Gun
+    fireRate: 3.5
     soundGunshot:
       path: /Audio/_Starlight/Weapons/Guns/Gunshots/1suppres.ogg
   - type: ItemSlots
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazinePistol40FMJ
+        startingItem: MagazinePistol40SP
         insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
         priority: 2
@@ -220,7 +221,7 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgePistol40FMJ
+        startingItem: CartridgePistol40SP
         priority: 1
         whitelist:
           tags:
@@ -268,7 +269,7 @@
 
 - type: entity
   name: Jungle Hawk
-  parent: [ BaseSecuritySalvageContraband, WeaponPistolN1984 ]
+  parent: [ BaseSyndicateContraband, WeaponPistolN1984 ]
   id: WeaponPistolDeagle
   description: A high-caliber handgun designed for putting down large game.
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -195,23 +195,22 @@
 
 - type: entity
   name: stechkin pistol
-  parent: [BaseSecuritySalvageContraband, WeaponPistolMk58]
+  parent: [BaseSecurityContraband, WeaponPistolMk58]
   id: WeaponPistolStechkin
-  description: A small, easily concealable .40 handgun. Has a threaded barrel for suppressors. Uses .40 ammo. Likely picked off some poor, low ranking SNKVD agents corpse and resold.
+  description: A small, easily concealable .40 handgun. Has a threaded barrel for suppressors. Uses .40 ammo.
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Pistols/stechkin.rsi
   - type: Clothing
     sprite: _Starlight/Objects/Weapons/Guns/Pistols/stechkin.rsi
   - type: Gun
-    fireRate: 3.5
     soundGunshot:
       path: /Audio/_Starlight/Weapons/Guns/Gunshots/1suppres.ogg
   - type: ItemSlots
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazinePistol40SP
+        startingItem: MagazinePistol40FMJ
         insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
         priority: 2
@@ -221,7 +220,7 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgePistol40SP
+        startingItem: CartridgePistol40FMJ
         priority: 1
         whitelist:
           tags:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -97,9 +97,9 @@
       - ShellShotgun
       - SpeedLoaderShotgun
     proto: ShellShotgun
-    capacity: 9
-    chambers: [ True, True, True, True, True, True, True, True, True ]
-    ammoSlots: [ null, null, null, null, null, null, null, null, null ]
+    capacity: 7
+    chambers: [ True, True, True, True, True, True, True, ]
+    ammoSlots: [ null, null, null, null, null, null, null, ]
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/shotgun_insert.ogg
   - type: ContainerContainer


### PR DESCRIPTION
many changes to hardsuits relating to salv and mining, as well as ticket vendor changes and other tweaks.

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Changes to most of the Hardsuits in Salvage and Mining, as well as ticket vendor tweaks and rebalances.
Removes bubble shield from Maxim because it was bugged to hell and wildly overpowered (it literally made ai ignore you and gave you free jets)
Remove Jhawk and its ammo from ticket vendor, replaced with a nerfed Stechkin and its ammo which now also starts with .40 sp so birds arent locked out of a sidearm option.
Added advanced mineral scanner to mining ticket vendor.
Lowered Cycler shotgun max ammo count so its more in line with combat shotty and not a Bulldog-lite.
Raised the price of and lowered values of the Merc web vest.
Changed immolator description since it was just base laser carbine description.

## Why we need to add this
Salvage, quite literally, had a better bloodred hardsuit, I am not overexaggerating this, the maxim was a buggy, overpowered mess, and it needed fixed ages ago, with this change it still remains a combat suit but not literally better than bloodred, caps, secs and literally every other hardsuit outside commander hardsuit, removed its bubble shield because it made no sense for salv to have this, at all, yes im sure it was cool, but this thing was genuinely insane, it gave you free jets in space and made ai ignore you, which is silly considering all salv fights is ai, this isnt even counting the fact its a literal bubble shield and protected you even more on top of the already insane stats for the maxim.

While lowering the values for salvager hardsuits where it made sense, i raised the values for mining suits where it mattered, i raised slash and blunt for mining suits and left their pierce low since they dont really need pierce resist and id rather not have salv pt.2.

Removed Jhawk in the ticket vendor because why the hell did salv have it, replaced it with a nerfed stechkin (worse than Due process now) that was formerly sec contra, yes im aware its in uplink but theres better option in there too if you want a silenced pistol, changed it to SalvSec contra and changed its starting ammo from fmj to sp.

Lowered Cycler shotgun max ammo count from 9 to 7 so its in line with combat shotty, this thing was pretty strong when paired with speedloaders, it was basically just a bulldog-lite, its still very good but this just neatens up the values a bit.

Raised price of and slightly lowered the stats for Merc web vest, it was 200 tickets in the vendor and was literally just better than sec armor, its still good for exped since it has no slowdown while maxim does now, also lowered its stam resist massively, it only tanks one more stun baton or disabler shot now.

## Media (Video/Screenshots)
<img width="406" height="364" alt="Screenshot 2025-11-13 061058" src="https://github.com/user-attachments/assets/a8d96a7b-bf4e-445d-9ac7-f8285cff5471" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Roro
- remove: Removed maxim bubble shield
- tweak: Removed Jhawk and its ammo from Salv ticket vendor, changed its contra label back to syndicate
- tweak: Tweaked resist for maxim, 40% blunt to 35%, 40% slash to 35%, 50% pierce to 35%, 70% heat to 40%, 90% rad to 70%, 80% explosive resist to 60%, also added 20% caustic since it had none
- tweak: Gave Maxim some actual slowdown as well as some slowdown for holding it.
- tweak: Tweaked resist for Salvager hardsuit, 30% blunt to 20%, 40% slash to 20%, 35% pierce to 25%
- tweak: Tweaked resists for Mining hardsuit, 15% blunt to 25%, 15% slash to 25%
- tweak: Tweaked resists and speed for Advanced Mining hardsuit, 25% blunt to 35%, 25% slash to 35%, 10% slowdown to 15%, also added slowdown when holding it in hand
- tweak: Tweaked Merc web vest resists and price, from 200 tickets to 350, 50% pierce to 40%, 45% stam resist to 15%
- tweak: Lowered ammo for cycler shotgun from 9 to 7
- tweak: Changed Immolators description so its not the same as Laser Carbines
- tweak: Space Hazard suit can now be used to craft a goliath hardsuit
- tweak: Added MK58 and its ammo to salv ticket vendor to replace the Jhawk, MK58 now has SalvSec contra label
