### PR TITLE
Traitor TC Buff

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
@@ -75,8 +75,8 @@ public sealed partial class TraitorRuleComponent : Component
     public SoundSpecifier GreetSoundNotification = new SoundPathSpecifier("/Audio/Ambience/Antag/traitor_start.ogg");
 
     /// <summary>
-    /// The amount of TC traitors start with.
+    /// The amount of TC traitors start with. Starlight Edit: 20 -> 25
     /// </summary>
     [DataField]
-    public FixedPoint2 StartingBalance = 20;
+    public FixedPoint2 StartingBalance = 25;
 }


### PR DESCRIPTION

## Short description
Increased the starting TC of Traitors from 20 to 25.

## Why we need to add this
In order to counteract the rampant shittery that comes with 130-200 population, we have progressively been buffing Security in order to keep the sanity on the station somewhat intact, both in giving them varied gear but mostly in increasing the number of Security roles.

This has also come at the cost of Antagonists however, which was expected knowing we'd have to buff them eventually to keep things balanced properly. Nukies have had their maximum numbers increased from 5 to 6 before as part of this, and Dragons have been buffed and nerfed a few times.

This change to Traitors is in line with that effort. Giving them 5 extra TC means they have a little more wiggle room to be aggressive if they get caught while still investing in useful, borderline necessary, tools to do their objectives. This should overall lead to more success from Traitors which generates more positive gameplay for the station overall.

The balance shouldn't be too bad, given how many Security there are. Even if 2 Traitors pool to buy a Mega Surplus Crate they are only slightly less at the whims of RNG, with 5 TC left each which is barely enough for a gun and some ammo if they get completely fucked.

## Media (Video/Screenshots)
<img width="1044" height="557" alt="image" src="https://github.com/user-attachments/assets/e1a5321e-5e00-4564-a3b2-1824036462ec" />


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Buffed Traitors starting Telecrystal balance from 20 to 25. This should allow Traitors to get a little more done despite the increased number of Security on Starlight's maps.

