### PR TITLE
Fixes spray painters consuming double ammo when painting pipes

### DIFF
--- a/Content.Server/SprayPainter/SprayPainterSystem.cs
+++ b/Content.Server/SprayPainter/SprayPainterSystem.cs
@@ -146,8 +146,13 @@ public sealed class SprayPainterSystem : SharedSprayPainterSystem
             return;
 
         if (!_charges.TryUseCharges((ent, charges), ent.Comp.PipeChargeCost))
-        // Starlight-edit: End
+        {
+            // extra check needed for recharging spraypainters
+            var msg = Loc.GetString("spray-painter-interact-no-charges");
+            _popup.PopupEntity(msg, args.User, args.User);
             return;
+        }
+        // Starlight-edit: End
 
         Audio.PlayPvs(ent.Comp.SpraySound, ent);
         _pipeColor.SetColor(target, color, args.Color);
@@ -165,17 +170,12 @@ public sealed class SprayPainterSystem : SharedSprayPainterSystem
 
         if (!painter.ColorPalette.TryGetValue(colorName, out var color))
             return;
-        // Starlight-edit: Start
-        if (!TryComp(args.Used, out LimitedChargesComponent? charges))
-        {
-            _popup.PopupEntity(Loc.GetString("spray-painter-interact-no-charges"), args.User, args.User);
-            return;
-        }
 
-        if (!_charges.TryUseCharges((args.Used, charges), painter.PipeChargeCost))
+        if (TryComp<LimitedChargesComponent>(args.Used, out var charges)
+            && _charges.GetCurrentCharges((args.Used, charges)) < painter.PipeChargeCost)
         {
-            _popup.PopupEntity(Loc.GetString("spray-painter-interact-no-charges"), args.User, args.User);
-            // Starlight-edit: End
+            var msg = Loc.GetString("spray-painter-interact-no-charges");
+            _popup.PopupEntity(msg, args.User, args.User);
             return;
         }
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes a bug introduced in #1553 where the function `OnPipeInteract()` was calling `.TryUseCharges()` which made it consume a paint charge when you _started_ painting a pipe.

After the doAfter finished, the function `OnPipeDoAfter()`, would call `.TryUseCharges()` again and consume a second paint charge.

**Note**: I reverted the code for `OnPipeInteract()` to upstream, hence why there's no Starlight comments there. I've adjusted the Starlight comments as needed in `OnPipeDoAfter()`

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Spray painting pipes is intended to cost 1 paint, not 2. I was wondering why I ran out of paint so quickly when painting pipes in Atmospherics.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/23bd57cc-7526-4b66-9fd4-f7f66d2f936d

fig 1. - Fixes shown:
- Spray painters only consume 1 paint when painting pipes, as intended
- Spray painters don't consume a paint charge if you start painting but then cancel the doAfter
- Spray painters now show a "Not enough paint" message if you run out of charges after having queued up a bunch of spray paints on pipes. Nice QoL change

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- fix: Spray painters no longer consume 2 paint charges when painting pipes (now correctly consume only 1 charge)
