### PR TITLE
Cleanup stasis system

### DIFF
--- a/Content.Server/_Starlight/Actions/EntitySystems/StasisSystem.cs
+++ b/Content.Server/_Starlight/Actions/EntitySystems/StasisSystem.cs
@@ -82,7 +82,7 @@ public sealed class StasisSystem : SharedStasisSystem
         var updatedDamage = new DamageSpecifier();
         foreach (var damage in args.Damage.DamageDict)
         {
-            var scaler = ent.Comp.CritDamageResistance;
+            var scaler = ent.Comp.StasisDamageReduction;
             updatedDamage.DamageDict[damage.Key] = damage.Value > 0 ? scaler * damage.Value : damage.Value;
         }
 

--- a/Content.Server/_Starlight/Actions/EntitySystems/StasisSystem.cs
+++ b/Content.Server/_Starlight/Actions/EntitySystems/StasisSystem.cs
@@ -1,80 +1,111 @@
-using System.Linq;
 using Content.Server.Body.Systems;
 using Content.Shared.Actions;
 using Content.Shared.Damage;
 using Robust.Shared.Timing;
-using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
-using Content.Shared.Mobs.Components;
 using Content.Shared._Starlight.Actions.EntitySystems;
 using Content.Shared._Starlight.Actions.Components;
 using Content.Shared._Starlight.Actions.Events;
-using Content.Shared.Body.Components;
+using Content.Shared.Mobs.Systems;
 using Robust.Shared.Player;
 
 namespace Content.Server._Starlight.Actions.EntitySystems;
 
 public sealed class StasisSystem : SharedStasisSystem
 {
-    [Dependency] private readonly DamageableSystem _damageableSystem = default!;
-    [Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<StasisComponent, DamageChangedEvent>(OnDamageChanged);
-        SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<StasisComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<StasisComponent, ComponentShutdown>(OnCompRemove);
+        SubscribeLocalEvent<StasisComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<StasisComponent, DamageModifyEvent>(OnDamageModify);
+        SubscribeLocalEvent<StasisComponent, PrepareStasisActionEvent>(OnPrepareStasisStart);
+        SubscribeLocalEvent<StasisComponent, EnterStasisActionEvent>(OnEnterStasisStart);
+        SubscribeLocalEvent<StasisComponent, ExitStasisActionEvent>(OnExitStasisStart);
     }
 
-    private void OnMobStateChanged(MobStateChangedEvent args)
+    public override void Update(float frameTime)
     {
-        // If the entity has a stasis component, and the new mob state is dead, exit stasis.
-        if (TryComp<StasisComponent>(args.Target, out var comp))
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        
+        var query = EntityQueryEnumerator<StasisComponent>();
+        while (query.MoveNext(out var uid, out var comp))
         {
-            if (args.NewMobState == MobState.Dead && comp.IsInStasis)
-            {
-                RaiseLocalEvent(args.Target, new ExitStasisActionEvent());
-            }
+            if (comp.NextHeal > curTime || !comp.IsInStasis)
+                continue;
+
+            // Negative because your healing
+            var modifier = _mobState.IsCritical(uid) ? -comp.CritHealingModifier : -1.0f;
+
+            _damageable.TryChangeDamage(uid, modifier * comp.HealingPerUpdate, true, origin: uid);
+
+            _bloodstream.TryModifyBleedAmount(uid, modifier * comp.BleedHealPerUpdate);
+
+            comp.NextHeal += comp.UpdateInterval;
         }
     }
 
-    protected override void OnMapInit(EntityUid uid, StasisComponent comp, MapInitEvent args)
+    private void OnMapInit(EntityUid uid, StasisComponent comp, MapInitEvent args)
     {
         _actionsSystem.AddAction(uid, ref comp.EnterStasisActionEntity, comp.EnterStasisAction);
     }
 
-    /// <summary>
-    /// Takeths away the action to preform stasis from the entity.
-    /// </summary>
-    protected override void OnCompRemove(EntityUid uid, StasisComponent comp, ComponentShutdown args)
+    private void OnCompRemove(EntityUid uid, StasisComponent comp, ComponentShutdown args)
     {
         _actionsSystem.RemoveAction(uid, comp.EnterStasisActionEntity);
         _actionsSystem.RemoveAction(uid, comp.ExitStasisActionEntity);
     }
 
-    protected override void OnPrepareStasisStart(EntityUid uid, StasisComponent comp,
-        PrepareStasisActionEvent args)
+    private void OnMobStateChanged(Entity<StasisComponent> ent, ref MobStateChangedEvent args)
     {
-        Dirty(uid, comp);
+        if (args.NewMobState == MobState.Dead && ent.Comp.IsInStasis)
+            RaiseLocalEvent(args.Target, new ExitStasisActionEvent());
+    }
 
+    private void OnDamageModify(Entity<StasisComponent> ent, ref DamageModifyEvent args)
+    {
+        // TODO: this might mean like hitting yourself with a bomb or something while in stasis wont resist damage.
+        if (!ent.Comp.IsInStasis || args.Origin == ent)
+            return;
+        
+        // Reduce all positive damage.
+        var updatedDamage = new DamageSpecifier();
+        foreach (var damage in args.Damage.DamageDict)
+        {
+            var scaler = ent.Comp.CritDamageResistance;
+            updatedDamage.DamageDict[damage.Key] = damage.Value > 0 ? scaler * damage.Value : damage.Value;
+        }
+
+        args.Damage = updatedDamage;
+    }
+
+    private void OnPrepareStasisStart(EntityUid uid, StasisComponent comp, PrepareStasisActionEvent args)
+    {
         EnsureComp<StasisFrozenComponent>(uid);
 
         _actionsSystem.RemoveAction(uid, comp.EnterStasisActionEntity);
         _actionsSystem.AddAction(uid, ref comp.ExitStasisActionEntity, comp.ExitStasisAction);
-        _actionsSystem.SetCooldown(comp.ExitStasisActionEntity,
-            TimeSpan.FromSeconds(comp.StasisEnterEffectLifetime + 1));
+        _actionsSystem.SetCooldown(comp.ExitStasisActionEntity, comp.StasisEnterEffectLifetime);
 
         // Send animation event to all clients
-        var ev = new StasisAnimationEvent(GetNetEntity(uid), GetNetCoordinates(Transform(uid).Coordinates),
-            StasisAnimationType.Prepare);
+        var ev = new StasisAnimationEvent(GetNetEntity(uid), GetNetCoordinates(Transform(uid).Coordinates), StasisAnimationType.Prepare);
         RaiseNetworkEvent(ev, Filter.Pvs(uid, entityManager: EntityManager));
 
+        // TODO: refactor this to not use timers
         // Schedule the enter stasis event after delay
-        Timer.Spawn(TimeSpan.FromSeconds(comp.StasisEnterEffectLifetime), () =>
+        Timer.Spawn(comp.StasisEnterEffectLifetime, () =>
         {
-            if (!TryComp<StasisComponent>(uid, out var stasisComp))
+            if (!HasComp<StasisComponent>(uid))
                 return;
 
             var enterEv = new EnterStasisActionEvent();
@@ -82,27 +113,20 @@ public sealed class StasisSystem : SharedStasisSystem
         });
     }
 
-    protected override void OnEnterStasisStart(EntityUid uid, StasisComponent comp,
-        EnterStasisActionEvent args)
+    private void OnEnterStasisStart(EntityUid uid, StasisComponent comp, EnterStasisActionEvent args)
     {
         comp.IsInStasis = true;
+        comp.NextHeal = _timing.CurTime;
         comp.IsVisible = false; // Entity becomes invisible when entering stasis to better show the effect
 
         Dirty(uid, comp);
 
-        // Remove bleeding when entering stasis
-        if (TryComp<BloodstreamComponent>(uid, out var bloodstream))
-        {
-            _bloodstreamSystem.TryModifyBleedAmount((uid, bloodstream), -bloodstream.BleedAmount);
-        }
-
         // Send animation event to all clients
-        var ev = new StasisAnimationEvent(GetNetEntity(uid), GetNetCoordinates(Transform(uid).Coordinates),
-            StasisAnimationType.Enter);
+        var ev = new StasisAnimationEvent(GetNetEntity(uid), GetNetCoordinates(Transform(uid).Coordinates), StasisAnimationType.Enter);
         RaiseNetworkEvent(ev, Filter.Pvs(uid, entityManager: EntityManager));
     }
 
-    protected override void OnExitStasisStart(EntityUid uid, StasisComponent comp, ExitStasisActionEvent args)
+    private void OnExitStasisStart(EntityUid uid, StasisComponent comp, ExitStasisActionEvent args)
     {
         comp.IsInStasis = false;
         comp.IsVisible = true; // Entity becomes visible when exiting stasis
@@ -111,7 +135,7 @@ public sealed class StasisSystem : SharedStasisSystem
 
         _actionsSystem.RemoveAction(uid, comp.ExitStasisActionEntity);
         _actionsSystem.AddAction(uid, ref comp.EnterStasisActionEntity, comp.EnterStasisAction);
-        _actionsSystem.SetCooldown(comp.EnterStasisActionEntity, TimeSpan.FromSeconds(comp.StasisCooldown));
+        _actionsSystem.SetCooldown(comp.EnterStasisActionEntity, comp.StasisCooldown);
 
         RemComp<StasisFrozenComponent>(uid);
 
@@ -120,125 +144,4 @@ public sealed class StasisSystem : SharedStasisSystem
             StasisAnimationType.Exit);
         RaiseNetworkEvent(ev, Filter.Pvs(uid, entityManager: EntityManager));
     }
-
-    public override void Update(float frameTime)
-    {
-        base.Update(frameTime);
-
-        var query = EntityQueryEnumerator<StasisComponent>();
-        while (query.MoveNext(out var uid, out var comp))
-        {
-            if (TryComp<MobStateComponent>(uid, out var mobState))
-            {
-                var currentState = mobState.CurrentState;
-                var healingValues = GetHealingValues(currentState, comp);
-                OnStasisUpdate(uid, comp, new FrameEventArgs(frameTime), healingValues);
-            }
-        }
-    }
-
-    private void OnDamageChanged(EntityUid uid, StasisComponent component, DamageChangedEvent args)
-    {
-        // If the entity has a mob state component, and the damage changed event is not healing, apply the resistance.
-        if (TryComp<MobStateComponent>(uid, out var mobState))
-        {
-            var currentState = mobState.CurrentState;
-            var healingValues = GetHealingValues(currentState, component);
-            ApplyResistance(uid, args, component, healingValues);
-        }
-    }
-
-    private void ApplyResistance(EntityUid uid, DamageChangedEvent args, StasisComponent comp,
-        StasisHealingValues healingValues)
-    {
-        // Skip if this is healing or if the damage change is from our own healing
-        if (!args.DamageIncreased || args.DamageDelta == null || args.Origin == uid)
-            return;
-
-        // Only apply resistance if in stasis
-        if (!comp.IsInStasis)
-            return;
-
-        // Skip if this damage was already modified by stasis
-        if (args.Origin == uid && args.DamageDelta.DamageDict.All(x => x.Value < 0))
-            return;
-
-        // Create new DamageSpecifier with reduced damage
-        var damageToApply = new DamageSpecifier();
-        foreach (var (type, amount) in args.DamageDelta.DamageDict)
-        {
-            damageToApply.DamageDict.Add(type, amount - (amount * healingValues.AdditionalDamageResistance));
-        }
-
-        // Apply the reduced damage
-        _damageableSystem.TryChangeDamage(uid, damageToApply, true, origin: uid);
-    }
-
-    private void OnStasisUpdate(EntityUid uid, StasisComponent comp, FrameEventArgs args,
-        StasisHealingValues healingValues)
-    {
-        if (!comp.IsInStasis)
-            return;
-
-        // Apply healing effect
-        var healAmount = new DamageSpecifier();
-        healAmount.DamageDict.Add("Blunt", FixedPoint2.New(healingValues.BluntHeal * args.DeltaSeconds * -1));
-        healAmount.DamageDict.Add("Slash", FixedPoint2.New(healingValues.SlashHeal * args.DeltaSeconds * -1));
-        healAmount.DamageDict.Add("Piercing",
-            FixedPoint2.New(healingValues.PiercingHeal * args.DeltaSeconds * -1));
-        healAmount.DamageDict.Add("Heat", FixedPoint2.New(healingValues.HeatHeal * args.DeltaSeconds * -1));
-        healAmount.DamageDict.Add("Cold", FixedPoint2.New(healingValues.ColdHeal * args.DeltaSeconds * -1));
-
-        if (TryComp<DamageableComponent>(uid, out _))
-        {
-            _damageableSystem.TryChangeDamage(uid, healAmount, true, origin: uid);
-        }
-
-        // Heal bleeding
-        if (TryComp<BloodstreamComponent>(uid, out var bloodstream) && bloodstream.BleedAmount > 0)
-        {
-            _bloodstreamSystem.TryModifyBleedAmount((uid, bloodstream), -healingValues.BleedHeal * (float)args.DeltaSeconds);
-        }
-    }
-
-    /// <summary>
-    /// Gets the healing values for the stasis effect based on the mob state.
-    /// </summary>
-    private StasisHealingValues GetHealingValues(MobState state, StasisComponent comp)
-    {
-        return state switch
-        {
-            MobState.Alive => new StasisHealingValues(comp.StasisBluntHealPerSecond, comp.StasisSlashingHealPerSecond,
-                comp.StasisPiercingHealPerSecond, comp.StasisHeatHealPerSecond, comp.StasisColdHealPerSecond,
-                comp.StasisBleedHealPerSecond, comp.StasisAdditionalDamageResistance),
-            MobState.Critical => new StasisHealingValues(comp.StasisInCritBluntHealPerSecond,
-                comp.StasisInCritSlashingHealPerSecond, comp.StasisInCritPiercingHealPerSecond,
-                comp.StasisInCritHeatHealPerSecond, comp.StasisInCritColdHealPerSecond,
-                comp.StasisInCritBleedHealPerSecond, comp.StasisInCritAdditionalDamageResistance),
-            MobState.Invalid => new StasisHealingValues(0, 0, 0, 0, 0, 0, 0),
-            MobState.Dead => new StasisHealingValues(0, 0, 0, 0, 0, 0, 0),
-            _ => new StasisHealingValues(0, 0, 0, 0, 0, 0, 0),
-        };
-    }
-}
-
-/// <summary>
-/// A struct that contains the healing values for the stasis effect.
-/// </summary>
-sealed class StasisHealingValues(
-    float bluntHeal,
-    float slashHeal,
-    float piercingHeal,
-    float heatHeal,
-    float coldHeal,
-    float bleedHeal,
-    float additionalDamageResistance)
-{
-    public float BluntHeal { get; private set; } = bluntHeal;
-    public float SlashHeal { get; private set; } = slashHeal;
-    public float PiercingHeal { get; private set; } = piercingHeal;
-    public float HeatHeal { get; private set; } = heatHeal;
-    public float ColdHeal { get; private set; } = coldHeal;
-    public float AdditionalDamageResistance { get; private set; } = additionalDamageResistance;
-    public float BleedHeal { get; private set; } = bleedHeal;
 }

--- a/Content.Shared/_Starlight/Actions/Components/StasisComponent.cs
+++ b/Content.Shared/_Starlight/Actions/Components/StasisComponent.cs
@@ -1,157 +1,132 @@
 using Content.Shared._Starlight.Actions.EntitySystems;
+using Content.Shared.Damage;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._Starlight.Actions.Components;
 
 /// <summary>
 /// Component that allows an entity to enter and exit stasis.
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(SharedStasisSystem)), AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause, Access(typeof(SharedStasisSystem))]
 public sealed partial class StasisComponent : Component
 {
     /// <summary>
     /// Whether the entity is currently in stasis.
     /// </summary>
-    [DataField] [AutoNetworkedField] public bool IsInStasis = false;
+    [DataField, AutoNetworkedField]
+    public bool IsInStasis;
 
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoNetworkedField, AutoPausedField]
+    public TimeSpan NextHeal = TimeSpan.Zero;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
+    
     /// <summary>
     /// Whether the entity should be visible. This is synced to ensure proper PVS handling.
     /// </summary>
-    [DataField] [AutoNetworkedField] public bool IsVisible = true;
-
-    /// <summary>
-    /// The second entity needed to preform stasis. This is used to leave stasis.
-    /// </summary>
-    [DataField(required: true)] [ViewVariables(VVAccess.ReadWrite)] [AutoNetworkedField]
-    public EntProtoId ExitStasisAction;
-
-    [AutoNetworkedField] [DataField("exitStasisActionEntity")]
-    public EntityUid? ExitStasisActionEntity;
+    [DataField, AutoNetworkedField]
+    public bool IsVisible = true;
 
     /// <summary>
     /// The entity needed to actually preform stasis. This will be granted (and removed) upon the entity's creation.
     /// </summary>
-    [DataField(required: true)] [ViewVariables(VVAccess.ReadWrite)] [AutoNetworkedField]
+    [DataField(required: true), AutoNetworkedField]
     public EntProtoId EnterStasisAction;
 
-    [AutoNetworkedField] [DataField("enterStasisActionEntity")]
+    /// <summary>
+    /// The second entity needed to preform stasis. This is used to leave stasis.
+    /// </summary>
+    [DataField(required: true), AutoNetworkedField]
+    public EntProtoId ExitStasisAction;
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? ExitStasisActionEntity;
+
+    [DataField, AutoNetworkedField]
     public EntityUid? EnterStasisActionEntity;
 
     /// <summary>
     /// The cooldown time for the stasis ability, in seconds.
     /// </summary>
-    [DataField] public float StasisCooldown = 300f;
+    [DataField]
+    public TimeSpan StasisCooldown = TimeSpan.FromSeconds(300);
 
     /// <summary>
-    /// The amount of brute damage the stasis ability will heal, per second.
+    /// How much the entity gets healed per update interval.
     /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisBluntHealPerSecond = 2f;
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier HealingPerUpdate = new();
 
     /// <summary>
-    /// The amount of sharp damage the stasis ability will heal, per second.
+    /// How much bleed is healed per update interval
     /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisSlashingHealPerSecond = 2f;
+    [DataField, AutoNetworkedField]
+    public float BleedHealPerUpdate = 1.0f;
 
     /// <summary>
-    /// The amount of piercing damage the stasis ability will heal, per second.
+    /// How much extra healing is done when the entity is in a critical state.
     /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisPiercingHealPerSecond = 2f;
+    [DataField, AutoNetworkedField]
+    public float CritHealingModifier = 2.0f;
 
     /// <summary>
-    /// The amount of heat damage the stasis ability will heal, per second.
+    /// Flat percentage damage resistance against ALL positive damage taken (Healing is not effected)
     /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisHeatHealPerSecond = 2f;
-
-    /// <summary>
-    /// The amount of cold damage the stasis ability will heal, per second.
-    /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisColdHealPerSecond = 2f;
-
-    /// <summary>
-    /// The amount of bleed the stasis ability will heal, per second.
-    /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisBleedHealPerSecond = 1.0f;
-
-    /// <summary>
-    /// The amount of additional damage resistance while in stasis (0-1, where 1 is 100% resistance), so 0.1 resistance lowers damage by 10%.
-    /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisAdditionalDamageResistance = 1.5f;
-
-    /// <summary>
-    /// The amount of brute damage the stasis ability will heal in critical status, per second.
-    /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisInCritBluntHealPerSecond = 1f;
-
-    /// <summary>
-    /// The amount of sharp damage the stasis ability will heal in critical status, per second.
-    /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisInCritSlashingHealPerSecond = 1f;
-
-    /// <summary>
-    /// The amount of piercing damage the stasis ability will heal in critical status, per second.
-    /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisInCritPiercingHealPerSecond = 1f;
-
-    /// <summary>
-    /// The amount of heat damage the stasis ability will heal in critical status, per second.
-    /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisInCritHeatHealPerSecond = 1f;
-
-    /// <summary>
-    /// The amount of cold damage the stasis ability will heal in critical status, per second.
-    /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisInCritColdHealPerSecond = 1f;
-
-    /// <summary>
-    /// The amount of bleed the stasis ability will heal in critical status, per second.
-    /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisInCritBleedHealPerSecond = 0.5f;
-
-    /// <summary>
-    /// The amount of additional damage resistance while in stasis in critical status (0-1, where 1 is 100% resistance), so 0.1 resistance lowers damage by 10%.
-    /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisInCritAdditionalDamageResistance = 1.5f;
+    [DataField, AutoNetworkedField]
+    public float CritDamageResistance = 0.5f;
 
     /// <summary>
     /// The prototype ID of the stasis effect to spawn when entering stasis.
     /// </summary>
-    [DataField] [AutoNetworkedField] public EntProtoId StasisEnterEffect = "EffectNanitesEnter";
+    [DataField, AutoNetworkedField]
+    public EntProtoId StasisEnterEffect = "EffectNanitesEnter";
 
     /// <summary>
     /// The lifetime of the entering stasis effect in seconds.
     /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisEnterEffectLifetime = 1.7f;
+    [DataField, AutoNetworkedField]
+    public TimeSpan StasisEnterEffectLifetime = TimeSpan.FromSeconds(1.7);
 
     /// <summary>
     /// The sound to play when entering stasis.
     /// </summary>
-    [DataField] [AutoNetworkedField] public string StasisEnterSound = "/Audio/_Starlight/Misc/alien_teleport.ogg";
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier StasisEnterSound =  new SoundPathSpecifier("/Audio/_Starlight/Misc/alien_teleport.ogg");
 
     /// <summary>
     /// The prototype ID of the stasis effect to spawn when exiting stasis.
     /// </summary>
-    [DataField] [AutoNetworkedField] public EntProtoId StasisExitEffect = "EffectNanitesExit";
+    [DataField, AutoNetworkedField]
+    public EntProtoId StasisExitEffect = "EffectNanitesExit";
 
     /// <summary>
     /// The lifetime of the exit stasis effect in seconds.
     /// </summary>
-    [DataField] [AutoNetworkedField] public float StasisExitEffectLifetime = 1.7f;
+    [DataField, AutoNetworkedField]
+    public float StasisExitEffectLifetime = 1.7f;
 
     /// <summary>
     /// The sound to play when exiting stasis.
     /// </summary>
-    [DataField] [AutoNetworkedField] public string StasisExitSound = "/Audio/_Starlight/Misc/alien_teleport.ogg";
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier StasisExitSound = new SoundPathSpecifier("/Audio/_Starlight/Misc/alien_teleport.ogg");
 
     /// <summary>
     /// The prototype ID of the stasis effect to spawn when stasis is currently in use.
     /// </summary>
-    [DataField] [AutoNetworkedField] public EntProtoId StasisContinuousEffect = "EffectNanitesCurrent";
+    [DataField, AutoNetworkedField]
+    public EntProtoId StasisContinuousEffect = "EffectNanitesCurrent";
 
     /// <summary>
     /// The entity reference for the continuous stasis effect.
     /// </summary>
-    [DataField] [AutoNetworkedField] public EntityUid? ContinuousEffectEntity;
+    [DataField, AutoNetworkedField]
+    public EntityUid? ContinuousEffectEntity;
 
     /// <summary>
     /// Client-side reference to the continuous stasis effect entity.

--- a/Content.Shared/_Starlight/Actions/Components/StasisComponent.cs
+++ b/Content.Shared/_Starlight/Actions/Components/StasisComponent.cs
@@ -78,7 +78,7 @@ public sealed partial class StasisComponent : Component
     /// Flat percentage damage resistance against ALL positive damage taken (Healing is not effected)
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float CritDamageResistance = 0.5f;
+    public float StasisDamageReduction = 0.5f;
 
     /// <summary>
     /// The prototype ID of the stasis effect to spawn when entering stasis.

--- a/Content.Shared/_Starlight/Actions/EntitySystems/SharedStasisSystem.cs
+++ b/Content.Shared/_Starlight/Actions/EntitySystems/SharedStasisSystem.cs
@@ -6,65 +6,19 @@ namespace Content.Shared._Starlight.Actions.EntitySystems;
 /// <summary>
 /// Allows mobs to enter nanite induced stasis <see cref="StasisComponent"/>.
 /// </summary>
-public abstract class SharedStasisSystem : EntitySystem
-{
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<StasisComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<StasisComponent, ComponentShutdown>(OnCompRemove);
-        SubscribeLocalEvent<StasisComponent, PrepareStasisActionEvent>(OnPrepareStasisStart);
-        SubscribeLocalEvent<StasisComponent, EnterStasisActionEvent>(OnEnterStasisStart);
-        SubscribeLocalEvent<StasisComponent, ExitStasisActionEvent>(OnExitStasisStart);
-    }
-
-    /// <summary>
-    /// Giveths the action to preform stasis on the entity
-    /// </summary>
-    protected virtual void OnMapInit(EntityUid uid, StasisComponent comp, MapInitEvent args)
-    {
-    }
-
-    /// <summary>
-    /// Takeths away the action to preform stasis from the entity.
-    /// </summary>
-    protected virtual void OnCompRemove(EntityUid uid, StasisComponent comp, ComponentShutdown args)
-    {
-    }
-
-    protected virtual void OnPrepareStasisStart(EntityUid uid, StasisComponent comp,
-        PrepareStasisActionEvent args)
-    {
-    }
-
-    protected virtual void OnEnterStasisStart(EntityUid uid, StasisComponent comp,
-        EnterStasisActionEvent args)
-    {
-    }
-
-    protected virtual void OnExitStasisStart(EntityUid uid, StasisComponent comp, ExitStasisActionEvent args)
-    {
-    }
-}
+public abstract class SharedStasisSystem : EntitySystem;
 
 /// <summary>
 /// Should be relayed upon using the action.
 /// </summary>
-public sealed partial class PrepareStasisActionEvent : InstantActionEvent
-{
-}
+public sealed partial class PrepareStasisActionEvent : InstantActionEvent;
 
 /// <summary>
 /// Should be relayed preparation to stasis being complete.
 /// </summary>
-public sealed partial class EnterStasisActionEvent : InstantActionEvent
-{
-}
+public sealed partial class EnterStasisActionEvent : InstantActionEvent;
 
 /// <summary>
 /// Should be relayed upon using the action.
 /// </summary>
-public sealed partial class ExitStasisActionEvent : InstantActionEvent
-{
-}
+public sealed partial class ExitStasisActionEvent : InstantActionEvent;

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -144,7 +144,15 @@
     - type: Stasis
       enterStasisAction: ActionStasisEnter
       exitStasisAction: ActionStasisExit
-
+      updateInterval: 1s
+      healingPerUpdate:
+        types:
+          Heat: 2
+          Cold: 2
+        groups:
+          Brute: 6
+      bleedHealPerUpdate: 1.0
+      critDamageResistance: 2.0
 # Chirp!
 
 - type: entity

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -152,7 +152,9 @@
         groups:
           Brute: 6
       bleedHealPerUpdate: 1.0
-      critDamageResistance: 2.0
+      critHealingModifier: 2.0
+      stasisDamageReduction: 0.5
+
 # Chirp!
 
 - type: entity

--- a/Resources/Prototypes/_StarLight/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Species/avali.yml
@@ -173,12 +173,3 @@
   baseSprite:
     sprite: _Starlight/Mobs/Species/Avali/parts.rsi
     state: r_foot
-
-- type: entity
-  id: Stasis
-  name: Avali Stasis
-  description: Allows Avali to enter nanite induced stasis.
-  components:
-    - type: Stasis
-      enterStasisAction: ActionStasisEnter
-      exitStasisAction: ActionStasisExit


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
title!

It was a little messy this just is a cleanup - most of the functionality remains the same. The main points:
1.) Made the damage healed per second be a damge specifier instead of each healing item being its own field
2.) Remove all the abstract shared functions (They didn't do anything it was all server side)
3.) Changed a few floats to timespans
4.) Made the updates only happen once per second so it works with small values like 0.5 - otherwise if the heal amount was small enough it would just be fped out and wouldn't heal anything.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- tweak: Avali no longer heal all bleed damage when going into stasis

