### PR TITLE
Increase damage threshold for crawling get-up stunlock

### DIFF
--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -297,7 +297,7 @@ public abstract partial class SharedStunSystem
         var doAfterArgs = new DoAfterArgs(EntityManager, entity, ev.DoAfterTime, new TryStandDoAfterEvent(), entity, entity)
         {
             BreakOnDamage = true,
-            DamageThreshold = 5,
+            DamageThreshold = 15, // Starlight
             CancelDuplicate = true,
             RequireCanInteract = false,
             BreakOnHandChange = true


### PR DESCRIPTION
## Short description
Increment the amount of damage required to break the "standing up" after crawling doafter from 5 to 15 points of damage

## Why we need to add this
As it works ingame, when you take damage while dropped/crawling and attempting to stand by pressing c, the action cancels and needs to be restarted. This has significant combat implications, as the stand up do after is slower than all melee/ranged weapons in the game. This means that you can get easily "stunlocked" on the floor by a person or even a simple hostile mob, with no way to fight back.
The counter to this is the "right click shove" - if you right click yourself with empty hands or a prone-attackable weapon, you instantly right yourself at the cost of a tiny amount of stamina. This is the intended counter to the stunlock.

Now that the background is over, the issue:
It has been ~6 months since crawling made it ingame, and the right click shove has not filtered its way down into casual player understanding - frequently you can watch instances of the following:
- players getting killed because they slip on a puddle while a slime is attacking them, and getting stunlocked as the slime kites them, resulting in them dying without being able to run or fight back
- a player who knows more about melee combat uses a taser before switching to a knife or gun, so that their target is stuck on the ground
- a player slips with a gun, and then can't do the "x 1 right click on self" input dance to unequip their weapon so they can shove themselves fast enough to stop themselves from just soaking all the rounds up and dying

This is entirely a knowledge problem - solved by knowing that you can right click yourself in harm mode to right - but again, this is an obscure fact that a lot of people don't seem to know
This results in a scenario where we are punishing less combat experienced players for not knowing a specific tactic, and giving an advantage to people who know of the meta - in combination with tasers this is very degenerative to gameplay

My proposal is to increment the damage required to 15 (potentially further depending on reception)
- this means that newer players can't get stuck on the floor by vent creatures like clown spiders or slimes
- this means that if you want to keep people "stunlocked" you need a spear or other high damage weapon, can't just use a generic combat knife
- this does NOT affect guns, as they usually all do over 15 damage - which may be a problem, as you can slip and get stuck in place by being shot in automatic

I've been thinking about pring this for a long time, but have kind of been waiting to see if people start to learn about how to escape being stuck on the floor - I haven't really seen much progression over time, and I don't see how this being removed will cause any loss of depth to gameplay

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- tweak: Increment the damage required to stunlock someone in crawl to 15
