### PR TITLE
Add randomizable gridfill component

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeOpsShuttleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeOpsShuttleComponent.cs
@@ -7,5 +7,5 @@
 public sealed partial class NukeOpsShuttleComponent : Component
 {
     [DataField]
-    public EntityUid AssociatedRule;
+    public EntityUid? AssociatedRule; // Starlight - make nullable to fix issues around serialization of prototypes that can add this
 }

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -329,16 +329,13 @@ public sealed partial class ShuttleSystem
 
         var untriedGrids = new Dictionary<ResPath, float>(component.PathWeights);
 
-        while (untriedGrids.Count > 0) {
-            ResPath selectedGridPath = _random.Pick(untriedGrids);
-
-            untriedGrids.Remove(selectedGridPath);
+        while (_random.TryPickAndTake(untriedGrids, out var selectedGridPath)) {
 
             // Spawn on a dummy map and try to dock if possible, otherwise dump it.
-            _mapSystem.CreateMap(out var mapId);
+            _mapSystem.CreateMap(out var tempMapId);
             var valid = false;
 
-            if (_loader.TryLoadGrid(mapId, selectedGridPath, out var grid))
+            if (_loader.TryLoadGrid(tempMapId, selectedGridPath, out var grid))
             {
                 var escape = GetSingleDock(grid.Value);
 
@@ -372,7 +369,7 @@ public sealed partial class ShuttleSystem
                 }
             }
 
-            _mapSystem.DeleteMap(mapId);
+            _mapSystem.DeleteMap(tempMapId);
 
             if (valid)
             {

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using Content.Server.Shuttles.Components;
 using Content.Server.Station.Events;
 using Content.Shared.CCVar;
+using Content.Shared.Random.Helpers; // Starlight
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Station.Components;
 using Robust.Shared.Collections;
@@ -22,6 +23,7 @@ public sealed partial class ShuttleSystem
         SubscribeLocalEvent<StationCargoShuttleComponent, StationPostInitEvent>(OnCargoSpawnPostInit);
 
         SubscribeLocalEvent<GridFillComponent, MapInitEvent>(OnGridFillMapInit);
+        SubscribeLocalEvent<RandomGridFillComponent, MapInitEvent>(OnRandomGridFillMapInit); // Starlight
 
         Subs.CVar(_cfg, CCVars.GridFill, OnGridFillChange);
     }
@@ -306,6 +308,81 @@ public sealed partial class ShuttleSystem
 
         _mapSystem.DeleteMap(mapId);
     }
+
+    // Starlight begin
+    private void OnRandomGridFillMapInit(EntityUid uid, RandomGridFillComponent component, MapInitEvent args)
+    {
+        if (!_cfg.GetCVar(CCVars.GridFill))
+            return;
+
+        if (!TryComp<DockingComponent>(uid, out var dock) ||
+            !TryComp(uid, out TransformComponent? xform) ||
+            xform.GridUid == null)
+        {
+            return;
+        }
+
+        if (component.PathWeights.Count == 0) {
+            Log.Error($"Error loading gridfill dock for {ToPrettyString(uid)} due to lacking any PathWeights");
+            return;
+        }
+
+        var untriedGrids = new Dictionary<ResPath, float>(component.PathWeights);
+
+        while (untriedGrids.Count > 0) {
+            ResPath selectedGridPath = _random.Pick(untriedGrids);
+
+            untriedGrids.Remove(selectedGridPath);
+
+            // Spawn on a dummy map and try to dock if possible, otherwise dump it.
+            _mapSystem.CreateMap(out var mapId);
+            var valid = false;
+
+            if (_loader.TryLoadGrid(mapId, selectedGridPath, out var grid))
+            {
+                var escape = GetSingleDock(grid.Value);
+
+                if (escape != null)
+                {
+                    var config = _dockSystem.GetDockingConfig(grid.Value, xform.GridUid.Value, escape.Value.Entity, escape.Value.Component, uid, dock);
+
+                    if (config != null)
+                    {
+                        var shuttleXform = Transform(grid.Value);
+                        FTLDock((grid.Value, shuttleXform), config);
+
+                        if (TryComp<StationMemberComponent>(xform.GridUid, out var stationMember))
+                        {
+                            _station.AddGridToStation(stationMember.Station, grid.Value);
+                        }
+
+                        valid = true;
+                    }
+                }
+
+                foreach (var compReg in component.AddComponents.Values)
+                {
+                    var compType = compReg.Component.GetType();
+
+                    if (HasComp(grid.Value, compType))
+                        continue;
+
+                    var comp = Factory.GetComponent(compType);
+                    AddComp(grid.Value, comp, true);
+                }
+            }
+
+            _mapSystem.DeleteMap(mapId);
+
+            if (valid)
+            {
+                return;
+            }
+        }
+
+        Log.Error($"Error loading all possible gridfills for gridfill dock for {ToPrettyString(uid)}");
+    }
+    // Starlight end
 
     private (EntityUid Entity, DockingComponent Component)? GetSingleDock(EntityUid uid)
     {

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -323,7 +323,7 @@ public sealed partial class ShuttleSystem
         }
 
         if (component.PathWeights.Count == 0) {
-            Log.Error($"Error loading gridfill dock for {ToPrettyString(uid)} due to lacking any PathWeights");
+            Log.Error($"Error loading gridfill dock {ToPrettyString(uid)} due to lacking any PathWeights");
             return;
         }
 
@@ -368,6 +368,10 @@ public sealed partial class ShuttleSystem
                     AddComp(grid.Value, comp, true);
                 }
             }
+            else
+            {
+                Log.Info($"Failed to place {selectedGridPath} for gridfill of dock {ToPrettyString(uid)}, cycling");
+            }
 
             _mapSystem.DeleteMap(tempMapId);
 
@@ -377,7 +381,8 @@ public sealed partial class ShuttleSystem
             }
         }
 
-        Log.Error($"Error loading all possible gridfills for gridfill dock for {ToPrettyString(uid)}");
+        Log.Error($"Error placing all possible gridfills for gridfill dock {ToPrettyString(uid)}");
+        DebugTools.Assert($"Error placing all possible gridfills for gridfill dock {ToPrettyString(uid)}");
     }
     // Starlight end
 

--- a/Content.Server/_Starlight/Shuttles/Components/RandomGridFillComponent.cs
+++ b/Content.Server/_Starlight/Shuttles/Components/RandomGridFillComponent.cs
@@ -1,0 +1,25 @@
+using Content.Server.Shuttles.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Shuttles.Components;
+
+/// <summary>
+/// If added to an airlock will try to autofill a grid onto it on MapInit
+/// using a randomly-selected grid from a list.
+/// </summary>
+[RegisterComponent, Access(typeof(ShuttleSystem))]
+public sealed partial class RandomGridFillComponent : Component
+{
+    /// <summary>
+    /// path to weight mapping
+    /// </summary>
+    [DataField("pathWeights", required: true)]
+    public Dictionary<ResPath, float> PathWeights = new();
+
+    /// <summary>
+    /// Components to be added to any spawned grids.
+    /// </summary>
+    [DataField]
+    public ComponentRegistry AddComponents = new();
+}

--- a/Resources/Maps/_Starlight/nukieplanet.yml
+++ b/Resources/Maps/_Starlight/nukieplanet.yml
@@ -2363,15 +2363,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: -59.5,-8.5
       parent: 1
+- proto: AirlockExternalGlassNukeopsShuttle
+  entities:
   - uid: 21230
     components:
     - type: Transform
       pos: -59.5,12.5
       parent: 1
-    - type: GridFill
-      addComponents:
-      - type: NukeOpsShuttle
-      path: /Maps/Shuttles/infiltrator.yml
 - proto: AirlockSyndicateGlass
   entities:
   - uid: 27

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Doors/Airlocks/access.yml
@@ -309,3 +309,15 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsSalvageMining ]
+
+# Grid-spawning airlocks
+- type: entity
+  parent: AirlockGlassShuttleSyndicate
+  id: AirlockExternalGlassNukeopsShuttle
+  suffix: Random Nukeops Shuttle
+  components:
+  - type: RandomGridFill
+    pathWeights:
+      "/Maps/Shuttles/infiltrator.yml": 1
+    addComponents:
+    - type: NukeOpsShuttle


### PR DESCRIPTION
## Short description
This allows selecting from a pool of grids instead of a fixed grid as with the normal GridFillComponent. If a given chosen grid can't fit on a given airlock, the roll is re-done without that grid. The component is used for a nuclear-operative-shuttle-spawning airlock and that's mapped into nukieplanet.

## Why we need to add this
There's interest in adding multiple possible shuttles for Nukeops, and this allows us to have them randomly spawned without admin intervention. This also opens up more things to randomization - e.g. randomly nicer or worse escape pods.

## Media (Video/Screenshots)
No in-game visible changes in this PR.

## Checks

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Penguinwizzard
- add: Added internal support for randomized grid fills (e.g. support for randomized escape pods and nukie ships)