### PR TITLE
Add the base framework for multiple nukie planets

### DIFF
--- a/Content.Server/GameTicking/Rules/DynamicRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DynamicRuleSystem.cs
@@ -102,7 +102,14 @@ public sealed class DynamicRuleSystem : GameRuleSystem<DynamicRuleComponent>
 
         foreach (var rule in GetRuleSpawns(entity))
         {
-            var res = GameTicker.StartGameRule(rule, out var ruleUid);
+            // Starlight start
+            var ruleUid = GameTicker.AddGameRule(rule);
+            // We add the rule before executing it so that the rule inheritance hierarchy is
+            // discoverable for child rules for event propagation.
+            entity.Comp.Rules.Add(ruleUid);
+            var res = GameTicker.StartGameRule(ruleUid);
+            // Starlight end
+            // var res = GameTicker.StartGameRule(rule, out var ruleUid); Starlight - commented out in favor of the above
             Debug.Assert(res);
 
             executedRules.Add(ruleUid);
@@ -118,7 +125,7 @@ public sealed class DynamicRuleSystem : GameRuleSystem<DynamicRuleComponent>
             }
         }
 
-        entity.Comp.Rules.AddRange(executedRules);
+        //entity.Comp.Rules.AddRange(executedRules); // Starlight - comment
         return executedRules;
     }
 

--- a/Content.Server/GameTicking/Rules/LoadMapRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/LoadMapRuleSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.GameTicking.Rules.Components;
 using Content.Server.GridPreloader;
 using Content.Server.StationEvents.Events;
 using Content.Shared.GameTicking.Components;
+using Content.Shared.GameTicking.Rules; // Starlight
 using Robust.Server.GameObjects;
 using Robust.Shared.EntitySerialization;
 using Robust.Shared.EntitySerialization.Systems;
@@ -19,8 +20,10 @@ public sealed class LoadMapRuleSystem : StationEventSystem<LoadMapRuleComponent>
     [Dependency] private readonly MapLoaderSystem _mapLoader = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly GridPreloaderSystem _gridPreloader = default!;
+    [Dependency] private readonly EntityManager _entMan = default!; // Starlight
+    [Dependency] private readonly DynamicRuleSystem _dynamicRule = default!; // Starlight
 
-    protected override void Added(EntityUid uid, LoadMapRuleComponent comp, GameRuleComponent rule, GameRuleAddedEvent args)
+    protected override void Started(EntityUid uid, LoadMapRuleComponent comp, GameRuleComponent rule, GameRuleStartedEvent args) // Starlight-edit - Added -> Started. This allows us to reference the rule tree, as during "added" the parent rule hasn't been told about the child rule yet.
     {
         if (comp.PreloadedGrid != null && !_gridPreloader.PreloadingEnabled)
         {
@@ -100,6 +103,26 @@ public sealed class LoadMapRuleSystem : StationEventSystem<LoadMapRuleComponent>
         var ev = new RuleLoadedGridsEvent(mapId, grids);
         RaiseLocalEvent(uid, ref ev);
 
-        base.Added(uid, comp, rule, args);
+        PropagateLoadEvent(uid, mapId, grids); // Starlight
+
+        base.Started(uid, comp, rule, args); // Starlight-edit - Added -> Started
     }
+
+    // Starlight begin
+    /// <summary>
+    /// Recursively propagate the load event up the rule tree.
+    /// </summary>
+    private void PropagateLoadEvent(EntityUid child, MapId mapId, IReadOnlyList<EntityUid> grids) {
+        var rules = _entMan.AllEntityQueryEnumerator<DynamicRuleComponent>();
+        while (rules.MoveNext(out var uid, out var comp))
+        {
+            if (_dynamicRule.Rules((uid, (DynamicRuleComponent?)comp)).Contains(child)) {
+                var ev = new RuleLoadedGridsEvent(mapId, grids);
+                RaiseLocalEvent(uid, ref ev);
+                PropagateLoadEvent(uid, mapId, grids);
+                break;
+            }
+        }
+    }
+    // Starlight end
 }

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -150,9 +150,14 @@
     # Starlight Start
     denyGameRules:
     - AbductorsSpawn
-    # Starlight End
-  - type: LoadMapRule
-    mapPath: /Maps/_Starlight/nukieplanet.yml
+  - type: DynamicRule
+    table: !type:GroupSelector
+      children:
+      - id: NukiePlanetSpawn
+  # Starlight end
+  # Starlight - removing the LoadMapRule from here to instead handle it in the dynamic rules above
+  #- type: LoadMapRule
+  #  mapPath: /Maps/_Starlight/nukieplanet.yml
   - type: AntagSelection
     selectionTime: PrePlayerSpawn
     definitions:

--- a/Resources/Prototypes/_StarLight/GameRules/nukie_planets.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/nukie_planets.yml
@@ -1,0 +1,6 @@
+- type: entity
+  parent: BaseGameRule
+  id: NukiePlanetSpawn
+  components:
+  - type: LoadMapRule
+    mapPath: /Maps/_Starlight/nukieplanet.yml


### PR DESCRIPTION
## Short description
This does a bit of restructuring to how the Nuclear Operative planet is chosen to set up the basis for further options to be added, but does not itself add those options.

## Why we need to add this
Adding this should hopefully be lower-risk than directly adding the planets, and this existing as a branch at all should make it easier to have in the history of multiple other PRs to reduce the potential for merge conflicts.

## Media (Video/Screenshots)
This PR makes no changes visible ingame.

## Checks

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Penguinwizzard
- add: Added base tooling around randomizing Nuclear Operative spawn planets.