### PR TITLE
Fix ore bags not working from belt slot

### DIFF
--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -18,6 +18,17 @@ public sealed partial class MagnetPickupComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField("slotFlags")]
     public SlotFlags SlotFlags = SlotFlags.BELT;
 
+    // Starlight Edit Start - Remove slot requirements
+    /// <summary>
+    /// Controlling whether the magnet needs to be equipped to work,
+    /// if false, it will work on the ground and in hands,
+    /// if true it wont work at all if not equipped.
+    /// This also makes it work in borg modules.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("requiresEquipping")]
+    public bool RequiresEquipping = true;
+    // Starlight Edit End
+
     [ViewVariables(VVAccess.ReadWrite), DataField("range")]
     public float Range = 1f;
 }

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -53,7 +53,7 @@ public sealed class MagnetPickupSystem : EntitySystem
 
             if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
             {
-                if (comp.SlotFlags != SlotFlags.All)
+                if (comp.RequiresEquipping)
                     continue;
             }
             else

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -53,7 +53,7 @@ public sealed class MagnetPickupSystem : EntitySystem
 
             if (!_inventory.TryGetContainingSlot((uid, xform, meta), out var slotDef))
             {
-                if (comp.SlotFlags != SlotFlags.NONE)
+                if (comp.SlotFlags != SlotFlags.All)
                     continue;
             }
             else

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -23,7 +23,7 @@
   - type: ComponentToggler
     components: 
     - type: MagnetPickup
-      slotFlags: 0  # Starlight Edit - make it work in slots other than belt - mostly for borgs but this just works better overall
+      slotFlags: All  # Starlight Edit - make it work in all slots
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Mining/ore_bag.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -19,11 +19,11 @@
       params:
         variation: 0.250
   - type: AltUseToggle
-    # Starlight End Start
+    # Starlight Edit End
   - type: ComponentToggler
     components: 
     - type: MagnetPickup
-      slotFlags: All  # Starlight Edit - make it work in all slots
+      requiresEquipping: false  # Starlight Edit - make it work even without being equipped
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Mining/ore_bag.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
@@ -12,7 +12,7 @@
     components: 
     - type: MagnetPickup
       range: 2
-      slotFlags: 0  # Starlight Edit - make it work in slots other than belt - This here is to make it work the same as a regular ore bag
+      slotFlags: All  # Starlight Edit - make it work in slots other than belt - This here is to make it work the same as a regular ore bag
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Mining/ore_bag_holding.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag_holding.yml
@@ -12,7 +12,7 @@
     components: 
     - type: MagnetPickup
       range: 2
-      slotFlags: All  # Starlight Edit - make it work in slots other than belt - This here is to make it work the same as a regular ore bag
+      requiresEquipping: false  # Starlight Edit - make it work even without being equipped
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Mining/ore_bag_holding.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -681,6 +681,7 @@
       components: 
       - type: MagnetPickup
         range: 3
+        requiresEquipping: false
         slotFlags: 0
     # starlight edit end
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes an issue of ore bags not working from belt slot.

## Why we need to add this
I seem to not know the difference between nothing and all

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Fixes an issue that caused ore bags to not work from belt slot.
