### PR TITLE
Attempting to balance species-specific jumps.

### DIFF
--- a/Content.Shared/_Starlight/Actions/EntitySystems/JumpPenaltyComponent.cs
+++ b/Content.Shared/_Starlight/Actions/EntitySystems/JumpPenaltyComponent.cs
@@ -1,0 +1,37 @@
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.Actions.EntitySystems;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(DamageableSystem), typeof(SharedJumpSystem))]
+public sealed partial class JumpPenaltyComponent : Component
+{
+    /// <summary>
+    /// Whether jumping is disabled entirely or not.
+    /// </summary>
+    [DataField, AutoNetworkedField] public bool JumpDisabled;
+
+    /// <summary>
+    /// Remaining time that jumping is disabled for.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan JumpDisabledTimer;
+
+    /// <summary>
+    /// How much time in seconds to disable jumping for when hitting the damage over time threshold.
+    /// </summary>
+    [DataField, AutoNetworkedField] public TimeSpan DamageOverTimePenalty;
+    
+    /// <summary>
+    /// How much damage over time is required to disable jumping.
+    /// </summary>
+    [DataField, AutoNetworkedField] public (float, TimeSpan) DamageOverTimeThreshold;
+
+    /// <summary>
+    /// How much total damage is required to trigger distance penalty.
+    /// </summary>
+    [DataField, AutoNetworkedField] public Dictionary<FixedPoint2, float> HighDamageThresholds;
+}

--- a/Content.Shared/_Starlight/Actions/EntitySystems/SharedJumpSystem.cs
+++ b/Content.Shared/_Starlight/Actions/EntitySystems/SharedJumpSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
@@ -12,6 +13,9 @@ using Robust.Shared.Timing;
 using Content.Shared.Stunnable;
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
 
 namespace Content.Shared._Starlight.Actions.EntitySystems;
 
@@ -27,6 +31,7 @@ public abstract class SharedJumpSystem : EntitySystem
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedChargesSystem _chargesSystem = default!;
+    [Dependency] private readonly SharedStaminaSystem _stamina = default!;
 
     public override void Initialize()
     {
@@ -37,6 +42,7 @@ public abstract class SharedJumpSystem : EntitySystem
         SubscribeLocalEvent<JumpComponent, JetJumpActionEvent>(OnJump);
         SubscribeLocalEvent<JumpComponent, GetItemActionsEvent>(OnGetItemActions);
         SubscribeLocalEvent<JumpComponent, ThrowDoHitEvent>(OnThrowCollide);
+        // SubscribeLocalEvent<DamageableComponent, DamageChangedEvent>(OnDamaged);
         SubscribeLocalEvent<JumpActionEvent>(OnJump);
     }
 
@@ -82,6 +88,20 @@ public abstract class SharedJumpSystem : EntitySystem
     protected virtual bool TryReleaseGas(Entity<JumpComponent> ent, ref JetJumpActionEvent args)
         => TryComp<GasTankComponent>(ent, out var gasTank) && gasTank.TotalMoles > args.MoleUsage;
 
+    // private void OnDamaged(EntityUid uid, DamageableComponent component, DamageChangedEvent ev)
+    // {
+    //     // entity got damaged, check if they have a jump action with a JumpPenaltyComponent.
+    //     if (!TryComp<ActionsComponent>(uid, out var actions)) return; // doesn't even have actions
+    //     foreach (var action in actions.Actions)
+    //     {
+    //         if (!TryComp<WorldTargetActionComponent>(action, out var wtAction)) continue;
+    //         if (wtAction.Event is not JumpActionEvent and not JetJumpActionEvent) return; // don't apply when its from a jetpack
+    //         if (!TryComp<JumpPenaltyComponent>(action, out var jumpPenalty)) continue;
+    //         
+    //         
+    //     }
+    // }
+    
     private void OnJump(Entity<JumpComponent> ent, ref JetJumpActionEvent args)
     {
         if (args.Handled
@@ -100,11 +120,11 @@ public abstract class SharedJumpSystem : EntitySystem
 
         if (args.FromGrid && !_mapMan.TryFindGridAt(userMapCoords, out _, out _)) return;
 
-        TryJump(args.Performer, args.Target, 15f, args.ToPointer, args.Sound, args.Distance);
+        TryJump(args.Performer, args.Target, 15f, args.ToPointer, args.Sound, args.Distance, false, args is not JetJumpActionEvent);
         args.Handled = true;
     }
 
-    public bool TryJump(Entity<JumpComponent?> ent, EntityCoordinates targetCoords, float speed = 15f, bool toPointer = false, SoundSpecifier? sound = null, float? distance = null, bool decreaseCharges = false)
+    public bool TryJump(Entity<JumpComponent?> ent, EntityCoordinates targetCoords, float speed = 15f, bool toPointer = false, SoundSpecifier? sound = null, float? distance = null, bool decreaseCharges = false, bool useStamina = false)
     {
         if (!Resolve(ent, ref ent.Comp, false)
             || ent.Comp.ActionEntity == null
@@ -112,11 +132,11 @@ public abstract class SharedJumpSystem : EntitySystem
             || _action.IsCooldownActive(action))
             return false;
 
-        Jump(new Entity<JumpComponent>(ent, ent.Comp), targetCoords, speed, toPointer, sound, distance, decreaseCharges);
+        Jump(new Entity<JumpComponent>(ent, ent.Comp), targetCoords, speed, toPointer, sound, distance, decreaseCharges, useStamina);
         return true;
     }
 
-    public void Jump(Entity<JumpComponent> ent, EntityCoordinates targetCoords, float speed = 15f, bool toPointer = false, SoundSpecifier? sound = null, float? distance = null, bool decreaseCharges = false)
+    public void Jump(Entity<JumpComponent> ent, EntityCoordinates targetCoords, float speed = 15f, bool toPointer = false, SoundSpecifier? sound = null, float? distance = null, bool decreaseCharges = false, bool useStamina = false)
     {
         if (ent.Comp.ActionEntity == null
             || (TryComp<LimitedChargesComponent>(ent.Comp.ActionEntity, out var limitedCharges)
@@ -127,11 +147,38 @@ public abstract class SharedJumpSystem : EntitySystem
         var userTransform = Transform(ent.Owner);
         var userMapCoords = _transform.GetMapCoordinates(userTransform);
         var targetMapCoords = _transform.ToMapCoordinates(targetCoords);
+        float staminaPenalty = 1;
+        if (TryComp<StaminaComponent>(ent.Owner, out var staminaComp) && useStamina) // only if wasn't with jetpack
+        {
+            // magic numbers go brrrr change this later
+            if (staminaComp.StaminaDamage < staminaComp.CritThreshold/1.6)
+                _stamina.TakeStaminaDamage(ent.Owner, staminaComp.CritThreshold/1.4f);
+            else if (staminaComp.StaminaDamage < staminaComp.CritThreshold/1.3f)
+            {
+                _stamina.TakeStaminaDamage(ent.Owner, staminaComp.CritThreshold/8); // take less damage actually because you want to be able to use all 3 if you have max stamina
+                staminaPenalty = 0.7f;
+            }
+            else
+            {
+                //force stun
+                _stamina.TakeStaminaDamage(ent.Owner, Math.Abs(staminaComp.StaminaDamage - staminaComp.CritThreshold));
+                // TODO: force a stun via stun system as well since if player is already at crit stamina and they use a jump charge, they wont get stunned from the above function call.
+                staminaPenalty = 0.4f;
+            }
+        }
 
+        float damagePenalty = 1;
+        if (TryComp<DamageableComponent>(ent.Owner, out var damageable) && TryComp<JumpPenaltyComponent>(ent.Comp.ActionEntity, out var penaltyComponent))
+        {
+            // find the highest threshold met
+            foreach (var threshold in penaltyComponent.HighDamageThresholds.Where(threshold =>
+                         damageable.TotalDamage >= threshold.Key)) damagePenalty = threshold.Value;
+        }
+        
         var vector = targetMapCoords.Position - userMapCoords.Position;
         if (distance != null
             && (!toPointer || Vector2.Distance(userMapCoords.Position, targetMapCoords.Position) > distance))
-            vector = Vector2.Normalize(vector) * distance.Value;
+            vector = Vector2.Normalize(vector) * distance.Value * staminaPenalty * damagePenalty;
 
         if (ent.Comp.ActionEntity != null && TryComp<ActionComponent>(ent.Comp.ActionEntity, out var action) && (limitedCharges == null || limitedCharges.MaxCharges <= 1))
             _action.SetCooldown((ent.Comp.ActionEntity.Value, action), TimeSpan.FromSeconds(ent.Comp.Cooldown));

--- a/Resources/Prototypes/_StarLight/Actions/jump.yml
+++ b/Resources/Prototypes/_StarLight/Actions/jump.yml
@@ -28,6 +28,7 @@
       distance: 10
       sound:
         path: /Audio/_Starlight/Effects/Jump/resomi.ogg
+  - type: JumpPenalty
 
 - type: entity
   parent: Jump
@@ -50,6 +51,11 @@
       speed: 4.5 # Equal to movement speed.
       sound:
         path: /Audio/_Starlight/Effects/Jump/moth.ogg
+  - type: JumpPenalty
+    highDamageThresholds:
+      0: 1
+      50: 0.6
+      80: 0.4 
 
 - type: entity
   parent: Jump
@@ -66,6 +72,7 @@
     event: !type:JumpActionEvent
       distance: 2
       #sound: The Silent Hunter.
+  - type: JumpPenalty
 
 - type: entity
   parent: Jump


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This is an attempt to balance jumps granted by being a specific species like resomi or moth.
Doesn't touch the jumps from jetpacks or jump boots, only the innate one that you get for simply choosing to be a certain species.
Currently gives a stamina penalty that reduces distance and will eventually stun you if used too much in succession, as well as a damage penalty that reduces distance when above a certain damage threshold.
Framework is in place to also incur a penalty that disables jumping entirely for a brief window if you take too much damage too quickly, but it has not been implemented yet.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This needs testing on Delta and a lot of tweaking before it's good, but this would be a good compromise between allowing players to have an option to escape melee range to give themselves a few seconds to actually prepare to defend against an attacker, while not letting them just escape melee range and *stay* out of melee range, for free, with no downsides. Because lets be honest, the current implementation is kinda bullshit.
## Media (Video/Screenshots)
(apologies for the compression)

https://github.com/user-attachments/assets/524e41b0-276f-4b3e-8cf9-4dce2ed75b9b
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- tweak: Jumping without the use of an item will now cost stamina, and expending all 3 charges will end with you stunned. You also get diminishing returns.
- tweak: Taking too much damage will affect the distance your species-innate jump travels.