### PR TITLE
lowered cost of syndicate chemical kit from 4tc to 3tc

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -686,9 +686,9 @@
   productEntity: ChemicalSynthesisKit
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 2 #Starlight-edit
   cost:
-    Telecrystal: 4
+    Telecrystal: 3 #Starlight-edit
   categories:
   - UplinkChemicals
 


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
very small change, just lowering the cost of the chemical kit by 1tc. 
was 4tc (3tc discounted), my change is it's now 3tc (2tc discounted)
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

the reasoning is that this item is not really useful unless youre a chemist, and even then is still not that great. youre better off buying the bottle of nocturne or some other kind of weapon/chemical/gadget than taking this in the vast majority of cases.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: nomad.marshall
- tweak: lowered TC cost of syndicate chemical kit down to 3tc (2tc discounted), from 4tc (3tc discounted) 