### PR TITLE
Make damaged plating repairable

### DIFF
--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -153,11 +153,8 @@ public sealed class TileSystem : EntitySystem
                 (_robustRandom.NextFloat() - 0.5f) * bounds));
 
         //Actually spawn the relevant tile item at the right position and give it some random offset.
-        if (!string.IsNullOrWhiteSpace(tileDef.ItemDropPrototypeName)) // Starlight - condition tile item drop on it being a non-empty prototype name
-        { // Starlight - add enclosing block
-            var tileItem = Spawn(tileDef.ItemDropPrototypeName, coordinates);
-            Transform(tileItem).LocalRotation = _robustRandom.NextDouble() * Math.Tau;
-        } // Starlight - add enclosing block
+        var tileItem = Spawn(tileDef.ItemDropPrototypeName, coordinates);
+        Transform(tileItem).LocalRotation = _robustRandom.NextDouble() * Math.Tau;
 
         // Destroy any decals on the tile
         var decals = _decal.GetDecalsInRange(gridUid, coordinates.SnapToGrid(EntityManager, _mapManager).Position, 0.5f);

--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -153,8 +153,11 @@ public sealed class TileSystem : EntitySystem
                 (_robustRandom.NextFloat() - 0.5f) * bounds));
 
         //Actually spawn the relevant tile item at the right position and give it some random offset.
-        var tileItem = Spawn(tileDef.ItemDropPrototypeName, coordinates);
-        Transform(tileItem).LocalRotation = _robustRandom.NextDouble() * Math.Tau;
+        if (!string.IsNullOrWhiteSpace(tileDef.ItemDropPrototypeName)) // Starlight - condition tile item drop on it being a non-empty prototype name
+        { // Starlight - add enclosing block
+            var tileItem = Spawn(tileDef.ItemDropPrototypeName, coordinates);
+            Transform(tileItem).LocalRotation = _robustRandom.NextDouble() * Math.Tau;
+        } // Starlight - add enclosing block
 
         // Destroy any decals on the tile
         var decals = _decal.GetDecalsInRange(gridUid, coordinates.SnapToGrid(EntityManager, _mapManager).Position, 0.5f);

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -89,6 +89,7 @@
     useSound:
       collection: Welder
     qualities: Welding
+  - type: ToolTileCompatible # Starlight - allow using welders on tiles (e.g. to repair damaged hull plate)
   - type: Welder
   - type: PointLight
     enabled: false

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -20,7 +20,7 @@
   - 1.0
   baseTurf: Plating # Starlight-edit - swap baseTurf to Plating, so when we weld it, we revert to that.
   deconstructTools: [ Welding ] # Starlight - add welding as a deconstruct interaction, so we have an easy way to mend it.
-  itemDrop: "" # Starlight - remove drop
+  itemDrop: NothingEntity # Starlight - remove drop
   isSubfloor: true
   footstepSounds:
     collection: FootstepPlating

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -18,7 +18,9 @@
   - 1.0
   - 1.0
   - 1.0
-  baseTurf: Lattice
+  baseTurf: Plating # Starlight-edit - swap baseTurf to Plating, so when we weld it, we revert to that.
+  deconstructTools: [ Welding ] # Starlight - add welding as a deconstruct interaction, so we have an easy way to mend it.
+  itemDrop: "" # Starlight - remove drop
   isSubfloor: true
   footstepSounds:
     collection: FootstepPlating

--- a/Resources/Prototypes/_StarLight/Entities/nothing.yml
+++ b/Resources/Prototypes/_StarLight/Entities/nothing.yml
@@ -1,0 +1,12 @@
+# This is an entity that immediately deletes itself, for cases
+# where you must spawn an entity due to some constraint, but
+# don't really want to, and want to avoid the merge pain from
+# changing the related c#.
+
+- type: entity
+  id: NothingEntity
+  name: nothing object
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TriggerOnSpawn
+  - type: DeleteOnTrigger


### PR DESCRIPTION
## Short description
This allows using a welder to convert PlatingDamaged to Plating.

## Why we need to add this
The intent with adding PlatingDamaged to a map is to add flavor to its history, but right now you can't place tile on it or repair it (without fully removing the tile with an RCD), which is a hassle.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/a6a7137c-edaf-4e4a-9ee8-485eef85dd6b



## Checks

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Penguinwizzard
- add: Added the ability to repair damaged hull plates with a welder.