### PR TITLE
Language Cost Adjustment

### DIFF
--- a/Resources/Prototypes/_StarLight/Traits/languages.yml
+++ b/Resources/Prototypes/_StarLight/Traits/languages.yml
@@ -3,7 +3,7 @@
   name: trait-language-foreigner-light-name
   description: trait-language-foreigner-light-desc
   category: LanguageTraits
-  cost: -1
+  cost: -2
   components:
   - type: ForeignerTrait
     cantUnderstand: false
@@ -14,7 +14,7 @@
   name: trait-language-foreigner-name
   description: trait-language-foreigner-desc
   category: LanguageTraits
-  cost: -2
+  cost: -4
   components:
   - type: ForeignerTrait
     baseTranslator: TranslatorForeigner
@@ -24,7 +24,7 @@
   name: trait-language-signlanguage-name
   description: trait-language-signlanguage-desc
   category: LanguageTraits
-  cost: 1
+  cost: 2
   components:
   - type: LanguageSpeaker
   languagesSpoken:
@@ -63,7 +63,7 @@
   name: trait-language-scratch-name
   description: trait-language-scratch-desc
   category: LanguageTraits
-  cost: 1
+  cost: 2
   components:
     - type: LanguageSpeaker
   languagesSpoken:
@@ -76,7 +76,7 @@
   name: trait-language-solcommon-name
   description: trait-language-solcommon-desc
   category: LanguageTraits
-  cost: 1
+  cost: 2
   components:
     - type: LanguageSpeaker
   languagesSpoken:


### PR DESCRIPTION
## Short description
foreigner traits double value. all languages cost the same.

## Why we need to add this
Balance needed. Almost the whole population of every round had scratch and sign language. This will encourage players to take a mix.

## Media (Video/Screenshots)
<img width="271" height="486" alt="image" src="https://github.com/user-attachments/assets/0b2ccb79-04a3-4f50-97fe-3e2d1d9eaf23" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Trep_Maul
- tweak: Adjusted language costs. Foreigner traits now give more options.