### PR TITLE
Adjust changelings devour.

### DIFF
--- a/Content.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -27,6 +27,7 @@ using Content.Shared.RetractableItemAction;
 using Content.Shared.Changeling.Systems;
 using Content.Shared.Changeling.Components;
 using Content.Server.Changeling.Systems;
+using Content.Shared.Humanoid;
 
 namespace Content.Server.Changeling;
 
@@ -140,11 +141,16 @@ public sealed partial class ChangelingSystem : EntitySystem
             bonusEvolutionPoints += 10;
             comp.MaxBiomass += targetComp.MaxBiomass / 2;
         }
-        else
+        else if (HasComp<HumanoidAppearanceComponent>(target))
         {
             popup = Loc.GetString("changeling-absorb-end-self");
             bonusChemicals += 10;
             bonusEvolutionPoints += 2;
+        }
+        else
+        {
+            popup = Loc.GetString("changeling-absorb-end-self");
+            bonusChemicals += 5;
         }
         TryStealDNA(uid, target, comp, true);
         comp.TotalAbsorbedEntities++;

--- a/Content.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -27,7 +27,7 @@ using Content.Shared.RetractableItemAction;
 using Content.Shared.Changeling.Systems;
 using Content.Shared.Changeling.Components;
 using Content.Server.Changeling.Systems;
-using Content.Shared.Humanoid;
+using Content.Shared.Humanoid; // Starlight edit
 
 namespace Content.Server.Changeling;
 
@@ -141,17 +141,19 @@ public sealed partial class ChangelingSystem : EntitySystem
             bonusEvolutionPoints += 10;
             comp.MaxBiomass += targetComp.MaxBiomass / 2;
         }
-        else if (HasComp<HumanoidAppearanceComponent>(target))
+        else if (HasComp<HumanoidAppearanceComponent>(target))  // Starlight edit
         {
             popup = Loc.GetString("changeling-absorb-end-self");
             bonusChemicals += 10;
             bonusEvolutionPoints += 2;
         }
+        // Starlight edit start
         else
         {
             popup = Loc.GetString("changeling-absorb-end-self");
             bonusChemicals += 5;
         }
+        // Starlight edit end
         TryStealDNA(uid, target, comp, true);
         comp.TotalAbsorbedEntities++;
 

--- a/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
@@ -85,7 +85,7 @@ public sealed partial class ChangelingDevourComponent : Component
     /// Damage cap that a target is allowed to be caused due to IdentityConsumption
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float DevourConsumeDamageCap = 350f;
+    public float DevourConsumeDamageCap = 180f;
 
     /// <summary>
     /// The Currently active devour sound in the world

--- a/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
+++ b/Content.Shared/Changeling/Components/ChangelingDevourComponent.cs
@@ -85,7 +85,7 @@ public sealed partial class ChangelingDevourComponent : Component
     /// Damage cap that a target is allowed to be caused due to IdentityConsumption
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float DevourConsumeDamageCap = 180f;
+    public float DevourConsumeDamageCap = 180f; // Starlight edit
 
     /// <summary>
     /// The Currently active devour sound in the world

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -91,7 +91,7 @@ public sealed class ChangelingDevourSystem : EntitySystem
         foreach (var damagePoints in comp.DamagePerTick.DamageDict)
         {
 
-            if (damage.Damage.DamageDict.TryGetValue(damagePoints.Key, out var val) && val >= comp.DevourConsumeDamageCap)
+            if (damage.Damage.DamageDict.TryGetValue(damagePoints.Key, out var val) && val >= comp.DevourConsumeDamageCap) // Starlight edit
                 return;
         }
         _damageable.TryChangeDamage(target, comp.DamagePerTick, true, true, damage, user);

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -91,7 +91,7 @@ public sealed class ChangelingDevourSystem : EntitySystem
         foreach (var damagePoints in comp.DamagePerTick.DamageDict)
         {
 
-            if (damage.Damage.DamageDict.TryGetValue(damagePoints.Key, out var val) && val > comp.DevourConsumeDamageCap)
+            if (damage.Damage.DamageDict.TryGetValue(damagePoints.Key, out var val) && val >= comp.DevourConsumeDamageCap)
                 return;
         }
         _damageable.TryChangeDamage(target, comp.DamagePerTick, true, true, damage, user);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR fixed two issues with current changelings
- changelings able to stack more than 180 cell damage on corpses by cancelling the doafter (abused by a couple of people)
- changelings getting the same amount of evo points and chemicals from animals as from humanoids

## Why we need to add this
The current meta has been a bit awkward, firstly it incentivises anti fun behaviour for other players, where you can cancel the doafter and stack up to 380 cell or so damage on a corpse. Which is annoying to clear (though its possible)

The other issue is that changelings dont get any need to ever fight humanoids, since they get the same amounts of points and chemicals from animals. And also the current meta is to stack on two mothroaches to get an armblade and then you are too powerful for a normal crew to stop.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Fix damage stacking on changeling's devour.
- fix: Fix animals giving full amount of points
