### PR TITLE
Add Automatic Text Highlights for Starlight Roles

### DIFF
--- a/Resources/Locale/en-US/_Starlight/chat/highlights.ftl
+++ b/Resources/Locale/en-US/_Starlight/chat/highlights.ftl
@@ -1,0 +1,27 @@
+# Command
+
+# NanoTrasen
+highlights-officer-blue-shield = Blue Shield, "BSO" # DOES NOT WORK WHATSOEVER
+highlights-magistrate = Magistrate, "Law"
+highlights-nanotrasen-representative = NanoTrasen Representative, "NTR", NT Rep, NTRep, "Law", "SOP", Standard Operating Procedure
+
+# Security
+highlights-brigmedic = Brigmedic, BrigMed, "BM", Security, "Sec"
+
+# Cargo
+highlights-mail-technician = Mail Technician, Mail Tech, "MT", Mail, Cargo
+highlights-mining-specialist = Mining Specialist, "MS", Mining Spec, Miner, Mine, Cargo
+highlights-salvage-lead = Salvage Lead, "SL", Salvager, Salvage, Cargo, Lead, "Salv"
+
+# Engineering
+
+# Medical
+highlights-surgeon = Surgeon, Medical, MedBay, "Med"
+
+# Science
+highlights-roboticist = Roboticist, Science, Robo, "Sci", Robotics
+
+# Civilian
+
+# Law
+highlights-internal-affairs-agent = Internal Affairs Agent, "IAA", "Law", "SOP", Standard Operating Procedure

--- a/Resources/Locale/en-US/chat/highlights.ftl
+++ b/Resources/Locale/en-US/chat/highlights.ftl
@@ -58,7 +58,7 @@ highlights-station-ai = Station AI, Silicon, "AI", "sAI"
 
 
 # Starlight start
-#Command
+# Command
 
 # NanoTrasen
 highlights-officer-blue-shield = Blue Shield, "BSO" # DOES NOT WORK WHATSOEVER

--- a/Resources/Locale/en-US/chat/highlights.ftl
+++ b/Resources/Locale/en-US/chat/highlights.ftl
@@ -54,4 +54,4 @@ highlights-psychologist = Psychologist, Psychology
 # Silicon
 highlights-personal-ai = Personal AI, "pAI"
 highlights-cyborg = Cyborg, Silicon, Borg
-highlights-station-ai = Station AI, Silicon, "AI", "sAI"
+highlights-station-ai = Station AI, Silicon, "AI", "sAI" 

--- a/Resources/Locale/en-US/chat/highlights.ftl
+++ b/Resources/Locale/en-US/chat/highlights.ftl
@@ -55,35 +55,3 @@ highlights-psychologist = Psychologist, Psychology
 highlights-personal-ai = Personal AI, "pAI"
 highlights-cyborg = Cyborg, Silicon, Borg
 highlights-station-ai = Station AI, Silicon, "AI", "sAI"
-
-
-# Starlight start
-# Command
-
-# NanoTrasen
-highlights-officer-blue-shield = Blue Shield, "BSO" # DOES NOT WORK WHATSOEVER
-highlights-magistrate = Magistrate, "Law"
-highlights-nanotrasen-representative = NanoTrasen Representative, "NTR", NT Rep, NTRep, "Law", "SOP", Standard Operating Procedure
-
-# Security
-highlights-brigmedic = Brigmedic, BrigMed, "BM", Security, "Sec"
-
-# Cargo
-highlights-mail-technician = Mail Technician, Mail Tech, "MT", Mail, Cargo
-highlights-mining-specialist = Mining Specialist, "MS", Mining Spec, Miner, Mine, Cargo
-highlights-salvage-lead = Salvage Lead, "SL", Salvager, Salvage, Cargo, Lead, "Salv"
-
-# Engineering
-
-# Medical
-highlights-surgeon = Surgeon, Medical, MedBay, "Med"
-
-# Science
-highlights-roboticist = Roboticist, Science, Robo, "Sci", Robotics
-
-# Civilian
-
-# Law
-highlights-internal-affairs-agent = Internal Affairs Agent, "IAA", "Law", "SOP", Standard Operating Procedure
-
-# Starlight end

--- a/Resources/Locale/en-US/chat/highlights.ftl
+++ b/Resources/Locale/en-US/chat/highlights.ftl
@@ -54,4 +54,4 @@ highlights-psychologist = Psychologist, Psychology
 # Silicon
 highlights-personal-ai = Personal AI, "pAI"
 highlights-cyborg = Cyborg, Silicon, Borg
-highlights-station-ai = Station AI, Silicon, "AI", "sAI" 
+highlights-station-ai = Station AI, Silicon, "AI", "sAI"

--- a/Resources/Locale/en-US/chat/highlights.ftl
+++ b/Resources/Locale/en-US/chat/highlights.ftl
@@ -55,3 +55,35 @@ highlights-psychologist = Psychologist, Psychology
 highlights-personal-ai = Personal AI, "pAI"
 highlights-cyborg = Cyborg, Silicon, Borg
 highlights-station-ai = Station AI, Silicon, "AI", "sAI"
+
+
+# Starlight start
+#Command
+
+# NanoTrasen
+highlights-officer-blue-shield = Blue Shield, "BSO" # DOES NOT WORK WHATSOEVER
+highlights-magistrate = Magistrate, "Law"
+highlights-nanotrasen-representative = NanoTrasen Representative, "NTR", NT Rep, NTRep, "Law", "SOP", Standard Operating Procedure
+
+# Security
+highlights-brigmedic = Brigmedic, BrigMed, "BM", Security, "Sec"
+
+# Cargo
+highlights-mail-technician = Mail Technician, Mail Tech, "MT", Mail, Cargo
+highlights-mining-specialist = Mining Specialist, "MS", Mining Spec, Miner, Mine, Cargo
+highlights-salvage-lead = Salvage Lead, "SL", Salvager, Salvage, Cargo, Lead, "Salv"
+
+# Engineering
+
+# Medical
+highlights-surgeon = Surgeon, Medical, MedBay, "Med"
+
+# Science
+highlights-roboticist = Roboticist, Science, Robo, "Sci", Robotics
+
+# Civilian
+
+# Law
+highlights-internal-affairs-agent = Internal Affairs Agent, "IAA", "Law", "SOP", Standard Operating Procedure
+
+# Starlight end


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds automatic text highlights for Starlight roles (as long as you have the option enabled). 

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
There is already a setting to automatically set text highlights based off your role, but it didn't have lists for Starlight roles. Now all Starlight roles have automatic text highlights!

That is, all roles _except BSO_. I am 99% confident it is _impossible_ to set it up for BSO because of how the automatic highlight system is set up. Since it bases the highlight list's name off the actual visible name of the role—in this case Officer "Blue Shield"—the quotation marks in the name screw up the whole process. I tried SO MANY THINGS, but I couldn't get it to work. It's just not happening.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="133" height="230" alt="image" src="https://github.com/user-attachments/assets/b6f17e3f-b2ee-42d8-9005-9c3c79b922cc" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CommanderAlex365
- add: Added automatic text highlights for Starlight roles (except for BSO)