### PR TITLE
Corpse Clothing

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Corpses/corpses.yml
+++ b/Resources/Prototypes/Entities/Mobs/Corpses/corpses.yml
@@ -5,16 +5,17 @@
   components:
   - type: Loadout
     prototypes:
-      - HoPGear
-      - ClownGear
-      - MimeGear
-      - JanitorGear
-      - ServiceWorkerGear
-      - MusicianGear
-      - BotanistGear
-      - ChefGear
-      - ChaplainGear
-      - AssistantGear
+      - HoPCorpseGear #SL Edit
+      - ClownCorpseGear #SL Edit
+      - MimeCorpseGear #SL Edit
+      - JanitorCorpseGear #SL Edit
+      - ServiceWorkerCorpseGear #SL Edit
+      - MusicianCorpseGear #SL Edit
+      - BotanistCorpseGear #SL Edit
+      - ChefCorpseGear #SL Edit
+      - ChaplainCorpseGear #SL Edit
+      - AssistantCorpseGear #SL Edit
+      - TiderCorpseGear #SL Edit
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -23,9 +24,9 @@
   components:
   - type: Loadout
     prototypes:
-    - TechnicalAssistantGear
-    - AtmosphericTechnicianGear
-    - StationEngineerGear
+    - TechnicalAssistantCorpseGear #SL Edit
+    - AtmosphericTechnicianCorpseGear #SL Edit
+    - StationEngineerCorpseGear #SL Edit
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -34,8 +35,10 @@
   components:
   - type: Loadout
     prototypes:
-    - CargoTechGear
-    - SalvageSpecialistGear
+    - CargoTechCorpseGear #SL Edit
+    - MailTechCorpseGear #SL Edit
+    - MinerCorpseGear #SL Edit
+    - SalvageSpecialistCorpseGear #SL Edit
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -44,10 +47,12 @@
   components:
   - type: Loadout
     prototypes:
-    - MedicalInternGear
-    - PsychologistGear
-    - ChemistGear
-    - DoctorGear
+    - MedicalInternCorpseGear #SL Edit
+    - PsychologistCorpseGear #SL Edit
+    - ChemistCorpseGear #SL Edit
+    - DoctorCorpseGear #SL Edit
+    - VirologistCorpseGear #SL Edit
+    - GeneticsCorpseGear #SL Edit
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -56,8 +61,9 @@
   components:
   - type: Loadout
     prototypes:
-    - ResearchAssistantGear
-    - ScientistGear
+    - ResearchAssistantCorpseGear #SL Edit
+    - ScientistCorpseGear #SL Edit
+    - RoboticistCorpseGear #SL Edit
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -66,10 +72,12 @@
   components:
   - type: Loadout
     prototypes:
-    - SecurityCadetGear
-    - SecurityOfficerGear
-    - DetectiveGear
-    - WardenGear
+    - SecurityCadetCorpseGear #SL Edit
+    - SecurityOfficerCorpseGear #SL Edit
+    - DetectiveCorpseGear #SL Edit
+    - BrigMedicCorpseGear #SL Edit
+    - WardenCorpseGear #SL Edit
+    - PrisonerCorpseGear #SL Edit
 
 - type: entity
   parent: SalvageHumanCorpse
@@ -78,11 +86,65 @@
   components:
   - type: Loadout
     prototypes:
-    - HoPGear
-    - CentcomGear
-    - CaptainGear
-    - HoSGear
-    - ResearchDirectorGear
-    - CMOGear
-    - ChiefEngineerGear
-    - QuartermasterGear
+    - HoPCorpseGear #SL Edit
+    - CentcomCorpseGear #SL Edit
+    - CaptainCorpseGear #SL Edit
+    - HoSCorpseGear #SL Edit
+    - ResearchDirectorCorpseGear #SL Edit
+    - CMOCorpseGear #SL Edit
+    - ChiefEngineerCorpseGear #SL Edit
+    - QuartermasterCorpseGear #SL Edit
+    - IAACorpseGear #SL Edit
+    - MagistrateCorpseGear #SL Edit
+    - NTRCorpseGear #SL Edit
+    - BSOCorpseGear #SL Edit
+    - NTMarineCorpseGear #SL Edit
+
+#Starlight Region Start (ANTAGS)
+
+- type: entity
+  parent: SalvageHumanCorpse
+  id: MobRandomSyndicateCorpse
+  suffix: Dead, Syndicate
+  components:
+  - type: Loadout
+    prototypes:
+    - SyndicateCorpseGear
+
+- type: entity
+  parent: SalvageHumanCorpse
+  id: MobRandomNukieCorpse
+  suffix: Dead, Nukie
+  components:
+  - type: Loadout
+    prototypes:
+    - NukieCorpseGear
+
+- type: entity
+  parent: SalvageHumanCorpse
+  id: MobRandomSovietCorpse
+  suffix: Dead, Soviet
+  components:
+  - type: Loadout
+    prototypes:
+    - SovietCorpseGear
+
+- type: entity
+  parent: SalvageHumanCorpse
+  id: MobRandomMercenaryCorpse
+  suffix: Dead, Mercenary
+  components:
+  - type: Loadout
+    prototypes:
+    - MercenaryCorpseGear
+
+- type: entity
+  parent: SalvageHumanCorpse
+  id: MobRandomPirateCorpse
+  suffix: Dead, Pirate
+  components:
+  - type: Loadout
+    prototypes:
+    - PirateCorpseGear
+
+#Starlight Region End (ANTAGS)

--- a/Resources/Prototypes/_StarLight/Entities/Markers/Spawners/corpses.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Markers/Spawners/corpses.yml
@@ -1,0 +1,59 @@
+- type: entity
+  name: Random Syndicate Corpse Spawner
+  id: RandomSyndicateCorpseSpawner
+  parent: SalvageHumanCorpseSpawner
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+  - type: ConditionalSpawner
+    prototypes:
+      - MobRandomSyndicateCorpse
+
+- type: entity
+  name: Random Nukie Corpse Spawner
+  id: RandomNukieCorpseSpawner
+  parent: SalvageHumanCorpseSpawner
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+  - type: ConditionalSpawner
+    prototypes:
+      - MobRandomNukieCorpse
+
+- type: entity
+  name: Random Soviet Corpse Spawner
+  id: RandomSovietCorpseSpawner
+  parent: SalvageHumanCorpseSpawner
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+  - type: ConditionalSpawner
+    prototypes:
+      - MobRandomSovietCorpse
+
+- type: entity
+  name: Random Mercenary Corpse Spawner
+  id: RandomMercenaryCorpseSpawner
+  parent: SalvageHumanCorpseSpawner
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+  - type: ConditionalSpawner
+    prototypes:
+      - MobRandomMercenaryCorpse
+
+- type: entity
+  name: Random Pirate Corpse Spawner
+  id: RandomPirateCorpseSpawner
+  parent: SalvageHumanCorpseSpawner
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+  - type: ConditionalSpawner
+    prototypes:
+      - MobRandomPirateCorpse

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/antag.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/antag.yml
@@ -1,0 +1,36 @@
+- type: startingGear
+  id: SyndicateCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitOperative
+    shoes: ClothingShoesBootsCombat
+    pocket1: SyndicateBusinessCard
+    pocket2: Telecrystal1
+
+- type: startingGear
+  id: NukieCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitOperative
+    shoes: ClothingShoesBootsCombat
+    outerClothing: ClothingOuterHardsuitSyndie
+    pocket1: WeaponPistolViper
+    pocket2: Telecrystal1
+
+- type: startingGear
+  id: SovietCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSovietFatigues
+    shoes: ClothingShoesBootsCombat
+    pocket1: CigPackSoviet
+
+- type: startingGear
+  id: MercenaryCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitMercenary
+    shoes: ClothingShoesBootsMerc
+
+- type: startingGear
+  id: PirateCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitPirate
+    outerClothing: ClothingOuterCoatPirate
+    pocket1: TreasureCoinGold

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/cargo.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/cargo.yml
@@ -22,7 +22,7 @@
     pocket1: AppraisalTool
 
 - type: startingGear
-  id: SalvagerCorpseGear
+  id: SalvageSpecialistCorpseGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitSalvageSpecialist
     ears: ClothingHeadsetCargo

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/cargo.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/cargo.yml
@@ -1,0 +1,54 @@
+- type: startingGear
+  id: MailTechCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCargo
+    ears: ClothingHeadsetCargo
+    shoes: ClothingShoesBootsWork
+    head: ClothingHeadHatCargosoft
+    gloves: ClothingHandsGlovesFingerless
+    belt: MailBag
+    pocket1: WeaponMeleeBoxcutter
+
+- type: startingGear
+  id: CargoTechCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCargo
+    ears: ClothingHeadsetCargo
+    shoes: ClothingShoesBootsWork
+    head: ClothingHeadHatCargosoft
+    outerClothing: ClothingOuterWinterCargo
+    gloves: ClothingHandsGlovesFingerless
+    belt: ClothingBeltUtility
+    pocket1: AppraisalTool
+
+- type: startingGear
+  id: SalvagerCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSalvageSpecialist
+    ears: ClothingHeadsetCargo
+    shoes: ClothingShoesBootsSalvage
+    gloves: ClothingHandsGlovesFingerless
+    belt: ClothingBeltUtility
+    pocket1: RadioHandheldExpedition
+
+- type: startingGear
+  id: MinerCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitMiningSpecialist
+    ears: ClothingHeadsetMining
+    shoes: ClothingShoesBootsSalvage
+    gloves: ClothingHandsGlovesFingerless
+    belt: OreBag
+    pocket1: RadioHandheldExpedition
+
+- type: startingGear
+  id: QuartermasterCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitQM
+    ears: ClothingHeadsetCargo
+    shoes: ClothingShoesBootsWork
+    head: ClothingHeadHatBeretQM
+    gloves: ClothingHandsGlovesFingerless
+    belt: ClothingBeltUtility
+    neck: ClothingNeckCloakQm
+    pocket1: CigarGold

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/engineer.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/engineer.yml
@@ -19,7 +19,7 @@
     pocket1: CableApcStack10
 
 - type: startingGear
-  id: StationEngineerCorpseGear
+  id: AtmosphericTechnicianCorpseGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAtmos
     ears: ClothingHeadsetEngineering

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/engineer.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/engineer.yml
@@ -1,0 +1,37 @@
+- type: startingGear
+  id: ChiefEngineerCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitChiefEngineer
+    ears: ClothingHeadsetEngineering
+    shoes: ClothingShoesBootsMag
+    head: ClothingHeadHatHardhatOrange
+    belt: ClothingBeltUtilityFilled
+    pocket1: RCD
+
+- type: startingGear
+  id: StationEngineerCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitEngineering
+    ears: ClothingHeadsetEngineering
+    shoes: ClothingShoesBootsWork
+    head: ClothingHeadHatHardhatOrange
+    belt: ClothingBeltUtilityFilled
+    pocket1: CableApcStack10
+
+- type: startingGear
+  id: StationEngineerCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitAtmos
+    ears: ClothingHeadsetEngineering
+    shoes: ClothingShoesBootsWork
+    head: ClothingHeadHatHardhatBlue
+    belt: ClothingBeltUtilityFilled
+    mask: ClothingMaskGasAtmos
+    pocket1: GasAnalyzer
+
+- type: startingGear
+  id: TechnicalAssistantCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitEngineering
+    ears: ClothingHeadsetEngineering
+    shoes: ClothingShoesBootsWork

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/medical.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/medical.yml
@@ -1,0 +1,49 @@
+- type: startingGear
+  id: CMOCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCMO
+    ears: ClothingHeadsetMedical
+    shoes: ClothingShoesColorWhite
+    head: ClothingHeadHatBeretCmo
+    belt: ClothingBeltMedicalFilled
+    pocket1: PillCanisterTricordrazine
+
+- type: startingGear
+  id: PsychologistCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitPsychologist
+    ears: ClothingHeadsetMedical
+    shoes: ClothingShoesColorWhite
+    pocket1: RandomFillStrangePill
+
+- type: startingGear
+  id: DoctorCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitMedicalDoctor
+    ears: ClothingHeadsetMedical
+    shoes: ClothingShoesColorWhite
+    belt: ClothingBeltMedicalFilled
+    pocket1: Gauze
+
+- type: startingGear
+  id: ChemistCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitChemistry
+    ears: ClothingHeadsetMedical
+    shoes: ClothingShoesColorWhite
+    belt: ChemBag
+    pocket1: SyringeInaprovaline
+
+- type: startingGear
+  id: VirologistCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitVirology
+    ears: ClothingHeadsetMedical
+    shoes: ClothingShoesColorWhite
+
+- type: startingGear
+  id: GeneticsCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitGenetics
+    ears: ClothingHeadsetMedical
+    shoes: ClothingShoesColorWhite

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/medical.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/medical.yml
@@ -14,7 +14,6 @@
     jumpsuit: ClothingUniformJumpsuitPsychologist
     ears: ClothingHeadsetMedical
     shoes: ClothingShoesColorWhite
-    pocket1: RandomFillStrangePill
 
 - type: startingGear
   id: DoctorCorpseGear
@@ -24,6 +23,13 @@
     shoes: ClothingShoesColorWhite
     belt: ClothingBeltMedicalFilled
     pocket1: Gauze
+
+- type: startingGear
+  id: MedicalInternCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitMedicalDoctor
+    ears: ClothingHeadsetMedical
+    shoes: ClothingShoesColorWhite
 
 - type: startingGear
   id: ChemistCorpseGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/ntcc.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/ntcc.yml
@@ -1,0 +1,53 @@
+- type: startingGear
+  id: IAACorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitLawyerBlack
+    ears: ClothingHeadsetIAA
+    shoes: ClothingShoesLeather
+    pocket1: LuxuryPen
+
+- type: startingGear
+  id: NTRCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitNtrep
+    shoes: ClothingShoesLeather
+    pocket1: LuxuryPen
+
+- type: startingGear
+  id: MagistrateCorpseGear
+  equipment:
+    jumpsuit: MagistrateUniformSuit
+    shoes: ClothingShoesLeather
+    pocket1: LuxuryPen
+    head: ClothingHeadHatPwig
+
+- type: startingGear
+  id: BSOCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitBlueShield
+    shoes: ClothingShoesBootsJackFilled
+    outerClothing: ClothingOuterArmorBlueShield
+    pocket1: Handcuffs
+    pocket2: TrackingImplanter
+
+- type: startingGear
+  id: CentcomCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCentcomOfficial
+    shoes: ClothingShoesBootsJackFilled
+    outerClothing: ClothingOuterVestWebEliteCentcomm
+    head: ClothingHeadHatCentcomcap
+
+- type: startingGear
+  id: NTMarineCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformNTNCFatigues
+    shoes: ClothingShoesBootsJackFilled
+    outerClothing: ClothingOuterVestNTNC
+
+- type: startingGear
+  id: CaptainCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCaptain
+    shoes: ClothingShoesLeather
+    head: ClothingHeadHatCapcap

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/science.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/science.yml
@@ -1,0 +1,32 @@
+- type: startingGear
+  id: ResearchDirectorCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitResearchDirector
+    ears: ClothingHeadsetScience
+    shoes: ClothingShoesLeather
+    head: ClothingHeadHatBeretRND
+    pocket1: ResearchDisk5000
+
+- type: startingGear
+  id: ResearchAssistantCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitScientist
+    ears: ClothingHeadsetScience
+    shoes: ClothingShoesColorPurple
+    pocket1: AnomalyScanner
+
+- type: startingGear
+  id: ScientistCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSeniorResearcher
+    ears: ClothingHeadsetScience
+    shoes: ClothingShoesColorPurple
+    pocket1: AnomalyScanner
+
+- type: startingGear
+  id: RoboticistCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitRoboticist
+    ears: ClothingHeadsetScience
+    shoes: ClothingShoesColorPurple
+    pocket1: Wristwatch

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/security.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/security.yml
@@ -1,0 +1,60 @@
+- type: startingGear
+  id: HoSCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHoS
+    ears: ClothingHeadsetSecurity
+    shoes: ClothingShoesBootsJackFilled
+    head: ClothingHeadHatBeretHoS
+    belt: ClothingBeltSecurityFilled
+    pocket1: Handcuffs
+
+- type: startingGear
+  id: SecurityCadetCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformSecurityTshirt
+    ears: ClothingHeadsetSecurity
+    shoes: ClothingShoesBootsJack
+    belt: ClothingBeltSecurity
+    outerClothing: ClothingOuterArmorBasic
+
+- type: startingGear
+  id: SecurityOfficerCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSec
+    ears: ClothingHeadsetSecurity
+    shoes: ClothingShoesBootsJackFilled
+    belt: ClothingBeltSecurity
+    outerClothing: ClothingOuterArmorBasic
+    pocket1: Handcuffs
+
+- type: startingGear
+  id: DetectiveCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitDetective
+    ears: ClothingHeadsetSecurity
+    shoes: ClothingShoesBootsJackFilled
+    outerClothing: ClothingOuterCoatDetective
+    pocket1: ForensicScanner
+
+- type: startingGear
+  id: BrigMedicCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitBrigmedic
+    ears: ClothingHeadsetSecurity
+    shoes: ClothingShoesBootsJack
+    pocket1: Gauze
+
+- type: startingGear
+  id: WardenCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitWarden
+    ears: ClothingHeadsetSecurity
+    shoes: ClothingShoesBootsJack
+    head: ClothingHeadHatBeretWarden
+    pocket1: Handcuffs
+
+- type: startingGear
+  id: PrisonerCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitPrisoner
+    shoes: ClothingShoesColorOrange

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/service.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Corpses/service.yml
@@ -1,0 +1,91 @@
+- type: startingGear
+  id: HoPCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHoP
+    ears: ClothingHeadsetService
+    shoes: ClothingShoesLeather
+    head: ClothingHeadHatHopcap
+    pocket1: LuxuryPen
+
+- type: startingGear
+  id: ClownCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitClown
+    ears: ClothingHeadsetService
+    shoes: ClothingShoesClown
+    mask: ClothingMaskClown
+    pocket1: BikeHorn
+
+- type: startingGear
+  id: MimeCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitMime
+    ears: ClothingHeadsetService
+    shoes: ClothingShoesColorBlack
+    mask: ClothingMaskMime
+
+- type: startingGear
+  id: JanitorCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitJanitor
+    ears: ClothingHeadsetService
+    shoes: ClothingShoesGaloshes
+    head: ClothingHeadHatPurplesoft
+    gloves: ClothingHandsGlovesJanitor
+    belt: ClothingBeltJanitor
+
+- type: startingGear
+  id: ServiceWorkerCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitBartender
+    ears: ClothingHeadsetService
+    shoes: ClothingShoesColorBlack
+    outerClothing: ClothingOuterApron
+
+- type: startingGear
+  id: MusicianCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitMusician
+    shoes: ClothingShoesColorBlack
+    ears: ClothingHeadsetService
+
+- type: startingGear
+  id: BotanistCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHydroponics
+    ears: ClothingHeadsetService
+    shoes: ClothingShoesColorBlack
+    outerClothing: ClothingOuterApronBotanist
+
+- type: startingGear
+  id: ChefCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitChef
+    ears: ClothingHeadsetService
+    shoes: ClothingShoesChef
+    head: ClothingHeadHatChef
+    outerClothing: ClothingOuterApronChef
+
+- type: startingGear
+  id: ChaplainCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitChaplain
+    shoes: ClothingShoesColorBlack
+    ears: ClothingHeadsetService
+
+- type: startingGear
+  id: AssistantCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitAncient
+    shoes: ClothingShoesColorBlack
+    ears: ClothingHeadsetAssistant
+
+- type: startingGear
+  id: TiderCorpseGear
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitAncient
+    shoes: ClothingShoesColorBlack
+    ears: ClothingHeadsetAssistant
+    mask: ClothingMaskGas
+    gloves: ClothingHandsGlovesFingerlessInsulated
+    pocket1: Multitool


### PR DESCRIPTION
## Short description
Fixes an oversight with Corpse Spawners to ensure they have actual clothing 95% of the time instead of 5% of the time.

Added Starlight specific jobs to the corpse pool.

Added antag corpse spawners for Syndicate, Nukie, Soviet, Pirate, and Mercenary.

## Why we need to add this
Due to an oversight in how Corpse Spawners work, most corpses used to spawn naked. They pulled from the (Job)Gear of a Job, which only had a headset and maybe gloves assigned because 99% of a Job's clothes are given by the Loadout system.

I fixed this issue by adding new (Job)CorpseGear StartingGear setups, to force them to spawn with clothing.

I also added in corpses for different Starlight unique jobs, like BSO, NT Rep, Magistrate, IAA, Roboticist, Mail Technician, Brig Medic, etc, to make it feel more integrated into our gameplay and world.

As a final treat, I added some extra antag corpse spawners for Syndicate, Nukie, Soviet, Pirate, and Mercenary. These are intended for wreck use (Soviet, Pirate, Mercenary, Syndicate) or ADMEME ONLY (Nukie). Useful to have the ability for Event Staff to plop down pre-dressed corpses of Syndicates or Nukies on the fly if needed.

## Media (Video/Screenshots)
<img width="936" height="611" alt="image" src="https://github.com/user-attachments/assets/aabfebe2-df98-4e01-891d-daaee5c346dc" />

New distribution, top to bottom; Cargo, Command, Engineering, Medical, Science, Security, Service

.

<img width="440" height="390" alt="image" src="https://github.com/user-attachments/assets/155b689a-1e3f-4cd4-b0a2-3e0f26b2b11b" />

Antag corpses, top to bottom; Mercenary, Pirate, Nukie, Syndicate, Soviet

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Fixed corpses spawned by wrecks and corpse markers being naked.
- add: Added Starlight specific jobs to the corpse pool.
- add: Added antag corpse spawners for Syndicate, Nukie, Pirate, Mercenary, and Soviet, for wreck/event use.