### PR TITLE
Update Lobby's Observe Warning

### DIFF
--- a/Content.Client/Lobby/UI/ObserveWarningWindow.xaml
+++ b/Content.Client/Lobby/UI/ObserveWarningWindow.xaml
@@ -2,8 +2,11 @@
     xmlns="https://spacestation14.io"
     xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls">
     <BoxContainer Orientation="Vertical">
-        <Label Text="{Loc 'observe-warning-1'}"/>
-        <Label Text="{Loc 'observe-warning-2'}"/>
+        <!-- Starlight begin - updated for our New Life system -->
+        <Label Text="{Loc 'starlight-observe-warning-1'}"/>
+        <Label Text="{Loc 'starlight-observe-warning-2'}"/>
+        <Label Text="{Loc 'starlight-observe-warning-3'}"/>
+        <!-- Starlight end -->
         <BoxContainer Orientation="Horizontal">
             <Button Name="NevermindButton" Text="{Loc 'observe-nevermind'}" SizeFlagsStretchRatio="1"/>
             <Control HorizontalExpand="True" SizeFlagsStretchRatio="2" />

--- a/Resources/Locale/en-US/_Starlight/lobby/observe-new-life.ftl
+++ b/Resources/Locale/en-US/_Starlight/lobby/observe-new-life.ftl
@@ -1,0 +1,3 @@
+starlight-observe-warning-1 = Are you sure you want to observe?
+starlight-observe-warning-2 = You will still be able to join the round with one of your existing characters.
+starlight-observe-warning-3 = You will not be able to customize or return to lobby until the round ends.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
The default observe warning text does not apply to Starlight, as we have the New Life system.

## Media (Video/Screenshots)
### Old
<img width="305" height="111" alt="Screenshot 2025-11-23 153158" src="https://github.com/user-attachments/assets/4d426e1b-9eab-451e-b39d-4ba4ec55ad5b" />

### New
<img width="593" height="154" alt="Screenshot 2025-11-23 154227" src="https://github.com/user-attachments/assets/67b358c9-ec05-4e83-b0df-72bd42d8a505" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- tweak: Updated lobby observe warning text to make more sense with our New Life system.

