### PR TITLE
Removes Exo Station from the map voting pool

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
@@ -5,7 +5,6 @@
   - StarlightBarratry
   - StarlightCog
   - StarlightCork
-  - StarlightExo
   - StarlightFland
   - StarlightHotel
   - StarlightLagan
@@ -26,6 +25,7 @@
   - StarlightSilica
   - StarlightCluster
   - StarlightBox
+# - StarlightExo
 # - StarlightMarathon
 # - StarlightMeta
 # - StarlightPacked


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Removes Exo Station (Exomorph Vessel "Conquest") from the map voting pool.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
As per @APOCAMANDER 
- It doesn't feel like Exo station meets Starlight's gameplay standards.
- The map is very unique with its bespoke sprite assets and odd layout..
- ... but it comes at the cost of gameplay. Departments being separated entirely, like Atmospherics being separate from Engineering, Chemistry being a disposal bin ride away from Medical, etc., just doesn't feel good.
- There are compounding engineering issues in general with the map, notably the radiation collectors are very far from the singularity chamber which makes it more prone to power issues due to distance, and the 'resin' windows on the TEG were insufficient after the Delta-P update.

**Players have generally bemoaned playing on Exo and the general idea is "remove it for now, pull the new Wizden version, and have someone rework it."**

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- remove: Exomorph Vessel "Conquest" from the voting map pool (to be reworked down the line)