### PR TITLE
Minor damage nerf for avali

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -134,7 +134,7 @@
       animation: WeaponArcClaw
       damage:
         types:
-          Slash: 6.25
+          Slash: 6
     - type: Temperature
       heatDamageThreshold: 310
       coldDamageThreshold: 223


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

They had an extra 0.25 damage compared to other species like vox, this brings them in line to be the same as other species with "increased" melee damage (Seems like the average DPS is around 6 for the higher damage species)

**Changelog**
:cl: STARLIGHT TEAM
- tweak: Slightly decreased Avali melee damage


