### PR TITLE
Fix vulpkanin drawlayers to match other species

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
@@ -91,24 +91,19 @@
     - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
     - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
     - map: [ "jumpsuit" ]
+    - map: [ "enum.HumanoidVisualLayers.LFoot" ] # Starlight: Layering fix
+    - map: [ "enum.HumanoidVisualLayers.RFoot" ] # Starlight: Layering fix
     - map: [ "enum.HumanoidVisualLayers.LHand" ]
     - map: [ "enum.HumanoidVisualLayers.RHand" ]
-    - map: [ "enum.HumanoidVisualLayers.LFoot" ]
-    - map: [ "enum.HumanoidVisualLayers.RFoot" ]
-    - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
-      color: "#ffffff"
-      sprite: Objects/Misc/handcuffs.rsi
-      state: body-overlay-2
-      visible: false
-    - map: [ "id" ]
     - map: [ "gloves" ]
-    - map: [ "shoes" ]
+    - map: [ "shoes" ] # Starlight start: Layering fix
     - map: [ "ears" ]
-    - map: [ "outerClothing" ]
     - map: [ "eyes" ]
+    - map: [ "outerClothing" ]
     - map: [ "belt" ]
-    - map: [ "neck" ]
+    - map: [ "id" ]
     - map: [ "back" ]
+    - map: [ "neck" ] # Starlight end: Layering fix
     - map: [ "enum.HumanoidVisualLayers.SnoutCover" ]
     - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
     - map: [ "enum.HumanoidVisualLayers.Hair" ]
@@ -119,6 +114,11 @@
     - map: [ "head" ]
     - map: [ "pocket1" ]
     - map: [ "pocket2" ]
+    - map: [ "enum.HumanoidVisualLayers.Handcuffs" ] # Starlight start: Layering fix
+      color: "#ffffff"
+      sprite: Objects/Misc/handcuffs.rsi
+      state: body-overlay-2
+      visible: false # Starlight end: Layering fix
     - map: [ "clownedon" ]
       sprite: "Effects/creampie.rsi"
       state: "creampie_vulpkanin"
@@ -142,7 +142,7 @@
     #        state: hair
   - type: Inventory
     speciesId: vulpkanin
-    displacements: 
+    displacements:
       head:
         sizeMaps:
           32:
@@ -219,7 +219,7 @@
   - type: Inventory
     speciesId: vulpkanin
     # Starlight start
-    displacements: 
+    displacements:
       jumpsuit:
         sizeMaps:
           32:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
For some peculiar reason Vulpkanins have a different drawlayer order to all* other species .

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Brings them in line with all* other species drawlayers.
Also fixes a minor visual bug where the neck would render below the bag.

_*note: excluding moths: their tail renders above the back -- this is because that drawlayer is used for wings_

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="284" height="317" alt="image" src="https://github.com/user-attachments/assets/452be1ba-a471-4ab9-989d-f2f5aa58a3d9" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- fix: Tweaked vulpkanin drawlayers to bring them in line with other species