### PR TITLE
Ported AI Navmap (Carpmosia)

### DIFF
--- a/Content.Client/Pinpointer/UI/NavMapControl.cs
+++ b/Content.Client/Pinpointer/UI/NavMapControl.cs
@@ -488,6 +488,27 @@ public partial class NavMapControl : MapGridControl
         }
     }
 
+    // Carpmosia-start - AI Navmap
+    public void AiFrameUpdate(float seconds, EntityUid? newMapUid)
+    {
+        if (MapUid != newMapUid)
+        {
+            MapUid = newMapUid;
+            ForceNavMapUpdate();
+        }
+        else
+        {
+            // Update the timer
+            _updateTimer += seconds;
+            if (_updateTimer >= UpdateTime)
+            {
+                _updateTimer -= UpdateTime;
+                UpdateNavMap();
+            }
+        }
+    }
+    // Carpmosia-end - AI Navmap
+
     protected virtual void UpdateNavMap()
     {
         // Clear stale values

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -67,10 +67,10 @@ public sealed class StationAiOverlay : Overlay
         // var playerEnt = _player.LocalEntity;
 
          var playerEnt = _player.LocalEntity;
-        _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform);
-        var gridUid = playerXform?.GridUid ?? EntityUid.Invalid;
-        _entManager.TryGetComponent(gridUid, out MapGridComponent? grid);
-        _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase); 
+        _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform); //moved to be after new playerEnt definition with edit, SL
+        var gridUid = playerXform?.GridUid ?? EntityUid.Invalid; //moved to be after new playerEnt definition with edit, SL
+        _entManager.TryGetComponent(gridUid, out MapGridComponent? grid); //moved to be after new playerEnt definition with edit, SL
+        _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase);  //moved to be after new playerEnt definition with edit, SL
 
         if (_entManager.TryGetComponent(playerEnt, out StationAiOverlayComponent? stationAiOverlay) 
             && stationAiOverlay.AllowCrossGrid 

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -64,18 +64,18 @@ public sealed class StationAiOverlay : Overlay
         var worldHandle = args.WorldHandle;
 
         var worldBounds = args.WorldBounds;
-        var playerEnt = _player.LocalEntity;
+        // var playerEnt = _player.LocalEntity;
+
+         var playerEnt = _player.LocalEntity;
+        _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform);
+        var gridUid = playerXform?.GridUid ?? EntityUid.Invalid;
+        _entManager.TryGetComponent(gridUid, out MapGridComponent? grid);
+        _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase); 
 
         if (_entManager.TryGetComponent(playerEnt, out StationAiOverlayComponent? stationAiOverlay) 
             && stationAiOverlay.AllowCrossGrid 
             && _entManager.TryGetComponent(playerEnt, out RelayInputMoverComponent? relay))
             playerEnt = relay.RelayEntity;
-
-        var playerEnt = _player.LocalEntity;
-        _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform);
-        var gridUid = playerXform?.GridUid ?? EntityUid.Invalid;
-        _entManager.TryGetComponent(gridUid, out MapGridComponent? grid);
-        _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase);
 
         var invMatrix = args.Viewport.GetWorldToLocalMatrix();
         _accumulator -= (float) _timing.FrameTime.TotalSeconds;

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -98,7 +98,7 @@ public sealed class StationAiOverlay : Overlay
             }
 
             var gridMatrix = xforms.GetWorldMatrix(gridUid);
-            var matty =  Matrix3x2.Multiply(gridMatrix, invMatrix);
+            var matty = Matrix3x2.Multiply(gridMatrix, invMatrix);
 
             // Draw visible tiles to stencil
             worldHandle.RenderInRenderTarget(res.StencilTexture!, () =>

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -66,11 +66,13 @@ public sealed class StationAiOverlay : Overlay
         var worldBounds = args.WorldBounds;
         // var playerEnt = _player.LocalEntity;
 
+         // Starlight-start: moved to be after new playerEnt definition with edit
          var playerEnt = _player.LocalEntity;
-        _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform); //moved to be after new playerEnt definition with edit, SL
-        var gridUid = playerXform?.GridUid ?? EntityUid.Invalid; //moved to be after new playerEnt definition with edit, SL
-        _entManager.TryGetComponent(gridUid, out MapGridComponent? grid); //moved to be after new playerEnt definition with edit, SL
-        _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase);  //moved to be after new playerEnt definition with edit, SL
+        _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform);
+        var gridUid = playerXform?.GridUid ?? EntityUid.Invalid;
+        _entManager.TryGetComponent(gridUid, out MapGridComponent? grid);
+        _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase);
+        // Starlight-end
 
         if (_entManager.TryGetComponent(playerEnt, out StationAiOverlayComponent? stationAiOverlay) 
             && stationAiOverlay.AllowCrossGrid 

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -1,9 +1,12 @@
 using System.Numerics;
+using System.Linq; // Carpmosia-edit - AI Navmap
+using Content.Client.Pinpointer.UI; // Carpmosia-edit - AI Navmap
 using Content.Client.Graphics;
 using Content.Shared.Movement.Components;
 using Content.Shared.Silicons.StationAi;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
+using Robust.Shared.Collections; // Carpmosia-edit - AI Navmap
 using Robust.Shared.Enums;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
@@ -27,8 +30,10 @@ public sealed class StationAiOverlay : Overlay
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
     private readonly HashSet<Vector2i> _visibleTiles = new();
+    private readonly NavMapControl _navMap = new(); // Carpmosia-edit - AI Navmap
 
     private readonly OverlayResourceCache<CachedResources> _resources = new();
+    private Dictionary<Color, Color> _sRGBLookUp = new(); // Carpmosia-edit - AI Navmap
 
     private float _updateRate = 1f / 30f;
     private float _accumulator;
@@ -36,6 +41,10 @@ public sealed class StationAiOverlay : Overlay
     public StationAiOverlay()
     {
         IoCManager.InjectDependencies(this);
+        // Carpmosia-start - AI Navmap
+        _navMap.WallColor = new(102, 102, 102);
+        _navMap.TileColor = new(30, 30, 30);
+        // Carpmosia-end - AI Navmap
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -62,13 +71,14 @@ public sealed class StationAiOverlay : Overlay
             && _entManager.TryGetComponent(playerEnt, out RelayInputMoverComponent? relay))
             playerEnt = relay.RelayEntity;
 
+        var playerEnt = _player.LocalEntity;
         _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform);
         var gridUid = playerXform?.GridUid ?? EntityUid.Invalid;
         _entManager.TryGetComponent(gridUid, out MapGridComponent? grid);
         _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase);
 
         var invMatrix = args.Viewport.GetWorldToLocalMatrix();
-        _accumulator -= (float)_timing.FrameTime.TotalSeconds;
+        _accumulator -= (float) _timing.FrameTime.TotalSeconds;
 
         if (grid != null && broadphase != null)
         {
@@ -79,6 +89,7 @@ public sealed class StationAiOverlay : Overlay
             if (stationAiOverlay is not null) // 🌟Starlight🌟
                 color = color.WithAlpha(stationAiOverlay.Alfa); // 🌟Starlight🌟
 
+            _navMap.AiFrameUpdate((float) _timing.FrameTime.TotalSeconds, gridUid); // Carpmosia-edit - AI Navmap
             if (_accumulator <= 0f)
             {
                 _accumulator = MathF.Max(0f, _accumulator + _updateRate);
@@ -87,7 +98,7 @@ public sealed class StationAiOverlay : Overlay
             }
 
             var gridMatrix = xforms.GetWorldMatrix(gridUid);
-            var matty = Matrix3x2.Multiply(gridMatrix, invMatrix);
+            var matty =  Matrix3x2.Multiply(gridMatrix, invMatrix);
 
             // Draw visible tiles to stencil
             worldHandle.RenderInRenderTarget(res.StencilTexture!, () =>
@@ -106,10 +117,13 @@ public sealed class StationAiOverlay : Overlay
             worldHandle.RenderInRenderTarget(res.StaticTexture!,
             () =>
             {
-                worldHandle.SetTransform(invMatrix);
-                var shader = _proto.Index(CameraStaticShader).Instance();
-                worldHandle.UseShader(shader);
-                worldHandle.DrawRect(worldBounds, Color.White);
+                // Carpmosia-start - AI Navmap
+                worldHandle.SetTransform(matty);
+                // var shader = _proto.Index(CameraStaticShader).Instance();
+                // worldHandle.UseShader(shader);
+                // worldHandle.DrawRect(worldBounds, Color.White);
+                DrawNavMap(worldHandle, grid);
+                // Carpmosia-end - AI Navmap
             },
             Color.Black);
         }
@@ -160,4 +174,69 @@ public sealed class StationAiOverlay : Overlay
             StencilTexture?.Dispose();
         }
     }
+
+    // Carpmosia-start - AI Navmap
+    protected void DrawNavMap(DrawingHandleWorld handle, MapGridComponent grid)
+    {
+        if (!_sRGBLookUp.TryGetValue(_navMap.WallColor, out var wallsRGB))
+        {
+            wallsRGB = Color.ToSrgb(_navMap.WallColor);
+            _sRGBLookUp[_navMap.WallColor] = wallsRGB;
+        }
+
+        // Draw floor tiles
+        if (_navMap.TilePolygons.Any())
+        {
+            foreach (var (polygonVerts, polygonColor) in _navMap.TilePolygons)
+            {
+                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, polygonVerts[..polygonVerts.Length], polygonColor);
+            }
+        }
+
+        // Draw map lines
+        if (_navMap.TileLines.Any())
+        {
+            var lines = new ValueList<Vector2>(_navMap.TileLines.Count * 2);
+
+            foreach (var (o, t) in _navMap.TileLines)
+            {
+                var origin = new Vector2(o.X, -o.Y);
+                var terminus = new Vector2(t.X, -t.Y);
+
+                lines.Add(origin);
+                lines.Add(terminus);
+            }
+
+            if (lines.Count > 0)
+                handle.DrawPrimitives(DrawPrimitiveTopology.LineList, lines.Span, wallsRGB);
+        }
+
+        // Draw map rects
+        if (_navMap.TileRects.Any())
+        {
+            var rects = new ValueList<Vector2>(_navMap.TileRects.Count * 8);
+
+            foreach (var (lt, rb) in _navMap.TileRects)
+            {
+                var leftTop = new Vector2(lt.X, -lt.Y);
+                var rightBottom = new Vector2(rb.X, -rb.Y);
+
+                var rightTop = new Vector2(rightBottom.X, leftTop.Y);
+                var leftBottom = new Vector2(leftTop.X, rightBottom.Y);
+
+                rects.Add(leftTop);
+                rects.Add(rightTop);
+                rects.Add(rightTop);
+                rects.Add(rightBottom);
+                rects.Add(rightBottom);
+                rects.Add(leftBottom);
+                rects.Add(leftBottom);
+                rects.Add(leftTop);
+            }
+
+            if (rects.Count > 0)
+                handle.DrawPrimitives(DrawPrimitiveTopology.LineList, rects.Span, wallsRGB);
+        }
+    }
+    // Carpmosia-end - AI Navmap
 }

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -78,7 +78,7 @@ public sealed class StationAiOverlay : Overlay
             playerEnt = relay.RelayEntity;
 
         var invMatrix = args.Viewport.GetWorldToLocalMatrix();
-        _accumulator -= (float) _timing.FrameTime.TotalSeconds;
+        _accumulator -= (float)_timing.FrameTime.TotalSeconds;
 
         if (grid != null && broadphase != null)
         {

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -42,8 +42,9 @@ public sealed class StationAiOverlay : Overlay
     {
         IoCManager.InjectDependencies(this);
         // Carpmosia-start - AI Navmap
-        _navMap.WallColor = new(102, 102, 102);
-        _navMap.TileColor = new(30, 30, 30);
+        //starlight change, colors are adjusted to be green tints
+        _navMap.WallColor = new(0, 131, 0);
+        _navMap.TileColor = new(0, 60, 0);
         // Carpmosia-end - AI Navmap
     }
 


### PR DESCRIPTION
## Short description
Ports a [port of the AI Navmap](https://github.com/carpmosia/carpmosia/pull/80) overlay replacement, licensed MIT, from Carpmosia. Replaces the AI out of bounds static overlay with the Navmap overlay, like station maps, power monitors, atmos monitors, etc use. 

## Why we need to add this
Visual clarity. The old effect could cause eye strain and headaches for players, due to just being a TV static effect. This also doesn't really give AI any new abilities beyond what they have currently- the same effect could be had by just keeping the crew monitor tab open when following a character for example. It just makes it less painful and ugly to play AI.

Original was relicensed by the creator and ported to Carpmosia under MIT, which is the version I ported. So license is good.

## Media (Video/Screenshots)
Video:
https://www.youtube.com/watch?v=xe0ykHC3ayo


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed the AI out of bounds static overlay to use the Navmap overlay instead, to reduce eye strain and headaches. Ported from Carpmosia, MIT.

