### PR TITLE
Have the librarian start rounds knowing all crew languages

### DIFF
--- a/Content.Shared/_Starlight/Language/Components/AdditionalLanguageKnowledgeComponent.cs
+++ b/Content.Shared/_Starlight/Language/Components/AdditionalLanguageKnowledgeComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared._Starlight.Language;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Starlight.Language.Components;
+
+/// <summary>
+///     Has a list of languages that get added to an entity's LanguageKnowledgeComponent on init
+/// </summary>
+[RegisterComponent]
+public sealed partial class AdditionalLanguageKnowledgeComponent : Component
+{
+    /// <summary>
+    ///     List of languages this entity can speak without any external tools.
+    /// </summary>
+    [DataField("speaks")]
+    public List<ProtoId<LanguagePrototype>> SpokenLanguages = new();
+
+    /// <summary>
+    ///     List of languages this entity can understand without any external tools.
+    /// </summary>
+    [DataField("understands")]
+    public List<ProtoId<LanguagePrototype>> UnderstoodLanguages = new();
+}

--- a/Content.Shared/_Starlight/Language/Systems/SharedLanguageSystem.cs
+++ b/Content.Shared/_Starlight/Language/Systems/SharedLanguageSystem.cs
@@ -42,6 +42,7 @@ public abstract partial class SharedLanguageSystem : EntitySystem
         
         SubscribeLocalEvent<LanguageKnowledgeComponent, CloningEvent>(OnClone);
         SubscribeLocalEvent<LanguageKnowledgeComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<AdditionalLanguageKnowledgeComponent, MapInitEvent>(OnMapInitAdditional);
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
     }
 
@@ -68,6 +69,22 @@ public abstract partial class SharedLanguageSystem : EntitySystem
     {
         var ev2 = new LanguageKnowledgeInitEvent(ent);
         RaiseLocalEvent(ent, ref ev2 , broadcast: true);
+    }
+
+    /// <summary>
+    /// Add additional languages, generally as part of a role
+    /// </summary>
+    private void OnMapInitAdditional(Entity<AdditionalLanguageKnowledgeComponent> ent, ref MapInitEvent ev)
+    {
+        if (TryComp<LanguageKnowledgeComponent>(ent, out var langComp))
+        {
+            langComp.SpokenLanguages = langComp.SpokenLanguages.Union(ent.Comp.SpokenLanguages).Distinct().ToList();
+            langComp.UnderstoodLanguages = langComp.UnderstoodLanguages.Union(ent.Comp.UnderstoodLanguages).Distinct().ToList();
+            if (TryComp<LanguageSpeakerComponent>(ent, out var speaker))
+            {
+                UpdateEntityLanguages((ent, speaker));
+            }
+        }
     }
 
     private void OnPrototypesReloaded(PrototypesReloadedEventArgs ev)

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -9,10 +9,43 @@
   access:
   - Service
   - Maintenance
-  special:
+  special: # Starlight start - librarian starts with crew languages
   - !type:AddComponentSpecial
     components:
-    - type: UniversalLanguageSpeaker #Lets them speak and understand all languages
+    - type: AdditionalLanguageKnowledge # If we just put in LanguageKnowledge, it'd overwrite your ability to e.g. understand mothroaches as a moth
+      speaks:
+      - GalacticCommon
+      - Scratch
+      - SolCommon
+      - Bubblish
+      - Canilunzt
+      - Chittin
+      - Draconic
+      - Marish
+      - Moffic
+      - Nekomimetic
+      - Sylvan
+      - Terrum
+      - Thaveyan
+      - VoxPidgin
+      - Sign
+      understands:
+      - GalacticCommon
+      - Scratch
+      - SolCommon
+      - Bubblish
+      - Canilunzt
+      - Chittin
+      - Draconic
+      - Marish
+      - Moffic
+      - Nekomimetic
+      - Sylvan
+      - Terrum
+      - Thaveyan
+      - VoxPidgin
+      - Sign
+  # Starlight end
 
 - type: startingGear
   id: LibrarianGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -9,6 +9,10 @@
   access:
   - Service
   - Maintenance
+  special:
+  - !type:AddComponentSpecial
+    components:
+    - type: UniversalLanguageSpeaker #Lets them speak and understand all languages
 
 - type: startingGear
   id: LibrarianGear


### PR DESCRIPTION
## Short description
Have the Librarian role start the round with all non-animal crew languages as speakable and understood.

## Why we need to add this
There's some discussion about making the librarian a more defined role on the station, and one of the ways suggested to do this is to have the librarian be able to act as a translator for even the most esoteric languages the crew might encounter.

## Media (Video/Screenshots)
![20251128212640_1](https://github.com/user-attachments/assets/3fb18540-059a-4c09-bc90-a342124170b6)

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- add: Librarians now can understand and speak all non-animal crew languages.