### PR TITLE
Fix laspi storage bug

### DIFF
--- a/Content.Shared/_Starlight/Storage/SharedPrivateStorageSystem.cs
+++ b/Content.Shared/_Starlight/Storage/SharedPrivateStorageSystem.cs
@@ -1,4 +1,6 @@
 using Content.Shared.DoAfter;
+using Content.Shared.Interaction;
+using Content.Shared.Interaction.Components;
 using Content.Shared.Popups;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
@@ -25,6 +27,7 @@ public abstract class SharedPrivateStorageSystem : EntitySystem
         
         SubscribeLocalEvent<PrivateStorageComponent, PrivateStorageDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<PrivateStorageComponent, GetVerbsEvent<ActivationVerb>>(AddPrivateStorageVerb);
+        SubscribeLocalEvent<PrivateStorageComponent, ActivateInWorldEvent>(OnActivate);
     }
 
     private void OnDoAfter(EntityUid uid, PrivateStorageComponent component, DoAfterEvent args)
@@ -86,6 +89,42 @@ public abstract class SharedPrivateStorageSystem : EntitySystem
                 new("/Textures/Interface/VerbIcons/open.svg.192dpi.png"));
         }
         args.Verbs.Add(verb);
+    }
+    
+    /// <summary>
+    /// Code used to open storage with action button over the verb
+    /// Required to be separated from Storage System due to doAfter needed for others to open it
+    /// </summary>
+    private void OnActivate(EntityUid uid, PrivateStorageComponent storageComp, ActivateInWorldEvent args)
+    {
+        if (args.Handled || !args.Complex || !CanInteract(args.User, (uid, storageComp)))
+            return;
+
+        // Toggle
+        if (_ui.IsUiOpen(uid, StorageComponent.StorageUiKey.Key, args.User))
+        {
+            _ui.CloseUi(uid, StorageComponent.StorageUiKey.Key, args.User);
+        }
+        else
+        {
+            StartPrivateStorageAccess(uid, args.User, storageComp);
+        }
+
+        args.Handled = true;
+    }
+    
+    private bool CanInteract(EntityUid user, Entity<PrivateStorageComponent> storage, bool canInteract = true, bool silent = true)
+    {
+        if (HasComp<BypassInteractionChecksComponent>(user))
+            return true;
+
+        if (!canInteract)
+            return false;
+
+        var ev = new StorageInteractAttemptEvent(silent);
+        RaiseLocalEvent(storage, ref ev);
+
+        return !ev.Cancelled;
     }
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -40,6 +40,7 @@
   - type: Storage
     clickInsert: false
     showVerb: false # Starlight Edit
+    openOnActivate: false # Starlight Edit
     grid:
     - 0,0,1,2
     maxItemSize: Large

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -39,8 +39,10 @@
   # they like eat it idk lol
   - type: Storage
     clickInsert: false
-    showVerb: false # Starlight Edit
-    openOnActivate: false # Starlight Edit
+    # Starlight-start
+    showVerb: false
+    openOnActivate: false
+    # Starlight-end
     grid:
     - 0,0,1,2
     maxItemSize: Large


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes laspi storage being accessible without a doAfter when done in combat mode, this was an obvious bug

## Why we need to add this
It fixes a bug

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Laspi storage skipping a doAfter
