### PR TITLE
fix operating tables speaking while unanchored

### DIFF
--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -224,7 +224,7 @@ public sealed class HealthAnalyzerSystem : EntitySystem
             unrevivable = true;
         
         // Starlight-start: Talking health analyzer
-        if (healthComp.Talk && healthComp.NextTalk < _timing.CurTime && TryComp<DamageableComponent>(target, out var damageable))
+        if (healthComp.Talk && healthComp.NextTalk < _timing.CurTime && TryComp<DamageableComponent>(target, out var damageable) && scanMode)
         {
             healthComp.NextTalk = _timing.CurTime + healthComp.TalkInterval;
             

--- a/Content.Server/_Starlight/Medical/Surgery/BodyScannerSystem.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/BodyScannerSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class BodyScannerSystem : SharedBodyScannerSystem
     
     private void OnStrapped(Entity<OperatingTableComponent> ent, ref StrappedEvent args)
     {        
-        if (ent.Comp.Scanner != null && TryComp<HealthAnalyzerComponent>(ent.Comp.Scanner, out var analyzer))
+        if (ent.Comp.Scanner != null && TryComp<HealthAnalyzerComponent>(ent.Comp.Scanner, out var analyzer) && Transform(ent.Comp.Scanner.Value).Anchored)
             _healthAnalyzer.BeginAnalyzingEntity((ent.Comp.Scanner.Value, analyzer), args.Buckle.Owner);
     }
     


### PR DESCRIPTION
## Short description
operating table no longer talks when unanchored and there is a patient on the linked bed

## Why we need to add this
fixes #1908 


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Arkanic
- fix: Fix operating computers speaking while unanchored
