### PR TITLE
Save VRAM by setting preload: false for all parallaxes

### DIFF
--- a/Resources/Textures/_Starlight/Parallaxes/Abyss.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/Abyss.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/AstroBackground_stars.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/AstroBackground_stars.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/AstroBackground_stars_2.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/AstroBackground_stars_2.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/AstroDust.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/AstroDust.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/AstroStars.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/AstroStars.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/AstroStars2.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/AstroStars2.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/AxiomaBackground_space.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/AxiomaBackground_space.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/AxiomaBackground_stars.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/AxiomaBackground_stars.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/AxiomaDust.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/AxiomaDust.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/AxiomaStars.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/AxiomaStars.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/DeltaParallaxBG.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/DeltaParallaxBG.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/DeltaParallaxNeb.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/DeltaParallaxNeb.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/EclipseBackground_space.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/EclipseBackground_space.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/EclipseDust.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/EclipseDust.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/EclipseNebulae.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/EclipseNebulae.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/EclipsePlanets.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/EclipsePlanets.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/EclipseStars.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/EclipseStars.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/EclipseStars_Background.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/EclipseStars_Background.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/IceParallax.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/IceParallax.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/LavaLightParallax.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/LavaLightParallax.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/LavaParallax.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/LavaParallax.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/blue_giant.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/blue_giant.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/donutspace.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/donutspace.png.yml
@@ -1,0 +1,1 @@
+preload: false

--- a/Resources/Textures/_Starlight/Parallaxes/shoreline_water.png.yml
+++ b/Resources/Textures/_Starlight/Parallaxes/shoreline_water.png.yml
@@ -1,0 +1,1 @@
+preload: false


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Drops from 849 MB to ~594 MB (depends on the parallax chosen)
`devwindow` in console to check this
Script in case anyone wants to run this again:
```csharp
            // Change this to your path locally
            var path = "C:\\Projects\\ss14-starlight\\Resources\\Textures\\_Starlight\\Parallaxes";
            var files = Directory.EnumerateFiles(path, "*.png");
            foreach (var file in files)
            {
                File.WriteAllText($"{file}.yml", "preload: false\n");
            }
```

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Before
<img width="1282" height="752" alt="Content Client_UfCrVCPHBt" src="https://github.com/user-attachments/assets/1358f658-6bf0-4900-b994-2d4fa6584c3a" />

After (Abyss.png was the chosen parallax for the round)
<img width="1282" height="752" alt="Content Client_1EsUFBsNdt" src="https://github.com/user-attachments/assets/ea7bdccb-d49f-4574-ae45-8e204e7e8e3c" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
