### PR TITLE
Minor terror spider updates & fixes

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/terror_spiders.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/terror_spiders.yml
@@ -68,8 +68,14 @@
   - type: MeleeChemicalInjector
     transferAmount: 0.75
     solution: melee
-  - type: ReplacementAccent
-    accent: xeno
+  - type: LanguageSpeaker
+  - type: LanguageKnowledge
+    speaks:
+    - Chittin
+    - Xeno
+    understands:
+    - Chittin
+    - Xeno
   - type: NoSlip
   - type: Spider
   - type: IgnoreSpiderWeb
@@ -97,7 +103,7 @@
     speedModifier: 1.5
     useSound:
       path: /Audio/Items/crowbar.ogg
-  - type: PassiveDamage 
+  - type: PassiveDamage
     allowedStates:
     - Alive
     damageCap: 89
@@ -139,7 +145,7 @@
     thresholds:
       0: Alive
       140: Dead
-  - type: PassiveDamage 
+  - type: PassiveDamage
     allowedStates:
     - Alive
     damageCap: 139
@@ -171,7 +177,7 @@
   components:
   - type: Evolving
     evolveTo: MobTerrorPurple
-    conditions: 
+    conditions:
     - !type:SpiderWebCondition
       targetWebAmount: 36
 
@@ -198,7 +204,7 @@
     thresholds:
       0: Alive
       80: Dead
-  - type: PassiveDamage 
+  - type: PassiveDamage
     allowedStates:
     - Alive
     damageCap: 79
@@ -235,10 +241,10 @@
   components:
   - type: Evolving
     evolveTo: MobTerrorBlack
-    conditions: 
+    conditions:
     - !type:SpiderWebCondition
       targetWebAmount: 36
-    
+
 - type: entity
   name: terror green
   parent: MobTerrorSpider
@@ -258,7 +264,7 @@
     thresholds:
       0: Alive
       80: Dead
-  - type: PassiveDamage 
+  - type: PassiveDamage
     allowedStates:
     - Alive
     damageCap: 79
@@ -301,7 +307,7 @@
   components:
   - type: Evolving
     evolveTo: MobTerrorWhite
-    conditions: 
+    conditions:
     - !type:EggsInjectCondition
 
 ##########
@@ -409,7 +415,7 @@
     damage:
       types:
         Piercing: 25
-  - type: PassiveDamage 
+  - type: PassiveDamage
     allowedStates:
     - Alive
     - Critical
@@ -439,7 +445,7 @@
     thresholds:
       0: Alive
       160: Dead
-  - type: PassiveDamage 
+  - type: PassiveDamage
     allowedStates:
     - Alive
     damageCap: 179

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/terror_spiders.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/terror_spiders.yml
@@ -85,7 +85,7 @@
   - type: Speech
     speechVerb: Arachnid
     speechSounds: Arachnid
-    allowedEmotes: ['Click', 'Chitter']
+    allowedEmotes: ['Click', 'Chitter', 'Hiss']
   - type: Vocal
     sounds:
       Male: UnisexArachnid

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/terror_spiders.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/terror_spiders.yml
@@ -85,7 +85,7 @@
   - type: Speech
     speechVerb: Arachnid
     speechSounds: Arachnid
-    allowedEmotes: ['Click', 'Chitter', 'Hiss']
+    allowedEmotes: ['Click', 'Chitter', 'Hisses']
   - type: Vocal
     sounds:
       Male: UnisexArachnid


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Gives terror spiders `Xeno` and `Chittin` languages.
Also lets them hiss.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Previously they just had a `ReplacementAccent`. We can do better than that.
Obviously they get Chittin, because they are spiders. But also they are hybrids of xenomorphs.
So they get the Xeno language too, for thematic flavour.
Also they should really be able to hiss? They're SPIDERS.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- add: Terror spiders can now speak/understand Xeno and Chittin
- add: Terror spiders can now hiss
