### PR TITLE
Make mimics (sometimes) hostile, as god intended.

### DIFF
--- a/Content.Server/Antag/Mimic/MobReplacementRuleComponent.cs
+++ b/Content.Server/Antag/Mimic/MobReplacementRuleComponent.cs
@@ -11,7 +11,7 @@ public sealed partial class MobReplacementRuleComponent : Component
     // If you want more components use generics, using a whitelist would probably kill the server iterating every single entity.
 
     [DataField]
-    public EntProtoId Proto = "MobMimic";
+    public Dictionary<EntProtoId, float> Protos = new(){["MobMimic"] = 1}; // Starlight edit
 
     /// <summary>
     /// Chance per-entity.

--- a/Content.Server/Antag/MobReplacementRuleSystem.cs
+++ b/Content.Server/Antag/MobReplacementRuleSystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Antag.Mimic;
 using Content.Server.GameTicking.Rules;
 using Content.Server.GameTicking.Rules.Components;
@@ -6,6 +5,7 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.VendingMachines;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
+using System.Linq; // Starlight
 
 namespace Content.Server.Antag;
 
@@ -35,18 +35,7 @@ public sealed class MobReplacementRuleSystem : GameRuleSystem<MobReplacementRule
 
             // Starlight start
             if(component.Protos.Count == 1) Spawn(component.Protos.First().Key, coordinates);
-            else
-            {
-                var totalWeight = component.Protos.Values.Sum();
-                var roll = (float)_random.NextDouble() * totalWeight;
-                foreach (var proto in component.Protos)
-                {
-                    roll -= proto.Value;
-                    if (roll > 0) continue;
-                    Spawn(proto.Key, coordinates);
-                    break;
-                }
-            }
+            else Spawn(_random.Pick(component.Protos).Key, coordinates);
             // Starlight end
         }
     }

--- a/Content.Server/Antag/MobReplacementRuleSystem.cs
+++ b/Content.Server/Antag/MobReplacementRuleSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Antag.Mimic;
 using Content.Server.GameTicking.Rules;
 using Content.Server.GameTicking.Rules.Components;
@@ -32,7 +33,21 @@ public sealed class MobReplacementRuleSystem : GameRuleSystem<MobReplacementRule
             var coordinates = entity.Coordinates;
             Del(entity.Entity);
 
-            Spawn(component.Proto, coordinates);
+            // Starlight start
+            if(component.Protos.Count == 1) Spawn(component.Protos.First().Key, coordinates);
+            else
+            {
+                var totalWeight = component.Protos.Values.Sum();
+                var roll = (float)_random.NextDouble() * totalWeight;
+                foreach (var proto in component.Protos)
+                {
+                    roll -= proto.Value;
+                    if (roll > 0) continue;
+                    Spawn(proto.Key, coordinates);
+                    break;
+                }
+            }
+            // Starlight end
         }
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -11,7 +11,7 @@
   - type: MobMover
   - type: NpcFactionMember
     factions:
-    - SimpleHostile
+    - SimpleNeutral # Starlight edit
   - type: Sprite
     drawdepth: Mobs
     sprite: Structures/Machines/VendingMachines/cola.rsi

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -44,3 +44,12 @@
     spawned:
     - id: DrinkChangelingStingCan
       amount: 1
+
+# Starlight
+- type: entity
+  id: MobMimicHostile
+  parent: MobMimic
+  components:
+    - type: HTN
+      rootTask:
+        task: SimpleHostileCompound

--- a/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/mimic.yml
@@ -49,6 +49,7 @@
 - type: entity
   id: MobMimicHostile
   parent: MobMimic
+  suffix: Hostile
   components:
     - type: HTN
       rootTask:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -682,6 +682,11 @@
     maxOccurrences: 1 # this event has diminishing returns on interesting-ness, so we cap it
     weight: 5
   - type: MobReplacementRule
+    # Starlight start
+    protos:
+      MobMimic: 45
+      MobMimicHostile: 55
+    # Starlight end
 
 - type: entity
   id: DoorLaggingVirus


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Mimics will now have a random chance of spawning as passive or hostile. weighted 45 to 55, so hostile is a bit more common.
Also slightly updates `MobReplacementRule` to allow specifying multiple prototypes with weight values.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Mimics were, evidently, always supposed to be hostile in the first place. They have hostile faction, all they were missing was the HTN component to give them enemy AI.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
![2025-11-2923-39-07-ezgif com-crop](https://github.com/user-attachments/assets/60aee0f6-891f-4aa5-9213-d6214600529a)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- add: Added hostile mimics.
- tweak: Made so MimicVendorRule can spawn either passive or hostile mimics.