### PR TITLE
Fix the Maroon Towel

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -473,8 +473,10 @@
   effects:
   - !type:JobRequirementLoadoutEffect
     requirement:
-      !type:RoleTimeRequirement
-      role: JobLawyer
+      # !type:RoleTimeRequirement # Starlight start: switch to law dept
+      # role: JobLawyer
+      !type:DepartmentTimeRequirement
+      department: Law # Starlight end
       time: 360000 # 100hr
   storage:
     back:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes the Maroon Towel to use the Law Department instead of Lawyer playtime.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
We replaced the Lawyer job. So it's broken.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="726" height="39" alt="image" src="https://github.com/user-attachments/assets/71b649fa-eccb-487f-8dee-07d85fe6025f" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- fix: Maroon Towel is now unlockable again.
