### PR TITLE
Make borg chassis require department time instead of job time.

### DIFF
--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -63,9 +63,9 @@
 
   # Starlight-start: Requirements
   requirements:
-  - !type:RoleTimeRequirement
-    role: JobTechnicalAssistant
-    time: 3600 # 1 hour as Technical Assistant
+  - !type:DepartmentTimeRequirement
+    department: Engineering
+    time: 3600 # 1 hour in Engineering
   # Starlight-end
 
 
@@ -104,9 +104,9 @@
 
   # Starlight-start: Requirements
   requirements:
-  - !type:RoleTimeRequirement
-    role: JobCargoTechnician
-    time: 5400 # 1 hour 30 minutes as Cargo Technician
+  - !type:DepartmentTimeRequirement
+    department: Cargo
+    time: 5400 # 1 hour 30 minutes in Cargo
   # Starlight-end
 
 
@@ -191,9 +191,9 @@
 
   # Starlight-start: Requirements
   requirements:
-  - !type:RoleTimeRequirement
-    role: JobMedicalIntern
-    time: 3600 # 1 hour as Medical Intern
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 3600 # 1 hour in medical
   # Starlight-end
 
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Changes the requirements for the medical, mining, and engi borgs to use department time requirements instead of job time requirements.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Somehow, unsure how but somehow, probably via time transfer or something, you can get permanently locked out of a borg chassis type if you manage to unlock the rest of a department, and the assistant role for that department becomes locked, and you don't have the required time. e.g., Essandra (Bug-Mush) somehow had zero hours as medical intern, could not play as medical intern again, and was locked out of the medical chassis.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Fixed borg chassis types using job time requirements instead of department time requirements.