### PR TITLE
Magenta Alert

### DIFF
--- a/Resources/Locale/en-US/_Starlight/alert-levels/alert-levels.ftl
+++ b/Resources/Locale/en-US/_Starlight/alert-levels/alert-levels.ftl
@@ -9,3 +9,7 @@ alert-level-psi-instructions = Avoid Hostile Cyborgs.
 alert-level-orange = Orange
 alert-level-orange-announcement = There is a critical station-wide structural or atmospheric threat and recovery is unlikely. Engineering staff are advised to minimize hazards and secure the Evacuation Dock. Crewmembers are advised to stay away from hazardous areas, and prepare for probable Evacuation.
 alert-level-orange-instructions = Avoid hazards and prepare for Evacuation.
+
+alert-level-magenta = Magenta
+alert-level-magenta-announcement = There is a confirmed threat onboard the station that endangers a large portion of the crew. Security should prepare to use force if required.
+alert-level-magenta-instructions = Crewmembers should find a safe place to shelter in, and are advised to follow any present authorities.

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -105,4 +105,12 @@
       emergencyLightColor: "#ff8119"
       forceEnableEmergencyLights: true
       shuttleTime: 600
+    magenta:
+      announcement: alert-level-magenta-announcement
+      selectable: true
+      sound: /Audio/Misc/notice1.ogg
+      color: Magenta
+      emergencyLightColor: Magenta
+      forceEnableEmergencyLights: true
+      shuttleTime: 600
       # end starlight

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -119,6 +119,7 @@
       - !type:AlertLevelCondition
         alertLevels:
         - blue
+        - magenta
         - red
         - gamma
         - psi
@@ -195,6 +196,7 @@
       - !type:AlertLevelCondition
         alertLevels:
         - blue
+        - magenta
         - violet
         - yellow
         - red
@@ -210,6 +212,7 @@
         alertLevels:
         - violet
         - yellow
+        - magenta
         - red
         - gamma
         - psi


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a new alert, Magenta, intended to bridge the gap between Blue and Red.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
A lot of the time, a threat is significant enough that Blue isn't the right alert, but it isn't bad for Red just yet.
This is intended to bridge the gap and be used in those situations.
Ideally, security SOP on Magenta should allow for "medium" weaponry (rifles, lasers, and SMGs) but not shotguns or the LMG, for example.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="433" height="79" alt="image" src="https://github.com/user-attachments/assets/864ac923-d695-4cf2-b11f-c2f340435a1e" />
<img width="537" height="297" alt="image" src="https://github.com/user-attachments/assets/6be3b90f-1d47-4d92-960f-f565a6191b1b" />



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- add: Magenta Alert, intended to bridge the gap between Blue and Red.
