### PR TITLE
Make loadout pens start in PDAs quietly

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -175,6 +175,24 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
 
         SetupCybernetics(entity.Value, profile?.Cybernetics ?? []); // Starlight
 
+        // Starlight begin
+        if (loadout != null && prototype?.StartingGear != null)
+        {
+            var startingGear = _prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear);
+            StarlightEquipRoleLoadout(entity.Value, loadout, [startingGear], roleProto!);
+        }
+        else if (loadout != null)
+        {
+            StarlightEquipRoleLoadout(entity.Value, loadout, [], roleProto!);
+        }
+        else if (prototype?.StartingGear != null)
+        {
+            var startingGear = _prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear);
+            EquipStartingGear(entity.Value, startingGear, raiseEvent: false);
+        }
+        // Starlight end
+
+        /* Starlight - add comment
         if (loadout != null)
         {
             EquipRoleLoadout(entity.Value, loadout, roleProto!);
@@ -185,6 +203,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
             var startingGear = _prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear);
             EquipStartingGear(entity.Value, startingGear, raiseEvent: false);
         }
+        */ // Starlight - add end of comment
 
         var gearEquippedEv = new StartingGearEquippedEvent(entity.Value);
         RaiseLocalEvent(entity.Value, ref gearEquippedEv);

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -176,14 +176,10 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
         SetupCybernetics(entity.Value, profile?.Cybernetics ?? []); // Starlight
 
         // Starlight begin
-        if (loadout != null && prototype?.StartingGear != null)
+        if (loadout != null)
         {
-            var startingGear = _prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear);
-            StarlightEquipRoleLoadout(entity.Value, loadout, [startingGear], roleProto!);
-        }
-        else if (loadout != null)
-        {
-            StarlightEquipRoleLoadout(entity.Value, loadout, [], roleProto!);
+            var startingGear = prototype?.StartingGear != null ? [_prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear)] : [];
+            StarlightEquipRoleLoadout(entity.Value, loadout, startingGear, roleProto!);
         }
         else if (prototype?.StartingGear != null)
         {

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -175,10 +175,11 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
 
         SetupCybernetics(entity.Value, profile?.Cybernetics ?? []); // Starlight
 
-        // Starlight begin
+        // Starlight begin - we try to do a unified load of loadout and startinggear in one shot to
+        // make it more consistent and equip things in a more effective order.
         if (loadout != null)
         {
-            var startingGear = prototype?.StartingGear != null ? [_prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear)] : [];
+            var startingGear = prototype?.StartingGear != null ? [_prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear)] : Array.Empty<IEquipmentLoadout>();
             StarlightEquipRoleLoadout(entity.Value, loadout, startingGear, roleProto!);
         }
         else if (prototype?.StartingGear != null)

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -290,7 +290,8 @@ namespace Content.Shared.Containers.ItemSlots
             ItemSlot slot,
             EntityUid item,
             EntityUid? user,
-            bool excludeUserAudio = false)
+            bool excludeUserAudio = false, // Starlight-edit - extend argument list
+            bool suppressSound = false) // Starlight - add suppressSound parameter
         {
             bool? inserted = slot.ContainerSlot != null ? _containers.Insert(item, slot.ContainerSlot) : null;
             // ContainerSlot automatically raises a directed EntInsertedIntoContainerMessage
@@ -300,6 +301,13 @@ namespace Content.Shared.Containers.ItemSlots
                 _adminLogger.Add(LogType.Action,
                     LogImpact.Low,
                     $"{ToPrettyString(user.Value)} inserted {ToPrettyString(item)} into {slot.ContainerSlot?.ID + " slot of "}{ToPrettyString(uid)}");
+
+            // Starlight start - support suppressing generation of sounds
+            if (suppressSound)
+            {
+                return;
+            }
+            // Starlight end
 
             _audioSystem.PlayPredicted(slot.InsertSound, uid, excludeUserAudio ? user : null);
         }
@@ -373,12 +381,13 @@ namespace Content.Shared.Containers.ItemSlots
             ItemSlot slot,
             EntityUid item,
             EntityUid? user,
-            bool excludeUserAudio = false)
+            bool excludeUserAudio = false, // Starlight-edit - extend argument list
+            bool suppressSound = false) // Starlight - add suppressSound parameter
         {
             if (!CanInsert(uid, item, user, slot))
                 return false;
 
-            Insert(uid, slot, item, user, excludeUserAudio: excludeUserAudio);
+            Insert(uid, slot, item, user, excludeUserAudio: excludeUserAudio, suppressSound); // Starlight-edit - pass through suppressSound
             return true;
         }
 
@@ -420,11 +429,13 @@ namespace Content.Shared.Containers.ItemSlots
         ///     If true, will exclude the user when playing sound. Does nothing client-side.
         ///     Useful for predicted interactions
         /// </param>
+        /// <param name="suppressSound">Prevent any audio from being generated for this operation</param> // Starlight
         /// <returns>False if failed to insert item</returns>
         public bool TryInsertEmpty(Entity<ItemSlotsComponent?> ent,
             EntityUid item,
             EntityUid? user,
-            bool excludeUserAudio = false)
+            bool excludeUserAudio = false, // Starlight-edit - extend argument list
+            bool suppressSound = false) // Starlight - add suppressSound parameter
         {
             if (!Resolve(ent, ref ent.Comp, false))
                 return false;
@@ -439,7 +450,7 @@ namespace Content.Shared.Containers.ItemSlots
             if (user != null && !_handsSystem.TryDrop(user.Value, item))
                 return false;
 
-            Insert(ent, itemSlot, item, user, excludeUserAudio: excludeUserAudio);
+            Insert(ent, itemSlot, item, user, excludeUserAudio: excludeUserAudio, suppressSound); // Starlight-edit - pass through suppressSound
             return true;
         }
 
@@ -544,7 +555,7 @@ namespace Content.Shared.Containers.ItemSlots
         /// <param name="excludeUserAudio">If true, will exclude the user when playing sound. Does nothing client-side.
         /// Useful for predicted interactions</param>
         private void Eject(EntityUid uid, ItemSlot slot, EntityUid item, EntityUid? user, bool excludeUserAudio = false, // Starlight-edit - extend argument list
-                EntityCoordinates? destination = null) // Starlight - add destination parameter
+                EntityCoordinates? destination = null, bool suppressSound = false) // Starlight - add destination and suppressSound parameters
         {
             bool? ejected = slot.ContainerSlot != null ? _containers.Remove(item, slot.ContainerSlot, destination: destination) : null; // Starlight-edit - pass through destination
             // ContainerSlot automatically raises a directed EntRemovedFromContainerMessage
@@ -555,6 +566,12 @@ namespace Content.Shared.Containers.ItemSlots
                     LogImpact.Low,
                     $"{ToPrettyString(user.Value)} ejected {ToPrettyString(item)} from {slot.ContainerSlot?.ID + " slot of "}{ToPrettyString(uid)}");
 
+            // Starlight start - support suppressing generation of sounds
+            if (suppressSound)
+            {
+                return;
+            }
+            // Starlight end
             _audioSystem.PlayPredicted(slot.EjectSound, uid, excludeUserAudio ? user : null);
         }
 
@@ -566,8 +583,9 @@ namespace Content.Shared.Containers.ItemSlots
             ItemSlot slot,
             EntityUid? user,
             [NotNullWhen(true)] out EntityUid? item,
-            bool excludeUserAudio = false, // Starlight-edit - extend argument list
-            EntityCoordinates? destination = null) // Starlight - add destination parameter
+            bool excludeUserAudio = false, // Starlight start - extend argument list, add destination and suppressSound
+            EntityCoordinates? destination = null,
+            bool suppressSound = false) // Starlight end
         {
             item = null;
 
@@ -581,7 +599,7 @@ namespace Content.Shared.Containers.ItemSlots
             if (user != null && item != null && !_actionBlockerSystem.CanPickup(user.Value, item.Value, showPopup: true))
                 return false;
 
-            Eject(uid, slot, item!.Value, user, excludeUserAudio, destination); // Starlight-edit - pass through destination
+            Eject(uid, slot, item!.Value, user, excludeUserAudio, destination, suppressSound); // Starlight-edit - pass through destination and suppressSound
             return true;
         }
 

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Whitelist;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Map; // Starlight
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Containers.ItemSlots
@@ -451,12 +452,14 @@ namespace Content.Shared.Containers.ItemSlots
         /// <param name="itemSlot">The ItemSlot on <paramref name="ent"/> to insert <paramref name="item"/> into.</param>
         /// <param name="emptyOnly"> True only returns slots that are empty.
         /// False returns any slot that is able to receive <paramref name="item"/>.</param>
+        /// <param name="allowSwap">Allow finding slots where insertion requires a swap</param> // Starlight
         /// <returns>True when a slot is found. Otherwise, false.</returns>
         public bool TryGetAvailableSlot(Entity<ItemSlotsComponent?> ent,
             EntityUid item,
             Entity<HandsComponent?>? userEnt,
             [NotNullWhen(true)] out ItemSlot? itemSlot,
-            bool emptyOnly = false)
+            bool emptyOnly = false, // Starlight-edit - change to second-to-last parameter
+            bool allowSwap = false) // Starlight - add parameter
         {
             itemSlot = null;
 
@@ -477,7 +480,7 @@ namespace Content.Shared.Containers.ItemSlots
                 if (emptyOnly && slot.ContainerSlot?.ContainedEntity != null)
                     continue;
 
-                if (CanInsert(ent, item, userEnt, slot))
+                if (CanInsert(ent, item, userEnt, slot, allowSwap)) //Starlight - add allowSwap parameter
                     slots.Add(slot);
             }
 
@@ -540,9 +543,10 @@ namespace Content.Shared.Containers.ItemSlots
         /// </summary>
         /// <param name="excludeUserAudio">If true, will exclude the user when playing sound. Does nothing client-side.
         /// Useful for predicted interactions</param>
-        private void Eject(EntityUid uid, ItemSlot slot, EntityUid item, EntityUid? user, bool excludeUserAudio = false)
+        private void Eject(EntityUid uid, ItemSlot slot, EntityUid item, EntityUid? user, bool excludeUserAudio = false, // Starlight-edit - extend argument list
+                EntityCoordinates? destination = null) // Starlight - add destination parameter
         {
-            bool? ejected = slot.ContainerSlot != null ? _containers.Remove(item, slot.ContainerSlot) : null;
+            bool? ejected = slot.ContainerSlot != null ? _containers.Remove(item, slot.ContainerSlot, destination: destination) : null; // Starlight-edit - pass through destination
             // ContainerSlot automatically raises a directed EntRemovedFromContainerMessage
 
             // Logging
@@ -562,7 +566,8 @@ namespace Content.Shared.Containers.ItemSlots
             ItemSlot slot,
             EntityUid? user,
             [NotNullWhen(true)] out EntityUid? item,
-            bool excludeUserAudio = false)
+            bool excludeUserAudio = false, // Starlight-edit - extend argument list
+            EntityCoordinates? destination = null) // Starlight - add destination parameter
         {
             item = null;
 
@@ -576,7 +581,7 @@ namespace Content.Shared.Containers.ItemSlots
             if (user != null && item != null && !_actionBlockerSystem.CanPickup(user.Value, item.Value, showPopup: true))
                 return false;
 
-            Eject(uid, slot, item!.Value, user, excludeUserAudio);
+            Eject(uid, slot, item!.Value, user, excludeUserAudio, destination); // Starlight-edit - pass through destination
             return true;
         }
 

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared.Containers.ItemSlots; // Starlight
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory;
@@ -8,6 +9,7 @@ using Content.Shared.Roles;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Collections;
+using Robust.Shared.Map; // Starlight
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
@@ -23,11 +25,13 @@ public abstract class SharedStationSpawningSystem : EntitySystem
     [Dependency] private readonly MetaDataSystem _metadata = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
+    [Dependency] private readonly ItemSlotsSystem _itemSlots = default!; // Starlight
 
     private EntityQuery<HandsComponent> _handsQuery;
     private EntityQuery<InventoryComponent> _inventoryQuery;
     private EntityQuery<StorageComponent> _storageQuery;
     private EntityQuery<TransformComponent> _xformQuery;
+    private EntityQuery<ItemSlotsComponent> _itemSlotsQuery; // Starlight
 
     public override void Initialize()
     {
@@ -36,6 +40,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         _inventoryQuery = GetEntityQuery<InventoryComponent>();
         _storageQuery = GetEntityQuery<StorageComponent>();
         _xformQuery = GetEntityQuery<TransformComponent>();
+        _itemSlotsQuery = GetEntityQuery<ItemSlotsComponent>(); // Starlight
     }
 
     /// <summary>
@@ -43,6 +48,14 @@ public abstract class SharedStationSpawningSystem : EntitySystem
     /// </summary>
     public void EquipRoleLoadout(EntityUid entity, RoleLoadout loadout, RoleLoadoutPrototype roleProto)
     {
+        // Starlight start
+        if (StarlightEquipRoleLoadout(entity, loadout, [], roleProto))
+        {
+            EquipRoleName(entity, loadout, roleProto);
+            return;
+        }
+        // Starlight end
+
         // Order loadout selections by the order they appear on the prototype.
         foreach (var group in loadout.SelectedLoadouts.OrderBy(x => roleProto.Groups.FindIndex(e => e == x.Key)))
         {
@@ -170,6 +183,21 @@ public abstract class SharedStationSpawningSystem : EntitySystem
                         _storage.Insert(slotEnt.Value, spawnedEntity, out _, storageComp: storage, playSound: false);
                     }
                 }
+                // Starlight start
+                else if (inventoryComp != null &&
+                    InventorySystem.TryGetSlotEntity(entity, slotName, out var slotEnt2, inventoryComponent: inventoryComp) &&
+                    _itemSlotsQuery.TryComp(slotEnt2, out var itemSlots))
+                {
+
+                    foreach (var entProto in entProtos)
+                    {
+                        var spawnedEntity = Spawn(entProto, coords);
+                        // Because we need an Entity<ItemSlotsComponent?>
+                        Entity<ItemSlotsComponent?> typed = (slotEnt2.Value, itemSlots);
+                        InsertIntoItemSlots(typed, spawnedEntity);
+                    }
+                }
+                // Starlight end
             }
         }
 
@@ -209,4 +237,154 @@ public abstract class SharedStationSpawningSystem : EntitySystem
 
         return null;
     }
+
+    // Starlight start
+    /// <summary>
+    /// A variant on the role loadout equip process that tries to be more deliberate about equipping
+    /// characters in the correct order to satisfy requirements (e.g. bags before contents).
+    /// </summary>
+    /// <param name="entity">The entity being equipped</param>
+    /// <param name="loadout">The loadout being equipped to the entity</param>
+    /// <param name="otherStartingGear">Other starting gear not listed in the role loadout</param>
+    /// <param name="roleProto">The base definition for the role</param>
+    /// <returns>true on success, false on failure</returns>
+    public bool StarlightEquipRoleLoadout(EntityUid entity, RoleLoadout loadout, IEnumerable<IEquipmentLoadout> otherStartingGear, RoleLoadoutPrototype roleProto)
+    {
+        List<IEquipmentLoadout> allStartingGear = new();
+
+        // Order loadout selections by the order they appear on the prototype.
+        // We're going to process the loadout entries in this order in each of the three passes.
+        foreach (var group in loadout.SelectedLoadouts.OrderBy(x => roleProto.Groups.FindIndex(e => e == x.Key)))
+        {
+            foreach (var items in group.Value)
+            {
+                if (!PrototypeManager.TryIndex(items.Prototype, out var loadoutProto))
+                {
+                    Log.Error($"Unable to find loadout prototype for {items.Prototype}");
+                    continue;
+                }
+
+                if (loadoutProto.StartingGear is not null) {
+                    PrototypeManager.Resolve(loadoutProto.StartingGear, out var gearProto);
+                    if (gearProto is IEquipmentLoadout equipmentProto) {
+                        allStartingGear.Add(equipmentProto);
+                    }
+                }
+                allStartingGear.Add(loadoutProto);
+            }
+        }
+
+        allStartingGear.AddRange(otherStartingGear);
+
+        var xform = _xformQuery.GetComponent(entity);
+        var coords = xform.Coordinates;
+
+        // Do three passes:
+        // 1. Add any equipment
+        // 2. Insert items into hands
+        // 3. Insert items into storages
+        // This avoids issues where the normal code may process a loadoutprototype that adds an equipment
+        // with storage after a loadoutprototype that tries to use that storage.
+
+        if (InventorySystem.TryGetSlots(entity, out var slotDefinitions))
+        {
+            foreach (var startingGear in allStartingGear) {
+                foreach (var slot in slotDefinitions)
+                {
+                    var equipmentStr = startingGear.GetGear(slot.Name);
+                    if (!string.IsNullOrEmpty(equipmentStr))
+                    {
+                        var equipmentEntity = Spawn(equipmentStr, xform.Coordinates);
+                        InventorySystem.TryEquip(entity, equipmentEntity, slot.Name, silent: true, force: true);
+                    }
+                }
+            }
+        }
+
+        if (_handsQuery.TryComp(entity, out var handsComponent))
+        {
+            foreach (var startingGear in allStartingGear) {
+                var inhand = startingGear.Inhand;
+                foreach (var prototype in inhand)
+                {
+                    var inhandEntity = Spawn(prototype, coords);
+
+                    if (_handsSystem.TryGetEmptyHand((entity, handsComponent), out var emptyHand))
+                    {
+                        _handsSystem.TryPickup(entity, inhandEntity, emptyHand, checkActionBlocker: false, handsComp: handsComponent);
+                    }
+                }
+            }
+        }
+
+        _inventoryQuery.TryComp(entity, out var inventoryComp);
+
+        foreach (var startingGear in allStartingGear)
+        {
+            foreach (var (slotName, entProtos) in startingGear.Storage)
+            {
+                if (entProtos == null || entProtos.Count == 0)
+                    continue;
+
+                if (inventoryComp != null &&
+                    InventorySystem.TryGetSlotEntity(entity, slotName, out var slotEnt, inventoryComponent: inventoryComp) &&
+                    _storageQuery.TryComp(slotEnt, out var storage))
+                {
+                    foreach (var entProto in entProtos)
+                    {
+                        var spawnedEntity = Spawn(entProto, coords);
+
+                        _storage.Insert(slotEnt.Value, spawnedEntity, out _, storageComp: storage, playSound: false);
+                    }
+                }
+                else if (inventoryComp != null &&
+                    InventorySystem.TryGetSlotEntity(entity, slotName, out var slotEnt2, inventoryComponent: inventoryComp) &&
+                    _itemSlotsQuery.TryComp(slotEnt2, out var itemSlots))
+                {
+
+                    foreach (var entProto in entProtos)
+                    {
+                        var spawnedEntity = Spawn(entProto, coords);
+                        // Because we need an Entity<ItemSlotsComponent?>
+                        Entity<ItemSlotsComponent?> typed = (slotEnt2.Value, itemSlots);
+                        InsertIntoItemSlots(typed, spawnedEntity);
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    private void InsertIntoItemSlots(Entity<ItemSlotsComponent?> typed, EntityUid entity) {
+        bool foundEmpty = _itemSlots.TryInsertEmpty(typed, entity, null, true);
+
+        if (!foundEmpty)
+        {
+            // Since we're not filling in an empty slot, try to stack
+            bool foundSlot = _itemSlots.TryGetAvailableSlot(typed, entity, null, out var writeSlot, false, false);
+            if (foundSlot)
+            {
+                _itemSlots.TryInsert(typed, writeSlot!, entity, null, false);
+            }
+            else
+            {
+                // We can't stack - go for a swap instead, and we'll delete the removed item
+                foundSlot = _itemSlots.TryGetAvailableSlot(typed, entity, null, out var writeSlotSwap, false, true);
+                if (foundSlot)
+                {
+                    var xform = _xformQuery.GetComponent(entity);
+                    // If we don't specify that we're ejecting it to invalid coordinates, then
+                    // when demo entities are loaded for the profile view in testing we'll try
+                    // to eject into a nonexistent map coordinate space, which fails the test.
+                    var gotDeletable = _itemSlots.TryEject(typed, writeSlotSwap!, null, out var removedItem, false, xform.Coordinates);
+                    if (gotDeletable)
+                    {
+                        QueueDel(removedItem);
+                    }
+                    _itemSlots.TryInsert(typed, writeSlotSwap!, entity, null, false);
+                }
+            }
+        }
+    }
+    // Starlight end
 }

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -356,32 +356,32 @@ public abstract class SharedStationSpawningSystem : EntitySystem
     }
 
     private void InsertIntoItemSlots(Entity<ItemSlotsComponent?> typed, EntityUid entity) {
-        bool foundEmpty = _itemSlots.TryInsertEmpty(typed, entity, null, true);
+        bool foundEmpty = _itemSlots.TryInsertEmpty(typed, entity, null, excludeUserAudio: true, suppressSound: true);
 
         if (!foundEmpty)
         {
             // Since we're not filling in an empty slot, try to stack
-            bool foundSlot = _itemSlots.TryGetAvailableSlot(typed, entity, null, out var writeSlot, false, false);
+            bool foundSlot = _itemSlots.TryGetAvailableSlot(typed, entity, null, out var writeSlot, emptyOnly: false, allowSwap: false);
             if (foundSlot)
             {
-                _itemSlots.TryInsert(typed, writeSlot!, entity, null, false);
+                _itemSlots.TryInsert(typed, writeSlot!, entity, null, excludeUserAudio: true, suppressSound: true);
             }
             else
             {
                 // We can't stack - go for a swap instead, and we'll delete the removed item
-                foundSlot = _itemSlots.TryGetAvailableSlot(typed, entity, null, out var writeSlotSwap, false, true);
+                foundSlot = _itemSlots.TryGetAvailableSlot(typed, entity, null, out var writeSlotSwap, emptyOnly: false, allowSwap: true);
                 if (foundSlot)
                 {
                     var xform = _xformQuery.GetComponent(entity);
                     // If we don't specify that we're ejecting it to invalid coordinates, then
                     // when demo entities are loaded for the profile view in testing we'll try
                     // to eject into a nonexistent map coordinate space, which fails the test.
-                    var gotDeletable = _itemSlots.TryEject(typed, writeSlotSwap!, null, out var removedItem, false, xform.Coordinates);
+                    var gotDeletable = _itemSlots.TryEject(typed, writeSlotSwap!, null, out var removedItem, excludeUserAudio: true, xform.Coordinates, suppressSound: true);
                     if (gotDeletable)
                     {
                         QueueDel(removedItem);
                     }
-                    _itemSlots.TryInsert(typed, writeSlotSwap!, entity, null, false);
+                    _itemSlots.TryInsert(typed, writeSlotSwap!, entity, null, excludeUserAudio: true, suppressSound: true);
                 }
             }
         }

--- a/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
@@ -54,4 +54,6 @@ loadout-group-salvage-id = Salvage Specialist ID
 loadout-group-salvage-lead-mantle = Salvage Lead mantle 
 
 # Other
+
 loadout-group-scarves = Scarf
+loadout-group-pens = Pen

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -75,7 +75,6 @@
   - GoldRing #SL
   - SilverRing #SL
   - Matchbox #SL
-  - FancyPen #SL
   - HonkImplant #SL
   - TromboneImplant #SL
   - NewtonsCradle #SL

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -12,6 +12,7 @@
   - SurvivalExtended
   - Trinkets
   - Scarves # Starlight
+  - CapPens # Starlight
   - CaptainJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -29,6 +30,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - HoPPens # Starlight
   - HoPJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -60,6 +62,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - AssistantJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -76,6 +79,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - BartenderJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -90,6 +94,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ServiceWorkerJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -107,6 +112,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ChefJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -121,6 +127,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - LuxuryPens # Starlight
   - LibrarianJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -135,6 +142,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - LuxuryPens # Starlight
   - LawyerJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -154,6 +162,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ChaplainJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -170,6 +179,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - JanitorJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -186,6 +196,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - BotanistJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -203,6 +214,7 @@
   - SurvivalClown
   - Trinkets
   - Scarves # Starlight
+  - ClownPens # Starlight
   - ClownJobTrinkets
 
 - type: roleLoadout
@@ -220,6 +232,7 @@
   - SurvivalMime
   - Trinkets
   - Scarves # Starlight
+  - MimePens # Starlight
   - MimeJobTrinkets
 
 - type: roleLoadout
@@ -235,6 +248,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - MusicianJobTrinkets
   - Instruments
   - GroupSpeciesBreathTool
@@ -254,6 +268,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - QuartermasterJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -271,6 +286,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - CargoTechnicianJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -287,6 +303,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - SalvageSpecialistJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -304,6 +321,7 @@
   - SurvivalExtended
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ChiefEngineerJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -316,6 +334,7 @@
   - SurvivalExtended
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - TechnicalAssistantJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -332,6 +351,7 @@
   - SurvivalExtended
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - StationEngineerJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -346,6 +366,7 @@
   - SurvivalExtended
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - AtmosphericTechnicianJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -365,6 +386,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ResearchDirectorJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -384,6 +406,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ScientistJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -397,6 +420,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ResearchAssistantJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -416,6 +440,7 @@
   - SurvivalSecurity
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - HeadofSecurityJobTrinkets
   - GroupSpeciesBreathToolSecurity
 
@@ -432,6 +457,7 @@
   - SurvivalSecurity
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - WardenJobTrinkets
   - GroupSpeciesBreathToolSecurity
 
@@ -451,6 +477,7 @@
   - SurvivalSecurity
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - SecurityJobTrinkets
   - GroupSpeciesBreathToolSecurity
 
@@ -467,6 +494,7 @@
   - SurvivalSecurity
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - DetectiveJobTrinkets
   - GroupSpeciesBreathToolSecurity
 
@@ -480,6 +508,7 @@
   - SurvivalSecurity
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - SecurityCadetJobTrinkets
   - GroupSpeciesBreathToolSecurity
 
@@ -500,6 +529,7 @@
   - SurvivalMedical
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ChiefMedicalOfficerJobTrinkets
   - GroupSpeciesBreathToolMedical
 
@@ -519,6 +549,7 @@
   - SurvivalMedical
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - MedicalDoctorJobTrinkets
   - GroupSpeciesBreathToolMedical
 
@@ -532,6 +563,7 @@
   - SurvivalMedical
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - MedicalInternJobTrinkets
   - GroupSpeciesBreathToolMedical
 
@@ -548,6 +580,7 @@
   - SurvivalMedical
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ChemistJobTrinkets
   - GroupSpeciesBreathToolMedical
 
@@ -566,6 +599,7 @@
   - SurvivalMedical
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ParamedicJobTrinkets
   - GroupSpeciesBreathToolMedical
 
@@ -580,6 +614,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - ZookeeperJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -594,6 +629,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - LuxuryPens # Starlight
   - ReporterJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -608,6 +644,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - PsychologistJobTrinkets
   - GroupSpeciesBreathTool
 
@@ -622,6 +659,7 @@
   - Survival
   - Trinkets
   - Scarves # Starlight
+  - Pens # Starlight
   - BoxerJobTrinkets
   - GroupSpeciesBreathTool
 

--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/pens.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/pens.yml
@@ -1,0 +1,59 @@
+- type: loadout
+  id: Pen
+  storage:
+    id:
+      - Pen
+
+- type: loadout
+  id: FancyPen
+  effects:
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:RoleTimeRequirement
+        role: JobLibrarian
+        time: 3600 # 1 hour of reading books (a fate worse than death)
+  storage:
+    id:
+      - LuxuryPen
+
+- type: loadout
+  id: FancyPenNoReq
+  storage:
+    id:
+      - LuxuryPen
+
+- type: loadout
+  id: PenHop
+  storage:
+    id:
+      - PenHop
+
+- type: loadout
+  id: PenCap
+  storage:
+    id:
+      - PenCap
+
+- type: loadout
+  id: PenNTR
+  storage:
+    id:
+      - PenNTR
+
+- type: loadout
+  id: PenCentcom
+  storage:
+    id:
+      - PenCentcom
+
+- type: loadout
+  id: CrayonOrange
+  storage:
+    id:
+      - CrayonOrange
+
+- type: loadout
+  id: CrayonMime
+  storage:
+    id:
+      - CrayonMime

--- a/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Miscellaneous/trinkets.yml
@@ -155,18 +155,6 @@
   groupBy: "smokeables"
 
 - type: loadout
-  id: FancyPen
-  effects:
-    - !type:JobRequirementLoadoutEffect
-      requirement:
-        !type:RoleTimeRequirement
-        role: JobLibrarian
-        time: 3600 # 1 hour of reading books (a fate worse than death)
-  storage:
-    back:
-      - LuxuryPen
-
-- type: loadout
   id: HonkImplant
   effects:
     - !type:JobRequirementLoadoutEffect

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -25,6 +25,76 @@
   - ScarfPrideLongBacon
 
 - type: loadoutGroup
+  id: Pens
+  name: loadout-group-pens
+  minLimit: 1
+  loadouts:
+  - Pen
+  - FancyPen
+
+- type: loadoutGroup
+  id: ClownPens
+  name: loadout-group-pens
+  minLimit: 1
+  loadouts:
+  - CrayonOrange
+  - Pen
+  - FancyPen
+
+- type: loadoutGroup
+  id: MimePens
+  name: loadout-group-pens
+  minLimit: 1
+  loadouts:
+  - CrayonMime
+  - Pen
+  - FancyPen
+
+- type: loadoutGroup
+  id: LuxuryPens
+  name: loadout-group-pens
+  minLimit: 1
+  loadouts:
+  - FancyPenNoReq
+  - Pen
+
+- type: loadoutGroup
+  id: HoPPens
+  name: loadout-group-pens
+  minLimit: 1
+  loadouts:
+  - PenHop
+  - Pen
+  - FancyPen
+
+- type: loadoutGroup
+  id: CapPens
+  name: loadout-group-pens
+  minLimit: 1
+  loadouts:
+  - PenCap
+  - Pen
+  - FancyPen
+
+- type: loadoutGroup
+  id: NTRPens
+  name: loadout-group-pens
+  minLimit: 1
+  loadouts:
+  - PenNTR
+  - Pen
+  - FancyPen
+
+- type: loadoutGroup
+  id: CCPens
+  name: loadout-group-pens
+  minLimit: 1
+  loadouts:
+  - PenCentcom
+  - Pen
+  - FancyPen
+
+- type: loadoutGroup
   id: AssistantGlasses
   name: loadout-group-assistant-glasses
   minLimit: 0

--- a/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
@@ -11,6 +11,7 @@
   - Survival
   - Trinkets
   - Scarves
+  - Pens
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -21,6 +22,7 @@
   - Survival
   - Trinkets
   - Scarves
+  - LuxuryPens
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -39,6 +41,7 @@
   - SurvivalMedical
   - Trinkets
   - Scarves
+  - Pens
   - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
@@ -51,6 +54,7 @@
   - NanotrasenRepresentativeShoes
   - Trinkets
   - Scarves
+  - NTRPens
   - Survival
   - GroupSpeciesBreathTool
 
@@ -63,6 +67,7 @@
   - LawyerShoes
   - Trinkets
   - Scarves
+  - LuxuryPens
   - Survival
   - GroupSpeciesBreathTool
 
@@ -78,6 +83,7 @@
   - BlueShieldEyewear
   - Trinkets
   - Scarves
+  - Pens
   - SurvivalSecurity
   - GroupSpeciesBreathToolSecurity
 
@@ -94,6 +100,7 @@
   - Survival
   - Trinkets
   - Scarves
+  - Pens
   - GroupSpeciesBreathTool
 
 - type: roleLoadout
@@ -109,6 +116,7 @@
   - Survival
   - Trinkets
   - Scarves
+  - Pens
   - GroupSpeciesBreathTool
 
 - type: roleLoadout


### PR DESCRIPTION
## Short description
This saves a little bit of fiddling on roundstart with moving a luxury pen into your PDA and dropping the base pen somewhere else. Additionally, there's a bit of supporting framework in this PR that should make it easier to add more such loadout items that fill in itemslots.

As a drive-by edit, this updates the default pen for the Magistrate and the IAA to LuxuryPen. The IAA is the replacement for the Lawyer, who upstream start with the Luxury Pen, and the Magistrate should have at least as fancy a pen.

As an additional bonus, this re-application of a reverted PR fixes the issue where you'd get sounds from items being added to and removed from PDAs constantly as the previews in your menus update.

## Why we need to add this
It's slightly more convenient, and would support us adding other such loadout items that start loaded into itemslots in your other loadout gear (e.g. a cartridge loaded at roundstart in your PDA).

## Media (Video/Screenshots)
<img width="422" height="256" alt="image" src="https://github.com/user-attachments/assets/93645f66-b010-44a8-b9e1-fa0b4dd42e5d" />
<img width="703" height="188" alt="image" src="https://github.com/user-attachments/assets/0d60263c-2386-44a2-acda-ab4151f60a5f" />
<img width="711" height="349" alt="image" src="https://github.com/user-attachments/assets/ab95432d-e1a6-4a1a-b7d4-b41197b59478" />
<img width="706" height="298" alt="image" src="https://github.com/user-attachments/assets/218317f9-6957-46cf-83a9-196ba009da6c" />

## Checks

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- tweak: The Luxury Pen trinket has been moved to its own trinket category, and is now a selectable option that will start in your PDA.