### PR TITLE
Updates/fixes for midround stations

### DIFF
--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -36,6 +36,8 @@ using Robust.Shared.Random;
 using Robust.Shared.Spawners;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Server._Starlight.Station; // Starlight
+using Content.Shared.Station.Components; // Starlight
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -95,6 +97,7 @@ public sealed class ArrivalsSystem : EntitySystem
         SubscribeLocalEvent<PlayerSpawningEvent>(HandlePlayerSpawning, before: new []{ typeof(SpawnPointSystem)}, after: new [] { typeof(ContainerSpawnPointSystem)});
 
         SubscribeLocalEvent<StationArrivalsComponent, StationPostInitEvent>(OnStationPostInit);
+        SubscribeLocalEvent<StationArrivalsComponent, ComponentShutdown>(OnStationShutdown); // Starlight
 
         SubscribeLocalEvent<ArrivalsShuttleComponent, ComponentStartup>(OnShuttleStartup);
         SubscribeLocalEvent<ArrivalsShuttleComponent, FTLTagEvent>(OnShuttleTag);
@@ -584,10 +587,26 @@ public sealed class ArrivalsSystem : EntitySystem
     {
         if (!Enabled)
             return;
+        
+        // Starlight start
+        if (TryComp<StationDataComponent>(uid, out var station))
+            foreach (var grid in station.Grids)
+            {
+                if (!TryComp<BecomesStationMidRoundComponent>(grid, out var becomesStation)) continue;
+                if (!becomesStation.UseArrivals)
+                    return;
+                break; // can break, we already found the grid that created this station
+            }
+        // Starlight end
 
         // If it's a latespawn station then this will fail but that's okey
         SetupShuttle(uid, component);
     }
+
+    //Starlight start
+    private void OnStationShutdown(EntityUid uid, StationArrivalsComponent component, ref ComponentShutdown ev) =>
+        QueueDel(component.Shuttle);
+    //Starlight end
 
     private void SetupShuttle(EntityUid uid, StationArrivalsComponent component)
     {

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -39,6 +39,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Server._Starlight.Station; // Starlight
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -473,6 +474,17 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
 
     private void OnStationStartup(Entity<StationEmergencyShuttleComponent> ent, ref StationPostInitEvent args)
     {
+        //Starlight start
+        if (TryComp<StationDataComponent>(ent, out var station))
+            foreach (var grid in station.Grids)
+            {
+                if (!TryComp<BecomesStationMidRoundComponent>(grid, out var becomesStation)) continue;
+                if (!becomesStation.UseEmergencyShuttle)
+                    return;
+                break; // can break, we already found the grid that created this station
+            }
+        //Starlight end
+        
         AddEmergencyShuttle((ent, ent));
     }
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -26,6 +26,8 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using FTLMapComponent = Content.Shared.Shuttles.Components.FTLMapComponent;
+using Content.Server._Starlight.Station; // Starlight
+using Content.Shared.Station.Components; // Starlight
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -100,6 +102,17 @@ public sealed partial class ShuttleSystem
 
     private void OnStationPostInit(ref StationPostInitEvent ev)
     {
+        //Starlight start
+        if (TryComp<StationDataComponent>(ev.Station, out var station))
+            foreach (var grid in station.Grids)
+            {
+                if (!TryComp<BecomesStationMidRoundComponent>(grid, out var becomesStation)) continue;
+                if (!becomesStation.UseArmories)
+                    return;
+                break; // can break, we already found the grid that created this station
+            }
+        //Starlight end
+        
         // Add all grid maps as ftl destinations that anyone can FTL to.
         foreach (var gridUid in ev.Station.Comp.Grids)
         {

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -9,11 +9,19 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using Content.Server._Starlight.Station; // Starlight
+using System.Linq; // Starlight
 
 namespace Content.Server.Shuttles.Systems;
 
 public sealed partial class ShuttleSystem
 {
+    //Starlight start
+    private static readonly string[] CargoShuttleKeys = ["cargo_salvage_shuttle", "cargo_mining_shuttle"];
+    private static readonly string[] TradeStationKeys = ["trade"];
+    private static readonly string[] RuinsKeys = ["ruins", "wrecks"];
+    //Starlight end
+
     private void InitializeGridFills()
     {
         SubscribeLocalEvent<GridSpawnComponent, StationPostInitEvent>(OnGridSpawnPostInit);
@@ -52,6 +60,14 @@ public sealed partial class ShuttleSystem
 
     private void OnCargoSpawnPostInit(EntityUid uid, StationCargoShuttleComponent component, ref StationPostInitEvent args)
     {
+        if (TryComp<StationDataComponent>(uid, out var station))
+            foreach (var grid in station.Grids)
+            {
+                if (!TryComp<BecomesStationMidRoundComponent>(grid, out var becomesStation)) continue;
+                if (!becomesStation.AllowCargoShuttles)
+                    return;
+                break; // can break, we already found the grid that created this station
+            }
         CargoSpawn(uid, component);
     }
 
@@ -117,7 +133,7 @@ public sealed partial class ShuttleSystem
     private bool TryGridSpawn(EntityUid targetGrid, EntityUid stationUid, MapId mapId, GridSpawnGroup group, out EntityUid spawned)
     {
         spawned = EntityUid.Invalid;
-
+        
         if (group.Paths.Count == 0)
         {
             Log.Error($"Found no paths for GridSpawn");
@@ -168,22 +184,46 @@ public sealed partial class ShuttleSystem
         // Spawn on a dummy map and try to FTL if possible, otherwise dump it.
         _mapSystem.CreateMap(out var mapId);
 
-        foreach (var group in component.Groups.Values)
+        foreach (var group in component.Groups) // SL edit
         {
-            var count = _random.Next(group.MinCount, group.MaxCount + 1);
+            var count = _random.Next(group.Value.MinCount, group.Value.MaxCount + 1); // SL edit
 
+            // Starlight start
+            BecomesStationMidRoundComponent? station = null;
+            if (TryComp<StationDataComponent>(uid, out var data))
+                foreach (var grid in data.Grids)
+                {
+                    if (!TryComp<BecomesStationMidRoundComponent>(grid, out var becomesStation)) continue;
+                    station = becomesStation;
+                    break; // can break, we already found the grid that created this station
+                }
+            // Starlight end
+            
             for (var i = 0; i < count; i++)
             {
                 EntityUid spawned;
 
-                switch (group)
+                switch (group.Value) // SL edit
                 {
                     case DungeonSpawnGroup dungeon:
+                        // Starlight start | block all dungeon spawns
+                        if(station is not null)
+                            if (!station.AllowDungeonSpawn)
+                                continue;
+                        // Starlight end
                         if (!TryDungeonSpawn(targetGrid.Value, dungeon, out spawned))
                             continue;
 
                         break;
                     case GridSpawnGroup grid:
+                        // Starlight start
+                        if (station is not null)
+                        {
+                            if (!station.AllowCargoShuttles && CargoShuttleKeys.Contains(group.Key)) continue;
+                            if (!station.AllowRuins && RuinsKeys.Contains(group.Key)) continue;
+                            if (!station.AllowTradingStation && TradeStationKeys.Contains(group.Key)) continue;
+                        }
+                        // Starlight end
                         if (!TryGridSpawn(targetGrid.Value, uid, mapId, grid, out spawned))
                             continue;
 
@@ -192,24 +232,24 @@ public sealed partial class ShuttleSystem
                         throw new NotImplementedException();
                 }
 
-                if (_protoManager.Resolve(group.NameDataset, out var dataset))
+                if (_protoManager.Resolve(group.Value.NameDataset, out var dataset)) // SL edit
                 {
                     _metadata.SetEntityName(spawned, _salvage.GetFTLName(dataset, _random.Next()));
                 }
 
-                if (group.Hide)
+                if (group.Value.Hide) // SL edit
                 {
                     var iffComp = EnsureComp<IFFComponent>(spawned);
                     iffComp.Flags |= IFFFlags.HideLabel;
                     Dirty(spawned, iffComp);
                 }
 
-                if (group.StationGrid)
+                if (group.Value.StationGrid) // SL edit
                 {
                     _station.AddGridToStation(uid, spawned);
                 }
 
-                EntityManager.AddComponents(spawned, group.AddComponents);
+                EntityManager.AddComponents(spawned, group.Value.AddComponents); // SL edit
             }
         }
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -16,12 +16,6 @@ namespace Content.Server.Shuttles.Systems;
 
 public sealed partial class ShuttleSystem
 {
-    //Starlight start
-    private static readonly string[] CargoShuttleKeys = ["cargo_salvage_shuttle", "cargo_mining_shuttle"];
-    private static readonly string[] TradeStationKeys = ["trade"];
-    private static readonly string[] RuinsKeys = ["ruins", "wrecks"];
-    //Starlight end
-
     private void InitializeGridFills()
     {
         SubscribeLocalEvent<GridSpawnComponent, StationPostInitEvent>(OnGridSpawnPostInit);
@@ -64,7 +58,7 @@ public sealed partial class ShuttleSystem
             foreach (var grid in station.Grids)
             {
                 if (!TryComp<BecomesStationMidRoundComponent>(grid, out var becomesStation)) continue;
-                if (!becomesStation.AllowCargoShuttles)
+                if (!becomesStation.AllowCargoShuttle)
                     return;
                 break; // can break, we already found the grid that created this station
             }
@@ -218,11 +212,7 @@ public sealed partial class ShuttleSystem
                     case GridSpawnGroup grid:
                         // Starlight start
                         if (station is not null)
-                        {
-                            if (!station.AllowCargoShuttles && CargoShuttleKeys.Contains(group.Key)) continue;
-                            if (!station.AllowRuins && RuinsKeys.Contains(group.Key)) continue;
-                            if (!station.AllowTradingStation && TradeStationKeys.Contains(group.Key)) continue;
-                        }
+                            if (!station.AllowedGridSpawns.Contains(group.Key)) continue; // group name must be whitelisted
                         // Starlight end
                         if (!TryGridSpawn(targetGrid.Value, uid, mapId, grid, out spawned))
                             continue;

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -39,6 +39,7 @@ public sealed partial class StationSystem : SharedStationSystem
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly PvsOverrideSystem _pvsOverride = default!;
     [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!; // Starlight
+    [Dependency] private readonly IPrototypeManager _prototype = default!; // Starlight
 
     private ISawmill _sawmill = default!;
 
@@ -223,7 +224,7 @@ public sealed partial class StationSystem : SharedStationSystem
             }
         }
         component.InitializedId = component.Id;
-        InitializeNewStationMidRound(uid, component.StationProto, component);
+        InitializeNewStationMidRound(uid, component.BaseStationProtos, component);
     }
     // Starlight End
     #endregion Event handlers
@@ -328,7 +329,10 @@ public sealed partial class StationSystem : SharedStationSystem
     }
 
     //SL start
-    public EntityUid InitializeNewStationMidRound(EntityUid gridId, EntProtoId stationProtoId, BecomesStationMidRoundComponent? comp = null)
+    public EntityUid InitializeNewStationMidRound(EntityUid gridId, EntProtoId stationProtoId,
+        BecomesStationMidRoundComponent? comp = null) => InitializeNewStationMidRound(gridId, [stationProtoId], comp);
+    
+    public EntityUid InitializeNewStationMidRound(EntityUid gridId, List<EntProtoId> stationProtoIds, BecomesStationMidRoundComponent? comp = null)
     {
         //logic for if was initialized via BecomesStationMidRoundComponent
         ComponentRegistry? registry = null;
@@ -344,7 +348,7 @@ public sealed partial class StationSystem : SharedStationSystem
                 registry.Add("StationJobs", new EntityPrototype.ComponentRegistryEntry(jobs, new MappingDataNode()));
             }
 
-            if (comp.EmergencyShuttleOverridePath is not null)
+            if (comp.EmergencyShuttleOverridePath is not null && comp.UseEmergencyShuttle) // no need to do this if its disabled anyway
             {
                 var shuttle = new StationEmergencyShuttleComponent
                 {
@@ -354,15 +358,37 @@ public sealed partial class StationSystem : SharedStationSystem
             }
         }
         
-        var station = EntityManager.SpawnEntity(stationProtoId, MapCoordinates.Nullspace, registry);
+        // var station = EntityManager.SpawnEntity(stationProtoId, MapCoordinates.Nullspace, registry);
+        var station = CreateCustomStation(stationProtoIds, MapCoordinates.Nullspace, registry, comp);
+        var data = EnsureComp<StationDataComponent>(station);
         RenameStation(station, MetaData(gridId).EntityName, false);
-        var data = Comp<StationDataComponent>(station);
         var name = MetaData(station).EntityName;
         AddGridToStation(station, gridId, null, data, name);
         var ev = new StationPostInitEvent((station, data));
         RaiseLocalEvent(station, ref ev, true);
         return station;
     }
+
+    private EntityUid CreateCustomStation(List<EntProtoId> protoIds, MapCoordinates? coords, ComponentRegistry? registry, BecomesStationMidRoundComponent? data = null)
+    {
+        var ent = EntityManager.CreateEntityUninitialized(null); // dummy entity
+        // do parents first
+        foreach (var protoId in protoIds)
+        {
+            if (!_prototype.TryIndex(protoId, out var proto)) continue;
+            foreach (var comp in proto.Components.Values.Where(comp => !HasComp(ent, comp.Component.GetType())))
+                AddComp(ent, comp.Component);
+        }
+        // now any of the extra overrides
+        if (registry is not null)
+        {
+            foreach (var comp in registry.Values.Where(comp => !HasComp(ent, comp.Component.GetType())))
+                AddComp(ent, comp.Component);
+        }
+        EntityManager.InitializeAndStartEntity(ent, coords!.Value.MapId);
+        return ent;
+    }
+    
     //SL end
     
     /// <summary>

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -372,6 +372,7 @@ public sealed partial class StationSystem : SharedStationSystem
     private EntityUid CreateCustomStation(List<EntProtoId> protoIds, MapCoordinates? coords, ComponentRegistry? registry, BecomesStationMidRoundComponent? data = null)
     {
         var ent = EntityManager.CreateEntityUninitialized(null); // dummy entity
+        data ??= EnsureComp<BecomesStationMidRoundComponent>(ent); // just ensure that this exists so that anything made with stationinit command will default to everything being blocked.
         // do parents first
         foreach (var protoId in protoIds)
         {

--- a/Content.Server/_Starlight/AlertArmory/AlertArmorySystem.cs
+++ b/Content.Server/_Starlight/AlertArmory/AlertArmorySystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Station.Components;
 using Robust.Shared.Physics.Components;
 using System.Numerics;
 using System.Linq;
+using Content.Server._Starlight.Station;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
@@ -63,6 +64,17 @@ public sealed class AlertArmorySystem : EntitySystem
     ///</summary>
     private void InitializeAlertArmoryStation(EntityUid uid, AlertArmoryStationComponent comp, StationPostInitEvent ev)
     {
+        //Starlight start
+        if (TryComp<StationDataComponent>(uid, out var station))
+            foreach (var grid in station.Grids)
+            {
+                if (!TryComp<BecomesStationMidRoundComponent>(grid, out var becomesStation)) continue;
+                if (!becomesStation.UseArmories)
+                    return;
+                break; // can break, we already found the grid that created this station
+            }
+        //Starlight end
+        
         var map = _map.CreateMap(out var mapId);
         _meta.SetEntityName(map, $"AlertArmories {uid}");
 

--- a/Content.Server/_Starlight/Station/BecomesStationMidRoundComponent.cs
+++ b/Content.Server/_Starlight/Station/BecomesStationMidRoundComponent.cs
@@ -19,10 +19,9 @@ public sealed partial class BecomesStationMidRoundComponent : Component
     [DataField] public bool UseEmergencyShuttle; // false will ignore any emergency shuttle related settings. | Prevents adding emergency shuttle comp
     [DataField] public bool UseArmories; // whether to spawn armories or not.
     [DataField] public bool UseArrivals; // whether to add to arrivals rotation or not.
-    [DataField] public bool AllowTradingStation; // should a new ATS spawn for this station or not. | Prevents adding shuttles comp
     [DataField] public bool AllowDungeonSpawn; // allow a new dungeon to spawn or not | Prevents spawning dungeon regardless of gridspawn
-    [DataField] public bool AllowCargoShuttles; // allow the cargo shuttles to spawn or not | Prevents all cargo related shuttles from spawning
-    [DataField] public bool AllowRuins; // allow ruins to generate or not | Prevents spawning ruins regardless of gridspawn
+    [DataField] public bool AllowCargoShuttle; // allows the cargo shuttle "ferry" to spawn or not.
+    [DataField] public string[] AllowedGridSpawns; // whitelisted gridspawn keys. Only affects GridSpawn groups, not DungeonSpawns.
     [DataField] public string? EmergencyShuttleOverridePath = null;
     [DataField] public Dictionary<ProtoId<JobPrototype>, int>? AvailableJobs = null; // null = no jobs
 }

--- a/Content.Server/_Starlight/Station/BecomesStationMidRoundComponent.cs
+++ b/Content.Server/_Starlight/Station/BecomesStationMidRoundComponent.cs
@@ -14,7 +14,15 @@ public sealed partial class BecomesStationMidRoundComponent : Component
 {
     [ViewVariables(VVAccess.ReadOnly)] public string? InitializedId = null;
     [DataField(required: true)] public string? Id = null;
-    [DataField] public EntProtoId StationProto = new("StandardNanotrasenStation");
+    [DataField] public List<EntProtoId> BaseStationProtos = default!; // will combine all components from specified station protos
+    [DataField] public bool AllowFTLDestination; // whether you can inherently FTL to the station or not.
+    [DataField] public bool UseEmergencyShuttle; // false will ignore any emergency shuttle related settings. | Prevents adding emergency shuttle comp
+    [DataField] public bool UseArmories; // whether to spawn armories or not.
+    [DataField] public bool UseArrivals; // whether to add to arrivals rotation or not.
+    [DataField] public bool AllowTradingStation; // should a new ATS spawn for this station or not. | Prevents adding shuttles comp
+    [DataField] public bool AllowDungeonSpawn; // allow a new dungeon to spawn or not | Prevents spawning dungeon regardless of gridspawn
+    [DataField] public bool AllowCargoShuttles; // allow the cargo shuttles to spawn or not | Prevents all cargo related shuttles from spawning
+    [DataField] public bool AllowRuins; // allow ruins to generate or not | Prevents spawning ruins regardless of gridspawn
     [DataField] public string? EmergencyShuttleOverridePath = null;
     [DataField] public Dictionary<ProtoId<JobPrototype>, int>? AvailableJobs = null; // null = no jobs
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes a few things relating to midround stations and makes them more customizable. See changelog at bottom for exact changes.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Yes.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- add: Added several parameters to BecomesStationMidRoundComponent to allow for better fine-tuning of how it gets set up.
- tweak: BecomesStationMidRoundComponent now accepts multiple station entity prototypes so you can include and exclude things as you see fit.
- fix: Fixed there being no cleanup for the arrivals shuttle if the station it belongs to were to get deleted.
- fix: By default, newly made stations will NOT cause cargo shuttles, ruins, wrecks, trading stations, arrivals, evacs, or armories to spawn. This only applies to stations made with stationinit or BecomesStationMidRoundComponent.