### PR TITLE
Block nexus completely when user is crit or asleep

### DIFF
--- a/Content.Server/_Starlight/CollectiveMind/CollectiveMind.cs
+++ b/Content.Server/_Starlight/CollectiveMind/CollectiveMind.cs
@@ -34,12 +34,13 @@ public sealed partial class CollectiveMind : SharedCollectiveMindSystem
 
         if (ent.Comp.CorruptWhenUnconscious)
         {
-            //we need to check if the entity is sleeping, or crit
+            // we need to check if the entity is sleeping, or crit
             if (TryComp<MobStateComponent>(uid, out var mobState))
             {
                 if (mobState.CurrentState == MobState.Critical || TryComp<SleepingComponent>(uid, out _))
                 {
-                    args.Message = Corrupt(args.Message, ref ent.Comp);
+                    args.Cancel();
+                    return;
                 }
             }
         }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR suggests a change to block nexus calls completely when the user is crit or asleep.

## Why we need to add this
To be fully fair, this is not a mald PR, i am an Avali player, for quite a long time now. With a consultation with a lot of "bird" players we did come to conclusion that this is a required change. The nexus users are very often using this ability as a free get out of jail card, which makes them harder as kill targets.

This is a necessary change for a game that centers around stealthy antagonistic play.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- tweak: Disable nexus when crit or asleep.
