### PR TITLE
No more Nukeductors

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GameRule.cs
+++ b/Content.Server/GameTicking/GameTicker.GameRule.cs
@@ -69,6 +69,20 @@ public sealed partial class GameTicker
     /// <returns>The entity for the added gamerule</returns>
     public EntityUid AddGameRule(string ruleId)
     {
+        // Starlight Start: Check if any active game rule denies this rule from being added
+        var activeRules = GetActiveGameRules();
+        foreach (var activeRuleUid in activeRules)
+        {
+            if (!TryComp<GameRuleComponent>(activeRuleUid, out var activeRuleComp))
+                continue;
+            if (activeRuleComp.DenyGameRules.Contains(ruleId))
+            {
+                _sawmill.Info($"Game rule {ruleId} was denied by active rule {ToPrettyString(activeRuleUid)}");
+                return EntityUid.Invalid;
+            }
+        }
+        // Starlight End
+
         var ruleEntity = Spawn(ruleId, MapCoordinates.Nullspace);
         _sawmill.Info($"Added game rule {ToPrettyString(ruleEntity)}");
         _adminLogger.Add(LogType.EventStarted, $"Added game rule {ToPrettyString(ruleEntity)}");

--- a/Content.Shared/GameTicking/Components/GameRuleComponent.cs
+++ b/Content.Shared/GameTicking/Components/GameRuleComponent.cs
@@ -35,6 +35,14 @@ public sealed partial class GameRuleComponent : Component
     /// </summary>
     [DataField]
     public MinMax? Delay;
+    // Starlight Start
+    /// <summary>
+    /// List of game rule IDs that this game rule prevents from occurring.
+    /// If this game rule is active, the denied rules/events will not run.
+    /// </summary>
+    [DataField]
+    public List<string> DenyGameRules = new();
+    // Starlight End
 }
 
 /// <summary>

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -123,6 +123,10 @@
   components:
   - type: GameRule
     minPlayers: 20
+    # Starlight Start
+    denyGameRules:
+    - AbductorsSpawn
+    # Starlight End
   - type: LoadMapRule
     mapPath: /Maps/_Starlight/nukieplanet.yml
   - type: AntagSelection


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds ``denyGameRules`` to the Gamerule comp allowing you to set Gamerules that cannot run when this one is active.
Stops Abductors rolling during Nukies
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Requested to make this
Fixes abductors spawning on nukie map
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- tweak: Abductors can no longer spawn during nukies.