### PR TITLE
Dragon Rift Fix

### DIFF
--- a/Content.Server/Dragon/DragonRiftSystem.cs
+++ b/Content.Server/Dragon/DragonRiftSystem.cs
@@ -124,6 +124,6 @@ public sealed class DragonRiftSystem : EntitySystem
         if (!TryComp<DragonComponent>(comp.Dragon, out var dragon) || dragon.Weakened)
             return;
 
-        _dragon.RiftDestroyed(comp.Dragon.Value, dragon);
+        _dragon.RiftDestroyed(comp.Dragon.Value, uid, dragon); // Starlight edit
     }
 }

--- a/Content.Server/Dragon/DragonSystem.cs
+++ b/Content.Server/Dragon/DragonSystem.cs
@@ -269,17 +269,34 @@ public sealed partial class DragonSystem : EntitySystem
     /// <summary>
     /// Do everything that needs to happen when a rift gets destroyed by the crew.
     /// </summary>
-    public void RiftDestroyed(EntityUid uid, DragonComponent? comp = null)
+    public void RiftDestroyed(EntityUid dragonUid, EntityUid riftUid, DragonComponent? comp = null) // Starlight edit
     {
-        if (!Resolve(uid, ref comp))
+        if (!Resolve(dragonUid, ref comp)) // Starlight edit
             return;
 
         // do reset the rift count since crew destroyed the rift, not deleted by the dragon dying.
-        DeleteRifts(uid, true, comp);
+        // Starlight edit Start
+        comp.Rifts.Remove(riftUid);
 
+        // Reset the rift count in objectives since crew destroyed a rift
+        if (TryComp<MindContainerComponent>(dragonUid, out var mindContainer) && mindContainer.HasMind)
+        {
+            var mind = Comp<MindComponent>(mindContainer.Mind.Value);
+            foreach (var objId in mind.Objectives)
+            {
+                if (_objQuery.TryGetComponent(objId, out var obj))
+                {
+                    _carpRifts.ResetRifts(objId, obj);
+                    break;
+                }
+            }
+        }
+        // Starlight edit End
         // We can't predict the rift being destroyed anyway so no point adding weakened to shared.
         comp.WeakenedAccumulator = comp.WeakenedDuration;
-        _movement.RefreshMovementSpeedModifiers(uid);
-        _popup.PopupEntity(Loc.GetString("carp-rift-destroyed"), uid, uid);
+        // Starlight edit Start
+        _movement.RefreshMovementSpeedModifiers(dragonUid);
+        _popup.PopupEntity(Loc.GetString("carp-rift-destroyed"), dragonUid, dragonUid);
+        // Starlight edit End
     }
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Dragon rifts now no longer delete all rifts when one is destroyed.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes https://github.com/ss14Starlight/space-station-14/issues/2324
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Dragon rifts no longer delete all rifts when one is destroyed.