### PR TITLE
Allow Science to use the mechs they make.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -320,7 +320,7 @@
 # Paddy
 - type: entity
   id: MechPaddy
-  parent: [ BaseMech, CombatMech, IndustrialMech, BaseSecurityContraband ]
+  parent: [ BaseMech, CombatMech, IndustrialMech, BaseSecurityScienceContraband ] # Starlight change: Sec/Sci contra
   name: Paddy
   description: Autonomous Power Loader Unit Subtype Paddy. A Modified MK-II Ripley design intended for light security use.
   components:
@@ -358,7 +358,7 @@
     bluntStaminaDamageFactor: 1.5 # 🌟Starlight-Change
     damage:
       types:
-        Blunt: 30 #Decent for a loader, but without the high structural damage of a combat mech. # 
+        Blunt: 30 #Decent for a loader, but without the high structural damage of a combat mech. #
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
     baseSprintSpeed: 4
@@ -622,7 +622,7 @@
 # Gygax
 - type: entity
   id: MechGygax
-  parent: [ BaseMech, CombatMech, BaseSecurityContraband ]
+  parent: [ BaseMech, CombatMech, BaseSecurityScienceContraband ] # Starlight change: Sec/Sci contra
   name: Gygax
   description: While lightly armored, the Gygax has incredible mobility thanks to its ability that lets it smash through walls at high speeds.
   components:
@@ -682,7 +682,7 @@
 # Durand
 - type: entity
   id: MechDurand
-  parent: [ BaseMech, CombatMech, BaseSecurityContraband ]
+  parent: [ BaseMech, CombatMech, BaseSecurityScienceContraband ] # Starlight change: Sec/Sci contra
   name: Durand
   description: A slow but beefy combat exosuit that is extra scary in confined spaces due to its punches. Xenos hate it!
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -193,7 +193,7 @@
 # Ripley MK-I
 - type: entity
   id: MechRipley
-  parent: [ BaseMech, IndustrialMech, BaseCargoContraband ]
+  parent: [ BaseMech, IndustrialMech, BaseCargoScienceContraband ] # Starlight change: Cargo/Sci contra
   name: Ripley APLU
   description: Versatile and lightly armored, the Ripley is useful for almost any heavy work scenario. The "APLU" stands for Autonomous Power Loading Unit.
   components:
@@ -252,7 +252,7 @@
 # Ripley MK-II
 - type: entity
   id: MechRipley2
-  parent: [ BaseMech, IndustrialMech, BaseCargoContraband ]
+  parent: [ BaseMech, IndustrialMech, BaseCargoScienceContraband ] # Starlight change: Cargo/Sci contra
   name: Ripley APLU MK-II
   description: The "MK-II" has a pressurized cabin for space operations, and stronger clamps are able to force doors open, but the added weight has slowed it down. # 🌟Starlight-Change
   components:
@@ -395,7 +395,7 @@
 # Clarke
 - type: entity
   id: MechClarke
-  parent: [ BaseMech, IndustrialMech, BaseCargoContraband ]
+  parent: [ BaseMech, IndustrialMech, BaseCargoScienceContraband ] # Starlight change: Cargo/Sci contra
   name: Clarke
   description: A fast-moving mech for space travel. It has built-in trusts.
   components:
@@ -449,7 +449,7 @@
 
 # H.O.N.K.
 - type: entity
-  parent: [ BaseMech, SpecialMech, BaseCivilianContraband ]
+  parent: [ BaseMech, SpecialMech, BaseCivilianScienceContraband ] # Starlight change: Civ/Sci conttra
   id: MechHonker
   name: H.O.N.K.
   description: "Produced by \"Tyranny of Honk, INC\", this exosuit is designed as heavy clown-support. Used to spread the fun and joy of life. HONK!"

--- a/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
@@ -55,6 +55,22 @@
     allowedDepartments: [ Security, Science ]
 
 - type: entity
+  id: BaseCargoScienceContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Cargo, Science ]
+
+- type: entity
+  id: BaseCivilianScienceContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Civilian, Science ]
+
+- type: entity
   id: BaseSecuritySalvageMiningContraband
   parent: BaseRestrictedContraband
   abstract: true

--- a/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
@@ -47,6 +47,14 @@
     allowedJobs: [ SalvageSpecialist, SalvageLead ]
 
 - type: entity
+  id: BaseSecurityScienceContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Security, Science ]
+
+- type: entity
   id: BaseSecuritySalvageMiningContraband
   parent: BaseRestrictedContraband
   abstract: true


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Makes all non-CentComm/Syndicate mechs Science contraband in addition to their respective department.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Science is responsible for making these, and is the only one who can. They should be able to use their own mechs.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- tweak: Science can now use their own mechs
