### PR TITLE
Various bag click-to-open bugfixes

### DIFF
--- a/Content.Shared/_Starlight/Inventory/SwitchableEquipModeSystem.cs
+++ b/Content.Shared/_Starlight/Inventory/SwitchableEquipModeSystem.cs
@@ -2,11 +2,11 @@ using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Inventory;
 using Content.Shared.Hands.EntitySystems;
-using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.Inventory.Events;
+using Content.Shared.Interaction.Components;
 
 namespace Content.Shared._Starlight.Inventory;
 
@@ -35,6 +35,8 @@ public sealed class SwitchableEquipModeSystem : EntitySystem
     private void OnInventoryUseSlot(EntityUid uid, SwitchableEquipModeComponent switchModeComp, ref InventoryUseSlotEvent args)
     {
         if (!TryComp<StorageComponent>(uid, out var storageComp)) return;
+
+        Resolve(uid, ref switchModeComp!, false);
 
         switch (switchModeComp.Mode)
         {
@@ -81,6 +83,7 @@ public sealed class SwitchableEquipModeSystem : EntitySystem
             Priority = 0,
             Act = () =>
             {
+                if(HasComp<UnremoveableComponent>(uid)) return;
                 _inventory.TryUnequip(user, slot.Name, false, true);
                 _hands.TryPickup(user, uid);
             }


### PR DESCRIPTION
## Short description
- fixes some minor client/server desync issues that happens when the two get confused about bag state
- stops unremovable bags from being removable via right click menu

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- fix: Some bag toggle bugfixes
