### PR TITLE
Minor salv/mining suit buffs

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -201,7 +201,7 @@
     - Hardsuit
     - WhitelistChameleon
 
-#Maxim Hardsuit
+# Hardsuit
 - type: entity
   parent: [ ClothingOuterHardsuitBase, BaseSalvageContraband ] #Starlight salvContra
   id: ClothingOuterHardsuitMaxim
@@ -228,8 +228,8 @@
         Radiation: 0.3 
         Caustic: 0.8 
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9 
+    walkModifier: 0.85
+    sprintModifier: 0.85 
   - type: ExplosionResistance
     damageCoefficient: 0.4 
     # end region starlight

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -142,9 +142,9 @@
     modifiers:
       coefficients:
       # region starlight: lowered values
-        Blunt: 0.8 
-        Slash: 0.8 
-        Piercing: 0.75 
+        Blunt: 0.7 
+        Slash: 0.7 
+        Piercing: 0.8
         # end region starlight
         Heat: 0.7
         Radiation: 0.3
@@ -181,11 +181,11 @@
     modifiers:
       coefficients:
         Blunt: 0.7
-        Slash: 0.7
+        Slash: 0.65 #SL change: thick goliath plates! resistant to slashing
         Piercing: 0.5
         Heat: 0.7 #Goliath hide gets grilled instead of you
         Radiation: 0.3
-        Caustic: 0.8
+        Caustic: 0.7 # Starlight change: Goliath hide gets slagged instead of you
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -228,8 +228,8 @@
         Radiation: 0.3 
         Caustic: 0.8 
   - type: ClothingSpeedModifier
-    walkModifier: 0.85 
-    sprintModifier: 0.85 
+    walkModifier: 0.9
+    sprintModifier: 0.9 
   - type: ExplosionResistance
     damageCoefficient: 0.4 
     # end region starlight

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -536,8 +536,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.75
-        Slash: 0.75
+        Blunt: 0.7
+        Slash: 0.7
         Piercing: 0.9
         Heat: 0.7
         Cold: 0.7


### PR DESCRIPTION
## Short description
Just some good old poking at the numbers for various Salvage/Mining hardsuits with their established roles in mind. 

## Why we need to add this
I understand the rationale for the recent nerfs to salvage hardsuits (#2195) but I personally feel said nerfs were heavier than necessary, and made some odd decisions particularly in regards to the Salvage hardsuit (It is explicitly for fighting wildlife, specifically carp and xenos... why is its best kinetic protection stat pierce?). I wanted to stake a compromise position that, while still discouraging Salvagers from "protagging"/validhunting given the quality of their gear, still actually gives them adequate protection for the combat situations they're *expected* to face. 

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: deltaVelocity
- tweak: Minor buffs and reshuffle of Salvage Suit protections. Its stats now primarily focus on the wildlife mentioned in its item description (30% blunt and pierce protection) while keeping pierce protection the same
- tweak: Increased mining suit's blunt/pierce protection to match the new salvage suit numbers
- tweak: increased the Goliath hardsuit's slash protection to 35% (thick Goliath hide makes good platemail!) while increasing its caustic protection to parity with its heat protection (acid melts the plates instead of you!)


