### PR TITLE
Remove the mandatory outer clothing for some jobs

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -197,6 +197,7 @@
 - type: loadoutGroup
   id: CaptainOuterClothing
   name: loadout-group-captain-outerclothing
+  minLimit: 0 # starlight
   loadouts:
   - CaptainOuterClothing
   - CaptainWintercoat
@@ -1170,6 +1171,7 @@
 - type: loadoutGroup
   id: HeadofSecurityOuterClothing
   name: loadout-group-head-of-security-outerclothing
+  minLimit: 0 # starlight
   loadouts:
   - HeadofSecurityCoat
   - HeadofSecurityWinterCoat
@@ -1192,6 +1194,7 @@
 - type: loadoutGroup
   id: WardenOuterClothing
   name: loadout-group-warden-outerclothing
+  minLimit: 0 # starlight
   loadouts:
   - WardenCoat
   - WardenArmoredWinterCoat
@@ -1234,6 +1237,7 @@
 - type: loadoutGroup
   id: BrigmedicOuterClothing
   name: loadout-group-brigmedic-outerclothing
+  minLimit: 0 # starlight
   loadouts:
   - BrigmedicCoat
   - SecurityOfficerWintercoat
@@ -1309,6 +1313,7 @@
 - type: loadoutGroup
   id: SecurityOuterClothing
   name: loadout-group-security-outerclothing
+  minLimit: 0 # starlight
   loadouts:
   - ArmorVest
   - ArmorVestSlim
@@ -1361,6 +1366,7 @@
 - type: loadoutGroup
   id: DetectiveOuterClothing
   name: loadout-group-detective-outerclothing
+  minLimit: 0 # starlight
   loadouts:
   - DetectiveArmorVest
   - DetectiveCoat

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -198,6 +198,7 @@
   id: CaptainOuterClothing
   name: loadout-group-captain-outerclothing
   minLimit: 0 # starlight
+  defaultSelected: 1 # starlight
   loadouts:
   - CaptainOuterClothing
   - CaptainWintercoat
@@ -1172,6 +1173,7 @@
   id: HeadofSecurityOuterClothing
   name: loadout-group-head-of-security-outerclothing
   minLimit: 0 # starlight
+  defaultSelected: 1 # starlight
   loadouts:
   - HeadofSecurityCoat
   - HeadofSecurityWinterCoat
@@ -1195,6 +1197,7 @@
   id: WardenOuterClothing
   name: loadout-group-warden-outerclothing
   minLimit: 0 # starlight
+  defaultSelected: 1 # starlight
   loadouts:
   - WardenCoat
   - WardenArmoredWinterCoat
@@ -1238,6 +1241,7 @@
   id: BrigmedicOuterClothing
   name: loadout-group-brigmedic-outerclothing
   minLimit: 0 # starlight
+  defaultSelected: 1 # starlight
   loadouts:
   - BrigmedicCoat
   - SecurityOfficerWintercoat
@@ -1314,6 +1318,7 @@
   id: SecurityOuterClothing
   name: loadout-group-security-outerclothing
   minLimit: 0 # starlight
+  defaultSelected: 1 # starlight
   loadouts:
   - ArmorVest
   - ArmorVestSlim
@@ -1367,6 +1372,7 @@
   id: DetectiveOuterClothing
   name: loadout-group-detective-outerclothing
   minLimit: 0 # starlight
+  defaultSelected: 1 # starlight
   loadouts:
   - DetectiveArmorVest
   - DetectiveCoat

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -167,12 +167,14 @@
 - type: loadoutGroup
   id: BlueShieldOuterclothing
   name: Loadout-group-blueshield-outerclothing
+  minLimit: 0
   loadouts:
   - BlueShieldVest
   - BlueShieldCoat
 
 - type: loadoutGroup
   id: BlueShieldNeck
+  minLimit: 0
   name: Loadout-group-blueshield-neck
   loadouts:
   - BlueShieldFormalCloak

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -168,6 +168,7 @@
   id: BlueShieldOuterclothing
   name: Loadout-group-blueshield-outerclothing
   minLimit: 0
+  defaultSelected: 1
   loadouts:
   - BlueShieldVest
   - BlueShieldCoat
@@ -175,6 +176,7 @@
 - type: loadoutGroup
   id: BlueShieldNeck
   minLimit: 0
+  defaultSelected: 1
   name: Loadout-group-blueshield-neck
   loadouts:
   - BlueShieldFormalCloak


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Changes jobs like Security Officer / Captain / Officer "Blue Shield" / et. al, to not force an outerclothing loadout option.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It's annoying that you *have* to start with one.
Plus, for all of these, the respective options can usually _all_ be found in the job's locker.
Also for some reason the BSO is required to spawn with a neck option??? Weird.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- tweak: Central Command now allows (amongst others) the Captain, Head of Security, and Warden to leave their coat at home.
- tweak: NanoTrasen doesn't force the Officer "Blue Shield" to have a cloak anymore.
- tweak: NanoTrasen now begrudgingly allows the Officer "Blue Shield" to leave their coat at home.