### PR TITLE
Add department assignments for some jobs that don't have them

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -50,6 +50,7 @@
   - ERTSecurity
   - ERTEngineer
   - DeathSquad
+  - CentralCommandOperator # Starlight Addition
   - NTNCBlueshield ## Starlight Addition
   editorHidden: true
   weight: 120

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/departments.yml
@@ -17,5 +17,7 @@
   - BlueShield
   - Magistrate
   - NanoTrasenRepresentative
+  - Decimus
+  - NanoTrasenSpecialForces
   primary: false
   weight: 50


### PR DESCRIPTION
## Short description
Without this, these roles don't show up in the ban menu, because the ban menu works off of the departments for categorization.

## Why we need to add this
Keeping our admins happy keeps us all happy

## Media (Video/Screenshots)
<img width="603" height="624" alt="image" src="https://github.com/user-attachments/assets/e9a70a05-cb3a-47a4-bbf2-cf95a5c71a57" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- tweak: Fixed a paperwork snafu at CentComm related to Operators, got the SpecOps teams to actually fill out their forms, and [REDACTED - NOTE HAS BEEN FILED FOR REVIEW]
