### PR TITLE
Fixes moths being able to jump way further than intended

### DIFF
--- a/Resources/Prototypes/_StarLight/Actions/jump.yml
+++ b/Resources/Prototypes/_StarLight/Actions/jump.yml
@@ -46,8 +46,9 @@
     rechargeDuration: 30
   - type: WorldTargetAction
     event: !type:JumpActionEvent
-      distance: 4.5
-      speed: 4.5 # Equal to movement speed.
+      distance: 2.25   # about 3 tiles after momentum / friction factors in
+      toPointer: false # moths only get control over direction, not distance
+      speed: 4.5       # equal to movement speed
       sound:
         path: /Audio/_Starlight/Effects/Jump/moth.ogg
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
At some point, moth jumps were made about 5 tiles long, which is a lot longer than they were intended to jump. This probably happened during one of the many jump bugfixes.

This PR restores the intended jump distance as per @Happyrobot33. The code says `2.25` tiles, but it's about 3 tiles after speed and friction is factored in.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix (ha ha moths). But seriously, as per Happy:
- **Moths**: More jumps, but shorter distance overall, and only control over direction (_not distance_)
- **Resomi**: One jump, but direct control over direction _and distance_, with a higher total distance covered

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/aafd434a-085d-4313-bdba-8882ed0fe971

fig. 1 - Moth jumps restored to how they used to be. **Take note of the mouse position in the video,** you can see that moths cannot 'short jump' (think of it like a video game dash where you're always taken the full distance of the dash).


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- fix: Moth jumps are now short (as intended)
- fix: Moth jumps always make you go the full jump distance (as intended)
