### PR TITLE
(Lobster) Set Lobster's maxPlayers to 150

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/lobster.yml
+++ b/Resources/Prototypes/_StarLight/Maps/lobster.yml
@@ -3,7 +3,7 @@
   mapName: 'Lobster Station'
   mapPath: /Maps/_Starlight/Stations/Lobster.yml
   minPlayers: 40
-  #maxPlayers: 75
+  maxPlayers: 150
   stations:
     StarlightLobster:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Sets the `maxPlayers` for Lobster to 150 players.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
https://discord.com/channels/1272545509562777621/1447003259394064404

Players voted to Lobster with like, 200 players today. Lobster can't handle that kind of population as it only has 142 jobs. There's bigger stations that should be used during times of extreme population like this.

This PR won't affect daily play, just extreme population days.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- tweak: (Lobster) Set Lobster's maxPlayers to 150 players (e.g. will no longer show up in the map vote when there's more than 150 players on Alpha).