### PR TITLE
FIX TASERS META(return ignore knockdown)

### DIFF
--- a/Content.Shared/Armor/ArmorComponent.cs
+++ b/Content.Shared/Armor/ArmorComponent.cs
@@ -17,9 +17,6 @@ public sealed partial class ArmorComponent : Component
     [DataField(required: true)]
     public DamageModifierSet Modifiers = default!;
     
-    [DataField("staminaModifier")]
-    public float StaminaDamageModifier = 1.0f;
-    
     /// <summary>
     /// A multiplier applied to the calculated point value
     /// to determine the monetary value of the armor
@@ -32,6 +29,21 @@ public sealed partial class ArmorComponent : Component
     /// </summary>
     [DataField]
     public bool ShowArmorOnExamine = true;
+
+    #region Starlight
+
+    /// <summary>
+    /// If true, ignores knockdown from tasers.
+    /// </summary>
+    [DataField]
+    public bool IgnoreKnockdown = false;
+
+    /// <summary>
+    /// Stamina damage reduction
+    /// </summary>
+    [DataField("staminaModifier")]
+    public float StaminaDamageModifier = 1.0f;
+    #endregion
 }
 
 /// <summary>

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Stunnable;
 using Content.Shared.Silicons.Borgs;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;
+using Content.Shared.Stunnable; // Starlight-edit
 
 namespace Content.Shared.Armor;
 
@@ -26,7 +27,20 @@ public abstract class SharedArmorSystem : EntitySystem
         SubscribeLocalEvent<ArmorComponent, InventoryRelayedEvent<StaminaModifyEvent>>(OnStaminaDamageModify);
         SubscribeLocalEvent<ArmorComponent, BorgModuleRelayedEvent<DamageModifyEvent>>(OnBorgDamageModify);
         SubscribeLocalEvent<ArmorComponent, GetVerbsEvent<ExamineVerb>>(OnArmorVerbExamine);
+
+        SubscribeLocalEvent<ArmorComponent, InventoryRelayedEvent<KnockDownAttemptEvent>>(OnKnockdownAttempt); // Starlight-edit
     }
+
+    #region Starlight
+    /// <summary>
+    /// Tries to cancel knockdown if it's armor ignores it.
+    /// </summary>
+    private void OnKnockdownAttempt(EntityUid uid, ArmorComponent component, InventoryRelayedEvent<KnockDownAttemptEvent> args)
+    {
+        if (component.IngoreKnockdown)
+            args.Args.Cancelled = true;
+    }
+    #endregion
 
     /// <summary>
     /// Get the total Damage reduction value of all equipment caught by the relay.

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -37,7 +37,7 @@ public abstract class SharedArmorSystem : EntitySystem
     /// </summary>
     private void OnKnockdownAttempt(EntityUid uid, ArmorComponent component, InventoryRelayedEvent<KnockDownAttemptEvent> args)
     {
-        if (component.IngoreKnockdown)
+        if (component.IgnoreKnockdown)
             args.Args.Cancelled = true;
     }
     #endregion

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -84,6 +84,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, UnwieldAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, IngestionAttemptEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, TryDetectItem>(RefRelayInventoryEvent); // Starlight
+        SubscribeLocalEvent<InventoryComponent, KnockDownAttemptEvent>(RefRelayInventoryEvent); // Starlight
 
         // Eye/vision events
         SubscribeLocalEvent<InventoryComponent, CanSeeAttemptEvent>(RelayInventoryEvent);

--- a/Content.Shared/Stunnable/StunnableEvents.cs
+++ b/Content.Shared/Stunnable/StunnableEvents.cs
@@ -2,6 +2,7 @@
 using Content.Shared.DoAfter;
 using Content.Shared.Popups;
 using Robust.Shared.Serialization;
+using Content.Shared.Inventory; // Starlight-edit
 
 namespace Content.Shared.Stunnable;
 
@@ -26,7 +27,7 @@ public record struct StunEndAttemptEvent(bool Cancelled);
 ///     knocked down arguments.
 /// </summary>
 [ByRefEvent]
-public record struct KnockDownAttemptEvent(bool AutoStand, bool Drop, TimeSpan? Time)
+public record struct KnockDownAttemptEvent(bool AutoStand, bool Drop, TimeSpan? Time) : IInventoryRelayEvent // Starlight-edit: Make it inventory relayed
 {
     public bool Cancelled;
 }

--- a/Content.Shared/Stunnable/StunnableEvents.cs
+++ b/Content.Shared/Stunnable/StunnableEvents.cs
@@ -29,6 +29,8 @@ public record struct StunEndAttemptEvent(bool Cancelled);
 [ByRefEvent]
 public record struct KnockDownAttemptEvent(bool AutoStand, bool Drop, TimeSpan? Time) : IInventoryRelayEvent // Starlight-edit: Make it inventory relayed
 {
+    public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET; // Starlight-edit
+
     public bool Cancelled;
 }
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -208,7 +208,10 @@
         Heat: 0.3
         Radiation: 0.5
         Caustic: 0.5
+    # Starlight-start
     staminaModifier: 0.35
+    ignoreKnockdown: true
+    # Starlight-end
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: FireProtection

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -176,7 +176,10 @@
         Slash: 0.6
         Piercing: 0.3
         Heat: 0.9
+    # Starlight-start
     staminaModifier: 0.55
+    ignoreKnockdown: true
+    # Starlight-end
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: StaticPrice
@@ -263,7 +266,10 @@
         Piercing: 0.35
         Heat: 0.3
         Caustic: 0.5
+    # Starlight-start
     staminaModifier: 0.1
+    ignoreKnockdown: true
+    # Starlight-end
   - type: ExplosionResistance
     damageCoefficient: 0.35
   - type: StaminaResistance # do not add these to other equipment or mobs, we don't want to microbalance these everywhere

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -666,7 +666,10 @@
         Heat: 0.5
         Radiation: 0.5
         Caustic: 0.5
+    # Starlight-start
     staminaModifier: 0.3
+    ignoreKnockdown: true
+    # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
@@ -737,7 +740,10 @@
         Heat: 0.2
         Radiation: 0.01
         Caustic: 0.5
+    # Starlight-start
     staminaModifier: 0.2
+    ignoreKnockdown: true
+    # Starlight-end
   - type: Item
     size: Huge
   - type: ClothingSpeedModifier
@@ -781,7 +787,10 @@
         Heat: 0.5
         Radiation: 0.25
         Caustic: 0.4
+    # Starlight-start
     staminaModifier: 0.1
+    ignoreKnockdown: true
+    # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
@@ -827,7 +836,10 @@
         Heat: 0.2
         Radiation: 0.2
         Caustic: 0.2
+    # Starlight-start
     staminaModifier: 0.1
+    ignoreKnockdown: true
+    # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
@@ -1005,18 +1017,19 @@
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertleader.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertleader.rsi
-  - type: ExplosionResistance #sl Change
-    damageCoefficient: 0.2 #sl Change
-  - type: Armor #sl Change
-    modifiers: #sl Change
-      coefficients: #sl Change
-        Blunt: 0.4 #sl Change
-        Slash: 0.4 #sl Change
-        Piercing: 0.3 #sl Change
-        Heat: 0.2 #sl Change
-        Radiation: 0.01 #sl Change
-        Caustic: 0.4 #sl Change
-    staminaModifier: 0.1
+  # Starlight-start
+  - type: ExplosionResistance
+    damageCoefficient: 0.2
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.4
+        Slash: 0.4
+        Piercing: 0.
+        Heat: 0.2
+        Radiation: 0.01
+        Caustic: 0.4
+    # Starlight-end
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTLeader
 
@@ -1130,7 +1143,10 @@
         Heat: 0.1
         Radiation: 0.1
         Caustic: 0.1
+    # Starlight-start
     staminaModifier: 0.0
+    ignoreKnockdown: true
+    # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -1171,7 +1187,10 @@
         Shock: 0.1
         Radiation: 0.1
         Caustic: 0.1
+    # Starlight-start
     staminaModifier: 0.2
+    ignoreKnockdown: true
+    # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Returns ignore knockdown property in armor, which is accidentally removed by walks after one upstream.

Full list of armors which are ignoring knockdown:

- Web vest(including: Mercenary and Elite versions)
- Syndie raid suit
- Blood-red hardsuit(including: Medic version)
- syndicate elite hardsuit
- syndicate commander hardsuit
- cybersun juggernaut suit
- CBURN exosuit
- ERT leader's hardsuit(parents commander suit)
- ERT chaplain's hardsuit(parents juggernaut suit)
- ERT engineer's hardsuit(parents CBURN suit)
- ERT medic's hardsuit(parents blood-red medic suit)
- ERT security's hardsuit(parents elite suit)
- ERT janitor's hardsuit(parents CBURN suit)
- death squad hardsuit

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Fixes tasers meta.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

No content.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rinary
- fix: Returned `ignoreknockdown` to armor.
- tweak: Changed a lot of armors/vests/hardsuits, so they ignore knockdown from tasers. (Check pr description for full list).