### PR TITLE
Buff Reinforced Glass

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -138,10 +138,10 @@
     Shock: 0
     Structural: 0.5
   flatReductions:
-    Blunt: 5
-    Slash: 5
-    Piercing: 5
-    Heat: 5
+    Blunt: 10
+    Slash: 10
+    Piercing: 10
+    Heat: 10
     Structural: 10
 
 - type: damageModifierSet


### PR DESCRIPTION
## Short description
Makes reinforced glass impervious to low-damage items.

## Why we need to add this
Despite being "Reinforced", these windows can be destroyed with no tools. Previously, they were immune to 5 and below damage. But, even small items (and some species claws/fists) do more then 5 damage. Thus, any crewmember could destroy a reinforced window using nothing but items picked up off a floor, or no items at all.

This was primarily an issue for security, as prisoners who decided to be difficult would abuse the items placed in genpop to destroy the windows and cause problems. Or, if they were a species that had hands dealing more then 5 damage, could just destroy the windows even if security removed all the tools from genpop. 

Now, reinforced windows are far more difficult to destroy. You need large weapons to damage them (Spears, fireaxes, firearms, etc). You can claw at the window, slam your dinky emergency crowbar into the window, or hit it with a garden trowel all you want: It will do nothing.

Current damage values make the Reinforced Glass (and all windows using its damage modified: see secure windoors, plasma glass, etc) reduce all incoming damage by 10. This leaves only big items capable of damaging them.

Firearms and makeshift weapons are capable of damaging the windows. Shotguns will be stopped, so load up some slugs if you want to get through the tougher stuff.


## Media (Video/Screenshots)
https://github.com/user-attachments/assets/89ef0732-0fdc-4125-9c2b-5c290e28e186

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Maxim
- tweak: Reinforced Glass and items sharing its damage modifier are now immune to low-damage tools.
