### PR TITLE
fix eyeobservers

### DIFF
--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -69,16 +69,18 @@ public sealed class StationAiOverlay : Overlay
 
          // Starlight-start: moved to be after new playerEnt definition with edit
          var playerEnt = _player.LocalEntity;
+
+        // Check for cross-grid viewing (e.g., Abductor remote eye) BEFORE getting gridUid
+        if (_entManager.TryGetComponent(playerEnt, out StationAiOverlayComponent? stationAiOverlay) 
+            && stationAiOverlay.AllowCrossGrid 
+            && _entManager.TryGetComponent(playerEnt, out RelayInputMoverComponent? relay))
+            playerEnt = relay.RelayEntity;
+    
         _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform);
         var gridUid = playerXform?.GridUid ?? EntityUid.Invalid;
         _entManager.TryGetComponent(gridUid, out MapGridComponent? grid);
         _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase);
         // Starlight-end
-
-        if (_entManager.TryGetComponent(playerEnt, out StationAiOverlayComponent? stationAiOverlay) 
-            && stationAiOverlay.AllowCrossGrid 
-            && _entManager.TryGetComponent(playerEnt, out RelayInputMoverComponent? relay))
-            playerEnt = relay.RelayEntity;
 
         var invMatrix = args.Viewport.GetWorldToLocalMatrix();
         _accumulator -= (float)_timing.FrameTime.TotalSeconds;


### PR DESCRIPTION
## Short description
let em see again cuh

but you still gotta "reset' camera because of tilting, i dont how to fix it yet.

## Why we need to add this
aint no fun seeing black square

## Media (Video/Screenshots)
<img width="1219" height="875" alt="image" src="https://github.com/user-attachments/assets/4ba54c5a-ce29-4691-9fbe-7d269aefd6a5" />
<img width="1215" height="887" alt="image" src="https://github.com/user-attachments/assets/7da596e1-9332-4ae1-8612-4af62ab7a60e" />

## Checks

- [] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: CringeCursed
- fix: Fixed bug with observer eyes seeing black screen.
