### PR TITLE
Fix the netrunner bath and other remote eyes not working if used from a different grid or map

### DIFF
--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -69,16 +69,19 @@ public sealed class StationAiOverlay : Overlay
 
          // Starlight-start: moved to be after new playerEnt definition with edit
          var playerEnt = _player.LocalEntity;
+        // Starlight-end
+
+        if (_entManager.TryGetComponent(playerEnt, out StationAiOverlayComponent? stationAiOverlay)
+            && stationAiOverlay.AllowCrossGrid
+            && _entManager.TryGetComponent(playerEnt, out RelayInputMoverComponent? relay))
+            playerEnt = relay.RelayEntity;
+
+        // Starlight-start: needs to be here to work with off-map syndie baths and other remote eyess properly
         _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform);
         var gridUid = playerXform?.GridUid ?? EntityUid.Invalid;
         _entManager.TryGetComponent(gridUid, out MapGridComponent? grid);
         _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase);
         // Starlight-end
-
-        if (_entManager.TryGetComponent(playerEnt, out StationAiOverlayComponent? stationAiOverlay) 
-            && stationAiOverlay.AllowCrossGrid 
-            && _entManager.TryGetComponent(playerEnt, out RelayInputMoverComponent? relay))
-            playerEnt = relay.RelayEntity;
 
         var invMatrix = args.Viewport.GetWorldToLocalMatrix();
         _accumulator -= (float)_timing.FrameTime.TotalSeconds;


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Original commit is here https://github.com/Afterlight-RnD/Afterlight-14/commit/69ffefa9b612b4c7364f60caff1889f2da7c62d0
Not sure what it was trying to fix, seems to be a lone commit, this keeps the one line that can be above, above
It was passing the player's grid to the ai overlay methods, instead of the relay's grid

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
[Content.Client_o8FQRctYVM.webm](https://github.com/user-attachments/assets/a494d7f0-268a-40b7-90e9-f905d426715a)

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: DrSmugleaf
- fix: Fixed the netrunner bath and other remote eyes not working if used from a different grid or map.
