### PR TITLE
(Fland) APC power limit pass, telecoms, evac shuttle fixes

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/emergency_delta.yml
+++ b/Resources/Maps/_Starlight/Shuttles/emergency_delta.yml
@@ -1,0 +1,6021 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 267.1.0
+  forkId: ""
+  forkVersion: ""
+  time: 12/12/2025 11:20:45
+  entityCount: 961
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  29: FloorDark
+  30: FloorDarkDiagonal
+  34: FloorDarkMono
+  38: FloorDarkPlastic
+  48: FloorGrassDark
+  3: FloorReinforced
+  84: FloorShuttleRed
+  89: FloorSteel
+  100: FloorSteelMono
+  101: FloorSteelOffset
+  2: FloorTechMaint
+  1: FloorTechMaint2
+  108: FloorWhite
+  120: Lattice
+  121: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NT Evac Delta
+    - type: Transform
+      pos: -0.5625,0.671875
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: HQAAAAADAB0AAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB0AAAAAAgAdAAAAAAMAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdAAAAAAAAHQAAAAABAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAEAAAAAAABZAAAAAAAAWQAAAAABAFkAAAAAAwBZAAAAAAMAeQAAAAAAAB0AAAAAAAAeAAAAAAAAHgAAAAACAB4AAAAAAgAdAAAAAAIAIgAAAAAAAB0AAAAAAAAdAAAAAAEAHQAAAAADAAAAAAAAAAABAAAAAAAAWQAAAAAAAFkAAAAAAwBZAAAAAAAAWQAAAAADACIAAAAAAAAdAAAAAAAAHgAAAAAAAB4AAAAAAgAeAAAAAAAAHQAAAAACAHkAAAAAAAAdAAAAAAAAHQAAAAAAAB0AAAAAAwAAAAAAAAAAeQAAAAAAAFkAAAAAAgBZAAAAAAMAWQAAAAADAFkAAAAAAgB5AAAAAAAAIgAAAAACACIAAAAAAgAdAAAAAAIAHQAAAAADAB0AAAAAAAB5AAAAAAAAHQAAAAABAB0AAAAAAAAdAAAAAAEAAAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAIgAAAAADACIAAAAAAgB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAB0AAAAAAgAdAAAAAAEAHQAAAAAAAB0AAAAAAwAdAAAAAAAAHQAAAAACAB0AAAAAAgAdAAAAAAEAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAdAAAAAAMAHgAAAAABAB4AAAAAAgAeAAAAAAEAHgAAAAAAAB4AAAAAAwAeAAAAAAEAHQAAAAACAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAHQAAAAACAB4AAAAAAAAeAAAAAAIAHgAAAAADAB4AAAAAAQAeAAAAAAMAHgAAAAADAB0AAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAB0AAAAAAwAeAAAAAAAAHgAAAAACAB4AAAAAAAAeAAAAAAIAHgAAAAADAB4AAAAAAQAdAAAAAAEAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAAdAAAAAAEAHQAAAAACAB0AAAAAAwAdAAAAAAIAHQAAAAAAAB0AAAAAAwAdAAAAAAAAHQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAHkAAAAAAABsAAAAAAEAbAAAAAACAGwAAAAAAABsAAAAAAMAeQAAAAAAAFkAAAAAAQBZAAAAAAAAWQAAAAACAFkAAAAAAABZAAAAAAAAWQAAAAAAAFkAAAAAAgBZAAAAAAAAWQAAAAACAAAAAAAAAAB5AAAAAAAAbAAAAAABAGwAAAAAAABsAAAAAAAAbAAAAAADAHkAAAAAAABkAAAAAAIAWQAAAAACAGQAAAAAAwB5AAAAAAAAZAAAAAABAFkAAAAAAgBkAAAAAAIAeQAAAAAAAGQAAAAAAwAAAAAAAAAAeQAAAAAAAGwAAAAAAABZAAAAAAMAWQAAAAABAFkAAAAAAQBZAAAAAAMAWQAAAAABAFkAAAAAAwBkAAAAAAMAeQAAAAAAAGQAAAAAAABZAAAAAAAAZAAAAAAAAHkAAAAAAABkAAAAAAAAAAAAAAAAAHkAAAAAAABsAAAAAAMAWQAAAAAAAFkAAAAAAQBZAAAAAAEAWQAAAAACAFkAAAAAAQBZAAAAAAIAZAAAAAADAHkAAAAAAABkAAAAAAAAWQAAAAAAAGQAAAAAAAB5AAAAAAAAZAAAAAABAAAAAAAAAAB5AAAAAAAAbAAAAAACAGwAAAAAAQBsAAAAAAIAbAAAAAAAAHkAAAAAAABZAAAAAAEAWQAAAAABAGQAAAAAAwB5AAAAAAAAZAAAAAACAFkAAAAAAQBkAAAAAAIAeQAAAAAAAGQAAAAAAQAAAAAAAAAAeQAAAAAAAGwAAAAAAgBsAAAAAAEAbAAAAAABAGwAAAAAAQB5AAAAAAAAZAAAAAADAFkAAAAAAABkAAAAAAAAeQAAAAAAAGQAAAAAAwBZAAAAAAMAZAAAAAADAHkAAAAAAABkAAAAAAMAAAAAAAAAAHkAAAAAAAB5AAAAAAAAZAAAAAADAGQAAAAAAwB5AAAAAAAAeQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAHkAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAB5AAAAAAAAAgAAAAAAAAAAAAAAAAB5AAAAAAAAWQAAAAADAFkAAAAAAgBZAAAAAAMAWQAAAAADAHkAAAAAAABkAAAAAAIAWQAAAAADAGQAAAAAAgB5AAAAAAAAZAAAAAAAAFkAAAAAAABkAAAAAAIAeQAAAAAAAGQAAAAAAQAAAAAAAAAAeQAAAAAAAFkAAAAAAgBlAAAAAAAAZQAAAAAAAFkAAAAAAwB5AAAAAAAAZAAAAAABAFkAAAAAAQBkAAAAAAEAeQAAAAAAAGQAAAAAAABZAAAAAAMAZAAAAAABAHkAAAAAAABkAAAAAAIAAAAAAAAAAHkAAAAAAABZAAAAAAMAZQAAAAAAAGUAAAAAAABZAAAAAAMAeQAAAAAAAGQAAAAAAQBZAAAAAAIAZAAAAAAAAHkAAAAAAABkAAAAAAEAWQAAAAAAAGQAAAAAAQB5AAAAAAAAZAAAAAACAAAAAAAAAAB5AAAAAAAAWQAAAAACAGUAAAAAAABlAAAAAAAAWQAAAAADAGQAAAAAAgBZAAAAAAAAWQAAAAABAGQAAAAAAwB5AAAAAAAAZAAAAAADAFkAAAAAAABkAAAAAAAAeQAAAAAAAGQAAAAAAgAAAAAAAAAAeQAAAAAAAFkAAAAAAABlAAAAAAAAZQAAAAAAAFkAAAAAAgBkAAAAAAIAWQAAAAAAAFkAAAAAAABkAAAAAAEAeQAAAAAAAGQAAAAAAwBZAAAAAAAAZAAAAAADAHkAAAAAAABkAAAAAAEAAAAAAAAAAHkAAAAAAABZAAAAAAEAZQAAAAAAAGUAAAAAAABZAAAAAAEAeQAAAAAAAFkAAAAAAABZAAAAAAEAWQAAAAACAFkAAAAAAQBZAAAAAAAAWQAAAAAAAFkAAAAAAwBZAAAAAAAAWQAAAAAAAAAAAAAAAAB5AAAAAAAAWQAAAAABAFkAAAAAAgBZAAAAAAMAWQAAAAAAAHkAAAAAAABZAAAAAAEAWQAAAAAAAFkAAAAAAgB5AAAAAAAAWQAAAAABAFkAAAAAAABZAAAAAAMAeQAAAAAAAFkAAAAAAgAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAACIAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAHkAAAAAAABZAAAAAAAAWQAAAAABAFkAAAAAAQBZAAAAAAEAeQAAAAAAAB0AAAAAAAAdAAAAAAAAHQAAAAABACIAAAAAAgAiAAAAAAAAeQAAAAAAAB0AAAAAAwAdAAAAAAEAHQAAAAABAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: WQAAAAADAFkAAAAAAwB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFkAAAAAAQBkAAAAAAIAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABZAAAAAAIAZAAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAACAGQAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFkAAAAAAgBZAAAAAAIAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABZAAAAAAEAWQAAAAACAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFkAAAAAAwBZAAAAAAMAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABZAAAAAAMAWQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAADAGQAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFkAAAAAAQBkAAAAAAIAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABZAAAAAAAAZAAAAAABAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAAAAFkAAAAAAgB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFkAAAAAAQBZAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABZAAAAAAIAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHQAAAAADAB0AAAAAAwB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,-2:
+          ind: -1,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeAAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAHgAAAAAAAB5AAAAAAAAHQAAAAADAB0AAAAAAQAdAAAAAAAAHQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHgAAAAAAAB4AAAAAAAAeQAAAAAAAB0AAAAAAAAiAAAAAAAAIgAAAAAAAB0AAAAAAgB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB4AAAAAAAAeAAAAAAAAHkAAAAAAAAdAAAAAAAAIgAAAAADACIAAAAAAwAdAAAAAAIAeQAAAAAAAAAAAAAAAAB4AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeAAAAAAAAHgAAAAAAAB5AAAAAAAAHQAAAAACAB0AAAAAAAAdAAAAAAEAHQAAAAAAAHkAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAHQAAAAADAHkAAAAAAAB5AAAAAAAAAAAAAAAAAHkAAAAAAABsAAAAAAMAbAAAAAAAAGwAAAAAAgBsAAAAAAIAeQAAAAAAAFkAAAAAAgBZAAAAAAIAWQAAAAAAAHkAAAAAAABZAAAAAAEAWQAAAAABAFkAAAAAAwB5AAAAAAAAWQAAAAAAAA==
+          version: 7
+        0,-2:
+          ind: 0,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAHkAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAADAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAAwAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAAAMAAAAAAAB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkAAAAAAAADAAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB5AAAAAAAAeQAAAAAAAHkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWQAAAAADAFkAAAAAAgB5AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      deviceNetId: Wireless
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            6: -12,-1
+            7: -13,-1
+            8: -14,-1
+            23: -11,-9
+            24: -11,-8
+            25: -11,-7
+            26: -14,-9
+            27: -14,-8
+            28: -14,-7
+            29: -14,-6
+            30: -14,-5
+            31: -14,-4
+            32: -11,-4
+            33: -11,-3
+            34: -14,-3
+            61: -7,-9
+            62: -7,-8
+            63: -7,-7
+            64: -7,-6
+            65: -7,-5
+            66: -5,-5
+            67: -5,-6
+            68: -5,-7
+            69: -5,-8
+            70: -5,-9
+            71: -9,-7
+            72: -9,-8
+            73: -9,-9
+            75: -9,-11
+            76: -7,-11
+            77: -7,-12
+            78: -5,-11
+            79: -5,-12
+            80: -5,-13
+            81: -7,-13
+            82: -7,-14
+            83: -5,-14
+            84: -5,-15
+            85: -7,-15
+            86: -9,-15
+            87: -3,-15
+            88: -3,-14
+            89: -3,-13
+            90: -3,-12
+            91: -3,-11
+            92: -1,-11
+            93: -1,-12
+            94: -1,-13
+            95: -1,-15
+            96: -1,-14
+            97: -1,-9
+            98: -1,-8
+            99: -1,-7
+            100: -1,-6
+            101: -1,-5
+            102: -3,-6
+            103: -3,-5
+            104: -3,-7
+            105: -3,-8
+            106: -3,-9
+            107: 1,-7
+            108: 1,-6
+            109: 1,-5
+            110: 1,-13
+            111: 1,-14
+            126: 1,-15
+            133: -9,2
+            134: -8,2
+            135: -6,-1
+            136: -5,-1
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerNe
+          decals:
+            169: -6,1
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            113: -4,7
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerNw
+          decals:
+            170: -8,1
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            112: -9,7
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSe
+          decals:
+            171: -6,0
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            114: -4,5
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteCornerSw
+          decals:
+            166: -8,0
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            115: -9,5
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteLineE
+          decals:
+            116: -4,6
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineN
+          decals:
+            172: -7,1
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteLineN
+          decals:
+            122: -8,7
+            123: -7,7
+            124: -6,7
+            125: -5,7
+        - node:
+            color: '#334E6DC8'
+            id: BrickTileWhiteLineS
+          decals:
+            167: -7,0
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteLineS
+          decals:
+            117: -8,5
+            118: -7,5
+            119: -6,5
+            120: -5,5
+        - node:
+            color: '#334E6DFF'
+            id: BrickTileWhiteLineW
+          decals:
+            121: -9,6
+        - node:
+            color: '#52B4E996'
+            id: CheckerNESW
+          decals:
+            47: -14,-11
+            48: -13,-11
+            49: -12,-11
+            50: -11,-11
+            51: -14,-16
+            52: -14,-17
+            53: -13,-17
+            54: -13,-16
+            55: -12,-16
+            56: -12,-17
+            57: -11,-17
+            58: -11,-16
+        - node:
+            color: '#DE3A3A96'
+            id: CheckerNWSE
+          decals:
+            156: 1,-1
+            157: 0,-1
+            158: -1,-1
+            159: -2,-1
+            160: -3,-1
+            161: -3,2
+            162: -2,2
+            163: -1,2
+            164: 0,2
+            165: 1,2
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            1: -12,2
+            2: -13,2
+            3: -14,2
+            19: -12,-9
+            20: -13,-9
+            21: -11,-6
+            22: -11,-5
+            35: -12,-3
+            36: -13,-3
+            37: -11,-13
+            38: -11,-14
+        - node:
+            color: '#334E6DC8'
+            id: FullTileOverlayGreyscale
+          decals:
+            151: -8,-2
+        - node:
+            color: '#52B4E996'
+            id: FullTileOverlayGreyscale
+          decals:
+            153: -10,-14
+            154: -10,-13
+        - node:
+            color: '#DE3A3A96'
+            id: FullTileOverlayGreyscale
+          decals:
+            152: 0,-2
+        - node:
+            color: '#EFB34196'
+            id: FullTileOverlayGreyscale
+          decals:
+            155: -3,-18
+        - node:
+            color: '#334E6DC8'
+            id: HalfTileOverlayGreyscale
+          decals:
+            139: -9,-3
+            140: -7,-3
+            150: -8,-3
+        - node:
+            color: '#52B4E996'
+            id: HalfTileOverlayGreyscale
+          decals:
+            44: -11,-12
+            45: -12,-12
+            46: -13,-12
+        - node:
+            color: '#DE3A3A96'
+            id: HalfTileOverlayGreyscale
+          decals:
+            137: -1,-3
+            138: 1,-3
+            149: 0,-3
+        - node:
+            color: '#52B4E996'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            41: -13,-15
+            42: -12,-15
+            43: -11,-15
+        - node:
+            color: '#EFB34196'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            146: -5,-17
+            147: -4,-17
+            148: -3,-17
+        - node:
+            color: '#52B4E996'
+            id: HalfTileOverlayGreyscale270
+          decals:
+            59: -14,-14
+            60: -14,-13
+            141: -9,-17
+            142: -9,-16
+            143: -9,-14
+            144: -9,-13
+            145: -9,-12
+        - node:
+            color: '#52B4E996'
+            id: ThreeQuarterTileOverlayGreyscale
+          decals:
+            39: -14,-12
+        - node:
+            color: '#52B4E996'
+            id: ThreeQuarterTileOverlayGreyscale270
+          decals:
+            40: -14,-15
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerNE
+          decals:
+            10: -12,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerNW
+          decals:
+            9: -13,-4
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSE
+          decals:
+            12: -12,-8
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSW
+          decals:
+            11: -13,-8
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            13: -12,-5
+            14: -12,-6
+            15: -12,-7
+            130: -7,-10
+            131: -3,-10
+            132: 1,-10
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            16: -13,-5
+            17: -13,-6
+            18: -13,-7
+            127: -9,-10
+            128: -5,-10
+            129: -1,-10
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 819
+          0,-1:
+            0: 29043
+          -1,0:
+            0: 3823
+          0,1:
+            0: 3
+            1: 4
+          -1,1:
+            0: 13115
+          -4,0:
+            0: 3310
+          -4,1:
+            1: 2
+            0: 12
+          -4,-1:
+            0: 49356
+          -3,0:
+            0: 3067
+          -3,1:
+            0: 52429
+          -3,-1:
+            0: 45243
+          -3,2:
+            1: 32
+            0: 12
+          -2,0:
+            0: 28671
+          -2,1:
+            0: 65535
+          -2,2:
+            0: 15
+          -2,-1:
+            0: 61887
+          -1,2:
+            0: 3
+            1: 64
+          -1,-1:
+            0: 57535
+          -4,-4:
+            0: 52428
+          -4,-3:
+            0: 51404
+          -4,-2:
+            0: 52428
+          -4,-5:
+            0: 49344
+            1: 32
+          -3,-4:
+            0: 65467
+          -3,-3:
+            0: 47547
+          -3,-2:
+            0: 65467
+          -3,-5:
+            0: 45296
+          -2,-4:
+            0: 48063
+          -2,-3:
+            0: 48059
+          -2,-2:
+            0: 48059
+          -2,-5:
+            0: 45196
+            1: 51
+          -1,-4:
+            0: 48063
+          -1,-3:
+            0: 48059
+          -1,-2:
+            0: 48059
+          -1,-5:
+            0: 45823
+          0,-4:
+            0: 13107
+          0,-3:
+            0: 29555
+          0,-2:
+            0: 13107
+          0,-5:
+            0: 12305
+            2: 34
+          -2,-6:
+            1: 13104
+            0: 51200
+          -1,-6:
+            0: 65280
+          0,-6:
+            0: 4352
+            2: 8704
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        - volume: 2500
+          immutable: True
+          moles: {}
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 1400.0662
+            Nitrogen: 5266.916
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: ImplicitRoof
+- proto: AirCanister
+  entities:
+  - uid: 326
+    components:
+    - type: Transform
+      pos: -13.5,-3.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -1.5,-18.5
+      parent: 1
+- proto: AirlockBrigGlassLocked
+  entities:
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+- proto: AirlockCommandGlassLocked
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 1
+- proto: AirlockCommandLocked
+  entities:
+  - uid: 136
+    components:
+    - type: Transform
+      pos: -9.5,1.5
+      parent: 1
+- proto: AirlockEngineeringLocked
+  entities:
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -2.5,-17.5
+      parent: 1
+- proto: AirlockExternalCommandLocked
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -14.5,0.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -14.5,1.5
+      parent: 1
+- proto: AirlockExternalGlassLocked
+  entities:
+  - uid: 433
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-19.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-20.5
+      parent: 1
+- proto: AirlockGlass
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 640
+    components:
+    - type: Transform
+      pos: -5.5,-15.5
+      parent: 1
+  - uid: 671
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-5.5
+      parent: 1
+  - uid: 672
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-4.5
+      parent: 1
+  - uid: 816
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-10.5
+      parent: 1
+- proto: AirlockMedicalGlass
+  entities:
+  - uid: 346
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-9.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-9.5
+      parent: 1
+  - uid: 666
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-12.5
+      parent: 1
+- proto: AirlockSecurityGlassLocked
+  entities:
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
+    - type: Fixtures
+      fixtures: {}
+  - uid: 39
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 348
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-9.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 351
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,-10.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 585
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-11.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 717
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 958
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-20.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-19.5
+      parent: 1
+  - uid: 583
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 696
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 761
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 763
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 765
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,0.5
+      parent: 1
+  - uid: 789
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,1.5
+      parent: 1
+- proto: AtmosFixAirMarker
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 1.5,-21.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 1.5,-20.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      pos: 1.5,-19.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      pos: 1.5,-18.5
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 295
+    components:
+    - type: Transform
+      pos: -10.5,-11.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: -13.5,-11.5
+      parent: 1
+- proto: BorgCharger
+  entities:
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-2.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-2.5
+      parent: 1
+- proto: BoxFlare
+  entities:
+  - uid: 285
+    components:
+    - type: Transform
+      pos: -13.337719,-7.4710283
+      parent: 1
+- proto: BoxFolderBlue
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -8.420452,8.586648
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -10.5,2.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -10.5,1.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -10.5,0.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -11.5,0.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -12.5,0.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -13.5,0.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -11.5,2.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -12.5,2.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -13.5,2.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -12.5,3.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -13.5,-0.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -7.5,5.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -8.5,5.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -9.5,5.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -9.5,7.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -8.5,7.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -7.5,4.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -10.5,-9.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -10.5,-8.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -11.5,-8.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      pos: -11.5,-7.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      pos: -11.5,-6.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      pos: -11.5,-4.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      pos: -12.5,-3.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      pos: -13.5,-3.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      pos: -13.5,-4.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      pos: -13.5,-5.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      pos: -13.5,-6.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      pos: -13.5,-7.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -12.5,-7.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      pos: -14.5,-10.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      pos: -13.5,-10.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      pos: -12.5,-10.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      pos: -12.5,-11.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      pos: -12.5,-12.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      pos: -12.5,-13.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      pos: -12.5,-14.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      pos: -12.5,-15.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: -11.5,-15.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      pos: -10.5,-15.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 1
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -10.5,-13.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -10.5,-12.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -10.5,-11.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -13.5,-12.5
+      parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -14.5,-12.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -14.5,-13.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      pos: -14.5,-14.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -14.5,-15.5
+      parent: 1
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      pos: -9.5,-11.5
+      parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 1
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 597
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 598
+    components:
+    - type: Transform
+      pos: -7.5,-11.5
+      parent: 1
+  - uid: 599
+    components:
+    - type: Transform
+      pos: -7.5,-12.5
+      parent: 1
+  - uid: 600
+    components:
+    - type: Transform
+      pos: -7.5,-13.5
+      parent: 1
+  - uid: 601
+    components:
+    - type: Transform
+      pos: -7.5,-15.5
+      parent: 1
+  - uid: 602
+    components:
+    - type: Transform
+      pos: -7.5,-14.5
+      parent: 1
+  - uid: 603
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 1
+  - uid: 604
+    components:
+    - type: Transform
+      pos: -7.5,-9.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      pos: -7.5,-8.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 612
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 616
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 617
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 618
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 619
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 621
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 622
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 623
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 1
+  - uid: 624
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 1
+  - uid: 625
+    components:
+    - type: Transform
+      pos: -3.5,-15.5
+      parent: 1
+  - uid: 626
+    components:
+    - type: Transform
+      pos: -4.5,-15.5
+      parent: 1
+  - uid: 627
+    components:
+    - type: Transform
+      pos: -6.5,-15.5
+      parent: 1
+  - uid: 628
+    components:
+    - type: Transform
+      pos: -5.5,-15.5
+      parent: 1
+  - uid: 629
+    components:
+    - type: Transform
+      pos: -2.5,-15.5
+      parent: 1
+  - uid: 630
+    components:
+    - type: Transform
+      pos: -1.5,-15.5
+      parent: 1
+  - uid: 631
+    components:
+    - type: Transform
+      pos: -0.5,-15.5
+      parent: 1
+  - uid: 632
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 1
+  - uid: 633
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 1
+  - uid: 634
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 1
+  - uid: 635
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 636
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+  - uid: 637
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 1
+  - uid: 638
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 645
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 646
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 647
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 648
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 649
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 650
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 651
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 652
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 711
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 718
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
+      parent: 1
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -4.5,-18.5
+      parent: 1
+  - uid: 720
+    components:
+    - type: Transform
+      pos: -5.5,-18.5
+      parent: 1
+  - uid: 721
+    components:
+    - type: Transform
+      pos: -6.5,-18.5
+      parent: 1
+  - uid: 722
+    components:
+    - type: Transform
+      pos: -7.5,-18.5
+      parent: 1
+  - uid: 723
+    components:
+    - type: Transform
+      pos: -8.5,-18.5
+      parent: 1
+  - uid: 724
+    components:
+    - type: Transform
+      pos: -9.5,-18.5
+      parent: 1
+  - uid: 725
+    components:
+    - type: Transform
+      pos: -10.5,-18.5
+      parent: 1
+  - uid: 726
+    components:
+    - type: Transform
+      pos: -11.5,-18.5
+      parent: 1
+  - uid: 727
+    components:
+    - type: Transform
+      pos: -12.5,-18.5
+      parent: 1
+  - uid: 728
+    components:
+    - type: Transform
+      pos: -13.5,-18.5
+      parent: 1
+  - uid: 732
+    components:
+    - type: Transform
+      pos: 0.5,-18.5
+      parent: 1
+  - uid: 733
+    components:
+    - type: Transform
+      pos: -0.5,-18.5
+      parent: 1
+  - uid: 734
+    components:
+    - type: Transform
+      pos: -1.5,-18.5
+      parent: 1
+  - uid: 735
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 1
+  - uid: 736
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 1
+  - uid: 752
+    components:
+    - type: Transform
+      pos: -12.5,4.5
+      parent: 1
+  - uid: 753
+    components:
+    - type: Transform
+      pos: -11.5,4.5
+      parent: 1
+  - uid: 754
+    components:
+    - type: Transform
+      pos: -13.5,4.5
+      parent: 1
+  - uid: 756
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 757
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 758
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 769
+    components:
+    - type: Transform
+      pos: -1.5,-19.5
+      parent: 1
+  - uid: 770
+    components:
+    - type: Transform
+      pos: -1.5,-20.5
+      parent: 1
+  - uid: 771
+    components:
+    - type: Transform
+      pos: -3.5,-19.5
+      parent: 1
+  - uid: 772
+    components:
+    - type: Transform
+      pos: -3.5,-20.5
+      parent: 1
+  - uid: 775
+    components:
+    - type: Transform
+      pos: -1.5,-21.5
+      parent: 1
+  - uid: 776
+    components:
+    - type: Transform
+      pos: -1.5,-22.5
+      parent: 1
+  - uid: 777
+    components:
+    - type: Transform
+      pos: -2.5,-22.5
+      parent: 1
+  - uid: 961
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 0.5,-21.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -0.5,-21.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 0.5,-19.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 0.5,-20.5
+      parent: 1
+  - uid: 677
+    components:
+    - type: Transform
+      pos: -0.5,-19.5
+      parent: 1
+  - uid: 688
+    components:
+    - type: Transform
+      pos: 0.5,-18.5
+      parent: 1
+  - uid: 730
+    components:
+    - type: Transform
+      pos: -0.5,-18.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -10.5,7.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -13.5,-7.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: -12.5,-12.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -10.5,-4.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -11.5,-4.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: -12.5,-4.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: -12.5,-5.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: -12.5,-6.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: -12.5,-7.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -12.5,-8.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -11.5,-7.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      pos: -10.5,-7.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -14.5,-7.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: -14.5,-6.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: -14.5,-5.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: -14.5,-4.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -14.5,-3.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -10.5,-8.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -10.5,-9.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -12.5,-9.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      pos: -12.5,-10.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -13.5,-10.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -14.5,-10.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: -1.5,-20.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      pos: -1.5,-21.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      pos: -0.5,-21.5
+      parent: 1
+  - uid: 584
+    components:
+    - type: Transform
+      pos: -11.5,-12.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      pos: -12.5,-11.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -10.5,-12.5
+      parent: 1
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
+      parent: 1
+  - uid: 591
+    components:
+    - type: Transform
+      pos: -8.5,-12.5
+      parent: 1
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -7.5,-12.5
+      parent: 1
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 1
+  - uid: 594
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 656
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 657
+    components:
+    - type: Transform
+      pos: -1.5,-19.5
+      parent: 1
+  - uid: 670
+    components:
+    - type: Transform
+      pos: -4.5,-19.5
+      parent: 1
+  - uid: 673
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
+      parent: 1
+  - uid: 693
+    components:
+    - type: Transform
+      pos: -4.5,-18.5
+      parent: 1
+  - uid: 694
+    components:
+    - type: Transform
+      pos: -3.5,-19.5
+      parent: 1
+  - uid: 695
+    components:
+    - type: Transform
+      pos: -2.5,-19.5
+      parent: 1
+  - uid: 737
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 1
+  - uid: 738
+    components:
+    - type: Transform
+      pos: -6.5,-14.5
+      parent: 1
+  - uid: 739
+    components:
+    - type: Transform
+      pos: -6.5,-15.5
+      parent: 1
+  - uid: 740
+    components:
+    - type: Transform
+      pos: -5.5,-15.5
+      parent: 1
+  - uid: 741
+    components:
+    - type: Transform
+      pos: -4.5,-15.5
+      parent: 1
+  - uid: 742
+    components:
+    - type: Transform
+      pos: -4.5,-16.5
+      parent: 1
+  - uid: 743
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
+      parent: 1
+  - uid: 959
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 1
+  - uid: 960
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 0.5,-20.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 674
+    components:
+    - type: Transform
+      pos: -0.5,-20.5
+      parent: 1
+  - uid: 706
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-19.5
+      parent: 1
+  - uid: 716
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-20.5
+      parent: 1
+  - uid: 729
+    components:
+    - type: Transform
+      pos: 0.5,-20.5
+      parent: 1
+  - uid: 778
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-21.5
+      parent: 1
+  - uid: 779
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-18.5
+      parent: 1
+  - uid: 804
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,-18.5
+      parent: 1
+  - uid: 805
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-18.5
+      parent: 1
+  - uid: 806
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-18.5
+      parent: 1
+  - uid: 807
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-18.5
+      parent: 1
+  - uid: 808
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-18.5
+      parent: 1
+  - uid: 809
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-18.5
+      parent: 1
+  - uid: 810
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 811
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 812
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 813
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,4.5
+      parent: 1
+  - uid: 814
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,4.5
+      parent: 1
+  - uid: 815
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,4.5
+      parent: 1
+- proto: ChairOfficeDark
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,7.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-0.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-0.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-8.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 501
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 503
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 504
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 505
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 506
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 507
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 508
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 510
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 511
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-14.5
+      parent: 1
+  - uid: 522
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-13.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-14.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-13.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-12.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-10.5
+      parent: 1
+  - uid: 538
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-13.5
+      parent: 1
+  - uid: 539
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-12.5
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-10.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-13.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-6.5
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-7.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-8.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-10.5
+      parent: 1
+  - uid: 555
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-14.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-13.5
+      parent: 1
+  - uid: 563
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-12.5
+      parent: 1
+  - uid: 681
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-21.5
+      parent: 1
+  - uid: 691
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-21.5
+      parent: 1
+  - uid: 759
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 1
+- proto: ClosetEmergencyFilledRandom
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      pos: -10.5,-8.5
+      parent: 1
+  - uid: 554
+    components:
+    - type: Transform
+      pos: -8.5,-15.5
+      parent: 1
+  - uid: 556
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 1
+  - uid: 567
+    components:
+    - type: Transform
+      pos: 1.5,-15.5
+      parent: 1
+  - uid: 683
+    components:
+    - type: Transform
+      pos: -4.5,-18.5
+      parent: 1
+  - uid: 835
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+- proto: ClosetEmergencyN2FilledRandom
+  entities:
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -13.5,-4.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 1
+- proto: ClosetFireFilled
+  entities:
+  - uid: 553
+    components:
+    - type: Transform
+      pos: -8.5,-16.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: Transform
+      pos: 1.5,-16.5
+      parent: 1
+  - uid: 836
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+- proto: ClothingBackpackDuffelSurgeryFilled
+  entities:
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -13.493203,-16.354408
+      parent: 1
+- proto: ClothingHeadHatHardhatYellow
+  entities:
+  - uid: 800
+    components:
+    - type: Transform
+      pos: -10.406327,-3.1185083
+      parent: 1
+- proto: ClothingMaskGas
+  entities:
+  - uid: 798
+    components:
+    - type: Transform
+      pos: -10.630073,-3.4031057
+      parent: 1
+- proto: computerBodyScanner
+  entities:
+  - uid: 418
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-16.5
+      parent: 1
+- proto: ComputerCrewMonitoring
+  entities:
+  - uid: 421
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-14.5
+      parent: 1
+- proto: ComputerEmergencyShuttle
+  entities:
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+- proto: ComputerId
+  entities:
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+- proto: ComputerMedicalRecords
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-12.5
+      parent: 1
+- proto: ComputerRadar
+  entities:
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 1
+- proto: CrateEmergencyInflatablewall
+  entities:
+  - uid: 290
+    components:
+    - type: Transform
+      pos: -13.5,-5.5
+      parent: 1
+- proto: CrateEmergencyInternalsLarge
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      pos: -13.5,-6.5
+      parent: 1
+- proto: Crowbar
+  entities:
+  - uid: 785
+    components:
+    - type: Transform
+      pos: -13.464078,-7.5057697
+      parent: 1
+- proto: Defibrillator
+  entities:
+  - uid: 415
+    components:
+    - type: Transform
+      pos: -10.524453,-16.401283
+      parent: 1
+- proto: EmergencyLight
+  entities:
+  - uid: 485
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 945
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,0.5
+      parent: 1
+  - uid: 946
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 947
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-12.5
+      parent: 1
+  - uid: 948
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 949
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 950
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-21.5
+      parent: 1
+  - uid: 951
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-11.5
+      parent: 1
+  - uid: 952
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 953
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 954
+    components:
+    - type: Transform
+      pos: -12.5,-2.5
+      parent: 1
+- proto: ExtendedEmergencyNitrogenTankFilled
+  entities:
+  - uid: 782
+    components:
+    - type: Transform
+      pos: -13.539676,-2.3258739
+      parent: 1
+- proto: ExtendedEmergencyOxygenTankFilled
+  entities:
+  - uid: 783
+    components:
+    - type: Transform
+      pos: -13.399051,-2.4508739
+      parent: 1
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 419
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -14.5,-11.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 569
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 571
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 572
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: FireAxeCabinetFilled
+  entities:
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: FirelockGlass
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 655
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      pos: -12.5,-9.5
+      parent: 1
+  - uid: 659
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 713
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 1
+  - uid: 715
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 1
+  - uid: 731
+    components:
+    - type: Transform
+      pos: -11.5,-9.5
+      parent: 1
+  - uid: 830
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 831
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 832
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 833
+    components:
+    - type: Transform
+      pos: -7.5,-9.5
+      parent: 1
+  - uid: 834
+    components:
+    - type: Transform
+      pos: -8.5,-9.5
+      parent: 1
+- proto: GasOutletInjector
+  entities:
+  - uid: 801
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-18.5
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 654
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-20.5
+      parent: 1
+- proto: GasPipeBend
+  entities:
+  - uid: 856
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-15.5
+      parent: 1
+  - uid: 881
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-15.5
+      parent: 1
+  - uid: 914
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-15.5
+      parent: 1
+- proto: GasPipeFourway
+  entities:
+  - uid: 839
+    components:
+    - type: Transform
+      pos: -2.5,-15.5
+      parent: 1
+- proto: GasPipeStraight
+  entities:
+  - uid: 395
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-20.5
+      parent: 1
+  - uid: 514
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-16.5
+      parent: 1
+  - uid: 643
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-20.5
+      parent: 1
+  - uid: 644
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-20.5
+      parent: 1
+  - uid: 675
+    components:
+    - type: Transform
+      pos: -2.5,-17.5
+      parent: 1
+  - uid: 680
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-18.5
+      parent: 1
+  - uid: 699
+    components:
+    - type: Transform
+      pos: -2.5,-19.5
+      parent: 1
+  - uid: 707
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 1
+  - uid: 802
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-18.5
+      parent: 1
+  - uid: 840
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-13.5
+      parent: 1
+  - uid: 842
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-15.5
+      parent: 1
+  - uid: 844
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 845
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 846
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 847
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 848
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 849
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 850
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 851
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 853
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-13.5
+      parent: 1
+  - uid: 855
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 857
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 858
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-10.5
+      parent: 1
+  - uid: 859
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 861
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 862
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 863
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-7.5
+      parent: 1
+  - uid: 864
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 865
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 866
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 867
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 872
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 873
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 874
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 875
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 878
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-15.5
+      parent: 1
+  - uid: 879
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-15.5
+      parent: 1
+  - uid: 880
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 1
+  - uid: 884
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-14.5
+      parent: 1
+  - uid: 888
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 889
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 890
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 891
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 895
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-13.5
+      parent: 1
+  - uid: 896
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-13.5
+      parent: 1
+  - uid: 897
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-13.5
+      parent: 1
+  - uid: 898
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 899
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-10.5
+      parent: 1
+  - uid: 900
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 901
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-8.5
+      parent: 1
+  - uid: 902
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 903
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 904
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-5.5
+      parent: 1
+  - uid: 905
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-5.5
+      parent: 1
+  - uid: 906
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-5.5
+      parent: 1
+  - uid: 907
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-5.5
+      parent: 1
+  - uid: 915
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-13.5
+      parent: 1
+  - uid: 916
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-13.5
+      parent: 1
+  - uid: 917
+    components:
+    - type: Transform
+      pos: -12.5,-14.5
+      parent: 1
+  - uid: 918
+    components:
+    - type: Transform
+      pos: -12.5,-12.5
+      parent: 1
+  - uid: 919
+    components:
+    - type: Transform
+      pos: -12.5,-11.5
+      parent: 1
+  - uid: 920
+    components:
+    - type: Transform
+      pos: -12.5,-9.5
+      parent: 1
+  - uid: 921
+    components:
+    - type: Transform
+      pos: -12.5,-8.5
+      parent: 1
+  - uid: 922
+    components:
+    - type: Transform
+      pos: -12.5,-7.5
+      parent: 1
+  - uid: 923
+    components:
+    - type: Transform
+      pos: -12.5,-6.5
+      parent: 1
+  - uid: 924
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-5.5
+      parent: 1
+  - uid: 929
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 930
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 931
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 932
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,1.5
+      parent: 1
+  - uid: 933
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,1.5
+      parent: 1
+  - uid: 934
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,1.5
+      parent: 1
+  - uid: 935
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,1.5
+      parent: 1
+  - uid: 938
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 939
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 940
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 941
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+- proto: GasPipeTJunction
+  entities:
+  - uid: 795
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-20.5
+      parent: 1
+  - uid: 841
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 843
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 852
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 854
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 860
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-12.5
+      parent: 1
+  - uid: 871
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 882
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-12.5
+      parent: 1
+  - uid: 883
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-13.5
+      parent: 1
+  - uid: 887
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 892
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 893
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 894
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 909
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-5.5
+      parent: 1
+  - uid: 910
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-13.5
+      parent: 1
+  - uid: 913
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-10.5
+      parent: 1
+  - uid: 925
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,0.5
+      parent: 1
+  - uid: 927
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 928
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 1
+- proto: GasPort
+  entities:
+  - uid: 687
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-18.5
+      parent: 1
+- proto: GasVentPump
+  entities:
+  - uid: 797
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-20.5
+      parent: 1
+  - uid: 868
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-12.5
+      parent: 1
+  - uid: 869
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 870
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 876
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 877
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 885
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-12.5
+      parent: 1
+  - uid: 886
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-6.5
+      parent: 1
+  - uid: 908
+    components:
+    - type: Transform
+      pos: -12.5,-4.5
+      parent: 1
+  - uid: 911
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-15.5
+      parent: 1
+  - uid: 912
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-10.5
+      parent: 1
+  - uid: 926
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 936
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,1.5
+      parent: 1
+  - uid: 937
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 661
+    components:
+    - type: Transform
+      pos: -0.5,-18.5
+      parent: 1
+  - uid: 685
+    components:
+    - type: Transform
+      pos: 0.5,-18.5
+      parent: 1
+  - uid: 686
+    components:
+    - type: Transform
+      pos: 0.5,-19.5
+      parent: 1
+  - uid: 689
+    components:
+    - type: Transform
+      pos: -0.5,-19.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -1.5,-21.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -12.5,3.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -10.5,7.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -14.5,-3.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -14.5,-4.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -14.5,-5.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: -14.5,-6.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: -14.5,-7.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -9.5,-11.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -14.5,-15.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -14.5,-14.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      pos: -14.5,-13.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -14.5,-12.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -11.5,-17.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -12.5,-17.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      pos: -6.5,-17.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      pos: -8.5,-17.5
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 483
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 773
+    components:
+    - type: Transform
+      pos: -1.5,-22.5
+      parent: 1
+  - uid: 774
+    components:
+    - type: Transform
+      pos: -2.5,-22.5
+      parent: 1
+  - uid: 818
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+  - uid: 822
+    components:
+    - type: Transform
+      pos: -5.5,-16.5
+      parent: 1
+  - uid: 823
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 1
+  - uid: 824
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 1
+  - uid: 825
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 826
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 827
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 828
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 829
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 747
+    components:
+    - type: Transform
+      pos: -11.5,4.5
+      parent: 1
+  - uid: 749
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+- proto: HolopadCentCommEvacShuttle
+  entities:
+  - uid: 942
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 1
+- proto: LockerEvacRepairFilled
+  entities:
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 1
+- proto: LockerWallMedicalFilled
+  entities:
+  - uid: 762
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-16.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: MagazinePistolSP
+  entities:
+  - uid: 784
+    components:
+    - type: Transform
+      pos: -2.2705026,-0.47059897
+      parent: 1
+- proto: MedicalBed
+  entities:
+  - uid: 409
+    components:
+    - type: Transform
+      pos: -13.5,-11.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      pos: -10.5,-11.5
+      parent: 1
+- proto: MedkitBurnFilled
+  entities:
+  - uid: 425
+    components:
+    - type: Transform
+      pos: -13.322543,-13.652935
+      parent: 1
+- proto: MedkitFilled
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -2.4709458,4.5597963
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      pos: -13.541293,-13.465435
+      parent: 1
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -13.556918,-14.277935
+      parent: 1
+  - uid: 668
+    components:
+    - type: Transform
+      pos: -13.556469,-7.3077974
+      parent: 1
+- proto: MedkitToxinFilled
+  entities:
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -13.369418,-14.44981
+      parent: 1
+- proto: OperatingTable
+  entities:
+  - uid: 417
+    components:
+    - type: Transform
+      pos: -12.5,-16.5
+      parent: 1
+- proto: OxygenTankFilled
+  entities:
+  - uid: 799
+    components:
+    - type: Transform
+      pos: -10.44437,-3.5553346
+      parent: 1
+- proto: PaperBin10
+  entities:
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+- proto: Pen
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -4.4614916,2.6592817
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -8.607952,8.414773
+      parent: 1
+- proto: PosterLegitEnlist
+  entities:
+  - uid: 788
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: PosterLegitHelpOthers
+  entities:
+  - uid: 790
+    components:
+    - type: Transform
+      pos: -14.5,-16.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: PottedPlantRandom
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 564
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 565
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 566
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 750
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 1
+- proto: PowerCellRecharger
+  entities:
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -9.5,4.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-2.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-15.5
+      parent: 1
+  - uid: 957
+    components:
+    - type: Transform
+      pos: -10.5,2.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,0.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-15.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-15.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-3.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-3.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-0.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,4.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,8.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-16.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-15.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 780
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-21.5
+      parent: 1
+  - uid: 793
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 794
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 943
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 944
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-8.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 450
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-11.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,-8.5
+      parent: 1
+  - uid: 642
+    components:
+    - type: Transform
+      pos: 1.5,-18.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 289
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-8.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-7.5
+      parent: 1
+  - uid: 796
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 1
+- proto: RandomPosterLegit
+  entities:
+  - uid: 570
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 786
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 1
+  - uid: 787
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 791
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 1
+  - uid: 792
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+- proto: RandomVendingDrinks
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      pos: -9.5,8.5
+      parent: 1
+- proto: RandomVendingSnacks
+  entities:
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+- proto: Screen
+  entities:
+  - uid: 438
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-9.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 766
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-15.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 767
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 768
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 781
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 838
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ShotGunCabinetFilled
+  entities:
+  - uid: 745
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ShuttleWindow
+  entities:
+  - uid: 6
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -12.5,3.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -10.5,7.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -8.5,9.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -7.5,9.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -14.5,-3.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 262
+    components:
+    - type: Transform
+      pos: -14.5,-4.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -14.5,-5.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -14.5,-6.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -14.5,-7.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -1.5,-22.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: -2.5,-22.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: -9.5,-11.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 338
+    components:
+    - type: Transform
+      pos: -11.5,-17.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -12.5,-17.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 342
+    components:
+    - type: Transform
+      pos: -14.5,-12.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -14.5,-13.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 344
+    components:
+    - type: Transform
+      pos: -14.5,-14.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -14.5,-15.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -8.5,-17.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 432
+    components:
+    - type: Transform
+      pos: -6.5,-17.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 469
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 470
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 471
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 478
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 479
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 513
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 515
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 530
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 533
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 535
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 557
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 712
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 760
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 764
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 817
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 819
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 820
+    components:
+    - type: Transform
+      pos: -5.5,-16.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 821
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 837
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+- proto: SignBridge
+  entities:
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: SignEngineering
+  entities:
+  - uid: 491
+    components:
+    - type: Transform
+      pos: -3.5,-17.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: SignEVA
+  entities:
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: SignMedical
+  entities:
+  - uid: 397
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-11.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 398
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-14.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: SignSecurity
+  entities:
+  - uid: 434
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: Sink
+  entities:
+  - uid: 408
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-15.5
+      parent: 1
+- proto: SMESBasic
+  entities:
+  - uid: 744
+    components:
+    - type: Transform
+      pos: 0.5,-21.5
+      parent: 1
+- proto: SpawnMobMedibot
+  entities:
+  - uid: 667
+    components:
+    - type: Transform
+      pos: -11.5,-12.5
+      parent: 1
+- proto: StasisBed
+  entities:
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -13.5,-10.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -10.5,-10.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 577
+    components:
+    - type: Transform
+      pos: -0.5,-21.5
+      parent: 1
+- proto: SuitStorageEVA
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -11.5,2.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -12.5,2.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -13.5,2.5
+      parent: 1
+- proto: Table
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      pos: -13.5,-2.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -9.5,4.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      pos: -13.5,-14.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -13.5,-16.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -13.5,-13.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      pos: -10.5,-15.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: -10.5,-16.5
+      parent: 1
+  - uid: 955
+    components:
+    - type: Transform
+      pos: -10.5,-0.5
+      parent: 1
+  - uid: 956
+    components:
+    - type: Transform
+      pos: -10.5,2.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 684
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,-18.5
+      parent: 1
+  - uid: 690
+    components:
+    - type: Transform
+      pos: -12.5,4.5
+      parent: 1
+  - uid: 701
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-18.5
+      parent: 1
+  - uid: 702
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-18.5
+      parent: 1
+  - uid: 703
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-18.5
+      parent: 1
+  - uid: 704
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-18.5
+      parent: 1
+  - uid: 705
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-18.5
+      parent: 1
+  - uid: 708
+    components:
+    - type: Transform
+      pos: -13.5,4.5
+      parent: 1
+  - uid: 748
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 751
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+- proto: ToolboxElectricalFilled
+  entities:
+  - uid: 669
+    components:
+    - type: Transform
+      pos: -13.603344,-8.292172
+      parent: 1
+- proto: ToolboxEmergencyFilled
+  entities:
+  - uid: 287
+    components:
+    - type: Transform
+      pos: -13.322094,-8.573422
+      parent: 1
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 664
+    components:
+    - type: Transform
+      pos: -13.462719,-8.417172
+      parent: 1
+- proto: VendingMachineEngivend
+  entities:
+  - uid: 692
+    components:
+    - type: Transform
+      pos: -4.5,-21.5
+      parent: 1
+- proto: VendingMachineSec
+  entities:
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -13.5,-0.5
+      parent: 1
+- proto: VendingMachineWallMedical
+  entities:
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -9.5,-10.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+- proto: VendingMachineYouTool
+  entities:
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -10.5,-2.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -8.5,3.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -9.5,2.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -9.5,3.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -10.5,3.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -11.5,3.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -10.5,4.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -14.5,2.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -14.5,-0.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -11.5,-1.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -12.5,-1.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -13.5,-1.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -13.5,3.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -14.5,3.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 2.5,-20.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 2.5,-18.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -14.5,-1.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 2.5,-21.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 2.5,-19.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -10.5,8.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -9.5,9.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -9.5,-2.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -14.5,-2.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -9.5,-10.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: -14.5,-9.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: -10.5,-9.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -13.5,-9.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 1.5,-22.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: -14.5,-8.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 0.5,-22.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      pos: -0.5,-22.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: -14.5,-10.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: -14.5,-11.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: -9.5,-15.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: -9.5,-16.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 2.5,-17.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: -13.5,-17.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -9.5,-17.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -10.5,-17.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -14.5,-16.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      pos: -14.5,-17.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -7.5,-17.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 2.5,-15.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      pos: -3.5,-17.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      pos: 1.5,-17.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      pos: -5.5,-17.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      pos: 0.5,-17.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 537
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 582
+    components:
+    - type: Transform
+      pos: -5.5,-18.5
+      parent: 1
+  - uid: 588
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 1
+  - uid: 639
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 1
+  - uid: 641
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      pos: -5.5,-22.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      pos: -5.5,-21.5
+      parent: 1
+  - uid: 678
+    components:
+    - type: Transform
+      pos: -1.5,-17.5
+      parent: 1
+  - uid: 679
+    components:
+    - type: Transform
+      pos: -0.5,-17.5
+      parent: 1
+  - uid: 697
+    components:
+    - type: Transform
+      pos: -4.5,-22.5
+      parent: 1
+  - uid: 698
+    components:
+    - type: Transform
+      pos: -3.5,-22.5
+      parent: 1
+  - uid: 714
+    components:
+    - type: Transform
+      pos: 2.5,-22.5
+      parent: 1
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -10.5,9.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 676
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,-18.5
+      parent: 1
+  - uid: 709
+    components:
+    - type: Transform
+      pos: -14.5,4.5
+      parent: 1
+  - uid: 710
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 803
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-18.5
+      parent: 1
+- proto: WaterTankFull
+  entities:
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -10.5,-6.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+- proto: WeldingFuelTankFull
+  entities:
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -10.5,-7.5
+      parent: 1
+- proto: WindoorSecureEngineeringLocked
+  entities:
+  - uid: 700
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-20.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+- proto: WindoorSecureSecurityLocked
+  entities:
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 115
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-21.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-19.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 130
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-20.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-18.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 660
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-19.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 682
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-18.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 746
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-21.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+  - uid: 755
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: DeltaPressure
+      gridUid: 1
+...

--- a/Resources/Prototypes/_StarLight/Maps/fland.yml
+++ b/Resources/Prototypes/_StarLight/Maps/fland.yml
@@ -13,7 +13,7 @@
             !type:NanotrasenNameGenerator
             prefixCreator: 'B'
         - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency_delta.yml
+          emergencyShuttlePath: /Maps/_Starlight/Shuttles/emergency_delta.yml
         - type: StationCargoShuttle
           path: /Maps/Shuttles/cargo_fland.yml
         - type: StationJobs


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds several APCs
- Telecoms was drawing 21kW, split into two APCs
- Xenoarch was drawing 17kW, split into two APCs
- Atmopsherics was drawing 18kW, split into three APCs
- Chemistry was drawing 16kW, split into two APCs

Adds a Starlight variant of the `emergency_delta.yml` evac shuttle (to avoid merge conflicts with upstream). The EVA room on the upstream version of this shuttle was entirely unpowered. Fland and Orwell use this evac shuttle.

Also fixes the telecom servers on this map to use the telecom server prototypes. Before this PR, the telecom servers were hand-loaded by the map maker with encryption keys.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
n/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- add: (Fland) New APCs added in Medical, Science, Engineering, and Telecoms to spread out power loads (no APC over 20kW)
- fix: (Fland) Telecom servers replaced with proper prototypes
- fix: (Fland) Emergency shuttle's EVA room was unpowered
