### PR TITLE
Fix: Gibbing broken while eye implant is installed

### DIFF
--- a/Resources/Prototypes/_StarLight/Body/Implants/eye.yml
+++ b/Resources/Prototypes/_StarLight/Body/Implants/eye.yml
@@ -7,7 +7,6 @@
     sprite: _Starlight/Objects/Specific/Medical/implants.rsi
   - type: Organ
   - type: EyeImplant
-  - type: Gibbable
   - type: FlavorProfile
     flavors:
       - people

--- a/Resources/Prototypes/_StarLight/Body/Organs/cyber_organs.yml
+++ b/Resources/Prototypes/_StarLight/Body/Organs/cyber_organs.yml
@@ -7,7 +7,6 @@
   - type: Sprite
     sprite: Mobs/Species/Human/organs.rsi
   - type: Organ
-  - type: Gibbable
   - type: Extractable
     juiceSolution:
       reagents:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removed Gibbable comp from eye implants

## Why we need to add this
Gibbable is used to mark things which should *be* gibbed, which implants cannot. This leads to the dev environment crashing entirely when attempted, and on servers (tested on Delta) it causes the body to stay intact, but drop all organs (except the implant).

Also included in https://github.com/ss14Starlight/space-station-14/pull/1295 but felt worth PRing on it's own if that one doesn't make it in.

## Media (Video/Screenshots)
This works now (and also drops the implant)
<img width="307" height="379" alt="image" src="https://github.com/user-attachments/assets/6b29f4c3-d281-45c3-8b57-de6665bf3f1d" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Citrea
- fix: Bodies with installed eye implants can now be properly gibbed.
