### PR TITLE
Support setting a multiplier on salaries

### DIFF
--- a/Content.Server/_Starlight/Economy/SalarySystem.cs
+++ b/Content.Server/_Starlight/Economy/SalarySystem.cs
@@ -22,12 +22,14 @@ using Content.Shared.Pinpointer;
 using Content.Shared.Roles;
 using Content.Shared.Stacks;
 using Content.Shared.Starlight.Antags.Abductor;
+using Content.Shared.Starlight.CCVar;
 using Content.Shared.Starlight.Medical.Surgery.Effects.Step;
 using Content.Shared.UserInterface;
 using NAudio.CoreAudioApi;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -49,6 +51,7 @@ public sealed partial class SalarySystem : SharedSalarySystem
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly RoleSystem _roles = default!;
     [Dependency] private readonly MindSystem _mind = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
 
     private float _delayAccumulator = 0f;
     private readonly Stopwatch _stopwatch = new();
@@ -114,6 +117,10 @@ public sealed partial class SalarySystem : SharedSalarySystem
         foreach (var bonus in _prototypes.EnumeratePrototypes<SalaryRoleBonusPrototype>())
             if(bonus.Roles.Any(playerData.Roles.Contains))
                 bonusMultiplier += bonus.Multiplayer;
+
+        var serverSalaryMultiplier = _configurationManager.GetCVar(StarlightCCVars.PayScaling);
+
+        bonusMultiplier *= serverSalaryMultiplier;
 
         return (int)Math.Ceiling(baseSalary * bonusMultiplier);
     }

--- a/Content.Server/_Starlight/Economy/SalarySystem.cs
+++ b/Content.Server/_Starlight/Economy/SalarySystem.cs
@@ -118,7 +118,7 @@ public sealed partial class SalarySystem : SharedSalarySystem
             if(bonus.Roles.Any(playerData.Roles.Contains))
                 bonusMultiplier += bonus.Multiplayer;
 
-        var serverSalaryMultiplier = _configurationManager.GetCVar(StarlightCCVars.PayScaling);
+        var serverSalaryMultiplier = _configurationManager.GetCVar(StarlightCCVars.SalaryMultiplier);
 
         bonusMultiplier *= serverSalaryMultiplier;
 

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
@@ -17,7 +17,7 @@ public sealed partial class StarlightCCVars
         CVarDef.Create("game.cryo_teleportation", true, CVar.SERVERONLY);
 
     /// <summary>
-    /// Sends afk players to cryo.
+    /// A limit on the maximum manual FTL range for shuttles, even if the shuttle's components are modified.
     /// </summary>
     public static readonly CVarDef<float> AdmemeShuttleLimit =
         CVarDef.Create("game.admeme_shuttle_limit", 1000f, CVar.SERVER | CVar.REPLICATED);
@@ -27,4 +27,10 @@ public sealed partial class StarlightCCVars
     /// </summary>
     public static readonly CVarDef<bool> FuckMappingCommand =
         CVarDef.Create("game.fuck_mapping", false, CVar.SERVERONLY | CVar.CONFIDENTIAL);
+
+    /// <summary>
+    /// A multiplier for how much everyone gets paid on salary ticks, e.g. for hazard pay to encourage playing on test branches.
+    /// </summary>
+    public static readonly CVarDef<float> PayScaling =
+        CVarDef.Create("game.pay_scaling", 1f, CVar.SERVERONLY);
 }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
@@ -31,6 +31,6 @@ public sealed partial class StarlightCCVars
     /// <summary>
     /// A multiplier for how much everyone gets paid on salary ticks, e.g. for hazard pay to encourage playing on test branches.
     /// </summary>
-    public static readonly CVarDef<float> PayScaling =
-        CVarDef.Create("game.pay_scaling", 1f, CVar.SERVERONLY);
+    public static readonly CVarDef<float> SalaryMultiplier =
+        CVarDef.Create("game.salary_multiplier", 1f, CVar.SERVERONLY);
 }


### PR DESCRIPTION


<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This allows us to multiply salaries on a per-server basis, through a new ccvar `game.pay_scaling`, which defaults to 1.

## Why we need to add this
This is intended as a way to incentivize playing on Delta when we want good coverage of a new payload.

## Media (Video/Screenshots)
I don't think there's a good way to screenshot this one?

## Checks

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- add: We talked to the finance department and it's now possible to adjust pay on a system-by-system basis.
