### PR TITLE
Fix NTSF ID cards

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/identification_cards.yml
@@ -318,7 +318,17 @@
   components:
   - type: Sprite
     layers:
-    - state: centcom
+    - sprite: *id-rsi
+      state: centcom
+    - sprite: *id-rsi
+      state: stripe_top
+      color: *color-centcomm-top
+    - sprite: *id-rsi
+      state: stripe_bottom
+      color: *color-centcomm-bottom
+    - sprite: *icon-rsi
+      offset: *icon-offset
+      state: Nanotrasen
   - type: Item
     heldPrefix: blue
   - type: PresetIdCard


### PR DESCRIPTION
## Short description
These were broken in the recent update; this updates them to be a relatively generic NT ID card, which roughly matches what they had previously.

## Why we need to add this
NTSF should have NT IDs.

## Media (Video/Screenshots)
![20251215115016_1 (Edited)](https://github.com/user-attachments/assets/96ba15b0-0ab8-430d-91e8-e3f4c493301f)

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- tweak: The special forces team found the box of ID cards that got buried under their extra ammo crates in the last shipment.
