### PR TITLE
Fix takeovers for roles with requirements

### DIFF
--- a/Content.Server/GameTicking/Events/IsRoleAllowedEvent.cs
+++ b/Content.Server/GameTicking/Events/IsRoleAllowedEvent.cs
@@ -10,15 +10,18 @@ namespace Content.Server.GameTicking.Events;
 /// <param name="player">The player.</param>
 /// <param name="jobs">Optional list of job prototype IDs</param>
 /// <param name="antags">Optional list of antag prototype IDs</param>
+/// <param name="isSpawning">Are we checking this in the context of spawning a new entity (as opposed to assuming the place of an existing one)?</param> // Starlight
 [ByRefEvent]
 public struct IsRoleAllowedEvent(
     ICommonSession player,
     List<ProtoId<JobPrototype>>? jobs,
     List<ProtoId<AntagPrototype>>? antags,
-    bool cancelled = false)
+    bool cancelled = false,
+    bool isSpawning = true) // Starlight - add isSpawning
 {
     public readonly ICommonSession Player = player;
     public readonly List<ProtoId<JobPrototype>>? Jobs = jobs;
     public readonly List<ProtoId<AntagPrototype>>? Antags = antags;
     public bool Cancelled = cancelled;
+    public bool IsSpawning = isSpawning; // Starlight - add isSpawning
 }

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -557,7 +557,7 @@ public sealed class GhostRoleSystem : EntitySystem
         List<ProtoId<JobPrototype>>? jobIds,
         List<ProtoId<AntagPrototype>>? antagIds)
     {
-        var ev = new IsRoleAllowedEvent(player, jobIds, antagIds);
+        var ev = new IsRoleAllowedEvent(player, jobIds, antagIds, cancelled: false, isSpawning: false); // Starlight-edit: add last two parameters
         RaiseLocalEvent(ref ev);
 
         return !ev.Cancelled;

--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
@@ -182,6 +182,14 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
 
     private void OnIsRoleAllowed(ref IsRoleAllowedEvent ev)
     {
+        // Starlight start
+        if (!ev.IsSpawning) {
+            if (!IsAllowedNonSpawning(ev.Player, ev.Jobs) || !IsAllowedNonSpawning(ev.Player, ev.Antags))
+                ev.Cancelled = true;
+            return;
+        }
+        // Starlight end
+
         if (!IsAllowed(ev.Player, ev.Jobs) || !IsAllowed(ev.Player, ev.Antags))
             ev.Cancelled = true;
     }
@@ -270,8 +278,15 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
 
         var playTimes = GetPlayTimesIfEnabled(player);
 
+        var requirements = _roles.GetRoleRequirements(job); // Starlight-edit - moved this up a bit
+
+        // Starlight start
+        // If this is a non-profile-selectable antag, don't check profiles
+        if (!_prototypes.Index<JobPrototype>(job).SetPreference)
+            return JobRequirements.TryRequirementsMet(requirements, player, playTimes, out _, EntityManager, _prototypes, null);
+        // Starlight end
+
         var allProfilesForJob = _preferencesManager.GetPreferences(player.UserId).GetAllEnabledProfilesForJob(job);
-        var requirements = _roles.GetRoleRequirements(job);
         return allProfilesForJob.Values.Any(profile => JobRequirements.TryRequirementsMet(
                     requirements,
                     player,
@@ -303,9 +318,15 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
         */// Starlight end
 
         var playTimes = GetPlayTimesIfEnabled(player);
+        var requirements = _roles.GetRoleRequirements(antag); // Starlight-edit - moved this up a bit
+
+        // Starlight start
+        // If this is a non-profile-selectable antag, don't check profiles
+        if (!_prototypes.Index<AntagPrototype>(antag).SetPreference)
+            return JobRequirements.TryRequirementsMet(requirements, player, playTimes, out _, EntityManager, _prototypes, null);
+        // Starlight end
 
         var allProfilesForAntag = _preferencesManager.GetPreferences(player.UserId).GetAllEnabledProfilesForAntag(antag);
-        var requirements = _roles.GetRoleRequirements(antag);
         return allProfilesForAntag.Values.Any(profile => JobRequirements.TryRequirementsMet(
                     requirements,
                     player,
@@ -354,4 +375,52 @@ public sealed class PlayTimeTrackingSystem : EntitySystem
     {
         _tracking.QueueRefreshTrackers(player);
     }
+
+    // Starlight start
+    /// <summary>
+    /// Checks if the player meets role requirements, without checking if they have a profile that has this job
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="jobs">A list of role prototype IDs</param>
+    /// <returns>Returns true if all requirements were met or there were no requirements.</returns>
+    public bool IsAllowedNonSpawning(ICommonSession player, List<ProtoId<JobPrototype>>? jobs)
+    {
+        if (jobs is null)
+            return true;
+
+        var playTimes = GetPlayTimesIfEnabled(player);
+
+        foreach (var job in jobs)
+        {
+            var requirements = _roles.GetRoleRequirements(job);
+            if (!JobRequirements.TryRequirementsMet(requirements, player, playTimes, out _, EntityManager, _prototypes, null))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Checks if the player meets role requirements, without checking if they have a profile that has this antag
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="antags">A list of role prototype IDs</param>
+    /// <returns>Returns true if all requirements were met or there were no requirements.</returns>
+    public bool IsAllowedNonSpawning(ICommonSession player, List<ProtoId<AntagPrototype>>? antags)
+    {
+        if (antags is null)
+            return true;
+
+        var playTimes = GetPlayTimesIfEnabled(player);
+
+        foreach (var antag in antags)
+        {
+            var requirements = _roles.GetRoleRequirements(antag);
+            if (!JobRequirements.TryRequirementsMet(requirements, player, playTimes, out _, EntityManager, _prototypes, null))
+                return false;
+        }
+
+        return true;
+    }
+    // Starlight end
 }

--- a/Resources/Prototypes/_StarLight/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Antags/revolutionary.yml
@@ -2,7 +2,7 @@
   id: SSF
   name: roles-antag-ssf-name
   antagonist: true
-  setPreference: true
+  setPreference: false
   objective: roles-antag-ssf-objective
   requirements:
   - !type:OverallPlaytimeRequirement


### PR DESCRIPTION
## Short description
We now explicitly provide no profile when roles aren't linked to profile-recorded preferences, and have a separate path for many pre-existing spawned-body ghost roles to avoid profile interaction entirely.

Oh, and as a drive-by, I made the SSF not show up in the preferences menu.

## Why we need to add this
It fixes taking the role of several of our antagonists.

## Media (Video/Screenshots)
Nothing that'd be visible from a screenshot; you can be an abductor again though.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Possessing ghost roles with requirements once again functions.