### PR TITLE
Borg hands are no longer being re-sorted

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.cs
@@ -95,6 +95,7 @@ public abstract partial class SharedHandsSystem
         //Starlight start
         switch (hand.Location) 
         {
+            case HandLocation.Middle: //Middle hands are functional hands but on hotbar. Special sorting for this would be possible, but quite inefficient.
             case HandLocation.Functional:
                 ent.Comp.SortedHands.Add(handName);
                 break;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes borg hand re-sorting

## Why we need to add this
During testing https://github.com/ss14Starlight/space-station-14/pull/2318, I seem to have missed that borg tools are being added as *middle* hands, rather than functional, which sorts them all to position 2 in the list... in reverse order, past the first item. As middle hands appear to just be used as functional hands for the hotbar, and never in conjunction with proper hands (for now), I am simply removing their sorting, rather than doing expensive calculations to always sort them between left and right hands.

## Media (Video/Screenshots)
Borg hands when first selecting a module
<img width="517" height="159" alt="image" src="https://github.com/user-attachments/assets/2a2a95f1-bd8b-430c-93a4-695ee93c6bf5" />
Borg hands when re-selecting that module - not shuffled!
<img width="512" height="138" alt="image" src="https://github.com/user-attachments/assets/9888666c-13da-4f2e-a943-ffff9e248da9" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
