### PR TITLE
Set Content.Starlight.Codegen to enable nullability

### DIFF
--- a/Content.Starlight.Codegen/Content.Starlight.Codegen.csproj
+++ b/Content.Starlight.Codegen/Content.Starlight.Codegen.csproj
@@ -5,6 +5,8 @@
     <LangVersion>12</LangVersion>
     <IsRoslynAnalyzer>true</IsRoslynAnalyzer>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Short description
We've been getting warnings on every PR that Content.Starlight.Codegen doesn't have nullability enabled, so this change enables it. This was also the last warning in that project, so I'm setting it to promote any new warnings to error.

## Why we need to add this
This is in service of our code quality goals.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

:cl:Penguinwizzard
- fix: Nullability fix (CL added by happyrobot33 to test CL pipeline)