### PR TITLE
Fix recharge of several auto-recharging guns

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -904,7 +904,6 @@
     maxCharge: 480
     startingCharge: 480
   - type: PredictedBatterySelfRecharger
-    autoRecharge: true
     autoRechargeRate: 20
     autoRechargePauseTime: 10
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -903,7 +903,7 @@
   - type: PredictedBattery
     maxCharge: 480
     startingCharge: 480
-  - type: BatterySelfRecharger
+  - type: PredictedBatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 20
     autoRechargePauseTime: 10

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -270,7 +270,7 @@
   - type: PredictedBattery
     maxCharge: 1500
     startingCharge: 1500
-  - type: BatterySelfRecharger
+  - type: PredictedBatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 20
 
@@ -315,7 +315,7 @@
   - type: PredictedBattery
     maxCharge: 2000
     startingCharge: 2000
-  - type: BatterySelfRecharger
+  - type: PredictedBatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 100
     autoRechargePauseTime: 44
@@ -341,7 +341,7 @@
     - Back
   - type: Gun
     fireRate: 0.6
-  - type: BatterySelfRecharger
+  - type: PredictedBatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 40 #100sec+60Sec Pause
     autoRechargePauseTime: 60
@@ -379,7 +379,7 @@
     - 0, 0, 3, 1
   - type: Gun
     fireRate: 0.6
-  - type: BatterySelfRecharger
+  - type: PredictedBatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 40 #100sec+60Sec Pause
     autoRechargePauseTime: 60
@@ -464,7 +464,7 @@
     size: Small
     shape:
     - 0, 0, 1, 1
-  - type: BatterySelfRecharger
+  - type: PredictedBatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 200
   - type: MagazineVisuals
@@ -786,7 +786,7 @@
   - type: PredictedBattery
     maxCharge: 2000
     startingCharge: 2000
-  - type: BatterySelfRecharger
+  - type: PredictedBatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 500
 
@@ -809,7 +809,7 @@
     - type: BatteryAmmoProvider
       proto: ProjectilePolyboltJohnToe
       fireCost: 200
-    - type: BatterySelfRecharger
+    - type: PredictedBatterySelfRecharger
       autoRecharge: true
       autoRechargeRate: 40 #every 5 seconds another becomes toe.
     - type: MagazineVisuals
@@ -880,7 +880,7 @@
   - type: PredictedBattery
     maxCharge: 1500
     startingCharge: 1500
-  - type: BatterySelfRecharger
+  - type: PredictedBatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 80
     autoRechargePauseTime: 10
@@ -923,7 +923,7 @@
   - type: PredictedBattery
     maxCharge: 500
     startingCharge: 500
-  - type: BatterySelfRecharger
+  - type: PredictedBatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 50
     autoRechargePauseTime: 10

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -271,7 +271,6 @@
     maxCharge: 1500
     startingCharge: 1500
   - type: PredictedBatterySelfRecharger
-    autoRecharge: true
     autoRechargeRate: 20
 
 - type: entity
@@ -316,7 +315,6 @@
     maxCharge: 2000
     startingCharge: 2000
   - type: PredictedBatterySelfRecharger
-    autoRecharge: true
     autoRechargeRate: 100
     autoRechargePauseTime: 44
 
@@ -342,7 +340,6 @@
   - type: Gun
     fireRate: 0.6
   - type: PredictedBatterySelfRecharger
-    autoRecharge: true
     autoRechargeRate: 40 #100sec+60Sec Pause
     autoRechargePauseTime: 60
   - type: BatteryAmmoProvider
@@ -380,7 +377,6 @@
   - type: Gun
     fireRate: 0.6
   - type: PredictedBatterySelfRecharger
-    autoRecharge: true
     autoRechargeRate: 40 #100sec+60Sec Pause
     autoRechargePauseTime: 60
   - type: BatteryAmmoProvider
@@ -465,7 +461,6 @@
     shape:
     - 0, 0, 1, 1
   - type: PredictedBatterySelfRecharger
-    autoRecharge: true
     autoRechargeRate: 200
   - type: MagazineVisuals
     magState: stun
@@ -787,7 +782,6 @@
     maxCharge: 2000
     startingCharge: 2000
   - type: PredictedBatterySelfRecharger
-    autoRecharge: true
     autoRechargeRate: 500
 
 - type: entity
@@ -810,7 +804,6 @@
       proto: ProjectilePolyboltJohnToe
       fireCost: 200
     - type: PredictedBatterySelfRecharger
-      autoRecharge: true
       autoRechargeRate: 40 #every 5 seconds another becomes toe.
     - type: MagazineVisuals
       magState: mag
@@ -881,7 +874,6 @@
     maxCharge: 1500
     startingCharge: 1500
   - type: PredictedBatterySelfRecharger
-    autoRecharge: true
     autoRechargeRate: 80
     autoRechargePauseTime: 10
 
@@ -924,6 +916,5 @@
     maxCharge: 500
     startingCharge: 500
   - type: PredictedBatterySelfRecharger
-    autoRecharge: true
     autoRechargeRate: 50
     autoRechargePauseTime: 10


### PR DESCRIPTION
## Short description
For PredictedBatteryComponent, we need to use
PredictedBatterySelfRechargerComponent, not BatterySelfRechargerComponent, or the client won't show the battery recharging.

## Why we need to add this
Without this it looks like the guns aren't recharging, and it can get very confusing.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: A number of self-recharging weapons got a firmware update and now properly display updates to their ammo when they recharge.
