### PR TITLE
long phone calls are now space legal

### DIFF
--- a/Content.Shared/Telephone/TelephoneComponent.cs
+++ b/Content.Shared/Telephone/TelephoneComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class TelephoneComponent : Component
     /// Sets how long the telephone can remain idle in-call before it automatically hangs up
     /// </summary>
     [DataField]
-    public float IdlingTimeout = 60;
+    public float IdlingTimeout = 600; // Starlight edit - 60 (1m) --> 600 (10m)
 
     /// <summary>
     /// Sets how long the telephone will stay in the hanging up state before return to idle


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
per [discord suggestion thread](https://discord.com/channels/1272545509562777621/1450130525091266686/1450130525091266686), allows holopad calls to not be automatically cut off after 60s (1m) - duration extended to 600s (10m).

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- tweak: Increases timeout on the holopad from 1 minute to 10 minutes, allowing for longer conversations without interruption.
