### PR TITLE
Allow firelocks to close over non-glass airlocks

### DIFF
--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -577,6 +577,13 @@ public abstract partial class SharedDoorSystem : EntitySystem
             if (!otherPhysics.Comp.CanCollide)
                 continue;
 
+            // Starlight start
+            // In order to make firelocks behave consistently between glass and non-glass airlocks, we
+            // need to match upstream's exclusion of glass airlock collision from the following block.
+            if (otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.AirlockLayer)
+                continue;
+            // Starlight end
+
             //TODO: Make only shutters ignore these objects upon colliding instead of all airlocks
             // Excludes Glasslayer for windows, GlassAirlockLayer for windoors, TableLayer for tables
             if (otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.GlassLayer || otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.GlassAirlockLayer || otherPhysics.Comp.CollisionLayer == (int) CollisionGroup.TableLayer)


### PR DESCRIPTION
## Short description
Right now firelocks can close over glass airlocks, but not non-glass airlocks. This changelist alters their rules so they're now able to close consistently, without regard to whether the airlock has glass in it.

## Why we need to add this
It's confusing and inconsistent that firelocks don't work the same way with and without a window in the airlock on the same tile.

## Media (Video/Screenshots)
No alarm state:
<img width="833" height="484" alt="airlock_preimage" src="https://github.com/user-attachments/assets/814246e7-329d-49ce-bd38-83ba92163e2b" />
Alarm state active:
<img width="833" height="484" alt="airlock_postimage" src="https://github.com/user-attachments/assets/03e5cd5c-059d-4c33-80c7-0cb3f97b423d" />


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- tweak: Firelocks now behave the same way when placed over glass and opaque airlocks, closing over the airlock if a linked air alarm is in an alarm state.
