### PR TITLE
Dispensers charge batteries again

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -105,6 +105,7 @@
     cellSlotId: cell_slot
   - type: Charger
     slotId: cell_slot
+    passiveDraw: 5
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -103,6 +103,8 @@
       cell_slot: !type:ContainerSlot { }
   - type: PowerCellSlot
     cellSlotId: cell_slot
+  - type: Charger
+    slotId: cell_slot
   - type: ItemSlots
     slots:
       cell_slot:


### PR DESCRIPTION
## Short description
Something in the upstream battery rework broke our dispensers charging contained batteries; this re-adds that functionality.

## Why we need to add this
Without this the bar would need multiple battery chargers to get through a normal shift.

## Media (Video/Screenshots)
<img width="984" height="519" alt="charging_in_dispenser" src="https://github.com/user-attachments/assets/ae759156-ad44-4427-9125-8b711a2bf747" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: We found an issue in our recently-issued dispenser machine boards, and they should now once again charge batteries (while anchored on LV power)

