### PR TITLE
Optimize solution regeneration because it is 4% of my server update time, and fix water regen

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionRegenerationSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Starlight.Chemistry.Components;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.FixedPoint;
@@ -38,14 +39,17 @@ public sealed class SolutionRegenerationSystem : EntitySystem
     {
         base.Update(frameTime);
 
-        var query = EntityQueryEnumerator<SolutionRegenerationComponent, SolutionContainerManagerComponent>();
-        while (query.MoveNext(out var uid, out var regen, out var manager))
+        // Starlight start
+        var time = _timing.CurTime;
+        var query = EntityQueryEnumerator<SLActiveSolutionRegenerationComponent, SolutionRegenerationComponent, SolutionContainerManagerComponent>();
+        while (query.MoveNext(out var uid, out _, out var regen, out var manager))
         {
-            if (_timing.CurTime < regen.NextRegenTime)
+            if (time < regen.NextRegenTime)
                 continue;
 
             // timer ignores if its full, it's just a fixed cycle
-            regen.NextRegenTime += regen.Duration;
+            // not anymore in Starlight! because I don't want to tick thousands of entities with this shit!
+            regen.NextRegenTime = time + regen.Duration;
             // Needs to be networked and dirtied so that the client can reroll it during prediction
             Dirty(uid, regen);
             if (!_solutionContainer.ResolveSolution((uid, manager),
@@ -56,7 +60,11 @@ public sealed class SolutionRegenerationSystem : EntitySystem
 
             var amount = FixedPoint2.Min(solution.AvailableVolume, regen.Generated.Volume);
             if (amount <= FixedPoint2.Zero)
+            {
+                RemCompDeferred<SLActiveSolutionRegenerationComponent>(uid);
                 continue;
+            }
+            // Starlight end
 
             // Don't bother cloning and splitting if adding the whole thing
             var generated = amount == regen.Generated.Volume

--- a/Content.Shared/_Starlight/Chemistry/Components/SLActiveSolutionRegenerationComponent.cs
+++ b/Content.Shared/_Starlight/Chemistry/Components/SLActiveSolutionRegenerationComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.Chemistry.Components;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(SLSolutionRegenerationSystem))]
+public sealed partial class SLActiveSolutionRegenerationComponent : Component;

--- a/Content.Shared/_Starlight/Chemistry/SLSolutionRegenerationSystem.cs
+++ b/Content.Shared/_Starlight/Chemistry/SLSolutionRegenerationSystem.cs
@@ -1,0 +1,29 @@
+﻿using Content.Shared._Starlight.Chemistry.Components;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._Starlight.Chemistry;
+
+public sealed class SLSolutionRegenerationSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<SolutionRegenerationComponent, SolutionContainerChangedEvent>(OnSolutionChanged);
+    }
+
+    private void OnSolutionChanged(Entity<SolutionRegenerationComponent> ent, ref SolutionContainerChangedEvent args)
+    {
+        // No component additions during client state application
+        if (_timing.ApplyingState)
+            return;
+
+        if (args.Solution.AvailableVolume <= FixedPoint2.Zero)
+            return;
+
+        EnsureComp<SLActiveSolutionRegenerationComponent>(ent);
+    }
+}

--- a/Resources/Prototypes/Entities/Tiles/water.yml
+++ b/Resources/Prototypes/Entities/Tiles/water.yml
@@ -25,7 +25,7 @@
         - ReagentId: Water
           Quantity: 9999999
   - type: SolutionRegeneration
-    solution: tank
+    solution: pool # Starlight
     generated:
       reagents:
       - ReagentId: Water

--- a/SpaceStation14.sln.DotSettings
+++ b/SpaceStation14.sln.DotSettings
@@ -79,6 +79,7 @@
     <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PNG/@EntryIndexedValue">PNG</s:String>
     <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RSI/@EntryIndexedValue">RSI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SA/@EntryIndexedValue">SA</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SL/@EntryIndexedValue">SL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SZ/@EntryIndexedValue">SZ</s:String>
     <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
     <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UTF/@EntryIndexedValue">UTF</s:String>


### PR DESCRIPTION
## Short description
Bonus trivia: Water had the wrong solution to regen the entire time, so every single water tile has been forever ticking to do absolutely nothing every single update loop. I think that's pretty wholesome.
I opted to remove solution regen in RMC instead, but this is the fix that makes it not tick everything for fun

## Why we need to add this

## Media (Video/Screenshots)
dotTrace
<img width="702" height="262" alt="dotTraceViewer64_pezAkfrUtU" src="https://github.com/user-attachments/assets/8f89917b-a0e8-44d7-a749-31139f62156c" />

In-game

https://github.com/user-attachments/assets/6aaa8f18-60e0-4a9e-8fc2-9aee0476e9a1


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

