### PR TITLE
Improve NoCargoOrderArbitrage stability

### DIFF
--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -25,6 +25,8 @@ public sealed class CargoTest
         new("FunCrateGambling")
     ];
 
+    private const float epsilon = 0.01f; // Starlight - reduce test flakiness
+
     [Test]
     public async Task NoCargoOrderArbitrage()
     {
@@ -49,7 +51,7 @@ public sealed class CargoTest
                     var ent = entManager.SpawnEntity(proto.Product, testMap.MapCoords);
                     var price = pricing.GetPrice(ent);
 
-                    Assert.That(price, Is.AtMost(proto.Cost), $"Found arbitrage on {proto.ID} cargo product! Cost is {proto.Cost} but sell is {price}!");
+                    Assert.That(price, Is.AtMost(proto.Cost + epsilon), $"Found arbitrage on {proto.ID} cargo product! Cost is {proto.Cost} but sell is {price}!"); // Starlight-edit - add epsilon to avoid fp precision issues
                     entManager.DeleteEntity(ent);
                 }
             });


### PR DESCRIPTION
## Short description
We sometimes get failures in this test that look to be related to some sort of floating-point imprecision around prices, meaning it fails because a total value of 800.0000053 is greater than the allowed value of 800.

Adding a small epsilon value to the allowed max should cut out these flakes.

## Why we need to add this
Flaky tests are a blight.

## Media (Video/Screenshots)
n/a

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
