### PR TITLE
Readd energy shotgun to warden locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -418,7 +418,7 @@
     children:
     - id: ClothingNeckCloakHosElite # Starlight
     - id: WeaponEnergySMG # Starlight
-    - id: WeaponEnergyMagnum
+    # - id: WeaponEnergyMagnum # Starlight - Removed, given to det
     - id: BookSpaceLaw
     - id: BoxEncryptionKeySecurity
     - id: CigarGoldCase

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -28,6 +28,7 @@
     children:
     - id: ClothingEyesHudSecurity #Starlight
     - id: ClothingHeadsetSecurityWarden #Starlight
+    - id: WeaponEnergyShotgun #Starlight
     - id: FlashlightSeclite
     - id: WeaponDisabler
     - id: WeaponTaser


### PR DESCRIPTION
## Short description
Upstream removed it in a PR that added separate spawners for the warden and HoS weapons, but because we haven't done the mapping work to use those spawners, I'm putting it back in the locker.

## Why we need to add this
Without this the item is effectively just removed, and it's an interesting steal objective and part of the warden's intended kit.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Addressed a disagreement between CC supply and facilities departments, re-adding the energy shotgun to the warden's locker.
- fix: Addressed a mis-order from CC supply of energy magnums, HOS's will now no longer get a copy of the detectives gun