### PR TITLE
Move Middle Eastern recipes from oven to microwave for consistency

### DIFF
--- a/Resources/Prototypes/_StarLight/Recipes/Cooking/mena_recipes.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Cooking/mena_recipes.yml
@@ -22,7 +22,6 @@
   result: FoodFalafel
   time: 5
   group: Savory
-  deviceType: Oven
   reagents:
     Hummus: 10
     TableSalt: 1
@@ -38,7 +37,6 @@
   result: FoodHummusDip
   time: 5
   group: Savory
-  deviceType: Oven
   reagents:
     Hummus: 10
     TableSalt: 1
@@ -55,7 +53,6 @@
   result: FoodShawarma
   time: 5
   group: Savory
-  deviceType: Oven
   reagents:
     Hummus: 10
   solids:
@@ -72,7 +69,6 @@
   result: FoodFalafelSandwich
   time: 5
   group: Savory
-  deviceType: Oven
   reagents:
     JuiceLemon: 1
   solids:
@@ -87,7 +83,6 @@
   result: FoodFalafelSandwich
   time: 5
   group: Savory
-  deviceType: Oven
   solids:
     FoodCheeseSlice: 1
     FoodFalafel: 1
@@ -103,7 +98,6 @@
   result: FoodSouvlaki
   time: 5
   group: Savory
-  deviceType: Oven
   solids:
     FoodMeatCutletCooked: 1
     FoodBreadPita: 1
@@ -118,7 +112,6 @@
   result: FoodDonerKebab
   time: 5
   group: Savory
-  deviceType: Oven
   reagents:
     Hummus: 10
   solids:
@@ -133,7 +126,6 @@
   result: FoodDonerKebab
   time: 5
   group: Savory
-  deviceType: Oven
   reagents:
     Hummus: 10
   solids:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This moves the recipes for Doner Kebab, Souvlaki, Falafel Sandwich, Chicken Shawarma, Hummus, and Falafel from the Oven to the Microwave. Pita bread is still cooked in the oven.

## Why we need to add this
Even though these recipes are cooked in the oven in real life, Starlight uniformly uses the oven for baking bread products and the microwave for most other food prep. So, this is more consistent with how the rest of the game.

## Media (Video/Screenshots)
n/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Rhetorica
- tweak: Moved new Middle Eastern recipes (falafel, hummus, shawarma, souvlaki, doner) from the oven to the microwave for consistency with other recipes
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
