### PR TITLE
make disabler/taser not show lasers when firing

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -16,12 +16,12 @@
       - HideContextMenu
   - type: AnimationPlayer
 
+# starlight start
 - type: entity
   id: BasicHitscan
+  parent: BasicHitscanNoBeam
   categories: [ HideSpawnMenu ]
   components:
-  - type: HitscanAmmo
-  - type: HitscanBasicRaycast
   - type: HitscanBasicVisuals
     muzzleFlash:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
@@ -32,8 +32,8 @@
     impactFlash:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
       state: impact_laser
-  - type: HitscanReflect
   - type: HitscanBasicEffects
+# starlight end
 
 - type: entity
   parent: BasicHitscan

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -17,6 +17,8 @@
   - type: AnimationPlayer
 
 # starlight start
+# split base laser hitscan into a variant with and without visual beams
+# this is done so that projectiles such as disablers and tasers do not have laser travel visuals
 - type: entity
   id: BasicHitscan
   parent: BasicHitscanNoBeam
@@ -32,7 +34,6 @@
     impactFlash:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
       state: impact_laser
-  - type: HitscanBasicEffects
 # starlight end
 
 - type: entity

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -1197,6 +1197,14 @@
 ## energy
 
 - type: entity
+  id: BasicHitscanNoBeam
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: HitscanAmmo
+  - type: HitscanBasicRaycast
+  - type: HitscanReflect
+
+- type: entity
   id: EnergyTrace
   parent: BasicHitscan
   categories: [ HideSpawnMenu ]
@@ -1243,7 +1251,7 @@
 - type: entity
   id: DestroyBeam
   name: destroying beam
-  parent: LaserTrace
+  parent: BasicHitscanNoBeam
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
@@ -1264,7 +1272,7 @@
 - type: entity 
   id: DeleteBeam
   name: erasing beam
-  parent: LaserTrace
+  parent: BasicHitscanNoBeam
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
@@ -1286,7 +1294,7 @@
 - type: entity
   id: DisablerBoltPractice
   name: disabler bolt practice
-  parent: EnergyTrace
+  parent: BasicHitscanNoBeam
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicRaycast
@@ -1318,7 +1326,7 @@
 - type: entity
   id: TaserBolt
   name: taser bolt
-  parent: EnergyTrace
+  parent: BasicHitscanNoBeam
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
@@ -1454,7 +1462,7 @@
 - type: entity
   id: PointDefenseBeam
   name: Point Defense beam
-  parent: LaserTrace
+  parent: BasicHitscanNoBeam
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicRaycast

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -1203,6 +1203,7 @@
   - type: HitscanAmmo
   - type: HitscanBasicRaycast
   - type: HitscanReflect
+  - type: HitscanBasicEffects
 
 - type: entity
   id: EnergyTrace
@@ -1304,6 +1305,8 @@
       sprite:
         sprite: Objects/Weapons/Guns/Projectiles/projectiles_tg.rsi
         state: omnilaser
+  - type: HitscanBasicEffects
+    hitColor: blue
 
 - type: entity
   id: DisablerBolt


### PR DESCRIPTION
## Short description
Hitscans were reworked into entities, wizden's bullet lasers (warden shotty, etc) are based on bullet prototype, ours are based on laser prototype
new laser prototype had a comp that made it display a red laser no matter what, so this rebases them off a new one which is lacking the basichitscaneffects

the above comp also includes hit sound effects, but there is none by default, and any projectile that has specified it will have manually re defined the comp to change those parameters (there are 0 instances of this at the moment, but just for future proofing)

if someone wanted to do a more robust pass around it would involve re designing all projectile-ish lasers to be based off upstream bullets

tested against all projectile lasers, and with generic laser weapons - all works as intended

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic, neomoth
- fix: fix disablers and tasers showing laser beams