### PR TITLE
[hotfix-ish] switch back to starlight vulpkanin sounds

### DIFF
--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -685,9 +685,9 @@
     Bark:
       collection: Bark #Starlight bark
     Whine:
-      collection: VulpkaninWhines
+      collection: Whine #Starlight
     Crying:
-      collection: VulpkaninWhines
+      collection: MaleCry
     Howl:
       path: /Audio/_Starlight/Effects/howl.ogg #Starlight howl
     Yip:
@@ -731,9 +731,9 @@
     Bark:
       collection: Bark #Starlight bark
     Whine:
-      collection: VulpkaninWhines
+      collection: Whine # Starlight
     Crying:
-      collection: VulpkaninWhines
+      collection: FemaleCry
     Howl:
       path: /Audio/_Starlight/Effects/howl.ogg #Starlight howl
     Yip:


### PR DESCRIPTION
## Short description
Switch back to starlight whine, and default cry for vulpkanin emote wheel

## Why we need to add this
Upstream added a new vulpkanin whine sound, and during upstream it replaced our emotes
problems are:
- from everyone I have gathered people seem to unanimously agree that the sound is pretty uncomfortable OOC (new wizden sound is attached below for your listening pleasure), and doesn't really express the emotes it is covering very well at all
https://github.com/ss14Starlight/space-station-14/raw/refs/heads/starlight-dev/Resources/Audio/Voice/Vulpkanin/dog_whine.ogg
- we already had a larger collection of sounds for the whining emote, this was overwritten by above sound
- this sound was set to cover whining and crying, which means that this singular sound (there is no variation) plays for no less than 10 emotes, which is pretty flat

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- fix: Switch back to starlight vulpkanin emote sounds