### PR TITLE
Improve a few irregular pluralizations

### DIFF
--- a/Content.IntegrationTests/Tests/_StarLight/Localization/PluralizationTests.cs
+++ b/Content.IntegrationTests/Tests/_StarLight/Localization/PluralizationTests.cs
@@ -1,7 +1,7 @@
 using Robust.Shared.Localization;
 using NUnit.Framework;
 
-namespace Content.IntegrationTests.Tests.Localization;
+namespace Content.IntegrationTests.Tests._Starlight.Localization;
 
 [TestFixture]
 public sealed class PluralizationTests

--- a/Content.IntegrationTests/Tests/_StarLight/Localization/PluralizationTests.cs
+++ b/Content.IntegrationTests/Tests/_StarLight/Localization/PluralizationTests.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.Localization;
+using NUnit.Framework;
+
+namespace Content.IntegrationTests.Tests.Localization;
+
+[TestFixture]
+public sealed class PluralizationTests
+{
+    [Test]
+    [TestCase(3, "cow", "There were 3 cows.")]
+    [TestCase(3, "thief", "There were 3 thieves.")]
+    [TestCase(3, "carp", "There were 3 carp.")]
+    public async Task EORPluralizationTest(int count, string antag, string expected)
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var locMan = server.ResolveDependency<ILocalizationManager>();
+
+        var result = locMan.GetString("objectives-round-end-result", ("count", count), ("agent", antag));
+
+        Assert.That(result, Is.EqualTo(expected));
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -84,6 +84,24 @@ namespace Content.Shared.Localizations
             return new LocValueString(string.Format(formatter, "{0:N}", number).TrimEnd('0').TrimEnd(char.Parse(formatter.NumberDecimalSeparator)));
         }
 
+        // Starlight start
+        private static readonly Dictionary<string, string> NonStandardPlurals = new() {
+            { "thief", "thieves" },
+            { "knife", "knives" },
+            { "life", "lives" },
+            { "leaf", "leaves" },
+            { "deer", "deer" },
+            { "fish", "fish" },
+            { "carp", "carp" },
+            { "half", "halves" },
+            { "die", "dice" },
+            { "foot", "feet" },
+            { "scarf", "scarves" },
+            { "shelf", "shelves" },
+            { "person", "people" },
+        };
+        // Starlight end
+
         private static readonly Regex PluralEsRule = new("^.*(s|sh|ch|x|z)$");
 
         private ILocValue FormatMakePlural(LocArgs args)
@@ -91,6 +109,15 @@ namespace Content.Shared.Localizations
             var text = ((LocValueString) args.Args[0]).Value;
             var split = text.Split(" ", 1);
             var firstWord = split[0];
+            // Starlight start
+            if (NonStandardPlurals.TryGetValue(firstWord, out var replacement))
+            {
+                if (split.Length == 1)
+                    return new LocValueString($"{replacement}");
+                else
+                    return new LocValueString($"{replacement} {split[1]}");
+            }
+            // Starlight end
             if (PluralEsRule.IsMatch(firstWord))
             {
                 if (split.Length == 1)


### PR DESCRIPTION
## Short description
We have fairly naiive code for handling autopluralization of English words that doesn't account for how jank English can be. This PR adds a table that fixes a few irregular plurals that might show up in SS14 contexts.

## Why we need to add this
The EOR screen saying "there were 3 thiefs" is a bit dumb.

## Media (Video/Screenshots)
See tests.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Fixed a few irregular pluralizations in the localization string system.
