### PR TITLE
Remove duplicate Assistant option from ID card console

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -11,6 +11,7 @@
 
 - type: job # Just ignore it. It’s a database workaround.
   id: Passenger
+  overrideConsoleVisibility: false # SL - don't show in ID console
   hidden: true
   name: job-name-assistant
   description: job-description-assistant


### PR DESCRIPTION
## Short description
We had two options because passenger was also showing up; adding this property prevents that.

## Why we need to add this
We generally want to avoid passenger-associated things from showing up, and having two entries labelled "Assistant" was also confusing.

## Media (Video/Screenshots)
<img width="528" height="177" alt="single_assistant_job" src="https://github.com/user-attachments/assets/6b91466c-1338-4d57-adf9-22c060de57aa" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: The "Assistant" job now only shows up once in the ID card computer's job list, rather than twice.
