### PR TITLE
Set issued users for emagnum and eshotty as noncontra

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -857,7 +857,7 @@
 
 - type: entity
   name: energy shotgun
-  parent: [BaseWeaponBattery, BaseGunWieldable, BaseGrandTheftContraband]
+  parent: [BaseWeaponBattery, BaseGunWieldable, BaseWardenGrandTheftContraband] # Starlight - warden grand contra
   id: WeaponEnergyShotgun
   description: A one-of-a-kind prototype energy weapon that uses various shotgun configurations. It offers the possibility of both lethal and non-lethal shots, making it a versatile weapon.
   components:
@@ -910,7 +910,7 @@
 
 - type: entity
   name: energy magnum
-  parent: [BaseWeaponBatterySmall, BaseGrandTheftContraband]
+  parent: [BaseWeaponBatterySmall, BaseDetectiveGrandTheftContraband] # Starlight - detective grand contra
   id: WeaponEnergyMagnum
   description: A high powered self-charging energy pistol designed for elite security personnel. It has has three firing modes allowing for either high damage, window piercing, or non-lethal disabling.
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
@@ -89,3 +89,22 @@
   components:
     - type: Contraband
       allowedDepartments: [ Engineering, Security ]
+
+# for ~objective items not held by command
+- type: entity
+  id: BaseWardenGrandTheftContraband
+  abstract: true
+  components:
+  - type: Contraband
+    severity: GrandTheft
+    allowedDepartments: [ Command ]
+    allowedJobs: [ Warden ]
+
+- type: entity
+  id: BaseDetectiveGrandTheftContraband
+  abstract: true
+  components:
+  - type: Contraband
+    severity: GrandTheft
+    allowedDepartments: [ Command ]
+    allowedJobs: [ Detective ]


### PR DESCRIPTION
## Short description
These were marked as grand contra due to being objectives, but that only allows command to use them.

## Why we need to add this
We want roles to be able to use their equipment as non-contra.

## Media (Video/Screenshots)
<img width="579" height="391" alt="detective_can_use_emagnum" src="https://github.com/user-attachments/assets/1d91b737-826f-4a45-967b-a43d5ce0aa48" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: The paperwork has finally gone through, and the Warden and Detective are now permitted to use their issued weapons as non-contraband. Thank you for refraining for using them while we were waiting on that to get filed, it must have been stressful.

