### PR TITLE
Fix the NT Rep's cane charging

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cane_nt.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cane_nt.yml
@@ -44,7 +44,7 @@
     damage: 40
     sound: /Audio/Weapons/egloves.ogg
   - type: LandAtCursor
-  - type: Battery
+  - type: PredictedBattery
     maxCharge: 1000
     startingCharge: 1000
   - type: UseDelay


### PR DESCRIPTION
## Short description
Another BatteryComponent->PredictedBatteryComponent swap T_T

## Why we need to add this
Chageables should be chargeable.

## Media (Video/Screenshots)
<img width="892" height="461" alt="cane_charge" src="https://github.com/user-attachments/assets/01cb38d8-5e66-48b0-ac83-9b56c3f7ae2e" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Changed the NT Rep's cane from Firewire back to USB-C so it can use the station chargers again.
