### PR TITLE
Update firelocks to allow engineering OR command

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -131,7 +131,7 @@
     - type: StaticPrice
       price: 150
     - type: AccessReader
-      access: [ [ "Engineering", "Command" ] ] # Starlight-edit
+      access: [ [ "Engineering" ], [ "Command" ] ] # Starlight-edit
       examinationText: access-reader-examination-functionality-restricted
     - type: PryUnpowered
       pryModifier: 0.5


### PR DESCRIPTION
## Short description
In a previous PR we intended to do this, but instead set firelocks to require both engineering and command access to open.

## Why we need to add this
Being able to directly open firelocks makes things a bit smoother for engineering and atmos work.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Fixed miscommunication; non-command engineers can now once again open firelocks when needed.
