### PR TITLE
Hugging cold things (avali) or hot things (??) damanges you

### DIFF
--- a/Content.Shared/Temperature/Components/TemperatureComponent.cs
+++ b/Content.Shared/Temperature/Components/TemperatureComponent.cs
@@ -76,4 +76,32 @@ public sealed partial class TemperatureComponent : Component
 
     [DataField]
     public ProtoId<AlertPrototype> ColdAlert = "Cold";
+    
+    // Starlight begin
+    
+    /// <summary>
+    /// How much damage you take when you or someone else hugs, and they are below your <see cref="ColdDamageThreshold"/>.
+    /// </summary>
+    [DataField]
+    public DamageSpecifier ColdHugDamage = new()
+    {
+        DamageDict = new()
+        {
+            { "Cold", 1.0 },
+        }
+    };
+
+    /// <summary>
+    /// How much damage you take when you or someone else hugs, and they are above your <see cref="HeatDamageThreshold"/>.
+    /// </summary>
+    [DataField]
+    public DamageSpecifier HeatHugDamage = new()
+    {
+        DamageDict = new()
+        {
+            { "Heat", 1.0 },
+        }
+    };
+
+    // Starlight end
 }

--- a/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedTemperatureSystem.cs
@@ -1,7 +1,10 @@
 using System.Linq;
 using Content.Shared.Atmos;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Popups;
 using Content.Shared.Temperature.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
@@ -15,6 +18,8 @@ public abstract class SharedTemperatureSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
+    [Dependency] private readonly DamageableSystem _damage = default!; // Starlight
+    [Dependency] private readonly SharedPopupSystem _popup = default!; // Starlight
 
     /// <summary>
     /// Band-aid for unpredicted atmos. Delays the application for a short period so that laggy clients can get the replicated temperature.
@@ -27,8 +32,39 @@ public abstract class SharedTemperatureSystem : EntitySystem
 
         SubscribeLocalEvent<TemperatureSpeedComponent, OnTemperatureChangeEvent>(OnTemperatureChanged);
         SubscribeLocalEvent<TemperatureSpeedComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeedModifiers);
+        SubscribeLocalEvent<TemperatureComponent, InteractionSuccessEvent>(OnInteractionSuccess); // Starlight
     }
 
+    // Starlight begin
+
+    private void OnInteractionSuccess(Entity<TemperatureComponent> ent, ref InteractionSuccessEvent args)
+    {
+        if (!TryComp<TemperatureComponent>(args.User, out var userTempComp))
+            return;
+        
+        DealHugTemperatureDamage(ent, (args.User, userTempComp));
+        DealHugTemperatureDamage((args.User, userTempComp), ent);
+    }
+
+    private void DealHugTemperatureDamage(Entity<TemperatureComponent> target, Entity<TemperatureComponent> giver)
+    {
+        var temp = giver.Comp.CurrentTemperature;
+
+        if (target.Comp.ColdDamageThreshold >= temp)
+        {
+            _damage.TryChangeDamage(target.Owner, target.Comp.ColdHugDamage, ignoreResistances: true, interruptsDoAfters: false);
+            _popup.PopupClient(Loc.GetString("hugging-too-cold"), target.Owner, PopupType.LargeCaution);
+        }
+
+        if (target.Comp.HeatDamageThreshold <= temp)
+        {
+            _damage.TryChangeDamage(target.Owner, target.Comp.HeatHugDamage, ignoreResistances: true, interruptsDoAfters: false);
+            _popup.PopupClient(Loc.GetString("hugging-too-hot"), target.Owner, PopupType.LargeCaution);
+        }
+    }
+
+    // Starlight end
+    
     private void OnTemperatureChanged(Entity<TemperatureSpeedComponent> ent, ref OnTemperatureChangeEvent args)
     {
         foreach (var (threshold, modifier) in ent.Comp.Thresholds)

--- a/Resources/Locale/en-US/_Starlight/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/interaction/interaction-popup-component.ftl
@@ -1,0 +1,2 @@
+hugging-too-cold = Your hands feel cold!
+hugging-too-hot = Your hands feel singed!

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -140,17 +140,17 @@
         types:
           Slash: 6.25
     - type: Temperature
-      heatDamageThreshold: 310
+      heatDamageThreshold: 315
       coldDamageThreshold: 223
-      currentTemperature: 261
+      currentTemperature: 255
       specificHeat: 48
     - type: ThermalRegulator
       metabolismHeat: 400 # icebirb go brrr
       radiatedHeat: 100
-      implicitHeatRegulation: 1500
+      implicitHeatRegulation: 2300
       sweatHeatRegulation: 2000
       shiveringHeatRegulation: 2000
-      normalBodyTemperature: 261
+      normalBodyTemperature: 255
       thermalRegulationTemperatureThreshold: 1
     - type: Stasis
       enterStasisAction: ActionStasisEnter


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Title! Hugging cold things freezes you slightly and hugging hot things burns you.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Avali have a weird temperature thing that isn't really communicated in game besides maybe the medical scanner telling you they are cold. I did not know this even after playing a long time with them! This is a fun RP way to give them another interesting angle. If Avali wear a coat then they heat up enough to where they dont do damage anymore as well!

The damage is very small (1) so in 90% of cases you will heal it fully off in ~25 seconds.

**Technical** 
I had to slightly tweak a few things about avalis temperature to get it to work proplerly. The only big one was I had to massively increase their `implicitHeatRegulation` because it makes no sense that they are this cold when the outer temperature is ambient (This is an issue before my PR). Basically I had to increase the magic funny number because they need to be slightly colder to do damage

:cl: ork
- add: Hugging cold or hot things now does a small amount of damage. This mainly applies to hugging Avali!

