### PR TITLE
Revert "Re-add wizard hardsuit"

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -344,5 +344,5 @@
     - id: NitrogenTankFilled # Starlight - vox gang
     - id: ClothingMaskBreath
     # TODO: Gone until reworked to have no space protection
-    - id: ClothingOuterHardsuitWizard # Starlight: Readd wizard suit
+    #- id: ClothingOuterHardsuitWizard
     #- id: JetpackVoidFilled


### PR DESCRIPTION
This reverts commit 0133604c175ad0ec55d9e04034c66d546cc8cb8e / https://github.com/ss14Starlight/space-station-14/pull/2348

## Why we need to add this
Wizard is supposed to be a glass cannon - this suit is comparable to a juggsuit. Combined with their abilities, they are very powerful.

I think a longer term solution is to convert their suit to a softsuit or something, but that can come after.

For awareness - the suits stats:
<img width="585" height="506" alt="image" src="https://github.com/user-attachments/assets/11d114c5-ed5f-45d5-891f-3015e6db1f1a" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- remove: Reverts PR 2348, removing the wizard hardsuit from spawning.

