### PR TITLE
Remove self-recharge from energy shotgun

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -903,10 +903,6 @@
   - type: PredictedBattery
     maxCharge: 480
     startingCharge: 480
-  - type: PredictedBatterySelfRecharger
-    autoRechargeRate: 20
-    autoRechargePauseTime: 10
-
 
 - type: entity
   name: energy magnum


### PR DESCRIPTION
## Short description
We had intentionally removed this downstream, and it got accidentally added back in the process of merging changes from upstream.

## Why we need to add this
Having the energy shotgun self-recharge when it's intended as a weapon for the Warden encourages wardloosing and is generally stronger than we'd like.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- tweak: We realized that when putting in the order for the new energy magnums, our supplier took the opportunity to upcharge us for autochargers for the energy shotguns. We've reminded them of our contracting process, so your energy shotguns will no longer self-recharge.
