### PR TITLE
Fix DAGD getting paired with escape alive

### DIFF
--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -46,10 +46,6 @@
       sprite: Structures/Furniture/chairs.rsi
       state: shuttle
   - type: EscapeShuttleCondition
-  - type: ObjectiveBlacklistRequirement # Starlight
-    blacklist:
-      components:
-        - EscapeShuttleCondition
 
 - type: entity
   parent: BaseTraitorObjective


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Title. Prototype inheritance overrwrote the basic blacklist from the `BaseLivingObjective`. From what I can tell it is useless because there are no other escape objectives besides this one (that can roll on traitors)

**Changelog**

:cl: ork
- fix: DAGD cannot be paired with escape alive anymore

