### PR TITLE
Copy job- and antag-specific components on polymorph

### DIFF
--- a/Content.Shared/Polymorph/PolymorphPrototype.cs
+++ b/Content.Shared/Polymorph/PolymorphPrototype.cs
@@ -162,7 +162,14 @@ public sealed partial record PolymorphConfiguration
     {
         "LanguageKnowledge",
         "LanguageSpeaker",
-        "Grammar"
+        "Grammar",
+        "MindShield",
+        "NukeOperative",
+        "HeadRevolutionary",
+        "Revolutionary",
+        "CommandStaff",
+        "BibleUser",
+        "MimePowers"
     };
     // Starlight - End
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Expand components copied on polymorph to include various important roundflow and job components.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Making the polymorph  system a bit more robust on component copying will reduce the wacky paths for exploitation.  Imagine using corgium foam on the bridge in a revs round, then flashing all the freshly-corgi'd command members.  Or if you managed to get them all, the game finds there are no longer any command members on the station.
Moving important components related to jobs and roundflow on polymorph makes it a little more robust against cheese.
(Also because if I wanna be a command corgi I don't suddenly lose my mindshield or my CommandStaff flag; or if I'm a nukie and get carp-rodded I don't trigger the nukie round-end by being the last nukie-fish standing).

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Polymorphed captain in dev environment now retains CommandStaff and Mindshield.
<img width="726" height="421" alt="image" src="https://github.com/user-attachments/assets/9e754f5f-614b-4460-b908-f6e6a3d2513c" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Sparlight
- tweak: Mindshields and round-flow components transfer by default when polymorphing.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
