### PR TITLE
Add the possibility of roundstart maints closet creatures

### DIFF
--- a/Content.Server/_Starlight/GameTicking/Rules/VariationPass/Components/MaintenanceMonstersVariationPassComponent.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/VariationPass/Components/MaintenanceMonstersVariationPassComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared.EntityTable.EntitySelectors;
+namespace Content.Server.GameTicking.Rules.VariationPass.Components;
+
+[RegisterComponent]
+public sealed partial class MaintenanceMonstersVariationPassComponent : Component
+{
+    [DataField(required: true)]
+    public EntityTableSelector SpawnTable = default!;
+
+    [DataField]
+    public float PerLockerProbability = 0.25f;
+}

--- a/Content.Server/_Starlight/GameTicking/Rules/VariationPass/Components/RoundstartMonsterSpawnComponent.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/VariationPass/Components/RoundstartMonsterSpawnComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Server.GameTicking.Rules.VariationPass.Components;
+
+[RegisterComponent]
+public sealed partial class RoundstartMonsterSpawnComponent : Component { }

--- a/Content.Server/_Starlight/GameTicking/Rules/VariationPass/MaintenanceMonstersVariationPassSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/VariationPass/MaintenanceMonstersVariationPassSystem.cs
@@ -1,0 +1,46 @@
+using Content.Server.GameTicking.Rules.VariationPass.Components;
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Storage.Components;
+using Content.Shared.EntityTable;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+
+namespace Content.Server.GameTicking.Rules.VariationPass;
+
+/// <summary>
+/// Handles putting things in lockers around the station, intended for creatures.
+/// </summary>
+public sealed class MaintenanceMonstersVariationPassSystem : VariationPassSystem<MaintenanceMonstersVariationPassComponent>
+{
+    [Dependency] private readonly EntityStorageSystem _entityStorage = default!;
+    [Dependency] private readonly EntityTableSystem _entityTable = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    protected override void ApplyVariation(Entity<MaintenanceMonstersVariationPassComponent> ent, ref StationVariationPassEvent args)
+    {
+        var query = AllEntityQuery<RoundstartMonsterSpawnComponent, EntityStorageComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var storage, out var transform))
+        {
+            // Ignore if not part of the station
+            if (!IsMemberOfStation((uid, transform), ref args))
+                continue;
+
+            // If we don't hit the random chance for this one, skip
+            if (!_random.Prob(ent.Comp.PerLockerProbability))
+                continue;
+
+            var protos = _entityTable.GetSpawns(ent.Comp.SpawnTable);
+
+            foreach (var proto in protos)
+            {
+                var spawn = EntityManager.Spawn(proto, MapCoordinates.Nullspace);
+                if (!_entityStorage.Insert(spawn, uid, storage))
+                {
+                    Del(spawn);
+                    // We failed to put one in the storage, so we're likely to fail at putting the rest in; go to the next storage.
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/closets.yml
@@ -160,6 +160,11 @@
   - type: EntityStorageVisuals
     stateDoorOpen: generic_open
     stateDoorClosed: generic_door
+  # Starlight start
+  - type: RoundstartMonsterSpawn
+  - type: EntityStorage
+    airtight: false # Allow air to move between the inside and outside of the locker, so that mobs that spawn in it don't suffocate
+  # Starlight end
 
 # Syndicate
 - type: entity

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -574,3 +574,7 @@
     - id: BasicDecalDirtMonospaceVariationPass
       prob: 0.50
       orGroup: monospaceDecals
+    # Starlight start
+    - id: MaintenanceMonstersVariationPass
+      prob: 0.2
+    # Starlight end

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/entity_tables.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/entity_tables.yml
@@ -1,0 +1,99 @@
+- type: entityTable
+  id: MaintsMonstersBasic
+  table: !type:GroupSelector
+    children:
+    # harmless critters (except for the radioactive mouse)
+    - !type:NestedSelector
+      tableId: SmallCritterEntityTable
+    # one or more larger harmless critters
+    - !type:GroupSelector
+      children:
+      - !type:AllSelector
+        children:
+        - id: MobChicken
+        - id: MobChicken
+        - id: MobChicken
+      - !type:AllSelector
+        children:
+        - id: MobDuckMallard
+        - id: MobDuckMallard
+        - id: MobDuckMallard
+      - !type:AllSelector
+        children:
+        - id: MobMoproachHat
+        - id: MobMoproach
+        - id: MobMoproach
+      - !type:AllSelector
+        children:
+        - id: MobHamster
+        - id: MobHamster
+        - id: MobHamster
+      - id: MobCow
+      - id: MobPig
+      - id: MobReindeerBuck
+      - id: MobReindeerDoe
+      - id: MobCatSpace
+      - id: MobEmotionalSupportScurret
+      - id: MobKangaroo
+      - id: MobBoxingKangaroo
+      - id: MobParrot
+      - id: MobCorgiSmart
+      - id: MobFox
+      - id: MobFerret
+      - id: MobMonkey
+      - id: MobKobold
+    # minor aggressive mobs
+    - !type:GroupSelector
+      children:
+      - !type:AllSelector
+        children:
+        - id: MobDinosaurCompy
+        - id: MobDinosaurCompy
+        - id: MobDinosaurCompy
+        - id: MobDinosaurCompy
+      - id: MobGorilla
+      # Hostile vent critters
+      - id: MobAdultSlimesBlueAngry
+      - id: MobAdultSlimesGreenAngry
+      - id: MobAdultSlimesYellowAngry
+      - id: MobPurpleSnake
+      - id: MobSmallPurpleSnake
+      - id: MobCobraSpace
+      - id: MobGiantSpiderAngry
+      - id: MobClownSpider
+    # space aggressive mobs
+    - !type:GroupSelector
+      children:
+      - id: MobKangarooSpace
+      - id: MobSpiderSpace
+      - id: MobCobraSpace
+      - id: MobBearSpace
+      - id: MobBearSoviet
+      - id: MobGoliath
+      - id: MobCarp
+    # reagent slimes
+    - !type:GroupSelector
+      children:
+      - id: ReagentSlime
+      - id: ReagentSlimeBeer
+      #- id: ReagentSlimeNocturne # Disabled this one because it's a lot of a syndie chem
+      - id: ReagentSlimeTHC
+      - id: ReagentSlimeBicaridine
+      - id: ReagentSlimeToxin
+      - id: ReagentSlimeNapalm
+      - id: ReagentSlimeOmnizine
+      - id: ReagentSlimeMuteToxin
+      - id: ReagentSlimeNorepinephricAcid
+      - id: ReagentSlimeEphedrine
+      - id: ReagentSlimeRobustHarvest
+    # xenos
+    - !type:GroupSelector
+      children:
+      - id: MobXeno
+      - id: MobXenoPraetorian
+      - id: MobXenoDrone
+      - id: MobXenoQueen
+      - id: MobXenoRavager
+      - id: MobXenoRunner
+      - id: MobXenoRouny
+      - id: MobXenoSpitter

--- a/Resources/Prototypes/_StarLight/GameRules/variation.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/variation.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: MaintenanceMonstersVariationPass
+  parent: BaseVariationPass
+  components:
+  - type: MaintenanceMonstersVariationPass
+    spawnTable: !type:NestedSelector
+      tableId: MaintsMonstersBasic


### PR DESCRIPTION
## Short description
This uses a fairly varied table to get a nice array of options. As a side change, this also makes maintenance closets no longer airtight, as otherwise many of these creatures rapidly suffocate. Roughly 20% of rounds, a quarter of the lockers will have some creature(s) spawn in them, which 60% of the time are hostile/dangerous.

## Why we need to add this
Requested by Grape as a way to increase the amount of variety in rounds.

## Media (Video/Screenshots)
No real new pictures; there's creatures in lockers some of the time.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- add: We've found a way to save some budget on pest control for the stations by simply not doing it. You'll probably be fine. If you do notice any critters running around the maintenance tunnels, get the zookeeper to take care of them.


