### PR TITLE
Adds pens to the PTech vending machine

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -9,7 +9,7 @@
     RubberStampDenied: 1
     BoxFolderPlasticClipboardEmpty: 2
     Paper: 10
-    Pen: 8
+    Pen: 8 # Starlight
     Envelope: 10
     HandLabeler: 2
     EncryptionKeyCargo: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -9,6 +9,7 @@
     RubberStampDenied: 1
     BoxFolderPlasticClipboardEmpty: 2
     Paper: 10
+    Pen: 8
     Envelope: 10
     HandLabeler: 2
     EncryptionKeyCargo: 2


### PR DESCRIPTION

## Short description
Adds 8 pens to the PTech vending machine

## Why we need to add this
Helps cargo more easily complete pen bounties, and fulfills request from the Tweaks, Edits and Thingimagigs request thread in the Discord.

## Media (Video/Screenshots)
<img width="452" height="412" alt="Screenshot 2025-12-25 at 8 41 49 AM" src="https://github.com/user-attachments/assets/3ed9968f-0849-43bd-9922-06cded1eb9e9" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: lyxcaster
- add: Added pens to the PTech vending machine
