### PR TITLE
Centcomm Loadouts

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/vibroblade_sheaths.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/vibroblade_sheaths.yml
@@ -31,6 +31,17 @@
   - type: Appearance
 
 - type: entity
+  parent: CentcommVibrobladeSheath
+  id: CentcommVibrobladeSheathFilled
+  name: CentComm vibroblade sheath
+  description: Vulcan Industries believed that maintenance of the Vibroweapons should be delayed as much as possible and the quality of the blades to be at top notch at all times; for the Corporate Consortium, specially designed sheaths were made where the subsonic piercing qualities would have it degradation slowed when not at use.
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+      - id: CentcommVibroblade
+
+- type: entity
   parent: [ClothingBeltBase, ClothingSlotBase, BaseCommandContraband]
   id: PrototypeVibrobladeSheath
   name: Prototype vibroblade sheath
@@ -61,3 +72,14 @@
           tags:
           - PrototypeVibroblade
   - type: Appearance
+
+- type: entity
+  parent: PrototypeVibrobladeSheath
+  id: PrototypeVibrobladeSheathFilled
+  name: Prototype vibroblade sheath
+  description: Vulcan Industries believed that maintenance of the Vibroweapons should be delayed as much as possible and the quality of the blades to be at top notch at all times, even for the prototypes of the final weapons that were to be completed and shipped out. This sheath was designed to fit one of the final prototype designs that Vulcan Industries would conceptalize and produce.
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+      - id: PrototypeVibroblade

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/vibroblade_sheaths.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/vibroblade_sheaths.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingBeltSheathe, BaseCentcommContraband]
+  parent: [ClothingBeltBase, ClothingSlotBase, BaseCentcommContraband]
   id: CentcommVibrobladeSheath
   name: CentComm vibroblade sheath
   description: Vulcan Industries believed that maintenance of the Vibroweapons should be delayed as much as possible and the quality of the blades to be at top notch at all times; for the Corporate Consortium, specially designed sheaths were made where the subsonic piercing qualities would have it degradation slowed when not at use.
@@ -43,7 +43,7 @@
       - CentcommVibroblade
 
 - type: entity
-  parent: [ClothingBeltSheathe, BaseCommandContraband]
+  parent: [ClothingBeltBase, ClothingSlotBase, BaseCentcommContraband]
   id: PrototypeVibrobladeSheath
   name: Prototype vibroblade sheath
   description: Vulcan Industries believed that maintenance of the Vibroweapons should be delayed as much as possible and the quality of the blades to be at top notch at all times, even for the prototypes of the final weapons that were to be completed and shipped out. This sheath was designed to fit one of the final prototype designs that Vulcan Industries would conceptalize and produce.

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/vibroblade_sheaths.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Belt/vibroblade_sheaths.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingBeltBase, ClothingSlotBase, BaseCentcommContraband]
+  parent: [ClothingBeltSheathe, BaseCentcommContraband]
   id: CentcommVibrobladeSheath
   name: CentComm vibroblade sheath
   description: Vulcan Industries believed that maintenance of the Vibroweapons should be delayed as much as possible and the quality of the blades to be at top notch at all times; for the Corporate Consortium, specially designed sheaths were made where the subsonic piercing qualities would have it degradation slowed when not at use.
@@ -37,12 +37,13 @@
   description: Vulcan Industries believed that maintenance of the Vibroweapons should be delayed as much as possible and the quality of the blades to be at top notch at all times; for the Corporate Consortium, specially designed sheaths were made where the subsonic piercing qualities would have it degradation slowed when not at use.
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: CentcommVibroblade
+  - type: ContainerFill
+    containers:
+      item:
+      - CentcommVibroblade
 
 - type: entity
-  parent: [ClothingBeltBase, ClothingSlotBase, BaseCommandContraband]
+  parent: [ClothingBeltSheathe, BaseCommandContraband]
   id: PrototypeVibrobladeSheath
   name: Prototype vibroblade sheath
   description: Vulcan Industries believed that maintenance of the Vibroweapons should be delayed as much as possible and the quality of the blades to be at top notch at all times, even for the prototypes of the final weapons that were to be completed and shipped out. This sheath was designed to fit one of the final prototype designs that Vulcan Industries would conceptalize and produce.
@@ -80,6 +81,7 @@
   description: Vulcan Industries believed that maintenance of the Vibroweapons should be delayed as much as possible and the quality of the blades to be at top notch at all times, even for the prototypes of the final weapons that were to be completed and shipped out. This sheath was designed to fit one of the final prototype designs that Vulcan Industries would conceptalize and produce.
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: PrototypeVibroblade
+  - type: ContainerFill
+    containers:
+      item:
+      - PrototypeVibroblade

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/operator.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/operator.yml
@@ -20,7 +20,6 @@
     jumpsuit: ClothingAltUniformJumpsuitCentcomOfficial
     back: ClothingBackpackSatchelCentcomm
     shoes: ClothingShoesBootsLaceup
-    head: ClothingHeadHatCentcomcap
     eyes: ClothingEyesGlassesCentComm
     gloves: ClothingHandsGlovesColorBlack
     id: CentCommOperatorPDA
@@ -39,7 +38,6 @@
     jumpsuit: ClothingUniformJumpskirtCentcommResearchFormalWear
     back: ClothingBackpackSatchelCentcomm
     shoes: ClothingShoesBootsLaceup
-    head: ClothingHeadHatCentcomcap
     eyes: ClothingEyesGlassesCentComm
     gloves: ClothingHandsGlovesColorBlack
     id: CentcomPDA
@@ -58,7 +56,6 @@
     jumpsuit: ClothingUniformJumpskirtCentcommAdminFormalWear
     back: ClothingBackpackSatchelCentcomm
     shoes: ClothingShoesBootsLaceup
-    head: ClothingHeadHatCentcomcap
     eyes: ClothingEyesGlassesCentComm
     gloves: ClothingHandsGlovesHop
     id: CentcomPDA
@@ -78,7 +75,6 @@
     jumpsuit: ClothingUniformJumpskirtCentcommCargoFormalWear
     back: ClothingBackpackSatchelCentcomm
     shoes: ClothingShoesBootsLaceup
-    head: ClothingHeadHatCentcomcap
     eyes: ClothingEyesGlassesCentComm
     gloves: ClothingHandsGlovesColorBlack
     id: CentcomPDA
@@ -117,7 +113,6 @@
     jumpsuit: ClothingUniformJumpskirtCentcommIntelFormalWear
     back: ClothingBackpackSatchelCentcomm
     shoes: ClothingShoesBootsLaceup
-    head: ClothingHeadHatCentcomcap
     gloves: ClothingHandsGlovesColorBlack
     eyes: ClothingEyesGlassesCentComm
     id: CentcomPDA
@@ -136,7 +131,6 @@
     jumpsuit: ClothingUniformJumpskirtCentcommMedFormalWear
     back: ClothingBackpackSatchelCentcomm
     shoes: ClothingShoesBootsLaceup
-    head: ClothingHeadHatCentcomcap
     eyes: ClothingEyesGlassesCentComm
     gloves: ClothingHandsGlovesNitrile 
     id: CentcomPDA
@@ -174,7 +168,6 @@
     jumpsuit: ClothingUniformJumpskirtCentcommSecurityFormalWear
     back: ClothingBackpackSatchelCentcomm
     shoes: ClothingShoesBootsCombatFilled
-    head: ClothingHeadHatCentcomcap
     eyes: ClothingEyesGlassesCentComm
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterArmorCentcommCarapace
@@ -195,7 +188,6 @@
     jumpsuit: ClothingUniformJumpskirtCentcommSpecialOpsFormalWear
     back: ClothingBackpackSatchelCentcomm
     shoes: ClothingShoesBootsCombatFilled
-    head: ClothingHeadHatCentcomcap
     eyes: ClothingEyesGlassesCentComm
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingOuterArmorCentcommCarapace

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/operator.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/operator.yml
@@ -18,11 +18,194 @@
   id: CentcomOperatorGear
   equipment:
     jumpsuit: ClothingAltUniformJumpsuitCentcomOfficial
-    shoes: ClothingShoesBootsCombatFilled
+    back: ClothingBackpackSatchelCentcomm
+    shoes: ClothingShoesBootsLaceup
+    head: ClothingHeadHatCentcomcap
     eyes: ClothingEyesGlassesCentComm
     gloves: ClothingHandsGlovesColorBlack
     id: CentCommOperatorPDA
     ears: ClothingHeadsetAltCentCom
-    belt: WeaponPistolN1984
-    pocket1: BoxFolderBlack
-    pocket2: PenCentcom
+    pocket1: WeaponPistolN1984
+    pocket2: BoxFolderCentComClipboardEmpty
+  storage:
+    back:
+    - RubberStampCentcom
+    - MindShieldImplanter
+
+# Central Domestic Division CDD
+- type: startingGear
+  id: CentralDomesticDivisionGear
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCentcommResearchFormalWear
+    back: ClothingBackpackSatchelCentcomm
+    shoes: ClothingShoesBootsLaceup
+    head: ClothingHeadHatCentcomcap
+    eyes: ClothingEyesGlassesCentComm
+    gloves: ClothingHandsGlovesColorBlack
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    pocket1: WeaponPistolN1984
+    pocket2: BoxFolderCentComClipboardEmpty
+  storage:
+    back:
+    - RubberStampCRD
+    - MindShieldImplanter
+
+# Central Administration Division CAD
+- type: startingGear
+  id: CentralAdministrationDivisionGear
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCentcommAdminFormalWear
+    back: ClothingBackpackSatchelCentcomm
+    shoes: ClothingShoesBootsLaceup
+    head: ClothingHeadHatCentcomcap
+    eyes: ClothingEyesGlassesCentComm
+    gloves: ClothingHandsGlovesHop
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    belt: BoxFolderHoPClipboard
+    pocket1: WeaponPistolN1984
+    pocket2: BoxFolderCentComClipboardEmpty
+  storage:
+    back:
+    - RubberStampCAD
+    - MindShieldImplanter
+
+# Central Cargo Division CCD
+- type: startingGear
+  id: CentralCargoDivisionGear
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCentcommCargoFormalWear
+    back: ClothingBackpackSatchelCentcomm
+    shoes: ClothingShoesBootsLaceup
+    head: ClothingHeadHatCentcomcap
+    eyes: ClothingEyesGlassesCentComm
+    gloves: ClothingHandsGlovesColorBlack
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    pocket1: WeaponPistolN1984
+    pocket2: BoxFolderCentComClipboardEmpty
+  storage:
+    back:
+    - RubberStampCCD
+    - MindShieldImplanter
+
+# Central Engineering Division CED
+- type: startingGear
+  id: CentralEngineeringDivisionGear
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtEngiCentcommFormalWear
+    back: ClothingBackpackSatchelCentcomm
+    shoes: ClothingShoesBootsMagAdv
+    head: ClothingHeadHatBeretEngineering
+    eyes: ClothingEyesGlassesCentComm
+    gloves: ClothingHandsGlovesColorYellow
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    belt: ClothingBeltChiefEngineerFilled
+    pocket1: WeaponPistolN1984
+    pocket2: BoxFolderCentComClipboardEmpty
+  storage:
+    back:
+    - RubberStampCED
+    - MindShieldImplanter
+
+# Central Intelligence Division CID
+- type: startingGear
+  id: CentralIntelligenceDivisionGear
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCentcommIntelFormalWear
+    back: ClothingBackpackSatchelCentcomm
+    shoes: ClothingShoesBootsLaceup
+    head: ClothingHeadHatCentcomcap
+    gloves: ClothingHandsGlovesColorBlack
+    eyes: ClothingEyesGlassesCentComm
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    pocket1: WeaponPistolN1984
+    pocket2: BoxFolderCentComClipboardEmpty
+  storage:
+    back:
+    - RubberStampCID
+    - MindShieldImplanter
+
+# Central Medical Division CMD
+- type: startingGear
+  id: CentralMedicalDivisionGear
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCentcommMedFormalWear
+    back: ClothingBackpackSatchelCentcomm
+    shoes: ClothingShoesBootsLaceup
+    head: ClothingHeadHatCentcomcap
+    eyes: ClothingEyesGlassesCentComm
+    gloves: ClothingHandsGlovesNitrile 
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    pocket1: WeaponPistolN1984
+    pocket2: BoxFolderCentComClipboardEmpty
+  storage:
+    back:
+    - RubberStampCMD
+    - MindShieldImplanter
+
+# Central Research Division CRD
+- type: startingGear
+  id: CentralResearchDivisionGear
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCentcommResearchFormalWear
+    back: ClothingBackpackSatchelCentcomm
+    shoes: ClothingShoesBootsLaceup
+    head: ClothingHeadHatCentcomcap
+    eyes: ClothingEyesGlassesCentComm
+    gloves: ClothingHandsGlovesColorPurple
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    pocket1: WeaponPistolN1984
+    pocket2: BoxFolderCentComClipboardEmpty
+  storage:
+    back:
+    - RubberStampCRD
+    - MindShieldImplanter
+
+# Central Security Division CSD
+- type: startingGear
+  id: CentralSecurityDivisionGear
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCentcommSecurityFormalWear
+    back: ClothingBackpackSatchelCentcomm
+    shoes: ClothingShoesBootsCombatFilled
+    head: ClothingHeadHatCentcomcap
+    eyes: ClothingEyesGlassesCentComm
+    gloves: ClothingHandsGlovesCombat
+    outerClothing: ClothingOuterArmorCentcommCarapace
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    belt: CentcommVibrobladeSheathFilled
+    pocket1: WeaponPistolN1984
+    pocket2: BoxFolderCentComClipboardEmpty
+  storage:
+    back:
+    - RubberStampCSD
+    - MindShieldImplanter
+
+# Central Special Operations Division CSOD
+- type: startingGear
+  id: CentralSpecialOperationsDivisionGear
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCentcommSpecialOpsFormalWear
+    back: ClothingBackpackSatchelCentcomm
+    shoes: ClothingShoesBootsCombatFilled
+    head: ClothingHeadHatCentcomcap
+    eyes: ClothingEyesGlassesCentComm
+    gloves: ClothingHandsGlovesCombat
+    outerClothing: ClothingOuterArmorCentcommCarapace
+    id: CentcomPDA
+    ears: ClothingHeadsetAltCentCom
+    belt: CentcommVibrobladeSheathFilled
+    pocket1: WeaponPistolN1984
+    pocket2: BoxFolderCentComClipboardEmpty
+  storage:
+    back:
+    - RubberStampCSOD
+    - MindShieldImplanter
+    


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds loadouts for each Central Command Division + Sheathed spawnables for the vibroblades

I wasnt too sure what to give most of the divisions, Im open to suggestions.

There is currently a bug causing containers to not be filled when using set outfit. This needs to be fixed, so currently the stamps and mindshield arent given (The poor trailmins)
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Trial admins cannot spawn stuff, they rely on loadouts. This also aims to set a direction for the default gear Central Command should be carrying around
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: CrazyPhantom
- add: ADMIN: Central Command Division loadouts. Trialmins rejoice
- add: ADMIN: Filled vibroblade sheath entitys.