### PR TITLE
Some AI related fixes

### DIFF
--- a/Content.Client/Silicons/StationAi/StationAiCustomizationBoundUserInterface.cs
+++ b/Content.Client/Silicons/StationAi/StationAiCustomizationBoundUserInterface.cs
@@ -21,12 +21,21 @@ public sealed class StationAiCustomizationBoundUserInterface : BoundUserInterfac
         _menu.OnClose += Close;
 
         _menu.SendStationAiCustomizationMessageAction += SendStationAiCustomizationMessage;
+        _menu.SendStationAiRenameMessageAction += SendStationAiRenameMessage; // Starlight
     }
 
     public void SendStationAiCustomizationMessage(ProtoId<StationAiCustomizationGroupPrototype> groupProtoId, ProtoId<StationAiCustomizationPrototype> customizationProtoId)
     {
         SendPredictedMessage(new StationAiCustomizationMessage(groupProtoId, customizationProtoId));
     }
+    
+    // Starlight begin
+    public void SendStationAiRenameMessage(string newName)
+    {
+        SendPredictedMessage(new StationAiRenameMessage(newName));
+        Close();
+    }
+    // Starlight end
 
     protected override void Dispose(bool disposing)
     {

--- a/Content.Client/Silicons/StationAi/StationAiCustomizationMenu.xaml.cs
+++ b/Content.Client/Silicons/StationAi/StationAiCustomizationMenu.xaml.cs
@@ -20,6 +20,7 @@ public sealed partial class StationAiCustomizationMenu : FancyWindow
     private Dictionary<ProtoId<StationAiCustomizationGroupPrototype>, ButtonGroup> _buttonGroups = new();
 
     public event Action<ProtoId<StationAiCustomizationGroupPrototype>, ProtoId<StationAiCustomizationPrototype>>? SendStationAiCustomizationMessageAction;
+    public event Action<string>? SendStationAiRenameMessageAction; // Starlight
 
     private const float IconScale = 1.75f;
 
@@ -52,6 +53,27 @@ public sealed partial class StationAiCustomizationMenu : FancyWindow
         }
 
         Title = Loc.GetString("station-ai-customization-menu");
+        
+        //Starlight begin | Add option to rename self if they are 
+        if (stationAiCustomization is null) return;
+        if (!stationAiCustomization.RenameAvailable) return;
+        var nameContainer = new BoxContainer();
+        var label = new Label();
+        var entryField = new LineEdit();
+        var submitButton = new Button();
+        label.Text = Loc.GetString("station-ai-customization-menu-label-rename");
+        submitButton.Text = Loc.GetString("ui-options-function-text-submit");
+        entryField.HorizontalExpand = true;
+        nameContainer.AddChild(label);
+        nameContainer.AddChild(entryField);
+        nameContainer.AddChild(submitButton);
+        CustomizationGroupsContainer.AddTab(nameContainer, Loc.GetString("station-ai-customization-name"));
+        submitButton.OnPressed += _ =>
+        {
+            if (string.IsNullOrWhiteSpace(entryField.Text)) return;
+            SendStationAiRenameMessageAction?.Invoke(entryField.Text);
+        };
+        //Starlight end
     }
 
     public void OnSendStationAiCustomizationMessage

--- a/Content.Server/Silicons/StationAi/StationAiSystem.cs
+++ b/Content.Server/Silicons/StationAi/StationAiSystem.cs
@@ -96,7 +96,7 @@ public sealed class StationAiSystem : SharedStationAiSystem
     private readonly ProtoId<ChatNotificationPrototype> _aiCriticalPowerChatNotificationPrototype = "AiCriticalPower";
 
     private readonly ProtoId<JobPrototype> _stationAiJob = "StationAi";
-    private readonly EntProtoId _stationAiBrain = "StationAiBrain";
+    private readonly EntProtoId _stationAiBrain = "StationAiBrainConstructed"; // SL edit
 
     private readonly ProtoId<AlertPrototype> _batteryAlert = "BorgBattery";
     private readonly ProtoId<AlertPrototype> _damageAlert = "BorgHealth";

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Customization.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Customization.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 
 #region Starlight
 using Content.Shared.Intellicard;
+using Content.Shared.NameIdentifier;
 #endregion Starlight
 
 namespace Content.Shared.Silicons.StationAi;
@@ -21,6 +22,7 @@ public abstract partial class SharedStationAiSystem
     private void InitializeCustomization()
     {
         SubscribeLocalEvent<StationAiCoreComponent, StationAiCustomizationMessage>(OnStationAiCustomization);
+        SubscribeLocalEvent<StationAiCoreComponent, StationAiRenameMessage>(OnStationAiRename); // Starlight
 
         SubscribeLocalEvent<StationAiCustomizationComponent, PlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<StationAiCustomizationComponent, PlayerDetachedEvent>(OnPlayerDetached);
@@ -53,6 +55,23 @@ public abstract partial class SharedStationAiSystem
         if (groupPrototype.Category == StationAiCustomizationType.CoreIconography && TryComp<StationAiHolderComponent>(entity, out var stationAiHolder))
             UpdateAppearance((entity, stationAiHolder));
     }
+    
+    // Starlight begin
+    private void OnStationAiRename(EntityUid uid, StationAiCoreComponent comp, StationAiRenameMessage args)
+    {
+        if (!TryGetHeld((uid, comp), out var core)) return;
+        if (comp.RemoteEntity is null) return;
+        var identifier = "";
+        if (TryComp<NameIdentifierComponent>(core, out var identifierComp))
+        {
+            identifier = identifierComp.FullIdentifier;
+        }
+        _metadata.SetEntityName(core.Value, args.NewName);
+        _metadata.SetEntityName(uid, $"{args.NewName} {identifier}");
+        _metadata.SetEntityName(comp.RemoteEntity.Value, $"{args.NewName} {identifier}");
+        Comp<StationAiCustomizationComponent>(core.Value).RenameAvailable = false;
+    }
+    // Starlight end
 
     private void OnPlayerAttached(Entity<StationAiCustomizationComponent> ent, ref PlayerAttachedEvent args)
     {

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -40,6 +40,8 @@ using Content.Shared._Starlight.Silicons.Borgs;
 using Content.Shared.Starlight;
 using Content.Shared.Starlight.TextToSpeech;
 using Robust.Shared.Player;
+using System.Linq;
+using Content.Shared.Silicons.Borgs.Components;
 #endregion Starlight
 
 namespace Content.Shared.Silicons.StationAi;
@@ -84,7 +86,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
     private EntityQuery<BroadphaseComponent> _broadphaseQuery;
     private EntityQuery<MapGridComponent> _gridQuery;
 
-    private static readonly EntProtoId DefaultAi = "StationAiBrain";
+    private static readonly EntProtoId DefaultAi = "StationAiBrainConstructed"; // Starlight edit
     private readonly ProtoId<ChatNotificationPrototype> _downloadChatNotificationPrototype = "IntellicardDownload";
 
     public override void Initialize()
@@ -130,8 +132,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         var user = args.User;
 
         // Admin option to take over the station AI core
-        if (_admin.IsAdmin(args.User) &&
-            !TryGetHeld((ent.Owner, ent.Comp), out _))
+        if (_admin.IsAdmin(args.User)) // removed check here since it just seemed to make things inconvenient for mins
         {
             args.Verbs.Add(new Verb()
             {
@@ -141,7 +142,15 @@ public abstract partial class SharedStationAiSystem : EntitySystem
                 {
                     if (_net.IsClient)
                         return;
+                    // Starlight start
+                    foreach (var entity in _containers.GetAllContainers(ent.Owner).SelectMany(container => container.ContainedEntities))
+                    {
+                        if (!HasComp<BorgBrainComponent>(entity)) continue;
+                        _mind.ControlMob(user, entity);
+                        return;
+                    }
                     var brain = SpawnInContainerOrDrop(DefaultAi, ent.Owner, StationAiCoreComponent.Container);
+                    // Starlight end
                     _mind.ControlMob(user, brain);
                 },
                 Impact = LogImpact.High,

--- a/Content.Shared/Silicons/StationAi/StationAiCustomizationComponent.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiCustomizationComponent.cs
@@ -21,6 +21,10 @@ public sealed partial class StationAiCustomizationComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public StationAiState State = StationAiState.Occupied;
+    
+    //Starlight begin
+    [DataField, AutoNetworkedField] public bool RenameAvailable = false;
+    //Starlight end
 }
 
 /// <summary>
@@ -38,6 +42,14 @@ public sealed class StationAiCustomizationMessage : BoundUserInterfaceMessage
         CustomizationProtoId = customizationProtoId;
     }
 }
+
+// Starlight begin
+[Serializable, NetSerializable]
+public sealed class StationAiRenameMessage(string newName) : BoundUserInterfaceMessage
+{
+    public readonly string NewName = newName;
+}
+// Starlight end
 
 /// <summary>
 /// Event raised when the station AI customization visual state changes

--- a/Resources/Locale/en-US/silicons/station-ai.ftl
+++ b/Resources/Locale/en-US/silicons/station-ai.ftl
@@ -35,6 +35,10 @@ station-ai-customization-categories = Categories
 station-ai-customization-options = Options (choice of one)
 station-ai-customization-core = AI core displays
 station-ai-customization-hologram = Holographic avatars
+# SL start
+station-ai-customization-menu-label-rename = New name:
+station-ai-customization-name = Rename
+# SL end
 
 # Customizations
 station-ai-icon-ai = Ghost in the machine

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -478,6 +478,16 @@
     chance: 0.6 # lets just try it at 3/4th the chance of a borg and see how bad it gets
     #endregion
 
+#SL start
+- type: entity
+  parent: StationAiBrain
+  id: StationAiBrainConstructed
+  categories: [ HideSpawnMenu, DoNotMap ]
+  components:
+    - type: StationAiCustomization
+      renameAvailable: true
+#SL end
+
 # Hologram projection that the AI's eye tracks.
 - type: entity
   parent:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
AI Takeover is now ALWAYS available to admins, instead of always making a new pb, it will attempt to control the one already in there if it exists, which also lets you retain the AI name.
Unnamed AI's can now rename themselves via the customization menu. This works for AIs contructed manually or any AI core that was spawned by an admin. Does not apply to job spawn AIs.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
AI's not created via the job spawn have no way of being named, defaulting to just the name of the positronic brain. This should more or less fix that issue.
Also the AI take over thing is in part due to it being annoying that you can't properly take over an existing AI with the verb (since it literally vanishes), as well as making sure someone elses PR idea works.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/966f7735-f6dd-4af0-b6d6-413f7f4198a4
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- add: Added the ability for newly created station AI's to rename themselves via the customization menu.
- tweak: AI takeover verb now attempts to setmind to an existing PB instead of always making a new one.