### PR TITLE
Station event and alert level behavior changes

### DIFF
--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -3,10 +3,10 @@ using Content.Shared.Light.Components;
 using Content.Shared.Light.EntitySystems;
 
 #region Starlight
-using Content.Shared.Station.Components;
 using Content.Server.Administration.Logs;
 using Content.Server.AlertLevel;
 using Content.Server.DeviceLinking.Systems;
+using Content.Shared.Station.Components; // Starlight
 using Content.Server.DeviceNetwork;
 using Content.Server.DeviceNetwork.Systems;
 #endregion Starlight

--- a/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/PoweredLightSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Light.Components;
 using Content.Shared.Light.EntitySystems;
 
 #region Starlight
+using Content.Shared.Station.Components;
 using Content.Server.Administration.Logs;
 using Content.Server.AlertLevel;
 using Content.Server.DeviceLinking.Systems;
@@ -68,6 +69,8 @@ public sealed class PoweredLightSystem : SharedPoweredLightSystem
         var query = EntityQueryEnumerator<PoweredLightComponent>();
         while (query.MoveNext(out var uid, out var light))
         {
+            if (!TryComp<StationMemberComponent>(Transform(uid).GridUid, out var stationMember)) continue;
+            if (stationMember.Station != args.Station) continue;
             if (args.AlertLevel == "delta" || args.AlertLevel == "epsilon")
                 SetState(uid, false, light);
             else

--- a/Content.Server/Screen/Systems/ScreenSystem.cs
+++ b/Content.Server/Screen/Systems/ScreenSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.DeviceNetwork.Events;
 using Robust.Shared.Timing;
 using Robust.Shared.Log;
 using Content.Shared.TextScreen;
+using Content.Shared.Station.Components; // Starlight
 
 
 namespace Content.Server.Screen.Systems;
@@ -45,6 +46,10 @@ public sealed class ScreenSystem : EntitySystem
         var query = EntityQueryEnumerator<ScreenComponent>();
         while (query.MoveNext(out var uid, out var screen))
         {
+            //Starlight begin
+            if (!TryComp<StationMemberComponent>(Transform(uid).GridUid, out var stationMember)) continue;
+            if (stationMember.Station != args.Station) continue;
+            //Starlight end
             _appearanceSystem.SetData(uid, TextScreenVisuals.AlertLevel, args.AlertLevel);
         }
     }

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -367,6 +367,9 @@ public sealed partial class StationSystem : SharedStationSystem
         AddGridToStation(station, gridId, null, data, name);
         var ev = new StationPostInitEvent((station, data));
         RaiseLocalEvent(station, ref ev, true);
+        if (comp is null) return station;
+        if (!comp.AllowEvents)
+            RemComp<StationEventEligibleComponent>(station);
         return station;
     }
 

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -367,8 +367,8 @@ public sealed partial class StationSystem : SharedStationSystem
         AddGridToStation(station, gridId, null, data, name);
         var ev = new StationPostInitEvent((station, data));
         RaiseLocalEvent(station, ref ev, true);
-        if (comp is null) return station;
-        if (!comp.AllowEvents)
+        if (comp is null) return station; // Starlight
+        if (!comp.AllowEvents) // Starlight
             RemComp<StationEventEligibleComponent>(station);
         return station;
     }

--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -87,4 +87,16 @@ public sealed partial class StationEventComponent : Component
     /// </summary>
     [DataField]
     public bool OccursDuringRoundEnd = true;
+    
+    //Starlight begin
+    /// <summary>
+    /// The station being targeted by this event. Note: does not actually limit to that station unless you only use this when making your event.
+    /// </summary>
+    [ViewVariables] public EntityUid? TargetStation = null;
+
+    /// <summary>
+    /// Whether to announce globally or only announce on the target station.
+    /// </summary>
+    [DataField] public bool GlobalAnnouncement = true;
+    //Starlight end
 }

--- a/Content.Server/StationEvents/Events/AlertLevelInterceptionRule.cs
+++ b/Content.Server/StationEvents/Events/AlertLevelInterceptionRule.cs
@@ -13,8 +13,14 @@ public sealed class AlertLevelInterceptionRule : StationEventSystem<AlertLevelIn
     {
         base.Started(uid, component, gameRule, args);
 
-        if (!TryGetRandomStation(out var chosenStation))
-            return;
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? chosenStation = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        chosenStation = stationEvent.TargetStation;
+        if (chosenStation is null)
+            if (!TryGetRandomStation(out chosenStation))
+                return;
+        //Starlight end
         if (_alertLevelSystem.GetLevel(chosenStation.Value) != "green")
             return;
 

--- a/Content.Server/StationEvents/Events/AnomalySpawnRule.cs
+++ b/Content.Server/StationEvents/Events/AnomalySpawnRule.cs
@@ -25,8 +25,14 @@ public sealed class AnomalySpawnRule : StationEventSystem<AnomalySpawnRuleCompon
     {
         base.Started(uid, component, gameRule, args);
 
-        if (!TryGetRandomStation(out var chosenStation))
-            return;
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? chosenStation = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        chosenStation = stationEvent.TargetStation;
+        if (chosenStation is null)
+            if (!TryGetRandomStation(out chosenStation))
+                return;
+        //Starlight end
 
         if (!TryComp<StationDataComponent>(chosenStation, out var stationData))
             return;

--- a/Content.Server/StationEvents/Events/BreakerFlipRule.cs
+++ b/Content.Server/StationEvents/Events/BreakerFlipRule.cs
@@ -28,8 +28,14 @@ public sealed class BreakerFlipRule : StationEventSystem<BreakerFlipRuleComponen
     {
         base.Started(uid, component, gameRule, args);
 
-        if (!TryGetRandomStation(out var chosenStation))
-            return;
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? chosenStation = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        chosenStation = stationEvent.TargetStation;
+        if (chosenStation is null)
+            if (!TryGetRandomStation(out chosenStation))
+                return;
+        //Starlight end
 
         var stationApcs = new List<Entity<ApcComponent>>();
         var query = EntityQueryEnumerator<ApcComponent, TransformComponent>();

--- a/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
@@ -18,8 +18,14 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
     {
         base.Started(uid, component, gameRule, args);
 
-        if (!TryGetRandomStation(out var chosenStation, HasComp<StationJobsComponent>))
-            return;
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? chosenStation = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        chosenStation = stationEvent.TargetStation;
+        if (chosenStation is null)
+            if (!TryGetRandomStation(out chosenStation))
+                return;
+        //Starlight end
 
         var jobList = _stationJobs.GetJobs(chosenStation.Value).Keys.ToList();
 

--- a/Content.Server/StationEvents/Events/CargoGiftsRule.cs
+++ b/Content.Server/StationEvents/Events/CargoGiftsRule.cs
@@ -43,9 +43,16 @@ public sealed class CargoGiftsRule : StationEventSystem<CargoGiftsRuleComponent>
 
         component.TimeUntilNextGifts += 30f;
 
-        if (!TryGetRandomStation(out var station, HasComp<StationCargoOrderDatabaseComponent>) ||
-                !TryComp<StationDataComponent>(station, out var stationData))
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? station = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        station = stationEvent.TargetStation;
+        if (station is null)
+            if (!TryGetRandomStation(out station, HasComp<StationCargoOrderDatabaseComponent>)) return;
+
+        if (!TryComp<StationDataComponent>(station, out var stationData))
             return;
+        //Starlight end
 
         if (!TryComp<StationCargoOrderDatabaseComponent>(station, out var cargoDb))
         {

--- a/Content.Server/StationEvents/Events/ClericalErrorRule.cs
+++ b/Content.Server/StationEvents/Events/ClericalErrorRule.cs
@@ -16,8 +16,14 @@ public sealed class ClericalErrorRule : StationEventSystem<ClericalErrorRuleComp
     {
         base.Started(uid, component, gameRule, args);
 
-        if (!TryGetRandomStation(out var chosenStation))
-            return;
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? chosenStation = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        chosenStation = stationEvent.TargetStation;
+        if (chosenStation is null)
+            if (!TryGetRandomStation(out chosenStation))
+                return;
+        //Starlight end
 
         if (!TryComp<StationRecordsComponent>(chosenStation, out var stationRecords))
             return;

--- a/Content.Server/StationEvents/Events/GreytideVirusRule.cs
+++ b/Content.Server/StationEvents/Events/GreytideVirusRule.cs
@@ -44,8 +44,14 @@ public sealed class GreytideVirusRule : StationEventSystem<GreytideVirusRuleComp
         if (virusComp.Severity == null)
             return;
 
-        if (!TryGetRandomStation(out var chosenStation))
-            return;
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? chosenStation = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        chosenStation = stationEvent.TargetStation;
+        if (chosenStation is null)
+            if (!TryGetRandomStation(out chosenStation))
+                return;
+        //Starlight end
 
         // pick random access groups
         var chosen = _random.GetItems(virusComp.AccessGroups, virusComp.Severity.Value, allowDuplicates: false);

--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -14,8 +14,14 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
     {
         base.Started(uid, comp, gameRule, args);
 
-        if (!TryGetRandomStation(out var chosenStation))
-            return;
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? chosenStation = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        chosenStation = stationEvent.TargetStation;
+        if (chosenStation is null)
+            if (!TryGetRandomStation(out chosenStation))
+                return;
+        //Starlight end
 
         var query = EntityQueryEnumerator<SiliconLawBoundComponent, TransformComponent, IonStormTargetComponent>();
         while (query.MoveNext(out var ent, out var lawBound, out var xform, out var target))

--- a/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
@@ -21,8 +21,14 @@ namespace Content.Server.StationEvents.Events
         {
             base.Started(uid, component, gameRule, args);
 
-            if (!TryGetRandomStation(out var chosenStation))
-                return;
+            //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+            EntityUid? chosenStation = null;
+            if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+            chosenStation = stationEvent.TargetStation;
+            if (chosenStation is null)
+                if (!TryGetRandomStation(out chosenStation))
+                    return;
+            //Starlight end
 
             component.AffectedStation = chosenStation.Value;
 

--- a/Content.Server/StationEvents/Events/RandomEntityStorageSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/RandomEntityStorageSpawnRule.cs
@@ -15,8 +15,14 @@ public sealed class RandomEntityStorageSpawnRule : StationEventSystem<RandomEnti
     {
         base.Started(uid, comp, gameRule, args);
 
-        if (!TryGetRandomStation(out var station))
-            return;
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? station = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        station = stationEvent.TargetStation;
+        if (station is null)
+            if (!TryGetRandomStation(out station))
+                return;
+        //Starlight end
 
         var validLockers = new List<(EntityUid, EntityStorageComponent)>();
         var spawn = Spawn(comp.Prototype, MapCoordinates.Nullspace);

--- a/Content.Server/StationEvents/Events/RandomSentienceRule.cs
+++ b/Content.Server/StationEvents/Events/RandomSentienceRule.cs
@@ -19,8 +19,14 @@ public sealed class RandomSentienceRule : StationEventSystem<RandomSentienceRule
 
     protected override void Started(EntityUid uid, RandomSentienceRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
-        if (!TryGetRandomStation(out var station))
-            return;
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? station = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        station = stationEvent.TargetStation;
+        if (station is null)
+            if (!TryGetRandomStation(out station))
+                return;
+        //Starlight end
 
         var targetList = new List<Entity<SentienceTargetComponent>>();
         var query = EntityQueryEnumerator<SentienceTargetComponent, TransformComponent>();

--- a/Content.Server/StationEvents/Events/SpaceSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/SpaceSpawnRule.cs
@@ -24,12 +24,18 @@ public sealed class SpaceSpawnRule : StationEventSystem<SpaceSpawnRuleComponent>
     {
         base.Added(uid, comp, gameRule, args);
 
-        if (!TryGetRandomStation(out var station))
-        {
-            ForceEndSelf(uid, gameRule);
-            return;
-        }
-
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? station = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        station = stationEvent.TargetStation;
+        if (station is null)
+            if (!TryGetRandomStation(out station))
+            {
+                ForceEndSelf(uid, gameRule);
+                return;
+            }
+        //Starlight end
+        
         // find a station grid
         var gridUid = StationSystem.GetLargestGrid(station.Value);
         if (gridUid == null || !TryComp<MapGridComponent>(gridUid, out var grid))

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.GameTicking.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Content.Shared.Station.Components; //Starlight
 
 namespace Content.Server.StationEvents.Events;
 
@@ -42,13 +43,56 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
 
         AdminLogManager.Add(LogType.EventAnnounced, $"Event added / announced: {ToPrettyString(uid)}");
 
+        //Starlight begin
+        if (TryGetRandomStation(out var chosenStation))
+            stationEvent.TargetStation = chosenStation;
+        //Starlight end stationEvent.TargetStation = station;
+
+        if (stationEvent.StartAnnouncement is not null)
+        {
+            if (stationEvent.GlobalAnnouncement)
+            {
+                var allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
+
+                if (stationEvent.StartAnnouncement != null)
+                    ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
+                        Loc.GetString(stationEvent.StartAnnouncement), playSound: false,
+                        colorOverride: stationEvent.StartAnnouncementColor);
+                
+                Audio.PlayGlobal(stationEvent.StartAudio, allPlayersInGame, true);
+            }
+            else
+            {
+                Log.Log(LogLevel.Info, $"Not global!");
+                var allPlayersOnStation = Filter.Empty().AddWhere(session =>
+                {
+                    Log.Log(LogLevel.Info, $"Checking filter for {session.Name}");
+                    if (session.AttachedEntity is null) return false;
+                    Log.Log(LogLevel.Info, $"{session.Name} has attached entity");
+                    if (!TryComp<StationMemberComponent>(Transform(session.AttachedEntity.Value).GridUid,
+                            out var stationGrid)) return false;
+                    Log.Log(LogLevel.Info, $"{session.Name} is on a grid that is a station");
+                    Log.Log(LogLevel.Info, $"{session.Name}: Checking: {stationGrid.Station}, {stationEvent.TargetStation}");
+                    if (stationGrid.Station == stationEvent.TargetStation)
+                    {
+                        Log.Log(LogLevel.Info, $"{session.Name}, {stationGrid.Station}, {stationEvent.TargetStation}");
+                        return true;
+                    }
+
+                    return false;
+                });
+                
+                ChatSystem.DispatchFilteredAnnouncement(allPlayersOnStation,
+                    Loc.GetString(stationEvent.StartAnnouncement), playSound: false,
+                    colorOverride: stationEvent.StartAnnouncementColor);
+                
+                Audio.PlayGlobal(stationEvent.StartAudio, allPlayersOnStation, true);
+            }
+        }
+        
         // we don't want to send to players who aren't in game (i.e. in the lobby)
-        Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
-
-        if (stationEvent.StartAnnouncement != null)
-            ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(stationEvent.StartAnnouncement), playSound: false, colorOverride: stationEvent.StartAnnouncementColor);
-
-        Audio.PlayGlobal(stationEvent.StartAudio, allPlayersInGame, true);
+        
+        //Starlight end
     }
 
     /// <inheritdoc/>

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -63,23 +63,12 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             }
             else
             {
-                Log.Log(LogLevel.Info, $"Not global!");
                 var allPlayersOnStation = Filter.Empty().AddWhere(session =>
                 {
-                    Log.Log(LogLevel.Info, $"Checking filter for {session.Name}");
                     if (session.AttachedEntity is null) return false;
-                    Log.Log(LogLevel.Info, $"{session.Name} has attached entity");
                     if (!TryComp<StationMemberComponent>(Transform(session.AttachedEntity.Value).GridUid,
                             out var stationGrid)) return false;
-                    Log.Log(LogLevel.Info, $"{session.Name} is on a grid that is a station");
-                    Log.Log(LogLevel.Info, $"{session.Name}: Checking: {stationGrid.Station}, {stationEvent.TargetStation}");
-                    if (stationGrid.Station == stationEvent.TargetStation)
-                    {
-                        Log.Log(LogLevel.Info, $"{session.Name}, {stationGrid.Station}, {stationEvent.TargetStation}");
-                        return true;
-                    }
-
-                    return false;
+                    return stationGrid.Station == stationEvent.TargetStation;
                 });
                 
                 ChatSystem.DispatchFilteredAnnouncement(allPlayersOnStation,

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -22,8 +22,14 @@ public sealed class VentClogRule : StationEventSystem<VentClogRuleComponent>
     {
         base.Started(uid, component, gameRule, args);
 
-        if (!TryGetRandomStation(out var chosenStation))
-            return;
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? chosenStation = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        chosenStation = stationEvent.TargetStation;
+        if (chosenStation is null)
+            if (!TryGetRandomStation(out chosenStation))
+                return;
+        //Starlight end
 
         // TODO: "safe random" for chems. Right now this includes admin chemicals.
         var allReagents = PrototypeManager.EnumeratePrototypes<ReagentPrototype>()

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -18,10 +18,14 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
     {
         base.Started(uid, component, gameRule, args);
 
-        if (!TryGetRandomStation(out var station))
-        {
-            return;
-        }
+        //Starlight begin | Prefer target station if there is one, if SOMEHOW that odesn't exist, fallback to existing trygetrandomstation call
+        EntityUid? station = null;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        station = stationEvent.TargetStation;
+        if (station is null)
+            if (!TryGetRandomStation(out station))
+                return;
+        //Starlight end
 
         var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
         var validLocations = new List<EntityCoordinates>();

--- a/Content.Server/_Starlight/Energy/Supermatter/SupermatterSystem.cs
+++ b/Content.Server/_Starlight/Energy/Supermatter/SupermatterSystem.cs
@@ -134,13 +134,18 @@ public sealed class SupermatterSystem : AccUpdateEntitySystem
 
         if (currentDurability > lastDurability)
             _radioSystem.SendRadioMessage(supermatter.Owner, $"The crystal is regenerating. Durability: {currentDurability}%", _engi, supermatter.Owner);
-        else switch (currentDurability)
-            {
-                case > 75: _radioSystem.SendRadioMessage(supermatter.Owner, $"Attention! The crystal is destabilizing. Durability: {currentDurability}%", _engi, supermatter.Owner); break;
-                case > 50: _chat.DispatchServerAnnouncement($"Attention! The crystal is destabilizing. Durability: {currentDurability}%", Color.Yellow); break;
-                case > 25: _chat.DispatchServerAnnouncement($"Critical state of the crystal! Durability: {currentDurability}%", Color.OrangeRed); break;
-                default: _chat.DispatchServerAnnouncement($"Crystal destruction is inevitable. Current durability: {currentDurability}%", Color.Red); break;
-            }
+        //Starlight begin - Stop dispatching server announcements for this.
+        else
+            _radioSystem.SendRadioMessage(supermatter.Owner,
+                $"Attention! The crystal is destabilizing. Durability: {currentDurability}%", _engi, supermatter.Owner);
+        // else switch (currentDurability)
+        //     {
+        //         case > 75: _radioSystem.SendRadioMessage(supermatter.Owner, $"Attention! The crystal is destabilizing. Durability: {currentDurability}%", _engi, supermatter.Owner); break;
+        //         case > 50: _chat.DispatchServerAnnouncement($"Attention! The crystal is destabilizing. Durability: {currentDurability}%", Color.Yellow); break;
+        //         case > 25: _chat.DispatchServerAnnouncement($"Critical state of the crystal! Durability: {currentDurability}%", Color.OrangeRed); break;
+        //         default: _chat.DispatchServerAnnouncement($"Crystal destruction is inevitable. Current durability: {currentDurability}%", Color.Red); break;
+        //     }
+        //Starlight end
     }
 
     private void HandleDestruction(Entity<SupermatterComponent> supermatter)

--- a/Content.Server/_Starlight/Energy/Supermatter/SupermatterSystem.cs
+++ b/Content.Server/_Starlight/Energy/Supermatter/SupermatterSystem.cs
@@ -134,7 +134,6 @@ public sealed class SupermatterSystem : AccUpdateEntitySystem
 
         if (currentDurability > lastDurability)
             _radioSystem.SendRadioMessage(supermatter.Owner, $"The crystal is regenerating. Durability: {currentDurability}%", _engi, supermatter.Owner);
-        //Starlight begin - Stop dispatching server announcements for this.
         else
             _radioSystem.SendRadioMessage(supermatter.Owner,
                 $"Attention! The crystal is destabilizing. Durability: {currentDurability}%", _engi, supermatter.Owner);
@@ -145,7 +144,6 @@ public sealed class SupermatterSystem : AccUpdateEntitySystem
         //         case > 25: _chat.DispatchServerAnnouncement($"Critical state of the crystal! Durability: {currentDurability}%", Color.OrangeRed); break;
         //         default: _chat.DispatchServerAnnouncement($"Crystal destruction is inevitable. Current durability: {currentDurability}%", Color.Red); break;
         //     }
-        //Starlight end
     }
 
     private void HandleDestruction(Entity<SupermatterComponent> supermatter)

--- a/Content.Server/_Starlight/Station/BecomesStationMidRoundComponent.cs
+++ b/Content.Server/_Starlight/Station/BecomesStationMidRoundComponent.cs
@@ -12,16 +12,56 @@ namespace Content.Server._Starlight.Station;
 [Access(typeof(GameTicker), typeof(StationSystem))]
 public sealed partial class BecomesStationMidRoundComponent : Component
 {
+    /// <summary>
+    /// Initialized ID of station
+    /// </summary>
     [ViewVariables(VVAccess.ReadOnly)] public string? InitializedId = null;
+    /// <summary>
+    /// ID of station
+    /// </summary>
     [DataField(required: true)] public string? Id = null;
-    [DataField] public List<EntProtoId> BaseStationProtos = default!; // will combine all components from specified station protos
-    [DataField] public bool AllowFTLDestination; // whether you can inherently FTL to the station or not.
-    [DataField] public bool UseEmergencyShuttle; // false will ignore any emergency shuttle related settings. | Prevents adding emergency shuttle comp
-    [DataField] public bool UseArmories; // whether to spawn armories or not.
-    [DataField] public bool UseArrivals; // whether to add to arrivals rotation or not.
-    [DataField] public bool AllowDungeonSpawn; // allow a new dungeon to spawn or not | Prevents spawning dungeon regardless of gridspawn
-    [DataField] public bool AllowCargoShuttle; // allows the cargo shuttle "ferry" to spawn or not.
-    [DataField] public string[] AllowedGridSpawns = default!; // whitelisted gridspawn keys. Only affects GridSpawn groups, not DungeonSpawns.
+    /// <summary>
+    /// Prototypes to use when constructing station
+    /// </summary>
+    [DataField] public List<EntProtoId> BaseStationProtos = default!;
+    /// <summary>
+    /// Always allow FTLing to this station
+    /// </summary>
+    [DataField] public bool AllowFTLDestination;
+    /// <summary>
+    /// Whether to use an emergency shuttle
+    /// </summary>
+    [DataField] public bool UseEmergencyShuttle;
+    /// <summary>
+    /// Whether to add armories or not
+    /// </summary>
+    [DataField] public bool UseArmories;
+    /// <summary>
+    /// Whether to add an arrivals shuttle or not
+    /// </summary>
+    [DataField] public bool UseArrivals;
+    /// <summary>
+    /// Prevents dungeons from spawning
+    /// </summary>
+    [DataField] public bool AllowDungeonSpawn;
+    /// <summary>
+    /// Allows the cargo ferry to spawn
+    /// </summary>
+    [DataField] public bool AllowCargoShuttle;
+    /// <summary>
+    /// Whitelisted gridspawns
+    /// </summary>
+    [DataField] public string[] AllowedGridSpawns = default!;
+    /// <summary>
+    /// Overrides the emergency shuttle grid
+    /// </summary>
     [DataField] public string? EmergencyShuttleOverridePath = null;
-    [DataField] public Dictionary<ProtoId<JobPrototype>, int>? AvailableJobs = null; // null = no jobs
+    /// <summary>
+    /// Jobs available on init
+    /// </summary>
+    [DataField] public Dictionary<ProtoId<JobPrototype>, int>? AvailableJobs = null;
+    /// <summary>
+    /// Allows events to target this station
+    /// </summary>
+    [DataField] public bool AllowEvents;
 }

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -27,6 +27,7 @@
       min: 10
       max: 10
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startColor: "#18abf5"
     startAudio:
       path: /Audio/Announcements/announce.ogg

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -103,6 +103,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncementColor: "#18abf5"
     startAudio:
       path: /Audio/Announcements/announce.ogg
@@ -142,6 +143,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 7
     duration: 1
     minimumPlayers: 15
@@ -152,6 +154,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-bureaucratic-error-announcement
     earliestStart: 40 # 🌟Starlight🌟 Why could this happen roundstart?!
     minimumPlayers: 40 # 🌟Starlight🌟
@@ -170,6 +173,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-clerical-error-announcement
     minimumPlayers: 15
     weight: 5
@@ -181,6 +185,7 @@
   id: ClosetSkeleton
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 5
     duration: 1
     minimumPlayers: 10
@@ -192,6 +197,7 @@
   id: DragonSpawn
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 3 # 🌟Starlight🌟 Casualization
     earliestStart: 50 # 🌟Starlight🌟 Casualization
     reoccurrenceDelay: 45 # 🌟Starlight🌟 Casualization
@@ -223,6 +229,7 @@
   id: NinjaSpawn
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 3 # 🌟Starlight🌟 Casualization
     duration: null
     earliestStart: 45 # 🌟Starlight🌟 Casualization
@@ -400,6 +407,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 5
     startAnnouncement: station-event-power-grid-check-start-announcement
     endAnnouncement: station-event-power-grid-check-end-announcement
@@ -444,6 +452,7 @@
   parent: BaseStationEventLongDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-clog-start-announcement
     startAudio:
       path: /Audio/_Starlight/Announcements/attention.ogg
@@ -458,6 +467,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/_Starlight/Announcements/attention.ogg
@@ -479,6 +489,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
@@ -500,6 +511,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/_Starlight/Announcements/attention.ogg
@@ -517,6 +529,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/_Starlight/Announcements/attention.ogg
@@ -652,6 +665,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     earliestStart: 20
     minimumPlayers: 15
     weight: 6
@@ -667,6 +681,7 @@
   id: IonStorm
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 8
     reoccurrenceDelay: 20
     duration: 1
@@ -693,6 +708,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 2
@@ -728,6 +744,7 @@
   id: DerelictEngineerCyborgSpawn
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 2.5
     earliestStart: 15
     reoccurrenceDelay: 20
@@ -749,6 +766,7 @@
   id: DerelictGenericCyborgSpawn
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 2.5
     earliestStart: 15
     reoccurrenceDelay: 20
@@ -770,6 +788,7 @@
   id: DerelictJanitorCyborgSpawn
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 2.5
     earliestStart: 15
     reoccurrenceDelay: 20
@@ -791,6 +810,7 @@
   id: DerelictMedicalCyborgSpawn
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 2.5
     earliestStart: 15
     reoccurrenceDelay: 20
@@ -812,6 +832,7 @@
   id: DerelictMiningCyborgSpawn
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 2.5
     earliestStart: 15
     reoccurrenceDelay: 20
@@ -833,6 +854,7 @@
   id: DerelictSyndicateAssaultCyborgSpawn
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 2.5
     earliestStart: 25
     reoccurrenceDelay: 20

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -23,6 +23,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
@@ -46,6 +47,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
@@ -72,6 +74,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
@@ -91,6 +94,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
@@ -106,6 +110,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg
@@ -125,6 +130,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg

--- a/Resources/Prototypes/GameRules/random_sentience.yml
+++ b/Resources/Prototypes/GameRules/random_sentience.yml
@@ -3,6 +3,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     weight: 6
     duration: 1
     maxOccurrences: 1 # this event has diminishing returns on interesting-ness, so we cap it

--- a/Resources/Prototypes/_StarLight/GameRules/events.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/events.yml
@@ -264,6 +264,7 @@
   id: DerelictBorgiSpawn
   components:
     - type: StationEvent
+      globalAnnouncement: false # Starlight
       weight: 5
       earliestStart: 15
       reoccurrenceDelay: 20


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Station alert levels now ACTUALLY only affect the current station as far as I am aware. Screens now only show alert level of the station that they are on, and only lights on the station will turn off on delta/epsilon.
Station events now pick their target station when added as opposed to during the event start. This also allows events to announce only to people on a grid belonging to the station, that way events that happen on a separate station are not announced to members of other stations.
Midround stations now are able to allow or deny events being able to target them. Unsure how effective this is. Needs testing on Delta.
Also makes supermatter no longer broadcast globally, only ever does so on comms.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Lights turning off literally everywhere is annoying, and realistically CC should not be getting affected by things happening on station. Same applies to separate stations.
Additionally, supermatter crystal no longer broadcasts globally when it is delamming on account of the fact that it makes it impossible to mess with it in aspace, and assuming there are two stations on separate maps, would cause confusion about which one is delamming.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/434bf317-50fd-48cf-a54f-faeab835dcc4

https://github.com/user-attachments/assets/2a9edec8-17f3-447d-be4c-9074b28d56a5
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- tweak: Lights only go out on the station that had its alert level set to delta or epsilon, no more pitch black CC after nuke explodes.
- tweak: Screens now only show the alert level of the station that they are on.
- tweak: Station events choose their target station on add now instead of as it starts.
- tweak: Station events now only broadcast their announcement to people currently on a grid belonging to the target station.
- tweak: Midround stations must now opt-in to having events target it.
- tweak: Supermatter destabilizing now only broadcasts over radio instead of a global announcement.