### PR TITLE
Have supermatter purchases start in a secure crate

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_engineering.yml
@@ -3,7 +3,7 @@
   icon:
     sprite: _Starlight/Objects/Specific/supermatter.rsi
     state: supermatter
-  product: SupermatterFlatpack
+  product: CrateSupermatterFlatpack
   cost: 8000
   category: cargoproduct-category-name-engineering
   group: market

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/engineering.yml
@@ -1,4 +1,16 @@
 - type: entity
+  id: CrateSupermatterFlatpack
+  parent: CrateEngineeringSecure
+  name: Supermatter Crate
+  description: Supermatter, your solution for things regular matter can't handle.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: SupermatterFlatpack
+
+- type: entity
   id: CrateEngineeringReflector
   parent: CrateEngineeringSecure
   name: Reflector Crate


### PR DESCRIPTION
## Short description
This causes the supermatter flatpack to spawn in a secure engineering crate, instead of just as a bare flatpack.

## Why we need to add this
It can be non-obvious to those who don't frequent engineering what exactly the supermatter is; someone mistook it for a salt lamp a couple of days ago.

## Media (Video/Screenshots)
<img width="242" height="205" alt="supermatter_secure_crate" src="https://github.com/user-attachments/assets/85b40b54-947b-4b54-9e32-3f5d1513252a" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- tweak: Supermatter flatpacks are now purchased in engineering-locked crates.

