### PR TITLE
Alert level locked weapons now work off-grid

### DIFF
--- a/Content.Server/_Starlight/StationGridMemory/StationGridMemorySystem.cs
+++ b/Content.Server/_Starlight/StationGridMemory/StationGridMemorySystem.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Content.Shared._Starlight.StationGridMemory;
+using Content.Shared.Station.Components;
+using Robust.Server.Containers;
+
+namespace Content.Server._Starlight.StationGridMemory;
+
+public sealed class StationGridMemorySystem : EntitySystem
+{
+    [Dependency] private readonly MetaDataSystem _meta = default!;
+    
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StationGridMemoryComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<StationGridMemoryComponent, GridUidChangedEvent>(OnGridUidChanged);
+        SubscribeLocalEvent<StationGridMemoryComponent, EntParentChangedMessage>(OnParentChanged);
+    }
+
+    private void OnInit(EntityUid uid, StationGridMemoryComponent comp, ComponentInit args)
+    {
+        _meta.AddFlag(uid, MetaDataFlags.ExtraTransformEvents);
+        if (!TryComp<StationMemberComponent>(Transform(uid).GridUid, out var stationMember)) return;
+        comp.LastStation = stationMember.Station;
+    }
+
+    private void OnGridUidChanged(EntityUid uid, StationGridMemoryComponent comp, GridUidChangedEvent ev)
+    {
+        if (!TryComp<StationMemberComponent>(ev.NewGrid, out var stationMember)) return;
+        comp.LastStation = stationMember.Station;
+    }
+
+    private void OnParentChanged(EntityUid uid, StationGridMemoryComponent comp, EntParentChangedMessage ev)
+    {
+        if (!TryComp<StationMemberComponent>(ev.Transform.GridUid, out var stationMember)) return;
+        comp.LastStation = stationMember.Station;
+    }
+}

--- a/Content.Server/_Starlight/Weapons/Ranged/Conditions/AlertLevelCondition.cs
+++ b/Content.Server/_Starlight/Weapons/Ranged/Conditions/AlertLevelCondition.cs
@@ -1,5 +1,6 @@
 using Content.Server.AlertLevel;
 using Content.Server.Popups;
+using Content.Shared._Starlight.StationGridMemory;
 using Content.Shared.Station.Components;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Systems;
@@ -31,16 +32,25 @@ public sealed partial class AlertLevelCondition : FireModeCondition
             || !entityManager.TryGetComponent<ActorComponent>(args.Shooter, out var actor))
             return false;
 
-        if (entityManager.TryGetComponent<StationMemberComponent>(transformComp.ParentUid, out var stationMember) &&
-            entityManager.TryGetComponent<AlertLevelComponent>(stationMember.Station, out var alertLevelComp))
-        {
-            var currentAlertLevel = alertSystem.GetLevel(stationMember.Station, alertLevelComp);
-            if (!AlertLevels.Contains(currentAlertLevel))
-                _popupSystem.PopupEntity(Loc.GetString(PopupMessage), args.Shooter, actor.PlayerSession);
-            return AlertLevels.Contains(currentAlertLevel);
-        }
-
+        if (args.Weapon is null) return false; // realistically this should never ever ever be null why the fuck would this be null
+        AlertLevelComponent? alertLevel = null;
+        var allowed = false;
+        if (entityManager.TryGetComponent<StationGridMemoryComponent>(args.Weapon.Value, out var stationMemory) &&
+            entityManager.TryGetComponent<AlertLevelComponent>(stationMemory.LastStation, out alertLevel))
+            allowed = CheckAlertLevel(stationMemory.LastStation, alertLevel, alertSystem);
+        //failsafe
+        else if (entityManager.TryGetComponent<StationMemberComponent>(transformComp.ParentUid, out var stationMember) &&
+            entityManager.TryGetComponent<AlertLevelComponent>(stationMember.Station, out alertLevel))
+            allowed = CheckAlertLevel(stationMember.Station, alertLevel, alertSystem);
+        
+        if(allowed) return true;
         _popupSystem.PopupEntity(Loc.GetString(PopupMessage), args.Shooter, actor.PlayerSession);
         return false;
+    }
+
+    private bool CheckAlertLevel(EntityUid station, AlertLevelComponent alertLevel, AlertLevelSystem alertSystem)
+    {
+        var currentAlertLevel = alertSystem.GetLevel(station, alertLevel);
+        return AlertLevels.Contains(currentAlertLevel);
     }
 }

--- a/Content.Shared/_Starlight/StationGridMemory/StationGridMemoryComponent.cs
+++ b/Content.Shared/_Starlight/StationGridMemory/StationGridMemoryComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared._Starlight.StationGridMemory;
+
+[RegisterComponent]
+public sealed partial class StationGridMemoryComponent : Component
+{
+    /// <summary>
+    /// The last station this entity was on.
+    /// </summary>
+    [ViewVariables] public EntityUid LastStation;
+}

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -94,6 +94,7 @@
   id: WeaponMiniEnergyGun
   description: An energy gun capable of switching between lethal and debilitating lasers.
   components:
+  - type: StationGridMemory
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Battery/mini.rsi
     layers:
@@ -164,6 +165,7 @@
   id: WeaponDominator
   description: A high-tech weapon created by the law enforcement organization Sibyl System, designed specifically to fight crime.
   components:
+  - type: StationGridMemory
   - type: Appearance
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Battery/dominator.rsi


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
If an `AlertLevelCondition` is able to find a `StationGridMemoryComponent` on the entity being checked, it will now use that instead of the grid the entity is currently on. `StationGridMemoryComponent` remembers the last valid station the entity was standing on. This allows things like the dominator to work off-station, as well as still being able to respect other station's alert levels. (e.g. if one station is on red and the other is on green, using the dominator on red station will allow lethal, and stepping off of that station will still allow lethal, but the moment you step onto a grid belonging to green station, you will be forced back to disabler bolt mode.)
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Dominator's lethal mode only working on station is lame. Also something something better multi-station support.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/a86cdd9c-cb4f-45f3-9cad-9fc8e25cea55
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- add: Added StationGridMemoryComponent/System
- tweak: Weapons locked to the station's alert level that also have a StationGridMemoryComponent should now respect the alert level of the last valid station it was on, allowing them to work off-station.
- tweak: The Dominator and the Miniature Energy Gun were given a StationGridMemoryComponent to allow them to work off-station.