### PR TITLE
Gives BSOs access to NTR Airlocks, NTR Lockers now use NTR access

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -623,7 +623,7 @@
   components:
   - type: Appearance
   - type: AccessReader
-    access: [["Command"]]
+    access: [["Ntrep"]] # Starlight
   - type: EntityStorageVisuals
     stateBaseClosed: hop
     stateDoorOpen: hop_open

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/Electronics/door_access.yml
@@ -1,10 +1,11 @@
+# NT Representative
 - type: entity
   parent: DoorElectronics
   id: DoorElectronicsNtrep
   suffix: Ntrep, Locked
   components:
   - type: AccessReader
-    access: [["Ntrep"]]
+    access: [["Ntrep"], ["BlueShield"]]
 
 # Robotics
 - type: entity

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -68,7 +68,7 @@
     stateDoorOpen: bssecure_open
     stateDoorClosed: bssecure_door
   - type: AccessReader
-    access: [ [ "BlueShield" ] ]
+    access: [["BlueShield"]]
   - type: WiresPanelSecurity
     securityLevel: medSecurity
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
NTR access airlocks like `AirlockNtrepGlassLocked` only allowed the NTR through. This PR changes it so that BSOs can also walk through these doors.

This PR also changes it so that the NT Rep's locker actually uses NT Rep access (instead of Command access).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Currently on Packed (added in #2108) and Plasma (upcoming in #2198), there are little nice NTR Rooms behind NTR-access airlocks. The trouble is that these rooms also gate access to the BSO's Locker.

This _could_ be solved by adding combination door prototypes (something like `AirlockNtrepBSOGlassLocked`, but:
- That sucks
- The door sprites would be identical so it would be easy to get confused why you can't access a room
- The doors sprites being identical makes it really easy to map this wrongly
- I don't think we need even more airlock prototypes

The BSO being able to walk through NTR doors just intuitively makes sense. BSOs protect NTRs, thus should have access through their doors.

As for the NTR Locker access: yeah no I don't know why this wasn't done when NTR access was added. This one is clearly an oversight.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/00b2060a-a4e3-45a5-9895-0a2314daba6d

fig. 1 - Demonstrating locker / airlock accesses with a HOS PDA, an NTR PDA, and a BSO PDA.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- add: BSO now has access to through NTR airlocks
- fix: NTR's locker is now locked behind NTR access (was previously Command access)
