### PR TITLE
Allow CC to receive announcements from station

### DIFF
--- a/Content.Server/Communications/CommunicationsConsoleComponent.cs
+++ b/Content.Server/Communications/CommunicationsConsoleComponent.cs
@@ -74,5 +74,13 @@ namespace Content.Server.Communications
         /// </summary>
         [DataField]
         public bool AnnounceSentBy = true;
+        
+        //Starlight begin
+        /// <summary>
+        /// Additional grids to broadcast messages to that aren't necessarily part of the station.
+        /// Upon map init, this will attempt to find this station's Central Command and automatically append it.
+        /// </summary>
+        [ViewVariables] public List<EntityUid> AdditionalGrids = [];
+        //Starlight end
     }
 }

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -22,7 +22,10 @@ using Robust.Shared.Configuration;
 // Starlight Start
 using System;
 using System.Collections.Generic;
+using Content.Server.Shuttles.Components;
 using Content.Shared.Speech;
+using Content.Shared.Station.Components;
+using Robust.Shared.Player;
 using Robust.Shared.Timing;
 // Starlight End
 
@@ -102,6 +105,13 @@ namespace Content.Server.Communications
         {
             comp.AnnouncementCooldownRemaining = comp.InitialDelay;
             UpdateCommsConsoleInterface(uid, comp);
+            
+            //Starlight begin
+            if (!TryComp<StationMemberComponent>(Transform(uid).GridUid, out var stationMember)) return;
+            if (!TryComp<StationCentcommComponent>(stationMember.Station, out var ccComp)) return;
+            if (ccComp.Entity is null) return;
+            comp.AdditionalGrids.Add(ccComp.Entity.Value);
+            //Starlight end
         }
 
         /// <summary>
@@ -310,6 +320,20 @@ namespace Content.Server.Communications
             }
 
             _chatSystem.DispatchCommunicationsConsoleAnnouncement(uid, msg, title, announcementSound: comp.Sound, colorOverride: comp.Color); // 🌟Starlight🌟
+            //Starlight begin
+            foreach (var grid in comp.AdditionalGrids)
+            {
+                var allPlayersOnGrid = Filter.Empty().AddWhere(session =>
+                {
+                    if (session.AttachedEntity is null) return false;
+                    var gridUid = Transform(session.AttachedEntity.Value).GridUid;
+                    if (gridUid == Transform(uid).GridUid) return false; // They already got the announcement from the dispatch above this
+                    return gridUid == grid;
+                });
+                
+                _chatSystem.DispatchFilteredAnnouncement(allPlayersOnGrid, msg, announcementSound: comp.Sound, colorOverride: comp.Color, sender: title);
+            }
+            //Starlight end
 
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"{ToPrettyString(message.Actor):player} has sent the following station announcement: {msg}");
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds `AdditionalGrids` to `CommunicationsConsoleComponent`. Players on these grids will also receive the announcement when it is sent, if the announcement is not already global. Upon map init, if the comms console is on a station grid, it will attempt to find the associated central command grid to add to this list, allowing CC to get announcements.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I've been told several times that CC sees station announcements IC, but due to restrictions in how the comms console works, you don't actually get the announcement while on CC in-game. This addresses that issue.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1517" height="844" alt="image" src="https://github.com/user-attachments/assets/97ba5507-cba2-4ade-94d5-12690a2ae57a" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- add: Additional grids can now be vvwritten into CommunicationsConsoleComponent to allow them to receive non-global announcements.
- tweak: Central Command now receives announcements from communication consoles on the station.