### PR TITLE
Fix server freeze in debug if SharedVendingMachineSystem.OnVendingGetState runs in a thread without IoC initialized

### DIFF
--- a/Content.Client/_Starlight/IoC/SLIoCSystem.cs
+++ b/Content.Client/_Starlight/IoC/SLIoCSystem.cs
@@ -1,0 +1,6 @@
+using Content.Shared._Starlight.IoC;
+
+namespace Content.Client._Starlight.IoC;
+
+[Obsolete]
+public sealed class SLIoCSystem : SharedSLIoCSystem;

--- a/Content.Server/_Starlight/IoC/SLIoCSystem.cs
+++ b/Content.Server/_Starlight/IoC/SLIoCSystem.cs
@@ -1,0 +1,20 @@
+using Content.Shared._Starlight.IoC;
+
+namespace Content.Server._Starlight.IoC;
+
+[Obsolete]
+public sealed class SLIoCSystem : SharedSLIoCSystem
+{
+    [Dependency] private readonly IDependencyCollection _dependency = default!;
+
+    public override void ServerInitIoC()
+    {
+        // TODO STARLIGHT delete this when SharedVendingMachineSystem.OnVendingGetState is fixed
+#if DEBUG
+        if (IoCManager.Instance != null)
+            return;
+
+        IoCManager.InitThread(_dependency);
+#endif
+    }
+}

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared._Starlight.IoC;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Advertise.Components;
@@ -13,6 +14,7 @@ using Content.Shared.Power.EntitySystems;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.GameStates;
+using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -35,6 +37,10 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
     [Dependency] protected readonly IRobustRandom Randomizer = default!;
     [Dependency] private readonly EmagSystem _emag = default!;
 
+    // Starlight
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedSLIoCSystem _slIoc = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -52,7 +58,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
             subs.Event<VendingMachineRequestBalanceMessage>(OnRequestBalanceMessage); // 🌟Starlight🌟
         });
     }
-    
+
     //#region starlight
     /// <summary>
     /// Restocks one item from the starting inventory, can also be overriden what is restocked on the VendingMachineComponent
@@ -80,12 +86,12 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
             return;
         var theItem = new Dictionary<string, uint>();
         theItem.Add(item, 1);
-        
+
         AddInventoryFromPrototype(uid, theItem, InventoryType.Regular, component);
         Dirty(uid, component);
     }
     //#endregion starlight
-    
+
     private void OnVendingGetState(Entity<VendingMachineComponent> entity, ref ComponentGetState args)
     {
         var component = entity.Comp;
@@ -109,13 +115,22 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
             contrabandInventory[weh.Key] = new(weh.Value);
         }
 
-    // 🌟Starlight🌟 Allow server-side systems to calculate prices
-    // If emagged for interaction, the machine becomes free
-    var isEmagged = _emag.CheckFlag(entity.Owner, EmagType.Interaction);
-    var showPricesNow = component.ShowPrices && !isEmagged;
-    CalculateInventoryPrices(inventory, showPricesNow);
-    CalculateInventoryPrices(emaggedInventory, showPricesNow);
-    CalculateInventoryPrices(contrabandInventory, showPricesNow);
+        // 🌟Starlight🌟 Allow server-side systems to calculate prices
+        // If emagged for interaction, the machine becomes free
+
+        // This is a hack, because this method is doing a lot of things it should not be in component get state
+        // EntityPrototype.TryGetComponent called in CalculateInventoryPrices > GuessCategory has a debug assert
+        // that resolves a dependency
+        // This breaks if this method runs on a thread other than the main thread without IoC initialized
+        // TODO STARLIGHT FIXME
+        if (_net.IsServer)
+            _slIoc.ServerInitIoC();
+
+        var isEmagged = _emag.CheckFlag(entity.Owner, EmagType.Interaction);
+        var showPricesNow = component.ShowPrices && !isEmagged;
+        CalculateInventoryPrices(inventory, showPricesNow);
+        CalculateInventoryPrices(emaggedInventory, showPricesNow);
+        CalculateInventoryPrices(contrabandInventory, showPricesNow);
 
         args.State = new VendingMachineComponentState()
         {
@@ -130,7 +145,8 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
             Broken = component.Broken,
         };
     }
-    // 🌟Starlight🌟 
+
+    // 🌟Starlight🌟
     /// <summary>
     /// Virtual method for calculating inventory prices. Override on server for actual pricing logic
     /// </summary>
@@ -182,7 +198,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
     }
 
     protected virtual void OnInventoryEjectMessage(Entity<VendingMachineComponent> entity, ref VendingMachineEjectMessage args)
-    { 
+    {
         if (!_receiver.IsPowered(entity.Owner) || Deleted(entity))
             return;
 
@@ -296,7 +312,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
         vendComponent.LastBuyer = user; // remember who initiated
         vendComponent.DebitApplied = false; // clear applied flag in case previous op. didnt finish correctly
         vendComponent.VendOperationId++; // bump operation id to mark a new vend
-        entry.Amount--; 
+        entry.Amount--;
         // Starlight-edit end:
 
         if (TryComp(uid, out SpeakOnUIClosedComponent? speakComponent))
@@ -305,7 +321,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
         Dirty(uid, vendComponent);
         UpdateUI((uid, vendComponent));
         TryUpdateVisualState((uid, vendComponent));
-        
+
         Audio.PlayPvs(vendComponent.SoundVend, uid); //starlight
     }
 

--- a/Content.Shared/_Starlight/IoC/SharedSLIoCSystem.cs
+++ b/Content.Shared/_Starlight/IoC/SharedSLIoCSystem.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared._Starlight.IoC;
+
+// TODO STARLIGHT delete this when SharedVendingMachineSystem.OnVendingGetState is fixed
+[Obsolete]
+public abstract class SharedSLIoCSystem : EntitySystem
+{
+    [Obsolete]
+    public virtual void ServerInitIoC()
+    {
+    }
+}


### PR DESCRIPTION
## Short description
I have not enough time to understand what this method is doing to fix it to not do all this in GetState, but I have enough time to fix my local dev environment having a 50% chance to crash every single time I start it
TODO markers are left to fix this properly in the future
Code only runs in debug

If you want to test the fix and you either don't have enough threads on your PC or aren't hitting the thread lottery, replace `Parallel.For(-1, _sessions.Length, opts, SerializeState);` in PvsSystem.SerializeStates with:
```csharp
        var thread = new Thread(() =>
        {
            for (var i = 0; i < _sessions.Length; i++)
            {
                SerializeState(i);
            }
        });
        thread.Start();
        thread.Join();
```

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
