### PR TITLE
Fix Sleeping/SSD ActiveNPC

### DIFF
--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.CCVar;
+using Content.Shared.NPC; // Starlight
 using Content.Shared.StatusEffectNew;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
@@ -83,6 +84,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
         {
             // Forces the entity to sleep when the time has come
             if (!ssd.IsSSD
+                || HasComp<ActiveNPCComponent>(uid) // Starlight
                 || ssd.NextUpdate > curTime
                 || ssd.FallAsleepTime > curTime
                 || TerminatingOrDeleted(uid))


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This fix Soviet and others ActiveNPC falling asleep when they have the SSDIndicator comp, this time its simply check if the Ent has the "ActiveNPC" Comp and if yes, then we dont put him asleep, a simple easy fix.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Fix Duh!

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Shades
- fix: NPCs, Soviets, Ect... wont fall asleep anymore...
