### PR TITLE
Removes Barratry Station from the map voting pool

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
@@ -2,7 +2,6 @@
   id: DefaultStarlightMapPool
   maps:
   - StarlightBagel
-  - StarlightBarratry
   - StarlightCog
   - StarlightCork
   - StarlightFland
@@ -26,6 +25,7 @@
   - StarlightCluster
   - StarlightBox
   - StarlightPacked
+# - StarlightBarratry
 # - StarlightExo
 # - StarlightMarathon
 # - StarlightMeta


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes Barratry from the map voting pool. It still exists in the files for Admeme purposes.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I haven't been Head Mapper that long and I have had people repeatedly approaching me to ask "when is Barratry getting removed?"

Not "hey can this get reworked?" or "hey can (department) in Barratry get (xyz improvement)?"

Just asking me _when_ it's getting axed, like it's a mere matter of time.

Both myself and others have made a bunch of PRs in the past to try and improve Barratry while still keeping its theme / gimmick of being run-down and a station that is missing the quality of life things that other stations have.

**Despite PRing improvements, players still hate Barratry.**

Not an exhaustive list, but:
- The station is incredibly ugly. Elkridge does a better job of feeling like a rusty, old, worn-down station without feeling ugly.
- The map intentionally didn't have _any_ station maps. I PR'd in one working map by the Bar and a bunch of unfinished maps, with the hope that people would finish construction of the maps in-round. Players never do. This leads to players getting incredibly lost all of the time - this is probably the single worst map for a new player to join on.
- The map intentionally lacked critical round-start Departmental resources (steel for Atmos, chemicals for Chemistry), which have been added in PRs with time..
- ...but map lacks still lacks other standard round-start Departmental stuff, like stasis beds in Medical. The station gimmick says is that you have to earn / build it yourself, but players just don't like doing that.
- The GenPop is really bad. Ugly, cramped, has a weird layout, and is inhumanely dirty.
- Engineering entirely lacks a front-desk area, making it feel even more segregated than usual.

I could go on.

I think it's evident that players fundamentally don't like Barratry's gimmick of being 'space Detroit.' It's just not what players are looking for in a SS14 map anymore.

I also don't have any motivation to rework the map. We have tons of cool custom maps already, and we have more on the way. I don't think Barratry will be missed.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- remove: Barratry from the voting map pool