### PR TITLE
Add SubRuleComponent for child rules with tight lifetime binding

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GameRule.cs
+++ b/Content.Server/GameTicking/GameTicker.GameRule.cs
@@ -67,7 +67,7 @@ public sealed partial class GameTicker
     /// start it yet, instead waiting until the rule is actually started by other code (usually roundstart)
     /// </summary>
     /// <returns>The entity for the added gamerule</returns>
-    public EntityUid AddGameRule(string ruleId)
+    public EntityUid AddGameRule(string ruleId, List<EntityUid>? siblings = null) // Starlight - add optional sibling list
     {
         // Starlight Start: Check if any active game rule denies this rule from being added
         var activeRules = GetActiveGameRules();
@@ -96,6 +96,11 @@ public sealed partial class GameTicker
         }
 #endif
         Log.Info(str);
+
+        // Starlight start
+        // We add this rule to its sibling list before the GameRuleAddedEvent fires so that the rule hierarchy is available in its Added method.
+        siblings?.Add(ruleEntity);
+        // Starlight end
 
         var ev = new GameRuleAddedEvent(ruleEntity, ruleId);
         RaiseLocalEvent(ruleEntity, ref ev, true);

--- a/Content.Server/GameTicking/Rules/DynamicRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DynamicRuleSystem.cs
@@ -103,10 +103,11 @@ public sealed class DynamicRuleSystem : GameRuleSystem<DynamicRuleComponent>
         foreach (var rule in GetRuleSpawns(entity))
         {
             // Starlight start
-            var ruleUid = GameTicker.AddGameRule(rule);
-            // We add the rule before executing it so that the rule inheritance hierarchy is
-            // discoverable for child rules for event propagation.
-            entity.Comp.Rules.Add(ruleUid);
+            // We add the rule passing along the list of child rules, so that
+            // if the rule is added, it's added to our child list before the
+            // events calling its Added method are fired. This makes the rule
+            // hierarchy available for the Added method.
+            var ruleUid = GameTicker.AddGameRule(rule, entity.Comp.Rules);
             var res = GameTicker.StartGameRule(ruleUid);
             // Starlight end
             // var res = GameTicker.StartGameRule(rule, out var ruleUid); Starlight - commented out in favor of the above

--- a/Content.Server/GameTicking/Rules/LoadMapRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/LoadMapRuleSystem.cs
@@ -9,7 +9,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.EntitySerialization;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
+using Robust.Shared.Map.Components; // Starlight
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
@@ -28,8 +28,8 @@ public sealed class LoadMapRuleSystem : StationEventSystem<LoadMapRuleComponent>
     [Dependency] private readonly EntityManager _entMan = default!;
     [Dependency] private readonly DynamicRuleSystem _dynamicRule = default!;
     #endregion Starlight
-    
-    protected override void Started(EntityUid uid, LoadMapRuleComponent comp, GameRuleComponent rule, GameRuleStartedEvent args) // Starlight-edit - Added -> Started. This allows us to reference the rule tree, as during "added" the parent rule hasn't been told about the child rule yet.
+
+    protected override void Added(EntityUid uid, LoadMapRuleComponent comp, GameRuleComponent rule, GameRuleAddedEvent args)
     {
         if (comp.PreloadedGrid != null && !_gridPreloader.PreloadingEnabled)
         {
@@ -39,8 +39,10 @@ public sealed class LoadMapRuleSystem : StationEventSystem<LoadMapRuleComponent>
             return;
         }
 
+        // Starlight start
         if (comp.MapTag.HasValue && LoadMapTag(uid, comp, rule, args, comp.MapTag.Value))
             return;
+        // Starlight end
 
         MapId mapId;
         IReadOnlyList<EntityUid> grids;
@@ -117,16 +119,15 @@ public sealed class LoadMapRuleSystem : StationEventSystem<LoadMapRuleComponent>
 
         PropagateLoadEvent(uid, mapId, grids); // Starlight
 
-        base.Started(uid, comp, rule, args); // Starlight-edit - Added -> Started
+        base.Added(uid, comp, rule, args);
     }
 
-    // Starlight begin
     /// <summary>
     /// Recursively propagate the load event up the rule tree.
     /// </summary>
     private void PropagateLoadEvent(EntityUid child, MapId mapId, IReadOnlyList<EntityUid> grids) {
-        var rules = _entMan.AllEntityQueryEnumerator<DynamicRuleComponent>();
-        while (rules.MoveNext(out var uid, out var comp))
+        var dynamicRules = _entMan.AllEntityQueryEnumerator<DynamicRuleComponent>();
+        while (dynamicRules.MoveNext(out var uid, out var comp))
         {
             if (_dynamicRule.Rules((uid, (DynamicRuleComponent?)comp)).Contains(child)) {
                 var ev = new RuleLoadedGridsEvent(mapId, grids);
@@ -135,9 +136,19 @@ public sealed class LoadMapRuleSystem : StationEventSystem<LoadMapRuleComponent>
                 break;
             }
         }
+        var parentRules = _entMan.AllEntityQueryEnumerator<SubRuleComponent>();
+        while (parentRules.MoveNext(out var uid, out var comp))
+        {
+            if (comp.Rules.Contains(child)) {
+                var ev = new RuleLoadedGridsEvent(mapId, grids);
+                RaiseLocalEvent(uid, ref ev);
+                PropagateLoadEvent(uid, mapId, grids);
+                break;
+            }
+        }
     }
 
-    private bool LoadMapTag(EntityUid uid, LoadMapRuleComponent comp, GameRuleComponent rule, GameRuleStartedEvent args, ProtoId<TagPrototype> MapTag)
+    private bool LoadMapTag(EntityUid uid, LoadMapRuleComponent comp, GameRuleComponent rule, GameRuleAddedEvent args, ProtoId<TagPrototype> MapTag)
     {
         MapId mapId;
         IReadOnlyList<EntityUid> grids;
@@ -162,7 +173,7 @@ public sealed class LoadMapRuleSystem : StationEventSystem<LoadMapRuleComponent>
 
                     PropagateLoadEvent(uid, mapId, grids);
 
-                    base.Started(uid, comp, rule, args);
+                    base.Added(uid, comp, rule, args);
 
                     return true;
                 }

--- a/Content.Server/_Starlight/GameTicking/Rules/SubRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/SubRuleSystem.cs
@@ -1,0 +1,110 @@
+using System.Diagnostics;
+using Content.Server.Administration.Logs;
+using Content.Shared.Database;
+using Content.Shared.EntityTable;
+using Content.Shared.EntityTable.Conditions;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.GameTicking.Rules;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server.GameTicking.Rules;
+
+/// <summary>
+/// A system to handle one-shot dynamic rules, with slightly different add/start semantics.
+/// </summary>
+public sealed class SubRuleSystem : GameRuleSystem<SubRuleComponent>
+{
+    [Dependency] private readonly IAdminLogManager _adminLog = default!;
+    [Dependency] private readonly EntityTableSystem _entityTable = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    protected override void Added(EntityUid uid, SubRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    {
+        base.Added(uid, component, gameRule, args);
+
+        component.Budget = _random.Next(component.BudgetMin, component.BudgetMax);;
+
+        AddChildRules((uid, component));
+    }
+
+    protected override void Started(EntityUid uid, SubRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        StartChildRules((uid, component));
+    }
+
+    protected override void Ended(EntityUid uid, SubRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
+    {
+        base.Ended(uid, component, gameRule, args);
+
+        foreach (var rule in component.Rules)
+        {
+            GameTicker.EndGameRule(rule);
+        }
+    }
+
+    /// <summary>
+    /// Generates and returns a list of randomly selected,
+    /// valid rules to spawn based on <see cref="SubRuleComponent.Table"/>.
+    /// </summary>
+    private IEnumerable<EntProtoId> GetRuleSpawns(Entity<SubRuleComponent> entity)
+    {
+        var ctx = new EntityTableContext(new Dictionary<string, object>
+        {
+            { HasBudgetCondition.BudgetContextKey, entity.Comp.Budget },
+        });
+
+        return _entityTable.GetSpawns(entity.Comp.Table, ctx: ctx);
+    }
+
+    /// <summary>
+    /// Uses the definition of the component to create and add sub rules, but not yet start them.
+    /// </summary>
+    /// <returns>
+    /// Returns a list of the rules that were added.
+    /// </returns>
+    private List<EntityUid> AddChildRules(Entity<SubRuleComponent> entity)
+    {
+        var addedRules = new List<EntityUid>();
+
+        foreach (var rule in GetRuleSpawns(entity))
+        {
+            var ruleUid = GameTicker.AddGameRule(rule, entity.Comp.Rules);
+
+            addedRules.Add(ruleUid);
+
+            if (TryComp<DynamicRuleCostComponent>(ruleUid, out var cost))
+            {
+                entity.Comp.Budget -= cost.Cost;
+                _adminLog.Add(LogType.EventRan, LogImpact.High, $"{ToPrettyString(entity)} ran rule {ToPrettyString(ruleUid)} with cost {cost.Cost} on budget {entity.Comp.Budget}.");
+            }
+            else
+            {
+                _adminLog.Add(LogType.EventRan, LogImpact.High, $"{ToPrettyString(entity)} ran rule {ToPrettyString(ruleUid)} which had no cost.");
+            }
+        }
+
+        return addedRules;
+    }
+
+    /// <summary>
+    /// Starts rules already added to the component.
+    /// </summary>
+    /// <returns>
+    /// Returns a list of the rules that were started.
+    /// </returns>
+    private List<EntityUid> StartChildRules(Entity<SubRuleComponent> entity)
+    {
+        var startedRules = new List<EntityUid>();
+
+        foreach (var ruleUid in entity.Comp.Rules)
+        {
+            var res = GameTicker.StartGameRule(ruleUid);
+            Debug.Assert(res);
+        }
+
+        return startedRules;
+    }
+}

--- a/Content.Server/_Starlight/GameTicking/Rules/SubRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/SubRuleSystem.cs
@@ -23,16 +23,33 @@ public sealed class SubRuleSystem : GameRuleSystem<SubRuleComponent>
     {
         base.Added(uid, component, gameRule, args);
 
-        component.Budget = _random.Next(component.BudgetMin, component.BudgetMax);;
+        component.Budget = _random.Next(component.BudgetMin, component.BudgetMax);
 
-        AddChildRules((uid, component));
+        foreach (var rule in GetRuleSpawns((uid, component)))
+        {
+            var ruleUid = GameTicker.AddGameRule(rule, component.Rules);
+
+            if (TryComp<DynamicRuleCostComponent>(ruleUid, out var cost))
+            {
+                component.Budget -= cost.Cost;
+                _adminLog.Add(LogType.EventRan, LogImpact.High, $"{ToPrettyString(uid)} ran rule {ToPrettyString(ruleUid)} with cost {cost.Cost} on budget {component.Budget}.");
+            }
+            else
+            {
+                _adminLog.Add(LogType.EventRan, LogImpact.High, $"{ToPrettyString(uid)} ran rule {ToPrettyString(ruleUid)} which had no cost.");
+            }
+        }
     }
 
     protected override void Started(EntityUid uid, SubRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, component, gameRule, args);
 
-        StartChildRules((uid, component));
+        foreach (var ruleUid in component.Rules)
+        {
+            var res = GameTicker.StartGameRule(ruleUid);
+            Debug.Assert(res);
+        }
     }
 
     protected override void Ended(EntityUid uid, SubRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
@@ -57,54 +74,5 @@ public sealed class SubRuleSystem : GameRuleSystem<SubRuleComponent>
         });
 
         return _entityTable.GetSpawns(entity.Comp.Table, ctx: ctx);
-    }
-
-    /// <summary>
-    /// Uses the definition of the component to create and add sub rules, but not yet start them.
-    /// </summary>
-    /// <returns>
-    /// Returns a list of the rules that were added.
-    /// </returns>
-    private List<EntityUid> AddChildRules(Entity<SubRuleComponent> entity)
-    {
-        var addedRules = new List<EntityUid>();
-
-        foreach (var rule in GetRuleSpawns(entity))
-        {
-            var ruleUid = GameTicker.AddGameRule(rule, entity.Comp.Rules);
-
-            addedRules.Add(ruleUid);
-
-            if (TryComp<DynamicRuleCostComponent>(ruleUid, out var cost))
-            {
-                entity.Comp.Budget -= cost.Cost;
-                _adminLog.Add(LogType.EventRan, LogImpact.High, $"{ToPrettyString(entity)} ran rule {ToPrettyString(ruleUid)} with cost {cost.Cost} on budget {entity.Comp.Budget}.");
-            }
-            else
-            {
-                _adminLog.Add(LogType.EventRan, LogImpact.High, $"{ToPrettyString(entity)} ran rule {ToPrettyString(ruleUid)} which had no cost.");
-            }
-        }
-
-        return addedRules;
-    }
-
-    /// <summary>
-    /// Starts rules already added to the component.
-    /// </summary>
-    /// <returns>
-    /// Returns a list of the rules that were started.
-    /// </returns>
-    private List<EntityUid> StartChildRules(Entity<SubRuleComponent> entity)
-    {
-        var startedRules = new List<EntityUid>();
-
-        foreach (var ruleUid in entity.Comp.Rules)
-        {
-            var res = GameTicker.StartGameRule(ruleUid);
-            Debug.Assert(res);
-        }
-
-        return startedRules;
     }
 }

--- a/Content.Shared/_Starlight/GameTicking/Rules/SubRuleComponent.cs
+++ b/Content.Shared/_Starlight/GameTicking/Rules/SubRuleComponent.cs
@@ -1,12 +1,11 @@
 using Content.Shared.EntityTable.EntitySelectors;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.GameTicking.Rules;
 
 /// <summary>
 /// Gamerule which creates starts a number of other gamerules at once based on a budget
 /// </summary>
-[RegisterComponent, AutoGenerateComponentPause]
+[RegisterComponent]
 public sealed partial class SubRuleComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_Starlight/GameTicking/Rules/SubRuleComponent.cs
+++ b/Content.Shared/_Starlight/GameTicking/Rules/SubRuleComponent.cs
@@ -1,0 +1,41 @@
+using Content.Shared.EntityTable.EntitySelectors;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.GameTicking.Rules;
+
+/// <summary>
+/// Gamerule which creates starts a number of other gamerules at once based on a budget
+/// </summary>
+[RegisterComponent, AutoGenerateComponentPause]
+public sealed partial class SubRuleComponent : Component
+{
+    /// <summary>
+    /// The total budget for antags.
+    /// </summary>
+    [DataField]
+    public float Budget;
+
+    /// <summary>
+    /// The minimum or lower bound for budgets to start at.
+    /// </summary>
+    [DataField]
+    public int BudgetMin = 200;
+
+    /// <summary>
+    /// The maximum or upper bound for budgets to start at.
+    /// </summary>
+    [DataField]
+    public int BudgetMax = 350;
+
+    /// <summary>
+    /// A table of rules that are picked from.
+    /// </summary>
+    [DataField]
+    public EntityTableSelector Table = new NoneSelector();
+
+    /// <summary>
+    /// The rules that have been spawned
+    /// </summary>
+    [DataField]
+    public List<EntityUid> Rules = new();
+}

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -150,7 +150,7 @@
     # Starlight Start
     denyGameRules:
     - AbductorsSpawn
-  - type: DynamicRule
+  - type: SubRule
     table: !type:GroupSelector
       children:
       - id: NukiePlanetSpawn


### PR DESCRIPTION
## Short description
This adds SubRuleComponent, which is highly similar to DynamicRuleComponent, except that the rules it adds have very tight bindings to the lifetime of their parent rules. DynamicRuleComponent can't add its child rules until it has already started, as it could add rules many times during its lifetime; in contract, since SubRuleComponent can only add rules once, it can add child rules during its own Added method.

## Why we need to add this
This has the advantage of allowing some rule components to interact much more closely to how they would if directly added to the same rule entity. As a practical example, the LoadMapRule which loads the nukie map normally does so in the Added method; other rules then depend on the map having been loaded in their Started methods. If done as a DynamicRule child, the DynamicRule's Started method Adds the LoadMapRule, meaning that it's not necessarily early enough for the result to be visible in the other rule components.

Practically, this means that ghost-following some antag ghost role spawners bugs out, which now works again with these changes.

## Media (Video/Screenshots)
No real visual difference.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Fixed internal sequencing issue in rule component evaluation that could lead to being unable to follow unclaimed spawners for nukeops and brighteyes.
- fix: Fixed an issue where the syndicate would keep allocating more bases to an established nukie team.