### PR TITLE
Bluespace Crystal Exploit

### DIFF
--- a/Content.Server/_Starlight/Bluespace/BluespaceCrystalSystem.cs
+++ b/Content.Server/_Starlight/Bluespace/BluespaceCrystalSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server._Starlight.Bluespace;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Stacks;
 using Content.Shared.Throwing;
 using Robust.Shared.Map;
@@ -51,7 +52,7 @@ public sealed class BluespaceCrystalSystem : EntitySystem
 
         Spawn(BluespaceCrystalEffect, EffectLocation);
         
-        if (component.Teleport && target is not null)
+        if (component.Teleport && target is not null && HasComp<MobStateComponent>(target)) // TODO: Do something else? This is there so we dont TELEPORT WALLS/DOORS...
         {
             var newCoords = EffectLocation; // This is a comment... (newCoords is fetch later.)
             for (var i = 0; i < MaxRandomTeleportAttempts; i++)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fix a huge bug/exploit that gave the ability of bluespace crystal to effects walls, windows, ect... this has been changed to only effect mobs now.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

VERY BAD EXPLOIT.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: Shades
- fix: Fix bluespace crystals able to teleport walls, doors and windows, now its only effect mobs.
