### PR TITLE
Brighteye Admin Patch

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -251,6 +251,7 @@ public sealed partial class AdminVerbSystem
                 Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_Starlight/Interface/Actions/shadekin.rsi"), "rest"),
                 Act = () =>
                 {
+                    _gameTicker.StartGameRule("TheDarkMap"); // The Dark should always be spawned for any brighteye.
                     _antag.ForceMakeAntag<BrighteyeRuleComponent>(targetPlayer, DefaultBrighteyeRule);
                 },
                 Impact = LogImpact.High,

--- a/Resources/Prototypes/_StarLight/GameRules/events.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/events.yml
@@ -341,3 +341,13 @@
     - id: RailroadingBrighteye
   - type: DynamicRuleCost
     cost: 150
+
+# This is used for admin/tools to spawn the dark without any antag.
+- type: entity
+  parent: BaseGameRule
+  id: TheDarkMap
+  components:
+  - type: StationEvent
+  - type: LoadMapRule
+    mapPath: /Maps/_Starlight/TheDark/Hideout.yml
+    mapTag: TheDark


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Makes so Admin Control to spawn a brighteye make sure the map is also spawned, if its is not this can block the ent in some ways; also add the map its own admin gamerule for easy spawn without antag spawns.

No CL needed

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

A patch for a possible incoming bug and issues, and gives more easy control over this important step.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
