### PR TITLE
Allow Map- and Player-associated GameRules to generally work

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -233,6 +233,11 @@ public sealed partial class GameTicker
         var rules = new List<EntityUid>(GetAddedGameRules());
         foreach (var rule in rules)
         {
+            // Starlight start
+            // We're only handling rules that aren't intentionally delayed. If a rule _is_ supposed to be delayed, ignore it.
+            if (HasComp<DelayedStartRuleComponent>(rule))
+                continue;
+            // Starlight end
             StartGameRule(rule);
         }
 
@@ -253,6 +258,9 @@ public sealed partial class GameTicker
             Log.Warning($"Rules added while starting preset rules - count updated from {expectedRuleCount} to {rules.Count}. Doing another pass to start extra rule(s)...");
             foreach (var rule in rules)
             {
+                // We're only handling rules that aren't intentionally delayed. If a rule _is_ supposed to be delayed, ignore it.
+                if (HasComp<DelayedStartRuleComponent>(rule))
+                    continue;
                 StartGameRule(rule);
             }
 

--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -5,6 +5,7 @@ using Content.Server.GameTicking.Presets;
 using Content.Server.Maps;
 using Content.Shared._Starlight.EntityTable; //#Starlight
 using Content.Shared.CCVar;
+using Content.Shared.GameTicking.Components; // Starlight
 using JetBrains.Annotations;
 using Robust.Shared.Player;
 
@@ -234,6 +235,38 @@ public sealed partial class GameTicker
         {
             StartGameRule(rule);
         }
+
+        // Starlight start
+        // We're not ingame yet, so if gamerules were added during the StartGameRule pass,
+        // they weren't started automatically. This leads to a bit of a chicken-and-egg
+        // problem, as the engine otherwise assumes that StartGamePresetRules will have
+        // moved any existing GameRule objects to a started state. To make this invariant
+        // hold properly, we continue iterating over the game rules until all are started.
+        var expectedRuleCount = rules.Count;
+        rules = new List<EntityUid>(GetAddedGameRules());
+        // The iteration count limit is supposed to prevent us from infinite looping in
+        // the event that a rule adds a copy of itself.
+        var iteration = 0;
+        const int maxIterations = 5;
+        while (expectedRuleCount != rules.Count && iteration < maxIterations)
+        {
+            Log.Warning($"Rules added while starting preset rules - count updated from {expectedRuleCount} to {rules.Count}. Doing another pass to start extra rule(s)...");
+            foreach (var rule in rules)
+            {
+                StartGameRule(rule);
+            }
+
+            expectedRuleCount = rules.Count;
+            rules = new List<EntityUid>(GetAddedGameRules());
+
+            iteration += 1;
+        }
+
+        if (iteration == maxIterations && expectedRuleCount != rules.Count)
+        {
+            _sawmill.Error($"Rule startup did not converge within {maxIterations} passes, continuing regardless - unstarted rules: {string.Join(", ", rules.Where(rule => !(HasComp<ActiveGameRuleComponent>(rule) || HasComp<EndedGameRuleComponent>(rule))).Select<EntityUid, string>(rule => ToPrettyString(rule)))}");
+        }
+        // Starlight end
     }
 
     private void IncrementRoundNumber()

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -421,9 +421,11 @@ namespace Content.Server.GameTicking
             // MapInitialize *before* spawning players, our codebase is too shit to do it afterwards...
             _map.InitializeMap(DefaultMap);
 
+            StartGamePresetRules(); // Starlight - Start any map-attached game rules
+
             SpawnPlayers(readyPlayers, readyPlayerIds, force);
 
-            StartGamePresetRules(); // Starlight - Start any map- or player-attached game rules
+            StartGamePresetRules(); // Starlight - Start any player-attached game rules
 
             _roundStartDateTime = DateTime.UtcNow;
             RunLevel = GameRunLevel.InRound;

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -423,6 +423,8 @@ namespace Content.Server.GameTicking
 
             SpawnPlayers(readyPlayers, readyPlayerIds, force);
 
+            StartGamePresetRules(); // Starlight - Start any map- or player-attached game rules
+
             _roundStartDateTime = DateTime.UtcNow;
             RunLevel = GameRunLevel.InRound;
 

--- a/Content.Server/_Starlight/GameTicking/Rules/SubRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/SubRuleSystem.cs
@@ -47,8 +47,11 @@ public sealed class SubRuleSystem : GameRuleSystem<SubRuleComponent>
 
         foreach (var ruleUid in component.Rules)
         {
-            var res = GameTicker.StartGameRule(ruleUid);
-            Debug.Assert(res);
+            // If our use of subrule was to add a delayed rule, we need to avoid double-triggering it, as that'd cause it to immediately fire.
+            if (HasComp<DelayedStartRuleComponent>(ruleUid))
+                continue;
+
+            GameTicker.StartGameRule(ruleUid);
         }
     }
 


### PR DESCRIPTION
## Short description
This adds additional passes over the game rule entities to ensure that they're properly started if they're added before we go InRound.

## Why we need to add this
This lets us do things like have maps add the visitor scheduler or meteors as rules when the map is used, rather than leaving it just locked to the gamemode. The crux of this change is that before the changes to GameTicker, rules added as part of a map aren't started due to being after the preset run, but before the game mode is set to InRound.

## Media (Video/Screenshots)
N/A (internals change)

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- add: Stations can now be cursed!
