### PR TITLE
Amended Space Law

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
@@ -420,7 +420,7 @@
   8. Sedition, Conspiracy, Treason, Enemy of Corporation
   
   ## Minor Crimes
-  Those who commit a minor crime should be issued a warning for their first offense, however repeat offenses are cumulative and should result in jail time of up to 10 minutes per minor crime committed. 
+  Those who commit a minor crime should be issued a warning for their first offense, however repeat offenses are cumulative and should result in jail time of up to 5 minutes per minor crime committed. 
   <Table Columns="2">
     <ColorBox>
       <Box>
@@ -505,7 +505,7 @@
   </Table>
 
   ## Moderate Crimes
-  Those who commit a moderate crime should receive up to a 10 minute sentence per moderate crime committed.
+  Those who commit a moderate crime should receive up to a 5 minute sentence per moderate crime committed.
   <Table Columns="2">
     <ColorBox>
       <Box>
@@ -590,7 +590,7 @@
   </Table>
 
   ## Major Crimes
-  Those who commit a major crime should receive up to 20 minutes of jail time per major crime committed. Major assault and manslaughter are linked crimes and do not stack against a suspect.
+  Those who commit a major crime should receive up to 10 minutes of jail time per major crime committed. Major assault and manslaughter are linked crimes and do not stack against a suspect.
   <Table Columns="2">
     <ColorBox>
       <Box>
@@ -735,7 +735,7 @@
   </Table>
 
   ## Extreme Crimes
-  Those who commit an extreme crime may receive up to 40 minutes of jail time per extreme crime committed. Particularly violent offenders may be placed in perma. Attempted murder and murder are linked crimes and cannot be stacked together.
+  Those who commit an extreme crime may receive up to 20 minutes of jail time per extreme crime committed. Particularly violent offenders may be placed in perma. Attempted murder and murder are linked crimes and cannot be stacked together.
   <Table Columns="2">
     <ColorBox>
       <Box>
@@ -863,7 +863,7 @@
     </ColorBox>
     <ColorBox Color="#4d2e2e">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To unlawfully execute an individual without authorization or outside of Standard Operating Procedure. This law is distinct from murder, and applies primarily to Security, Command, and Central Command forces such as Emergency Response
+        To unlawfully execute an individual without authorization or outside of Standard Operating Procedure. This law is distinct from murder, and applies primarily to Security, Command, and Central Command forces such as Emergency Response Teams.
       </Box>
     </ColorBox>
     <ColorBox Color="#4d2e2e">

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -67,7 +67,7 @@
   During a confirmed Revolution, the Head of Security or Warden are permitted to authorize execution of an individual if a Mind Shielding fails or is refused. No other officers are granted this authorization. Execution of those charged with Refusal of Mental Shielding outside of a confirmed Revolution must be authorized by the Captain or Central Command on a case by case basis every time it happens.
   
   ## Sentencing
-  Sentencing of under 20 minutes is the responsibility of the arresting officer. When an individual has been detained, they must be promptly marked as such in the Criminal Records Computer. Likewise, when they have been released they must be promptly marked as such. If an individual has been detained but had no preexisting warrant, their criminal record should be updated to reflect them; marking them as wanted and writing in why, before marking them detained.
+  Sentencing of under 10 minutes is the responsibility of the arresting officer. When an individual has been detained, they must be promptly marked as such in the Criminal Records Computer. Likewise, when they have been released they must be promptly marked as such. If an individual has been detained but had no preexisting warrant, their criminal record should be updated to reflect them; marking them as wanted and writing in why, before marking them detained.
 
   The Prisoner's charges must be read to them in front of the Warden or Head of Security.
 
@@ -77,8 +77,8 @@
   
   [color=#a4885c]Stackable Crimes:[/color] Crimes are to be considered 'stackable' in the sense that if you charge someone with two or more different crimes, you may combine the times you would give them for each crime.
   
-  - Example: If a suspect has committed Major Possession and Major Syndicate Possession, the maximum sentence would be 40 minutes due to them being linked crimes.
-  - Example 2: If a suspect has committed Secure Trespass and Manslaughter, the maximum sentence would be 40 minutes due to them being unlinked crimes.
+  - Example: If a suspect has committed Major Possession and Major Syndicate Possession, the maximum sentence would be 20 minutes due to them being linked crimes.
+  - Example 2: If a suspect has committed Secure Trespass and Manslaughter, the maximum sentence would be 20 minutes due to them being unlinked crimes.
   - Context is vital. If you are unsure, seek assistance from the Warden or Head of Security.
 
   [color=#a4885c]Repeater Offenders:[/color] Repeated crimes are when someone is released for a crime and then commits the same crime again within the same shift. Repeated crimes can be charged with additional time. Every repeat adds 5 minutes.
@@ -92,6 +92,8 @@
   [color=#a4885c]Absence of Intent:[/color] Criminals who committed their crime unintentionally may have their sentence reduced by 50% at the sentencing officer's discretion.
 
   [color=#a4885c]Disclosure and Surrender:[/color] Criminals who fully cooperate with the investigation should have their sentence reduced by 50-75% at the sentencing officer's discretion. This includes turning in evidence, turning in accomplices, or recounting the crime in detail.
+  
+  [color=#a4885c]Resisting Arrest:[/color] Resisting Arrest: Criminals who behave in a noncompliant manner including resisting arrest, fleeing during processing, or those who become combative may receive sentence times up to double that of the maximum sentence.
   
   ## Normal Punishments
   - [color=#a4885c]Warning:[/color] For minor crimes it is best to fix the issue then warn the person not to attempt the crime again. If they still proceed to do it at a later date, a brig time may be better.


### PR DESCRIPTION

## Short description
Halves maximum sentence times, but allows for sentences to be doubled (so what they are now) if criminals resist arrest or become combative.

## Why we need to add this
People are often given the maximum sentence for each crime, effectively round removing antags. Sitting in genpop for 40 minutes after a failed murder attempt often means they won't get another chance. It also punishes new players and encourages antags to always use meta strategies instead of coming up with new (potentially riskier) schemes. A recent poll shows that 72% and 77% of non-SEC mains and SEC mains who voted agree with this change, respectively. 74% of total players who participated are in favor of this change.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Karma
- tweak: Updated Corporate Law in Game
