### PR TITLE
Fix Vox organs taking priority on verbs

### DIFF
--- a/Content.Shared/Body/Systems/SharedInternalsSystem.cs
+++ b/Content.Shared/Body/Systems/SharedInternalsSystem.cs
@@ -259,14 +259,12 @@ public abstract class SharedInternalsSystem : EntitySystem
     public Entity<GasTankComponent>? FindBestGasTank(
         Entity<HandsComponent?, InventoryComponent?, ContainerManagerComponent?> user)
     {
-        // Starlight edit start - Add a check for whether the user can breathe from organs
         // TODO use _respirator.CanMetabolizeGas() to prioritize metabolizable gasses
         // Lookup order:
-        // 1. Organs
-        // 2. Back
-        // 3. Exo-slot
-        // 4. In-hand
-        // 5. Pocket/belt
+        // 1. Back
+        // 2. Exo-slot
+        // 3. In-hand
+        // 4. Pocket/belt
         // Jetpacks will only be used as a fallback if no other tank is found
 
         // Store the first jetpack seen
@@ -275,24 +273,6 @@ public abstract class SharedInternalsSystem : EntitySystem
         if (!Resolve(user, ref user.Comp2, ref user.Comp3))
             return null;
 
-        if (TryComp<BodyComponent>(user.Owner, out var body) &&
-            TryComp<InternalsComponent>(user.Owner, out var internals) &&
-            internals.BreathTools.Count > 0)
-        {
-            var organTanks = _body.GetBodyOrganEntityComps<GasTankComponent>((user.Owner, body));
-            foreach (var organTank in organTanks)
-            {
-                if (organTank.Comp1.IsConnected && organTank.Comp1.User == user.Owner)
-                {
-                    return (organTank.Owner, organTank.Comp1);
-                }
-                else if (_gasTank.CanConnectToInternals((organTank.Owner, organTank.Comp1)))
-                {
-                    return (organTank.Owner, organTank.Comp1);
-                }
-            }
-        }
-        // Starlight edit end
         if (_inventory.TryGetSlotEntity(user, "back", out var backEntity, user.Comp2, user.Comp3) &&
             TryComp<GasTankComponent>(backEntity, out var backGasTank) &&
             _gasTank.CanConnectToInternals((backEntity.Value, backGasTank)))


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This fix makes it so other people can turn on vox internals on gas tanks

## Why we need to add this
There has been a very awkward balancing issue where if a vox lost all of the gas in their internal organ, they could not be given an external gas tank by other people.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Other people being unable to give vox an external tank.
