### PR TITLE
Borg subtypes now apply an appropriate inventory template

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -253,6 +253,11 @@
   - type: Blindable
   - type: EyeProtection
   - type: Stripping
+  - type: InteractionPopup # All Borgs should now be pettable again
+    interactSuccessString: petting-success-generic-cyborg
+    interactFailureString: petting-failure-generic-cyborg
+    interactSuccessSound:
+      path: /Audio/Ambience/Objects/periodic_beep.ogg
   #endregion
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -395,6 +395,8 @@
     interfaces:
       enum.WiresUiKey.Key:
         type: WiresBoundUserInterface
+      enum.StrippingUiKey.Key:              # Starlight
+        type: StrippableBoundUserInterface  # Starlight Readded stipping UI to medibots, wirepanels overwrote them
 
 - type: entity
   parent:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/borg_subtypes.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/borg_subtypes.yml
@@ -11,6 +11,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
+      inventoryTemplateId: borgShort
 
 - type: entity
   parent: BorgEngineerSubtypeBase
@@ -23,6 +24,7 @@
       spriteHasMindState: generic_e
       spriteNoMindState: generic_e_r
       spriteToggleLightState: generic_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgEngineerSubtypeBase
@@ -35,6 +37,7 @@
       spriteHasMindState: antique_e
       spriteNoMindState: antique_e_r
       spriteToggleLightState: antique_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgEngineerSubtypeBase
@@ -47,6 +50,7 @@
       spriteHasMindState: noble_e
       spriteNoMindState: noble_e_r
       spriteToggleLightState: noble_l
+      inventoryTemplateId: borgDutch
 
 - type: entity
   parent: BorgEngineerSubtypeBase
@@ -59,6 +63,7 @@
       spriteHasMindState: cricket_e
       spriteNoMindState: cricket_e_r
       spriteToggleLightState: cricket_l
+      inventoryTemplateId: borgDutch
 
 # region Generic
 
@@ -73,6 +78,7 @@
       spriteHasMindState: generic_e
       spriteNoMindState: generic_e_r
       spriteToggleLightState: generic_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgGenericSubtypeBase
@@ -85,6 +91,7 @@
       spriteHasMindState: droid_e
       spriteNoMindState: droid_e_r
       spriteToggleLightState: droid_l
+      inventoryTemplateId: borgShort
 
 - type: entity
   parent: BorgGenericSubtypeBase
@@ -97,6 +104,7 @@
       spriteHasMindState: noble_e
       spriteNoMindState: noble_e_r
       spriteToggleLightState: noble_l
+      inventoryTemplateId: borgDutch
 
 # region Janitor
 
@@ -111,6 +119,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
+      inventoryTemplateId: borgShort
 
 - type: entity
   parent: BorgJanitorSubtypeBase
@@ -123,6 +132,7 @@
       spriteHasMindState: generic_e
       spriteNoMindState: generic_e_r
       spriteToggleLightState: generic_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgJanitorSubtypeBase
@@ -135,6 +145,7 @@
       spriteHasMindState: mopbot_e
       spriteNoMindState: mopbot_e_r
       spriteToggleLightState: mopbot_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgJanitorSubtypeBase
@@ -147,6 +158,7 @@
       spriteHasMindState: noble_e
       spriteNoMindState: noble_e_r
       spriteToggleLightState: noble_l
+      inventoryTemplateId: borgDutch
 
 - type: entity
   parent: BorgJanitorSubtypeBase
@@ -159,6 +171,7 @@
       spriteHasMindState: cricket_e
       spriteNoMindState: cricket_e_r
       spriteToggleLightState: cricket_l
+      inventoryTemplateId: borgDutch
 
 # region Medical
 
@@ -173,6 +186,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
+      inventoryTemplateId: borgShort
 
 - type: entity
   parent: BorgMedicalSubtypeBase
@@ -185,6 +199,7 @@
       spriteHasMindState: generic_e
       spriteNoMindState: generic_e_r
       spriteToggleLightState: generic_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgMedicalSubtypeBase
@@ -197,6 +212,7 @@
       spriteHasMindState: generic_e
       spriteNoMindState: generic_e_r
       spriteToggleLightState: generic_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgMedicalSubtypeBase
@@ -209,6 +225,7 @@
       spriteHasMindState: droid_e
       spriteNoMindState: droid_e_r
       spriteToggleLightState: droid_l
+      inventoryTemplateId: borgDutch
 
 - type: entity
   parent: BorgMedicalSubtypeBase
@@ -221,6 +238,7 @@
       spriteHasMindState: noble_e
       spriteNoMindState: noble_e_r
       spriteToggleLightState: noble_l
+      inventoryTemplateId: borgDutch
 
 - type: entity
   parent: BorgMedicalSubtypeBase
@@ -233,6 +251,7 @@
       spriteHasMindState: cricket_e
       spriteNoMindState: cricket_e_r
       spriteToggleLightState: cricket_l
+      inventoryTemplateId: borgDutch
 
 # region Mining(Salvage)
 
@@ -247,6 +266,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
+      inventoryTemplateId: borgShort
 
 - type: entity
   parent: BorgMiningSubtypeBase
@@ -259,6 +279,7 @@
       spriteHasMindState: generic_e
       spriteNoMindState: generic_e_r
       spriteToggleLightState: generic_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgMiningSubtypeBase
@@ -271,6 +292,7 @@
       spriteHasMindState: droid_e
       spriteNoMindState: droid_e_r
       spriteToggleLightState: droid_l
+      inventoryTemplateId: borgDutch
 
 - type: entity
   parent: BorgMiningSubtypeBase
@@ -283,6 +305,7 @@
       spriteHasMindState: noble_e
       spriteNoMindState: noble_e_r
       spriteToggleLightState: noble_l
+      inventoryTemplateId: borgDutch
 
 - type: entity
   parent: BorgMiningSubtypeBase
@@ -295,6 +318,7 @@
       spriteHasMindState: cricket_e
       spriteNoMindState: cricket_e_r
       spriteToggleLightState: cricket_l
+      inventoryTemplateId: borgDutch
 
 # region Service
 
@@ -309,6 +333,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
+      inventoryTemplateId: borgShort
 
 - type: entity
   parent: BorgServiceSubtypeBase
@@ -318,6 +343,7 @@
     - type: BorgSubtypeDefinition
       spritePath: Mobs/Silicon/Chassis/service.rsi
       spriteBodyState: generic
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgServiceSubtypeBase
@@ -327,6 +353,7 @@
     - type: BorgSubtypeDefinition
       spritePath: Mobs/Silicon/Chassis/service.rsi
       spriteBodyState: waitress
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgServiceSubtypeBase
@@ -338,6 +365,7 @@
       spriteBodyState: brobot
       spriteHasMindState: brobot_e
       spriteNoMindState: brobot_e_r
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgServiceSubtypeBase
@@ -350,6 +378,7 @@
       spriteHasMindState: maximillion_e
       spriteNoMindState: maximillion_e_r
       price: 500
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgServiceSubtypeBase
@@ -362,6 +391,7 @@
       spriteHasMindState: noble_e
       spriteNoMindState: noble_e_r
       spriteToggleLightState: noble_l
+      inventoryTemplateId: borgDutch
 
 - type: entity
   parent: BorgServiceSubtypeBase
@@ -374,6 +404,7 @@
       spriteHasMindState: cricket_e
       spriteNoMindState: cricket_e_r
       spriteToggleLightState: cricket_l
+      inventoryTemplateId: borgDutch
 
 # Security
 
@@ -388,6 +419,7 @@
       spriteHasMindState: red-knight_e
       spriteNoMindState: red-knight_e_r
       spriteToggleLightState: red-knight_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgSecuritySubtypeBase
@@ -400,6 +432,7 @@
       spriteHasMindState: black-knight_e
       spriteNoMindState: black-knight_e_r
       spriteToggleLightState: black-knight_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgSecuritySubtypeBase
@@ -412,6 +445,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
+      inventoryTemplateId: borgShort
 
 - type: entity
   parent: BorgSecuritySubtypeBase
@@ -424,6 +458,7 @@
       spriteHasMindState: noble_e
       spriteNoMindState: noble_e_r
       spriteToggleLightState: noble_l
+      inventoryTemplateId: borgDutch
 
 - type: entity
   parent: BorgSecuritySubtypeBase
@@ -436,6 +471,7 @@
       spriteHasMindState: cricket_e
       spriteNoMindState: cricket_e_r
       spriteToggleLightState: cricket_l
+      inventoryTemplateId: borgDutch
 
 - type: entity
   parent: BorgSecuritySubtypeBase
@@ -448,3 +484,4 @@
       spriteHasMindState: heavy_e
       spriteNoMindState: heavy_e_r
       spriteToggleLightState: heavy_l
+      inventoryTemplateId: borgShort

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/borg_subtypes.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/borg_subtypes.yml
@@ -11,7 +11,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
-      inventoryTemplateId: borgShort
+      inventoryTemplateId: borg
 
 - type: entity
   parent: BorgEngineerSubtypeBase
@@ -91,7 +91,7 @@
       spriteHasMindState: droid_e
       spriteNoMindState: droid_e_r
       spriteToggleLightState: droid_l
-      inventoryTemplateId: borgShort
+      inventoryTemplateId: borg
 
 - type: entity
   parent: BorgGenericSubtypeBase
@@ -119,7 +119,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
-      inventoryTemplateId: borgShort
+      inventoryTemplateId: borg
 
 - type: entity
   parent: BorgJanitorSubtypeBase
@@ -186,7 +186,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
-      inventoryTemplateId: borgShort
+      inventoryTemplateId: borg
 
 - type: entity
   parent: BorgMedicalSubtypeBase
@@ -266,7 +266,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
-      inventoryTemplateId: borgShort
+      inventoryTemplateId: borg
 
 - type: entity
   parent: BorgMiningSubtypeBase
@@ -333,7 +333,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
-      inventoryTemplateId: borgShort
+      inventoryTemplateId: borg
 
 - type: entity
   parent: BorgServiceSubtypeBase
@@ -445,7 +445,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
-      inventoryTemplateId: borgShort
+      inventoryTemplateId: borg
 
 - type: entity
   parent: BorgSecuritySubtypeBase
@@ -484,4 +484,4 @@
       spriteHasMindState: heavy_e
       spriteNoMindState: heavy_e_r
       spriteToggleLightState: heavy_l
-      inventoryTemplateId: borgShort
+      inventoryTemplateId: borg

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -21,7 +21,7 @@
   - Science
 
   # Visual
-  inventoryTemplateId: borgShort
+  inventoryTemplateId: borg # Starlight - why was this not always the case?
   spritePath: Mobs/Silicon/Chassis/generic.rsi
 
   # Pet


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adresses borg hat displacements

## Why we need to add this
Borg subtypes deserve fitting hats.
Also adresses medibots not actually being strippable since wirepanels were added and *all* borgs are now pettable.
Standard borg frame now uses the same displacements as the unpicked frame, no idea why it used the short template.
Closes https://github.com/ss14Starlight/space-station-14/issues/1888

## Media (Video/Screenshots)
<img width="419" height="481" alt="image" src="https://github.com/user-attachments/assets/dc75a8a9-4107-48ed-9f5a-93ee7560a1b5" />
Addendum: Standard borg frames. Left is unpicked, the other two are the Standard types for generic and medical
<img width="647" height="344" alt="image" src="https://github.com/user-attachments/assets/634b9194-eb82-4bf0-b014-3a257e232679" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- tweak: Alternate borg frames now have reasonably sensible hat placements.
- tweak: All borgs are now pettable.
- fix: Medibots can be given hats again.
- fix: Standard borg frames no longer use hat displacements for short borgs
