### PR TITLE
[Species Balancing] Cyclorite Crawling Changes - Wave 2

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
@@ -78,6 +78,9 @@
       Male: MaleCyclorite
       Female: FemaleCyclorite
       Unsexed: MaleCyclorite
+  - type: Crawler
+    standTime: 4
+    knockdownDamageThreshold: 10
   - type: Inventory
     speciesId: cyclorite
     templateId: cyclorite

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
@@ -81,6 +81,8 @@
   - type: Crawler
     standTime: 4
     knockdownDamageThreshold: 10
+  - type: Stamina
+    forceStandStamina: 20
   - type: Inventory
     speciesId: cyclorite
     templateId: cyclorite


### PR DESCRIPTION
## Short description
Cyclorites now take 4 seconds instead of 2 when attempting to stand from prone. They also take 20 stamina to push themselves up rather than 10.

## Why we need to add this
This change is on top of https://github.com/ss14Starlight/space-station-14/pull/2600 which goes into depth making Cyclorites more stronger but slower/rigid making making them stand out more compared to other races. 

This also makes getting proned a lot more worrying for a Cyclorite which goes into making them worse at being chased or chasing others. 

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/b4033c9d-8ef3-4cd9-bb77-758ca6161ca1


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Coolsurf6
- tweak: Cyclorites take twice as long to stand up from prone.
- tweak: Cyclorites now use twice as much stamina to force themselves up.

