### PR TITLE
Removed mention of Death Squads in Magistrate guidebook entry

### DIFF
--- a/Resources/ServerInfo/Guidebook/StarlightSOP/NanoTrasenEmployeeSOP/nano-trasen-employee-sop-magistrate.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/NanoTrasenEmployeeSOP/nano-trasen-employee-sop-magistrate.xml
@@ -5,7 +5,7 @@
 
 2. The Magistrate is responsible for ensuring that those prisoners that are to receive capital punishment are given a fair and balanced trial, consisting of a jury of 6 of their peers.
 
-3. The Magistrate may overrule any sentencing imposed upon station crew, but may not pass judgement on any Central Command, ERT or Death Squad personnel.
+3. The Magistrate may overrule any sentencing imposed upon station crew, but may not pass judgement on any Central Command officials and personnel.
 
 4. The Magistrate may not overly impede the inner workings of security.
 


### PR DESCRIPTION
## Short description
Simply removes the mention of Death squads from the guidebook, instead replacing it with generally all Central Command officials which already includes ERT, and [REDACTED]

## Why we need to add this
Guidebooks are generally seen as IC as people RP "viewing" it on their PDA. If Deathsquads are meant to be a secret, why are they in the guidebook? Just keeps things consistent.

## Media (Video/Screenshots)
<img width="940" height="714" alt="image" src="https://github.com/user-attachments/assets/8f5d8941-be4f-4697-8b2e-4568d76de984" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Coolsurf6
- tweak: Scrubbed secret CC knowledge from Magistrate guidebook entry


