### PR TITLE
Added Xenoborgs to Metashield under Secure Knowledge

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/Clarifications/Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/Clarifications/Metashield.xml
@@ -136,7 +136,6 @@ The Wizard Federation is very outspoken about their so-called 'magic', but most 
 Xenoborgs are rogue man-machine hybrids that are known for assimilating whole stations and replicating. They are known harvesting the brains of unfortunate crew members to bring back to their mothership. Preventing crew from being abducted should be prioritised to prevent an armada of dangerous silicon borgs.
 
 
-
 [bold][color=#f00000]Syndicate Equipment || [/color][/bold]
 Security is aware of some specific equipment associated with the Syndicate. They are not aware of all or even most of the items within the uplink, however they do get foreknowledge of;
 - Syndicate Hardsuits, EVA Suits, Jetpacks, Mag Boots, Chest Rigs, and Web Vests

--- a/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/Clarifications/Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/Clarifications/Metashield.xml
@@ -132,6 +132,10 @@ The fact that Vampires are real is unknown to the general public. While not inhe
 [bold][color=#f00000]Wizards || [/color][/bold]
 The Wizard Federation is very outspoken about their so-called 'magic', but most consider them to be nutjobs roleplaying in space. Whether that they do is actually 'magic' or not, they are a danger and Security has been briefed on them. Security knows they may have access to strange abilities, but they do not know the extent of the Wizard's capabilities.
 
+[bold][color=#f00000]Xenoborgs || [/color][/bold]
+Xenoborgs are rogue man-machine hybrids that are known for assimilating whole stations and replicating. They are known harvesting the brains of unfortunate crew members to bring back to their mothership. Preventing crew from being abducted should be prioritised to prevent an armada of dangerous silicon borgs.
+
+
 
 [bold][color=#f00000]Syndicate Equipment || [/color][/bold]
 Security is aware of some specific equipment associated with the Syndicate. They are not aware of all or even most of the items within the uplink, however they do get foreknowledge of;

--- a/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/Clarifications/Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/Clarifications/Metashield.xml
@@ -132,8 +132,8 @@ The fact that Vampires are real is unknown to the general public. While not inhe
 [bold][color=#f00000]Wizards || [/color][/bold]
 The Wizard Federation is very outspoken about their so-called 'magic', but most consider them to be nutjobs roleplaying in space. Whether that they do is actually 'magic' or not, they are a danger and Security has been briefed on them. Security knows they may have access to strange abilities, but they do not know the extent of the Wizard's capabilities.
 
-[bold][color=#f00000]Xenoborgs || [/color][/bold]
-Xenoborgs are rogue man-machine hybrids that are known for assimilating whole stations and replicating. They are known harvesting the brains of unfortunate crew members to bring back to their mothership. Preventing crew from being abducted should be prioritised to prevent an armada of dangerous silicon borgs.
+[bold][color=#f00000]Xenoborgs || [/color][/bold] 
+Xenoborgs are rogue Silicons that have started assimilating organics to grow their number. They are known to harvest the brains of unfortunate crew members, whose bodies they destroy before they turn them into more xenoborgs. Preventing crew from being abducted is imperative to prevent a critical mass of hostile borgs.
 
 
 [bold][color=#f00000]Syndicate Equipment || [/color][/bold]


### PR DESCRIPTION
## Short description
Added Xenoborg entry for Secure Knowledge in the Metashield. This means that security are aware of Xenoborgs existing.

## Why we need to add this
New antag without a metashield entry was confusing. This just adds a basic entry for Xenoborgs.

**IF ANYONE CAN WRITE IT BETTER PLEASE DO.** I will more than happily change the entry as this is apart of server rules and will require admins to be happy with the change. Due to requiring admins for this change, I do require assistance to complete this PR.

## Media (Video/Screenshots)
<img width="542" height="147" alt="image" src="https://github.com/user-attachments/assets/2fadb8a4-bd9f-4bf3-9a91-1184da0ba083" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Coolsurf6
- add: Added Xenoborgs to Metashield under Secure Knowledge for Security to know of their existence

