### PR TITLE
Remove alt + click refill on breathable organs

### DIFF
--- a/Content.Server/_Starlight/BreathOrgan/Systems/OrganGasTankFillSystem.cs
+++ b/Content.Server/_Starlight/BreathOrgan/Systems/OrganGasTankFillSystem.cs
@@ -23,10 +23,10 @@ public sealed class OrganGasTankFillSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<GasCanisterComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        SubscribeLocalEvent<GasCanisterComponent, GetVerbsEvent<Verb>>(OnGetVerbs);
     }
 
-    private void OnGetVerbs(Entity<GasCanisterComponent> canister, ref GetVerbsEvent<AlternativeVerb> args)
+    private void OnGetVerbs(Entity<GasCanisterComponent> canister, ref GetVerbsEvent<Verb> args)
     {
         if (!args.CanAccess || !args.CanInteract || args.Hands == null)
             return;
@@ -57,11 +57,10 @@ public sealed class OrganGasTankFillSystem : EntitySystem
 
         // Add a verb to refill the organ
         var user = args.User;
-        args.Verbs.Add(new AlternativeVerb
+        args.Verbs.Add(new Verb
         {
             Text = Loc.GetString("verb-fill-organ"),
-            Act = () => FillOrganGasTanks(canister, user, organTanks),
-            Priority = 1
+            Act = () => FillOrganGasTanks(canister, user, organTanks)
         });
     }
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Removes alt+click refill on breathable organs, this was a mistake on my side, i did not think about this.

## Why we need to add this
It was a mistake.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Fixed breathable organs activating on a wrong verb.
