### PR TITLE
Remove vox breathable lungs and return their loadout options

### DIFF
--- a/Resources/Prototypes/Body/Organs/vox.yml
+++ b/Resources/Prototypes/Body/Organs/vox.yml
@@ -30,7 +30,7 @@
 - type: entity
   id: OrganVoxLungs
   parent: OrganHumanLungs
-  description: "The blue, anaerobic lungs of a vox, they intake nitrogen to breathe. Any form of gaseous oxygen is lethally toxic if breathed in. Can hold up to 10L of gas."
+  description: "The blue, anaerobic lungs of a vox, they intake nitrogen to breathe. Any form of gaseous oxygen is lethally toxic if breathed in."
   suffix: "vox"
   components:
   - type: Sprite
@@ -39,40 +39,9 @@
     metabolizerTypes: [ Vox ]
   - type: Lung
     alert: LowNitrogen
-    #Starlight start - Make vox lungs work as a gas tank
   - type: Item
-    size: Normal # Increased due to it becoming a gas tank, needs to be rebalanced for that
+    size: Small
     heldPrefix: lungs
-    shape:
-    - 0,0,3,3
-  - type: BreathMask
-  - type: OrganBreathTool
-    startActivated: true
-  - type: GasTank
-    air:
-      volume: 10
-      moles:
-        Nitrogen: 4.1027581 # Prefill with 10L of nitrogen
-      temperature: 293.15
-    outputPressure: 21.3
-  - type: OrganGasTankFillable
-    targetPressure: 1000.0 # 1MPa of pressure target on refill
-  - type: UseDelay
-    delays:
-      gasTank:
-        length: 1.0
-  - type: ActivatableUI
-    key: enum.SharedGasTankUiKey.Key
-  - type: UserInterface
-    interfaces:
-      enum.SharedGasTankUiKey.Key:
-        type: GasTankBoundUserInterface
-      enum.SharedGasTankUiKey.OrganKey:
-        type: BreathableOrganBoundUserInterface
-  - type: Tag
-    tags:
-    - GasTank
-    #Starlight end
 
 - type: entity
   parent: OrganHumanStomach

--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -572,7 +572,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ChallengeVictimCaptain, ChallengeVictimCaptainAlt ] #!! This is supposed to be for challenge events. Its intentionally missing QOL gear to make interesting scenarios.
-      # roleLoadout: [ RoleSurvivalVoxSupport ] - Starlight edit - Should no longer be needed
+      roleLoadout: [ RoleSurvivalVoxSupport ]
     - type: RandomMetadata
       nameSegments:
       - NamesFirst
@@ -593,7 +593,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ChallengeVictimCE, ChallengeVictimCEAlt ] #!! This is supposed to be for challenge events. Its intentionally missing QOL gear to make interesting scenarios.
-      # roleLoadout: [ RoleSurvivalVoxSupport ] - Starlight edit - Should no longer be needed
+      roleLoadout: [ RoleSurvivalVoxSupport ]
     - type: RandomMetadata
       nameSegments:
       - NamesFirst
@@ -614,7 +614,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ChallengeVictimCMO, ChallengeVictimCMOAlt ] #!! This is supposed to be for challenge events. Its intentionally missing QOL gear to make interesting scenarios.
-      # roleLoadout: [ RoleSurvivalVoxSupport ] - Starlight edit - Should no longer be needed
+      roleLoadout: [ RoleSurvivalVoxSupport ]
     - type: RandomMetadata
       nameSegments:
       - NamesFirst
@@ -635,7 +635,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ChallengeVictimHOP, ChallengeVictimHOPAlt ] #!! This is supposed to be for challenge events. Its intentionally missing QOL gear to make interesting scenarios.
-      # roleLoadout: [ RoleSurvivalVoxSupport ] - Starlight edit - Should no longer be needed
+      roleLoadout: [ RoleSurvivalVoxSupport ]
     - type: RandomMetadata
       nameSegments:
       - NamesFirst
@@ -656,7 +656,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ChallengeVictimHOS, ChallengeVictimHOSAlt ] #!! This is supposed to be for challenge events. Its intentionally missing QOL gear to make interesting scenarios.
-      # roleLoadout: [ RoleSurvivalVoxSupport ] - Starlight edit - Should no longer be needed
+      roleLoadout: [ RoleSurvivalVoxSupport ]
     - type: RandomMetadata
       nameSegments:
       - NamesFirst
@@ -677,7 +677,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ChallengeVictimRD, ChallengeVictimRDAlt ] #!! This is supposed to be for challenge events. Its intentionally missing QOL gear to make interesting scenarios.
-      # roleLoadout: [ RoleSurvivalVoxSupport ] - Starlight edit - Should no longer be needed
+      roleLoadout: [ RoleSurvivalVoxSupport ]
     - type: RandomMetadata
       nameSegments:
       - NamesFirst
@@ -698,7 +698,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ChallengeVictimQM, ChallengeVictimQMAlt ] #!! This is supposed to be for challenge events. Its intentionally missing QOL gear to make interesting scenarios.
-      # roleLoadout: [ RoleSurvivalVoxSupport ] - Starlight edit - Should no longer be needed
+      roleLoadout: [ RoleSurvivalVoxSupport ]
     - type: RandomMetadata
       nameSegments:
       - NamesFirst
@@ -723,7 +723,7 @@
     - type: GhostTakeoverAvailable
     - type: Loadout
       prototypes: [ ChallengeCargoTechGearSuit, ChallengeCargoTechGearCoat ] #!! This is supposed to be for challenge events. Its intentionally missing QOL gear to make interesting scenarios.
-      # roleLoadout: [ RoleSurvivalVoxSupport ] - Starlight edit - Should no longer be needed
+      roleLoadout: [ RoleSurvivalVoxSupport ]
     - type: RandomMetadata
       nameSegments:
       - NamesFirst

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -300,7 +300,7 @@
       pickPlayer: false
       startingGear: ParadoxCloneGear
       roleLoadout:
-      # - RoleSurvivalVoxTank - Starlight edit - Should no longer be needed
+      - RoleSurvivalVoxTank # give vox something to breath in case they don't get a copy
       briefing:
         text: paradox-clone-role-greeting
         color: lightblue

--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -267,15 +267,13 @@
 # Pre-equipped species gear
 
 # Full tank for vox as part of any Survival loadout
-# Starlight edit start - Removed - vox no longer spawn with nitrogen tanks automatically
-# - type: loadout
-#   id: LoadoutSpeciesVoxNitrogen
-#   effects:
-#   - !type:GroupLoadoutEffect
-#     proto: EffectSpeciesVox
-#   equipment:
-#     suitstorage: DoubleEmergencyNitrogenTankFilled
-# Starlight edit end
+- type: loadout
+  id: LoadoutSpeciesVoxNitrogen
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: EffectSpeciesVox
+  equipment:
+    suitstorage: DoubleEmergencyNitrogenTankFilled
 
 # Full EVA Tank, Any Species
 - type: loadout
@@ -312,37 +310,35 @@
     pocket1: DoubleEmergencyOxygenTankFilled
 
 # Tank Harness
-# Starlight edit start - Removed - vox no longer spawn with gas tanks
-# - type: loadout
-#   id: LoadoutTankHarness
-#   effects:
-#   - !type:GroupLoadoutEffect
-#     proto: EffectSpeciesVox
-#   equipment:
-#     outerClothing: ClothingOuterVestTank
+- type: loadout
+  id: LoadoutTankHarness
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: EffectSpeciesVox
+  equipment:
+    outerClothing: ClothingOuterVestTank
 
 # Breath Tool On Face
-# - type: loadout
-#   id: LoadoutSpeciesBreathTool
-#   effects:
-#   - !type:GroupLoadoutEffect
-#     proto: EffectSpeciesVox
-#   equipment:
-#     mask: ClothingMaskBreath
+- type: loadout
+  id: LoadoutSpeciesBreathTool
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: EffectSpeciesVox
+  equipment:
+    mask: ClothingMaskBreath
 
-# - type: loadout
-#   id: LoadoutSpeciesBreathToolMedical
-#   effects:
-#   - !type:GroupLoadoutEffect
-#     proto: EffectSpeciesVox
-#   equipment:
-#     mask: ClothingMaskBreathMedical
+- type: loadout
+  id: LoadoutSpeciesBreathToolMedical
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: EffectSpeciesVox
+  equipment:
+    mask: ClothingMaskBreathMedical
 
-# - type: loadout
-#   id: LoadoutSpeciesBreathToolSecurity
-#   effects:
-#   - !type:GroupLoadoutEffect
-#     proto: EffectSpeciesVox
-#   equipment:
-#     mask: ClothingMaskGasSecurity
-# Starlight edit end
+- type: loadout
+  id: LoadoutSpeciesBreathToolSecurity
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: EffectSpeciesVox
+  equipment:
+    mask: ClothingMaskGasSecurity

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -117,15 +117,13 @@
   - GlassesJamjar
   - GlassesJensen
 
-# Starlight edit start - Removed - vox no longer spawn with tank harness
-# - type: loadoutGroup
-#   id: GroupTankHarness
-#   name: loadout-group-tank-harness
-#   minLimit: 1
-#   hidden: true
-#   loadouts:
-#   - LoadoutTankHarness
-# Starlight edit end
+- type: loadoutGroup
+  id: GroupTankHarness
+  name: loadout-group-tank-harness
+  minLimit: 1
+  hidden: true
+  loadouts:
+  - LoadoutTankHarness
 
 - type: loadoutGroup
   id: Survival
@@ -135,7 +133,7 @@
   loadouts:
   - EmergencyNitrogen
   - EmergencyOxygen
-#  - LoadoutSpeciesVoxNitrogen - Starlight removed
+  - LoadoutSpeciesVoxNitrogen
   - EmergencyNonBreather # 🌟Starlight🌟
 
 # nitrogen or oxygen tank, depending on what your species needs
@@ -148,14 +146,12 @@
   - LoadoutSpeciesEVAOxygen
 
 # vox get a nitrogen tank, other species get nothing
-# Starlight edit start - Removed - vox no longer spawn with nitrogen tanks automatically
-# - type: loadoutGroup
-#   id: GroupEVATankVox
-#   name: loadout-group-vox-tank
-#   hidden: true
-#   loadouts:
-#   - LoadoutSpeciesVoxNitrogen
-# Starlight edit end
+- type: loadoutGroup
+  id: GroupEVATankVox
+  name: loadout-group-vox-tank
+  hidden: true
+  loadouts:
+  - LoadoutSpeciesVoxNitrogen
 
 - type: loadoutGroup
   id: GroupPocketTankDouble
@@ -719,7 +715,7 @@
   loadouts:
   - EmergencyNitrogenClown
   - EmergencyOxygenClown
-#  - LoadoutSpeciesVoxNitrogen - Starlight removed
+  - LoadoutSpeciesVoxNitrogen
   - EmergencyNonBreatherClown # 🌟Starlight🌟
 
 - type: loadoutGroup
@@ -786,7 +782,7 @@
   - EmergencyNitrogenMime
   - EmergencyOxygenMime
   - EmergencySpeciesMothMime
-#  - LoadoutSpeciesVoxNitrogen - Starlight removed
+  - LoadoutSpeciesVoxNitrogen
   - EmergencyNonBreatherMime # 🌟Starlight🌟
 
 - type: loadoutGroup
@@ -1186,7 +1182,7 @@
   loadouts:
   - EmergencyNitrogenExtended
   - EmergencyOxygenExtended
-#  - LoadoutSpeciesVoxNitrogen - Starlight removed
+  - LoadoutSpeciesVoxNitrogen
   - EmergencyNonBreatherExtended # 🌟Starlight🌟
 
 # Science
@@ -1647,7 +1643,7 @@
   loadouts:
   - EmergencyNitrogenSecurity
   - EmergencyOxygenSecurity
-#  - LoadoutSpeciesVoxNitrogen - Starlight removed
+  - LoadoutSpeciesVoxNitrogen
   - EmergencyNonbreatherSecurity # 🌟Starlight🌟
 
 # Medical
@@ -1909,7 +1905,7 @@
   loadouts:
   - EmergencyNitrogenMedical
   - EmergencyOxygenMedical
-#  - LoadoutSpeciesVoxNitrogen - Starlight removed
+  - LoadoutSpeciesVoxNitrogen
   - EmergencyNonBreatherMedical # 🌟Starlight🌟
 
 # Wildcards
@@ -1982,34 +1978,32 @@
   loadouts:
   - EmergencyNitrogenSyndicate
   - EmergencyOxygenSyndicate
-#  - LoadoutSpeciesVoxNitrogen - Starlight removed
+  - LoadoutSpeciesVoxNitrogen
   - EmergencyNonBreatherSyndicate # 🌟Starlight🌟
 
-# Starlight edit start - Removed - vox no longer spawn with gas masks automatically
-# - type: loadoutGroup
-#   id: GroupSpeciesBreathTool
-#   name: loadout-group-breath-tool
-#   minLimit: 1
-#   maxLimit: 1
-#   hidden: true
-#   loadouts:
-#   - LoadoutSpeciesBreathTool
+- type: loadoutGroup
+  id: GroupSpeciesBreathTool
+  name: loadout-group-breath-tool
+  minLimit: 1
+  maxLimit: 1
+  hidden: true
+  loadouts:
+  - LoadoutSpeciesBreathTool
 
-# - type: loadoutGroup
-#   id: GroupSpeciesBreathToolMedical
-#   name: loadout-group-breath-tool
-#   minLimit: 1
-#   maxLimit: 1
-#   hidden: true
-#   loadouts:
-#   - LoadoutSpeciesBreathToolMedical
+- type: loadoutGroup
+  id: GroupSpeciesBreathToolMedical
+  name: loadout-group-breath-tool
+  minLimit: 1
+  maxLimit: 1
+  hidden: true
+  loadouts:
+  - LoadoutSpeciesBreathToolMedical
 
-# - type: loadoutGroup
-#   id: GroupSpeciesBreathToolSecurity
-#   name: loadout-group-breath-tool
-#   minLimit: 1
-#   maxLimit: 1
-#   hidden: true
-#   loadouts:
-#   - LoadoutSpeciesBreathToolSecurity
-# Starlight edit end
+- type: loadoutGroup
+  id: GroupSpeciesBreathToolSecurity
+  name: loadout-group-breath-tool
+  minLimit: 1
+  maxLimit: 1
+  hidden: true
+  loadouts:
+  - LoadoutSpeciesBreathToolSecurity

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -14,12 +14,12 @@
   - Scarves # Starlight
   - CapPens # Starlight
   - CaptainJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobHeadOfPersonnel
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - HoPHead
   - HoPNeck
   - HoPJumpsuit
@@ -32,7 +32,7 @@
   - Scarves # Starlight
   - HoPPens # Starlight
   - HoPJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 # Silicons
 - type: roleLoadout
@@ -53,7 +53,7 @@
 - type: roleLoadout
   id: JobAssistant
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - AssistantJumpsuit
   - AssistantBackpack #starlight
   - AssistantNeck
@@ -68,12 +68,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - AssistantJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobBartender
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - BartenderHead
   - BartenderJumpsuit
   - CommonBackpack
@@ -85,12 +85,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - BartenderJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobServiceWorker
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - BartenderJumpsuit
   - CommonBackpack
   - CivilianShoes # 🌟Starlight🌟
@@ -100,12 +100,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ServiceWorkerJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobChef
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ChefHead
   - ChefMask
   - ChefJumpsuit
@@ -118,12 +118,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ChefJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobLibrarian
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - LibrarianJumpsuit
   - CommonBackpack
   - CivilianShoes # 🌟Starlight🌟
@@ -133,12 +133,12 @@
   - Scarves # Starlight
   - LuxuryPens # Starlight
   - LibrarianJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobLawyer
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - LawyerNeck
   - LawyerJumpsuit
   - CommonBackpack
@@ -148,12 +148,12 @@
   - Scarves # Starlight
   - LuxuryPens # Starlight
   - LawyerJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobChaplain
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ChaplainHead
   - ChaplainMask
   - ChaplainNeck
@@ -168,12 +168,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ChaplainJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobJanitor
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - JanitorHead
   - JanitorJumpsuit
   - JanitorGloves
@@ -185,12 +185,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - JanitorJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobBotanist
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - BotanistHead
   - BotanistJumpsuit
   - BotanistBackpack
@@ -202,13 +202,13 @@
   - Scarves # Starlight
   - Pens # Starlight
   - BotanistJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobClown
   canCustomizeName: true
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ClownHead
   - ClownJumpsuit
   - ClownBackpack
@@ -225,7 +225,7 @@
   id: JobMime
   canCustomizeName: true
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - MimeHead
   - MimeMask
   - MimeJumpsuit
@@ -243,7 +243,7 @@
   id: JobMusician
   canCustomizeName: true
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - MusicianJumpsuit
   - CommonBackpack
   - MusicianOuterClothing
@@ -255,13 +255,13 @@
   - Pens # Starlight
   - MusicianJobTrinkets
   - Instruments
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 # Cargo
 - type: roleLoadout
   id: JobQuartermaster
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - QuartermasterHead
   - QuartermasterNeck
   - QuartermasterJumpsuit
@@ -274,12 +274,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - QuartermasterJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobCargoTechnician
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - CargoTechnicianHead
   - CargoTechnicianJumpsuit
   - CargoTechnicianBackpack
@@ -292,12 +292,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - CargoTechnicianJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobSalvageSpecialist
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - SalvageSpecialistBackpack
   - SalvageSpecialistJumpsuit # afterlight
   - SalvageSpecialistOuterClothing
@@ -309,13 +309,13 @@
   - Scarves # Starlight
   - Pens # Starlight
   - SalvageSpecialistJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 # Engineering
 - type: roleLoadout
   id: JobChiefEngineer
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ChiefEngineerHead
   - ChiefEngineerJumpsuit
   - StationEngineerBackpack
@@ -327,12 +327,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ChiefEngineerJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobTechnicalAssistant
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - TechnicalAssistantJumpsuit
   - StationEngineerBackpack
   - SurvivalExtended
@@ -340,12 +340,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - TechnicalAssistantJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobStationEngineer
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - StationEngineerHead
   - StationEngineerJumpsuit
   - StationEngineerBackpack
@@ -357,12 +357,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - StationEngineerJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobAtmosphericTechnician
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - AtmosphericTechnicianJumpsuit
   - AtmosphericTechnicianBackpack
   - AtmosphericTechnicianOuterClothing
@@ -372,13 +372,13 @@
   - Scarves # Starlight
   - Pens # Starlight
   - AtmosphericTechnicianJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 # Science
 - type: roleLoadout
   id: JobResearchDirector
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ResearchDirectorHead
   - ResearchDirectorNeck
   - ResearchDirectorJumpsuit
@@ -392,12 +392,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ResearchDirectorJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobScientist
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ScientistHead
   - ScientistNeck
   - ScientistJumpsuit
@@ -412,12 +412,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ScientistJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobResearchAssistant
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ResearchAssistantJumpsuit
   - ScientistBackpack
   - Glasses
@@ -426,7 +426,7 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ResearchAssistantJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 # Security
 - type: roleLoadout
@@ -446,7 +446,7 @@
   - Scarves # Starlight
   - Pens # Starlight
   - HeadofSecurityJobTrinkets
-#  - GroupSpeciesBreathToolSecurity - Starlight removed
+  - GroupSpeciesBreathToolSecurity
 
 - type: roleLoadout
   id: JobWarden
@@ -463,7 +463,7 @@
   - Scarves # Starlight
   - Pens # Starlight
   - WardenJobTrinkets
-#  - GroupSpeciesBreathToolSecurity - Starlight removed
+  - GroupSpeciesBreathToolSecurity
 
 - type: roleLoadout
   id: JobSecurityOfficer
@@ -483,7 +483,7 @@
   - Scarves # Starlight
   - Pens # Starlight
   - SecurityJobTrinkets
-#  - GroupSpeciesBreathToolSecurity - Starlight removed
+  - GroupSpeciesBreathToolSecurity
 
 - type: roleLoadout
   id: JobDetective
@@ -500,7 +500,7 @@
   - Scarves # Starlight
   - Pens # Starlight
   - DetectiveJobTrinkets
-#  - GroupSpeciesBreathToolSecurity - Starlight removed
+  - GroupSpeciesBreathToolSecurity
 
 - type: roleLoadout
   id: JobSecurityCadet
@@ -514,13 +514,13 @@
   - Scarves # Starlight
   - Pens # Starlight
   - SecurityCadetJobTrinkets
-#  - GroupSpeciesBreathToolSecurity - Starlight removed
+  - GroupSpeciesBreathToolSecurity
 
 # Medical
 - type: roleLoadout
   id: JobChiefMedicalOfficer
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ChiefMedicalOfficerHead
   - MedicalMask
   - ChiefMedicalOfficerJumpsuit
@@ -535,12 +535,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ChiefMedicalOfficerJobTrinkets
-#  - GroupSpeciesBreathToolMedical - Starlight removed
+  - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
   id: JobMedicalDoctor
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - MedicalDoctorHead
   - MedicalMask
   - MedicalDoctorJumpsuit
@@ -555,12 +555,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - MedicalDoctorJobTrinkets
-#  - GroupSpeciesBreathToolMedical - Starlight removed
+  - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
   id: JobMedicalIntern
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - MedicalInternJumpsuit
   - MedicalBackpack
   - MedicalEyewear
@@ -569,12 +569,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - MedicalInternJobTrinkets
-#  - GroupSpeciesBreathToolMedical - Starlight removed
+  - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
   id: JobChemist
   groups:
-# - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ChemistHead # Starlight
   - MedicalMask
   - ChemistJumpsuit
@@ -592,12 +592,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ChemistJobTrinkets
-#  - GroupSpeciesBreathToolMedical - Starlight removed
+  - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
   id: JobParamedic
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ParamedicHead
   - MedicalMask
   - ParamedicJumpsuit
@@ -612,13 +612,13 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ParamedicJobTrinkets
-#  - GroupSpeciesBreathToolMedical - Starlight removed
+  - GroupSpeciesBreathToolMedical
 
 # Wildcards
 - type: roleLoadout
   id: JobZookeeper
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - CommonBackpack
   - CivilianShoes # 🌟Starlight🌟
   - Glasses
@@ -627,12 +627,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - ZookeeperJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobReporter
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - ReporterJumpsuit
   - CommonBackpack
   - CivilianShoes # 🌟Starlight🌟
@@ -642,12 +642,12 @@
   - Scarves # Starlight
   - LuxuryPens # Starlight
   - ReporterJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobPsychologist
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - PsychologistJumpsuit
   - MedicalBackpack
   - CivilianShoes # 🌟Starlight🌟
@@ -657,12 +657,12 @@
   - Scarves # Starlight
   - Pens # Starlight
   - PsychologistJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobBoxer
   groups:
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
   - BoxerJumpsuit
   - BoxerGloves
   - CommonBackpack
@@ -672,78 +672,76 @@
   - Scarves # Starlight
   - Pens # Starlight
   - BoxerJobTrinkets
-#  - GroupSpeciesBreathTool - Starlight removed
+  - GroupSpeciesBreathTool
 
 # These loadouts are used for non-crew spawns, like off-station antags and event mobs
 # They will be used without player configuration, thus they will only ever apply what is forced by MinLimit
 
-# Starlight edit start - vox no longer spawn with gas tanks
 # gives vox a harness and breathing mask
 # nitrogen tank not included
-# - type: roleLoadout
-#   id: RoleSurvivalVoxSupport
-#   groups:
-#   - GroupSpeciesBreathTool
-#   - GroupTankHarness
+- type: roleLoadout
+  id: RoleSurvivalVoxSupport
+  groups:
+  - GroupSpeciesBreathTool
+  - GroupTankHarness
 
 # gives vox a nitrogen breathing tank
 # other species get nothing
-# - type: roleLoadout
-#   id: RoleSurvivalVoxTank
-#   groups:
-#   - GroupEVATankVox
-# Starlight edit end
+- type: roleLoadout
+  id: RoleSurvivalVoxTank
+  groups:
+  - GroupEVATankVox
 
 - type: roleLoadout
   id: RoleSurvivalStandard
   groups:
   - Survival
-#  - GroupSpeciesBreathTool - Starlight removed
-#  - GroupTankHarness - Starlight removed
+  - GroupSpeciesBreathTool
+  - GroupTankHarness
 
 - type: roleLoadout
   id: RoleSurvivalClown
   groups:
   - SurvivalClown
-#  - GroupTankHarness - Starlight removed
+  - GroupTankHarness
 
 - type: roleLoadout
   id: RoleSurvivalExtended
   groups:
   - SurvivalExtended
-#  - GroupSpeciesBreathTool - Starlight removed
-#  - GroupTankHarness - Starlight removed
+  - GroupSpeciesBreathTool
+  - GroupTankHarness
 
 - type: roleLoadout
   id: RoleSurvivalMedical
   groups:
   - SurvivalMedical
-#  - GroupSpeciesBreathToolMedical - Starlight removed
-#  - GroupTankHarness - Starlight removed
+  - GroupSpeciesBreathToolMedical
+  - GroupTankHarness
 
 - type: roleLoadout
   id: RoleSurvivalSecurity
   groups:
   - SurvivalSecurity
-#  - GroupSpeciesBreathToolSecurity - Starlight removed
-#  - GroupTankHarness - Starlight removed
+  - GroupSpeciesBreathToolSecurity
+  - GroupTankHarness
 
 - type: roleLoadout
   id: RoleSurvivalSyndicate
   groups:
   - SurvivalSyndicate
-#  - GroupSpeciesBreathTool - Starlight removed
-#  - GroupTankHarness - Starlight removed
+  - GroupSpeciesBreathTool
+  - GroupTankHarness
 
 - type: roleLoadout
   id: RoleSurvivalNukie
   groups:
   - SurvivalSyndicate
-#  - GroupSpeciesBreathTool - Starlight removed
-#  - GroupPocketTankDouble - Starlight removed
+  - GroupSpeciesBreathTool
+  - GroupPocketTankDouble
 
 - type: roleLoadout
   id: RoleSurvivalEVA
   groups:
-#  - GroupEVATank - Starlight removed
+  - GroupEVATank
   - SurvivalExtended

--- a/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
@@ -12,6 +12,7 @@
   - Trinkets
   - Scarves
   - Pens
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobMagistrate
@@ -22,10 +23,12 @@
   - Trinkets
   - Scarves
   - LuxuryPens
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobSurgeon
   groups:
+  - GroupTankHarness
   - MedicalDoctorHead
   - MedicalMask
   - MedicalDoctorJumpsuit
@@ -39,6 +42,7 @@
   - Trinkets
   - Scarves
   - Pens
+  - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
   id: JobNanoTrasenRepresentative
@@ -52,6 +56,7 @@
   - Scarves
   - NTRPens
   - Survival
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobIAA
@@ -64,6 +69,7 @@
   - Scarves
   - LuxuryPens
   - Survival
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobBlueShield
@@ -79,10 +85,12 @@
   - Scarves
   - Pens
   - SurvivalSecurity
+  - GroupSpeciesBreathToolSecurity
 
 - type: roleLoadout
   id: JobMiningSpecialist
   groups:
+  - GroupTankHarness
   - SalvageSpecialistBackpack
   - MiningSpecialistJumpsuit
   - SalvageSpecialistOuterClothing
@@ -93,10 +101,12 @@
   - Trinkets
   - Scarves
   - Pens
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobMailTech
   groups:
+  - GroupTankHarness
   - CargoTechnicianHead
   - CargoTechnicianJumpsuit
   - CargoTechnicianBackpack
@@ -107,6 +117,7 @@
   - Trinkets
   - Scarves
   - Pens
+  - GroupSpeciesBreathTool
 
 - type: roleLoadout
   id: JobBrigmedic
@@ -127,10 +138,12 @@
     - SecuritySidearm
     - SurvivalSecurity
     - Trinkets
+    - GroupSpeciesBreathToolSecurity
 
 - type: roleLoadout
   id: JobSalvageLead
   groups:
+    - GroupTankHarness
     - SalvageSpecialistBackpack
     - SalvageLeadJumpsuit
     - SalvageLeadNeck
@@ -140,6 +153,7 @@
     - Glasses
     - Survival
     - Trinkets
+    - GroupSpeciesBreathTool
 
 # Antagonist Loadouts
 - type: roleLoadout

--- a/Resources/ServerInfo/Guidebook/Mobs/Vox.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Vox.xml
@@ -11,9 +11,6 @@
   Unfortunately, space stations tend to be full of oxygen,
   so Vox must use an internal nitrogen supply at almost all times to avoid fatal exposure.
 
-  The years of bioengineering have allowed Vox to develop a special set of lungs that can be filled with any breathable gas mixture.
-  It can hold up to 10L of gas, and allows for about half an hour of breathing without any modifications.
-
   Vox always spawn wearing working nitrogen internals equipment.
   A spare breathing mask and an emergency nitrogen canister is provided in their survival box.
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Original PR: https://github.com/ss14Starlight/space-station-14/pull/2586
This PR aims to return Voxes to how they worked before they gained the breathable organ ability. This makes their lungs work like before, with no gas tank function, as well as returns their loadout to always ensure a tank and a gas mask, as well as a tank harness.

## Why we need to add this
There has been a very lengthy discussion regarding this change:
https://discord.com/channels/1272545509562777621/1455394432734990539
https://discord.com/channels/1272545509562777621/1456864597012254863

the change was... mostly disliked by players of the species, as well as i was given a lot of good arguments that made me believe that his is a good step. The change was made without enough planning and communication to the players, as well as contains mechanics that aren't communicated well enough to new players.

The main argument that made me take this decision is further supported by the document that i had sent in another PR recently
https://docs.google.com/document/d/1D-XeWN8Ki-_xRgL4rDvBgO_J04llJb9IOyyjmbDjYu8/edit?pli=1&tab=t.0
which is something of an inspiration to my species design, after talking to the players i have realized that, voxes already don't eat steak. To be a Vox it means that you maybe blend the steak and inject it, maybe you space yourself to eat free of oxygen, or maybe you enjoy the little bit of adrenaline that comes from eating a steak. 

Vox are already a very unique species, that has a lot of identity, and people who enjoy playing it. The lack of mask that this PR brought further conflicts with the image of Vox as well as makes the species play too closely to others. In a way, in me trying to give them a unique mechanic, i have made them play closer to humans, which makes them less unique.

In my original PR i have mentioned how i don't believe that we should respect decisions of making them into a hard mode, because the players don't care about that, but after probably most people who played Vox for longer (considering their very low player count) i believe that it is natural for some species to be "worse" at surviving, they are a species who was made to live in a completely different environment, who work for NT for various reasons, in their lore it is said that they are somewhat a rare sight, which fully works with the amount of players that can be seen on SL. 

I think some species being just... differently adapted is natural and this behavior should be upkept.

A very important note is that the cybernetic with the same function will still stay in the game.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- add: Added back Vox gas tanks, tank harnesses, and masks on roundstart.
- remove: Removed gas tank lungs from Vox.
