### PR TITLE
Clean up 87 Starlight-added warnings from Content.Server

### DIFF
--- a/Content.Server/_Starlight/Administration/Systems/Commands/ShuttleCalls.cs
+++ b/Content.Server/_Starlight/Administration/Systems/Commands/ShuttleCalls.cs
@@ -16,6 +16,7 @@ namespace Content.Server.Administration.Commands
         [Dependency] private readonly ChatSystem _chatSystem = default!;
         [Dependency] private readonly IPrototypeManager _proto = default!;
         [Dependency] private readonly IResourceManager _res = default!;
+        [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
 
         public override string Command => "shuttlecalls";
         public override string Description => "Enable, disable, toggle, or check the status of emergency shuttle calls.";
@@ -34,11 +35,10 @@ namespace Content.Server.Administration.Commands
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            var roundEndSystem = EntitySystem.Get<RoundEndSystem>();
 
             if (args.Length == 0)
             {
-                PrintStatus(shell, roundEndSystem.GetShuttleCallsEnabled());
+                PrintStatus(shell, _roundEndSystem.GetShuttleCallsEnabled());
                 shell.WriteLine(Help);
                 return;
             }
@@ -48,15 +48,15 @@ namespace Content.Server.Administration.Commands
             // Status
             if (arg0 == "status")
             {
-                PrintStatus(shell, roundEndSystem.GetShuttleCallsEnabled());
+                PrintStatus(shell, _roundEndSystem.GetShuttleCallsEnabled());
                 return;
             }
 
             // Toggle
             if (arg0 == "toggle")
             {
-                var newState = !roundEndSystem.GetShuttleCallsEnabled();
-                roundEndSystem.SetShuttleCallsEnabled(newState);
+                var newState = !_roundEndSystem.GetShuttleCallsEnabled();
+                _roundEndSystem.SetShuttleCallsEnabled(newState);
                 PrintStatus(shell, newState);
 
                 var makeAnnouncement = true;
@@ -72,7 +72,7 @@ namespace Content.Server.Administration.Commands
             // Set directly (true/false)
             if (bool.TryParse(arg0, out var allowed))
             {
-                roundEndSystem.SetShuttleCallsEnabled(allowed);
+                _roundEndSystem.SetShuttleCallsEnabled(allowed);
                 PrintStatus(shell, allowed);
 
                 // Announce (default true)
@@ -93,7 +93,7 @@ namespace Content.Server.Administration.Commands
             }
 
             shell.WriteError("First argument must be true, false, toggle, or status.");
-            PrintStatus(shell, roundEndSystem.GetShuttleCallsEnabled());
+            PrintStatus(shell, _roundEndSystem.GetShuttleCallsEnabled());
         }
 
         private void PrintStatus(IConsoleShell shell, bool allowed)

--- a/Content.Server/_Starlight/AlertArmory/AlertArmorySystem.cs
+++ b/Content.Server/_Starlight/AlertArmory/AlertArmorySystem.cs
@@ -39,7 +39,6 @@ public sealed class AlertArmorySystem : EntitySystem
     [Dependency] private readonly NavMapSystem _nav = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
-    [Dependency] private readonly ActorSystem _actor = default!;
 
     private EntityQuery<PendingClockInComponent> _pendingQuery;
     private EntityQuery<ArrivalsBlacklistComponent> _blacklistQuery;

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
@@ -23,7 +23,6 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
     [Dependency] private readonly PullingSystem _pullingSystem = default!;
     [Dependency] private readonly InventorySystem _inv = default!;
-    [Dependency] private readonly StarlightActionsSystem _starlightActions = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly RemoteEyeSystem _remoteEye = default!;
 

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
@@ -25,7 +25,6 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     [Dependency] private readonly NumberObjectiveSystem _number = default!;
     [Dependency] private readonly SharedItemSwitchSystem _itemSwitch = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly VendingMachineSystem _vending = default!;
     
     public void InitializeConsole()

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Extractor.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Extractor.cs
@@ -51,7 +51,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     
     private void OnExtractDoAfter(Entity<AbductorExtractorComponent> ent, ref AbductorExtractDoAfterEvent args)
     {
-        if (args.Target == null || args.User == null) return;
+        if (args.Target == null) return;
         
         if (!_body.TryGetBodyOrganEntityComps<OrganHeartComponent>(args.Target.Value, out var hearts))
             return;

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Vest.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Vest.cs
@@ -27,7 +27,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
    
     private void OnEquipped(Entity<AbductorVestComponent> ent, ref GotEquippedEvent args)
     {
-        if (args.Equipee != null && !HasComp<StealthComponent>(args.Equipee) && ent.Comp.CurrentState != AbductorArmorModeType.Combat)
+        if (!HasComp<StealthComponent>(args.Equipee) && ent.Comp.CurrentState != AbductorArmorModeType.Combat)
         {
             AddComp<StealthComponent>(args.Equipee);
             AddComp<StealthOnMoveComponent>(args.Equipee);
@@ -36,7 +36,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
    
     private void OnUnequipped(Entity<AbductorVestComponent> ent, ref GotUnequippedEvent args)
     {
-        if (args.Equipee != null && HasComp<StealthComponent>(args.Equipee))
+        if (HasComp<StealthComponent>(args.Equipee))
         {
             RemComp<StealthComponent>(args.Equipee);
             RemComp<StealthOnMoveComponent>(args.Equipee);

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.cs
@@ -13,19 +13,14 @@ namespace Content.Server.Starlight.Antags.Abductor;
 
 public sealed partial class AbductorSystem : SharedAbductorSystem
 {
-    [Dependency] private readonly StationSystem _stationSystem = default!;
     [Dependency] private readonly EntityManager _entityManager = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
-    [Dependency] private readonly SharedEyeSystem _eye = default!;
-    [Dependency] private readonly SharedMoverController _mover = default!;
     [Dependency] private readonly ActionsSystem _actions = default!;
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly TransformSystem _xformSys = default!;
     [Dependency] private readonly TagSystem _tags = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly ContainerSystem _container = default!;
-    [Dependency] private readonly SharedHandsSystem _hands = default!;
-    [Dependency] private readonly SharedVirtualItemSystem _virtualItem = default!;
 
     public override void Initialize()
     {

--- a/Content.Server/_Starlight/Antags/Actions/EMPScreamSystem.cs
+++ b/Content.Server/_Starlight/Antags/Actions/EMPScreamSystem.cs
@@ -13,7 +13,6 @@ namespace Content.Server._Starlight.Antags.Actions;
 
 public sealed partial class EMPScreamSystem : EntitySystem
 {
-    [Dependency] private readonly SharedChargesSystem _chargesSystem = default!;
     [Dependency] private readonly EmpSystem _emp = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly ISharedPlayerManager _player = default!;

--- a/Content.Server/_Starlight/Atmos/EntitySystems/DockPipeSystem.cs
+++ b/Content.Server/_Starlight/Atmos/EntitySystems/DockPipeSystem.cs
@@ -66,7 +66,7 @@ namespace Content.Server.Atmos.EntitySystems
                 var pipeAType = pipeA.GetType().Name;
                 var pipeADir = pipeA.CurrentPipeDirection;
                 var pipeALayer = pipeA.CurrentPipeLayer;
-                var pipeAAnchored = EntityManager.GetComponent<TransformComponent>(pipeA.Owner).Anchored;
+                var pipeAAnchored = Transform(pipeA.Owner).Anchored;
 
                 if (!anchoredA.Contains(pipeA.Owner) || !pipeAAnchored) continue;
                 foreach (var pipeB in dockBConnecting)
@@ -74,7 +74,7 @@ namespace Content.Server.Atmos.EntitySystems
                     var pipeBType = pipeB.GetType().Name;
                     var pipeBDir = pipeB.CurrentPipeDirection;
                     var pipeBLayer = pipeB.CurrentPipeLayer;
-                    var pipeBAnchored = EntityManager.GetComponent<TransformComponent>(pipeB.Owner).Anchored;
+                    var pipeBAnchored = Transform(pipeB.Owner).Anchored;
 
                     if (!anchoredB.Contains(pipeB.Owner) || !pipeBAnchored) continue;
                     var canConnect = CanConnect(pipeA, pipeB) && pipeA.CurrentPipeLayer == pipeB.CurrentPipeLayer;
@@ -93,7 +93,7 @@ namespace Content.Server.Atmos.EntitySystems
                     var pipeType = pipe.GetType().Name;
                     var pipeDir = pipe.CurrentPipeDirection;
                     var pipeLayer = pipe.CurrentPipeLayer;
-                    var pipeAnchored = EntityManager.GetComponent<TransformComponent>(pipe.Owner).Anchored;
+                    var pipeAnchored = Transform(pipe.Owner).Anchored;
                     if (!pipeAnchored) continue;
                     CheckForDockConnections(pipe.Owner, pipe);
                 }
@@ -104,7 +104,8 @@ namespace Content.Server.Atmos.EntitySystems
         {
             if (!DockPipes)
                 return new();
-            if (!TryComp<TransformComponent>(dock, out var xform) || xform.GridUid == null)
+            var xform = Transform(dock);
+            if (xform.GridUid == null)
                 return new();
             if (!TryComp<MapGridComponent>(xform.GridUid.Value, out var grid))
                 return new();
@@ -122,7 +123,8 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 if (!TryComp<NodeContainerComponent>(ent, out var nodeContainer))
                     continue;
-                if (!TryComp<TransformComponent>(ent, out var entXform) || !entXform.Anchored)
+                var entXform = Transform(ent);
+                if (!entXform.Anchored)
                     continue;
 
                 foreach (var node in nodeContainer.Nodes.Values.OfType<PipeNode>())
@@ -135,8 +137,7 @@ namespace Content.Server.Atmos.EntitySystems
                     if (!hasDir)
                         continue;
 
-                    if (!TryComp<TransformComponent>(node.Owner, out var pipeXform))
-                        continue;
+                    var pipeXform = Transform(node.Owner);
                     var pipeTile = _mapSystem.TileIndicesFor(xform.GridUid.Value, grid, pipeXform.Coordinates);
 
                     var dockPos = xform.Coordinates.Position;
@@ -186,10 +187,10 @@ namespace Content.Server.Atmos.EntitySystems
 
             foreach (var pipeA in pipesA)
             {
-                if (!anchoredA.Contains(pipeA.Owner) || !EntityManager.GetComponent<TransformComponent>(pipeA.Owner).Anchored) continue;
+                if (!anchoredA.Contains(pipeA.Owner) || !Transform(pipeA.Owner).Anchored) continue;
                 foreach (var pipeB in pipesB)
                 {
-                    if (!anchoredB.Contains(pipeB.Owner) || !EntityManager.GetComponent<TransformComponent>(pipeB.Owner).Anchored) continue;
+                    if (!anchoredB.Contains(pipeB.Owner) || !Transform(pipeB.Owner).Anchored) continue;
                     if (pipeA.CurrentPipeLayer == pipeB.CurrentPipeLayer)
                     {
                         pipeA.RemoveAlwaysReachable(pipeB);
@@ -211,7 +212,8 @@ namespace Content.Server.Atmos.EntitySystems
         private List<(PipeNode pipe, int visualLayer)> GetTilePipesWithRotation(EntityUid dock, out int gridRotation)
         {
             gridRotation = 0;
-            if (!TryComp<TransformComponent>(dock, out var xform) || xform.GridUid == null)
+            var xform = Transform(dock);
+            if (xform.GridUid == null)
                 return new();
 
             if (!TryComp<MapGridComponent>(xform.GridUid.Value, out var grid))
@@ -239,7 +241,7 @@ namespace Content.Server.Atmos.EntitySystems
         // Grid rotation
         private int GetGridRotation(EntityUid gridUid)
         {
-            var gridXform = EntityManager.GetComponent<TransformComponent>(gridUid);
+            var gridXform = Transform(gridUid);
             var angle = gridXform.LocalRotation.Theta;
             return ((int)Math.Round(angle / (Math.PI / 2)) % 4 + 4) % 4;
         }
@@ -253,7 +255,8 @@ namespace Content.Server.Atmos.EntitySystems
         {
             if (!DockPipes)
                 return new();
-            if (!TryComp<TransformComponent>(dock, out var xform) || xform.GridUid == null)
+            var xform = Transform(dock);
+            if (xform.GridUid == null)
                 return new();
 
             if (!TryComp<MapGridComponent>(xform.GridUid.Value, out var grid))
@@ -267,7 +270,8 @@ namespace Content.Server.Atmos.EntitySystems
                     continue;
                 if (!TryComp<NodeContainerComponent>(ent, out var nodeContainer))
                     continue;
-                if (!TryComp<TransformComponent>(ent, out var entXform) || !entXform.Anchored)
+                var entXform = Transform(ent);
+                if (!entXform.Anchored)
                     continue;
                 foreach (var pipe in nodeContainer.Nodes.Values.OfType<PipeNode>().Where(pipe => !pipe.Deleting))
                 {
@@ -300,7 +304,8 @@ namespace Content.Server.Atmos.EntitySystems
                 return;
             if (!EntityManager.TryGetComponent<NodeContainerComponent>(pipeEntity, out var nodeContainer))
                 return;
-            if (!EntityManager.TryGetComponent<TransformComponent>(pipeEntity, out var xform) || xform.GridUid == null || !xform.Anchored)
+            var xform = Transform(pipeEntity);
+            if (xform.GridUid == null || !xform.Anchored)
                 return;
             if (!EntityManager.TryGetComponent<MapGridComponent>(xform.GridUid.Value, out var grid))
                 return;
@@ -321,8 +326,7 @@ namespace Content.Server.Atmos.EntitySystems
                 var nodeDir = node.CurrentPipeDirection;
                 if (!nodeDir.HasDirection(dockDir.ToPipeDirection()))
                     continue;
-                if (!EntityManager.TryGetComponent<TransformComponent>(node.Owner, out var nodeXform))
-                    continue;
+                var nodeXform = Transform(node.Owner);
                 var nodeTile = _mapSystem.TileIndicesFor(xform.GridUid.Value, grid, nodeXform.Coordinates);
                 var dockPos = xform.Coordinates.Position;
                 var nodePos = nodeXform.Coordinates.Position;
@@ -330,7 +334,7 @@ namespace Content.Server.Atmos.EntitySystems
 
                 if (nodeTile == edgeTile)
                 {
-                    if (nodesToConnect.Count == 0 || dist < (nodesToConnect.Count > 0 ? (dockPos - EntityManager.GetComponent<TransformComponent>(nodesToConnect[0].Owner).Coordinates.Position).Length() : float.MaxValue))
+                    if (nodesToConnect.Count == 0 || dist < (nodesToConnect.Count > 0 ? (dockPos - Transform(nodesToConnect[0].Owner).Coordinates.Position).Length() : float.MaxValue))
                     {
                         nodesToConnect.Clear();
                         nodesToConnect.Add(node);
@@ -367,7 +371,7 @@ namespace Content.Server.Atmos.EntitySystems
                 var docking = EntityManager.GetComponent<DockingComponent>(ent);
                 var otherDock = docking.DockedWith!.Value;
                 var pipesOther = GetDockConnectingPipe(otherDock)
-                    .Where(p => EntityManager.GetComponent<TransformComponent>(p.Owner).Anchored && ShouldDockPipeType(p))
+                    .Where(p => Transform(p.Owner).Anchored && ShouldDockPipeType(p))
                     .ToList();
                 foreach (var node in nodesToConnect)
                 foreach (var pipeB in pipesOther)
@@ -396,7 +400,8 @@ namespace Content.Server.Atmos.EntitySystems
             if (!_dockConnectionsChecked.Add(pipeEntity))
                 return;
 
-            if (!EntityManager.TryGetComponent<TransformComponent>(pipeEntity, out var xform) || xform.GridUid == null || !xform.Anchored)
+            var xform = Transform(pipeEntity);
+            if (xform.GridUid == null || !xform.Anchored)
                 return;
             if (!EntityManager.TryGetComponent<MapGridComponent>(xform.GridUid.Value, out var grid))
                 return;
@@ -412,7 +417,7 @@ namespace Content.Server.Atmos.EntitySystems
             {
                 var docking = EntityManager.GetComponent<DockingComponent>(ent);
                 var otherDock = docking.DockedWith!.Value;
-                var pipesOther = GetDockConnectingPipe(otherDock).Where(p => EntityManager.GetComponent<TransformComponent>(p.Owner).Anchored);
+                var pipesOther = GetDockConnectingPipe(otherDock).Where(p => Transform(p.Owner).Anchored);
                 foreach (var pipeB in pipesOther)
                 {
                     var pipeBType = pipeB.GetType().Name;
@@ -534,8 +539,8 @@ namespace Content.Server.Atmos.EntitySystems
                 foreach (var pipeB in pipesB)
                 {
                     if (!anchoredA.Contains(pipeA.Owner) || !anchoredB.Contains(pipeB.Owner) ||
-                        !EntityManager.GetComponent<TransformComponent>(pipeA.Owner).Anchored ||
-                        !EntityManager.GetComponent<TransformComponent>(pipeB.Owner).Anchored) continue;
+                        !Transform(pipeA.Owner).Anchored ||
+                        !Transform(pipeB.Owner).Anchored) continue;
                     var reachableA = pipeA.GetAlwaysReachable();
                     var reachableB = pipeB.GetAlwaysReachable();
                     if (reachableA != null && reachableA.Contains(pipeB))
@@ -546,8 +551,8 @@ namespace Content.Server.Atmos.EntitySystems
                 foreach (var pipeA in pipesA)
                 foreach (var pipeB in pipesB)
                     if (anchoredA.Contains(pipeA.Owner) && anchoredB.Contains(pipeB.Owner) &&
-                        EntityManager.GetComponent<TransformComponent>(pipeA.Owner).Anchored &&
-                        EntityManager.GetComponent<TransformComponent>(pipeB.Owner).Anchored &&
+                        Transform(pipeA.Owner).Anchored &&
+                        Transform(pipeB.Owner).Anchored &&
                         CanConnect(pipeA, pipeB))
                     {
                         pipeA.AddAlwaysReachable(pipeB);

--- a/Content.Server/_Starlight/CollectiveMind/CollectiveMind.cs
+++ b/Content.Server/_Starlight/CollectiveMind/CollectiveMind.cs
@@ -18,8 +18,6 @@ namespace Content.Server.CollectiveMind;
 
 public sealed partial class CollectiveMind : SharedCollectiveMindSystem
 {
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-    [Dependency] private readonly IComponentFactory _componentFactory = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     public override void Initialize()
     {

--- a/Content.Server/_Starlight/Commands/CloudEmotesCommand.cs
+++ b/Content.Server/_Starlight/Commands/CloudEmotesCommand.cs
@@ -12,7 +12,6 @@ namespace Content.Server._Starlight.Commands;
 [UsedImplicitly, AnyCommand]
 public sealed class CloudEmoteCommand : LocalizedCommands
 {
-    [Dependency] private readonly IEntitySystemManager _entitySystems = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IEntityNetworkManager _net = default!;

--- a/Content.Server/_Starlight/Economy/Atm/ATMSystem.cs
+++ b/Content.Server/_Starlight/Economy/Atm/ATMSystem.cs
@@ -48,7 +48,7 @@ public sealed partial class ATMSystem : SharedATMSystem
         playerData.Balance -= args.Amount;
         var cash = SpawnAtPosition(_cash, Transform(uid).Coordinates);
         var stack = EnsureComp<StackComponent>(cash);
-        _stack.SetCount(cash, args.Amount, stack);
+        _stack.SetCount((cash, stack), args.Amount);
         _hands.TryPickup(args.Actor, cash);
         _uiSystem.SetUiState(uid, ATMUIKey.Key, new ATMBuiState() { Balance = playerData.Balance });
         _audioSystem.PlayPvs(component.WithdrawSound, uid);

--- a/Content.Server/_Starlight/Economy/SalarySystem.cs
+++ b/Content.Server/_Starlight/Economy/SalarySystem.cs
@@ -42,7 +42,6 @@ public sealed partial class SalarySystem : SharedSalarySystem
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly INullLinkPlayerManager _nullLinkRoles = default!;
     [Dependency] private readonly IPlayerRolesManager _playerRolesManager = default!;
-    [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IGameTiming _time = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;

--- a/Content.Server/_Starlight/Energy/Supermatter/SupermatterCascadeSystem.cs
+++ b/Content.Server/_Starlight/Energy/Supermatter/SupermatterCascadeSystem.cs
@@ -12,7 +12,6 @@ public sealed class SupermatterCascadeSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
 
     private readonly LinkedList<Branch> _branches = [];

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -15,8 +15,6 @@ namespace Content.Server.Starlight.GameTicking;
 public sealed class PeacefulRoundEndSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
-    [Dependency] private readonly IPrototypeManager _proto = default!;
-    [Dependency] private readonly ISharedPlayersRoleManager _sharedPlayersRoleManager = default!;
     [Dependency] private readonly ISharedNullLinkPlayerRolesReqManager _rolesReq = default!;
 
     private bool _isEnabled = false;

--- a/Content.Server/_Starlight/GameTicking/GameTicker.RoundEndVote.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.RoundEndVote.cs
@@ -30,7 +30,7 @@ public sealed class RoundEndVoteSystem : EntitySystem
     {
         if (_playerManager.PlayerCount < _cfg.GetCVar(StarlightCCVars.MinPlayerToVote))
         {
-            Logger.Warning($"Not enought players, player count: {_playerManager.PlayerCount}");
+            Log.Warning($"Not enought players, player count: {_playerManager.PlayerCount}");
             return;
         }
         

--- a/Content.Server/_Starlight/GhostTheme/GhostThemeSystem.cs
+++ b/Content.Server/_Starlight/GhostTheme/GhostThemeSystem.cs
@@ -50,9 +50,7 @@ public sealed class GhostThemeSystem : EntitySystem
 {
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly EuiManager _euiManager = default!;
-    [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-    [Dependency] private readonly ISharedNullLinkPlayerRolesReqManager _nulllinkPlayerRoles = default!;
     [Dependency] private readonly IPlayerRolesManager _playerRoles = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
 

--- a/Content.Server/_Starlight/Implants/USSPUplinkSystem.cs
+++ b/Content.Server/_Starlight/Implants/USSPUplinkSystem.cs
@@ -27,7 +27,7 @@ public sealed class USSPUplinkSystem : EntitySystem
         SubscribeLocalEvent<USSPUplinkImplantComponent, ImplantImplantedEvent>(OnImplantImplanted);
         SubscribeLocalEvent<RoundEndSystemChangedEvent>(OnRoundEnd);
     }
-    
+
     /// <summary>
     /// Handles the event when a round ends.
     /// Resets all stock-limited listings in the uplink catalog.
@@ -37,7 +37,7 @@ public sealed class USSPUplinkSystem : EntitySystem
         // Reset all stock-limited listings in the uplink catalog
         ResetUplinkStocks();
     }
-    
+
     /// <summary>
     /// Resets all stock-limited listings in the uplink catalog.
     /// This is called when a round ends to ensure each new round starts with fresh stock counts.
@@ -46,54 +46,54 @@ public sealed class USSPUplinkSystem : EntitySystem
     {
         // Use reflection to access the private static dictionaries in StockLimitedListingCondition
         var type = typeof(Content.Shared.Store.Conditions.StockLimitedListingCondition);
-        
+
         // Get the _stockCounts dictionary
-        var stockCountsField = type.GetField("_stockCounts", 
+        var stockCountsField = type.GetField("_stockCounts",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        
+
         // Get the _stockLimits dictionary
-        var stockLimitsField = type.GetField("_stockLimits", 
+        var stockLimitsField = type.GetField("_stockLimits",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        
+
         // Get the _lastPurchasers dictionary
-        var lastPurchasersField = type.GetField("_lastPurchasers", 
+        var lastPurchasersField = type.GetField("_lastPurchasers",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        
+
         // Get the _outOfStock dictionary
-        var outOfStockField = type.GetField("_outOfStock", 
+        var outOfStockField = type.GetField("_outOfStock",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        
+
         // Get the _modifiedListings dictionary
-        var modifiedListingsField = type.GetField("_modifiedListings", 
+        var modifiedListingsField = type.GetField("_modifiedListings",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        
+
         // Reset the dictionaries
         if (stockCountsField != null && stockCountsField.GetValue(null) is Dictionary<string, int> stockCounts)
             stockCounts.Clear();
-        
+
         if (stockLimitsField != null && stockLimitsField.GetValue(null) is Dictionary<string, int> stockLimits)
             stockLimits.Clear();
-        
+
         if (lastPurchasersField != null && lastPurchasersField.GetValue(null) is Dictionary<string, string> lastPurchasers)
             lastPurchasers.Clear();
-        
+
         if (outOfStockField != null && outOfStockField.GetValue(null) is Dictionary<string, bool> outOfStock)
             outOfStock.Clear();
-        
+
         if (modifiedListingsField != null && modifiedListingsField.GetValue(null) is Dictionary<string, bool> modifiedListings)
             modifiedListings.Clear();
-        
+
         // Update all uplink UIs to show the reset stock counts
         UpdateAllUplinkListings();
     }
-    
-    
+
+
     /// <summary>
     /// Synchronizes all uplinks in the game to ensure they have the correct currency values.
     /// This is called periodically to ensure that uplinks are always in sync.
     /// </summary>
     public void SynchronizeAllUplinks()
-    {        
+    {
         // Get all head revolutionaries
         var headQuery = EntityManager.EntityQueryEnumerator<HeadRevolutionaryComponent>();
         while (headQuery.MoveNext(out var uid, out var headRev))
@@ -102,47 +102,47 @@ public sealed class USSPUplinkSystem : EntitySystem
             _rev.SynchronizeAllUplinksByOwner(uid);
         }
     }
-    
+
     /// <summary>
     /// Directly synchronizes telebonds and conversions between two uplinks.
     /// This ensures that when a revolutionary gets a head revolutionary's uplink,
     /// they immediately receive the correct currency values.
-    /// 
+    ///
     /// For telebonds, it only synchronizes if both uplinks have the same owner.
     /// For conversions, it always synchronizes as this is a global counter.
     /// </summary>
     public void SyncUplinkCurrencies(EntityUid sourceUplinkUid, EntityUid targetUplinkUid)
     {
-        if (!TryComp<StoreComponent>(sourceUplinkUid, out var sourceStore) || 
+        if (!TryComp<StoreComponent>(sourceUplinkUid, out var sourceStore) ||
             !TryComp<StoreComponent>(targetUplinkUid, out var targetStore))
             return;
-            
+
         // Get the currency values from the source uplink
         var sourceTelebond = sourceStore.Balance.GetValueOrDefault("Telebond", FixedPoint2.Zero);
         var sourceConversion = sourceStore.Balance.GetValueOrDefault("Conversion", FixedPoint2.Zero);
-        
+
         // Make sure the target store has both currencies initialized
         if (!targetStore.Balance.ContainsKey("Telebond"))
         {
             targetStore.Balance["Telebond"] = FixedPoint2.Zero;
         }
-        
+
         if (!targetStore.Balance.ContainsKey("Conversion"))
         {
             targetStore.Balance["Conversion"] = FixedPoint2.Zero;
         }
-        
+
         // Check if both uplinks have the same owner for telebond synchronization
         bool sameOwner = false;
         EntityUid? sourceOwner = null;
         EntityUid? targetOwner = null;
-        
+
         if (TryComp<USSPUplinkOwnerComponent>(sourceUplinkUid, out var sourceOwnerComp))
             sourceOwner = sourceOwnerComp.OwnerUid;
-            
+
         if (TryComp<USSPUplinkOwnerComponent>(targetUplinkUid, out var targetOwnerComp))
             targetOwner = targetOwnerComp.OwnerUid;
-            
+
         // If both uplinks have the same owner, or if one doesn't have an owner but the other does
         if (sourceOwner != null && targetOwner != null && sourceOwner == targetOwner)
             sameOwner = true;
@@ -160,16 +160,16 @@ public sealed class USSPUplinkSystem : EntitySystem
             newOwnerComp.OwnerUid = targetOwner;
             sameOwner = true;
         }
-        
+
         // Update the target uplink with the source telebond value if they're higher AND they have the same owner
         if (sameOwner && targetStore.Balance["Telebond"] < sourceTelebond)
             targetStore.Balance["Telebond"] = sourceTelebond;
-        
+
         // Always update Conversion as it's a global counter
         if (targetStore.Balance["Conversion"] < sourceConversion)
             targetStore.Balance["Conversion"] = sourceConversion;
     }
-        
+
     /// <summary>
     /// Handles the event when a USSP uplink implant is implanted.
     /// If the implanted entity is a head revolutionary, updates their HeadRevolutionaryImplantComponent
@@ -181,14 +181,14 @@ public sealed class USSPUplinkSystem : EntitySystem
         EntityUid? originalOwner = null;
         if (TryComp<USSPUplinkOwnerComponent>(uid, out var existingOwnerComp) && existingOwnerComp.OwnerUid != null)
             originalOwner = existingOwnerComp.OwnerUid;
-            
+
         // Check if the implanted entity is a head revolutionary
         if (HasComp<HeadRevolutionaryComponent>(args.Implanted))
         {
             // Update the head revolutionary's implant component to point to this implant
             var implantComponent = EnsureComp<HeadRevolutionaryImplantComponent>(args.Implanted);
             implantComponent.ImplantUid = uid;
-            
+
             // If the uplink doesn't have an owner yet, set this head revolutionary as the owner
             if (originalOwner == null)
             {
@@ -196,49 +196,49 @@ public sealed class USSPUplinkSystem : EntitySystem
                 uplinkOwnerComp.OwnerUid = args.Implanted;
                 originalOwner = args.Implanted;
             }
-            
+
             // Ensure the store component has both currencies initialized
             if (TryComp<StoreComponent>(uid, out var store))
             {
                 if (!store.Balance.ContainsKey("Telebond"))
                     store.Balance["Telebond"] = FixedPoint2.Zero;
-                
+
                 if (!store.Balance.ContainsKey("Conversion"))
                     store.Balance["Conversion"] = FixedPoint2.Zero;
             }
-            
+
             // Find all revolutionaries that were converted by this head revolutionary
             // and add telebonds for each one
             var convertedRevs = EntityManager.EntityQuery<RevolutionaryComponent, RevolutionaryConverterComponent>();
             int convertedCount = 0;
-            
+
             foreach (var (_, converterComp) in convertedRevs)
             {
                 // Check if this revolutionary was converted by this head revolutionary
                 if (converterComp.ConverterUid != args.Implanted)
                     continue;
-                
+
                 convertedCount++;
-                
+
                 // Add a telebond for each converted revolutionary
                 if (TryComp<StoreComponent>(uid, out var storeComp))
                     storeComp.Balance["Telebond"] = storeComp.Balance.GetValueOrDefault("Telebond") + FixedPoint2.New(1);
             }
-            
+
             // Synchronize all uplinks to ensure this one has the correct values
             SynchronizeAllUplinks();
-            
+
             // Show the current telebond and conversion values
             if (TryComp<StoreComponent>(uid, out var storeAfterSync))
             {
                 var telebonds = storeAfterSync.Balance.GetValueOrDefault("Telebond", FixedPoint2.Zero);
                 var conversions = storeAfterSync.Balance.GetValueOrDefault("Conversion", FixedPoint2.Zero);
-                
+
                 var convertedMessage = convertedCount > 0 ? $" (+{convertedCount} from previous conversions)" : "";
-                _popup.PopupEntity(Loc.GetString($"Implanted! Current Telebonds: {telebonds}{convertedMessage}, Conversions: {conversions}"), 
+                _popup.PopupEntity(Loc.GetString($"Implanted! Current Telebonds: {telebonds}{convertedMessage}, Conversions: {conversions}"),
                     args.Implanted, args.Implanted, PopupType.Medium);
             }
-            
+
             // If the head revolutionary is implanting an uplink that belongs to another head revolutionary,
             // we need to update the ownership to the current head revolutionary
             if (originalOwner != null && originalOwner.Value != args.Implanted)
@@ -246,19 +246,19 @@ public sealed class USSPUplinkSystem : EntitySystem
                 // Only change ownership if the implanted entity is a head revolutionary
                 var uplinkOwnerComp = EnsureComp<Content.Shared.Implants.Components.USSPUplinkOwnerComponent>(uid);
                 uplinkOwnerComp.OwnerUid = args.Implanted;
-                                    
+
                 // Notify the original owner that their uplink has been claimed by another head revolutionary
-                _popup.PopupEntity(Loc.GetString($"Your uplink has been claimed by {Identity.Name(args.Implanted, EntityManager)}"), 
+                _popup.PopupEntity(Loc.GetString($"Your uplink has been claimed by {Identity.Name(args.Implanted, EntityManager)}"),
                     originalOwner.Value, originalOwner.Value, PopupType.Medium);
             }
         }
         // Check if the implanted entity is a regular revolutionary
         else if (HasComp<RevolutionaryComponent>(args.Implanted))
-        {                
+        {
             // If the uplink doesn't have an owner component yet, try to find its owner
             if (originalOwner == null)
             {
-                var ownerComp = EnsureComp<USSPUplinkOwnerComponent>(uid);                    
+                var ownerComp = EnsureComp<USSPUplinkOwnerComponent>(uid);
                 // Try to find a head revolutionary who might own this uplink
                 var headQuery = EntityManager.EntityQueryEnumerator<HeadRevolutionaryComponent, HeadRevolutionaryImplantComponent>();
                 while (headQuery.MoveNext(out var implantOwner, out var _, out var headRevImplant))
@@ -269,50 +269,50 @@ public sealed class USSPUplinkSystem : EntitySystem
                     originalOwner = implantOwner;
                     break;
                 }
-                
+
                 // If we still don't have an owner, try to find a head revolutionary who has this implant
                 if (ownerComp.OwnerUid == null)
                 {
                     // Get all head revolutionaries
-                    var allHeadRevs = EntityManager.EntityQuery<HeadRevolutionaryComponent>();
-                    foreach (var headRev in allHeadRevs)
+                    var headRevsQuery = EntityManager.EntityQueryEnumerator<HeadRevolutionaryComponent>();
+                    while (headRevsQuery.MoveNext(out var headRevOwner, out var headRev))
                     {
                         // Check if this head revolutionary has this implant
-                        if (_implant.TryGetImplants(headRev.Owner, out var implants))
+                        if (_implant.TryGetImplants(headRevOwner, out var implants))
                         {
                             foreach (var implant in implants)
                             {
                                 if (implant == uid)
                                 {
-                                    ownerComp.OwnerUid = headRev.Owner;
-                                    originalOwner = headRev.Owner;
-                                    
+                                    ownerComp.OwnerUid = headRevOwner;
+                                    originalOwner = headRevOwner;
+
                                     // Also update the head revolutionary's implant component
-                                    var headRevImplantComp = EnsureComp<HeadRevolutionaryImplantComponent>(headRev.Owner);
-                                    headRevImplantComp.ImplantUid = uid;                                        
+                                    var headRevImplantComp = EnsureComp<HeadRevolutionaryImplantComponent>(headRevOwner);
+                                    headRevImplantComp.ImplantUid = uid;
                                     break;
                                 }
                             }
-                            
+
                             if (ownerComp.OwnerUid != null)
                                 break;
                         }
                     }
                 }
-                
+
                 // If we still don't have an owner, find the head revolutionary who most recently converted this revolutionary
                 if (ownerComp.OwnerUid == null)
                 {
                     // Get all head revolutionaries
-                    var allHeadRevs = EntityManager.EntityQuery<HeadRevolutionaryComponent, HeadRevolutionaryImplantComponent>();
-                    foreach (var (_, headRevImplant) in allHeadRevs)
+                    var implantedHeadRevsQuery = EntityManager.EntityQueryEnumerator<HeadRevolutionaryComponent, HeadRevolutionaryImplantComponent>();
+                    while (implantedHeadRevsQuery.MoveNext(out var headRevImplantOwner, out var _, out var headRevImplant))
                     {
                         if (headRevImplant.ImplantUid != null && EntityManager.EntityExists(headRevImplant.ImplantUid.Value))
                         {
                             // Set this head revolutionary as the owner of the uplink
-                            ownerComp.OwnerUid = headRevImplant.Owner;
-                            originalOwner = headRevImplant.Owner;
-                            
+                            ownerComp.OwnerUid = headRevImplantOwner;
+                            originalOwner = headRevImplantOwner;
+
                             // Directly sync with this head revolutionary's uplink
                             SyncUplinkCurrencies(headRevImplant.ImplantUid.Value, uid);
                             break;
@@ -320,11 +320,11 @@ public sealed class USSPUplinkSystem : EntitySystem
                     }
                 }
             }
-            
+
             // Add HeadRevolutionaryImplantComponent to the revolutionary to track the implant
             var implantComponent = EnsureComp<HeadRevolutionaryImplantComponent>(args.Implanted);
             implantComponent.ImplantUid = uid;
-                            
+
             // Ensure the store component has the correct currencies
             if (TryComp<StoreComponent>(uid, out var store))
             {
@@ -333,63 +333,63 @@ public sealed class USSPUplinkSystem : EntitySystem
                 {
                     store.Balance["Telebond"] = FixedPoint2.Zero;
                 }
-                
+
                 if (!store.Balance.ContainsKey("Conversion"))
                 {
                     store.Balance["Conversion"] = FixedPoint2.Zero;
                 }
-                
+
                 // Find all uplinks owned by the same head revolutionary and get the maximum currency values
                 var allUplinks = new List<EntityUid>();
                 var maxTelebond = store.Balance.GetValueOrDefault("Telebond", FixedPoint2.Zero);
                 var maxConversion = store.Balance.GetValueOrDefault("Conversion", FixedPoint2.Zero);
-                
+
                 // Only synchronize telebonds with uplinks from the same owner
                 if (originalOwner != null)
                 {
                     // Find all uplinks owned by this head revolutionary
-                    var uplinkQuery = EntityManager.EntityQuery<Content.Shared.Implants.Components.USSPUplinkOwnerComponent, StoreComponent>();
-                    foreach (var (uplinkOwner, uplinkStore) in uplinkQuery)
+                    var uplinkQuery = EntityManager.EntityQueryEnumerator<Content.Shared.Implants.Components.USSPUplinkOwnerComponent, StoreComponent>();
+                    while (uplinkQuery.MoveNext(out var uplinkOwnerOwner, out var uplinkOwner, out var uplinkStore))
                     {
-                        if (uplinkOwner.OwnerUid == originalOwner && uplinkOwner.Owner != uid)
+                        if (uplinkOwner.OwnerUid == originalOwner && uplinkOwnerOwner != uid)
                         {
-                            allUplinks.Add(uplinkOwner.Owner);
-                            
+                            allUplinks.Add(uplinkOwnerOwner);
+
                             // Get the currency values
                             var otherTelebonds = uplinkStore.Balance.GetValueOrDefault("Telebond", FixedPoint2.Zero);
                             var otherConversions = uplinkStore.Balance.GetValueOrDefault("Conversion", FixedPoint2.Zero);
-                                                            
+
                             // Update the maximum values
                             if (otherTelebonds > maxTelebond)
                             {
                                 maxTelebond = otherTelebonds;
                             }
-                            
+
                             if (otherConversions > maxConversion)
                             {
                                 maxConversion = otherConversions;
                             }
                         }
                     }
-                    
+
                     // Also check if the owner has an uplink
-                    if (TryComp<HeadRevolutionaryImplantComponent>(originalOwner.Value, out var ownerImplant) && 
-                        ownerImplant.ImplantUid != null && 
+                    if (TryComp<HeadRevolutionaryImplantComponent>(originalOwner.Value, out var ownerImplant) &&
+                        ownerImplant.ImplantUid != null &&
                         EntityManager.EntityExists(ownerImplant.ImplantUid.Value) &&
                         ownerImplant.ImplantUid.Value != uid)
                     {
                         var ownerUplinkUid = ownerImplant.ImplantUid.Value;
-                        
+
                         if (TryComp<StoreComponent>(ownerUplinkUid, out var ownerStore))
                         {
                             var ownerTelebonds = ownerStore.Balance.GetValueOrDefault("Telebond", FixedPoint2.Zero);
                             var ownerConversions = ownerStore.Balance.GetValueOrDefault("Conversion", FixedPoint2.Zero);
-                                                            
+
                             if (ownerTelebonds > maxTelebond)
                             {
                                 maxTelebond = ownerTelebonds;
                             }
-                            
+
                             if (ownerConversions > maxConversion)
                             {
                                 maxConversion = ownerConversions;
@@ -401,73 +401,73 @@ public sealed class USSPUplinkSystem : EntitySystem
                 {
                     // If we don't have an owner, just get the global maximum conversion value
                     // This ensures we get the correct values even if the original owner isn't properly set
-                    var uplinkQuery = EntityManager.EntityQuery<StoreComponent>();
-                    foreach (var uplinkStore in uplinkQuery)
+                    var uplinkQuery = EntityManager.EntityQueryEnumerator<StoreComponent>();
+                    while (uplinkQuery.MoveNext(out var uplinkStoreOwner, out var uplinkStore))
                     {
-                        if (uplinkStore.Owner == uid)
+                        if (uplinkStoreOwner == uid)
                             continue;
-                            
+
                         if (uplinkStore.Balance.TryGetValue("Conversion", out var conversion) && conversion > maxConversion)
                         {
                             maxConversion = conversion;
                         }
                     }
                 }
-                
+
                 // Update the current uplink with the maximum values
                 if (maxTelebond > store.Balance["Telebond"])
                 {
                     store.Balance["Telebond"] = maxTelebond;
                 }
-                
+
                 if (maxConversion > store.Balance["Conversion"])
                 {
                     store.Balance["Conversion"] = maxConversion;
                 }
-                
+
                 // Synchronize all uplinks to ensure this one has the correct values
                 SynchronizeAllUplinks();
-                
+
                 // Always show +1 telebond and +1 conversion in the popup, regardless of the actual values
                 //var ownerInfo = originalOwner != null ? $" (owned by {Identity.Name(originalOwner.Value, EntityManager)})" : "";
-                //_popup.PopupEntity(Loc.GetString($"Uplink implanted{ownerInfo}. +1 Telebond, +1 Conversion"), 
+                //_popup.PopupEntity(Loc.GetString($"Uplink implanted{ownerInfo}. +1 Telebond, +1 Conversion"),
                 //    args.Implanted, args.Implanted, PopupType.Medium);
             }
-            
+
             // If we have an original owner, notify them that their uplink has been implanted in someone else
             if (originalOwner != null && originalOwner.Value != args.Implanted)
             {
-                _popup.PopupEntity(Loc.GetString($"Your uplink has been implanted in {Identity.Name(args.Implanted, EntityManager)}"), 
+                _popup.PopupEntity(Loc.GetString($"Your uplink has been implanted in {Identity.Name(args.Implanted, EntityManager)}"),
                     originalOwner.Value, originalOwner.Value, PopupType.Medium);
-                
+
                 // Call the RevolutionaryRuleSystem to synchronize all uplinks owned by this head revolutionary
                 _rev.SynchronizeAllUplinksByOwner(originalOwner.Value);
-                
+
                 // Special case: If the implanted entity was just converted by the head revolutionary,
                 // we need to make sure the uplink has the latest values
-                if (HasComp<RevolutionaryComponent>(args.Implanted) && 
-                    TryComp<HeadRevolutionaryImplantComponent>(originalOwner.Value, out var headRevImplant) && 
-                    headRevImplant.ImplantUid != null && 
+                if (HasComp<RevolutionaryComponent>(args.Implanted) &&
+                    TryComp<HeadRevolutionaryImplantComponent>(originalOwner.Value, out var headRevImplant) &&
+                    headRevImplant.ImplantUid != null &&
                     EntityManager.EntityExists(headRevImplant.ImplantUid.Value))
                 {
                     // Directly sync the currencies from the head revolutionary's uplink to this uplink
                     SyncUplinkCurrencies(headRevImplant.ImplantUid.Value, uid);
-                    
+
                     // Update the UI to show the latest values
                     if (TryComp<StoreComponent>(uid, out var finalStore))
                     {
                         var finalTelebonds = finalStore.Balance.GetValueOrDefault("Telebond", FixedPoint2.Zero);
                         var finalConversions = finalStore.Balance.GetValueOrDefault("Conversion", FixedPoint2.Zero);
-                        
+
                         // Show an additional popup with the updated values
-                        _popup.PopupEntity(Loc.GetString($"Uplink synchronized! Current Telebonds: {finalTelebonds}, Conversions: {finalConversions}"), 
+                        _popup.PopupEntity(Loc.GetString($"Uplink synchronized! Current Telebonds: {finalTelebonds}, Conversions: {finalConversions}"),
                             args.Implanted, args.Implanted, PopupType.Medium);
                     }
                 }
             }
         }
     }
-        
+
     /// <summary>
     /// Handles the event when a purchase is made from a store.
     /// Restores any spent Conversion currency since it's a global headrev progression score, not a spendable currency.
@@ -478,7 +478,7 @@ public sealed class USSPUplinkSystem : EntitySystem
         // Get the store component
         if (!_entityManager.TryGetComponent(args.StoreUid, out StoreComponent? store))
             return;
-        
+
         // Check if this store uses Conversion currency
         if (store.CurrencyWhitelist.Contains("Conversion"))
         {
@@ -492,7 +492,7 @@ public sealed class USSPUplinkSystem : EntitySystem
                     break;
                 }
             }
-            
+
             if (conversionWasSpent)
             {
                 // Calculate how much Conversion was spent
@@ -505,13 +505,13 @@ public sealed class USSPUplinkSystem : EntitySystem
                         break;
                     }
                 }
-                
+
                 // Add the Conversion currency back
                 var currencyToAdd = new Dictionary<string, FixedPoint2> { { "Conversion", spentAmount } };
                 _storeSystem.TryAddCurrency(currencyToAdd, args.StoreUid);
             }
         }
-        
+
         // Check if this is a stock-limited listing
         bool isStockLimited = false;
         if (args.PurchasedItem.Conditions != null)
@@ -525,7 +525,7 @@ public sealed class USSPUplinkSystem : EntitySystem
                 }
             }
         }
-        
+
         // If this is a stock-limited listing, update all uplinks
         if (isStockLimited && store.CurrencyWhitelist.Contains("Telebond"))
         {
@@ -533,56 +533,56 @@ public sealed class USSPUplinkSystem : EntitySystem
             UpdateAllUplinkListings();
         }
     }
-        
+
     /// <summary>
     /// Adds Conversion currency to all head revolutionary uplinks.
     /// This is a shared counter that tracks total conversions by all head revolutionaries.
     /// </summary>
     public void AddConversionToAllHeadRevs(StoreSystem storeSystem)
-    {        
+    {
         // Get all USSPUplinkImplant entities in the game
-        var query = EntityManager.EntityQuery<MetaDataComponent, StoreComponent>(true);
+        var query = EntityManager.AllEntityQueryEnumerator<MetaDataComponent, StoreComponent>();
         var uplinkEntities = new List<EntityUid>();
-        
-        foreach (var (metadata, _) in query)
+
+        while (query.MoveNext(out var metadataOwner, out var metadata, out var _))
         {
             if (metadata.EntityPrototype?.ID == "USSPUplinkImplant")
             {
-                uplinkEntities.Add(metadata.Owner);
+                uplinkEntities.Add(metadataOwner);
             }
         }
-        
+
         // Add Conversion to all uplinks
         foreach (var uplinkEntity in uplinkEntities)
         {
             var currencyToAdd = new Dictionary<string, FixedPoint2> { { "Conversion", FixedPoint2.New(1) } };
             var success = storeSystem.TryAddCurrency(currencyToAdd, uplinkEntity);
         }
-        
+
         // Show popup to all head revolutionaries (private)
-        var headRevQuery = EntityManager.EntityQuery<HeadRevolutionaryComponent>();
-        foreach (var headRev in headRevQuery)
+        var headRevsQuery = EntityManager.EntityQueryEnumerator<HeadRevolutionaryComponent>();
+        while (headRevsQuery.MoveNext(out var headRevOwner, out var headRev))
         {
             // Get the current conversion value to show in the popup
             var conversionValue = FixedPoint2.New(1); // Default to 1 if we can't find the actual value
-            
+
             // Try to get the head revolutionary's uplink
-            if (TryComp<HeadRevolutionaryImplantComponent>(headRev.Owner, out var implantComp) && 
-                implantComp.ImplantUid != null && 
+            if (TryComp<HeadRevolutionaryImplantComponent>(headRevOwner, out var implantComp) &&
+                implantComp.ImplantUid != null &&
                 EntityManager.EntityExists(implantComp.ImplantUid.Value) &&
                 TryComp<StoreComponent>(implantComp.ImplantUid.Value, out var store))
             {
                 conversionValue = store.Balance.GetValueOrDefault("Conversion", FixedPoint2.New(1));
             }
-            
-            _popup.PopupEntity(Loc.GetString($"+1 Conversion (Total: {conversionValue})"), headRev.Owner, headRev.Owner, PopupType.Medium);
+
+            _popup.PopupEntity(Loc.GetString($"+1 Conversion (Total: {conversionValue})"), headRevOwner, headRevOwner, PopupType.Medium);
         }
-        
+
         // Also show popup to all revolutionaries with implants
         // var revQuery = EntityManager.EntityQuery<RevolutionaryComponent, HeadRevolutionaryImplantComponent>();
         // foreach (var (_, revImplant) in revQuery)
         // {
-        //     if (revImplant.ImplantUid != null && 
+        //     if (revImplant.ImplantUid != null &&
         //         EntityManager.EntityExists(revImplant.ImplantUid.Value) &&
         //         TryComp<StoreComponent>(revImplant.ImplantUid.Value, out var store))
         //     {
@@ -591,21 +591,21 @@ public sealed class USSPUplinkSystem : EntitySystem
         //     }
         // }
     }
-        
+
     /// <summary>
     /// Updates all USSP uplink listings with the current stock count and last purchaser information.
     /// </summary>
     public void UpdateAllUplinkListings()
-    {            
+    {
         // Use the StoreSystem's method to update all USSP uplink UIs
         _storeSystem.UpdateAllUSSPUplinkUIs();
-        
+
         // Get all head revolutionaries
-        var headRevs = EntityManager.EntityQuery<HeadRevolutionaryComponent>();
-        foreach (var headRev in headRevs)
+        var headRevsQuery = EntityManager.EntityQueryEnumerator<HeadRevolutionaryComponent>();
+        while (headRevsQuery.MoveNext(out var headRevOwner, out var _))
         {
             // Synchronize all uplinks owned by this head revolutionary
-            _rev.SynchronizeAllUplinksByOwner(headRev.Owner);
+            _rev.SynchronizeAllUplinksByOwner(headRevOwner);
         }
     }
 }

--- a/Content.Server/_Starlight/Medical/LimbDamageSystem.cs
+++ b/Content.Server/_Starlight/Medical/LimbDamageSystem.cs
@@ -27,10 +27,10 @@ using Robust.Shared.Random;
 namespace Content.Server._Starlight.Medical;
 public sealed class LimbDamageSystem : EntitySystem
 {
-    [Dependency] private readonly IRobustRandom _rand = default!;
-    [Dependency] private readonly BodySystem _body = default!;
-    [Dependency] private readonly ContainerSystem _containers = default!;
-    [Dependency] private readonly HandsSystem _hands = default!;
+    //[Dependency] private readonly IRobustRandom _rand = default!;
+    //[Dependency] private readonly BodySystem _body = default!;
+    //[Dependency] private readonly ContainerSystem _containers = default!;
+    //[Dependency] private readonly HandsSystem _hands = default!;
 
     public override void Initialize()
     {

--- a/Content.Server/_Starlight/Medical/Limbs/CyberLimbSystem.cs
+++ b/Content.Server/_Starlight/Medical/Limbs/CyberLimbSystem.cs
@@ -11,7 +11,6 @@ public sealed partial class CyberLimbSystem : EntitySystem
     [Dependency] private readonly ActionsSystem _actions = default!;
     [Dependency] private readonly StarlightEntitySystem _slEnt = default!;
     [Dependency] private readonly HandsSystem _hands = default!;
-    [Dependency] private readonly TransformSystem _xform = default!;
     [Dependency] private readonly ContainerSystem _container = default!;
     [Dependency] private readonly LimbSystem _limb = default!;
     [Dependency] private readonly AudioSystem _audio = default!;

--- a/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
@@ -27,8 +27,7 @@ namespace Content.Server.Starlight.Medical.Surgery;
 //However, I don’t want to touch the official systems, so I need to come up with extensions for them.
 public sealed partial class SurgerySystem : SharedSurgerySystem
 {
-    [Dependency] protected readonly IGameTiming Timing = default!;
-    [Dependency] private readonly IComponentFactory _compFactory = default!;
+    [Dependency] private readonly IGameTiming Timing = default!;
     [Dependency] private readonly LimbSystem _limbSystem = default!;
     [Dependency] private readonly StarlightEntitySystem _entity = default!;
     [Dependency] private readonly SharedBloodstreamSystem _bloodstreamSystem = default!;

--- a/Content.Server/_Starlight/MentorSystem.cs
+++ b/Content.Server/_Starlight/MentorSystem.cs
@@ -47,7 +47,6 @@ public sealed partial class MentorSystem : SharedMentorSystem
     private const string RateLimitKey = "MentorHelp";
 
     [Dependency] private readonly IPlayerManager _playerManager = default!;
-    [Dependency] private readonly IPlayerRolesManager _playerRolesManager = default!;
     [Dependency] private readonly ISharedNullLinkPlayerRolesReqManager _playerRoles = default!;
     [Dependency] private readonly INullLinkPlayerManager _nullLinkPlayers = default!;
     [Dependency] private readonly IAdminManager _adminManager = default!;

--- a/Content.Server/_Starlight/NullSpace/NullSpaceDrainerSystem.cs
+++ b/Content.Server/_Starlight/NullSpace/NullSpaceDrainerSystem.cs
@@ -10,7 +10,6 @@ namespace Content.Server._Starlight.NullSpace;
 
 public sealed class NullSpaceDrainerSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     public override void Initialize()
     {

--- a/Content.Server/_Starlight/Physics/HandleMobMovementJob.cs
+++ b/Content.Server/_Starlight/Physics/HandleMobMovementJob.cs
@@ -45,7 +45,7 @@ public struct HandleMobMovementJob(SLMoverController moverController) : IParalle
             _sounds[index] = playSound;
             _rotations[index] = rotation;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
 
         }

--- a/Content.Server/_Starlight/Power/DockCableSystem.cs
+++ b/Content.Server/_Starlight/Power/DockCableSystem.cs
@@ -102,7 +102,8 @@ namespace Content.Server.Power.EntitySystems
         
         public IEnumerable<CableNode> GetDockCableNodes(EntityUid dock)
         {
-            if (!TryComp<TransformComponent>(dock, out var xform) || xform.GridUid == null)
+            var xform = Transform(dock);
+            if (xform.GridUid == null)
                 yield break;
             if (!TryComp<MapGridComponent>(xform.GridUid.Value, out var grid))
                 yield break;
@@ -115,7 +116,8 @@ namespace Content.Server.Power.EntitySystems
                     continue;
                 if (!TryComp<NodeContainerComponent>(ent, out var nodeContainer))
                     continue;
-                if (!TryComp<TransformComponent>(ent, out var entXform) || !entXform.Anchored)
+                var entXform = Transform(ent);
+                if (!entXform.Anchored)
                     continue;
                 foreach (var node in nodeContainer.Nodes.Values.OfType<CableNode>())
                 {
@@ -165,7 +167,8 @@ namespace Content.Server.Power.EntitySystems
         {
             if (!ShouldDockCableType(node))
                 return;
-            if (!TryComp<TransformComponent>(node.Owner, out var xform) || xform.GridUid == null || !xform.Anchored)
+            var xform = Transform(node.Owner);
+            if (xform.GridUid == null || !xform.Anchored)
                 return;
             if (!TryComp<MapGridComponent>(xform.GridUid.Value, out var grid))
                 return;
@@ -181,7 +184,7 @@ namespace Content.Server.Power.EntitySystems
             {
                 var docking = Comp<DockingComponent>(ent);
                 var otherDock = docking.DockedWith!.Value;
-                var otherCables = GetDockCableNodes(otherDock).Where(p => TryComp<TransformComponent>(p.Owner, out var pXform) && pXform.Anchored);
+                var otherCables = GetDockCableNodes(otherDock).Where(p => Transform(p.Owner).Anchored);
                 foreach (var otherCable in otherCables)
                 {
                     if (CanConnect(node, otherCable))
@@ -223,7 +226,8 @@ namespace Content.Server.Power.EntitySystems
             if (!_dockConnectionsChecked.Add(cableEntity))
                 return;
 
-            if (!TryComp<TransformComponent>(cableEntity, out var xform) || xform.GridUid == null || !xform.Anchored)
+            var xform = Transform(cableEntity);
+            if (xform.GridUid == null || !xform.Anchored)
                 return;
             if (!TryComp<MapGridComponent>(xform.GridUid.Value, out var grid))
                 return;
@@ -239,7 +243,7 @@ namespace Content.Server.Power.EntitySystems
             {
                 var docking = Comp<DockingComponent>(ent);
                 var otherDock = docking.DockedWith!.Value;
-                var cablesOther = GetDockCableNodes(otherDock).Where(p => TryComp<TransformComponent>(p.Owner, out var pXform) && pXform.Anchored);
+                var cablesOther = GetDockCableNodes(otherDock).Where(p => Transform(p.Owner).Anchored);
                 foreach (var other in cablesOther)
                 {
                     if (CanConnect(cableNode, other))

--- a/Content.Server/_Starlight/Railroading/HandlerSystem/RailroadingModifyIdCardHandlerSystem.cs
+++ b/Content.Server/_Starlight/Railroading/HandlerSystem/RailroadingModifyIdCardHandlerSystem.cs
@@ -13,7 +13,6 @@ public sealed partial class RailroadingModifyIdCardHandlerSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IdCardSystem _idCard = default!;
-    [Dependency] private readonly HandsSystem _hands = default!;
     [Dependency] private readonly AccessSystem _access = default!;
 
     public override void Initialize()

--- a/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingConsumeTaskSystem.cs
+++ b/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingConsumeTaskSystem.cs
@@ -17,13 +17,7 @@ namespace Content.Server._Starlight.Railroading;
 public sealed partial class RailroadingConsumeTaskSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _proto = default!;
-    [Dependency] private readonly IPlayerManager _players = default!;
-    [Dependency] private readonly IAdminManager _admins = default!;
-    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
-    [Dependency] private readonly EuiManager _euiManager = default!;
-    [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly RailroadingSystem _railroading = default!;
-    [Dependency] private readonly StarlightEntitySystem _entitySystem = default!;
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingDeliveryOpenTaskSystem.cs
+++ b/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingDeliveryOpenTaskSystem.cs
@@ -9,7 +9,6 @@ namespace Content.Server._Starlight.Railroading;
 
 public sealed partial class RailroadingDeliveryOpenTaskSystem : EntitySystem
 {
-    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly RailroadingSystem _railroading = default!;
 
     public override void Initialize()

--- a/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingMetabolizeTaskSystem.cs
+++ b/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingMetabolizeTaskSystem.cs
@@ -19,13 +19,7 @@ namespace Content.Server._Starlight.Railroading;
 public sealed partial class RailroadingMetabolizeTaskSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _proto = default!;
-    [Dependency] private readonly IPlayerManager _players = default!;
-    [Dependency] private readonly IAdminManager _admins = default!;
-    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
-    [Dependency] private readonly EuiManager _euiManager = default!;
-    [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly RailroadingSystem _railroading = default!;
-    [Dependency] private readonly StarlightEntitySystem _entitySystem = default!;
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingTimerTaskSystem.cs
+++ b/Content.Server/_Starlight/Railroading/TaskSystems/RailroadingTimerTaskSystem.cs
@@ -20,7 +20,6 @@ namespace Content.Server._Starlight.Railroading;
 
 public sealed partial class RailroadingTimerTaskSystem : AccUpdateEntitySystem
 {
-    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly RailroadingSystem _railroading = default!;
     public override void Initialize()

--- a/Content.Server/_Starlight/Speech/EntitySystems/ChavAccentSystem.cs
+++ b/Content.Server/_Starlight/Speech/EntitySystems/ChavAccentSystem.cs
@@ -8,8 +8,6 @@ namespace Content.Server.Speech.EntitySystems
 {
     public sealed class ChavAccentSystem : EntitySystem
     {
-        [Dependency] private readonly IRobustRandom _random = default!;
-
         // Regex for splitting on words:
         private static readonly Regex s_wordSplit = new(pattern: "([\\p{P}\\p{Z}])",
             options: RegexOptions.Compiled | RegexOptions.IgnoreCase);

--- a/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
+++ b/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Server.StationEvents.Components;
 
-[RegisterComponent, Access(typeof(WreckSwarmSystem)), AutoGenerateComponentPause]
+[RegisterComponent, Access(typeof(WreckSwarmSystem))]
 public sealed partial class WreckSwarmComponent : Component
 {
     [DataField]

--- a/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
+++ b/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
@@ -113,7 +113,7 @@ public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent>
         ForceEndSelf(uid, gameRule);
     }
 
-    protected ResPath SelectGrid(WreckSwarmComponent component) {
+    private ResPath SelectGrid(WreckSwarmComponent component) {
         if (component.FixedGrid is not null) {
             return (ResPath)component.FixedGrid;
         } else {
@@ -131,7 +131,7 @@ public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent>
         }
     }
 
-    protected void Announce(string announcement, SoundSpecifier? sound) {
+    private void Announce(string announcement, SoundSpecifier? sound) {
         // Let the players know (but we don't want to send to players who aren't in game (i.e. in the lobby))
         Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
 

--- a/Content.Server/_Starlight/Weapons/WeaponDismantleOnShootSystem.cs
+++ b/Content.Server/_Starlight/Weapons/WeaponDismantleOnShootSystem.cs
@@ -22,15 +22,8 @@ using Content.Shared.Damage.Systems;
 namespace Content.Server._Starlight.Weapon.Systems;
 public sealed partial class WeaponDismantleOnShootSystem : SharedWeaponDismantleOnShootSystem
 {
-    [Dependency] private readonly TagSystem _tagSystem = default!;
-    [Dependency] private readonly SharedGunSystem _gunSystem = default!;
-    [Dependency] private readonly ILogManager _log = default!;
-    [Dependency] protected readonly SharedTransformSystem _transformSystem = default!;
-    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly ThrowingSystem _throwing = default!;
-    [Dependency] private readonly InventorySystem _inventory = default!;
-    [Dependency] protected readonly DamageableSystem Damageable = default!;
+    [Dependency] private readonly DamageableSystem Damageable = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     public override void Initialize()


### PR DESCRIPTION
## Short description
These were mostly fairly rote; we had a lot of dependency locals that the compiler could see we weren't using, a couple of cases where we're not pulling TransformComponents how the RT folks would like, and other assorted small issues.

## Why we need to add this
Some day (probably not soon) upstream might build without warnings, and if we have too many warnings then, we'll look bad.

## Media (Video/Screenshots)
No in-game changes.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
