### PR TITLE
Fix translator working on an empty bettery

### DIFF
--- a/Content.Server/_Starlight/Language/TranslatorSystem.cs
+++ b/Content.Server/_Starlight/Language/TranslatorSystem.cs
@@ -142,8 +142,9 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
 
     private void OnPowerCellChanged(EntityUid translator, HandheldTranslatorComponent component, PowerCellChangedEvent args)
     {
-        component.Enabled = !args.Ejected;
-        _powerCell.SetDrawEnabled(translator, !args.Ejected);
+        var canEnable = !args.Ejected && _powerCell.HasDrawCharge(translator);
+        component.Enabled = canEnable;
+        _powerCell.SetDrawEnabled(translator, canEnable);
         OnAppearanceChange(translator, component);
 
         if (_containers.TryGetContainingContainer((translator, null, null), out var holderCont) && HasComp<LanguageSpeakerComponent>(holderCont.Owner))
@@ -152,8 +153,9 @@ public sealed class TranslatorSystem : SharedTranslatorSystem
 
     private void OnItemToggled(EntityUid translator, HandheldTranslatorComponent component, ItemToggledEvent args)
     {
-        component.Enabled = args.Activated;
-        _powerCell.SetDrawEnabled(translator, args.Activated);
+        var canEnable = args.Activated && _powerCell.HasDrawCharge(translator);
+        component.Enabled = canEnable;
+        _powerCell.SetDrawEnabled(translator, canEnable);
         OnAppearanceChange(translator, component);
 
         if (_containers.TryGetContainingContainer((translator, null, null), out var holderCont) && HasComp<LanguageSpeakerComponent>(holderCont.Owner))


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR aims to fix translators working on empty batteries, currently when you put an empty battery into a translator it will turn on automatically and keep working without taking any charge.

## Why we need to add this
Well, it is a bug.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Fixed translators working on empty batteries.
