### PR TITLE
Hands are now added to the UI in the correct order

### DIFF
--- a/Content.Client/UserInterface/Systems/Hands/HandsUIController.cs
+++ b/Content.Client/UserInterface/Systems/Hands/HandsUIController.cs
@@ -347,8 +347,12 @@ public sealed class HandsUIController : UIController, IOnStateEntered<GameplaySt
             if (hand.Location == HandLocation.Functional)
                 HandsGui.FunctionalHandContainer.AddButton(button);
             else
-            // 🌟Starlight🌟  end
+            {
+                var existingHands = HandsGui.HandContainer.ButtonCount;
                 HandsGui.HandContainer.AddButton(button);
+                button.SetPositionInParent(Math.Min((int)hand.Location, existingHands));
+            }
+            // 🌟Starlight🌟  end
         }
         else
         {


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes adding hands through surgery.

## Why we need to add this
I had already fixed the sorted hands list not actually ever being sorted, but as it turns out, that change only works *before* the UI is loaded - this change addresses adding a hand while the UI is already active.

## Media (Video/Screenshots)
<img width="605" height="79" alt="image" src="https://github.com/user-attachments/assets/6384fef1-8c4e-4be7-a4b5-0a86eaac03c8" />
<img width="805" height="88" alt="image" src="https://github.com/user-attachments/assets/018bc67a-74f6-45d2-9d4b-3468e6390923" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Fixed hands swapping order when surgically attaching a left hand before a right hand. Again.
