### PR TITLE
Upping the limit of Red Regalia in Fashionvend

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/fashion.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/VendingMachines/Inventories/fashion.yml
@@ -465,4 +465,4 @@
     - SLFashionOther
   conditions:
     - !type:ListingLimitedStockCondition
-      stock: 1
+      stock: 2


### PR DESCRIPTION
## Short description
Ups the limit of a fancy red outfit.

## Why we need to add this
Im doing yall a favor and preventing crimes from occurring over fashion. Im not kidding. This is requested by Azzy and Morrie. Yes, i know its a one line change. Yes, I think its hilarious.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: DocMoth
- tweak: upped limit of Red Regalia to 2
