### PR TITLE
Consent for no anesthetics on surgery consent form

### DIFF
--- a/Resources/Locale/en-US/_Starlight/paper/doc-printer.ftl
+++ b/Resources/Locale/en-US/_Starlight/paper/doc-printer.ftl
@@ -1041,6 +1041,8 @@ doc-text-printer-surgery-consent-permit =
 
    ⠀[check] I authorize the Medical Department to dispose of any tissues or organs removed from my body as they see fit, including possibly donating such tissues or organs to other patients.
 
+   ⠀[check] I consent to the operation proceeding without the use of anesthetics.
+
    ⠀ [italic]This form is not legal unless it has been signed by the patient and stamped by the station's Chief Medical Officer or one of the Chief Medical Officer's superiors. It is not required for life-saving surgeries. For punitive and non-elective surgeries, such as those ordered by Security, please file a Medical Intervention Order.[/italic]
 
     ────────────────────────────────────────


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds a new checkbox to the surgery consent form.

## Why we need to add this
Current options for anesthetics med has access to are universally just *bad*, and not suited for surgery. Many people therefore do consent to doing surgery without it... but then forget to add the required consent to the form (manually). To make this easier, faster, and all around less annoying for everyone involved, the option should just be on the form itself.

## Media (Video/Screenshots)
<img width="937" height="1048" alt="image" src="https://github.com/user-attachments/assets/7cc8da07-e4d5-4d8f-bc7b-80f54d93bd41" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- tweak: To more easily comply with SOP, surgery consent forms now come with a checkbox to refuse anesthetics, if such is desired.
