### PR TITLE
Middle hands no longer get resorted

### DIFF
--- a/Content.Client/UserInterface/Systems/Hands/HandsUIController.cs
+++ b/Content.Client/UserInterface/Systems/Hands/HandsUIController.cs
@@ -350,7 +350,8 @@ public sealed class HandsUIController : UIController, IOnStateEntered<GameplaySt
             {
                 var existingHands = HandsGui.HandContainer.ButtonCount;
                 HandsGui.HandContainer.AddButton(button);
-                button.SetPositionInParent(Math.Min((int)hand.Location, existingHands));
+                if (hand.Location != HandLocation.Middle) //Borg hand re-sorting fix again
+                    button.SetPositionInParent(Math.Min((int)hand.Location, existingHands));
             }
             // 🌟Starlight🌟  end
         }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Borg hands are no longer being re-sorted.

## Why we need to add this
Same issue as the original hand sorting fix; I once again forgot that borg hands are *middle* hands, rather than functional hands.

## Media (Video/Screenshots)
<img width="602" height="190" alt="image" src="https://github.com/user-attachments/assets/50f5e046-a608-4d69-ad6f-939f7d7972ef" />
No longer messed up!

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Borg hands are once again no longer being re-sorted.
