### PR TITLE
Fix borgi cubes sometimes not working

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/base_borgi_chassis.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/base_borgi_chassis.yml
@@ -2,7 +2,6 @@
   parent: [ MobCorgiSmart, BaseBorgiLanguages ]
   id: BaseBorgiChassis
   save: false
-  abstract: true
   components:
     - type: RandomMetadata
       nameSegments:
@@ -190,7 +189,6 @@
   name: Smart Borgi
   description: A unusually smart dog, loves stating it's laws.
   save: false
-  abstract: true
   components:
     - type: AccessReader
       access: [["Command"], ["Robotics"]]

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/base_borgi_chassis.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/base_borgi_chassis.yml
@@ -2,6 +2,7 @@
   parent: [ MobCorgiSmart, BaseBorgiLanguages ]
   id: BaseBorgiChassis
   save: false
+  abstract: true
   components:
     - type: RandomMetadata
       nameSegments:
@@ -189,6 +190,7 @@
   name: Smart Borgi
   description: A unusually smart dog, loves stating it's laws.
   save: false
+  abstract: true
   components:
     - type: AccessReader
       access: [["Command"], ["Robotics"]]

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/rehydrateable.yml
@@ -8,7 +8,6 @@
     possibleSpawns:
     - SmartSubwooferBorgiChassis
     - SubwooferBorgiChassis
-    - BaseStationBorgiChassis
     - StationBorgiChassis
     - MobCorgiSmart
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Occasionally during a round, when you add water to a borgi cube, nothing happens.  A workaround is to take a bite out of the cube and put more water in.
The reason this happens is because when a borgi cube is hydrated, it will spawn one of five prototypes randomly.  These are as follows:
    - SmartSubwooferBorgiChassis
    - SubwooferBorgiChassis
    - BaseStationBorgiChassis
    - StationBorgiChassis
    - MobCorgiSmart
To add context as to why there's so many protos for this, it's as follows:
Stationborgi and SubwooferBorgi are intended to only be able to speak Dog.  SmartSubwoofer is intended to be able to speak Galactic Common in addition to Dog.  MobCorgiSmart is just a smart corgi, but not a borgi - as a means of allowing failure in the creation process.
We included a BaseStationBorgiChassis in this list, which is abstract.  It's a base class, not intended to be spawned.

When it attempts to spawn BaseStationBorgiChassis, it throws an invalid prototype error since you're not meant to spawn abstract prototypes.  The fix was just to drop the BaseStationBorgiChassis from being spawned.
This brings us to a 25% chance to spawn a smart corgi instead of a 20% from the cube but that seems fine.

As an aside, the initial admeme version of borgis was intended to give two variants of borgi:  one that could play music, and then one that could not.  And between those two types, they were subdivided one level further into one that could speak languages, and one that could only speak with dog speech.  Somewhere along this process I think we lost the plot and now we just have a bunch of redundant protos that all speak galcom.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Not being able to moisturize 2/5 of your borgi cubes and throwing console errors is not good

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Sparlight
- fix: Fixed borgi cubes sometimes not hydrating.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
