### PR TITLE
Remove abstract MobOreCrab from the Gold extract table

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/xenobiology_tables.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/xenobiology_tables.yml
@@ -476,7 +476,6 @@
       - id: MobCarpDungeon
       - id: MobShark
       - id: MobCluwneBeast
-      - id: MobOreCrab
       - id: MobQuartzCrab
       - id: MobIronCrab
       - id: MobCoalCrab


### PR DESCRIPTION
## Short description
The gold extract can spawn a variety of creatures; unfortunately, MobOreCrabs are abstract, and thus lead to test failures if they're randomly selected as the spawn. I checked, and it's the only entry in this file that's one of the 1079 abstract prototypes.

## Why we need to add this
EntityTables shouldn't generally contain abstract entities

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
