### PR TITLE
[Hotfix] Our species should have a little more blood

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/abductor.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/abductor.yml
@@ -51,7 +51,7 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: AbductorBlood
-        Quantity: 1
+        Quantity: 300
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -130,7 +130,7 @@
       bloodReferenceSolution:
         reagents:
         - ReagentId: AvaliBlood
-          Quantity: 1
+          Quantity: 300
     - type: MeleeWeapon
       soundHit:
         path: /Audio/Weapons/pierce.ogg

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/cyclorites.yml
@@ -72,7 +72,7 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: CopperBlood
-        Quantity: 1
+        Quantity: 300
   - type: Vocal
     sounds:
       Male: MaleCyclorite

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/resomi.yml
@@ -39,7 +39,7 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: ResomiBlood
-        Quantity: 1
+        Quantity: 300
   - type: FireVisuals
     sprite: _Starlight/Mobs/Effects/onfire.rsi
     normalState: Resomi_minor_burning


### PR DESCRIPTION
## Short description
300 units is the standard for player species across the board upstream; as part of the recent refactors upstream to how bloodstreams are defined, our species got dropped down to 1 unit.

## Why we need to add this
It'll probably make vamps a bit anticlimactic otherwise.

## Media (Video/Screenshots)
<img width="699" height="362" alt="image" src="https://github.com/user-attachments/assets/54456ad1-beae-43b2-9cc3-e17f9ddd2869" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: I accidentally drained all but one unit of blood from abductors, cyclorites, avali, and resomi; turns out they need that.
