### PR TITLE
Added overwritten tags back to the botany cybertools

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Tools/cyberlimb.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Tools/cyberlimb.yml
@@ -759,6 +759,8 @@
     - type: Tag
       tags:
         - CyberHandItem
+        - BotanyHoe
+        - Hoe
 
 - type: entity
   name: plant clippers cybernetic arm attachment
@@ -772,6 +774,7 @@
     - type: Tag
       tags:
         - CyberHandItem
+        - PlantSampleTaker
 
 - type: entity
   name: scythe cybernetic arm attachment
@@ -798,6 +801,7 @@
     - type: Tag
       tags:
         - CyberHandItem
+        - BotanyHatchet
 
 - type: entity
   name: spade cybernetic arm attachment
@@ -811,6 +815,7 @@
     - type: Tag
       tags:
         - CyberHandItem
+        - BotanyShovel
 
 
 - type: entity


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes persephone arm tools

## Why we need to add this
Apparently I broke the already tested tools on the persephone arm when I added the cyberarm tool tag to them

## Media (Video/Screenshots)
<img width="415" height="268" alt="image" src="https://github.com/user-attachments/assets/c9396d99-7b0e-42a2-bd8b-38a607423270" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Persephone arm tools are now working as intended.
