### PR TITLE
Tweaks Beta's secret gamemode numbers + adds Xenoborgs to Beta's secret pool

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,4 +1,4 @@
-# Alpha's Secret Rotation
+# Starlight - Alpha's Secret Pool
 - type: weightedRandom
   id: Secret
   weights:
@@ -16,7 +16,7 @@
     ShitStation: 0.10 #SL
     Xenoborgs: 0.15 #SL
 
-# Beta's Secret Rotation
+# Starlight - Beta's Secret Pool
 - type: weightedRandom
   id: SecretLP
   weights:

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,3 +1,4 @@
+# Alpha's Secret Rotation
 - type: weightedRandom
   id: Secret
   weights:
@@ -15,17 +16,19 @@
     ShitStation: 0.10 #SL
     Xenoborgs: 0.15 #SL
 
+# Beta's Secret Rotation
 - type: weightedRandom
   id: SecretLP
   weights:
-    Nukeops: 0.028818444
-    Traitor: 0.461095101
-    Zombie: 0.005763689
-    Changeling: 0.057636888 #SL
-    Zombieteors: 0.005763689
-    Survival: 0.057636888
-    KesslerSyndrome: 0.028818444
-    Revolutionary: 0.057636888
-    #Vampire: 0.115273775 #SL
-    Extended: 0.152737752
-    Wizard: 0.028818444
+    Nukeops: 0.05
+    Traitor: 0.45
+    Zombie: 0.05
+    Changeling: 0.05
+    Zombieteors: 0.01
+    Survival: 0.05
+    KesslerSyndrome: 0.01
+    Revolutionary: 0.05
+    #Vampire: 0.10
+    Extended: 0.15
+    Wizard: 0.03
+    Xenoborgs: 0.10


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- I didn't know how `SecretLP` worked, I though there was some magic number somewhere that determined what 'low pop' was
- There's no magic number. The Secret CVAR is just set to `SecretLP` for Beta.
- I added comments to the `secret_weights.yml` file so that this is obvious for future PRs

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Xenoborgs was added to Alpha's Secret pool a while ago in #2598 but because we didn't really understand how it worked, it didn't get added to Beta's secret pool. A bad assumption was made by me and others that `SecretLP` got automagically picked when the player count is below some number of players. It doesn't!

```csharp
    public static readonly CVarDef<string> SecretWeightPrototype =
        CVarDef.Create("game.secret_weight_prototype", "Secret", CVar.SERVERONLY);
```

This CVAR is set to `SecretLP` for Beta.

```csharp
    public static readonly CVarDef<string> SecretWeightPrototype =
        CVarDef.Create("game.secret_weight_prototype", "SecretLP", CVar.SERVERONLY);
```

Silly misunderstanding, whoops.

I put the Xenoborgs number a little higher ($10\\%$) because they're new and novel. This number can get bumped down to 5% when people get tired of them.

For the logic behind the numbers:
- Traitor or Extended still rolls $60\\%$ of the time
- "PvP modes" (Nukeops, Zombies, Revolutionaries, Xenoborgs) roll $25\\%$ of the time.
- The other $15\\%$ is the Misc. modes (Survival, Changelings, Zomieteors, Kessler, Wizard)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- add: Added Xenoborgs to Beta's Secret rotation (secret enjoyers rejoice)
- tweak: Tweaked Beta's Secret gamemode values to be round numbers, some gamemode odds tweaked