### PR TITLE
Revert "Raising playtime required for antags and some jobs, small nukie buff, no more lings in revs or nukeops"

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/syndiedrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/syndiedrobe.yml
@@ -15,8 +15,6 @@
     ClothingNeckScarfStripedSyndieGreen: 2
     ClothingNeckScarfStripedSyndieRed: 2
     ClothingShoesBootsWinterSyndicate: 2
-    ClothingBackpackSyndicate: 4 #SL edit
-    ClothingBackpackDuffelSyndicate: 4 #SL edit
   contrabandInventory:
     ToyFigurineFootsoldier: 1
     ToyFigurineNukieElite: 1

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -88,18 +88,16 @@
     price: 3000
 
 - type: entity
-  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband, ClothingShoesMilitaryBase] #Starlight edit
+  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband]
   id: ClothingShoesBootsMagSyndie
   name: blood-red magboots
-  description: Reverse-engineered from ERT magboots, they have a heavy magnetic pull, integrated thrusters and are designed for combat. It can hold 0.75 L of gas.
+  description: Reverse-engineered from ERT magboots, they have a heavy magnetic pull and integrated thrusters. It can hold 0.75 L of gas.
   components:
   - type: Sprite
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
     state: icon
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
-  - type: ClothingSlowOnDamageModifier #Starlight edit
-    modifier: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/Roles/Antags/changeling.yml
@@ -8,6 +8,6 @@
   guides: [ Changelings ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 24h
+    time: 3h
   playTimeTracker: AntagChangeling
   # Starlight end

--- a/Resources/Prototypes/Roles/Antags/dragon.yml
+++ b/Resources/Prototypes/Roles/Antags/dragon.yml
@@ -8,7 +8,5 @@
   - !type:RoleTimeRequirement
     role: JobSalvageSpecialist
     time: 3h
-  - !type:OverallPlaytimeRequirement
-    time: 24h
   playTimeTracker: AntagDragon
   # Starlight end

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -10,9 +10,7 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Security
-    time: 9h
-  - !type:OverallPlaytimeRequirement
-    time: 48h
+    time: 3h
   playTimeTracker: AntagNinja
   # Starlight end
 

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -6,13 +6,10 @@
   objective: roles-antag-nuclear-operative-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72h # Starlight
-  - !type:RoleTimeRequirement #Starlight - former time allowed you to literally play 6 hours of cadet and get nukie
-    role: JobSecurityOfficer
-    time: 15h
-  - !type:DepartmentTimeRequirement #Starlight - at the very least please know basic med
-    department: Medical
-    time: 10h
+    time: 24h # Starlight
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 6h # Starlight
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateOperativeGearFull
   playTimeTracker: AntagNukeops # Starlight
@@ -25,16 +22,16 @@
   objective: roles-antag-nuclear-operative-agent-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72h # Starlight
+    time: 24h # Starlight
   - !type:RoleTimeRequirement
     role: JobChemist
-    time: 18h # Starlight - chem knowledge is vital, and since you are a solo chemist, tasked with remembering every chem mix you need, this is a fair time.
+    time: 6h # Starlight
   - !type:RoleTimeRequirement
     role: JobSurgeon
     time: 3h # Starlight
-  - !type:RoleTimeRequirement #Starlight
-    role: JobSecurityOfficer
-    time: 15h
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 3h # Starlight
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateOperativeMedicFull
   playTimeTracker: AntagNukeopsMedic # Starlight
@@ -47,16 +44,13 @@
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 96h # Starlight
-  - !type:RoleTimeRequirement #Starlight
-    role: JobSecurityOfficer
-    time: 25h
+    time: 24h # Starlight
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 12h # Starlight
   - !type:DepartmentTimeRequirement
     department: Command
-    time: 12h # Starlight
-  - !type:DepartmentTimeRequirement #Starlight
-    department: Medical
-    time: 10h
+    time: 6h # Starlight
   # should be changed to nukie playtime when thats tracked (wyci)
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateCommanderGearFull

--- a/Resources/Prototypes/Roles/Antags/paradoxClone.yml
+++ b/Resources/Prototypes/Roles/Antags/paradoxClone.yml
@@ -7,7 +7,7 @@
   # Starlight start
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 48h # this antag is hard to change times for since its absolute random
+    time: 24h
   playTimeTracker: AntagParadoxClone
   # Starlight end
 

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -5,18 +5,16 @@
   setPreference: true
   objective: roles-antag-rev-head-objective
   guides: [ Revolutionaries ]
-  # Starlight-start
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72h
-  - !type:RoleTimeRequirement
-    role: JobSecurityOfficer
-    time: 9h
+    time: 24h # Starlight
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 6h # Starlight
   - !type:DepartmentTimeRequirement
     department: Command
-    time: 12h
-  playTimeTracker: AntagHeadRev
-  # Starlight-end
+    time: 6h # Starlight
+  playTimeTracker: AntagHeadRev # Starlight
 
 - type: antag
   id: Rev

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -5,12 +5,10 @@
   setPreference: true
   objective: roles-antag-thief-objective
   guides: [ Thieves ]
-  # Starlight-start
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 12h
-  playTimeTracker: AntagThief
-  # Starlight-end
+    time: 3h # Starlight
+  playTimeTracker: AntagThief # Starlight
 
 - type: startingGear
   id: ThiefGear

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -5,12 +5,10 @@
   setPreference: true
   objective: roles-antag-syndicate-agent-objective
   guides: [ Traitors ]
-  # Starlight-start
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 24h # Starlight
-  playTimeTracker: AntagTraitor
-  # Starlight-end
+    time: 3h # Starlight
+  playTimeTracker: AntagTraitor # Starlight
 
 - type: antag
   id: TraitorSleeper
@@ -19,12 +17,10 @@
   setPreference: true
   objective: roles-antag-syndicate-agent-sleeper-objective
   guides: [ Traitors ]
-  # Starlight-start
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 24h
-  playTimeTracker: AntagTraitor
-  # Starlight-end
+    time: 3h # Starlight
+  playTimeTracker: AntagTraitor # Starlight
 
 # Syndicate Operative Outfit - Monkey
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -14,7 +14,7 @@
   objective: roles-antag-wizard-objective # TODO: maybe give random objs and stationary ones from AntagObjectives and AntagRandomObjectives
   requirements: # I hate time locked roles but this should be enough time for someone to be acclimated
   - !type:OverallPlaytimeRequirement
-    time: 48h # Starlight
+    time: 24h # Starlight
   - !type:DepartmentTimeRequirement
     department: Security
     time: 6h # Starlight

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -5,15 +5,10 @@
   setPreference: true
   objective: roles-antag-initial-infected-objective
   guides: [ Zombies ]
-  # Starlight-start
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 24h
-  - !type:DepartmentTimeRequirement
-    department: Medical
-    time: 10h
-  playTimeTracker: AntagInitialInfected
-  # Starlight-end
+    time: 3h # Starlight
+  playTimeTracker: AntagInitialInfected # Starlight
 
 - type: antag
   id: Zombie

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -12,7 +12,7 @@
       time: 5h # Starlight
     - !type:DepartmentTimeRequirement
       department: Cargo
-      time: 30h # Starlight
+      time: 20h # Starlight
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -6,9 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Cargo
-      time: 10h #Starlight
-    - !type:OverallPlaytimeRequirement #Starlight
-      time: 16h
+      time: 2.5h
   icon: "JobIconSalvageSpec" # Starlight - New distinct icon
   startingGear: SalvageSpecialistGear
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
@@ -5,13 +5,13 @@
   playTimeTracker: JobCBURN
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72h #Starlight
+    time: 72000 # 20h
   - !type:RoleTimeRequirement
     role: JobMedicalDoctor
-    time: 10h #Starlight
+    time: 18000 # 5h
   - !type:RoleTimeRequirement
     role: JobSecurityOfficer
-    time: 10h #Starlight
+    time: 18000 # 5h
   setPreference: false
   startingGear: CBURNGear
   icon: "JobIconCentComm"

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -6,16 +6,13 @@
   playTimeTracker: JobERTLeader
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 96h
+    time: 72000 # 20h
   - !type:DepartmentTimeRequirement
     department: CentralCommand
-    time: 10h
+    time: 36000 # 10h
   - !type:DepartmentTimeRequirement
     department: Command
-    time: 20h #Starlight
-  - !type:RoleTimeRequirement
-    role: JobSecurityOfficer
-    time: 25h #Starlight, if theyre not an admin, they NEED to be good in combat (this prolly isnt even needed with CC hours)
+    time: 36000 # 10h
   setPreference: false
   startingGear: ERTLeaderGearEVA
   icon: "JobIconCentComm"
@@ -122,10 +119,10 @@
   playTimeTracker: JobERTChaplain
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72h #Starlight
+    time: 72000 # 20h
   - !type:RoleTimeRequirement
     role: JobChaplain
-    time: 5h
+    time: 18000 # 5h
   setPreference: false
   startingGear: ERTChaplainGear
   icon: "JobIconCentComm"
@@ -222,10 +219,10 @@
   playTimeTracker: JobERTEngineer
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72h #Starlight
+    time: 72000 # 20h
   - !type:RoleTimeRequirement
     role: JobStationEngineer
-    time: 10h #Starlight
+    time: 18000 # 5h
   setPreference: false
   startingGear: ERTEngineerGearEVA
   icon: "JobIconCentComm"
@@ -311,10 +308,10 @@
   playTimeTracker: JobERTSecurity
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72h #Starlight
+    time: 72000 # 20h
   - !type:RoleTimeRequirement
     role: JobSecurityOfficer
-    time: 15h #Starlight, your whole job here is fighting and following orders.
+    time: 18000 # 5h
   setPreference: false
   startingGear: ERTEngineerGearEVA
   icon: "JobIconCentComm"
@@ -418,16 +415,13 @@
   playTimeTracker: JobERTMedical
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72h #Starlight
+    time: 72000 # 20h
   - !type:RoleTimeRequirement
     role: JobMedicalDoctor
-    time: 10h #Starlight
+    time: 18000 # 5h
   - !type:RoleTimeRequirement
     role: JobChemist
-    time: 10h #Starlight
-  - !type:RoleTimeRequirement
-    role: JobSecurityOfficer
-    time: 10h #Starlight, youre a medic but you WILL be fighting at some point
+    time: 18000 # 5h
   setPreference: false
   startingGear: ERTMedicalGearEVA
   icon: "JobIconCentComm"
@@ -505,10 +499,10 @@
   playTimeTracker: JobERTJanitor
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72h #Starlight
+    time: 72000 # 20h
   - !type:RoleTimeRequirement
     role: JobJanitor
-    time: 5h
+    time: 18000 # 5h
   setPreference: false
   startingGear: ERTJanitorGearEVA
   icon: "JobIconCentComm"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -7,7 +7,7 @@
     # Starlight - we've changed basically this whole block to be service instead of captain-lite
     - !type:DepartmentTimeRequirement
       department: Civilian
-      time: 30h #Starlight
+      time: 20h
     - !type:RoleTimeRequirement
       role: JobBotanist
       time: 3h

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -12,7 +12,7 @@
       time: 7h # Starlight
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 30h # Starlight
+      time: 20h # Starlight
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -4,9 +4,9 @@
   description: job-description-chemist
   playTimeTracker: JobChemist
   requirements:
-    - !type:RoleTimeRequirement
-      role: JobMedicalDoctor
-      time: 7h # Starlight
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 5h
   startingGear: ChemistGear
   icon: "JobIconChemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -14,7 +14,7 @@
       time: 7h # Starlight
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 30h # Starlight
+      time: 20h # Starlight
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -4,9 +4,9 @@
   description: job-description-paramedic
   playTimeTracker: JobParamedic
   requirements:
-    - !type:RoleTimeRequirement
-      role: JobMedicalDoctor
-      time: 7h # Starlight
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 2.5h
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -12,7 +12,7 @@
     time: 5h # Starlight
   - !type:DepartmentTimeRequirement
     department: Science
-    time: 30h # Starlight
+    time: 20h # Starlight
 
   weight: 10
   startingGear: ResearchDirectorGear

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -6,7 +6,7 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobSecurityOfficer
-    time: 15h # Starlight
+    time: 10h # Starlight
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -6,16 +6,16 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobWarden
-      time: 10h # Starlight
+      time: 5h # Starlight
     - !type:RoleTimeRequirement
       role: JobDetective
-      time: 10h # knowing how to use the tools is important # Starlight
+      time: 5h # knowing how to use the tools is important # Starlight
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 25h
+      time: 5h
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 60h # Starlight - Literally the most pressured role in the game, you need extensive knowledge of your department
+      time: 20h # Starlight
 
   weight: 10
   startingGear: HoSGear

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -6,13 +6,10 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 25h # Starlight
+      time: 20h # Starlight
     - !type:RoleTimeRequirement
       role: JobDetective # Starlight
-      time: 5h
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 45h # Starlight - 2nd in command to HoS, and you usually do their job for them
+      time: 1h # Starlight
   weight: 5
   startingGear: WardenGear
   icon: "JobIconWarden"

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
@@ -6,7 +6,9 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Cargo
-    time: 10h #parity with salv
+    time: 10800 # 3 hrs
+  - !type:OverallPlaytimeRequirement
+    time: 36000 #10 hrs
   icon: "JobIconShaftMiner"
   startingGear: MiningSpecialistGear
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
@@ -6,13 +6,10 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 60h #you are the sole bodyguard of the highest ranking people on the station, you have to be good.
+      time: 72000 # 20 hrs
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 30h
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 15h #you need to know how to treat people as this role its necessary
+      time: 72000 # 20 hrs
     - !type:RolesRequirement
       proto: ExtRolesReq
   startingGear: BlueShieldGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 40h #parity with magi, git gud at command before you boss em around
+      time: 72000 # 20 hrs
     - !type:RolesRequirement
       proto: ExtRolesReq
   startingGear: NanoTrasenRepresentativeGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
@@ -6,13 +6,10 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 10h
-    - !type:RoleTimeRequirement
-      role: JobChemist
-      time: 10h #yes, chem knowledge is necessary
+      time: 36000 # 10 hrs
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 20h #less of a secoff more of a medic
+      time: 28800 # 8 hrs
   startingGear: BrigmedicGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -191,7 +191,7 @@
   rules:
   - Nukeops
   # - DummyNonAntagChance 🌟Starlight🌟
-  - SubGamemodesRuleNoChangelings #Starlight, Lings suck on both nukie and crew side here as well
+  - SubGamemodesRule
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -210,7 +210,7 @@
   rules:
   # - DummyNonAntagChance 🌟Starlight🌟
   - Revolutionary
-  - SubGamemodesRuleNoChangelings #Starlight, Lings are rev supersoldiers and noone wants to fight em, they suck for both sides
+  - SubGamemodesRule
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,14 +2,14 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.05
+    Nukeops: 0.03
     Traitor: 0.40
     Zombie: 0.05
     Changeling: 0.10 #SL
     Zombieteors: 0.01
     Survival: 0.05
     KesslerSyndrome: 0.01
-    Revolutionary: 0.05 #SL lowering because holy hell its just as rough as nukies now
+    Revolutionary: 0.10
     #Vampire: 0.15 #SL
     Wizard: 0.10
     Traitorling: 0.10 #SL


### PR DESCRIPTION
Reverts ss14Starlight/space-station-14#2664

Done due to hindsight and sudden community outburst. this does NOT mean we are not raising role timers. This revert is in place so once the other merge blockers of delta are finished, we can push to live without this still being in the code. expect a future pr with different numbers

:cl: Happyrobot33
- tweak: Revert role timer changes for now pending additional changes