### PR TITLE
Xenoborgs minPlayers decreased from 40 readied players to 20 readied players

### DIFF
--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -117,7 +117,7 @@
   - type: XenoborgsRule
   - type: RuleGrids
   - type: GameRule
-    minPlayers: 40
+    minPlayers: 20
   - type: LoadMapRule
     gridPath: /Maps/Shuttles/mothership.yml
   - type: AntagMultipleRoleSpawner

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -117,7 +117,7 @@
   - type: XenoborgsRule
   - type: RuleGrids
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 20 # Starlight
   - type: LoadMapRule
     gridPath: /Maps/Shuttles/mothership.yml
   - type: AntagMultipleRoleSpawner


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Decreases the required number of **readied** players for Xenoborgs from 40 down to 20.
- This is the same as gamemodes as Nukeops and Zombies
- This is still higher than stuff like Revolutionaries, which needs 15 readied players

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Beta never has 40 people all readied up at the same time, even at peak hours. This requirement is just straight up impossible to meet for an antagonist gamemode.

The whole `minPlayers` parameter is kinda misleading. It really just does check for readied players, not "how many players are connected to the server" or anything like that.
```csharp
if (gameRule.CancelPresetOnTooFewPlayers)
{
    ChatManager.SendAdminAnnouncement(Loc.GetString("preset-not-enough-ready-players",
        ("readyPlayersCount", args.Players.Length),
        ("minimumPlayers", minPlayers),
        ("presetName", name)));
    args.Cancel();
    //TODO remove this once announcements are logged
    Log.Info($"Rule '{name}' requires {minPlayers} players, but only {args.Players.Length} are ready.");
}
else
{
    ForceEndSelf(uid, gameRule);
}
```
`Content.Server\GameTicking\Rules\GameRuleSystem.cs`
If there's ~20 players readied up on Beta, it means that the server's playercount is usually around 30-40+, which is fine for Xenoborgs.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- tweak: Xenoborgs now only needs 20 minimum readied players to start instead of 40 (same as Nukeops, Zombies)
