### PR TITLE
Add All Starlight Accesses to the Turret Control Panel

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
@@ -126,6 +126,18 @@
     - Security
     - Service
     - Theatre
+    # Starlight start
+    - BlueShield
+    - Brigmedic
+    - Cadet 
+    - Magistrate
+    - Mining
+    - Ntrep
+    - Paramedic
+    - Robotics
+    - SalvageLead 
+    - Surgery
+    # Starlight end
   - type: DeviceList
     isAllowList: true
   - type: DeviceNetwork


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds all Starlight-specific accesses to the turret control panel.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It's meant to have all accesses on it. Also, this allows Security to stop the armory turret from shooting cadets all the time.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Brigmedic and Cadet access in the menu:
<img width="267" height="290" alt="image" src="https://github.com/user-attachments/assets/f6cc24fd-3938-4339-8adc-0c1ed568d113" />
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CommanderAlex365
- add: Added all Starlight specific accesses to the turret control panel.