### PR TITLE
Fix avali 0g movement + vulp cleanup

### DIFF
--- a/Resources/Prototypes/_StarLight/Body/Parts/vulpkanin.yml
+++ b/Resources/Prototypes/_StarLight/Body/Parts/vulpkanin.yml
@@ -91,7 +91,6 @@
       sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
       state: "l_leg"
     - type: MovementBodyPart
-      walkSpeed : 2.7
       sprintSpeed : 4.5
 
 - type: entity
@@ -103,7 +102,6 @@
       sprite: _Starlight/Mobs/Species/Vulpkanin/parts.rsi
       state: "r_leg"
     - type: MovementBodyPart
-      walkSpeed : 2.7
       sprintSpeed : 4.5
 
 - type: entity

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -133,9 +133,9 @@
         Female: FemaleAvali
         Unsexed: MaleAvali
     - type: MovementSpeedModifier
-      weightlessAcceleration: 1.6 # Avalis are specifically built to fly in low-g environments
-      weightlessFriction: 1
-      weightlessModifier: 1
+      baseWeightlessAcceleration: 1.6 # Avalis are specifically built to fly in low-g environments
+      baseWeightlessFriction: 1
+      baseWeightlessModifier: 1
     - type: Damageable
       damageContainer: Biological
       damageModifierSet: Avali


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR fixes the value that seemingly has never worked, because of incorrect yaml value used.
As well as removes change that is never documented for vulpkanins, which i assume was a mistake in merge.

## Why we need to add this
The Avali fix is a bug, they were intended to have this from the beginning, but used a wrong value.
The Vulpkanin change is a cleanup, it seems that it was left after possibly an upstream change, it returns the walk speed to default value. since i don't think it was ever mentioned as a species trait

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- tweak: Changed Vulpkanin walking speed.
- fix: Fixed Avali 0g movement.
