### PR TITLE
Happy honk meal rerehonked

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -520,8 +520,20 @@
     - BoxCardboard
   - type: EntityTableContainerFill
     containers:
-      storagebase: !type:NestedSelector
-        tableId: HappyHonkToySafeEntityTable
+      # Starlight-start
+      storagebase: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: HappyHonkToySafeEntityTable
+        - !type:NestedSelector
+          tableId: HappyHonkDrinkEntityTable
+        - !type:NestedSelector
+          tableId: HappyHonkBurgerEntityTable
+        - !type:NestedSelector
+          tableId: HappyHonkDonkEntityTable
+        - !type:NestedSelector
+          tableId: HappyHonkSidesEntityTable
+      # Starlight-end
 
 - type: entity
   id: HappyHonkMime
@@ -693,7 +705,7 @@
         id: MaterialCloth10
 
 - type: entityTable
-  id: HappyHonkToySafeEntityTable
+  id: HappyHonkToySafeEntityTable # size: 2x2-1
   table: !type:GroupSelector
     children:
     - id: ToyMouse
@@ -707,7 +719,7 @@
     - id: FoamBlade
     - id: ClothingHeadHatBunny
     - id: PersonalAI
-    - id: CrayonBox
+    - id: CrayonMagic # Starlight-edit
     - id: ToySword
     - id: RevolverCapGun
     - id: ToyRubberDuck

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -1,0 +1,89 @@
+# Used for the HappyHonk fill.
+- type: entityTable
+  id: HappyHonkDrinkEntityTable # size: 1x2
+  table: !type:GroupSelector
+    children:
+    - id: DrinkColaCan
+    - id: DrinkIcedTeaCan
+    - id: DrinkLemonLimeCan
+    - id: DrinkLemonLimeCranberryCan
+    - id: DrinkGrapeCan
+    - id: DrinkRootBeerCan
+    - id: DrinkSodaWaterCan
+    - id: DrinkSpaceMountainWindCan
+    - id: DrinkSpaceUpCan
+    - id: DrinkSolDryCan
+    - id: DrinkStarkistCan
+    - id: DrinkTonicWaterCan
+    - id: DrinkFourteenLokoCan
+    - id: DrinkDrGibbCan
+    - id: DrinkNukieCan
+      weight: 0.1
+    - id: DrinkEnergyDrinkCan
+    - id: DrinkPwrGameCan
+
+- type: entityTable
+  id: HappyHonkBurgerEntityTable # size: 1x2
+  table: !type:GroupSelector
+    children:
+    - id: FoodBurgerJelly
+    - id: FoodBurgerBacon
+    - id: FoodBurgerBaseball
+    - id: FoodBurgerBear
+    - id: FoodBurgerBig
+    - id: FoodBurgerCheese
+    - id: FoodBurgerChicken
+    - id: FoodBurgerClown
+    - id: FoodBurgerCrab
+    - id: FoodBurgerCarp
+    - id: FoodBurgerFive
+    - id: FoodBurgerMcguffin
+    - id: FoodBurgerMcrib
+    - id: FoodBurgerPlain
+    - id: FoodBurgerRat
+    - id: FoodBurgerSoy
+    - id: FoodBurgerSuper
+    - id: FoodBurgerMime
+
+- type: entityTable
+  id: HappyHonkDonkEntityTable # size: 1x1
+  table: !type:GroupSelector
+    children:
+    - id: FoodDonkpocket
+    - id: FoodDonkpocketDank
+    - id: FoodDonkpocketSpicy
+    - id: FoodDonkpocketTeriyaki
+    - id: FoodDonkpocketPizza
+    - id: FoodDonkpocketHonk
+    - id: FoodDonkpocketBerry
+    - id: FoodDonkpocketStonk
+    - id: FoodDonkpocketCarp
+    - id: FoodDonkpocketDink
+    - id: FoodDonkpocketMoth
+
+- type: entityTable
+  id: HappyHonkSidesEntityTable # size: 2x2-1
+  table: !type:GroupSelector
+    children:
+    - id: FoodCakeCheeseSlice
+    - id: FoodCakeOrangeSlice
+    - id: FoodCakeChocolateSlice
+    - id: FoodCakeBirthdaySlice
+    - id: FoodCakeSuppermatterSlice
+    - id: FoodCakeCottonSlice
+    - id: FoodCakeBerryDelightSlice
+    - id: FoodDonutPink
+    - id: FoodDonutChocolate
+    - id: FoodBakedMuffinBerry
+    - id: FoodBakedCookie
+    - id: FoodBakedCannoli
+    - id: FoodBakedBrownie
+    - id: FoodBakedCroissant
+    - id: FoodFrozenSundae
+    - id: FoodFrozenCornuto
+    - id: CigPackBlue
+    - id: CigPackSyndicate
+      weight: 0.1
+    - id: CigPackMixed
+    - id: CigPackRollie
+    - id: CigPackMedRollie


### PR DESCRIPTION
## Short description
Readded the meal part of #1483, verified that it fills properly with the largest items.

## Why we need to add this
Seems to have been accidentally removed with the conversion to EntityTableContainerFill.
Added a size comment to HappyHonkToySafeEntityTable since the one that will be added from upstream won't be accurate.

## Media (Video/Screenshots)

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: SnappingOpossum
- add: Redone happy honk meals are back, containing a toy, drink, burger, donk pocket, and side once more.
- tweak: Crayon boxes in current and future happy honk meals have been replaced with magic crayons.
