### PR TITLE
Add labeler sanitization with tag whitelist, fix another cmdlink exploit

### DIFF
--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Numerics;
 using System.Threading;
 using Content.Client.Verbs;
+using Content.Shared._Starlight.Utility;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Input;
@@ -238,8 +239,9 @@ namespace Content.Client.Examine
 
             if (knowTarget)
             {
-                var itemName = FormattedMessage.EscapeText(Identity.Name(target, EntityManager, player));
-                var labelMessage = FormattedMessage.FromMarkupPermissive($"[bold]{itemName}[/bold]");
+                var itemName = Identity.Name(target, EntityManager, player); // Starlight: Do not blanket escape.
+                var labelMessage = FormattedMessage.FromMarkupPermissive($"[bold]{itemName}[/bold]")
+                        .SanitizeWhitelist(FormattedMessageSanitizer.ItemLabelTags); // Starlight: Instead, sanitize to permitted tags.
                 var label = new RichTextLabel();
                 label.SetMessage(labelMessage);
                 hBox.AddChild(label);

--- a/Content.Shared/Labels/EntitySystems/LabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/LabelSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared._Starlight.Utility;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Examine;
 using Content.Shared.Labels.Components;
@@ -54,7 +55,11 @@ public sealed partial class LabelSystem : EntitySystem
     {
         label ??= EnsureComp<LabelComponent>(uid);
 
-        label.CurrentLabel = text == null ? null : FormattedMessage.EscapeText(text);
+        label.CurrentLabel = text == null // STARLIGHT: Don't blanket escape, instead sanitize using whitelist.
+            ? null
+            : FormattedMessage.FromMarkupPermissive(text)
+                .SanitizeWhitelist(FormattedMessageSanitizer.ItemLabelTags)
+                .ToMarkup();
         _nameModifier.RefreshNameModifiers(uid);
 
         Dirty(uid, label);
@@ -68,9 +73,10 @@ public sealed partial class LabelSystem : EntitySystem
         if (ent.Comp.CurrentLabel == null)
             return;
 
-        var message = new FormattedMessage();
-        message.AddText(Loc.GetString("hand-labeler-has-label", ("label", ent.Comp.CurrentLabel)));
-        args.PushMessage(message);
+        // STARLIGHT: Remove all markup for the examine text.
+        var text = Loc.GetString("hand-labeler-has-label", ("label", ent.Comp.CurrentLabel));
+        var message = FormattedMessage.FromMarkupPermissive(text).ToString();
+        args.PushMarkup(message);
     }
 
     private void OnRefreshNameModifiers(Entity<LabelComponent> entity, ref RefreshNameModifiersEvent args)
@@ -116,7 +122,9 @@ public sealed partial class LabelSystem : EntitySystem
 
             args.PushMarkup(Loc.GetString("comp-paper-label-has-label"));
             var text = paper.Content;
-            args.PushMarkup(text.TrimEnd());
+            // STARLIGHT: Remove all markup for the examine text.
+            var message = FormattedMessage.FromMarkupPermissive(text.TrimEnd()).ToString();
+            args.PushMarkup(message);
         }
     }
 

--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Starlight.Utility;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Examine;
@@ -8,6 +9,7 @@ using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 using Robust.Shared.Network;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Labels.EntitySystems;
 
@@ -152,6 +154,8 @@ public abstract class SharedHandLabelerSystem : EntitySystem
         var text = ent.Comp.AssignedLabel == string.Empty
             ? Loc.GetString("hand-labeler-examine-blank")
             : Loc.GetString("hand-labeler-examine-label-text", ("label-text", ent.Comp.AssignedLabel));
-        args.PushMarkup(text);
+        // STARLIGHT: Remove all markup for the examine text.
+        var message = FormattedMessage.FromMarkupPermissive(text).ToString();
+        args.PushMarkup(message);
     }
 }

--- a/Content.Shared/_Starlight/Utility/FormattedMessageSanitizer.cs
+++ b/Content.Shared/_Starlight/Utility/FormattedMessageSanitizer.cs
@@ -1,0 +1,45 @@
+﻿using System.Linq;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._Starlight.Utility;
+
+/**
+ * Extension methods for <see cref="FormattedMessage"/>s centered around sanitization.
+ */
+public static class FormattedMessageSanitizer
+{
+    /**
+     * Simple tags that are safe to use for item labels. No interactive tags, size changes (head tag) or images.
+     */
+    public static string[] ItemLabelTags = new[] { "color", "bold", "bolditalic", "italic", "mono" };
+
+    /// <summary>
+    /// Sanitize the given message using a whitelist, allowing only explicitly permitted tags and/or raw text. 
+    /// </summary>
+    /// <param name="message">The message to sanitize</param>
+    /// <param name="permittedTagTypes">The tag names that are permitted</param>
+    /// <param name="permitText">If raw text is permitted</param>
+    /// <returns>A new <see cref="FormattedMessage"/> without the nodes that failed to pass the filter.</returns>
+    public static FormattedMessage SanitizeWhitelist(this FormattedMessage message, string[] permittedTagTypes,
+        bool permitText = true)
+    {
+        FormattedMessage sanitized = new();
+        foreach (var node in message.Nodes)
+        {
+            // If text tag and it's permitted
+            if (node.Name == null && permitText)
+            {
+                sanitized.PushTag(node);
+                continue;
+            }
+
+            // If non-text tag and it's whitelisted
+            if (node.Name != null && permittedTagTypes.Contains(node.Name))
+                sanitized.PushTag(node);
+
+            // The rest is removed.
+        }
+
+        return sanitized;
+    }
+}


### PR DESCRIPTION

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

User-friendly TL;DR:
- **Important** patch to prevent players from being able to craft paperwork links that close your game
- Allows colored chem labels again yaaaay (and not much beyond that)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

- Closing other peoples games bad (or horrible if its an admin since it allows literally any console command, including toolshed stuff)
- Colored labels good

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->


### Unpatched paperwork label

https://github.com/user-attachments/assets/8bfac8b1-9068-4a78-bd88-53cbef9d38f5

### Patched paperwork label

https://github.com/user-attachments/assets/89fe12d0-5d30-4113-a14f-42d8d3c0fdfe

### Sanitized labeler

https://github.com/user-attachments/assets/fdfae63c-bb13-4355-b881-9ecead0c8b7f


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: Patched paperwork labels on items being able to execute console commands
- add: Labelers now support basic markup again (color, bold, italic)
