### PR TITLE
Tune down maintenance monsters for lowpop

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/entity_tables.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/entity_tables.yml
@@ -68,9 +68,11 @@
       - id: MobSpiderSpace
       - id: MobCobraSpace
       - id: MobBearSpace
-      - id: MobBearSoviet
       - id: MobGoliath
       - id: MobCarp
+      conditions:
+      - !type:PlayerCountCondition
+        min: 35
     # reagent slimes
     - !type:GroupSelector
       children:
@@ -79,13 +81,13 @@
       #- id: ReagentSlimeNocturne # Disabled this one because it's a lot of a syndie chem
       - id: ReagentSlimeTHC
       - id: ReagentSlimeBicaridine
-      - id: ReagentSlimeToxin
-      - id: ReagentSlimeNapalm
       - id: ReagentSlimeOmnizine
-      - id: ReagentSlimeMuteToxin
       - id: ReagentSlimeNorepinephricAcid
       - id: ReagentSlimeEphedrine
       - id: ReagentSlimeRobustHarvest
+      conditions:
+      - !type:PlayerCountCondition
+        min: 35
     # xenos
     - !type:GroupSelector
       children:
@@ -97,3 +99,17 @@
       - id: MobXenoRunner
       - id: MobXenoRouny
       - id: MobXenoSpitter
+      conditions:
+      - !type:PlayerCountCondition
+        min: 35
+    # high threat
+    - !type:GroupSelector
+      weight: 0.3 # On stations with enough players for these to show up, we still don't want too many of them
+      children:
+      - id: MobBearSoviet # Too high-tier to have roundstart in maints on lower pop
+      - id: ReagentSlimeToxin # This will likely three-shot you
+      - id: ReagentSlimeNapalm # Has wiped a security department
+      - id: ReagentSlimeMuteToxin # Silence effects are strong
+      conditions:
+      - !type:PlayerCountCondition
+        min: 70


### PR DESCRIPTION
## Short description
 This change cuts off the more threatening monsters under 35 population, and removes a few of the biggest potential problem monsters outright.

## Why we need to add this
On some lowpop forks the number and power of monsters was way overtuned, and lead to unfun situations and wiped stations.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- add: We're once again doing some sweeping of your maintenance tunnels, but only if we're sending a light crew; if you're well-staffed enough, you need to handle it yourselves.