### PR TITLE
Make patch packs also labeled upon creating patches in ChemMaster

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -264,6 +264,8 @@ namespace Content.Server.Chemistry.EntitySystems
             var needed = message.Dosage * message.Number;
             if (!WithdrawFromBeaker(chemMaster, needed, user, out var withdrawal)) // Starlight-edit
                 return;
+            
+            _labelSystem.Label(container, message.Label);
 
             for (var i = 0; i < message.Number; i++)
             {


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

Creating patches in a ChemMaster left the patch pack unlabeled, while the created patches all had labels. This makes it impossible to tell what a patch pack contains without opening it.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

- Makes it possible to tell what a patch box contains by examining (assuming the label isn't a lie, hehe).
- Much easier on the player in high tension scenarios (e.g. combat).
- Matches the behavior the player expects since it's identical to how pill canisters get labeled.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/e2ece3e0-3c2c-451b-811f-94c020df83de


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Patch packs now also get labeled when creating patches in a ChemMaster
