### PR TITLE
Fix chemmaster pill/patch create buttons being enabled at the same time

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -357,11 +357,13 @@ namespace Content.Client.Chemistry.UI
             var rowCount = 0;
 
             // Handle entities if they are not null
-            var entities = info.PillEntities ?? info.PatchEntities; // Starlight edit
+            // Starlight-start
+            var entities = info.PillEntities ?? info.PatchEntities;
             if (entities != null)
             {
                 foreach (var (id, quantity) in entities.Select(x => (x.Id, x.Quantity)))
                 {
+                    // Starlight-end
                     control.Children.Add(BuildReagentRow(default(Color), rowCount++, id, default(ReagentId), quantity, false, addReagentButtons));
                 }
             }

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -163,8 +163,8 @@ namespace Content.Client.Chemistry.UI
             InputEjectButton.Disabled = castState.InputContainerInfo is null;
             OutputEjectButton.Disabled = castState.OutputContainerInfo is null;
             CreateBottleButton.Disabled = castState.OutputContainerInfo?.Reagents == null;
-            CreatePillButton.Disabled = castState.OutputContainerInfo?.Entities == null;
-            CreatePatchButton.Disabled = castState.OutputContainerInfo?.Entities == null; // Starlight-edit
+            CreatePillButton.Disabled = castState.OutputContainerInfo?.PillEntities == null; // Starlight-edit
+            CreatePatchButton.Disabled = castState.OutputContainerInfo?.PatchEntities == null; // Starlight-edit
             
             UpdateDosageFields(castState);
         }
@@ -357,9 +357,10 @@ namespace Content.Client.Chemistry.UI
             var rowCount = 0;
 
             // Handle entities if they are not null
-            if (info.Entities != null)
+            var entities = info.PillEntities ?? info.PatchEntities; // Starlight edit
+            if (entities != null)
             {
-                foreach (var (id, quantity) in info.Entities.Select(x => (x.Id, x.Quantity)))
+                foreach (var (id, quantity) in entities.Select(x => (x.Id, x.Quantity)))
                 {
                     control.Children.Add(BuildReagentRow(default(Color), rowCount++, id, default(ReagentId), quantity, false, addReagentButtons));
                 }

--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -391,7 +391,7 @@ namespace Content.Server.Chemistry.EntitySystems
                 return null;
             
             //Starlight-start
-            var pills = storage.Container.ContainedEntities.Select((Func<EntityUid, (string, FixedPoint2 quantity)>) (pill =>
+            var items = storage.Container.ContainedEntities.Select((Func<EntityUid, (string, FixedPoint2 quantity)>) (pill =>
             {
                 if (_solutionContainerSystem.TryGetSolution(pill, SharedChemMaster.PillSolutionName, out _, out var solution))
                 {
@@ -412,13 +412,13 @@ namespace Content.Server.Chemistry.EntitySystems
             {
                 return new ContainerInfo(name, _storageSystem.GetCumulativeItemAreas((container.Value, storage)) / 2, storage.Grid.GetArea() / 2)
                 {
-                    Entities = pills
+                    PatchEntities = items
                 };
             }
 
             return new ContainerInfo(name, _storageSystem.GetCumulativeItemAreas((container.Value, storage)), storage.Grid.GetArea())
             {
-                Entities = pills
+                PillEntities = items
             };
             //Starlight-end
         }

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -166,9 +166,16 @@ namespace Content.Shared.Chemistry
         public readonly FixedPoint2 MaxVolume;
 
         /// <summary>
-        /// A list of the entities and their sizes within the container
+        /// A list of the pill entities and their sizes within the container
+        /// STARLIGHT: Edited to only be pills and not both pills and patches.
         /// </summary>
-        public List<(string Id, FixedPoint2 Quantity)>? Entities { get; init; }
+        public List<(string Id, FixedPoint2 Quantity)>? PillEntities { get; init; }
+        
+        /// <summary>
+        /// A list of the patch entities and their sizes within the container
+        /// STARLIGHT: Added specifically for patches
+        /// </summary>
+        public List<(string Id, FixedPoint2 Quantity)>? PatchEntities { get; init; }
 
         public List<ReagentQuantity>? Reagents { get; init; }
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

Fixes the chemmaster pill/patch "Create" buttons both being enabled for both container types.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

You can currently press Create on Patches when you have a pill canister inserted, causing the patches to spawn on top of the ChemMaster. This is not only very confusing and annoying but patches also cannot currently be ground up to regain the reagents. Same applies in reverse minus the grinding part.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Before

https://github.com/user-attachments/assets/97fa9a17-bc57-4510-a8bb-77896132c3aa

### After

https://github.com/user-attachments/assets/159003e0-bfad-4ba9-9853-86919ae0056e

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: The ChemMaster will now only allow you to produce the correct item for the inserted container (pills for pill bottles, etc)

