### PR TITLE
Make patches grindable to recover their reagents

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/bandaid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/bandaid.yml
@@ -18,6 +18,8 @@
   - type: Tag
     tags:
       - Patch
+  - type: Extractable
+    grindableSolutionName: patch
       
 - type: entity
   id: Patch


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

I racked up quite a lot of chem hours recently and it annoyed me to no end that making a mistake in the chem mix prior to creating a patch was basically unrecoverable.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

No more losing all your reagents in patches if you make a mistake or change your mind on the mix.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/4ba54dcf-30ca-4d7f-a5b3-58a0980b2978


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Patches can now be grinded to recover their reagents
