### PR TITLE
Fix shadekin guidebook resistance info

### DIFF
--- a/Resources/ServerInfo/_StarLight/Guidebook/Mobs/Shadekin.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Mobs/Shadekin.xml
@@ -12,8 +12,8 @@
 
   ## Racial Features
 
-  - Receive [color=#ffa500]20% more heat damage[/color] and [color=#1e90ff]25% less cold damage[/color] and [color=#1e90ff]85% less cellular damage[/color].
-  - Receive [color=#ffa500]25% more bloodloss damage[/color] and [color=#ffa500]30% more radiation damage[/color] and [color=#ffa500]25% more shock damage[/color].
+  - Receive [color=#ffa500]20% more heat damage[/color], [color=#1e90ff]25% less cold damage[/color], and [color=#1e90ff]75% less cellular damage[/color].
+  - Receive [color=#ffa500]170% more bloodloss damage[/color] (and [color=#ffa500]heal bloodloss damage 75% slower[/color]), [color=#ffa500]30% more radiation damage[/color], and [color=#ffa500]25% more shock damage[/color].
   - They do not breathe and thus require no air.
   - Flashes stun time are doubled.
   - Deal [color=red]5[/color] slashing damage with claws.


### PR DESCRIPTION
## Short description
The shadekin guidebook currently overstates the cellular resistance by 10% and vastly underestimates the bloodloss damage.

## Why we need to add this
The guidebook being accurate helps guide player understanding.

## Media (Video/Screenshots)
<img width="563" height="669" alt="image" src="https://github.com/user-attachments/assets/bece997a-5aa4-46f5-9b9f-2fe41dc98e97" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Turns out that we were issuing wildly incorrect guidebooks on Shadekin; an updated edition should now be available for crews.
