### PR TITLE
Set the new death implants to have mental activation

### DIFF
--- a/Resources/Prototypes/_StarLight/Actions/implant.yml
+++ b/Resources/Prototypes/_StarLight/Actions/implant.yml
@@ -16,7 +16,7 @@
         state: gorilla_rampage
 
 - type: entity
-  parent: BaseImplantAction
+  parent: [BaseMentalAction, BaseImplantAction]
   id: ActionActivateBluespaceImplant
   name: An advanced subdermal implant that, when activated, teleports the user far away.
   description: An advanced subdermal implant that, when activated, teleports the user far away.
@@ -34,7 +34,7 @@
       state: bluespace_implant
 
 - type: entity
-  parent: BaseImplantAction
+  parent: [BaseMentalAction, BaseImplantAction]
   id: ActionActivateRedspaceImplant
   name: An advanced subdermal implant that, when activated, teleports the user far away.
   description: An advanced subdermal implant that, when activated, teleports the user far away.
@@ -53,7 +53,7 @@
 
 # Gear Acidifier
 - type: entity
-  parent: BaseImplantAction
+  parent: [BaseMentalAction, BaseImplantAction]
   id: ActionActivateGearAcidifier
   name: Activate Gear-Acidifier
   description: Activates your gear-acidifier, melting your equipment but leaving your body intact


### PR DESCRIPTION
Right now these implants can't be activated when crit, which loses a lot of the utility compared to the old acidifier implants.

## Short description
This makes the bluespace, redspace, and gear acidifier implant activations mental actions, allowing them to be used while crit.

## Why we need to add this
Right now these implants can't be activated when crit, which loses a lot of the utility compared to the old acidifier implants.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Fixed ability to use the new gear denial implants while crit.

