### PR TITLE
Space Mall Update 2

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
+++ b/Resources/Prototypes/_StarLight/Maps/Pools/default.yml
@@ -26,4 +26,5 @@
   - StarlightBox
   - StarlightPlasma
   - StarlightPacked
+  - StarlightSpaceMall
 # - StarlightBarratry

--- a/Resources/Prototypes/_StarLight/Maps/spacemall.yml
+++ b/Resources/Prototypes/_StarLight/Maps/spacemall.yml
@@ -52,6 +52,7 @@
             Detective: [ 1, 2 ]
             SecurityCadet: [ 4, 4 ]
             Brigmedic: [ 1, 2 ]
+            DutyOfficer: [ 1, 2]
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 4 ]
@@ -74,3 +75,4 @@
             #Representives
             BlueShield: [ 1, 1 ]
             NanoTrasenRepresentative: [ 1, 1 ]
+            NanotrasenCareerTrainer: [ 1, 2 ]


### PR DESCRIPTION
## Short description
Fixes the handful of issues found during Space Mall's playtest and adds it to the map pool officially. Also added NanoTRasen Career Trainer and Duty Officer to the map.

## Why we need to add this
Update, map to pool, new job slots.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added Space Mall to the map pool officially. It will now appear in normal rounds from 60-350 pop.
- add: (Space Mall) Added Duty Officer and NanoTrasen Career Trainers to the station.
- fix: (Space Mall) Fixed missing tiles under a couple doors.
- fix: (Space Mall) Fixed 1 incorrect turnstile in Genpop letting prisoners enter the Security Front Desk.
- fix: (Space Mall) Fixed Disposals linking and the pipe no longer throws trash into the wall so hard it bounces off the belt.
- fix: (Space Mall) Swapped the Syndicate Jetpacks in EVA with normal ones- those are HoP's but you wouldn't tell the police on them right? You aren't a Narc right Nerevarine?
- fix: (Space Mall) Gave janitors 300% more bucket. Dear god.