### PR TITLE
(Starboard) New roles + Mapping catch-up

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/starboard.yml
+++ b/Resources/Prototypes/_StarLight/Maps/starboard.yml
@@ -47,6 +47,7 @@
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 2, 2 ]
+            DutyOfficer: [ 2, 2 ]
             Detective: [ 1, 1 ]
             SecurityOfficer: [ 6, 10 ]
             SecurityCadet: [ 4, 6 ]
@@ -74,3 +75,4 @@
             #Representives
             BlueShield: [ 1, 1 ]
             NanoTrasenRepresentative: [ 1, 1 ]
+            NanotrasenCareerTrainer: [ 1, 2 ]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Major stuff:
- Enables Duty Officers
- Enables Nanotraven Career Trainers
- Renovated the 'Command Receptionist' area into an NCT office

Plus mapping catch up (see below)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- [x] Supports #2697
- [x] Supports #2854
- [x] Supports #2855
- [x] Supports #2864
- [x] Supports #2871
- [x] Supports #2878
- [x] Supports #2879

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="979" height="588" alt="image" src="https://github.com/user-attachments/assets/4529d171-a857-46ab-aea6-2ea8f72587c5" />

fig. 1 - Duty Officers mapped

<img width="534" height="492" alt="image" src="https://github.com/user-attachments/assets/b765d7fd-a366-4cda-b736-964f4278aa52" />

fig. 2 - Nanotrasen Career Trainers mapped + new office

<img width="1257" height="971" alt="image" src="https://github.com/user-attachments/assets/4b846040-d731-4186-a0f0-3c0e9cb7a593" />

fig. 3 - Wall mounted mass scanners by Cago (near bottom of image and right side of image)

<img width="495" height="576" alt="image" src="https://github.com/user-attachments/assets/c71b2226-5ac6-4d78-b20d-8a01c4d92efc" />
<img width="501" height="639" alt="image" src="https://github.com/user-attachments/assets/5ac659b7-ad68-45ce-b254-baa0ccdb6db2" />
<img width="822" height="675" alt="image" src="https://github.com/user-attachments/assets/1fdf2877-0091-4f49-a3d3-3b9c2a66d127" />

fig. 4 - IAA & Magistrate lockers

<img width="892" height="640" alt="image" src="https://github.com/user-attachments/assets/c8c1caac-a4aa-4d34-aacf-1ddd4e9da91f" />

fig. 5 - `SpawnPointLateJoin` by arrivals

<img width="844" height="753" alt="image" src="https://github.com/user-attachments/assets/6e587558-24b9-4195-81fa-191e168341b3" />
<img width="679" height="682" alt="image" src="https://github.com/user-attachments/assets/842a8998-0c9a-448a-8b6f-4a25f136b168" />

fig. 6 - AI Restoration Consoles

<img width="743" height="454" alt="image" src="https://github.com/user-attachments/assets/8179d6cb-91fa-4151-92e7-bb4086968e7f" />

fig. 7 - HOS weapon spawner


## Checks
<!-- check boxes for faster reviewing of your PR -->
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- add: (Starboard) Enabled Duty Officers
- add: (Starboard) Enabled Nanotrasen Career Trainers (NCT)
- add: (Starboard) Replaced the 'Command Receptionist' area with a new NCT office
- add: (Starboard) New wall-mounted mass scanners by Cargo
- add: (Starboard) Magistrate Locker
- add: (Starboard) IAA Lockers
- add: (Starboard) SpawnPointLateJoin by Arrivals
- add: (Starboard) AI Restoration Consoles in RD Office and AI Core
- tweak: (Starboard) Replaced HOS WT550 with the 'HOS weapon spawner' (no gameplay difference, just mapping stuff)
- fix: (Starboard) Fixed the mirrors in the bathroom being the wrong way around