### PR TITLE
(Starboard) Removes 2nd Warden job slot

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/starboard.yml
+++ b/Resources/Prototypes/_StarLight/Maps/starboard.yml
@@ -46,8 +46,8 @@
             Roboticist: [ 2, 3 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
-            Warden: [ 2, 2 ]
-            DutyOfficer: [ 2, 2 ]
+            Warden: [ 1, 1 ]
+            DutyOfficer: [ 2, 3 ]
             Detective: [ 1, 1 ]
             SecurityOfficer: [ 6, 10 ]
             SecurityCadet: [ 4, 6 ]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes the 2nd Warden job slot

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The idea of "multiple wardens" was tested on some maps (notably Starboard and Manor), but it's no longer needed with the introduction of Duty Officers.

I enabled 1 more latejoin Duty Officer spawn for Starboard since it's one of our largest maps (2 roundstart, 3 total)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- tweak: (Starboard) Removed 2nd Warden (replaced by Duty Officer slots)
