### PR TITLE
Fland Update (Xenobio Ruins, IAA/Magi lockers, NCT, speakers, etc)

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/fland.yml
+++ b/Resources/Prototypes/_StarLight/Maps/fland.yml
@@ -54,6 +54,7 @@
             Detective: [ 2, 2 ]
             SecurityCadet: [ 4, 4 ]
             Brigmedic: [ 1, 1 ]
+            DutyOfficer: [ 1, 2]
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 5, 5 ]
@@ -75,3 +76,4 @@
             #Representives
             BlueShield: [ 1, 1 ]
             NanoTrasenRepresentative: [ 1, 1 ]
+            NanotrasenCareerTrainer: [ 1, 2 ]


### PR DESCRIPTION

## Short description
Adds all the new stuff to Fland. Xenobio ruins, NCT, duty officer, magi/iaa lockers ,etc

## Why we need to add this
Upkeep

## Media (Video/Screenshots)
<img width="786" height="808" alt="image" src="https://github.com/user-attachments/assets/b799fac8-1f52-409b-b57e-23913b4a0254" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: (Fland) Added Xenobio ruins, NCT, Duty Officer, IAA/Magistrate lockers, Speakers, etc

