### PR TITLE
Kiloton update (xenobio ruins, IAA/Magi lockers, speakers, duty officer, nct, etc)

### DIFF
--- a/Resources/Prototypes/_StarLight/Maps/kiloton.yml
+++ b/Resources/Prototypes/_StarLight/Maps/kiloton.yml
@@ -53,6 +53,7 @@
             Detective: [ 1, 1 ]
             SecurityCadet: [ 4, 4 ]
             Brigmedic: [ 2, 2 ]
+            DutyOfficer: [ 1, 2]
             #supply
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 3, 4 ]
@@ -75,3 +76,4 @@
             #Representives
             BlueShield: [ 1, 1 ]
             NanoTrasenRepresentative: [ 1, 1 ]
+            NanotrasenCareerTrainer: [ 1, 2 ]


### PR DESCRIPTION

## Short description
adds everything from the newest update to kiloton

## Why we need to add this
upkeep

## Media (Video/Screenshots)
<img width="601" height="801" alt="image" src="https://github.com/user-attachments/assets/04691143-7fa1-4afe-a2bd-d91452901ca4" />


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: (Kiloton) Added Xenobio ruins, speakers, IAA/Magistrate lockers, speakers, NCT, Duty Officer, etc
