### PR TITLE
Silica - Disposals trash actually lands on the belt

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Silica.yml
+++ b/Resources/Maps/_Starlight/Stations/Silica.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 267.1.0
+  engineVersion: 268.0.0
   forkId: ""
   forkVersion: ""
-  time: 12/15/2025 05:56:08
-  entityCount: 25895
+  time: 01/21/2026 03:38:52
+  entityCount: 25896
 maps:
 - 1
 grids:
@@ -9458,6 +9458,7 @@ entities:
     - type: BecomesStation
       id: StarlightSilica
     - type: NavMap
+    - type: ExplosionAirtightGrid
 - proto: AcousticGuitarInstrument
   entities:
   - uid: 3
@@ -12965,7 +12966,7 @@ entities:
       pos: -29.5,-12.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -125402.336
+      secondsUntilStateChange: -125605.64
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -12977,7 +12978,7 @@ entities:
       pos: 30.5,-28.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -125408.836
+      secondsUntilStateChange: -125612.14
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -12989,7 +12990,7 @@ entities:
       pos: 30.5,-24.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -125409.53
+      secondsUntilStateChange: -125612.836
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -14140,7 +14141,7 @@ entities:
       pos: 36.5,0.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -217105.64
+      secondsUntilStateChange: -217308.95
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -26566,8 +26567,6 @@ entities:
     - type: Transform
       pos: -38.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: BaseChemistryEmptyVial
   entities:
   - uid: 2696
@@ -69072,8 +69071,8 @@ entities:
     - type: Transform
       parent: 6
     - type: Clothing
-      inSlotFlag: BACK
       inSlot: back
+      inSlotFlag: BACK
     - type: Physics
       canCollide: False
 - proto: ClothingBackpackSatchelLeather
@@ -69083,8 +69082,8 @@ entities:
     - type: Transform
       parent: 10899
     - type: Clothing
-      inSlotFlag: BACK
       inSlot: back
+      inSlotFlag: BACK
     - type: Physics
       canCollide: False
   - uid: 10904
@@ -69092,8 +69091,8 @@ entities:
     - type: Transform
       parent: 10903
     - type: Clothing
-      inSlotFlag: BACK
       inSlot: back
+      inSlotFlag: BACK
     - type: Physics
       canCollide: False
 - proto: ClothingBeltUtilityFilled
@@ -69120,8 +69119,8 @@ entities:
     - type: Transform
       parent: 10911
     - type: Clothing
-      inSlotFlag: EYES
       inSlot: eyes
+      inSlotFlag: EYES
     - type: Physics
       canCollide: False
 - proto: ClothingHandsGlovesColorYellow
@@ -69152,8 +69151,8 @@ entities:
     - type: Transform
       parent: 10918
     - type: Clothing
-      inSlotFlag: HEAD
       inSlot: head
+      inSlotFlag: HEAD
     - type: Physics
       canCollide: False
 - proto: ClothingHeadHatCone
@@ -69273,8 +69272,8 @@ entities:
     - type: Transform
       parent: 6
     - type: Clothing
-      inSlotFlag: HEAD
       inSlot: head
+      inSlotFlag: HEAD
     - type: Physics
       canCollide: False
 - proto: ClothingHeadHatWelding
@@ -69306,9 +69305,9 @@ entities:
     - type: Transform
       parent: 10903
     - type: Clothing
-      inSlotFlag: HEAD
-      inSlot: head
       equippedPrefix: up
+      inSlot: head
+      inSlotFlag: HEAD
     - type: Item
       heldPrefix: up
     - type: ItemToggle
@@ -69327,8 +69326,8 @@ entities:
     - type: Transform
       parent: 10947
     - type: Clothing
-      inSlotFlag: HEAD
       inSlot: head
+      inSlotFlag: HEAD
     - type: Physics
       canCollide: False
 - proto: ClothingHeadHelmetEVALarge
@@ -69376,8 +69375,8 @@ entities:
     - type: Transform
       parent: 10961
     - type: Clothing
-      inSlotFlag: HEAD
       inSlot: head
+      inSlotFlag: HEAD
     - type: Physics
       canCollide: False
 - proto: ClothingMaskBreath
@@ -69445,8 +69444,8 @@ entities:
     - type: Transform
       parent: 10973
     - type: Clothing
-      inSlotFlag: MASK
       inSlot: mask
+      inSlotFlag: MASK
     - type: Physics
       canCollide: False
 - proto: ClothingMaskMime
@@ -69516,8 +69515,8 @@ entities:
     - type: Transform
       parent: 10973
     - type: Clothing
-      inSlotFlag: NECK
       inSlot: neck
+      inSlotFlag: NECK
     - type: Physics
       canCollide: False
 - proto: ClothingNeckScarfStripedBlue
@@ -69570,8 +69569,8 @@ entities:
     - type: Transform
       parent: 10911
     - type: Clothing
-      inSlotFlag: OUTERCLOTHING
       inSlot: outerClothing
+      inSlotFlag: OUTERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingOuterFlannelGreen
@@ -69581,8 +69580,8 @@ entities:
     - type: Transform
       parent: 10973
     - type: Clothing
-      inSlotFlag: OUTERCLOTHING
       inSlot: outerClothing
+      inSlotFlag: OUTERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingOuterHardsuitEVAPrisoner
@@ -69615,8 +69614,8 @@ entities:
     - type: Transform
       parent: 10903
     - type: Clothing
-      inSlotFlag: OUTERCLOTHING
       inSlot: outerClothing
+      inSlotFlag: OUTERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingOuterVestTank
@@ -69626,8 +69625,8 @@ entities:
     - type: Transform
       parent: 6
     - type: Clothing
-      inSlotFlag: OUTERCLOTHING
       inSlot: outerClothing
+      inSlotFlag: OUTERCLOTHING
     - type: Physics
       canCollide: False
   - uid: 10968
@@ -69656,8 +69655,8 @@ entities:
     - type: Transform
       parent: 10993
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
   - uid: 10996
@@ -69665,8 +69664,8 @@ entities:
     - type: Transform
       parent: 10995
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
   - uid: 10998
@@ -69674,8 +69673,8 @@ entities:
     - type: Transform
       parent: 10997
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
   - uid: 11000
@@ -69683,8 +69682,8 @@ entities:
     - type: Transform
       parent: 10999
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
   - uid: 11001
@@ -69889,8 +69888,8 @@ entities:
     - type: Transform
       parent: 10947
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingUniformJumpskirtMaid
@@ -69907,8 +69906,8 @@ entities:
     - type: Transform
       parent: 10961
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingUniformJumpskirtPrisoner
@@ -69940,8 +69939,8 @@ entities:
     - type: Transform
       parent: 10899
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingUniformJumpskirtScientistFormal
@@ -69981,8 +69980,8 @@ entities:
     - type: Transform
       parent: 10918
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingUniformJumpsuitAerostatic
@@ -70059,8 +70058,8 @@ entities:
     - type: Transform
       parent: 10911
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingUniformJumpsuitDetective
@@ -70070,8 +70069,8 @@ entities:
     - type: Transform
       parent: 10973
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingUniformJumpsuitEngineeringHazard
@@ -70081,8 +70080,8 @@ entities:
     - type: Transform
       parent: 10903
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingUniformJumpsuitFlannel
@@ -70092,8 +70091,8 @@ entities:
     - type: Transform
       parent: 6
     - type: Clothing
-      inSlotFlag: INNERCLOTHING
       inSlot: jumpsuit
+      inSlotFlag: INNERCLOTHING
     - type: Physics
       canCollide: False
 - proto: ClothingUniformJumpsuitFormalBlueShield
@@ -80506,8 +80505,8 @@ entities:
     - type: GasTank
       toggleActionEntity: 8
     - type: Clothing
-      inSlotFlag: SUITSTORAGE
       inSlot: suitstorage
+      inSlotFlag: SUITSTORAGE
     - type: Physics
       canCollide: False
   - uid: 12799
@@ -87464,8 +87463,8 @@ entities:
     - type: Transform
       parent: 10899
     - type: Clothing
-      inSlotFlag: HEAD
       inSlot: head
+      inSlotFlag: HEAD
     - type: Physics
       canCollide: False
 - proto: GasFilter
@@ -122417,22 +122416,16 @@ entities:
     - type: Transform
       pos: 47.5,18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 18375
     components:
     - type: Transform
       pos: 51.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 18376
     components:
     - type: Transform
       pos: 23.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: InflatableWall
   entities:
   - uid: 18377
@@ -122440,15 +122433,11 @@ entities:
     - type: Transform
       pos: 47.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 18378
     components:
     - type: Transform
       pos: 50.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: IngotGold
   entities:
   - uid: 18379
@@ -127392,44 +127381,32 @@ entities:
     - type: Transform
       pos: 36.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 18953
     components:
     - type: Transform
       pos: -24.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 18954
     components:
     - type: Transform
       pos: 33.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 18955
     components:
     - type: Transform
       pos: 37.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 18956
     components:
     - type: Transform
       pos: 34.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 18957
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: PlasmaTankFilled
   entities:
   - uid: 18958
@@ -127499,8 +127476,6 @@ entities:
     - type: Transform
       pos: 35.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: PlasmaWindowDirectional
   entities:
   - uid: 18971
@@ -127509,24 +127484,18 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 18972
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 18973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: PlasticFlapsAirtightClear
   entities:
   - uid: 18974
@@ -135848,162 +135817,116 @@ entities:
     - type: Transform
       pos: 57.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20409
     components:
     - type: Transform
       pos: 59.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20410
     components:
     - type: Transform
       pos: 58.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20411
     components:
     - type: Transform
       pos: 58.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20412
     components:
     - type: Transform
       pos: 3.5,51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20413
     components:
     - type: Transform
       pos: 25.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20414
     components:
     - type: Transform
       pos: 23.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20415
     components:
     - type: Transform
       pos: -3.5,51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20416
     components:
     - type: Transform
       pos: -1.5,51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20417
     components:
     - type: Transform
       pos: 59.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20418
     components:
     - type: Transform
       pos: 46.5,47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20419
     components:
     - type: Transform
       pos: 48.5,47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20420
     components:
     - type: Transform
       pos: 50.5,47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20421
     components:
     - type: Transform
       pos: 52.5,47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20422
     components:
     - type: Transform
       pos: 54.5,47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20423
     components:
     - type: Transform
       pos: 56.5,47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20424
     components:
     - type: Transform
       pos: 57.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20425
     components:
     - type: Transform
       pos: 58.5,47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20426
     components:
     - type: Transform
       pos: 5.5,51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20427
     components:
     - type: Transform
       pos: -0.5,49.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20428
     components:
     - type: Transform
       pos: -0.5,50.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20429
     components:
     - type: Transform
       pos: 2.5,50.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20430
     components:
     - type: Transform
       pos: 2.5,49.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ReinforcedWindow
   entities:
   - uid: 20431
@@ -136011,2717 +135934,1941 @@ entities:
     - type: Transform
       pos: -20.5,-51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20432
     components:
     - type: Transform
       pos: -21.5,-51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20433
     components:
     - type: Transform
       pos: -22.5,-51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20434
     components:
     - type: Transform
       pos: -9.5,-51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20435
     components:
     - type: Transform
       pos: -10.5,-51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20436
     components:
     - type: Transform
       pos: -11.5,-51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20437
     components:
     - type: Transform
       pos: -36.5,30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20438
     components:
     - type: Transform
       pos: 30.5,-25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20439
     components:
     - type: Transform
       pos: 47.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20440
     components:
     - type: Transform
       pos: 47.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20441
     components:
     - type: Transform
       pos: 60.5,29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20442
     components:
     - type: Transform
       pos: 60.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20443
     components:
     - type: Transform
       pos: -47.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20444
     components:
     - type: Transform
       pos: 20.5,61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20445
     components:
     - type: Transform
       pos: -49.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20446
     components:
     - type: Transform
       pos: 20.5,58.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20447
     components:
     - type: Transform
       pos: 9.5,51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20448
     components:
     - type: Transform
       pos: -50.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20449
     components:
     - type: Transform
       pos: 34.5,-21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20450
     components:
     - type: Transform
       pos: -26.5,28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20451
     components:
     - type: Transform
       pos: -3.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20452
     components:
     - type: Transform
       pos: 42.5,-21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20453
     components:
     - type: Transform
       pos: -29.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20454
     components:
     - type: Transform
       pos: -29.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20455
     components:
     - type: Transform
       pos: 40.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20456
     components:
     - type: Transform
       pos: -9.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20457
     components:
     - type: Transform
       pos: -10.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20458
     components:
     - type: Transform
       pos: -10.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20459
     components:
     - type: Transform
       pos: -11.5,-35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20460
     components:
     - type: Transform
       pos: -11.5,-36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20461
     components:
     - type: Transform
       pos: 32.5,-21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20462
     components:
     - type: Transform
       pos: -52.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20463
     components:
     - type: Transform
       pos: -53.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20464
     components:
     - type: Transform
       pos: 18.5,-61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20465
     components:
     - type: Transform
       pos: -44.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20466
     components:
     - type: Transform
       pos: -47.5,25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20467
     components:
     - type: Transform
       pos: 9.5,49.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20468
     components:
     - type: Transform
       pos: 55.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20469
     components:
     - type: Transform
       pos: -33.5,42.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20470
     components:
     - type: Transform
       pos: 4.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20471
     components:
     - type: Transform
       pos: -2.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20472
     components:
     - type: Transform
       pos: -24.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20473
     components:
     - type: Transform
       pos: -24.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20474
     components:
     - type: Transform
       pos: -23.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20475
     components:
     - type: Transform
       pos: -25.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20476
     components:
     - type: Transform
       pos: -8.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20477
     components:
     - type: Transform
       pos: -25.5,-30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20478
     components:
     - type: Transform
       pos: -6.5,-30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20479
     components:
     - type: Transform
       pos: -21.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20480
     components:
     - type: Transform
       pos: -17.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20481
     components:
     - type: Transform
       pos: -19.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20482
     components:
     - type: Transform
       pos: -20.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20483
     components:
     - type: Transform
       pos: -18.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20484
     components:
     - type: Transform
       pos: -22.5,-23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20485
     components:
     - type: Transform
       pos: -22.5,-21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20486
     components:
     - type: Transform
       pos: -6.5,-28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20487
     components:
     - type: Transform
       pos: -21.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20488
     components:
     - type: Transform
       pos: -19.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20489
     components:
     - type: Transform
       pos: -18.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20490
     components:
     - type: Transform
       pos: -22.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20491
     components:
     - type: Transform
       pos: -3.5,-28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20492
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20493
     components:
     - type: Transform
       pos: -19.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20494
     components:
     - type: Transform
       pos: -19.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20495
     components:
     - type: Transform
       pos: -19.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20496
     components:
     - type: Transform
       pos: -22.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20497
     components:
     - type: Transform
       pos: 12.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20498
     components:
     - type: Transform
       pos: 15.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20499
     components:
     - type: Transform
       pos: 19.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20500
     components:
     - type: Transform
       pos: 17.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20501
     components:
     - type: Transform
       pos: 16.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20502
     components:
     - type: Transform
       pos: 26.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20503
     components:
     - type: Transform
       pos: 25.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20504
     components:
     - type: Transform
       pos: 17.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20505
     components:
     - type: Transform
       pos: 19.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20506
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20507
     components:
     - type: Transform
       pos: 12.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20508
     components:
     - type: Transform
       pos: 13.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20509
     components:
     - type: Transform
       pos: 14.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20510
     components:
     - type: Transform
       pos: 18.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20511
     components:
     - type: Transform
       pos: 23.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20512
     components:
     - type: Transform
       pos: 27.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20513
     components:
     - type: Transform
       pos: 27.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20514
     components:
     - type: Transform
       pos: 26.5,4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20515
     components:
     - type: Transform
       pos: -16.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20516
     components:
     - type: Transform
       pos: -15.5,-23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20517
     components:
     - type: Transform
       pos: 29.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20518
     components:
     - type: Transform
       pos: 39.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20519
     components:
     - type: Transform
       pos: 41.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20520
     components:
     - type: Transform
       pos: 14.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20521
     components:
     - type: Transform
       pos: 13.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20522
     components:
     - type: Transform
       pos: 11.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20523
     components:
     - type: Transform
       pos: 11.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20524
     components:
     - type: Transform
       pos: 11.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20525
     components:
     - type: Transform
       pos: 19.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20526
     components:
     - type: Transform
       pos: 17.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20527
     components:
     - type: Transform
       pos: 18.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20528
     components:
     - type: Transform
       pos: 16.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20529
     components:
     - type: Transform
       pos: 15.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20530
     components:
     - type: Transform
       pos: 12.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20531
     components:
     - type: Transform
       pos: 16.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20532
     components:
     - type: Transform
       pos: 17.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20533
     components:
     - type: Transform
       pos: 18.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20534
     components:
     - type: Transform
       pos: 14.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20535
     components:
     - type: Transform
       pos: 13.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20536
     components:
     - type: Transform
       pos: 12.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20537
     components:
     - type: Transform
       pos: 12.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20538
     components:
     - type: Transform
       pos: 12.5,-23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20539
     components:
     - type: Transform
       pos: 12.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20540
     components:
     - type: Transform
       pos: 13.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20541
     components:
     - type: Transform
       pos: 14.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20542
     components:
     - type: Transform
       pos: 16.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20543
     components:
     - type: Transform
       pos: 17.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20544
     components:
     - type: Transform
       pos: 18.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20545
     components:
     - type: Transform
       pos: -15.5,-21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20546
     components:
     - type: Transform
       pos: 29.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20547
     components:
     - type: Transform
       pos: 28.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20548
     components:
     - type: Transform
       pos: 31.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20549
     components:
     - type: Transform
       pos: 25.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20550
     components:
     - type: Transform
       pos: 31.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20551
     components:
     - type: Transform
       pos: 25.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20552
     components:
     - type: Transform
       pos: 31.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20553
     components:
     - type: Transform
       pos: 7.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20554
     components:
     - type: Transform
       pos: 6.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20555
     components:
     - type: Transform
       pos: 8.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20556
     components:
     - type: Transform
       pos: 11.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20557
     components:
     - type: Transform
       pos: -5.5,-20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20558
     components:
     - type: Transform
       pos: -5.5,-17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20559
     components:
     - type: Transform
       pos: -25.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20560
     components:
     - type: Transform
       pos: 5.5,48.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20561
     components:
     - type: Transform
       pos: -25.5,-28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20562
     components:
     - type: Transform
       pos: 20.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20563
     components:
     - type: Transform
       pos: -15.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20564
     components:
     - type: Transform
       pos: -16.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20565
     components:
     - type: Transform
       pos: 16.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20566
     components:
     - type: Transform
       pos: -30.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20567
     components:
     - type: Transform
       pos: -31.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20568
     components:
     - type: Transform
       pos: -31.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20569
     components:
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20570
     components:
     - type: Transform
       pos: -9.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20571
     components:
     - type: Transform
       pos: -10.5,-24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20572
     components:
     - type: Transform
       pos: -10.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20573
     components:
     - type: Transform
       pos: -11.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20574
     components:
     - type: Transform
       pos: -20.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20575
     components:
     - type: Transform
       pos: -17.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20576
     components:
     - type: Transform
       pos: -14.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20577
     components:
     - type: Transform
       pos: -25.5,-27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20578
     components:
     - type: Transform
       pos: -3.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20579
     components:
     - type: Transform
       pos: -6.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20580
     components:
     - type: Transform
       pos: -6.5,44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20581
     components:
     - type: Transform
       pos: -1.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20582
     components:
     - type: Transform
       pos: 29.5,64.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20583
     components:
     - type: Transform
       pos: 29.5,67.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20584
     components:
     - type: Transform
       pos: 29.5,69.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20585
     components:
     - type: Transform
       pos: 29.5,61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20586
     components:
     - type: Transform
       pos: 29.5,66.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20587
     components:
     - type: Transform
       pos: 29.5,68.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20588
     components:
     - type: Transform
       pos: 29.5,70.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20589
     components:
     - type: Transform
       pos: 29.5,62.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20590
     components:
     - type: Transform
       pos: 29.5,60.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20591
     components:
     - type: Transform
       pos: 15.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20592
     components:
     - type: Transform
       pos: 16.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20593
     components:
     - type: Transform
       pos: 17.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20594
     components:
     - type: Transform
       pos: 18.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20595
     components:
     - type: Transform
       pos: 19.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20596
     components:
     - type: Transform
       pos: 20.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20597
     components:
     - type: Transform
       pos: 24.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20598
     components:
     - type: Transform
       pos: 27.5,-47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20599
     components:
     - type: Transform
       pos: 27.5,-48.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20600
     components:
     - type: Transform
       pos: 27.5,-49.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20601
     components:
     - type: Transform
       pos: 21.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20602
     components:
     - type: Transform
       pos: 22.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20603
     components:
     - type: Transform
       pos: 23.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20604
     components:
     - type: Transform
       pos: -6.5,46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20605
     components:
     - type: Transform
       pos: -6.5,43.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20606
     components:
     - type: Transform
       pos: 22.5,50.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20607
     components:
     - type: Transform
       pos: 3.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20608
     components:
     - type: Transform
       pos: -6.5,42.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20609
     components:
     - type: Transform
       pos: 34.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20610
     components:
     - type: Transform
       pos: -0.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20611
     components:
     - type: Transform
       pos: -2.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20612
     components:
     - type: Transform
       pos: 32.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20613
     components:
     - type: Transform
       pos: 0.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20614
     components:
     - type: Transform
       pos: -10.5,29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20615
     components:
     - type: Transform
       pos: -10.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20616
     components:
     - type: Transform
       pos: 15.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20617
     components:
     - type: Transform
       pos: 17.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20618
     components:
     - type: Transform
       pos: 2.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20619
     components:
     - type: Transform
       pos: 3.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20620
     components:
     - type: Transform
       pos: 3.5,41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20621
     components:
     - type: Transform
       pos: 3.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20622
     components:
     - type: Transform
       pos: -0.5,43.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20623
     components:
     - type: Transform
       pos: 3.5,44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20624
     components:
     - type: Transform
       pos: 3.5,43.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20625
     components:
     - type: Transform
       pos: 3.5,48.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20626
     components:
     - type: Transform
       pos: -1.5,48.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20627
     components:
     - type: Transform
       pos: -3.5,48.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20628
     components:
     - type: Transform
       pos: -0.5,44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20629
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20630
     components:
     - type: Transform
       pos: -8.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20631
     components:
     - type: Transform
       pos: -7.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20632
     components:
     - type: Transform
       pos: -8.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20633
     components:
     - type: Transform
       pos: 26.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20634
     components:
     - type: Transform
       pos: 30.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20635
     components:
     - type: Transform
       pos: 29.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20636
     components:
     - type: Transform
       pos: 32.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20637
     components:
     - type: Transform
       pos: 28.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20638
     components:
     - type: Transform
       pos: 33.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20639
     components:
     - type: Transform
       pos: 27.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20640
     components:
     - type: Transform
       pos: 26.5,37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20641
     components:
     - type: Transform
       pos: 45.5,43.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20642
     components:
     - type: Transform
       pos: 47.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20643
     components:
     - type: Transform
       pos: 48.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20644
     components:
     - type: Transform
       pos: 49.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20645
     components:
     - type: Transform
       pos: 50.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20646
     components:
     - type: Transform
       pos: 51.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20647
     components:
     - type: Transform
       pos: 52.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20648
     components:
     - type: Transform
       pos: 53.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20649
     components:
     - type: Transform
       pos: 54.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20650
     components:
     - type: Transform
       pos: 55.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20651
     components:
     - type: Transform
       pos: 56.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20652
     components:
     - type: Transform
       pos: 57.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20653
     components:
     - type: Transform
       pos: 58.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20654
     components:
     - type: Transform
       pos: 59.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20655
     components:
     - type: Transform
       pos: 61.5,43.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20656
     components:
     - type: Transform
       pos: 45.5,42.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20657
     components:
     - type: Transform
       pos: 61.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20658
     components:
     - type: Transform
       pos: 61.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20659
     components:
     - type: Transform
       pos: 61.5,42.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20660
     components:
     - type: Transform
       pos: 61.5,41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20661
     components:
     - type: Transform
       pos: 45.5,41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20662
     components:
     - type: Transform
       pos: 45.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20663
     components:
     - type: Transform
       pos: 45.5,37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20664
     components:
     - type: Transform
       pos: 46.5,45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20665
     components:
     - type: Transform
       pos: 29.5,47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20666
     components:
     - type: Transform
       pos: 30.5,47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20667
     components:
     - type: Transform
       pos: 36.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20668
     components:
     - type: Transform
       pos: 37.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20669
     components:
     - type: Transform
       pos: 38.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20670
     components:
     - type: Transform
       pos: 22.5,48.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20671
     components:
     - type: Transform
       pos: -42.5,13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20672
     components:
     - type: Transform
       pos: -42.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20673
     components:
     - type: Transform
       pos: -42.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20674
     components:
     - type: Transform
       pos: -42.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20675
     components:
     - type: Transform
       pos: -42.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20676
     components:
     - type: Transform
       pos: 41.5,47.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20677
     components:
     - type: Transform
       pos: 6.5,-25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20678
     components:
     - type: Transform
       pos: -8.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20679
     components:
     - type: Transform
       pos: -7.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20680
     components:
     - type: Transform
       pos: -6.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20681
     components:
     - type: Transform
       pos: 47.5,64.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20682
     components:
     - type: Transform
       pos: 47.5,61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20683
     components:
     - type: Transform
       pos: 47.5,63.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20684
     components:
     - type: Transform
       pos: 17.5,-65.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20685
     components:
     - type: Transform
       pos: 18.5,-65.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20686
     components:
     - type: Transform
       pos: 19.5,-65.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20687
     components:
     - type: Transform
       pos: 23.5,-65.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20688
     components:
     - type: Transform
       pos: 24.5,-65.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20689
     components:
     - type: Transform
       pos: 25.5,-65.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20690
     components:
     - type: Transform
       pos: 26.5,-65.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20691
     components:
     - type: Transform
       pos: 23.5,-75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20692
     components:
     - type: Transform
       pos: 24.5,-75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20693
     components:
     - type: Transform
       pos: 25.5,-75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20694
     components:
     - type: Transform
       pos: 26.5,-75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20695
     components:
     - type: Transform
       pos: 16.5,-75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20696
     components:
     - type: Transform
       pos: 17.5,-75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20697
     components:
     - type: Transform
       pos: 18.5,-75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20698
     components:
     - type: Transform
       pos: 19.5,-75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20699
     components:
     - type: Transform
       pos: 13.5,-68.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20700
     components:
     - type: Transform
       pos: 13.5,-69.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20701
     components:
     - type: Transform
       pos: 13.5,-70.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20702
     components:
     - type: Transform
       pos: 13.5,-71.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20703
     components:
     - type: Transform
       pos: 13.5,-72.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20704
     components:
     - type: Transform
       pos: 7.5,-25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20705
     components:
     - type: Transform
       pos: 8.5,-25.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20706
     components:
     - type: Transform
       pos: -13.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20707
     components:
     - type: Transform
       pos: -3.5,-35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20708
     components:
     - type: Transform
       pos: -3.5,-36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20709
     components:
     - type: Transform
       pos: -9.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20710
     components:
     - type: Transform
       pos: 33.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20711
     components:
     - type: Transform
       pos: 30.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20712
     components:
     - type: Transform
       pos: 29.5,74.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20713
     components:
     - type: Transform
       pos: 29.5,72.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20714
     components:
     - type: Transform
       pos: 46.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20715
     components:
     - type: Transform
       pos: 47.5,73.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20716
     components:
     - type: Transform
       pos: 47.5,60.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20717
     components:
     - type: Transform
       pos: 47.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20718
     components:
     - type: Transform
       pos: 42.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20719
     components:
     - type: Transform
       pos: 43.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20720
     components:
     - type: Transform
       pos: 44.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20721
     components:
     - type: Transform
       pos: 47.5,71.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20722
     components:
     - type: Transform
       pos: 47.5,72.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20723
     components:
     - type: Transform
       pos: 47.5,68.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20724
     components:
     - type: Transform
       pos: 47.5,70.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20725
     components:
     - type: Transform
       pos: 47.5,69.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20726
     components:
     - type: Transform
       pos: 47.5,67.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20727
     components:
     - type: Transform
       pos: 47.5,66.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20728
     components:
     - type: Transform
       pos: 47.5,74.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20729
     components:
     - type: Transform
       pos: 29.5,71.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20730
     components:
     - type: Transform
       pos: 29.5,73.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20731
     components:
     - type: Transform
       pos: 29.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20732
     components:
     - type: Transform
       pos: 31.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20733
     components:
     - type: Transform
       pos: 29.5,58.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20734
     components:
     - type: Transform
       pos: 47.5,65.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20735
     components:
     - type: Transform
       pos: 29.5,63.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20736
     components:
     - type: Transform
       pos: 29.5,65.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20737
     components:
     - type: Transform
       pos: 45.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20738
     components:
     - type: Transform
       pos: 47.5,62.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20739
     components:
     - type: Transform
       pos: 47.5,58.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20740
     components:
     - type: Transform
       pos: 54.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20741
     components:
     - type: Transform
       pos: 56.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20742
     components:
     - type: Transform
       pos: 56.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20743
     components:
     - type: Transform
       pos: 54.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20744
     components:
     - type: Transform
       pos: 56.5,53.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20745
     components:
     - type: Transform
       pos: 59.5,53.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20746
     components:
     - type: Transform
       pos: 54.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20747
     components:
     - type: Transform
       pos: 52.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20748
     components:
     - type: Transform
       pos: -28.5,-15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20749
     components:
     - type: Transform
       pos: -32.5,-15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20750
     components:
     - type: Transform
       pos: 3.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20751
     components:
     - type: Transform
       pos: -24.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20752
     components:
     - type: Transform
       pos: 61.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20753
     components:
     - type: Transform
       pos: 3.5,-43.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20754
     components:
     - type: Transform
       pos: 3.5,-42.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20755
     components:
     - type: Transform
       pos: 3.5,-41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20756
     components:
     - type: Transform
       pos: 3.5,-39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20757
     components:
     - type: Transform
       pos: 3.5,-40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20758
     components:
     - type: Transform
       pos: 3.5,-44.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20759
     components:
     - type: Transform
       pos: 5.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20760
     components:
     - type: Transform
       pos: 38.5,-36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20761
     components:
     - type: Transform
       pos: 31.5,-35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20762
     components:
     - type: Transform
       pos: -31.5,40.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20763
     components:
     - type: Transform
       pos: 55.5,29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20764
     components:
     - type: Transform
       pos: -31.5,28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20765
     components:
     - type: Transform
       pos: 39.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20766
     components:
     - type: Transform
       pos: -51.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20767
     components:
     - type: Transform
       pos: 41.5,50.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20768
     components:
     - type: Transform
       pos: 33.5,-21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20769
     components:
     - type: Transform
       pos: -31.5,41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20770
     components:
     - type: Transform
       pos: 9.5,50.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20771
     components:
     - type: Transform
       pos: -31.5,43.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20772
     components:
     - type: Transform
       pos: 17.5,-61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20773
     components:
     - type: Transform
       pos: -33.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20774
     components:
     - type: Transform
       pos: -3.5,-30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20775
     components:
     - type: Transform
       pos: 32.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20776
     components:
     - type: Transform
       pos: 30.5,-27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20777
     components:
     - type: Transform
       pos: 25.5,-61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20778
     components:
     - type: Transform
       pos: 29.5,-61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20779
     components:
     - type: Transform
       pos: 31.5,-61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20780
     components:
     - type: Transform
       pos: 30.5,-61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20781
     components:
     - type: Transform
       pos: 19.5,-61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20782
     components:
     - type: Transform
       pos: 23.5,-61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20783
     components:
     - type: Transform
       pos: 24.5,-61.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20784
     components:
     - type: Transform
       pos: 16.5,-65.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20785
     components:
     - type: Transform
       pos: 6.5,-62.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20786
     components:
     - type: Transform
       pos: 6.5,-63.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20787
     components:
     - type: Transform
       pos: 6.5,-64.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20788
     components:
     - type: Transform
       pos: 4.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20789
     components:
     - type: Transform
       pos: -20.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20790
     components:
     - type: Transform
       pos: -11.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20791
     components:
     - type: Transform
       pos: 0.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20792
     components:
     - type: Transform
       pos: -17.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20793
     components:
     - type: Transform
       pos: -1.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20794
     components:
     - type: Transform
       pos: -2.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20795
     components:
     - type: Transform
       pos: -0.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20796
     components:
     - type: Transform
       pos: -3.5,-32.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20797
     components:
     - type: Transform
       pos: -44.5,29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20798
     components:
     - type: Transform
       pos: 32.5,57.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20799
     components:
     - type: Transform
       pos: 53.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20800
     components:
     - type: Transform
       pos: 53.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20801
     components:
     - type: Transform
       pos: 53.5,-14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20802
     components:
     - type: Transform
       pos: 53.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20803
     components:
     - type: Transform
       pos: 53.5,-17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20804
     components:
     - type: Transform
       pos: 53.5,-18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20805
     components:
     - type: Transform
       pos: 48.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20806
     components:
     - type: Transform
       pos: 47.5,-19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20807
     components:
     - type: Transform
       pos: 48.5,-19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20808
     components:
     - type: Transform
       pos: -23.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20809
     components:
     - type: Transform
       pos: -22.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20810
     components:
     - type: Transform
       pos: -33.5,30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20811
     components:
     - type: Transform
       pos: -37.5,30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20812
     components:
     - type: Transform
       pos: -34.5,30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20813
     components:
     - type: Transform
       pos: -36.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20814
     components:
     - type: Transform
       pos: -34.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20815
     components:
     - type: Transform
       pos: 13.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20816
     components:
     - type: Transform
       pos: 10.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20817
     components:
     - type: Transform
       pos: -42.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20818
     components:
     - type: Transform
       pos: -42.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ReinforcedWindowDiagonal
   entities:
   - uid: 20819
@@ -138730,93 +137877,69 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -11.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20820
     components:
     - type: Transform
       pos: -11.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,-45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,-45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,-46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20825
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,-46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,-50.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20827
     components:
     - type: Transform
       pos: 26.5,-50.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20828
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,-52.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20829
     components:
     - type: Transform
       pos: 25.5,-51.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 20830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: RemoteSignaller
   entities:
   - uid: 20831
@@ -140422,60 +139545,44 @@ entities:
     - type: Transform
       pos: 37.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21006
     components:
     - type: Transform
       pos: 36.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21007
     components:
     - type: Transform
       pos: 40.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21008
     components:
     - type: Transform
       pos: 39.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21009
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21010
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21011
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21012
     components:
     - type: Transform
       pos: 38.5,75.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ShuttersNormalOpen
   entities:
   - uid: 21013
@@ -140484,188 +139591,138 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -19.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21014
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21015
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21016
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21017
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21018
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21019
     components:
     - type: Transform
       pos: 41.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21020
     components:
     - type: Transform
       pos: 40.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21021
     components:
     - type: Transform
       pos: 39.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21022
     components:
     - type: Transform
       pos: 27.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21023
     components:
     - type: Transform
       pos: 28.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21024
     components:
     - type: Transform
       pos: 29.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21025
     components:
     - type: Transform
       pos: -11.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21026
     components:
     - type: Transform
       pos: -10.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21027
     components:
     - type: Transform
       pos: -9.5,-31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21028
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21029
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21030
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21031
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,39.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21032
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21033
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21034
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21035
     components:
     - type: Transform
       pos: -0.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21036
     components:
     - type: Transform
       pos: -1.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21037
     components:
     - type: Transform
       pos: -2.5,-34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ShuttersRadiationOpen
   entities:
   - uid: 21038
@@ -140673,36 +139730,26 @@ entities:
     - type: Transform
       pos: 36.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21039
     components:
     - type: Transform
       pos: 37.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21040
     components:
     - type: Transform
       pos: 38.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21041
     components:
     - type: Transform
       pos: 39.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21042
     components:
     - type: Transform
       pos: 40.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ShuttersWindow
   entities:
   - uid: 21043
@@ -140710,15 +139757,11 @@ entities:
     - type: Transform
       pos: 11.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21044
     components:
     - type: Transform
       pos: 12.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ShuttersWindowOpen
   entities:
   - uid: 21045
@@ -140727,142 +139770,104 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21046
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21047
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21048
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21049
     components:
     - type: Transform
       pos: 12.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21050
     components:
     - type: Transform
       pos: 13.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21051
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21052
     components:
     - type: Transform
       pos: 15.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21053
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21054
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21055
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21056
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21057
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21058
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21059
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21060
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21061
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21062
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 21063
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: SignAi
   entities:
   - uid: 21064
@@ -167379,47 +166384,35 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 36.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25629
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25630
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25632
     components:
     - type: Transform
       pos: 25.5,-23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25633
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorHydroponicsLocked
   entities:
   - uid: 25634
@@ -167428,16 +166421,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -20.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25635
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureBarLocked
   entities:
   - uid: 25636
@@ -167445,16 +166434,12 @@ entities:
     - type: Transform
       pos: -2.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25637
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureCargoLocked
   entities:
   - uid: 25638
@@ -167465,40 +166450,30 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25639
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25641
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25642
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureChemistryLocked
   entities:
   - uid: 25643
@@ -167507,47 +166482,35 @@ entities:
       rot: 3.141592653589793 rad
       pos: -22.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25644
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25645
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25646
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25647
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25648
     components:
     - type: Transform
       pos: -22.5,13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureCommandLocked
   entities:
   - uid: 25649
@@ -167555,8 +166518,6 @@ entities:
     - type: Transform
       pos: 40.5,-37.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureEngineeringLocked
   entities:
   - uid: 25650
@@ -167565,8 +166526,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 28.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:
   - uid: 25651
@@ -167575,8 +166534,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 12.5,-22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureMedicalLocked
   entities:
   - uid: 25652
@@ -167584,30 +166541,22 @@ entities:
     - type: Transform
       pos: -23.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25653
     components:
     - type: Transform
       pos: -14.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25654
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25655
     components:
     - type: Transform
       pos: -25.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureSalvageMiningLocked
   entities:
   - uid: 25656
@@ -167616,8 +166565,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -31.5,29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureScienceLocked
   entities:
   - uid: 25657
@@ -167626,16 +166573,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 2.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25658
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureSecurityLawyerLocked
   entities:
   - uid: 25659
@@ -167644,8 +166587,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 14.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureSecurityLocked
   entities:
   - uid: 25660
@@ -167653,15 +166594,11 @@ entities:
     - type: Transform
       pos: 13.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25661
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: Window
   entities:
   - uid: 25662
@@ -167669,715 +166606,511 @@ entities:
     - type: Transform
       pos: 48.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25663
     components:
     - type: Transform
       pos: 45.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25664
     components:
     - type: Transform
       pos: 47.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25665
     components:
     - type: Transform
       pos: 46.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25666
     components:
     - type: Transform
       pos: 44.5,54.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25667
     components:
     - type: Transform
       pos: 7.5,-42.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25668
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25669
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25670
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25671
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25672
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25673
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25674
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25675
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25676
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25677
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25678
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25679
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25680
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25681
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25682
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25683
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25684
     components:
     - type: Transform
       pos: -16.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25685
     components:
     - type: Transform
       pos: -16.5,4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25686
     components:
     - type: Transform
       pos: -12.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25687
     components:
     - type: Transform
       pos: -19.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25688
     components:
     - type: Transform
       pos: -27.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25689
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25690
     components:
     - type: Transform
       pos: -19.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25691
     components:
     - type: Transform
       pos: -17.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25692
     components:
     - type: Transform
       pos: -17.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25693
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25694
     components:
     - type: Transform
       pos: -16.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25695
     components:
     - type: Transform
       pos: -16.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25696
     components:
     - type: Transform
       pos: -24.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25697
     components:
     - type: Transform
       pos: -23.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25698
     components:
     - type: Transform
       pos: -22.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25699
     components:
     - type: Transform
       pos: -21.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25700
     components:
     - type: Transform
       pos: -19.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25701
     components:
     - type: Transform
       pos: -12.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25702
     components:
     - type: Transform
       pos: -16.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25703
     components:
     - type: Transform
       pos: -16.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25704
     components:
     - type: Transform
       pos: -16.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25705
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25706
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25707
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25708
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25709
     components:
     - type: Transform
       pos: 11.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25710
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25711
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25712
     components:
     - type: Transform
       pos: 11.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25713
     components:
     - type: Transform
       pos: 22.5,-27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25714
     components:
     - type: Transform
       pos: 22.5,-30.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25715
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25716
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25717
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25718
     components:
     - type: Transform
       pos: -7.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25719
     components:
     - type: Transform
       pos: -10.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25720
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25721
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25722
     components:
     - type: Transform
       pos: 7.5,-41.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25723
     components:
     - type: Transform
       pos: 12.5,-45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25724
     components:
     - type: Transform
       pos: 10.5,-45.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25725
     components:
     - type: Transform
       pos: 8.5,-38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25726
     components:
     - type: Transform
       pos: 10.5,-38.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25727
     components:
     - type: Transform
       pos: 13.5,-46.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25728
     components:
     - type: Transform
       pos: 13.5,-50.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25729
     components:
     - type: Transform
       pos: 11.5,33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25730
     components:
     - type: Transform
       pos: 17.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25731
     components:
     - type: Transform
       pos: -12.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25732
     components:
     - type: Transform
       pos: -19.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25733
     components:
     - type: Transform
       pos: -17.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25734
     components:
     - type: Transform
       pos: 9.5,29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25735
     components:
     - type: Transform
       pos: 14.5,33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25736
     components:
     - type: Transform
       pos: 8.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25737
     components:
     - type: Transform
       pos: 10.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25738
     components:
     - type: Transform
       pos: 9.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25739
     components:
     - type: Transform
       pos: -12.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25740
     components:
     - type: Transform
       pos: 11.5,35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25741
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25742
     components:
     - type: Transform
       pos: 11.5,34.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25743
     components:
     - type: Transform
       pos: 12.5,33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25744
     components:
     - type: Transform
       pos: -14.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25745
     components:
     - type: Transform
       pos: -13.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25746
     components:
     - type: Transform
       pos: -12.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25747
     components:
     - type: Transform
       pos: 34.5,28.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25748
     components:
     - type: Transform
       pos: 34.5,26.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25749
     components:
     - type: Transform
       pos: 34.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25750
     components:
     - type: Transform
       pos: 34.5,33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25751
     components:
     - type: Transform
       pos: 31.5,33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25752
     components:
     - type: Transform
       pos: 31.5,31.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25753
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25754
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25755
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25756
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25757
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25758
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25759
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25760
     components:
     - type: Transform
       pos: 7.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25761
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25762
     components:
     - type: Transform
       pos: 9.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25763
     components:
     - type: Transform
       pos: 10.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindowDirectional
   entities:
   - uid: 25764
@@ -168386,8 +167119,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -12.5,13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindowFrostedDirectional
   entities:
   - uid: 25765
@@ -168396,117 +167127,87 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -39.5,21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25766
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,22.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25767
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25769
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25770
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25771
     components:
     - type: Transform
       pos: -13.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25772
     components:
     - type: Transform
       pos: -15.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25773
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25774
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25775
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25776
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-29.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25778
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25779
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindowReinforcedDirectional
   entities:
   - uid: 25780
@@ -168515,353 +167216,269 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -43.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25781
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -43.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -43.5,13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25784
     components:
     - type: Transform
       pos: -12.5,33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25785
     components:
     - type: Transform
       pos: -11.5,33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25786
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25787
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25788
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25789
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25790
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25791
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25792
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25793
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-21.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25794
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25795
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25796
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25797
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25798
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25799
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25800
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25801
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25802
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25803
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25804
     components:
     - type: Transform
       pos: 0.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25805
     components:
     - type: Transform
       pos: 1.5,36.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25806
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,35.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25807
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,33.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25808
     components:
     - type: Transform
       pos: 20.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25809
     components:
     - type: Transform
       pos: 22.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25810
     components:
     - type: Transform
       pos: 18.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25811
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,27.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,23.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,24.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25815
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 54.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 54.5,-14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 54.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 54.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 54.5,-17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25820
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 54.5,-18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25821
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 47.5,-20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25822
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 48.5,-20.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -43.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
   - uid: 25824
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -43.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
+  - uid: 25896
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 45.5,-7.5
+      parent: 2
 - proto: WoodenBench
   entities:
   - uid: 25825


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds a reinforced glass window to the disposals belt on Silica to stop trash from falling off the belt.

## Why we need to add this
By default, all trash on Silica ends up on the floor rather than on the recycler belt.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Before:
<img width="1064" height="811" alt="image" src="https://github.com/user-attachments/assets/f361601e-1fcc-42a8-94c3-5a1803968e9b" />
Video https://github.com/user-attachments/assets/12a0b70c-5916-41aa-aff5-322e0e27d13a

After:
<img width="1064" height="811" alt="image" src="https://github.com/user-attachments/assets/5f825168-d2c0-49cd-a367-d465d927c7ca" />
Video https://github.com/user-attachments/assets/4c2553ef-f381-43ce-988b-beeca284a265

**First PR, I'd appreciate a sanity check that I didn't accidentally somehow break the entire map before it gets merged.** 

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Ohelig
- fix: Silica trash now lands on the belt in disposals.
