### PR TITLE
Move some perms to danger flag

### DIFF
--- a/Content.Server/GameTicking/Commands/ForceMapCommand.cs
+++ b/Content.Server/GameTicking/Commands/ForceMapCommand.cs
@@ -17,7 +17,7 @@ namespace Content.Server.GameTicking.Commands
         [Dependency] private readonly IGameMapManager _gameMapManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
-        public override string Command => "forcemap";
+        public override string Command => "setgamemap";
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {

--- a/Content.Server/GameTicking/Commands/ForceMapCommand.cs
+++ b/Content.Server/GameTicking/Commands/ForceMapCommand.cs
@@ -17,7 +17,7 @@ namespace Content.Server.GameTicking.Commands
         [Dependency] private readonly IGameMapManager _gameMapManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
-        public override string Command => "setgamemap";
+        public override string Command => "setgamemap"; // Starlight-edit
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {

--- a/Content.Server/GameTicking/Commands/ForcePresetCommand.cs
+++ b/Content.Server/GameTicking/Commands/ForcePresetCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Danger)]
+    [AdminCommand(AdminFlags.Danger)] // Starlight-edit
     public sealed class ForcePresetCommand : LocalizedEntityCommands
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;

--- a/Content.Server/GameTicking/Commands/ForcePresetCommand.cs
+++ b/Content.Server/GameTicking/Commands/ForcePresetCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Round)]
+    [AdminCommand(AdminFlags.Danger)]
     public sealed class ForcePresetCommand : LocalizedEntityCommands
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;

--- a/Content.Server/GameTicking/Commands/GoLobbyCommand.cs
+++ b/Content.Server/GameTicking/Commands/GoLobbyCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Console;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Round)]
+    [AdminCommand(AdminFlags.Danger)]
     public sealed class GoLobbyCommand : LocalizedEntityCommands
     {
         [Dependency] private readonly IConfigurationManager _configManager = default!;

--- a/Content.Server/GameTicking/Commands/GoLobbyCommand.cs
+++ b/Content.Server/GameTicking/Commands/GoLobbyCommand.cs
@@ -7,7 +7,7 @@ using Robust.Shared.Console;
 
 namespace Content.Server.GameTicking.Commands
 {
-    [AdminCommand(AdminFlags.Danger)]
+    [AdminCommand(AdminFlags.Danger)] // Starlight-edit
     public sealed class GoLobbyCommand : LocalizedEntityCommands
     {
         [Dependency] private readonly IConfigurationManager _configManager = default!;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Moves:
- forcegamepreset
- golobby

commands into Danger admin flag. So now only approved admins/devs can use them on release.

also renames forcemap into setgamemap.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Darkrell request. Removes confusion.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Rinary
- tweak: Changed `forcemap` command name to `setgamemap` to fix confusion.
- tweak: Changed `golobby` and `forcegamepreset` commands flag to DANGER, so regular admins can't use them.