### PR TITLE
Rebalance tasers

### DIFF
--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Clothing.Components;
+using Content.Shared.Clothing.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Examine;
@@ -41,8 +41,10 @@ public abstract class SharedArmorSystem : EntitySystem
     /// </summary>
     private void OnKnockdownAttempt(EntityUid uid, ArmorComponent component, InventoryRelayedEvent<KnockDownAttemptEvent> args)
     {
-        if (component.IgnoreKnockdown)
+        // Starlight edit start - add check for voluntary value, cancel only involuntary knockdown
+        if (component.IgnoreKnockdown && !args.Args.Voluntary)
             args.Args.Cancelled = true;
+        // Starlight edit end
     }
     #endregion
 

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -274,7 +274,9 @@ public abstract partial class SharedStunSystem
 
         if (!Resolve(entity, ref entity.Comp2, false))
         {
-            TryKnockdown(entity.Owner, entity.Comp1.DefaultKnockedDuration, true, false, false);
+            // Starlight edit start - Add voluntary value
+            TryKnockdown(entity.Owner, entity.Comp1.DefaultKnockedDuration, true, false, false, false, true);
+            // Starlight edit end
             return;
         }
 

--- a/Content.Shared/Stunnable/SharedStunSystem.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.cs
@@ -181,7 +181,9 @@ public abstract partial class SharedStunSystem : EntitySystem
         if (!Resolve(entity, ref entity.Comp, false))
             return false;
 
-        return TryKnockdown(entity, time, refresh, autoStand, drop, force);
+        // Starlight edit start - add voluntary value
+        return TryKnockdown(entity, time, refresh, autoStand, drop, force, voluntary: true);
+        // Starlight edit end
     }
 
     /// <inheritdoc cref="TryCrawling(Entity{CrawlerComponent?},TimeSpan?,bool,bool,bool,bool)"/>
@@ -195,7 +197,9 @@ public abstract partial class SharedStunSystem : EntitySystem
         if (!Resolve(entity, ref entity.Comp, false))
             return false;
 
-        return TryKnockdown(entity, entity.Comp.DefaultKnockedDuration, refresh, autoStand, drop, force);
+        // Starlight edit start - add voluntary value
+        return TryKnockdown(entity, entity.Comp.DefaultKnockedDuration, refresh, autoStand, drop, force, voluntary: true);
+        // Starlight edit end
     }
 
     /// <summary>
@@ -206,8 +210,11 @@ public abstract partial class SharedStunSystem : EntitySystem
     /// <param name="autoStand">Whether we want to automatically stand when knockdown ends.</param>
     /// <param name="drop">Whether we should drop items.</param>
     /// <param name="force">Should we force the status effect?</param>
-    public bool CanKnockdown(Entity<StandingStateComponent?> entity, ref TimeSpan? time, ref bool autoStand, ref bool drop, bool force = false)
+    /// <param name="voluntary">Indicates whether the knockdown is voluntary</param>
+    // Starlight edit start - add voluntary value
+    public bool CanKnockdown(Entity<StandingStateComponent?> entity, ref TimeSpan? time, ref bool autoStand, ref bool drop, bool force = false, bool voluntary = false)
     {
+    // Starlight edit end
         if (time <= TimeSpan.Zero)
             return false;
 
@@ -215,7 +222,9 @@ public abstract partial class SharedStunSystem : EntitySystem
         if (!Resolve(entity, ref entity.Comp, false))
             return false;
 
-        var evAttempt = new KnockDownAttemptEvent(autoStand, drop, time);
+        // Starlight edit start - add voluntary value
+        var evAttempt = new KnockDownAttemptEvent(autoStand, drop, time, voluntary);
+        // Starlight edit end
         RaiseLocalEvent(entity, ref evAttempt);
 
         autoStand = evAttempt.AutoStand;
@@ -233,10 +242,13 @@ public abstract partial class SharedStunSystem : EntitySystem
     /// <param name="autoStand">Whether we want to automatically stand when knockdown ends.</param>
     /// <param name="drop">Whether we should drop items.</param>
     /// <param name="force">Should we force the status effect?</param>
-    public bool TryKnockdown(Entity<CrawlerComponent?> entity, TimeSpan? time, bool refresh = true, bool autoStand = true, bool drop = true, bool force = false)
+    /// <param name="voluntary">Indicates whether the knockdown is voluntary</param>
+    // Starlight edit start - add voluntary value
+    public bool TryKnockdown(Entity<CrawlerComponent?> entity, TimeSpan? time, bool refresh = true, bool autoStand = true, bool drop = true, bool force = false, bool voluntary = false)
     {
-        if (!CanKnockdown(entity.Owner, ref time, ref autoStand, ref drop, force))
+        if (!CanKnockdown(entity.Owner, ref time, ref autoStand, ref drop, force, voluntary))
             return false;
+    // Starlight edit end
 
         // If the entity can't crawl they also need to be stunned, and therefore we should be using paralysis status effect.
         // Also time shouldn't be null if we're and trying to add time but, we check just in case anyways.

--- a/Content.Shared/Stunnable/StunnableEvents.cs
+++ b/Content.Shared/Stunnable/StunnableEvents.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Alert;
+using Content.Shared.Alert;
 using Content.Shared.DoAfter;
 using Content.Shared.Popups;
 using Robust.Shared.Serialization;
@@ -26,9 +26,11 @@ public record struct StunEndAttemptEvent(bool Cancelled);
 ///     Raised directed on an entity before it is knocked down to see if it should be cancelled, and to determine
 ///     knocked down arguments.
 /// </summary>
+// Starlight edit start -  Make it inventory relayed, add voluntary value to indicate whether the knockdown is voluntary
 [ByRefEvent]
-public record struct KnockDownAttemptEvent(bool AutoStand, bool Drop, TimeSpan? Time) : IInventoryRelayEvent // Starlight-edit: Make it inventory relayed
+public record struct KnockDownAttemptEvent(bool AutoStand, bool Drop, TimeSpan? Time, bool Voluntary = false) : IInventoryRelayEvent
 {
+// Starlight edit end 
     public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET; // Starlight-edit
 
     public bool Cancelled;

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -184,7 +184,6 @@
         Heat: 0.9
     # Starlight-start
     staminaModifier: 0.55
-    ignoreKnockdown: true
     # Starlight-end
   - type: ExplosionResistance
     damageCoefficient: 0.9
@@ -216,7 +215,6 @@
         Caustic: 0.5
     # Starlight-start
     staminaModifier: 0.35
-    ignoreKnockdown: true
     # Starlight-end
   - type: ExplosionResistance
     damageCoefficient: 0.5

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -131,6 +131,9 @@
         Piercing: 0.95
         Heat: 0.90
         Radiation: 0.25
+    # Starlight edit start - ignore knockdown
+    ignoreKnockdown: true
+    # Starlight edit end
   - type: ToggleableClothing
     slot: head
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -668,7 +668,6 @@
         Caustic: 0.5
     # Starlight-start
     staminaModifier: 0.3
-    ignoreKnockdown: true
     # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 0.9
@@ -742,7 +741,6 @@
         Caustic: 0.5
     # Starlight-start
     staminaModifier: 0.2
-    ignoreKnockdown: true
     # Starlight-end
   - type: Item
     size: Huge
@@ -789,7 +787,6 @@
         Caustic: 0.4
     # Starlight-start
     staminaModifier: 0.1
-    ignoreKnockdown: true
     # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 0.95
@@ -838,7 +835,6 @@
         Caustic: 0.2
     # Starlight-start
     staminaModifier: 0.1
-    ignoreKnockdown: true
     # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 0.65
@@ -1162,7 +1158,6 @@
         Caustic: 0.1
     # Starlight-start
     staminaModifier: 0.0
-    ignoreKnockdown: true
     # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 1.0
@@ -1206,7 +1201,6 @@
         Caustic: 0.1
     # Starlight-start
     staminaModifier: 0.2
-    ignoreKnockdown: true
     # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 1.0

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -618,7 +618,6 @@
         Radiation: 0.35
         Caustic: 0.35
     staminaModifier: 0.0
-    ignoreKnockdown: true
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -667,7 +666,6 @@
         Radiation: 0.25
         Caustic: 0.25
     staminaModifier: 0.0
-    ignoreKnockdown: true
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -717,7 +715,6 @@
         Radiation: 0.05
         Caustic: 0.05
     staminaModifier: 0.0
-    ignoreKnockdown: true
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Hello, this is not a mald PR, well.. it is, because these topics have been bothering me for as long as we have the "taser immunity" as i will call it. The issues are three:
- You cannot crawl while having the taser immunity, it is bothering me, its because the system was written so it doesn't allow for you to be knocked down, for simplicity, no matter how much someone would sell it, its just a bug.
- Web Vests have taser immunity - i honestly have no idea why they have it, its not a full body suit, its just a vest, they are a strong option already.
- Only antagonist's hardsuits have taser immunity - this does not make sense to me, since it was made as a balancing change in my eyes, just to buff nukies.

As such i propose these changes:

I have fixed the taser immunity making you unable to crawl, i have added a value that indicates whether the knockdown is voluntary or not, a simple change, it should be fine to keep.

Additionally i have removed taser immunity from web vests, those vests are insanely powerful, they are very small to store, occupying only 2x2 size, they have pockets which are actually bigger than the size they occupy, effectively increasing your storage space while kept in bag. They are not that easy to see on your character, as well as provide insane resistances for the price, both from damage, as well as stamina damage. Web Vests are just powerful, against a lone secoff, you most likely will win even without a taser immunity, sure they might take your weapon, but they effectively cannot stamina crit you, as long as you have a backup you can even try shoving their taser out of their hands. 

I think that having a split between hardsuits and web vests is good, it makes a good gameplay choice of whether you want to choose a blood-red or a web vest from the uplink, trading a bit more slowdown as well as TC for taser immunity.

This is however not a security buff, if anything this is a security nerf, a big one, suddenly a lot of crew has access to taser immunity, a bad one, but it is still there, they have to think before picking the taser. This will matter a lot for revs.

I have also added taser immunity to ALL HARDSUITS, with a very important clarification - hardsuits, not softsuits. This change in my opinion makes for more interesting gameplay, possibly making antagonists decide whether they would want to pick an engineering hardsuit over a vest for taser immunity, as well as makes for more interesting gameplay, it makes antagonists more carefully consider their targets, for example, you wouldn't buy a mini energy crossbow if your target is a CE, since they are immune to its stun, similarly, if the station is attacked by a dragon, your plans might suddenly get changed because the captain might be wearing their hardsuit. It makes it more interesting for lobster because you know that most sec wont be wearing hardsuits, you might consider using the mini energy crossbows, it makes things more dynamic.

Why is mini energy crossbow blocked on hardsuits - simple answer is that they already block poison injection, as far as i can tell, so this change just pairs with that, if it doesn't inject it also shouldn't stun.

There are some "weird" exceptions:
- Raidsuit - i have decided to leave its taser immunity - reason being, its a full body suit, i think its fine, i can live with this.
- Paramedic Voidsuit - apparently the game considers this a softsuit, therefore no paramedic buff.
- Clown hardsuit - this is a hardsuit, clown buffs.

## Why we need to add this
It fixes a bug that does not make sense, as well as introduces more dynamic split second decisions to both security as well as antagonists play.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- add: Added taser immunity to all hardsuits.
- remove: Removed taser immunity from web vests.
- fix: Fixed taser immunity preventing crawling.
