### PR TITLE
Fixes NCT Station Beacon text

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -857,7 +857,7 @@
   suffix: NCT
   components:
   - type: NavMapBeacon
-    text: station-beacon-nct
+    defaultText: station-beacon-nct
 
 
 # Ghost Only Beacons


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
The `text` properly on `DefaultStationBeaconNCT` was set instead of `defaultText`.
- This meant that you saw maps proudly proclaim **station-beacon-nct** instead of "NCT Office"

Easy fix. Won't require any edits to existing maps.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="418" height="350" alt="image" src="https://github.com/user-attachments/assets/8c78d027-d564-4c1f-ba25-071c604200a6" />

fig. 1 - Fixed beacon now reads "NCT Office"

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- fix: Nanotrasen Career Trainer station beacon text has now been fixed. Visit your local NCT Office today!
