### PR TITLE
another xenobiology bug fix

### DIFF
--- a/Content.Shared/_Starlight/Xenobiology/SlimeSystem.cs
+++ b/Content.Shared/_Starlight/Xenobiology/SlimeSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.EntitySystems;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization;
 
@@ -64,7 +65,7 @@ public sealed class SlimeSystem : EntitySystem
         {
             Entity = GetNetEntity(slime.Owner, MetaData(slime.Owner)),
             Angle = Angle.FromWorldVec(vector),
-        });
+        }, Filter.Pvs(slime.Owner, 0.5F));
 
         if (returnDamage.AnyPositive())
         {


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Hopefully fixed a PVS bug where an eating slime entering PVS range would cause a client crash.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: STARLIGHT TEAM
- fix: Hopefully fixed a PVS bug where an eating slime entering PVS range would cause a client crash.