### PR TITLE
Firing Pins Doafter Tweak

### DIFF
--- a/Content.Shared/_Starlight/FiringPins/FiringPinSystem.cs
+++ b/Content.Shared/_Starlight/FiringPins/FiringPinSystem.cs
@@ -77,7 +77,7 @@ public sealed partial class FiringPinSystem : EntitySystem
                 return;
             }
 
-            _tool.UseTool(args.Used, args.User, ent.Owner, 1.5f, ent.Comp.PinExtractionMethod, new FiringPinRemovalFinishEvent(), toolComponent: toolComp);
+            _tool.UseTool(args.Used, args.User, ent.Owner, 15f, ent.Comp.PinExtractionMethod, new FiringPinRemovalFinishEvent(), toolComponent: toolComp);
         }
     }
 


### PR DESCRIPTION
## Short description
Increases the time it takes to remove a firing pin from 1.5s to 15s. 

## Why we need to add this
You should not be able to render basically any gun in the game useless with such a short doafter. This is both for verisimilitude reasons (you cannot disassemble a gun fast enough to get the pin out in under two seconds, not even if you can strip your weapon like forrest gump) and balance reasons (an emagged borg should _not_ be able to brick the armory in a matter of seconds just by running in there and taking all the firing pins out). With the change both installing and removing the pin takes a significant amount of time. It's not something you can do willy-nilly.

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: deltaVelocity
- tweak: increased the doafter on firing pin removal/insertion to 15s, from 1.5s. Nanotrasen has redesigned their firearms so the damned things don't just fall out if you look at the gun wrong.

