### PR TITLE
Reduce gaseous frezon effects, increase liquid frezon effects, buff related healing chemicals

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -352,9 +352,9 @@
       - !type:ModifyStatusEffect
         effectProto: StatusEffectSeeingRainbow
         type: Add
-        time: 15
+        time: 40 # Starlight: Liquid frezon way more potent (its denser!)
       - !type:Drunk
-        boozePower: 15
+        boozePower: 40  # Starlight: Liquid frezon way more potent (its denser!)
       - !type:PopupMessage
         type: Local
         messages: [ "frezon-lungs-cold" ]
@@ -379,9 +379,9 @@
         minScale: 1
         effectProto: StatusEffectSeeingRainbow
         type: Add
-        time: 500
+        time: 20  # Starlight: Down from 500 (holy shit)
       - !type:Drunk
-        boozePower: 500
+        boozePower: 20 # Starlight: Down from 500 (holy shit)
         minScale: 1
       - !type:PopupMessage
         type: Local

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -111,7 +111,7 @@
       effects:
       - !type:ModifyStatusEffect
         effectProto: StatusEffectDrunk
-        time: 6.0
+        time: 20.0 # Starlight: More potent, up from 6
         type: Remove
       - !type:HealthChange
         damage:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1562,7 +1562,7 @@
         type: Remove
       - !type:ModifyStatusEffect
         effectProto: StatusEffectSeeingRainbow
-        time: 10.0
+        time: 30.0 # Starlight: More potent, up from 10
         type: Remove
       - !type:AdjustReagent
         reagent: Desoxyephedrine


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

- Liquid frezon stronger effects
- Gaseous frezon WAY weaker effects
- Haloperidol stronger against hallucination status effect
- Ehtylredoxrazine stronger against drunk status effect

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

This is what happens *without* this PR if you get caught in a frezon gas leak (relying on #2931 to show you):

https://github.com/user-attachments/assets/34b70457-0a0c-433d-a961-db385b16f2b6

And the medicine are basically useless

https://github.com/user-attachments/assets/584e01ad-9367-492e-b9a3-4e741e558d39

You're basically f'd unless you want to die and get cloned just to be rid of it.


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Uploaded to Cloudflare bucket since its too large (its only 2 mins): https://s.redmushie.me/2026/01/Content.Client_2yLSEa4wxa.mp4


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: Reduced gaseous frezon hallucination/drunkness effects down from hours/days to minutes
- tweak: Buffed liquid frezon hallucination/drunkness effects
- tweak: Haloperidol is now more potent against hallucinations
- tweak: Ethylredoxrazine is now more potent against drunkness

