### PR TITLE
remove xenobio crate and research from visibility in-game

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_science.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_science.yml
@@ -1,9 +1,10 @@
-- type: cargoProduct
-  id: ScienceStarterXenobiology
-  icon:
-    sprite: _Starlight/Mobs/XenoSlimes/test_sprite.rsi
-    state: test_slime
-  product: CrateStarterXenobiology
-  cost: 5000
-  category: cargoproduct-category-name-science
-  group: market
+#TODO: uncomment once xenobio is properly balanced and sprited
+# - type: cargoProduct
+#   id: ScienceStarterXenobiology
+#   icon:
+#     sprite: _Starlight/Mobs/XenoSlimes/test_sprite.rsi
+#     state: test_slime
+#   product: CrateStarterXenobiology
+#   cost: 5000
+#   category: cargoproduct-category-name-science
+#   group: market

--- a/Resources/Prototypes/_StarLight/Research/experimental.yml
+++ b/Resources/Prototypes/_StarLight/Research/experimental.yml
@@ -1,17 +1,18 @@
 # Tier 1
-- type: technology
-  id: BasicXenobiologyResearch
-  name: research-technology-basic-xenobiology
-  icon:
-    sprite: _Starlight/Mobs/XenoSlimes/test_sprite.rsi
-    state: test_slime
-  discipline: Experimental
-  tier: 1
-  cost: 1000
-  recipeUnlocks:
-  - HandheldSlimeScanner
-  - SlimeProcessorMachineCircuitboard
-  - XenobiologyConsoleCircuitboard
+#TODO: uncomment once xenobio is properly balanced and sprited
+# - type: technology
+#   id: BasicXenobiologyResearch
+#   name: research-technology-basic-xenobiology
+#   icon:
+#     sprite: _Starlight/Mobs/XenoSlimes/test_sprite.rsi
+#     state: test_slime
+#   discipline: Experimental
+#   tier: 1
+#   cost: 1000
+#   recipeUnlocks:
+#   - HandheldSlimeScanner
+#   - SlimeProcessorMachineCircuitboard
+#   - XenobiologyConsoleCircuitboard
 
 # Tier 2
 - type: technology


### PR DESCRIPTION
## Short description
Xenobio is clearly NOT ready for unsupervised playtime and passive feedback... (see: buff ratking in the gold slime spawn pool)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ ] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Walksanatora
- remove: Xenobiology Starter Crate and T1 research are removed until xenobiology is more balanced (admemes can still spawn requsite stuffs, including tech disk)

