### PR TITLE
Fix heavy xenoborg laser cannon recharging

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1050,7 +1050,7 @@
   id: WeaponLaserCannonXenoborg
   name: xenoborg laser cannon
   components:
-  - type: BatterySelfRecharger
+  - type: PredictedBatterySelfRecharger # Starlight: Fixed recharging switching to Predicted variant
     autoRechargeRate: 30
   # "remove" wield bonus and penalty so borgs can use it
   - type: GunWieldBonus

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1050,7 +1050,7 @@
   id: WeaponLaserCannonXenoborg
   name: xenoborg laser cannon
   components:
-  - type: PredictedBatterySelfRecharger # Starlight: Fixed recharging switching to Predicted variant
+  - type: PredictedBatterySelfRecharger # Starlight: Fixed recharging by switching to Predicted variant
     autoRechargeRate: 30
   # "remove" wield bonus and penalty so borgs can use it
   - type: GunWieldBonus


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Heavy xenoborg "laser cannon" module had a laser that didn't recharge. Now it does.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

It was broken, meaning heavy xenoborgs either run out and find out mid combat, or are stuck on the lower damage default laser.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/c331d7d0-183c-4066-b408-b3291b4076c4


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: Fixed heavy xenoborg laser cannon not recharging

