### PR TITLE
Cotton buns can contain Starlight plushies

### DIFF
--- a/Resources/Locale/en-US/_Starlight/nutrition/components/food-sequence.ftl
+++ b/Resources/Locale/en-US/_Starlight/nutrition/components/food-sequence.ftl
@@ -1,0 +1,20 @@
+# COTTON BURGERS
+
+food-sequence-cotton-burger-content-plushie-panda = panda
+food-sequence-cotton-burger-content-plushie-deer = deer
+food-sequence-cotton-burger-content-plushie-mimelizard = silent
+food-sequence-cotton-burger-content-plushie-abductor = alien
+food-sequence-cotton-burger-content-plushie-axolotl = axolotl
+food-sequence-cotton-burger-content-plushie-borb = borb
+food-sequence-cotton-burger-content-plushie-creature = YIPPIE
+food-sequence-cotton-burger-content-plushie-gnome = fooberry
+food-sequence-cotton-burger-content-plushie-goat = soft
+food-sequence-cotton-burger-content-plushie-lisa = corgi
+food-sequence-cotton-burger-content-plushie-kitten = mew
+food-sequence-cotton-burger-content-plushie-pig = pig
+food-sequence-cotton-burger-content-plushie-renault = yip
+food-sequence-cotton-burger-content-plushie-snail = snail
+food-sequence-cotton-burger-content-plushie-cow = cow
+food-sequence-cotton-burger-content-plushie-frog = frog
+food-sequence-cotton-burger-content-plushie-sus = sus
+food-sequence-cotton-burger-content-plushie-shadekin = marr

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Fun/plushies.yml
@@ -383,6 +383,9 @@
     requiresSpecialDigestion: true
     useSound:
       path: /Audio/_Starlight/Items/Toys/panda_noise2.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: PandaPlushie
 
 - type: entity
   parent: BasePlushie
@@ -416,6 +419,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/_Starlight/Items/Toys/deerplush_nun.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: DeerPlushie
 
 - type: entity
   parent: BaseLizardPlushie
@@ -428,6 +434,9 @@
     state: icon
   - type: Item
     heldPrefix: plushielizard
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: PlushieMimeLizard
 
 - type: entity
   parent: BasePlushie
@@ -461,6 +470,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/_Starlight/Items/Toys/deerplush_nun.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: OddDeerPlushie
 
 - type: entity
   parent: BaseVulpkaninPlushie
@@ -507,6 +519,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Weapons/Guns/Hits/taser_hit.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: AbductorPlushie
       
 - type: entity
   parent: BasePlushie
@@ -540,6 +555,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Items/Toys/toysqueak3.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: AxolotlPlushie
       
 - type: entity
   parent: BasePlushie
@@ -573,6 +591,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Items/Toys/toysqueak3.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: BorbPlushie
 
 - type: entity
   parent: BasePlushie
@@ -606,6 +627,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/_Starlight/Items/Toys/yippie.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: CreaturePlushie
       
 - type: entity
   parent: BasePlushie
@@ -639,6 +663,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/_Starlight/Items/Toys/gnome_murderer.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: GnomePlushie
       
 - type: entity
   parent: BasePlushie
@@ -672,6 +699,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Items/Toys/toysqueak3.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: GoatPlushie
       
 - type: entity
   parent: BasePlushie
@@ -705,6 +735,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Animals/dog_bark2.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: StarlightIanPlushie
       
 - type: entity
   parent: BasePlushie
@@ -738,6 +771,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Animals/dog_bark2.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: LisaPlushie
       
 - type: entity
   parent: BasePlushie
@@ -771,6 +807,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Animals/cat_hiss.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: KittenPlushie
       
 - type: entity
   parent: BasePlushie
@@ -804,6 +843,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Animals/pig_oink.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: PigPlushie
       
 - type: entity
   parent: BasePlushie
@@ -837,6 +879,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Animals/fox11.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: RenaultPlushie
       
 - type: entity
   parent: BasePlushie
@@ -870,6 +915,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Items/Toys/toysqueak2.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: SnailPlushie
       
 - type: entity
   parent: BasePlushie
@@ -903,6 +951,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Items/Toys/toysqueak2.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: SquishimsCow
       
 - type: entity
   parent: BasePlushie
@@ -936,6 +987,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Items/Toys/toysqueak2.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: SquishimsFrog
       
 - type: entity
   parent: BasePlushie
@@ -969,6 +1023,9 @@
     wideAnimationRotation: 180
     soundHit:
       path: /Audio/Items/Toys/toysqueak2.ogg
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: SusPlushie
 
 - type: entity
   parent: BasePlushie
@@ -1193,6 +1250,9 @@
   - type: Sprite
     sprite: _Starlight/Objects/Fun/Plushies/shadekin_plushie.rsi
     state: icon
+  - type: FoodSequenceElement
+    entries:
+      CottonBurger: PlushieShadekin
 
 - type: entity
   parent: PlushieHuman

--- a/Resources/Prototypes/_StarLight/Recipes/Cooking/food_sequence_element.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Cooking/food_sequence_element.yml
@@ -7,3 +7,178 @@
   - Cooked
   - Meat
   - Sausage
+
+#Panda Plushie
+- type: foodSequenceElement
+  id: PandaPlushie
+  scale: 0.75, 0.75
+  name: food-sequence-cotton-burger-content-plushie-panda
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/panda_plushie.rsi
+    state: icon
+
+#Deer Plushie
+- type: foodSequenceElement
+  id: DeerPlushie
+  scale: 0.8, 0.8
+  name: food-sequence-cotton-burger-content-plushie-deer
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/deer_plushie.rsi
+    state: icon_no_eyebrows
+
+#Odd Deer Plushie
+- type: foodSequenceElement
+  id: OddDeerPlushie
+  scale: 0.8, 0.8
+  name: food-sequence-cotton-burger-content-plushie-deer
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/deer_plushie.rsi
+    state: icon_eyebrows
+
+#Lizard Mime Plushie
+- type: foodSequenceElement
+  id: PlushieMimeLizard
+  name: food-sequence-cotton-burger-content-plushie-mimelizard
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/mime_lizard_plushie.rsi
+    state: icon
+
+#Abductor Plushie
+- type: foodSequenceElement
+  id: AbductorPlushie
+  scale: 0.8, 0.8
+  name: food-sequence-cotton-burger-content-plushie-abductor
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/abductor_plushie.rsi
+    state: icon
+
+#Axolotl Plushie
+- type: foodSequenceElement
+  id: AxolotlPlushie
+  scale: 0.75, 0.75
+  name: food-sequence-cotton-burger-content-plushie-axolotl
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/axolotl_plushie.rsi
+    state: icon
+
+#Borb Plushie
+- type: foodSequenceElement
+  id: BorbPlushie
+  name: food-sequence-cotton-burger-content-plushie-borb
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/borb_plushie.rsi
+    state: icon
+
+#Creature Plushie
+- type: foodSequenceElement
+  id: CreaturePlushie
+  scale: 0.8, 0.8
+  name: food-sequence-cotton-burger-content-plushie-creature
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/creature_plushie.rsi
+    state: icon
+
+#Gnome Plushie
+- type: foodSequenceElement
+  id: GnomePlushie
+  scale: 0.8, 0.8
+  name: food-sequence-cotton-burger-content-plushie-gnome
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/gnome_plushie.rsi
+    state: icon
+
+#Goat Plushie
+- type: foodSequenceElement
+  id: GoatPlushie
+  scale: 0.8, 0.8
+  name: food-sequence-cotton-burger-content-plushie-goat
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/goat_plushie.rsi
+    state: icon
+
+#Ian Plushie
+- type: foodSequenceElement
+  id: StarlightIanPlushie
+  name: food-sequence-cotton-burger-content-plushie-ian
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/ian_plushie.rsi
+    state: icon
+
+#Lisa Plushie
+- type: foodSequenceElement
+  id: LisaPlushie
+  name: food-sequence-cotton-burger-content-plushie-lisa
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/lisa_plushie.rsi
+    state: icon
+
+#Kitten Plushie
+- type: foodSequenceElement
+  id: KittenPlushie
+  scale: 0.8, 0.8
+  name: food-sequence-cotton-burger-content-plushie-kitten
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/kitten_plushie.rsi
+    state: icon
+
+#Pig Plushie
+- type: foodSequenceElement
+  id: PigPlushie
+  scale: 0.75, 0.75
+  name: food-sequence-cotton-burger-content-plushie-pig
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/pig_plushie.rsi
+    state: icon
+
+#Renault Plushie
+- type: foodSequenceElement
+  id: RenaultPlushie
+  name: food-sequence-cotton-burger-content-plushie-renault
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/renault_plushie.rsi
+    state: icon
+
+#Snail Plushie
+- type: foodSequenceElement
+  id: SnailPlushie
+  scale: 0.8, 0.8
+  name: food-sequence-cotton-burger-content-plushie-snail
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/snail_plushie.rsi
+    state: icon
+
+#Squishims Cow Plushie
+- type: foodSequenceElement
+  id: SquishimsCow
+  scale: 0.5, 0.5
+  name: food-sequence-cotton-burger-content-plushie-cow
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/cow_squishims_plushie.rsi
+    state: icon
+
+#Squishims Frog Plushie
+- type: foodSequenceElement
+  id: SquishimsFrog
+  scale: 0.5, 0.5
+  name: food-sequence-cotton-burger-content-plushie-frog
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/frog_squishims_plushie.rsi
+    state: icon
+
+#Sus Plushie
+- type: foodSequenceElement
+  id: SusPlushie
+  scale: 0.8, 0.8
+  name: food-sequence-cotton-burger-content-plushie-sus
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/sus_plushie.rsi
+    state: icon
+
+#Shadekin Plushie
+- type: foodSequenceElement
+  id: PlushieShadekin
+  scale: 0.8, 0.8
+  name: food-sequence-cotton-burger-content-plushie-shadekin
+  sprites:
+  - sprite: _Starlight/Objects/Fun/Plushies/shadekin_plushie.rsi
+    state: icon


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Allows Starlight plushies to be added to Cotton Buns.

## Why we need to add this
Creating Cotton Burgers is currently inconsistent and confusing, since only upstream plushies could be used. Starlight plushies are frequent in game, so any chef attempting to do so had a high likelihood of trying to do so with a Starlight plushie.

Most plushies are scaled down by 20% or 25%, which is consistent with upstream scaling as well. Some very large plushies are scaled down by 50% for visibility purposes.

Individual character / crew plushies are still prohibited.

## Media (Video/Screenshots)
#### Screenshots
<img height="160" alt="image" src="https://github.com/user-attachments/assets/f72d5898-5e64-44a7-8c30-9551fef2df0f" />

<img height="160" alt="image" src="https://github.com/user-attachments/assets/5b48d2f1-4f9f-4b84-835f-32956c92b2d0" />

#### Text prefix
As with existing burgers, an prefix is added to the burger name based on the item.
| Plushie  | Prefix |
| ------------- | ------------- |
| Panda Plushie | panda |
| Deer Plushie | deer |
| Odd Deer Plushie | deer |
| Lizard Mime Plushie | silent |
| Abductor Plushie | alien |
| Axolotl Plushie | axolotl  |
| Borb Plushie | borb  |
| Creature Plushie | YIPPIE  |
| Gnome Plushie | fooberry |
| Goat Plushie | soft |
| Ian Plushie | corgi |
| Lisa Plushie | corgi |
| Kitten Plushie | mew |
| Pig Plushie | pig |
| Renault Plushie | yip |
| Snail Plushie | snail |
| Squishims Cow Plushie | cow |
| Squishims Frog Plushie | frog |
| Sus Plushie | sus |
| Shadekin Plushie | marr |

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- tweak: Cotton Bun can now hold most Starlight plushies
