### PR TITLE
Fixed displacement pathing for resomi

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/resomi.yml
@@ -150,7 +150,7 @@
       misc: # Starlight start
         sizeMaps:
           32:
-            sprite: Mobs/Species/Resomi/displacement.rsi
+            sprite: _Starlight/Mobs/Species/Resomi/displacement.rsi
             state: neck # Starlight end
       mask:
         sizeMaps:
@@ -216,7 +216,7 @@
       misc: # Starlight start
         sizeMaps:
           32:
-            sprite: Mobs/Species/Resomi/displacement.rsi
+            sprite: _Starlight/Mobs/Species/Resomi/displacement.rsi
             state: neck # Starlight end
       mask:
         sizeMaps:
@@ -368,7 +368,7 @@
       misc: # Starlight start
         sizeMaps:
           32:
-            sprite: Mobs/Species/Resomi/displacement.rsi
+            sprite: _Starlight/Mobs/Species/Resomi/displacement.rsi
             state: neck # Starlight end
       mask:
         sizeMaps:
@@ -434,7 +434,7 @@
       misc: # Starlight start
         sizeMaps:
           32:
-            sprite: Mobs/Species/Resomi/displacement.rsi
+            sprite: _Starlight/Mobs/Species/Resomi/displacement.rsi
             state: neck # Starlight end
       mask:
         sizeMaps:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Buxfix to fix displacement sprite path.

## Why we need to add this
bugfix, the paths didn't get adjusted when the resomi files were moved with the resprite


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

