### PR TITLE
[Hotfix] Fix display for non-job requirements

### DIFF
--- a/Content.Shared/Players/PlayTimeTracking/PlayTimeTrackerPrototype.cs
+++ b/Content.Shared/Players/PlayTimeTracking/PlayTimeTrackerPrototype.cs
@@ -9,4 +9,15 @@ namespace Content.Shared.Players.PlayTimeTracking;
 public sealed partial class PlayTimeTrackerPrototype : IPrototype
 {
     [IdDataField] public string ID { get; private set; } = default!;
+
+    // Starlight start
+    /// <summary>
+    ///     The name of this job as displayed to players.
+    /// </summary>
+    [DataField]
+    public LocId Name { get; private set; } = "generic-unknown";
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public string LocalizedName => Loc.GetString(Name);
+    // Starlight end
 }

--- a/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
@@ -57,6 +57,41 @@ public sealed partial class RoleTimeRequirement : JobRequirement
 
         var jobProto = jobSystem.GetJobPrototype(proto);
 
+        // Starlight start
+        // Handle non-job role time requirements
+        if (jobProto is null)
+        {
+            if (!protoManager.TryIndex<PlayTimeTrackerPrototype>(proto, out var tracker))
+                return false;
+
+            if (!Inverted)
+            {
+                if (roleDiff <= 0)
+                    return true;
+
+                reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
+                    "role-timer-role-insufficient",
+                    ("time", formattedRoleDiff),
+                    ("job", tracker.LocalizedName),
+                    ("departmentColor", departmentColor.ToHex())));
+                return false;
+            }
+            else
+            {
+                if (roleDiff <= 0)
+                {
+                    reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
+                        "role-timer-role-too-high",
+                        ("time", formattedRoleDiff),
+                        ("job", tracker.LocalizedName),
+                        ("departmentColor", departmentColor.ToHex())));
+                    return false;
+                }
+                return true;
+            }
+        }
+        // Starlight end
+
         if (jobSystem.TryGetDepartment(jobProto, out var departmentProto))
             departmentColor = departmentProto.Color;
 

--- a/Content.Shared/Roles/Jobs/SharedJobSystem.cs
+++ b/Content.Shared/Roles/Jobs/SharedJobSystem.cs
@@ -49,9 +49,14 @@ public abstract class SharedJobSystem : EntitySystem
     /// </summary>
     /// <param name="trackerProto"></param>
     /// <returns></returns>
-    public string GetJobPrototype(string trackerProto)
+    public string? GetJobPrototype(string trackerProto) // Starlight - make return value nullable
     {
         DebugTools.Assert(_prototypes.HasIndex<PlayTimeTrackerPrototype>(trackerProto));
+        // Starlight start
+        // We have non-job playtimetrackers
+        if (!_inverseTrackerLookup.ContainsKey(trackerProto))
+            return null;
+        // Starlight end
         return _inverseTrackerLookup[trackerProto];
     }
 

--- a/Resources/Locale/en-US/_Starlight/roles/role_names.ftl
+++ b/Resources/Locale/en-US/_Starlight/roles/role_names.ftl
@@ -1,0 +1,2 @@
+ghost-role-critter-harmless = Harmless Critter
+ghost-role-bot-harmless = Harmless Bot

--- a/Resources/Prototypes/_StarLight/Roles/antag_play_time_trackers.yml
+++ b/Resources/Prototypes/_StarLight/Roles/antag_play_time_trackers.yml
@@ -1,71 +1,95 @@
 - type: playTimeTracker
   id: AntagDragon
+  name: ghost-role-information-space-dragon-name
 
 - type: playTimeTracker
   id: AntagNinja
+  name: ghost-role-information-space-ninja-name
 
 - type: playTimeTracker
   id: AntagChangeling
+  name: role-subtype-changeling
 
 - type: playTimeTracker
   id: AntagNukeops
+  name: roles-antag-nuclear-operative-name
 
 - type: playTimeTracker
   id: AntagNukeopsMedic
+  name: roles-antag-nuclear-operative-agent-name
 
 - type: playTimeTracker
   id: AntagNukeopsCommander
+  name: roles-antag-nuclear-operative-commander-name
 
 - type: playTimeTracker
   id: AntagParadoxClone
+  name: role-subtype-paradox-clone
 
 - type: playTimeTracker
   id: AntagHeadRev
+  name: role-subtype-head-revolutionary
 
 - type: playTimeTracker
   id: AntagRev
+  name: role-subtype-revolutionary
 
 - type: playTimeTracker
   id: AntagSubvertedSilicon
+  name: role-subtype-subverted
 
 - type: playTimeTracker
   id: AntagThief
+  name: role-subtype-thief
 
 - type: playTimeTracker
   id: AntagTraitor
+  name: role-subtype-traitor
 
 - type: playTimeTracker
   id: AntagVampire
+  name: roles-antag-vamire-name
 
 - type: playTimeTracker
   id: AntagSurvivor
+  name: role-subtype-survivor
 
 - type: playTimeTracker
   id: AntagWizard
+  name: role-subtype-wizard
 
 - type: playTimeTracker
   id: AntagMothershipCore
+  name: role-subtype-xenoborg-core
 
 - type: playTimeTracker
   id: AntagXenoborg
+  name: role-subtype-xenoborg
 
 - type: playTimeTracker
   id: AntagInitialInfected
+  name: role-subtype-initial-infected
 
 - type: playTimeTracker
   id: AntagZombie
+  name: role-subtype-zombie
 
 - type: playTimeTracker
   id: AntagLoneAbductor
+  name: role-subtype-abductor
 
 - type: playTimeTracker
   id: AntagPirate
+  name: ghost-role-information-pirate-name
 
 - type: playTimeTracker
   id: AntagPirateCaptain
+  name: ghost-role-information-pirate-captain-name
 
 - type: playTimeTracker
   id: AntagRatKing
+  name: ghost-role-information-rat-king-name
 
 - type: playTimeTracker
   id: AntagSSF
+  name: ghost-role-information-soviet-marine-name

--- a/Resources/Prototypes/_StarLight/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/_StarLight/Roles/play_time_trackers.yml
@@ -56,21 +56,28 @@
 
 - type: playTimeTracker
   id: GhostPAI
+  name: pai-system-role-name
 
 - type: playTimeTracker
   id: GhostCritterHarmless
+  name: ghost-role-critter-harmless
 
 - type: playTimeTracker
   id: GhostBotHarmless
+  name: ghost-role-bot-harmless
 
 - type: playTimeTracker
   id: GhostNecktie
+  name: ghost-role-information-horrific-tie-name
 
 - type: playTimeTracker
   id: GhostSkeleton
+  name: species-name-skeleton
 
 - type: playTimeTracker
   id: GhostXeno
+  name: ghost-role-information-xeno-name
 
 - type: playTimeTracker
   id: Observer
+  name: lobby-state-player-status-observer


### PR DESCRIPTION
## Short description
The role time requirements check was assuming that all roles with time trackers were job roles; in order to fix this, this change adds a way for it to find the display name for non-job playtime trackers.

## Why we need to add this
Right now opening loadouts fails because it can't find the job backing the pAI playtime tracker for the golden pAI trinket.

## Media (Video/Screenshots)
<img width="775" height="237" alt="image" src="https://github.com/user-attachments/assets/708449ce-79dd-4623-acbb-e539eb14ebdf" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Fixed editing loadouts.
