### PR TITLE
tying up loose ends with station events

### DIFF
--- a/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
@@ -14,7 +14,7 @@ using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
-public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
+public sealed class MeteorSwarmSystem : StationEventSystem<MeteorSwarmComponent>
 {
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
@@ -26,14 +26,12 @@ public sealed class MeteorSwarmSystem : GameRuleSystem<MeteorSwarmComponent>
         base.Added(uid, component, gameRule, args);
 
         component.WaveCounter = component.Waves.Next(RobustRandom);
-
-        // we don't want to send to players who aren't in game (i.e. in the lobby)
-        Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
-
+        
+        //Starlight begin
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
         if (component.Announcement is { } locId)
-            _chat.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(locId), playSound: false, colorOverride: Color.Gold);
-
-        _audio.PlayGlobal(component.AnnouncementSound, allPlayersInGame, true);
+            Announce(stationEvent, locId, false, colorOverride: Color.Gold);
+        //Starlight end
     }
 
     protected override void ActiveTick(EntityUid uid, MeteorSwarmComponent component, GameRuleComponent gameRule, float frameTime)

--- a/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
@@ -14,7 +14,7 @@ using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
-public sealed class MeteorSwarmSystem : StationEventSystem<MeteorSwarmComponent>
+public sealed class MeteorSwarmSystem : StationEventSystem<MeteorSwarmComponent> // Starlight-edit: Use station event system
 {
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly AudioSystem _audio = default!;

--- a/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
@@ -41,13 +41,13 @@ public sealed class MeteorSwarmSystem : StationEventSystem<MeteorSwarmComponent>
 
         component.NextWaveTime += TimeSpan.FromSeconds(component.WaveCooldown.Next(RobustRandom));
 
-
-        if (_station.GetStations().Count == 0)
+        //Starlight begin
+        if(!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        
+        if (stationEvent.TargetStation is null) return;
+        if (_station.GetLargestGrid(stationEvent.TargetStation.Value) is not { } grid)
             return;
-
-        var station = RobustRandom.Pick(_station.GetStations());
-        if (_station.GetLargestGrid(station) is not { } grid)
-            return;
+        //Starlight end
 
         var mapId = Transform(grid).MapID;
         var playableArea = _physics.GetWorldAABB(grid);

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -9,7 +9,8 @@ using Content.Shared.GameTicking.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
-using Content.Shared.Station.Components; //Starlight
+using Content.Shared.Station.Components;
+using Robust.Shared.Audio; //Starlight
 
 namespace Content.Server.StationEvents.Events;
 
@@ -48,36 +49,7 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             stationEvent.TargetStation = chosenStation;
         //Starlight end stationEvent.TargetStation = station;
 
-        if (stationEvent.StartAnnouncement is not null)
-        {
-            if (stationEvent.GlobalAnnouncement)
-            {
-                var allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
-
-                if (stationEvent.StartAnnouncement != null)
-                    ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
-                        Loc.GetString(stationEvent.StartAnnouncement), playSound: false,
-                        colorOverride: stationEvent.StartAnnouncementColor);
-                
-                Audio.PlayGlobal(stationEvent.StartAudio, allPlayersInGame, true);
-            }
-            else
-            {
-                var allPlayersOnStation = Filter.Empty().AddWhere(session =>
-                {
-                    if (session.AttachedEntity is null) return false;
-                    if (!TryComp<StationMemberComponent>(Transform(session.AttachedEntity.Value).GridUid,
-                            out var stationGrid)) return false;
-                    return stationGrid.Station == stationEvent.TargetStation;
-                });
-                
-                ChatSystem.DispatchFilteredAnnouncement(allPlayersOnStation,
-                    Loc.GetString(stationEvent.StartAnnouncement), playSound: false,
-                    colorOverride: stationEvent.StartAnnouncementColor);
-                
-                Audio.PlayGlobal(stationEvent.StartAudio, allPlayersOnStation, true);
-            }
-        }
+        Announce(stationEvent, stationEvent.StartAnnouncement, false, stationEvent.StartAnnouncementColor, stationEvent.StartAudio);
         
         // we don't want to send to players who aren't in game (i.e. in the lobby)
         
@@ -114,13 +86,10 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
 
         AdminLogManager.Add(LogType.EventStopped, $"Event ended: {ToPrettyString(uid)}");
 
+        //Starlight begin
         // we don't want to send to players who aren't in game (i.e. in the lobby)
-        Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
-
-        if (stationEvent.EndAnnouncement != null)
-            ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame, Loc.GetString(stationEvent.EndAnnouncement), playSound: false, colorOverride: stationEvent.EndAnnouncementColor);
-
-        Audio.PlayGlobal(stationEvent.EndAudio, allPlayersInGame, true);
+        Announce(stationEvent, stationEvent.EndAnnouncement, false, stationEvent.EndAnnouncementColor, stationEvent.EndAudio);
+        //Starlight end
     }
 
     /// <summary>
@@ -148,4 +117,37 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             }
         }
     }
+    
+    //Starlight begin
+    public void Announce(StationEventComponent stationEvent, LocId? announcementLocId, bool dispatchSound, Color? colorOverride = null, SoundSpecifier? soundOverride = null)
+    {
+        if (announcementLocId is null) return;
+        if (stationEvent.GlobalAnnouncement)
+        {
+            var allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
+
+            ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
+                Loc.GetString(announcementLocId), playSound: dispatchSound,
+                colorOverride: colorOverride);
+                
+            if(soundOverride is not null) Audio.PlayGlobal(soundOverride, allPlayersInGame, true);
+        }
+        else
+        {
+            var allPlayersOnStation = Filter.Empty().AddWhere(session =>
+            {
+                if (session.AttachedEntity is null) return false;
+                if (!TryComp<StationMemberComponent>(Transform(session.AttachedEntity.Value).GridUid,
+                        out var stationGrid)) return false;
+                return stationGrid.Station == stationEvent.TargetStation;
+            });
+
+            ChatSystem.DispatchFilteredAnnouncement(allPlayersOnStation,
+                Loc.GetString(announcementLocId), playSound: dispatchSound,
+                colorOverride: colorOverride);
+
+            if(soundOverride is not null) Audio.PlayGlobal(soundOverride, allPlayersOnStation, true);
+        }
+    }
+    //Starlight end
 }

--- a/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
+++ b/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
@@ -20,7 +20,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Server.StationEvents.Events;
 
-public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent>
+public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent> // Starlight-edit: Use StationEventSystem.
 {
     private readonly List<SalvageMapPrototype> _salvageMaps = new();
 
@@ -53,6 +53,13 @@ public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent>
             return;
         }
 
+        // tf are you doing without one of these
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent))
+        {
+            ForceEndSelf(uid, gameRule);
+            return;
+        }
+
         var mapId = Transform(grid).MapID;
         var playableArea = _physics.GetWorldAABB(grid);
 
@@ -79,7 +86,7 @@ public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent>
            )
         {
             // We couldn't load it, or it loaded empty - blame it on CC
-            Announce(Loc.GetString("station-event-incoming-wreck-swarm-spawn-failed"), null);
+            // Announce(stationEvent, Loc.GetString("station-event-incoming-wreck-swarm-spawn-failed"), false);
 
             _mapSystem.DeleteMap(wreckMapXform.MapID);
 
@@ -107,7 +114,7 @@ public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent>
         _mapSystem.DeleteMap(wreckMapXform.MapID);
 
         if (component.Announcement is { } locId)
-            Announce(Loc.GetString(locId), component.AnnouncementSound);
+            // Announce(stationEvent, Loc.GetString(locId), false, null, component.AnnouncementSound);
 
         // Done processing, don't recur on next tick
         ForceEndSelf(uid, gameRule);
@@ -131,14 +138,15 @@ public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent>
         }
     }
 
-    private void Announce(string announcement, SoundSpecifier? sound) {
-        // Let the players know (but we don't want to send to players who aren't in game (i.e. in the lobby))
-        Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
-
-        _chat.DispatchFilteredAnnouncement(allPlayersInGame, announcement, playSound: false, colorOverride: Color.Gold);
-
-        if (sound is not null) {
-            _audio.PlayGlobal(sound, allPlayersInGame, true);
-        }
-    }
+    // Scrapped in favor of StationEventSystem.Announce
+    // private void Announce(string announcement, SoundSpecifier? sound) {
+    //     // Let the players know (but we don't want to send to players who aren't in game (i.e. in the lobby))
+    //     Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
+    //
+    //     _chat.DispatchFilteredAnnouncement(allPlayersInGame, announcement, playSound: false, colorOverride: Color.Gold);
+    //
+    //     if (sound is not null) {
+    //         _audio.PlayGlobal(sound, allPlayersInGame, true);
+    //     }
+    // }
 }

--- a/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
+++ b/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
@@ -20,7 +20,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Server.StationEvents.Events;
 
-public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent> // Starlight-edit: Use StationEventSystem.
+public sealed class WreckSwarmSystem : StationEventSystem<WreckSwarmComponent>
 {
     private readonly List<SalvageMapPrototype> _salvageMaps = new();
 
@@ -114,7 +114,7 @@ public sealed class WreckSwarmSystem : GameRuleSystem<WreckSwarmComponent> // St
         _mapSystem.DeleteMap(wreckMapXform.MapID);
 
         if (component.Announcement is { } locId)
-            // Announce(stationEvent, Loc.GetString(locId), false, null, component.AnnouncementSound);
+            Announce(stationEvent, Loc.GetString(locId), false, null, component.AnnouncementSound);
 
         // Done processing, don't recur on next tick
         ForceEndSelf(uid, gameRule);

--- a/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
+++ b/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using System.Linq;
 using Content.Server.Chat.Systems;
+using Content.Server.Database.Migrations.Sqlite;
 using Content.Server.GameTicking.Rules;
 using Content.Server.Station.Systems;
 using Content.Server.StationEvents.Components;
@@ -45,16 +46,16 @@ public sealed class WreckSwarmSystem : StationEventSystem<WreckSwarmComponent>
             ForceEndSelf(uid, gameRule);
             return;
         }
-
-        var station = RobustRandom.Pick(_station.GetStations());
-        if (_station.GetLargestGrid(station) is not { } grid)
+        
+        // tf are you doing without one of these
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent))
         {
             ForceEndSelf(uid, gameRule);
             return;
         }
 
-        // tf are you doing without one of these
-        if (!TryComp<StationEventComponent>(uid, out var stationEvent))
+        if (stationEvent.TargetStation is null) return;
+        if (_station.GetLargestGrid(stationEvent.TargetStation.Value) is not { } grid)
         {
             ForceEndSelf(uid, gameRule);
             return;
@@ -137,16 +138,4 @@ public sealed class WreckSwarmSystem : StationEventSystem<WreckSwarmComponent>
             return map.MapPath;
         }
     }
-
-    // Scrapped in favor of StationEventSystem.Announce
-    // private void Announce(string announcement, SoundSpecifier? sound) {
-    //     // Let the players know (but we don't want to send to players who aren't in game (i.e. in the lobby))
-    //     Filter allPlayersInGame = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
-    //
-    //     _chat.DispatchFilteredAnnouncement(allPlayersInGame, announcement, playSound: false, colorOverride: Color.Gold);
-    //
-    //     if (sound is not null) {
-    //         _audio.PlayGlobal(sound, allPlayersInGame, true);
-    //     }
-    // }
 }

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -120,6 +120,7 @@
       min:  30
       max:  30
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncementColor: "#18abf5"
     startAudio:
       path: /Audio/Announcements/announce.ogg
@@ -392,6 +393,7 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     startAnnouncement: station-event-gas-leak-start-announcement
     startAudio:
       path: /Audio/_Starlight/Announcements/attention.ogg
@@ -634,6 +636,7 @@
   id: SleeperAgents
   components:
   - type: StationEvent
+    globalAnnouncement: false # Starlight
     earliestStart: 40 # 🌟Starlight🌟 Casualization
     weight: 6 # 🌟Starlight🌟 Casualization
     minimumPlayers: 15


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Updates some more station event related things that I missed in the last PR related to this. Namely, meteor and wreck events no longer announce globally, as well as some others that were doing it that shouldn't. Also makes the end announcements also not broadcast globally anymore either.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Consistency with previous PR
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Additional station events that were broadcasting globally have been fixed to no longer globally announce.
- fix: Station event ending announcements no longer announce globally.