### PR TITLE
Make the wrecks in the wreck swarm faster

### DIFF
--- a/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
+++ b/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Server.StationEvents.Components;
 public sealed partial class WreckSwarmComponent : Component
 {
     [DataField]
-    public float Velocity = 20f;
+    public float Velocity = 80f;
 
     /// <summary>
     /// The announcement played when a meteor swarm begins.


### PR DESCRIPTION
## Short description
behold: impromptu ramops

## Why we need to add this
currently they just kinda bounce off the station without doing alot of dammage

## Media (Video/Screenshots)
I pelted a few at cog
<img width="449" height="490" alt="image" src="https://github.com/user-attachments/assets/bf13c9d3-8979-4374-a2f3-3d0a21c10c62" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- tweak: Made wrecks from the wreck swarm event 4x faster so they actually did more then scratch the paint.