### PR TITLE
Add SpaceMall to the station power test map list

### DIFF
--- a/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
+++ b/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
@@ -63,6 +63,7 @@ public sealed class StationPowerTests
         "StarlightReach",
         "StarlightSaltern",
         "StarlightSilica",
+        "StarlightSpaceMall",
         "StarlightCluster",
         "StarlightStationBuilding",
         "StarlightPlasma",


### PR DESCRIPTION
## Short description
Adds SpaceMall to the starting power window and APC overload tests.

## Why we need to add this
This should improve our coverage and help catch potential issues in later updates, if any.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
