### PR TITLE
Paranoia

### DIFF
--- a/Resources/Prototypes/SoundCollections/traits.yml
+++ b/Resources/Prototypes/SoundCollections/traits.yml
@@ -76,3 +76,11 @@
   - /Audio/Voice/Zombie/zombie-2.ogg
   - /Audio/Voice/Zombie/zombie-3.ogg
   - /Audio/Voice/Vox/shriek1.ogg
+  - /Audio/Voice/Xenoborg/xenoborg_ask.ogg #Starlight
+  - /Audio/Voice/Xenoborg/xenoborg_talk.ogg #Starlight
+  - /Audio/_Starlight/Misc/alien_teleport.ogg #Starlight
+  - /Audio/Effects/Changeling/devour_consume.ogg #Starlight 
+  - /Audio/Effects/Changeling/devour_windup.ogg #Starlight
+  - /Audio/_Starlight/Weapons/Guns/Gunshots/minotaur.ogg #Starlight
+  - /Audio/_Starlight/Weapons/Guns/Gunshots/mosin.ogg #Starlight
+  - /Audio/_Starlight/Weapons/Guns/Gunshots/ppsh.ogg #Starlight


### PR DESCRIPTION

## Short description
Adds new sounds to the Paracusia sound collection, which plays if you have the paracusia trait or when the mass hallucination event triggers. Includes: Xenoborg Ask, Xenoborg Talk, Abductor Teleport, Changeling Devour, Changeling Devour Windup, Minotaur gunshot, Mosin gunshot, PPSH gunshot.

## Why we need to add this
Increases paranoia. The Mass Hallucination event is a very important anti-metagame tool, playing random sounds makes people question if what they heard in maints in real or not, which makes them less prone to metagaming mindshielded things. Adding Xenoborgs, Changelings, and a handful of other Starlight sounds helps this purpose.

## Media (Video/Screenshots)
<img width="1600" height="1560" alt="image" src="https://github.com/user-attachments/assets/12f6a3a9-2d74-4951-be6c-69dfd20a327d" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added Something.
- remove: Removed Sanity.
- tweak: Changed Everything.
- fix: Fixed The Ceiling There Is No Ceiling There Is No Ceiling There Is No Ceiling LOOK UP LOOK UP LOOK U-
