### PR TITLE
Fix corgi not having a thermal regulation

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3057,7 +3057,13 @@
       Dead: CorgiDead
   - type: Blindable # why is this not base?
   - type: ThermalRegulator # Lower radiated heat, Corgis are smaller so their body surface area is also smaller.
+    metabolismHeat: 400 # half of human's
     radiatedHeat: 35 # This affects them reallistically only when dead in a spaced room, makes the cold damage scale slower.
+    implicitHeatRegulation: 250 # Add implicit heat regulation because they lacked it for some reason
+    sweatHeatRegulation: 500 # Allow corgis to sweat, i dont know if dogs sweat but i am not implementing a different way of regulation just for them
+    shiveringHeatRegulation: 500 # Allow corgis to shiver to warm up
+    normalBodyTemperature: 310.15 # Same as human
+    thermalRegulationTemperatureThreshold: 2 # Same as human
   # Starlight End
 
 - type: entity


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR fixes an oversight which is: Corgi did not have any thermal regulation defined, which made them overheat in hardsuits after blocking their radiated heat.

## Why we need to add this
Fixes: https://discord.com/channels/1272545509562777621/1465187620475637842
For the Corgi enjoyers this is somewhat of a necessary change to be able to survive in a hardsuit.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Fixed Corgi overheating in hardsuits.
