### PR TITLE
Move MetabolizerComponent to Shared

### DIFF
--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using Content.Server.Body.Components;
+using Content.Shared.Body.Components;
 using Content.Shared.Body.Events;
 using Content.Shared.Body.Organ;
 using Content.Shared.Body.Prototypes;
@@ -74,6 +74,7 @@ public sealed class MetabolizerSystem : SharedMetabolizerSystem
     private void OnApplyMetabolicMultiplier(Entity<MetabolizerComponent> ent, ref ApplyMetabolicMultiplierEvent args)
     {
         ent.Comp.UpdateIntervalMultiplier = args.Multiplier;
+        Dirty(ent);
     }
 
     public override void Update(float frameTime)
@@ -306,29 +307,38 @@ public sealed class MetabolizerSystem : SharedMetabolizerSystem
         return true;
     }
 
-    public bool TryAddMetabolizerType(MetabolizerComponent component, string metabolizerType)
+    public bool TryAddMetabolizerType(Entity<MetabolizerComponent> ent, string metabolizerType)
     {
         if (!_prototypeManager.HasIndex<MetabolizerTypePrototype>(metabolizerType))
             return false;
 
-        if (component.MetabolizerTypes == null)
-            component.MetabolizerTypes = new();
+        ent.Comp.MetabolizerTypes ??= new();
+        if (!ent.Comp.MetabolizerTypes.Add(metabolizerType))
+            return false;
 
-        return component.MetabolizerTypes.Add(metabolizerType);
+        Dirty(ent);
+        return true;
     }
 
-    public bool TryRemoveMetabolizerType(MetabolizerComponent component, string metabolizerType)
+    public bool TryRemoveMetabolizerType(Entity<MetabolizerComponent> ent, string metabolizerType)
     {
-        if (component.MetabolizerTypes == null)
+        if (ent.Comp.MetabolizerTypes == null)
             return true;
 
-        return component.MetabolizerTypes.Remove(metabolizerType);
+        if (!ent.Comp.MetabolizerTypes.Remove(metabolizerType))
+            return false;
+
+        Dirty(ent);
+        return true;
     }
 
-    public void ClearMetabolizerTypes(MetabolizerComponent component)
+    public void ClearMetabolizerTypes(Entity<MetabolizerComponent> ent)
     {
-        if (component.MetabolizerTypes != null)
-            component.MetabolizerTypes.Clear();
+        if (ent.Comp.MetabolizerTypes == null || ent.Comp.MetabolizerTypes.Count == 0)
+            return;
+
+        ent.Comp.MetabolizerTypes.Clear();
+        Dirty(ent);
     }
 }
 

--- a/Content.Server/EntityConditions/Conditions/MetabolizerTypesEntityConditionSystem.cs
+++ b/Content.Server/EntityConditions/Conditions/MetabolizerTypesEntityConditionSystem.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Content.Server.Body.Components;
+﻿using Content.Shared.Body.Components;
 using Content.Shared.EntityConditions;
 using Content.Shared.EntityConditions.Conditions.Body;
 

--- a/Content.Server/Vampire/VampireSystem.Transform.cs
+++ b/Content.Server/Vampire/VampireSystem.Transform.cs
@@ -77,15 +77,16 @@ public sealed partial class VampireSystem
         {
             if (TryComp<MetabolizerComponent>(organ.Id, out var metabolizer))
             {
+                var metabolizerEnt = new Entity<MetabolizerComponent>(organ.Id, metabolizer);
                 if (TryComp<StomachComponent>(organ.Id, out var stomachComponent))
                 {
                     //Override the stomach, prevents humans getting sick when ingesting blood
-                    _metabolism.ClearMetabolizerTypes(metabolizer);
+                    _metabolism.ClearMetabolizerTypes(metabolizerEnt);
                     _stomach.SetSpecialDigestible(stomachComponent, VampireComponent.AcceptableFoods);
                 }
 
-                _metabolism.TryAddMetabolizerType(metabolizer, VampireComponent.MetabolizerVampire);
-                _metabolism.TryAddMetabolizerType(metabolizer, VampireComponent.MetabolizerBloodsucker);
+                _metabolism.TryAddMetabolizerType(metabolizerEnt, VampireComponent.MetabolizerVampire);
+                _metabolism.TryAddMetabolizerType(metabolizerEnt, VampireComponent.MetabolizerBloodsucker);
             }
         }
     }
@@ -134,7 +135,7 @@ public sealed partial class VampireSystem
         {
             if (TryComp<MetabolizerComponent>(organ.Id, out var metabolizer))
             {
-                _metabolism.TryRemoveMetabolizerType(metabolizer, VampireComponent.MetabolizerVampire);
+                _metabolism.TryRemoveMetabolizerType((organ.Id, metabolizer), VampireComponent.MetabolizerVampire);
             }
         }
 

--- a/Content.Shared/Body/Components/MetabolizerComponent.cs
+++ b/Content.Shared/Body/Components/MetabolizerComponent.cs
@@ -1,20 +1,22 @@
-using Content.Shared.Body.Components;
-using Content.Server.Body.Systems;
 using Content.Shared.Body.Prototypes;
+using Content.Shared.Body.Systems;
 using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Serialization;
 
-namespace Content.Server.Body.Components
+namespace Content.Shared.Body.Components
 {
     /// <summary>
     ///     Handles metabolizing various reagents with given effects.
     /// </summary>
-    [RegisterComponent, AutoGenerateComponentPause, Access(typeof(MetabolizerSystem))]
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+    [Access(typeof(SharedMetabolizerSystem))]
     public sealed partial class MetabolizerComponent : Component
     {
         /// <summary>
         ///     The next time that reagents will be metabolized.
+        ///     Not networked as the client does not use this.
         /// </summary>
         [DataField, AutoPausedField]
         public TimeSpan NextUpdate;
@@ -23,13 +25,13 @@ namespace Content.Server.Body.Components
         ///     How often to metabolize reagents.
         /// </summary>
         /// <returns></returns>
-        [DataField]
+        [DataField, AutoNetworkedField]
         public TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
 
         /// <summary>
         /// Multiplier applied to <see cref="UpdateInterval"/> for adjusting based on metabolic rate multiplier.
         /// </summary>
-        [DataField]
+        [DataField, AutoNetworkedField]
         public float UpdateIntervalMultiplier = 1f;
 
         /// <summary>
@@ -41,7 +43,7 @@ namespace Content.Server.Body.Components
         /// <summary>
         ///     From which solution will this metabolizer attempt to metabolize chemicals
         /// </summary>
-        [DataField("solution")]
+        [DataField("solution"), AutoNetworkedField]
         public string SolutionName = BloodstreamComponent.DefaultBloodSolutionName;
 
         /// <summary>
@@ -50,21 +52,21 @@ namespace Content.Server.Body.Components
         /// <remarks>
         ///     Most things will use the parent entity (bloodstream).
         /// </remarks>
-        [DataField]
+        [DataField, AutoNetworkedField]
         public bool SolutionOnBody = true;
 
         /// <summary>
         ///     List of metabolizer types that this organ is. ex. Human, Slime, Felinid, w/e.
         /// </summary>
-        [DataField]
-        [Access(typeof(MetabolizerSystem), Other = AccessPermissions.ReadExecute)] // FIXME Friends
+        [DataField, AutoNetworkedField]
+        [Access(typeof(SharedMetabolizerSystem), Other = AccessPermissions.ReadExecute)] // FIXME Friends
         public HashSet<ProtoId<MetabolizerTypePrototype>>? MetabolizerTypes;
 
         /// <summary>
         ///     Should this metabolizer remove chemicals that have no metabolisms defined?
         ///     As a stop-gap, basically.
         /// </summary>
-        [DataField]
+        [DataField, AutoNetworkedField]
         public bool RemoveEmpty;
 
         /// <summary>
@@ -72,13 +74,13 @@ namespace Content.Server.Body.Components
         ///     Used to nerf 'stacked poisons' where having 5+ different poisons in a syringe, even at low
         ///     quantity, would be muuuuch better than just one poison acting.
         /// </summary>
-        [DataField("maxReagents")]
+        [DataField("maxReagents"), AutoNetworkedField]
         public int MaxReagentsProcessable = 3;
 
         /// <summary>
         ///     A list of metabolism groups that this metabolizer will act on, in order of precedence.
         /// </summary>
-        [DataField("groups")]
+        [DataField("groups"), AutoNetworkedField]
         public List<MetabolismGroupEntry>? MetabolismGroups;
     }
 
@@ -87,6 +89,7 @@ namespace Content.Server.Body.Components
     ///     This allows metabolizers to remove certain groups much faster, or not at all.
     /// </summary>
     [DataDefinition]
+    [Serializable, NetSerializable]
     public sealed partial class MetabolismGroupEntry
     {
         [DataField(required: true)]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Moves MetabolizerComponent to shared, updates usages, adds any necessary Dirty calls.
NextUpdate is intentionally not networked, since it's not used on the client and would only spam out states.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Need this to be able to access metabolizer component information from client code, which I need for more features than I can remember, but right now I need it to be able to compute on the client what reagent metabolization does depending on the organs of an entity.
Moving code to shared good, predict all of SS14 2026

Already a thing in wizden as of 4 days ago, but that change is part of larger metabolism/body changes, this is the minimum lines changed to do just this
If you are merging those changes as is to Starlight, you might want to wait for that instead of using this PR

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

