### PR TITLE
Mald PR: make Avali and Resomi not get poisoned from ammonia gas

### DIFF
--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -237,7 +237,7 @@
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Rat ]
+          type: [ Rat, Avali, Resomi ] #Starlight
           inverted: true
         - !type:ReagentCondition
           reagent: Ammonia
@@ -250,7 +250,7 @@
         probability: 0.12
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Rat, Vox ]
+          type: [ Rat, Vox, Avali, Resomi ] #Starlight
           inverted: true
         - !type:ReagentCondition
           reagent: Ammonia


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR makes it so avali and resomi don't vomit nor get poisoned from ammonia gas.

## Why we need to add this
In my humble opinion it makes zero sense, considering that we accepted their lore of having ammonia based blood, as well as come from mostly ammonia covered planet, they shouldn't be poisoned by it?

It is not really a buff since... i don't think an average person finds large clouds of ammonia in atmos very often.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Fixed Avali and Resomi getting poisoned from ammonia.
