### PR TITLE
Mald PR: Fix changelings being untestable after being hollowed

### DIFF
--- a/Content.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -27,9 +27,8 @@ using Content.Shared.RetractableItemAction;
 using Content.Shared.Changeling.Systems;
 using Content.Shared.Changeling.Components;
 using Content.Server.Changeling.Systems;
-using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Humanoid; // Starlight edit
-using Content.Shared.Body.Components;
+using Content.Shared.Body.Components; // Starlight edit
 
 namespace Content.Server.Changeling;
 

--- a/Content.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -27,7 +27,9 @@ using Content.Shared.RetractableItemAction;
 using Content.Shared.Changeling.Systems;
 using Content.Shared.Changeling.Components;
 using Content.Server.Changeling.Systems;
+using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Humanoid; // Starlight edit
+using Content.Shared.Body.Components;
 
 namespace Content.Server.Changeling;
 
@@ -127,9 +129,19 @@ public sealed partial class ChangelingSystem : EntitySystem
 
         UpdateBiomass(uid, comp, comp.MaxBiomass - comp.TotalAbsorbedEntities);
 
-        _blood.ChangeBloodReagent(target, "FerrochromicAcid");
-        _blood.SpillAllSolutions(target);
-
+        // Starlight edit start - Mix blood from the target with ferrochromic acid instead of replacing it
+        // allows for ling tests to still pass despite being hollowed.
+        if (TryComp<BloodstreamComponent>(target, out var bloodstream) && bloodstream.BloodReferenceSolution is { } originalBlood)
+        {
+            var mixedBlood = originalBlood.Clone();
+            mixedBlood.ScaleTo(FixedPoint2.New(150));
+            mixedBlood.AddReagent("FerrochromicAcid", FixedPoint2.New(150));
+        
+            _blood.ChangeBloodReagents(target, mixedBlood);
+            _blood.SpillAllSolutions(target);
+        }
+        // Starlight edit end
+        
         EnsureComp<AbsorbedComponent>(target);
 
         var popup = Loc.GetString("changeling-absorb-end-self-ling");


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR aims to make changeling victims correctly testable, the original code made it so all blood in a changeling victim was turned into Ferrochromic Acid, which to my knowledge was just a flavor of changeling devouring their victim in such a way. 

This however made it so people who got hollowed forever lost their original blood, making changelings untestable. This did not make much sense in my opinion, so i have mixed Ferrochromic acid with the victim's original blood in ratio 1:1 giving it a beautiful brown color.

## Why we need to add this
I believe this was an oversight, as well as it makes little sense that a changeling victim starts living off of ferrochromic acid, their organs producing it.

## Media (Video/Screenshots)
<img width="297" height="547" alt="image" src="https://github.com/user-attachments/assets/4c6bf24f-8e0b-44cc-a5a8-6dc51160a962" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
