### PR TITLE
Fix changelings blood

### DIFF
--- a/Content.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -27,8 +27,11 @@ using Content.Shared.RetractableItemAction;
 using Content.Shared.Changeling.Systems;
 using Content.Shared.Changeling.Components;
 using Content.Server.Changeling.Systems;
-using Content.Shared.Humanoid; // Starlight edit
-using Content.Shared.Body.Components; // Starlight edit
+// Starlight edit start
+using Content.Shared.Humanoid;
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Reagent;
+// Starlight edit end
 
 namespace Content.Server.Changeling;
 
@@ -128,16 +131,17 @@ public sealed partial class ChangelingSystem : EntitySystem
 
         UpdateBiomass(uid, comp, comp.MaxBiomass - comp.TotalAbsorbedEntities);
 
-        // Starlight edit start - Mix blood from the target with ferrochromic acid instead of replacing it
+        // Starlight edit start - Do not turn the victim's blood into ferrochromic acid permanently
         // allows for ling tests to still pass despite being hollowed.
         if (TryComp<BloodstreamComponent>(target, out var bloodstream) && bloodstream.BloodReferenceSolution is { } originalBlood)
         {
-            var mixedBlood = originalBlood.Clone();
-            mixedBlood.ScaleTo(FixedPoint2.New(150));
-            mixedBlood.AddReagent("FerrochromicAcid", FixedPoint2.New(150));
+            var blood = originalBlood.Clone();
+            blood.ScaleTo(originalBlood.Volume);
+            var ferroAcid = new ReagentQuantity("FerrochromicAcid", originalBlood.Volume);
         
-            _blood.ChangeBloodReagents(target, mixedBlood);
+            _blood.ChangeBloodReagents(target, new Solution([ferroAcid]));
             _blood.SpillAllSolutions(target);
+            _blood.ChangeBloodReagents(target, blood);
         }
         // Starlight edit end
         

--- a/Content.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Server/Changeling/ChangelingSystem.cs
@@ -58,7 +58,10 @@ using Content.Shared.Mobs.Components;
 using Content.Server.Stunnable;
 using Content.Shared.Jittering;
 using System.Linq;
-using Content.Shared.Radio;
+// Starlight edit start
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Reagent;
+// Starlight edit end
 using Content.Shared.Zombies;
 
 namespace Content.Server.Changeling;
@@ -578,7 +581,13 @@ public sealed partial class ChangelingSystem : EntitySystem
         UpdateBiomass(uid, comp, 0);
 
         // make their blood unreal
-        _blood.ChangeBloodReagent(uid, "BloodChangeling");
+        // Starlight edit start - remove deprecated method
+        if (TryComp<BloodstreamComponent>(uid, out var bloodstream) &&
+            bloodstream.BloodReferenceSolution is { } originalBlood)
+        {
+            _blood.ChangeBloodReagents(uid, new Solution([new ReagentQuantity("BloodChangeling", originalBlood.Volume)]));
+        }
+        // Starlight edit end
     }
 
     private void OnMobStateChange(EntityUid uid, ChangelingComponent comp, ref MobStateChangedEvent args)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
https://github.com/ss14Starlight/space-station-14/pull/3011
This is a quick fix to the previous PR that aimed to make changelings testable after being hollowed, the original PR was mixing blood which made the blood look brown, removing the iconic changeling cyan color. This PR aimed to fix that by temporarily changing the blood into ferrochromic acid, and reverting it afterwards.

However i have also detected a bug in how changelings worked so i have fixed it, by using a deprecated method the changeling blood volume was set to 1u.

## Why we need to add this
Update a deprecated method as well as in my opinion better feel of the change in general.

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/dee61445-c51b-4cb8-a7e5-c764bd57a2de


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Fixed Changelings having 1u of blood.
