### PR TITLE
Chemical contra alignment

### DIFF
--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -56,6 +56,11 @@
   flavor: bitter
   color: "#9e9886"
   physicalDesc: reagent-physical-desc-bubbling
+  # Starlight Edits
+  contrabandSeverity: Major
+  allowedJobs:
+  - Botanist
+  # Starlight End
   plantMetabolism:
     - !type:PlantAdjustToxins
       amount: 4
@@ -80,6 +85,11 @@
   flavor: bitter
   color: "#49002E"
   physicalDesc: reagent-physical-desc-bubbling
+  # Starlight Edits
+  contrabandSeverity: Major
+  allowedJobs:
+  - Botanist
+  # Starlight End
   plantMetabolism:
     - !type:PlantAdjustToxins
       amount: 6
@@ -181,6 +191,11 @@
   flavor: bitter
   color: "#968395"
   physicalDesc: reagent-physical-desc-bubbling
+  # Starlight Edits
+  contrabandSeverity: Major
+  allowedJobs:
+  - Botanist
+  # Starlight End
   plantMetabolism:
     - !type:PlantAdjustToxins
       amount: 4

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -26,6 +26,11 @@
   group: Elements
   desc: reagent-desc-chlorine
   physicalDesc: reagent-physical-desc-gaseous
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedJobs:
+  - Chemist
+  # Starlight End
   flavor: bitter
   color: "#a2ff00"
   meltingPoint: -101.5
@@ -83,6 +88,11 @@
   group: Elements
   desc: reagent-desc-fluorine
   physicalDesc: reagent-physical-desc-gaseous
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedJobs:
+  - Chemist
+  # Starlight End
   flavor: bitter
   color: "#ba85cc"
   boilingPoint: -188.11
@@ -228,6 +238,11 @@
   group: Elements
   desc: reagent-desc-potassium
   physicalDesc: reagent-physical-desc-shiny
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedJobs:
+  - Chemist
+  # Starlight End
   flavor: metallic
   color: "#c6c8cc"
   meltingPoint: 65.5
@@ -239,6 +254,11 @@
   group: Elements
   desc: reagent-desc-phosphorus
   physicalDesc: reagent-physical-desc-powdery
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedJobs:
+  - Chemist
+  # Starlight End
   flavor: metallic
   color: "#f5da9a"
   meltingPoint: 44.2
@@ -258,6 +278,11 @@
   parent: Uranium
   desc: reagent-desc-radium
   physicalDesc: reagent-physical-desc-glowing
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedDepartments:
+  - Engineering
+  # Starlight End
   flavor: metallic
   color: "#00ff04"
   meltingPoint: 700.0
@@ -269,6 +294,11 @@
   group: Elements
   desc: reagent-desc-silicon
   physicalDesc: reagent-physical-desc-crystalline
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedJobs:
+  - Chemist
+  # Starlight End
   flavor: metallic
   color: "#364266"
   boilingPoint: 3265.0
@@ -298,6 +328,7 @@
   group: Elements
   desc: reagent-desc-sulfur
   physicalDesc: reagent-physical-desc-powdery
+  contrabandSeverity: Minor # Starlight None -> Minor
   flavor: bitter
   color: "#fff385"
   boilingPoint: 445.0
@@ -327,6 +358,13 @@
   group: Elements
   desc: reagent-desc-uranium
   physicalDesc: reagent-physical-desc-metallic
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedDepartments:
+  - Engineering
+  allowedJobs:
+  - Bartender
+  # Starlight End
   flavor: metallic
   color: "#8fa191"
   meltingPoint: 1133.0

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -48,7 +48,7 @@
   group: Toxins
   desc: reagent-desc-buzzochloric-bees
   physicalDesc: reagent-physical-desc-buzzy
-  contrabandSeverity: Minor
+  contrabandSeverity: Major # Starlight Minor -> Major
   flavor: bee
   color: "#FFD35D"
   tileReactions:
@@ -159,7 +159,7 @@
   group: Toxins
   desc: reagent-desc-licoxide
   physicalDesc: reagent-physical-desc-electric
-  contrabandSeverity: Minor
+  contrabandSeverity: Major # Starlight Minor -> Major
   flavor: shocking
   color: "#FDD023"
   metabolisms:
@@ -176,6 +176,7 @@
     requiredSlipSpeed: 3.5
   desc: reagent-desc-razorium
   physicalDesc: reagent-physical-desc-reflective
+  contrabandSeverity: Major # Starlight None -> Major
   flavor: sharp
   color: "#e3fffb"
   reactiveEffects:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -795,6 +795,11 @@
   group: Medicine
   desc: reagent-desc-synaptizine
   physicalDesc: reagent-physical-desc-pungent
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedDepartments:
+  - Security
+  # Starlight End
   flavor: medicine
   color: "#d49a2f"
   metabolisms:
@@ -994,6 +999,7 @@
   desc: reagent-desc-ethyloxyephedrine
   group: Medicine
   physicalDesc: reagent-physical-desc-shiny
+  contrabandSeverity: Minor # Starlight None -> Minor
   flavor: medicine
   color: "#d5d5e4"
   metabolisms:
@@ -1474,6 +1480,7 @@
   group: Medicine
   desc: reagent-desc-psicodine
   physicalDesc: reagent-physical-desc-shiny
+  contrabandSeverity: Minor # Starlight None -> Minor
   flavor: bitter
   color: "#07E79E"
   metabolisms:

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -4,7 +4,7 @@
   group: Narcotics
   desc: reagent-desc-desoxyephedrine
   physicalDesc: reagent-physical-desc-translucent
-  contrabandSeverity: Minor
+  contrabandSeverity: Major # Starlight Minor -> Major
   flavor: bitter
   color: "#FAFAFA"
   boilingPoint: 212.0  # Dexosyephedrine vape when?
@@ -73,6 +73,11 @@
   group: Narcotics
   desc: reagent-desc-ephedrine
   physicalDesc: reagent-physical-desc-powdery
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedDepartments:
+  - Security
+  # Starlight End
   flavor: bitter
   color: "#D2FFFA"
   boilingPoint: 255.0
@@ -224,6 +229,7 @@
   flavorMinimum: 0.05
   color: "#808080"
   physicalDesc: reagent-physical-desc-crystalline
+  contrabandSeverity: Minor # Starlight None -> Minor
   plantMetabolism:
   - !type:PlantAdjustNutrition
     amount: -5
@@ -284,6 +290,7 @@
   group: Narcotics
   desc: reagent-desc-space-drugs
   physicalDesc: reagent-physical-desc-syrupy
+  contrabandSeverity: Minor # Starlight None -> Minor
   flavor: bitter
   color: "#63806e"
   metabolisms:
@@ -361,7 +368,7 @@
   group: Narcotics
   desc: reagent-desc-norepinephric-acid
   physicalDesc: reagent-physical-desc-milky
-  contrabandSeverity: Minor
+  contrabandSeverity: Major # Starlight Minor -> Major
   flavor: salty
   color: "#96a8b5"
   boilingPoint: 255.0
@@ -408,6 +415,7 @@
   group: Narcotics
   desc: reagent-desc-tear-gas
   physicalDesc: reagent-physical-desc-milky
+  contrabandSeverity: Major # Starlight None -> Major
   allowedDepartments:
   - Security
   flavor: salty
@@ -469,6 +477,11 @@
   group: Narcotics
   desc: reagent-desc-happiness
   physicalDesc: reagent-physical-desc-soothing
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedJobs:
+  - Clown
+  # Starlight End
   flavor: paintthinner
   color: "#EE35FF"
   metabolisms:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -6,7 +6,7 @@
   flavor: bitter
   color: "#cf3600"
   physicalDesc: reagent-physical-desc-opaque
-  contrabandSeverity: Minor
+  contrabandSeverity: Major # Starlight Minor -> Major
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: 10
@@ -93,6 +93,7 @@
   flavor: bitter
   color: "#acc91a"
   physicalDesc: reagent-physical-desc-putrid
+  contrabandSeverity: Minor # Starlight None -> Minor
   metabolisms:
     Poison:
       effects:
@@ -179,6 +180,7 @@
   flavor: sour
   color: "#48b3b8"
   physicalDesc: reagent-physical-desc-ferrous
+  contrabandSeverity: Major # Starlight None -> Major
   metabolisms:
     Drink:
       effects:
@@ -197,7 +199,7 @@
   group: Toxins
   desc: reagent-desc-fluorosulfuric-acid
   physicalDesc: reagent-physical-desc-strong-smelling
-  contrabandSeverity: Minor
+  contrabandSeverity: Major # Starlight Minor -> Major
   flavor: acid
   color: "#5050ff"
   boilingPoint: 165
@@ -345,6 +347,7 @@
   group: Toxins
   desc: reagent-desc-mindbreaker-toxin
   physicalDesc: reagent-physical-desc-opaque
+  contrabandSeverity: Minor # Starlight None -> Minor
   flavor: bitter
   color: "#77b58e"
   plantMetabolism:
@@ -696,8 +699,11 @@
   group: Toxins
   desc: reagent-desc-lipolicide
   physicalDesc: reagent-physical-desc-strong-smelling
-  allowedDepartments:
-  - Medical
+  # Starlight Edits
+  contrabandSeverity: Major
+  # allowedDepartments:
+  # - Medical
+  # Starlight End
   flavor: mothballs #why does weightloss juice taste like mothballs
   color: "#F0FFF0"
   metabolisms:
@@ -723,6 +729,7 @@
   flavor: sweet
   color: "#00b408"
   physicalDesc: reagent-physical-desc-nondescript
+  contrabandSeverity: Major # Starlight None -> Major
   metabolisms:
     Poison:
       metabolismRate: 0.2 # Slower metabolism so it can build up over time for slowdown

--- a/Resources/Prototypes/_StarLight/Reagents/medicine.yml
+++ b/Resources/Prototypes/_StarLight/Reagents/medicine.yml
@@ -35,6 +35,11 @@
   group: Medicine
   desc: reagent-desc-amoxla
   physicalDesc: reagent-physical-desc-opaque
+  # Starlight Edits
+  contrabandSeverity: Minor
+  allowedDepartments:
+  - Medical
+  # Starlight End
   flavor: medicine
   color: "#51c38c"
   metabolisms:


### PR DESCRIPTION
## Short description
Updates most Chems' guidebook entries to include Starlight's contraband status.

## Why we need to add this
The Guidebook's in-line contraband status feature was added after we established our own set of contraband chemicals with Medical's SOP, so we needed to align the canned designations with our own, and add ones that were missing.

## Media (Video/Screenshots)


## Checks
- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: r3d3mpt1on
- tweak: Aligned the Guidebook's Chemical Contraband statuses with our own designations from Medical's SOP.

