### PR TITLE
added syndicate shuttle board to traitor uplink

### DIFF
--- a/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
@@ -81,3 +81,6 @@ uplink-glue-grenade-desc = Special grenade for shenanigans, releasing large clou
 
 uplink-pizza-bomb-name = Nefarious Pizza bomb
 uplink-pizza-bomb-desc = Originally developed by covertly by DONK Co to disuade the heretics who prefer their pizza not in pocket form. This pizza box is wired, and explodes within moments of being opened. 
+
+uplink-shuttle-board-name = Syndicate Shuttle Console Board
+uplink-shuttle-board-desc = A computer printed circuit board for a syndicate shuttle console.

--- a/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
@@ -594,7 +594,24 @@
   categories:
   - UplinkDisruption
 
-
+- type: listing
+  id: SyndicateShuttleBoard
+  name: uplink-shuttle-board-name
+  description: uplink-shuttle-board-desc
+  productEntity: SyndicateShuttleConsoleCircuitboard
+  icon: { sprite: Objects/Misc/module.rsi, state: cpu_syndicate }
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 2
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkDisruption
+  conditions:
+    - !type:StoreWhitelistCondition
+      blacklist:
+        tags:
+          - NukeOpsUplink
 
 - type: listing
   id: uplinkRiggedBoxingGlovesBoxer

--- a/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
@@ -607,11 +607,6 @@
     Telecrystal: 4
   categories:
   - UplinkDisruption
-  conditions:
-    - !type:StoreWhitelistCondition
-      blacklist:
-        tags:
-          - NukeOpsUplink
 
 - type: listing
   id: uplinkRiggedBoxingGlovesBoxer


### PR DESCRIPTION
## Short description
Syndicate shuttle board added to uplink for 4 tc

## Why we need to add this
This change would add a shuttle board to the uplink for traitors who are intending to build a shuttle but are not on one of the many maps with a round start shuttle board or do not want to wait for science to research shuttle boards. Players still have to make their entire shuttle this only supplies the shuttle board itself which helps with the time bottleneck acquiring one can cause players. 

Suggestion Thread
https://discord.com/channels/1272545509562777621/1451811049593372703

## Media (Video/Screenshots)
<img width="462" height="463" alt="image" src="https://github.com/user-attachments/assets/eb4f4292-666b-4c1e-b6b3-c119d6b2354f" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: katte
- add: Syndicate Shuttle Board to Traitor Uplink.
