### PR TITLE
CC emags no longer play "death to nanotrasen" soundbite

### DIFF
--- a/Content.Shared/Emag/Components/EmagComponent.cs
+++ b/Content.Shared/Emag/Components/EmagComponent.cs
@@ -78,5 +78,15 @@ public sealed partial class EmagComponent : Component
     /// </summary>
     [DataField]
     public HashSet<ProtoId<RadioChannelPrototype>> ChannelAdd = ["Syndicate"];
+
+    /// <summary>
+    /// Overrides borg emagged sound if specified.
+    /// </summary>
+    [DataField] public SoundSpecifier? EmaggedSoundOverride;
+    
+    /// <summary>
+    /// Whether to even play the emagged sound or not.
+    /// </summary>
+    [DataField] public bool DoEmaggedSound = true;
     //#endregion Starlight
 }

--- a/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
+++ b/Content.Shared/Silicons/Laws/SharedSiliconLawSystem.cs
@@ -72,7 +72,12 @@ public abstract partial class SharedSiliconLawSystem : EntitySystem
 
         component.OwnerName = Name(args.UserUid);
 
-        NotifyLawsChanged(uid, component.EmaggedSound);
+        //Starlight begin
+        if(args.EmagComponent is not null)
+            NotifyLawsChanged(uid, args.EmagComponent.DoEmaggedSound ? args.EmagComponent.EmaggedSoundOverride ?? component.EmaggedSound : null);
+        else
+            NotifyLawsChanged(uid, component.EmaggedSound);
+        //Starlight end
         if (_mind.TryGetMind(uid, out var mindId, out _))
             EnsureSubvertedSiliconRole(mindId);
 

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Tools/emag.yml
@@ -31,6 +31,7 @@
       accessGroups: [CentralCommand]
       channelAdd: [CentCom]
       lawset: CCLawset
+      doEmaggedSound: false
     - type: Sprite
       sprite: _Starlight/Objects/Tools/ccemag.rsi
       state: icon


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
What it says on the tin.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Doesn't make sense that it does. Imagine being emagged by CC and you hear "Death to NanoTrasen!" in your ear. Very conflicting.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Borgs emagged by a CC Emag will no longer hear the "Death to NanoTrasen" soundbite when their laws get updated.