### PR TITLE
Allow zookeepers to understand various animals

### DIFF
--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Wildcards/zookeeper.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Wildcards/zookeeper.yml
@@ -13,6 +13,26 @@
   - !type:GiveItemOnHolidaySpecial
     holiday: MonkeyDay
     prototype: MonkeyCubeBox
+  - !type:AddComponentSpecial
+    components:
+    - type: AdditionalLanguageKnowledge # If we just put in LanguageKnowledge, it'd overwrite your normal languages
+      understands:
+      - Ancestor
+      - Bat
+      - Carptongue
+      - Cat
+      - Chicken
+      - Dog
+      - Duck
+      - Fox
+      - Mothroach
+      - Mouse
+      - Pig
+      - ScurretSign
+      - Xeno
+      # While spoken by some crew, these are spoken by slimes and spiders as their language
+      - Bubblish
+      - Chittin
 
 - type: startingGear
   id: ZookeeperGear


### PR DESCRIPTION
## Short description
This change gives the zookeeper the ability to understand, but not speak, what I believe is all non-crew, non-mechanical creature languages currently available.

## Why we need to add this
This should allow them greater latitude in their jobs, and more opportunities to act as in-betweens and RP with the various creatures on the station.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- add: Zookeepers can now understand a variety of additional interesting...languages?