### PR TITLE
Adds Syndicate Shuttle Crate and Friendship Bundle to Traitor Uplink

### DIFF
--- a/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
@@ -84,3 +84,9 @@ uplink-pizza-bomb-desc = Originally developed by covertly by DONK Co to disuade 
 
 uplink-shuttle-board-name = Syndicate Shuttle Console Board
 uplink-shuttle-board-desc = A computer printed circuit board for a syndicate shuttle console.
+
+uplink-shuttle-bundle-name = Syndicate Shuttle Crate
+uplink-shuttle-bundle-desc = Everything but the shuttle board. It's a shuttle in a crate* (Some assembly required)
+
+uplink-friendship-bundle-name = Friendship Bundle
+uplink-friendship-bundle-desc = Friendship packaged in a convenient crate*. (Some assembly required)

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/shuttle.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/shuttle.yml
@@ -1,0 +1,53 @@
+- type: entity
+  parent: CrateSyndicate
+  id: CrateNameSyndicateShuttleBundle
+  name: Shuttle Bundle Crate
+  description: Everything but the shuttle board. It's a shuttle in a crate* (Some assembly required)
+  components:
+  - type: StorageFill
+    contents:
+    - id: GyroscopeFlatpack
+    - id: ThrusterFlatpack
+    - id: ThrusterFlatpack
+    - id: ThrusterFlatpack
+    - id: ThrusterFlatpack
+    - id: CableMVStack
+    - id: CableHVStack
+    - id: CableApcStack
+    - id: CableApcStack
+    - id: Multitool
+    - id: WallmountSubstationElectronics
+    - id: APCElectronics
+    - id: WallmountGeneratorAPUElectronics
+    - id: WallmountGeneratorAPUElectronics
+    - id: SheetSteel
+    - id: PartRodMetal
+    - id: MicroManipulatorStockPart
+    - id: PowerCellSmall
+    - id: SheetGlass1
+      amount: 2
+    
+- type: entity
+  parent: CrateSyndicate
+  id: CrateNameSyndicateFriendshipBundle
+  name: Friendship Bundle Crate
+  description: Friendship in a crate*. (Some assembly required)
+  components:
+  - type: StorageFill
+    contents:
+    - id: ShuttleGunFriendshipCircuitboard
+    - id: CableHVStack1
+      amount: 5
+    - id: SheetSteel1
+      amount: 12
+    - id: MicroManipulatorStockPart
+      amount: 5
+    - id: CableApcStack1
+    - id: RemoteSignaller
+    - id: Multitool
+    - id: GrenadeBlast
+    - id: GrenadeBlast
+    - id: GrenadeBlast
+    - id: GrenadeBlast
+    - id: GrenadeBlast
+    - id: GrenadeBlast

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/shuttle.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/shuttle.yml
@@ -33,21 +33,20 @@
   name: Friendship Bundle Crate
   description: Friendship in a crate*. (Some assembly required)
   components:
-  - type: StorageFill
-    contents:
-    - id: ShuttleGunFriendshipCircuitboard
-    - id: CableHVStack1
-      amount: 5
-    - id: SheetSteel1
-      amount: 12
-    - id: MicroManipulatorStockPart
-      amount: 5
-    - id: CableApcStack1
-    - id: RemoteSignaller
-    - id: Multitool
-    - id: GrenadeBlast
-    - id: GrenadeBlast
-    - id: GrenadeBlast
-    - id: GrenadeBlast
-    - id: GrenadeBlast
-    - id: GrenadeBlast
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: ShuttleGunFriendshipCircuitboard
+        - id: CableHVStack1
+          amount: 5
+        - id: SheetSteel10
+        - id: SheetSteel1
+          amount: 2
+        - id: MicroManipulatorStockPart
+          amount: 5
+        - id: CableApcStack1
+        - id: RemoteSignaller
+        - id: Multitool
+        - id: GrenadeBlast
+          amount: 6

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/shuttle.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/shuttle.yml
@@ -4,28 +4,28 @@
   name: Shuttle Bundle Crate
   description: Everything but the shuttle board. It's a shuttle in a crate* (Some assembly required)
   components:
-  - type: StorageFill
-    contents:
-    - id: GyroscopeFlatpack
-    - id: ThrusterFlatpack
-    - id: ThrusterFlatpack
-    - id: ThrusterFlatpack
-    - id: ThrusterFlatpack
-    - id: CableMVStack
-    - id: CableHVStack
-    - id: CableApcStack
-    - id: CableApcStack
-    - id: Multitool
-    - id: WallmountSubstationElectronics
-    - id: APCElectronics
-    - id: WallmountGeneratorAPUElectronics
-    - id: WallmountGeneratorAPUElectronics
-    - id: SheetSteel
-    - id: PartRodMetal
-    - id: MicroManipulatorStockPart
-    - id: PowerCellSmall
-    - id: SheetGlass1
-      amount: 2
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: GyroscopeFlatpack
+        - id: ThrusterFlatpack
+          amount: 4
+        - id: CableMVStack
+        - id: CableHVStack
+        - id: CableApcStack
+          amount: 2
+        - id: Multitool
+        - id: WallmountSubstationElectronics
+        - id: APCElectronics
+        - id: WallmountGeneratorAPUElectronics
+          amount: 2
+        - id: SheetSteel
+        - id: PartRodMetal
+        - id: MicroManipulatorStockPart
+        - id: PowerCellSmall
+        - id: SheetGlass1
+          amount: 2
     
 - type: entity
   parent: CrateSyndicate

--- a/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
@@ -600,13 +600,46 @@
   description: uplink-shuttle-board-desc
   productEntity: SyndicateShuttleConsoleCircuitboard
   icon: { sprite: Objects/Misc/module.rsi, state: cpu_syndicate }
-  discountCategory: usualDiscounts
+  discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 1
   cost:
-    Telecrystal: 4
+    Telecrystal: 2
   categories:
   - UplinkDisruption
+
+- type: listing
+  id: SyndicateShuttleBundle
+  name: uplink-shuttle-bundle-name
+  description: uplink-shuttle-bundle-desc
+  productEntity: CrateNameSyndicateShuttleBundle
+  icon: { sprite: Structures/Shuttles/thruster.rsi, state: base }
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 4
+  cost:
+    Telecrystal: 6
+  categories:
+  - UplinkDisruption
+
+- type: listing
+  id: SyndicateFriendshipBundle
+  name: uplink-friendship-bundle-name
+  description: uplink-friendship-bundle-desc
+  productEntity: CrateNameSyndicateFriendshipBundle
+  icon: { sprite: Objects/Weapons/Guns/Shuttles/launcher.rsi, state: exp-320g }
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 11
+  cost:
+    Telecrystal: 15
+  categories:
+  - UplinkWeaponry
+#  conditions:
+#    - !type:StoreWhitelistCondition
+#      whitelist:
+#        tags:
+#          - NukeOpsUplink          
 
 - type: listing
   id: uplinkRiggedBoxingGlovesBoxer


### PR DESCRIPTION
## Short description
Adds syndicate shuttle crate and friendship bundle crate as well as adjusts shuttle board price in uplink

## Why we need to add this
The shuttle crate is there to inspire more shuttle related antag gameplay by adding everything needed to construct a small craft minus the shuttle board (meant to pair with the shuttle board in the uplink). The Friendship bundle(subject to tc price change)  needs to be added because not enough people seemed to dislike the idea of it and revelation thought it would make things fun : ) Also the shuttle board price is adjusted since many maps have a free round start shuttle board and to combo better with the uplink shuttle crate.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="469" height="465" alt="image" src="https://github.com/user-attachments/assets/e7c1b415-13b7-49dc-a345-0af97d89c3ad" />
<img width="472" height="472" alt="image" src="https://github.com/user-attachments/assets/83c8092e-941a-4cb5-9cff-843e1d865d7e" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**



:cl: katte
- add: Added syndicate shuttle crate to uplink
- add: Added friendship bundle to uplink
- tweak: Changed syndicate shuttle board price from 4tc to 2tc.