### PR TITLE
AIs can no longer accidentally round-remove themselves

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Robotics/mmi.yml
@@ -14,6 +14,7 @@
     - type: BlockMovement
     - type: Examiner
     - type: BorgBrain
+      borgConsent: true #AIs sign up to play Silicon
     - type: IntrinsicRadioReceiver
     - type: IntrinsicRadioTransmitter
       channels:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
AI shunt is not designated as having consented to be a silicon.

## Why we need to add this
I missed that one when originally pre-setting borging consent. Woops.


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Citrea
- fix: AI can no longer accidentally round-remove itself
