### PR TITLE
Fix blue ointment icon when stored

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/medical.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/medical.yml
@@ -69,6 +69,10 @@
   components:
   - type: Sprite
     state: blueointment
+  - type: Item
+    storedSprite:
+      state: blueointment
+      sprite: Objects/Specific/Medical/medical.rsi
   - type: Stack
     stackType: Blueointment
     count: 1
@@ -82,6 +86,10 @@
   components:
   - type: Sprite
     state: blueointment2
+  - type: Item
+    storedSprite:
+      state: blueointment2
+      sprite: Objects/Specific/Medical/medical.rsi
   - type: Stack
     stackType: Blueointment
     count: 10
@@ -95,6 +103,10 @@
   components:
   - type: Sprite
     state: blueointment3
+  - type: Item
+    storedSprite:
+      state: blueointment3
+      sprite: Objects/Specific/Medical/medical.rsi
   - type: Stack
     stackType: Blueointment
     count: 20


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fix blue ointment inventory sprite to once again be blue, rather than green.

## Why we need to add this
Upstream (https://github.com/space-wizards/space-station-14/pull/41764) merged a custom sprite for Ointment when stored. Since the Blue Ointment is based on the regular ointment, the Blue Ointment inherited this sprite. Unfortunately this made visual distinguishment in inventory impossible.

## Media (Video/Screenshots)
### Inventory Spites (Single, 50% Stack, Full Stack)
<img width="143" height="300" alt="image" src="https://github.com/user-attachments/assets/bd5fea3f-2286-49b9-b72a-ceadd445fc82" />

### General Sprites (Unchanged, Single, 50% Stack, Full Stack)
<img height="200" alt="image" src="https://github.com/user-attachments/assets/1bc4e52a-985a-496f-9281-0b4f51d56982" />

### Medical Dispenser Sprite (Unchanged)
<img height="300" alt="image" src="https://github.com/user-attachments/assets/b47f9ed9-9c83-4c24-bb36-f48d8485a5ea" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- fix: Fix blue ointment inventory sprite