### PR TITLE
Add Chameleon Medal slot item

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -343,6 +343,9 @@ uplink-cane-blade-desc = A cane that has a hidden blade that can be unsheathed.
 uplink-chameleon-name = Chameleon Kit
 uplink-chameleon-desc = A backpack full of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more!
 
+uplink-chameleon-bundle-name = Chameleon Kit Crate
+uplink-chameleon-bundle-desc = A crate containing a backpack full of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more!
+
 uplink-clothing-no-slips-shoes-name = No-slip Shoes
 uplink-clothing-no-slips-shoes-desc = Chameleon shoes that protect you from slips.
 

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -271,7 +271,7 @@
         - id: ClothingEyesChameleon
         - id: ClothingHeadsetChameleon
         - id: ClothingShoesChameleon
-        - id: ChameleonControllerImplanter
+        - id: ClothingMiscChameleon # Starlight Removed the Implanter from the backpack to make space for the Medal slot item.
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle

--- a/Resources/Prototypes/Catalog/Fills/Lockers/space_ruin.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/space_ruin.yml
@@ -60,6 +60,7 @@
   table: !type:AllSelector
     children:
     - id: ClothingBackpackChameleonFill
+    - id: ChameleonControllerImplanter # Starlight Adding the implanter manually now that it's no longer in the backpack fill.
     - id: CrowbarRed
       prob: 0.6
     - id: ClothingShoesBootsCombat

--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -7,6 +7,7 @@
     state: icon
   content:
   - ClothingBackpackChameleonFill
+  - ChameleonControllerImplanter # Starlight Adding the implanter manually now that it's no longer in the backpack fill.
   - ChameleonProjector
   - FakeMindShieldImplanter
   - AgentIDCard

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1724,11 +1724,25 @@
   categories:
   - UplinkWearables
 
+# Starlight, listing disabled and replaced with chameleon crate
+# - type: listing
+#  id: UplinkChameleon
+#  name: uplink-chameleon-name
+#  description: uplink-chameleon-desc
+#  productEntity: ClothingBackpackChameleonFill
+#  icon: { sprite: /Textures/Clothing/Uniforms/Jumpsuit/rainbow.rsi, state: icon }
+#  discountCategory: usualDiscounts
+#  discountDownTo:
+#    Telecrystal: 2
+#  cost:
+#    Telecrystal: 4
+#  categories:
+#    - UplinkWearables
 - type: listing
-  id: UplinkChameleon
-  name: uplink-chameleon-name
-  description: uplink-chameleon-desc
-  productEntity: ClothingBackpackChameleonFill
+  id: UplinkChameleonBundle
+  name: uplink-chameleon-bundle-name
+  description: uplink-chameleon-bundle-desc
+  productEntity: CrateSyndicateChameleonBundle
   icon: { sprite: /Textures/Clothing/Uniforms/Jumpsuit/rainbow.rsi, state: icon }
   discountCategory: usualDiscounts
   discountDownTo:
@@ -1737,6 +1751,7 @@
     Telecrystal: 4
   categories:
     - UplinkWearables
+# Starlight End
 
 - type: listing
   id: UplinkClothingNoSlipsShoes

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/syndicate.yml
@@ -1,0 +1,14 @@
+- type: entity
+  id: CrateSyndicateChameleonBundle
+  suffix: Filled
+  parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
+  name: Chameleon Kit Crate
+  description: Contains a backpack full of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more!
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: ClothingBackpackChameleonFill
+        - id: ChameleonControllerImplanter
+        

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/specific.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Neck/specific.yml
@@ -1,0 +1,18 @@
+- type: entity
+  parent: [ClothingMiscBase, BaseChameleon]
+  id: ClothingMiscChameleon
+  name: gold medal of crewmanship
+  description: Given to crewmates who display excellent crewmanship.
+  suffix: Chameleon
+  components:
+    - type: Tag
+      tags: # ignore "WhitelistChameleon" tag
+      - Medal
+    - type: Sprite
+      sprite: Clothing/Neck/Medals/gold.rsi
+    - type: Clothing
+      sprite: Clothing/Neck/Medals/gold.rsi
+    - type: ChameleonClothing
+      slot: [MISC]
+      default: ClothingNeckGoldmedal
+      


### PR DESCRIPTION
## Short description
Adds a Chameleon item for the Misc/Medal slot to the Chameleon Kit.  This booted the implanter from the bag, but it's still available via the same methods.

## Why we need to add this
Follow-up to #3028 where we noticed there wasn't a Chameleon item added for the Misc slot when it was implemented.

## Media (Video/Screenshots)
New Chameleon Medal
<img width="426" height="269" alt="Screenshot 2026-01-29 115351" src="https://github.com/user-attachments/assets/dcbf0d51-27e7-46ad-99e7-2027b23f5b27" />

Imitate existing pins and badges
<img width="381" height="301" alt="Screenshot 2026-01-29 115441" src="https://github.com/user-attachments/assets/76e0f8f4-3753-485f-bce1-6fc56e2d533e" />

Syndicate uplink catalog item replacement
<img width="947" height="514" alt="image" src="https://github.com/user-attachments/assets/22c7636f-9f1b-40dc-92d4-7b8af8e3500e" />


## Checks
- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: r3d3mpt1on
- add: Added Chameleon Medal for the Misc/Medal slot.
- remove: Removed Chameleon Controller implant from the Chameleon Backpack (filled).
- add: Added Chameleon Controller implant to the Thief toolbox's Chameleon set.  It will be in whatever satchel you receive for your other selection.
- tweak: Replaced the Chameleon Kit syndicate uplink catalog item with a Crate that contains the filled backpack and one implanter.
