### PR TITLE
The End of Forever Traitor & Greenshift-likes, the Start of Proper Antag Scaling

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -261,7 +261,7 @@
     definitions:
     - prefRoles: [ Traitor ]
       max: 24 # Starlight. More of future proofing. If we ever actually average 252 pop then we'll need to actually do something else.
-      playerRatio: 10.5 # Starlight. It's this weird number so Beta doesn't lose out on their 6th traitor.
+      playerRatio: 10 # Starlight. It's this number so Beta doesn't lose out on their 6th traitor.
       blacklist:
         components:
         - AntagImmune
@@ -295,7 +295,7 @@
     definitions:
     - prefRoles: [ Changeling ]
       max: 6 # Starlight. Not a huge increase, but allows lings to actually become a force on alpha that doesn't get wiped out immediately.
-      playerRatio: 17.5 # Starlight. Allows Beta to still keep only 3 lings.
+      playerRatio: 17 # Starlight. Allows Beta to still keep only 3 lings.
       briefing:
         text: changeling-role-greeting
         color: Red

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -21,15 +21,15 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.5
+      prob: 0.45 # Starlight, to account for Wizard and Xenoborgs
     - id: SLChangeling #Starlight lings
       prob: 0.4
 #    - id: Vampire # Starlight - disabled until reworked
 #      prob: 0.25
     - id: SubWizard
-      prob: 0.05
+      prob: 0.07 # Starlight. Wizard is incredibly rare. There are players with 1k hours that have never rolled it.
     - id: Xenoborgs
-      prob: 0.05
+      prob: 0.08 # Starlight. To account for their secret mode being lowered.
 
 - type: entity
   parent: BaseGameRule
@@ -38,13 +38,13 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.5
+      prob: 0.51 # Starlight. To make this add up to 1.
     - id: SLChangeling # StarlightLings
-      prob: 0.4
+      prob: 0.41 # Starlight. To make this add up to 1.
 #    - id: Vampire # Starlight - disabled until reworked
 #      prob: 0.25
     - id: Xenoborgs
-      prob: 0.05
+      prob: 0.08 # Starlight. Space is dangerous, yo.
 
 - type: entity
   parent: BaseGameRule
@@ -53,9 +53,9 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.5
+      prob: 0.58 # Starlight. 87% chance of thieves over wizard.
     - id: SubWizard
-      prob: 0.05
+      prob: 0.07 # Starlight. Same reasoning as prior.
 
 - type: entity
   parent: BaseGameRule
@@ -260,8 +260,8 @@
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Traitor ]
-      max: 8
-      playerRatio: 10
+      max: 24 # Starlight. More of future proofing. If we ever actually average 252 pop then we'll need to actually do something else.
+      playerRatio: 10.5 # Starlight. It's this weird number so Beta doesn't lose out on their 6th traitor.
       blacklist:
         components:
         - AntagImmune
@@ -294,8 +294,8 @@
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Changeling ]
-      max: 3
-      playerRatio: 15
+      max: 6 # Starlight. Not a huge increase, but allows lings to actually become a force on alpha that doesn't get wiped out immediately.
+      playerRatio: 17.5 # Starlight. Allows Beta to still keep only 3 lings.
       briefing:
         text: changeling-role-greeting
         color: Red
@@ -403,14 +403,14 @@
   id: Wizard
   components:
   - type: GameRule
-    minPlayers: 10
+    minPlayers: 40 # Starlight. So a Wizard can actually spawn on Beta.
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn
     definitions:
     - prefRoles: [ Wizard ]
-      max: 1
-      playerRatio: 1
+      max: 6 # Starlight. If Wizard is to be its own Gamemode, then...
+      playerRatio: 40 # Starlight, ensures Beta only has 1 wizard.
       spawnerPrototype: SpawnPointGhostWizard
       roleLoadout:
        - RoleSurvivalExtended

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -19,7 +19,7 @@
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Thief ]
-      max: 3
+      max: 6 # Starlight. Allows alpha to have more thieves without impacting beta.
       playerRatio: 20
       lateJoinAdditional: true
       allowNonHumans: true
@@ -36,7 +36,7 @@
         sound: "/Audio/Misc/thief_greeting.ogg"
   - type: DynamicRuleCost
     cost: 75
-        
+
 - type: entity
   parent: BaseGameRule
   id: SLChangeling
@@ -46,8 +46,8 @@
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
-      max: 3
-      playerRatio: 10
+      max: 6 # Starlight, same reasoning as the roundstart changeling change, for alpha.
+      playerRatio: 20 # Starlight, to make sure Beta doesn't get more than 3 changelings as a submode.
       lateJoinAdditional: true
       allowNonHumans: false
       multiAntagSetting: None
@@ -89,8 +89,8 @@
     selectionTime: PrePlayerSpawn
     definitions:
     - prefRoles: [ Wizard ]
-      max: 1
-      playerRatio: 1
+      max: 3 # Starlight. Less egregious than the full wizard mode.
+      playerRatio: 55 # Starlight, ensures Beta only has 1 wizard. Also less egregious.
       spawnerPrototype: SpawnPointGhostWizard
       roleLoadout:
       - RoleSurvivalExtended

--- a/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
@@ -22,13 +22,13 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.5
+      prob: 0.85 # Starlight. Adds up to 1.
 #    - id: Vampire # disabled until reworked
 #      prob: 0.25
     - id: SubWizard
-      prob: 0.05
+      prob: 0.07 # Starlight. Wizard is incredibly rare. There are players with 1k hours that have never rolled it.
     - id: Xenoborgs
-      prob: 0.05
+      prob: 0.08 # Starlight. To account for their secret mode being lowered.
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
@@ -29,7 +29,35 @@
       prob: 0.05
     - id: Xenoborgs
       prob: 0.05
-      
+
+- type: entity
+  parent: BaseGameRule
+  id: SubGamemodesRuleLessThieves
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: ThiefLess # So that only 3 thieves max spawn in rev games.
+      prob: 0.45 # Starlight, to account for Wizard and Xenoborgs
+    - id: SLChangeling #Starlight lings
+      prob: 0.4
+#    - id: Vampire # Starlight - disabled until reworked
+#      prob: 0.25
+    - id: SubWizard
+      prob: 0.07 # Starlight. Wizard is incredibly rare. There are players with 1k hours that have never rolled it.
+    - id: Xenoborgs
+      prob: 0.08 # Starlight. To account for their secret mode being lowered.
+
+- type: entity
+  parent: BaseGameRule
+  id: SubGamemodesRuleZombieCompliantAntags
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: ThiefLess
+      prob: 0.92
+    - id: Xenoborgs # I think there's interesting roleplay opportunity if Xenoborgs spawn. You could willingly choose to get borged to prevent infection. I want to see how this plays out.
+      prob: 0.08
+
 - type: entity
   parent: BaseGameRule
   id: ThiefGamerule

--- a/Resources/Prototypes/_StarLight/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/subgamemodes.yml
@@ -1,0 +1,39 @@
+# Variant of thieves that only spawn up to 3. Used in revs to prevent emags from being too easily obtained.
+- type: entity
+  parent: Thief
+  id: ThiefLess
+  components:
+  - type: ThiefRule
+  - type: AntagObjectives
+    objectives:
+    - EscapeThiefShuttleObjective
+  - type: AntagRandomObjectives
+    sets:
+    - groups: ThiefBigObjectiveGroups
+      prob: 0.7
+      maxPicks: 1
+    - groups: ThiefObjectiveGroups
+      maxPicks: 10
+    maxDifficulty: 2.5
+  - type: AntagSelection
+    agentName: thief-round-end-agent-name
+    selectionTime: IntraPlayerSpawn
+    definitions:
+    - prefRoles: [ Thief ]
+      max: 3 # Starlight. Prevents excess thieves from spawning on Revs.
+      playerRatio: 20
+      lateJoinAdditional: true
+      allowNonHumans: true
+      multiAntagSetting: NotExclusive
+      startingGear: ThiefGear
+      components:
+      - type: Pacified
+      - type: Thieving
+        stripTimeReduction: 2
+        stealthy: true
+      mindRoles:
+      - MindRoleThief
+      briefing:
+        sound: "/Audio/Misc/thief_greeting.ogg"
+  - type: DynamicRuleCost
+    cost: 75

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -210,7 +210,7 @@
   rules:
   # - DummyNonAntagChance 🌟Starlight🌟
   - Revolutionary
-  - SubGamemodesRule
+  - SubGamemodesRuleLessThieves # Starlight. 3 max thieves on revs, so they can't be guaranteed an Emag.
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -242,7 +242,7 @@
   rules:
   - Xenoborgs
   # - DummyNonAntagChance 🌟Starlight🌟
-  - SubGamemodesRuleNoWizardNoXenoborg # no two motherships
+  - SubGamemodesRuleNoXenoborg # Starlight. no two motherships. Allows wizards to spawn on Xenoborgs. Space is dangerous, yo.
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -262,6 +262,7 @@
   showInVote: true # 🌟Starlight🌟
   rules:
   - Zombie
+  - SubGamemodesRuleZombieCompliantAntags # Starlight. I want to trial this, see how it plays out. If it goes poorly, we'll remove Xenoborgs from it.
   - BasicStationEventScheduler
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
@@ -279,6 +280,7 @@
   showInVote: true # 🌟Starlight🌟
   rules:
   - Zombie
+  - SubGamemodesRuleZombieCompliantAntags # Starlight. I want to trial this, see how it plays out. If it goes poorly, we'll remove Xenoborgs from it.
   - BasicStationEventScheduler
   - KesslerSyndromeScheduler
   - SpaceTrafficControlEventScheduler
@@ -359,12 +361,17 @@
   minPlayers: 60
   rules:
     - DerelictGenericCyborgSpawn
+    - DerelictGenericCyborgSpawn # Starlight. To account for the ultrapop.
     - BasicStationEventScheduler
+    - BasicStationEventScheduler # Starlight. More events without ramping events. What could go wrong?
     - MeteorSwarmMildScheduler
     - SubGamemodesRule
     - IonStorm
+    - IonStorm # Starlight. They're mostly harmless, and fun to work around.
     - CockroachMigration
     - MouseMigration
     - BasicRoundstartVariation
     - BasicRoundstartVariation
     - BasicRoundstartVariation
+    - BasicRoundstartVariation # Starlight. Dirtier.
+    - BasicRoundstartVariation # Starlight. This is Janitor Kessler.

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,19 +2,19 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.03
-    Traitor: 0.40
-    Zombie: 0.05
-    Changeling: 0.10 #SL
-    Zombieteors: 0.01
-    Survival: 0.05
-    KesslerSyndrome: 0.01
-    Revolutionary: 0.10
+    Nukeops: 0.10 # SL
+    Traitor: 0.20 # SL
+    Zombie: 0.10 # SL
+    Changeling: 0.05 #SL
+    Zombieteors: 0.03 # SL
+    Survival: 0.11 # SL
+    KesslerSyndrome: 0.02 # SL
+    Revolutionary: 0.11 # SL
     #Vampire: 0.15 #SL
-    Wizard: 0.10
-    Traitorling: 0.10 #SL
-    ShitStation: 0.10 #SL
-    Xenoborgs: 0.15 #SL
+    Wizard: 0.05 # SL
+    Traitorling: 0.11 #SL
+    ShitStation: 0.05 #SL
+    Xenoborgs: 0.07 #SL
 
 # Starlight - Beta's Secret Pool
 - type: weightedRandom


### PR DESCRIPTION
## Short description
Redoes Alpha's secret weights entirely, bringing them closer to how they were prior to https://github.com/ss14Starlight/space-station-14/pull/2166. Also increases the max amount of Traitors, Thieves, Lings, and Wizards to actually account for Alpha's population size, instead of keeping the Wizden defaults. None of these changes impact Beta, which should be discussed separately.

Only up to 3 Thieves will spawn on Zombie/Zombieteor/Rev rounds.

## Why we need to add this
Alpha's secret weights were reverted from https://github.com/ss14Starlight/space-station-14/pull/2046. in https://github.com/ss14Starlight/space-station-14/pull/2166, with the justification for 2046 being that action gamemodes were removed from voting, and 2166 being that they were added back, but, as voting has been removed entirely, this reversion is now moot, and Alpha currently has an 80% chance to roll Traitor or Greenshift-like modes, which has made the game experience severely slower/plainer for Alpha's action oriented audience.

Likewise, Alpha's antags have been scaling based on Wizden's old population cap of 80, which has made traitors an increasingly smaller part of the shift, even though security scales with pop. This change actually allows traitors to reclaim their 10% of the crew intent. (Likewise, Thieves and Lings scale higher too, to account for the increased security presence.)

Midround wizards/sleeper agents are unaffected.

55% "Traitor/Greenshift-like" modes (Traitor, Changeling, Kessler, Wizard, Traitorling, ShitStation, Xenoborgs), 45% "Action" modes. (Nukies, Zombies, Zombieteors, Survival, Revs)

- NukeOps 2.5% to 10%
- Traitor 33.33% to 20%
- Zombie 4.17% to 10%
- Changeling 8.33% to 5%
- Zombieteors 0.83% to 3%
- Survival 4.17% to 11%
- Kessler 0.83% to 2%
- Revolutionary 8.33% to 11%
- Wizard 8.33% to 5%
- Traitorling 8.33% to 11%
- ShitStation 8.33% to 5%
- Xenoborgs 12.5% to 7%

Wizard and Xenoborgs' appearances in subgamemodes has increased from 5% to 7% and 8% respectively.

Thieves and Xenoborgs can now show up in Zombies/Zombieteors.

Wizards can now show up in Xenoborgs.

ShitStation now has 66% more roundstart shit, double the Ion Storms, an extra guaranteed Derelict Cyborg, and a second Extended scheduler.

## Media (Video/Screenshots)
<img width="295" height="304" alt="image" src="https://github.com/user-attachments/assets/60b8f452-5ed2-4828-8228-f034adf02943" />


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Redid Alpha's secret chances entirely, roughly based on https://github.com/ss14Starlight/space-station-14/pull/2046. (It now actually adds up to 1.)
- tweak: Traitors now scale properly to 10% of the crew on Alpha, with an upper limit of 24 at 252pop. I don't think we'll hit that anytime soon, but if we do, I'll increase it further...
- tweak: Thieves and lings now scale up to 6 each. Proper scaling would've been to increase them to 9 or even further, but I don't think we need 9 of them. These numbers only go above 3 above Beta's max pop size, so this doesn't affect beta negatively.
- tweak: Wizards (the gamerule) now scale 1:40, with a maximum of 6 on 240 pop.
- tweak: Wizards (the subgamemode) now scales 1:55, with a maximum of 3 on 165 pop.
- tweak: Only up to 3 Thieves can spawn in Rev games, to prevent easy access to Emags. (Internally referred to as ThiefLess, for people making gamemodes)
- tweak: Wizards and Xenoborgs are now more common as SubGameModes. (Up from 5% to 7% and 8% respectively.)
- tweak: Thieves and Xenoborgs can now show up in Zombies/Zombieteors.
- tweak: Wizards can now show up in Xenoborgs.
- tweak: ShitStation now has 66% more roundstart shit, double the Ion Storms, an extra guaranteed Derelict Cyborg, and a second Extended scheduler.
