### PR TITLE
The Regime Knows Best

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -253,7 +253,6 @@
     - components:
       - type: BatteryDrainer
       - type: StunProvider
-        cooldown: 10
         noPowerPopup: ninja-no-power
         whitelist:
           components:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -19,10 +19,10 @@
   - type: Clothing
     slots:
     - outerClothing
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
-  - type: HeldSpeedModifier
+  # - type: ClothingSpeedModifier # Starlight removal: Why did WizDen do this???
+  #   walkModifier: 0.9
+  #   sprintModifier: 0.9
+  # - type: HeldSpeedModifier
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -175,10 +175,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.8
+        Blunt: 0.7 # SL start - 30% on all
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.7 # SL end
   # phase cloak
   - type: ToggleClothing
     action: ActionTogglePhaseCloak


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes the 10% slowdown on the ninja suit.
Also reverts https://github.com/space-wizards/space-station-14/pull/39707

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Requested by Lyn.
<img width="1022" height="166" alt="image" src="https://github.com/user-attachments/assets/c03b5302-dd8b-40f1-a094-155d03af0ec3" />

The ninja gloves change was _directly_ a mald PR. It was merged _specifically because_ they got robusted by a ninja.
And the slowdown doesn't really make any sense. The boots are 30%, so it's unlikely to be intended -- or else the boots would be 20% and the suit would have no slowdown.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower, LynatiKr20
- remove: Removed 10% slowdown on ninja suit
- remove: Reverted upstream change to ninja gloves: 10s cooldown for stun.
- tweak: Reverted Ninja suit to old 30/30/30/30.