### PR TITLE
Fix concurrent exception

### DIFF
--- a/Content.Client/_NullLink/NullLinkPlayerRolesManager.cs
+++ b/Content.Client/_NullLink/NullLinkPlayerRolesManager.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Linq;
 using Content.Client.Administration.Managers;
 using Content.Shared._NullLink;
@@ -10,7 +11,7 @@ public sealed class NullLinkPlayerRolesManager : INullLinkPlayerRolesManager
     [Dependency] private readonly IClientNetManager _netMgr = default!;
     [Dependency] private readonly ILogManager _logManager = default!;
 
-    private HashSet<ulong> _roles = [];
+    private ImmutableHashSet<ulong> _roles = [];
     private string? _discordLink;
     private ISawmill _sawmill = default!;
 

--- a/Content.Server/_NullLink/PlayerData/NullLinkPlayerManager.Roles.cs
+++ b/Content.Server/_NullLink/PlayerData/NullLinkPlayerManager.Roles.cs
@@ -1,21 +1,8 @@
-﻿using System.Collections.Concurrent;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Content.Server._NullLink.Core;
-using Content.Server._NullLink.Helpers;
-using Content.Server.Database;
 using Content.Shared._NullLink;
-using Content.Shared.NullLink.CCVar;
-using Content.Shared.Starlight;
-using Robust.Server.Player;
-using Robust.Shared.Configuration;
-using Robust.Shared.Enums;
-using Robust.Shared.Network;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
-using Starlight.NullLink;
 using Starlight.NullLink.Event;
 
 namespace Content.Server._NullLink.PlayerData;
@@ -26,8 +13,7 @@ public sealed partial class NullLinkPlayerManager : INullLinkPlayerManager
     {
         if (!_playerById.TryGetValue(ev.Player, out var playerData))
             return ValueTask.CompletedTask;
-        playerData.Roles.Clear();
-        playerData.Roles.UnionWith(ev.Roles);
+        playerData.SyncRoles(ev);
         playerData.DiscordId = ev.DiscordId;
 
         MentorCheck(ev.Player, playerData);
@@ -42,8 +28,7 @@ public sealed partial class NullLinkPlayerManager : INullLinkPlayerManager
     {
         if (!_playerById.TryGetValue(ev.Player, out var playerData))
             return ValueTask.CompletedTask;
-        playerData.Roles.ExceptWith(ev.Remove);
-        playerData.Roles.UnionWith(ev.Add);
+        playerData.UpdateRoles(ev);
         playerData.DiscordId = ev.DiscordId;
 
         MentorCheck(ev.Player, playerData);
@@ -54,7 +39,7 @@ public sealed partial class NullLinkPlayerManager : INullLinkPlayerManager
         return ValueTask.CompletedTask;
     }
 
-    private void SendPlayerRoles(ICommonSession session, HashSet<ulong> roles)
+    private void SendPlayerRoles(ICommonSession session, ImmutableHashSet<ulong> roles)
     => _netMgr.ServerSendMessage(new MsgUpdatePlayerRoles
     {
         Roles = roles,

--- a/Content.Server/_NullLink/PlayerData/PlayerData.cs
+++ b/Content.Server/_NullLink/PlayerData/PlayerData.cs
@@ -1,4 +1,7 @@
-﻿using Robust.Shared.Player;
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Robust.Shared.Player;
+using Starlight.NullLink.Event;
 
 namespace Content.Server._NullLink.PlayerData;
 
@@ -6,7 +9,17 @@ public sealed class PlayerData
 {
     public string? Title { get; set; }
     public required ICommonSession Session { get; init; }
-    public HashSet<ulong> Roles { get; set; } = [];
+    public ImmutableHashSet<ulong> Roles { get; set; } = [];
     public Dictionary<string, Dictionary<string, TimeSpan>> RolePlayTimePerServer { get; set; } = [];
     public ulong DiscordId { get; set; }
+
+    public void SyncRoles(PlayerRolesSyncEvent ev) => Roles = [.. ev.Roles];
+
+    public void UpdateRoles(RolesChangedEvent ev)
+    {
+        var roles = Roles.ToHashSet();
+        roles.ExceptWith(ev.Remove);
+        roles.UnionWith(ev.Add);
+        Roles = [.. roles];
+    }
 }

--- a/Content.Shared/_NullLink/MsgUpdatePlayerRoles.cs
+++ b/Content.Shared/_NullLink/MsgUpdatePlayerRoles.cs
@@ -1,4 +1,6 @@
-﻿using Lidgren.Network;
+﻿using System.Collections.Immutable;
+using Content.Shared.Teleportation.Systems;
+using Lidgren.Network;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
@@ -7,7 +9,7 @@ public sealed class MsgUpdatePlayerRoles : NetMessage
 {
     public override MsgGroups MsgGroup => MsgGroups.Command;
 
-    public HashSet<ulong> Roles = [];
+    public ImmutableHashSet<ulong> Roles = [];
     public string? DiscordLink;
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
@@ -15,9 +17,11 @@ public sealed class MsgUpdatePlayerRoles : NetMessage
         DiscordLink = buffer.ReadString();
 
         var length = buffer.ReadVariableInt32();
-        Roles.Clear();
+        var roles = new HashSet<ulong>(length);
         for (var i = 0; i < length; i++)
-            Roles.Add(buffer.ReadUInt64());
+            roles.Add(buffer.ReadUInt64());
+
+        Roles = [.. roles];
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Fixes:

```
Caught exception in GameTicker
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at Content.Server._NullLink.PlayerData.PlayerRolesReqManager.IsAllRolesAvailable(ICommonSession session) in /home/runner/work/space-station-14/space-station-14/Content.Server/_NullLink/PlayerData/PlayerRolesReqManager.cs:line 20
   at Content.Shared.Roles.DepartmentTimeRequirement.Check(IEntityManager entManager, ICommonSession player, IPrototypeManager protoManager, HumanoidCharacterProfile profile, IReadOnlyDictionary`2 playTimes, FormattedMessage& reason) in /home/runner/work/space-station-14/space-station-14/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs:line 37
   at Content.Server.Players.PlayTimeTracking.PlayTimeTrackingSystem.<>c__DisplayClass33_1.<RemoveDisallowedJobs>b__0(HumanoidCharacterProfile profile) in /home/runner/work/space-station-14/space-station-14/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs:line 370
   at Content.Server.Players.PlayTimeTracking.PlayTimeTrackingSystem.RemoveDisallowedJobs(NetUserId userId, List`1 jobs) in /home/runner/work/space-station-14/space-station-14/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs:line 369
   at Content.Server.Station.Systems.StationJobsSystem.GetPlayersJobCandidates(Nullable`1 weight, Nullable`1 selectedPriority, ICollection`1 players) in /home/runner/work/space-station-14/space-station
```

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Bugfix

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.