### PR TITLE
Fix borgi causing issues to clients when dying (please do not kill borgis)

### DIFF
--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -393,7 +393,11 @@ public abstract partial class SharedBorgSystem : EntitySystem
         else
         {
             SetActive(chassis, false, user: args.Origin);
-            
+
+            // This can be null apparently when borg dies before being "witnessed" by a client.
+            if (chassis.Comp.ModuleContainer == null)
+                return;
+
             foreach (var ent in chassis.Comp.ModuleContainer.ContainedEntities.ToList())
             {
                 if (!TryComp<ItemBorgModuleComponent>(ent, out var module)) continue;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Apparently when Borgi dies without being seen by a client, the state catch up wont be able to properly handle it.
Returning early from this function should not have an effect on clients that are updating their state (Honestly this code should have been on the server side most likely).

## Why we need to add this
Fixes:
https://discord.com/channels/1272545509562777621/1466938896649687274
https://discord.com/channels/1272545509562777621/1466605907214602383

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Fixed Borgi causing client refresh.
