### PR TITLE
[Fixup] Change chem/first aid modules based on StarLight borger feedback

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -140,6 +140,11 @@
     allowedModes:
     - JetInjectorDynamicMode
     - JetInjectorInjectMode
+  # Starlight start
+  - type: Tag
+    tags:
+    - JetInjector
+  # Starlight end
 
 - type: entity
   parent: JetInjector
@@ -232,6 +237,11 @@
     price: 75 # These are limited supply items.
   - type: TrashOnSolutionEmpty
     solution: pen
+  # Starlight start
+  - type: Tag
+    tags:
+    - Medipen
+  # Starlight end
 
 - type: entity
   parent: ChemicalMedipen

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -906,7 +906,18 @@
   - type: ItemBorgModule
     hands:
     - item: HandheldHealthAnalyzer
-    - item: AdvancedJetInjector
+    #- item: AdvancedJetInjector # Starlight-disable - remove jet injector in favor of a syringe that can be replaced with a jet injector as resources allow
+    # Starlight start - add swappable syringe slot
+    - item: Syringe
+      hand:
+        emptyLabel: borg-slot-syringe-empty
+        emptyRepresentative: Syringe
+        whitelist:
+          tags:
+          - Syringe
+          - JetInjector
+          - Medipen
+    # Starlight end
     - item: Gauze
       hand:
         emptyLabel: borg-slot-topicals-empty
@@ -928,6 +939,28 @@
         whitelist:
           components:
           - Healing
+    # Starlight start - improve first aid module ergonomics
+    - item: PillCanister
+      hand:
+        emptyLabel: borg-slot-small-containers-empty
+        emptyRepresentative: PillCanister
+        whitelist:
+          tags:
+          - PillCanister
+          - Bottle
+          - Pill
+          - PatchPack # Starlight
+          - Patch # Starlight
+    - item: Beaker
+      hand:
+        emptyLabel: borg-slot-chemical-containers-empty
+        emptyRepresentative: Beaker
+        whitelist:
+          components:
+          - FitsInDispenser
+          tags:
+          - ChemDispensable
+    # Starlight end - improve first aid module ergonomics
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: treatment-module }
 
@@ -970,6 +1003,7 @@
           tags:
           - Dropper
           - Syringe
+    - item: BorgDropper # Starlight
     - item: PillCanister
       hand:
         emptyLabel: borg-slot-small-containers-empty
@@ -979,6 +1013,7 @@
           - PillCanister
           - Bottle
           - Pill
+          - PatchPack # Starlight
           - Patch # Starlight
     - item: Beaker
       hand:
@@ -1015,29 +1050,79 @@
     hands:
     - item: HandheldHealthAnalyzer
     - item: BorgHypo
-    - item: Gauze
+    # Starlight-remove - drop the topical slots to make room for our added automenders and beaker slots
+    #- item: Gauze
+    #  hand:
+    #    emptyLabel: borg-slot-topicals-empty
+    #    emptyRepresentative: Gauze
+    #    whitelist:
+    #      components:
+    #      - Healing
+    #- item: Brutepack
+    #  hand:
+    #    emptyLabel: borg-slot-topicals-empty
+    #    emptyRepresentative: Brutepack
+    #    whitelist:
+    #      components:
+    #      - Healing
+    #- item: Ointment
+    #  hand:
+    #    emptyLabel: borg-slot-topicals-empty
+    #    emptyRepresentative: Ointment
+    #    whitelist:
+    #      components:
+    #      - Healing
+    # Starlight start - we added automenders a while ago, and more recently added beakers after they got removed from the advanced chem module
+    - item: AutoMenderBrute
+    - item: AutoMenderBurn
+    - item: Syringe
       hand:
-        emptyLabel: borg-slot-topicals-empty
-        emptyRepresentative: Gauze
+        emptyLabel: borg-slot-syringe-empty
+        emptyRepresentative: Syringe
+        whitelist:
+          tags:
+          - Syringe
+          - JetInjector
+          - Medipen
+    - item: PillCanister
+      hand:
+        emptyLabel: borg-slot-small-containers-empty
+        emptyRepresentative: PillCanister
+        whitelist:
+          tags:
+          - PillCanister
+          - Bottle
+          - Pill
+          - PatchPack # Starlight
+          - Patch # Starlight
+    - item: Beaker
+      hand:
+        emptyLabel: borg-slot-chemical-containers-empty
+        emptyRepresentative: Beaker
         whitelist:
           components:
-          - Healing
-    - item: Brutepack
+          - FitsInDispenser
+          tags:
+          - ChemDispensable
+    - item: Beaker
       hand:
-        emptyLabel: borg-slot-topicals-empty
-        emptyRepresentative: Brutepack
+        emptyLabel: borg-slot-chemical-containers-empty
+        emptyRepresentative: Beaker
         whitelist:
           components:
-          - Healing
-    - item: Ointment
+          - FitsInDispenser
+          tags:
+          - ChemDispensable
+    - item: Beaker
       hand:
-        emptyLabel: borg-slot-topicals-empty
-        emptyRepresentative: Ointment
+        emptyLabel: borg-slot-chemical-containers-empty
+        emptyRepresentative: Beaker
         whitelist:
           components:
-          - Healing
-    - item: AutoMenderBrute # Starlight
-    - item: AutoMenderBurn # Starlight
+          - FitsInDispenser
+          tags:
+          - ChemDispensable
+    # Starlight end - improve advanced first aid module ergonomics
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: adv-chem-module }
 

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -424,6 +424,8 @@
         whitelist:
           tags:
           - Syringe
+          - JetInjector
+          - Medipen
     - item: BorgDropper
     - item: Beaker
       hand:

--- a/Resources/Prototypes/_StarLight/tags.yml
+++ b/Resources/Prototypes/_StarLight/tags.yml
@@ -273,6 +273,10 @@
 - type: Tag
   id: IteratorTraitBackground
 
+# Used for the jet injector and advanced jet injector
+- type: Tag
+  id: JetInjector
+
 - type: Tag
   id: L6Saw
 
@@ -323,6 +327,10 @@
 
 - type: Tag
   id: MedCyberEyes
+
+# Used for the one-use disposable medipens
+- type: Tag
+  id: Medipen
 
 - type: Tag
   id: Meson


### PR DESCRIPTION
## Short description
This change alters the advanced first aid module from having a lot of topicals slots to having a bigger focus on chem administration. In general advanced med gameplay in ss14 focuses a lot more on effective use of chems than on spamming out topicals.

The first aid module is swapped from having a fixed advanced jet injector to a syringe, but a beaker hand is added, along with a hand for handling pill/patch administration.

The syringe slot in the first aid, advanced first aid, and syndicate chem borg modules is changed from a fixed item to a slot that starts with a syringe, but can be upgraded by replacing the syringe with a jet injector. It can also hold and use medipens.

## Why we need to add this
This is a follow-up to the recently-landed upstream payload which included some changes to the topicals, advanced topicals, chem, and advanced chem modules. On discussion with the local players of mediborgs there's significant ergonomic or usability issues with the changes that make them undesirable.

## Media (Video/Screenshots)
First aid module
<img width="533" height="137" alt="image" src="https://github.com/user-attachments/assets/26c07256-0ded-49bc-9ca0-a0606b7e3181" />
Advanced first aid module
<img width="551" height="133" alt="image" src="https://github.com/user-attachments/assets/32c33237-7cc8-413e-bb68-bbbbb074b14e" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- tweak: The advanced first aid borg module has been changed to be much closer to the previous advanced chemical module, focused on treatment of injuries through targeted application of medical reagents.
- tweak: The first aid and advanced first aid borg modules have gained a slot for administering pills and patches.
- tweak: The chem borg module has gained a hydraulic dropper.
- tweak: The first aid module has been swapped to hold a syringe by default, rather than a jet injector, and has gained a beaker slot.
- tweak: The syringe slots on the first aid, advanced first aid, and syndicate advanced chemical modules can now be swapped out for jet injectors or medipens.