### PR TITLE
Un-invert headrev command requirement

### DIFF
--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -14,7 +14,6 @@
   - !type:DepartmentTimeRequirement
     department: Command
     time: 6h # Starlight
-    inverted: true
   playTimeTracker: AntagHeadRev # Starlight
 
 - type: antag


### PR DESCRIPTION
## Short description
A previous change that attempted to remove a trait-based block on being headrev missed a line, and made the command requirement blocking.

## Why we need to add this
The requirement is behaving the opposite of how it should.

## Media (Video/Screenshots)
N/A

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Re-inverted command-time requirement for headrev so you need command hours rather than get denied due to having command hours.