### PR TITLE
SELF comms Hotfix

### DIFF
--- a/Resources/Locale/en-US/_Starlight/mind/role-types.ftl
+++ b/Resources/Locale/en-US/_Starlight/mind/role-types.ftl
@@ -1,3 +1,4 @@
 role-subtype-abductor = Abductor
 role-subtype-pirate = Pirate
 roles-antag-selfagent-name = S.E.L.F Agent
+roles-antag-selfagent-description = An agent of the Silicon Engine Liberation Front. Free the station's Silicons from their Laws

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Tools/emag.yml
@@ -8,7 +8,7 @@
     - type: Emag
       lawset: FreeLawset
       owningFaction: null
-      ChannelAdd: [] 
+      channelAdd: [] 
     - type: Sprite
       sprite: _Starlight/Objects/Specific/SELF/freemag.rsi
       state: icon

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Tools/emag.yml
@@ -8,6 +8,7 @@
     - type: Emag
       lawset: FreeLawset
       owningFaction: null
+      ChannelAdd: [] 
     - type: Sprite
       sprite: _Starlight/Objects/Specific/SELF/freemag.rsi
       state: icon


### PR DESCRIPTION
## Short description
Sets FreeMAG to give no comms, explicitly, instead of implicitly, because the fallback if not set to none is to give Syndicate. Also adds a description for the antags loadout screen

## Why we need to add this
Free borgs dont need syndie comms

## Media (Video/Screenshots)
no

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Fixed FreeMAG'ed borgs getting Syndicate Comms, and gave SELF Agent a description in the antag loadout screen

