### PR TITLE
Allow Iterators to be Command.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -13,10 +13,6 @@
     - !type:DepartmentTimeRequirement
       department: Cargo
       time: 20h # Starlight
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -16,10 +16,6 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 25h # Starlight
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -17,10 +17,6 @@
     - !type:RoleTimeRequirement
       role: JobJanitor
       time: 3h
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
 
   weight: 20
   startingGear: HoPGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -13,10 +13,6 @@
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 20h # Starlight
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,10 +15,6 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 20h # Starlight
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -13,10 +13,6 @@
   - !type:DepartmentTimeRequirement
     department: Science
     time: 20h # Starlight
-  - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
 
   weight: 10
   startingGear: ResearchDirectorGear

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -16,10 +16,6 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 20h # Starlight
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
 
   weight: 10
   startingGear: HoSGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/salvage_lead.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/salvage_lead.yml
@@ -7,10 +7,6 @@
     - !type:RoleTimeRequirement
       role: JobQuartermaster
       time: 18000 # 5 hours
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
   icon: "JobIconSalvageLead"
   startingGear: SalvageLeadGear
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Law/Magistrate.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Law/Magistrate.yml
@@ -12,10 +12,6 @@
       time: 36000 # 10h
     - !type:RolesRequirement
       proto: ExtRolesReq
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
   startingGear: MagistrateGear
   icon: "JobIconMagistrate"
   rules: job-rules-corporate-aligned

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Law/iaa.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Law/iaa.yml
@@ -10,10 +10,6 @@
   - !type:DepartmentTimeRequirement
     department: Security
     time: 36000 # 10h
-  - !type:TraitsRequirement
-    traits:
-    - Iterator
-    inverted: true
   startingGear: IAAGear
   icon: "JobIconIAA"
   rules: job-rules-corporate-aligned

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
@@ -12,10 +12,6 @@
       time: 72000 # 20 hrs
     - !type:RolesRequirement
       proto: ExtRolesReq
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
   startingGear: BlueShieldGear
   icon: JobIconBlueShield
   rules: job-rules-corporate-aligned

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
@@ -9,10 +9,6 @@
       time: 72000 # 20 hrs
     - !type:RolesRequirement
       proto: ExtRolesReq
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
   startingGear: NanoTrasenRepresentativeGear
   icon: JobIconNanotrasen
   rules: job-rules-corporate-aligned

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nct.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nct.yml
@@ -6,10 +6,6 @@
   requirements:
     - !type:RolesRequirement
       proto: StaffAndMentorOnlyRolesReq
-    - !type:TraitsRequirement
-      traits:
-      - Iterator
-      inverted: true
   startingGear: NanotrasenCareerTrainerGear
   icon: JobIconNanotrasenCareerTrainer
   rules: job-rules-corporate-aligned


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Allows characters with the Iterator trait to be Command members.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This is stupid that they can't.
Are we going to block Foreigners from being Command next?

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower

- tweak: Iterator-traited people can now be Command.
