### PR TITLE
Fix centcom-operator loc string

### DIFF
--- a/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/operator.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/CentComm/operator.yml
@@ -1,6 +1,6 @@
 - type: job
   id: CentralCommandOperator
-  name: job-name-centcomoperator
+  name: job-name-centcommoperator
   description: job-description-centcomoperator
   playTimeTracker: JobCentralCommandOperator
   setPreference: false
@@ -132,7 +132,7 @@
     back: ClothingBackpackSatchelCentcomm
     shoes: ClothingShoesBootsLaceup
     eyes: ClothingEyesGlassesCentComm
-    gloves: ClothingHandsGlovesNitrile 
+    gloves: ClothingHandsGlovesNitrile
     id: CentcomPDA
     ears: ClothingHeadsetAltCentCom
     pocket1: WeaponPistolN1984
@@ -200,4 +200,4 @@
     back:
     - RubberStampCSOD
     - MindShieldImplanter
-    
+


### PR DESCRIPTION
## Short description
Adjusts the spelling of a localization tag to match upstream change.
Fixes #3085.

## Why we need to add this
Upstream changed the number of 'm's in the name of this loc string, leading to failed localization calls on our side.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Fixed localization string for centcomm operator job.