### PR TITLE
Still Fast But Slightly Less Fast Wreck Swarm

### DIFF
--- a/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
+++ b/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Server.StationEvents.Components;
 public sealed partial class WreckSwarmComponent : Component
 {
     [DataField]
-    public float Velocity = 60f;
+    public float Velocity = 50;
 
     /// <summary>
     /// The announcement played when a meteor swarm begins.

--- a/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
+++ b/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Server.StationEvents.Components;
 public sealed partial class WreckSwarmComponent : Component
 {
     [DataField]
-    public float Velocity = 80f;
+    public float Velocity = 60f;
 
     /// <summary>
     /// The announcement played when a meteor swarm begins.

--- a/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
+++ b/Content.Server/_Starlight/StationEvents/Components/WreckSwarmComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Server.StationEvents.Components;
 public sealed partial class WreckSwarmComponent : Component
 {
     [DataField]
-    public float Velocity = 50;
+    public float Velocity = 50f;
 
     /// <summary>
     /// The announcement played when a meteor swarm begins.

--- a/Resources/Prototypes/Maps/salvage.yml
+++ b/Resources/Prototypes/Maps/salvage.yml
@@ -18,11 +18,6 @@
   sizeString: salvage-map-wreck-size-small
 
 - type: salvageMap
-  id: Small3
-  mapPath: /Maps/Salvage/small-3.yml
-  sizeString: salvage-map-wreck-size-small
-
-- type: salvageMap
   id: SmallAISurveyDrone
   mapPath: /Maps/Salvage/small-ai-survey-drone.yml
   sizeString: salvage-map-wreck-size-small
@@ -147,6 +142,13 @@
   sizeString: salvage-map-wreck-size-medium
 
 # """Large""" maps
+
+# Starlight
+# Moved from small due to sheer station damage caused by mass/plastinium walls. This grid is 22x22
+- type: salvageMap
+  id: MazeMap
+  mapPath: /Maps/Salvage/small-3.yml
+  sizeString: salvage-map-wreck-size-large
 
 - type: salvageMap
   id: StationStation


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Quick adjustment to the wreck events. I've toned the speed to be 2.5x the original rather than 4x. The 22x22 maze wreck with plastinium walls, small-3, consistently does too much damage for a small wreck. As such, small-3 has been moved to the large map category. It seems like it should have been in the large category as the listed max size for small wrecks is 7x7 and the listed max size for medium wrecks is 15x15. Moving this problem child to Large should make the more devastating events significantly less common.

2.5x seemed to be a sweet spot for small wrecks to do localized damage without eating too much of their own grid to be interesting.

In general, wrecks should be significant and not simply ignorable in terms of damage. This provides more interesting events for engineering and more lethality in areas that need it, dumping space animals onto the station, spacing areas of the station. But wrecks should not cause too much damage too often. The scale of the wreck should determine the scale of the damage, with variance with the different wrecks that can hit the station. If wrecks are still consistently proving to be too devastating too often after this PR, velocity should be altered again. But wrecks should be a threat to the station and her crew.

## Why we need to add this
Wrecks thrown at the station do too much damage right now, deleting entire departments. One wreck in particular does too much damage and seems to be miscategorized. 

## Media (Video/Screenshots)
Small wrecks
<img width="2372" height="1465" alt="image" src="https://github.com/user-attachments/assets/3a4e322d-22d3-4c75-abfc-c36bfb2f48f7" />
Large wrecks
<img width="2365" height="1443" alt="image" src="https://github.com/user-attachments/assets/ef8792e1-7df9-4908-9690-ff139ace52b8" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AegisShield
- tweak: Moved the largest small wreck to large
- tweak: Made wreck velocity 2.5x base rather than 4x