### PR TITLE
Change nukeops to use syndicate jobicon again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -1016,7 +1016,7 @@
       state: SyndicateOperative
   - type: AgentIDCard
   - type: IdCard
-    jobIcon: JobIconSyndicateOperative
+    jobIcon: JobIconSyndicate # Starlight-edit - SyndicateOperative -> Syndicate
 
 - type: entity
   parent: [ SyndiOperativeIDCard, BaseSyndicateContraband ]
@@ -1034,7 +1034,7 @@
       offset: *icon-offset
       state: SyndicateCorpsman
   - type: IdCard
-    jobIcon: JobIconSyndicateCorpsman
+    jobIcon: JobIconSyndicate # Starlight-edit - SyndicateCorpsman -> Syndicate
 
 - type: entity
   parent: [ SyndiOperativeIDCard, BaseSyndicateContraband ]
@@ -1052,7 +1052,7 @@
       offset: *icon-offset
       state: SyndicateCommander
   - type: IdCard
-    jobIcon: JobIconSyndicateCommander
+    jobIcon: JobIconSyndicate # Starlight-edit - SyndicateCommander -> Syndicate
 
 - type: entity
   parent: [ IDCardStandard, BaseHighlyIllegalContraband ]

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -87,7 +87,7 @@
   id: NukeopsOutfit
   name: roles-antag-nuclear-operative-name
   startingGear: SyndicateOperativeGearFullNoUplink
-  icon: "JobIconSyndicateOperative"
+  icon: "JobIconSyndicate" # Starlight - SyndicateOperative -> Syndicate
   equipment:
     head: ClothingHeadHelmetHardsuitSyndie
     neck: ClothingNeckScarfStripedSyndieRed
@@ -108,7 +108,7 @@
   id: NukeopsCommanderOutfit
   name: roles-antag-nuclear-operative-commander-name
   startingGear: SyndicateCommanderGearFull
-  icon: "JobIconSyndicateCommander"
+  icon: "JobIconSyndicate" # Starlight - SyndicateCommander -> Syndicate
   equipment:
     head: ClothingHeadHelmetHardsuitSyndieCommander
     neck: ClothingNeckScarfStripedSyndieGreen
@@ -140,7 +140,7 @@
   id: NukeopsMedicOutfit
   name: roles-antag-nuclear-operative-agent-name
   startingGear: SyndicateOperativeMedicFull
-  icon: "JobIconSyndicateCorpsman"
+  icon: "JobIconSyndicate" # Starlight - SyndicateCorpsman -> Syndicate
   equipment:
     head: ClothingHeadHelmetHardsuitSyndieMedic
     neck: ClothingNeckScarfStripedLightBlue


### PR DESCRIPTION
## Short description
Upstream changed nuclear operatives to have distinct job icons; this change reverts them to being the base syndicate icon.

## Why we need to add this
Requested by Medwia; most of the icons in the upstream change were reasonable, but these are not aligned with what we want (e.g. operatives being red HoP). There's a separate change coming in for recoloring the ERT ones.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- tweak: Reverted Nukeops job icons based on feedback on our end.