### PR TITLE
Vampires Fixes nd Stuff

### DIFF
--- a/Content.Server/_Starlight/Antags/Vampires/Systems/Classes/DantalionSystem.cs
+++ b/Content.Server/_Starlight/Antags/Vampires/Systems/Classes/DantalionSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Bible.Components;
 using Content.Shared._Starlight.Antags.Vampires;
 using Content.Shared._Starlight.Antags.Vampires.Components;
 using Content.Shared._Starlight.Antags.Vampires.Components.Classes;
+using Content.Shared._Starlight.Medical.Damage;
 using Content.Shared.Bed.Sleep;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.CollectiveMind;
@@ -42,7 +43,7 @@ public sealed class DantalionSystem : EntitySystem
     private static readonly ProtoId<DamageGroupPrototype> _bruteGroupId = "Brute";
     private static readonly ProtoId<DamageGroupPrototype> _burnGroupId = "Burn";
     private static readonly ProtoId<DamageTypePrototype> _asphyxiationTypeId = "Asphyxiation";
-    private static readonly ProtoId<DamageTypePrototype> _bluntTypeId = "Blunt";
+    private static readonly ProtoId<DamageTypePrototype> _heatTypeId = "Heat";
 
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -85,6 +86,9 @@ public sealed class DantalionSystem : EntitySystem
         SubscribeLocalEvent<DantalionComponent, VampireMassHysteriaActionEvent>(OnMassHysteria);
 
         SubscribeLocalEvent<DantalionComponent, VampireBloodDrankEvent>(OnBloodDrank);
+
+        SubscribeLocalEvent<DantalionComponent, DamageBeforeApplyEvent>(OnDantalionDamage);
+        SubscribeLocalEvent<VampireThrallComponent, DamageBeforeApplyEvent>(OnThrallDamage);
     }
 
     public override void Update(float frameTime)
@@ -136,7 +140,19 @@ public sealed class DantalionSystem : EntitySystem
 
         var target = args.Target;
 
+        if (HasComp<BibleUserComponent>(target) && vampire.FullPower != true)
+        {
+            _popup.PopupEntity(Loc.GetString("vampire-target-protected-by-faith"), uid, uid, PopupType.MediumCaution);
+            return;
+        }
+        
         if (!IsValidEnthrallTarget(uid, target))
+        {
+            _popup.PopupEntity(Loc.GetString("vampire-enthrall-invalid"), uid, uid, PopupType.MediumCaution);
+            return;
+        }
+
+        if (HasComp<MindShieldComponent>(target))
         {
             _popup.PopupEntity(Loc.GetString("vampire-enthrall-invalid"), uid, uid, PopupType.MediumCaution);
             return;
@@ -184,6 +200,12 @@ public sealed class DantalionSystem : EntitySystem
         var target = args.Target.Value;
 
         if (!IsValidEnthrallTarget(uid, target))
+        {
+            _popup.PopupEntity(Loc.GetString("vampire-enthrall-invalid"), uid, uid, PopupType.SmallCaution);
+            return;
+        }
+
+        if (HasComp<MindShieldComponent>(target))
         {
             _popup.PopupEntity(Loc.GetString("vampire-enthrall-invalid"), uid, uid, PopupType.SmallCaution);
             return;
@@ -290,9 +312,6 @@ public sealed class DantalionSystem : EntitySystem
             return false;
 
         if (HasComp<VampireComponent>(target) || HasComp<VampireThrallComponent>(target))
-            return false;
-
-        if (HasComp<MindShieldComponent>(target))
             return false;
 
         return true;
@@ -616,7 +635,7 @@ public sealed class DantalionSystem : EntitySystem
                 return;
             }
 
-            ActivateBloodBond(uid, dantalion, actionEntity, args.Range, args.BloodCostPerSecond, args.TickInterval);
+            ActivateBloodBond(uid, dantalion, actionEntity, args.Range, args.BloodCostPerTick, args.TickInterval);
             _popup.PopupEntity(Loc.GetString("vampire-blood-bond-start"), uid, uid);
         }
 
@@ -626,7 +645,7 @@ public sealed class DantalionSystem : EntitySystem
         args.Handled = true;
     }
 
-    private void ActivateBloodBond(EntityUid uid, DantalionComponent dantalion, EntityUid actionEntity, float range, float bloodCostPerSecond, TimeSpan tickInterval)
+    private void ActivateBloodBond(EntityUid uid, DantalionComponent dantalion, EntityUid actionEntity, float range, int bloodCostPerTick, TimeSpan tickInterval)
     {
         dantalion.BloodBondActive = true;
         dantalion.BloodBondLoopId++;
@@ -637,7 +656,7 @@ public sealed class DantalionSystem : EntitySystem
 
         Dirty(uid, dantalion);
 
-        StartBloodBondLoop(uid, actionEntity, range, bloodCostPerSecond, tickInterval);
+        StartBloodBondLoop(uid, actionEntity, range, bloodCostPerTick, tickInterval);
     }
 
     private void DeactivateBloodBond(EntityUid uid, DantalionComponent dantalion)
@@ -659,7 +678,7 @@ public sealed class DantalionSystem : EntitySystem
         Dirty(uid, dantalion);
     }
 
-    private void StartBloodBondLoop(EntityUid uid, EntityUid actionEntity, float range, float bloodCostPerSecond, TimeSpan tickInterval)
+    private void StartBloodBondLoop(EntityUid uid, EntityUid actionEntity, float range, int bloodCostPerTick, TimeSpan tickInterval)
     {
         if (!Exists(uid)
             || !TryComp<VampireComponent>(uid, out var comp)
@@ -668,7 +687,7 @@ public sealed class DantalionSystem : EntitySystem
             return;
 
         if (TryComp<MobStateComponent>(uid, out var mobState)
-            && mobState.CurrentState == MobState.Dead)
+            && mobState.CurrentState is MobState.Dead or MobState.Critical)
         {
             DeactivateBloodBond(uid, dantalion);
             if (Exists(actionEntity) && _actions.GetAction(actionEntity) is { } action)
@@ -676,8 +695,7 @@ public sealed class DantalionSystem : EntitySystem
             return;
         }
 
-        var bloodCost = (int) Math.Ceiling(bloodCostPerSecond * tickInterval.TotalSeconds);
-        if (comp.DrunkBlood < bloodCost)
+        if (comp.DrunkBlood < bloodCostPerTick)
         {
             DeactivateBloodBond(uid, dantalion);
             _popup.PopupEntity(Loc.GetString("vampire-blood-bond-stop-blood"), uid, uid);
@@ -686,8 +704,8 @@ public sealed class DantalionSystem : EntitySystem
             return;
         }
 
-        // Consume blood and update alerts
-        _vampire.CheckAndConsumeBloodCost(uid, comp, null, bloodCost);
+        // Consume blood
+        _vampire.CheckAndConsumeBloodCost(uid, comp, null, bloodCostPerTick);
 
         // Find thralls in range
         var coords = Transform(uid).Coordinates;
@@ -713,9 +731,6 @@ public sealed class DantalionSystem : EntitySystem
         dantalion.BloodBondLinkedThralls = linkedThralls.ToHashSet();
         UpdateBloodBondBeamNetwork(uid, linkedThralls, range);
 
-        if (linkedThralls.Count > 0)
-            ApplyBloodBondDamageSharing(uid, linkedThralls);
-
         var expectedLoopId = dantalion.BloodBondLoopId;
 
         Timer.Spawn(tickInterval, () =>
@@ -724,65 +739,86 @@ public sealed class DantalionSystem : EntitySystem
                 return;
             if (!d2.BloodBondActive || d2.BloodBondLoopId != expectedLoopId)
                 return;
-            StartBloodBondLoop(uid, actionEntity, range, bloodCostPerSecond, tickInterval);
+            StartBloodBondLoop(uid, actionEntity, range, bloodCostPerTick, tickInterval);
         });
     }
 
-    private void ApplyBloodBondDamageSharing(EntityUid vampire, List<EntityUid> thralls)
+    private void OnDantalionDamage(EntityUid uid, DantalionComponent dantalion, ref DamageBeforeApplyEvent args)
     {
-        var participants = new List<EntityUid> { vampire };
-        participants.AddRange(thralls);
-
-        var totalHealthRatio = 0f;
-        var validParticipants = new List<(EntityUid entity, DamageableComponent damageable, float healthRatio)>();
-
-        foreach (var participant in participants)
-        {
-            if (!TryComp<DamageableComponent>(participant, out var damageable))
-                continue;
-
-            // Consider only damage that we can actually heal,
-            // otherwise other damage would lower the ratio but never would be healed,
-            // causing other participants to take brute damage for nothing
-            var healableDamage = 0f;
-            if (damageable.DamagePerGroup.TryGetValue(_bruteGroupId, out var brute))
-                healableDamage += brute.Float();
-            if (damageable.DamagePerGroup.TryGetValue(_burnGroupId, out var burn))
-                healableDamage += burn.Float();
-
-            var maxHealth = 100f;
-
-            var healthRatio = Math.Max(0f, 1f - (healableDamage / maxHealth));
-            totalHealthRatio += healthRatio;
-            validParticipants.Add((participant, damageable, healthRatio));
-        }
-
-        if (validParticipants.Count < 2)
+        if (!dantalion.BloodBondActive || dantalion.BloodBondProcessingDamage)
             return;
 
-        var averageHealthRatio = totalHealthRatio / validParticipants.Count;
+        SplitBloodBondDamage(uid, uid, dantalion, ref args);
+    }
 
-        foreach (var (entity, _, healthRatio) in validParticipants)
+    private void OnThrallDamage(EntityUid uid, VampireThrallComponent thrall, ref DamageBeforeApplyEvent args)
+    {
+        if (!TryComp<DantalionComponent>(thrall.Master, out var dantalion))
+            return;
+
+        if (!dantalion.BloodBondActive || dantalion.BloodBondProcessingDamage)
+            return;
+
+        if (!dantalion.BloodBondLinkedThralls.Contains(uid))
+            return;
+
+        SplitBloodBondDamage(uid, thrall.Master.Value, dantalion, ref args);
+    }
+
+    private void SplitBloodBondDamage(EntityUid damagedEntity, EntityUid vampire, DantalionComponent dantalion, ref DamageBeforeApplyEvent args)
+    {
+        if (args.Damage.GetTotal() <= 0)
+            return;
+
+        var participants = new List<EntityUid> { vampire };
+        foreach (var thrall in dantalion.BloodBondLinkedThralls)
         {
-            var deviation = healthRatio - averageHealthRatio;
-            var adjustmentAmount = Math.Abs(deviation) * 5f;
+            if (Exists(thrall))
+                participants.Add(thrall);
+        }
 
-            if (adjustmentAmount < 0.1f)
-                continue;
+        if (participants.Count < 2)
+            return;
 
-            if (deviation > 0)
+        var totalDamage = FixedPoint2.Zero;
+        foreach (var (_, value) in args.Damage.DamageDict)
+        {
+            if (value > 0)
+                totalDamage += value;
+        }
+
+        var damageShare = totalDamage / participants.Count;
+
+        var originalTargetDamage = new DamageSpecifier();
+        foreach (var (type, value) in args.Damage.DamageDict)
+        {
+            if (value > 0)
             {
-                var spec = new DamageSpecifier(_proto.Index<DamageTypePrototype>(_bluntTypeId), FixedPoint2.New(adjustmentAmount));
-                _damageableSystem.TryChangeDamage(entity, spec, true, origin: vampire);
+                originalTargetDamage.DamageDict[type] = value / participants.Count;
             }
             else
             {
-                var healSpec = new DamageSpecifier();
-                healSpec += new DamageSpecifier(_proto.Index<DamageGroupPrototype>(_bruteGroupId), -FixedPoint2.New(adjustmentAmount * 0.7f));
-                healSpec += new DamageSpecifier(_proto.Index<DamageGroupPrototype>(_burnGroupId), -FixedPoint2.New(adjustmentAmount * 0.3f));
-                _damageableSystem.TryChangeDamage(entity, healSpec, true, origin: vampire);
+                originalTargetDamage.DamageDict[type] = value;
             }
         }
+        args.Damage = originalTargetDamage;
+
+        var redistributedDamage = new DamageSpecifier(_proto.Index<DamageTypePrototype>(_heatTypeId), damageShare);
+
+        dantalion.BloodBondProcessingDamage = true;
+
+        foreach (var other in participants)
+        {
+            if (other == damagedEntity)
+                continue;
+
+            if (!Exists(other))
+                continue;
+
+            _damageableSystem.TryChangeDamage(other, redistributedDamage, ignoreResistances: true, origin: args.Origin);
+        }
+
+        dantalion.BloodBondProcessingDamage = false;
     }
 
     private void UpdateBloodBondBeamNetwork(EntityUid vampire, List<EntityUid> targets, float range)

--- a/Content.Server/_Starlight/Antags/Vampires/Systems/Classes/GargantuaSystem.cs
+++ b/Content.Server/_Starlight/Antags/Vampires/Systems/Classes/GargantuaSystem.cs
@@ -9,7 +9,6 @@ using Content.Shared.Actions;
 using Content.Shared.Alert;
 using Content.Shared.CombatMode;
 using Content.Shared.Damage;
-using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Damage.Prototypes;
@@ -699,7 +698,7 @@ public sealed class GargantuaSystem : EntitySystem
             // Static obstacle
             var obstacleCoords = Transform(other).Coordinates;
 
-            _audio.PlayPvs(chargeEv.Sound, obstacleCoords);
+            _audio.PlayPvs(chargeEv.Sound, obstacleCoords, AudioParams.Default.WithVolume(3f));
 
             if (HasComp<DestructibleComponent>(other))
                 _destructible.DestroyEntity(other);
@@ -714,7 +713,7 @@ public sealed class GargantuaSystem : EntitySystem
             || !TryGetVampireActionEvent<VampireChargeActionEvent>(vampire, ChargeActionId, out var chargeEv))
             return;
 
-        _audio.PlayPvs(chargeEv.Sound, target);
+        _audio.PlayPvs(chargeEv.Sound, target, AudioParams.Default.WithVolume(3f));
 
         var damageSpec = new DamageSpecifier();
         damageSpec.DamageDict["Blunt"] = chargeEv.CreatureDamage;

--- a/Content.Server/_Starlight/Antags/Vampires/Systems/Classes/GargantuaSystem.cs
+++ b/Content.Server/_Starlight/Antags/Vampires/Systems/Classes/GargantuaSystem.cs
@@ -483,12 +483,15 @@ public sealed class GargantuaSystem : EntitySystem
         for (var i = 1; i <= maxTiles; i++)
         {
             var tileIndex = i;
-            var tileCoords = xform.Coordinates.Offset(direction * tileIndex);
+            var tileMapCoords = _transform.ToMapCoordinates(xform.Coordinates.Offset(direction * tileIndex));
 
             Timer.Spawn(delayPerTile * i, () =>
             {
                 if (!Exists(uid) || stopped)
                     return;
+
+                // Convert back to EntityCoordinates inside the callback
+                var tileCoords = _transform.ToCoordinates(tileMapCoords);
 
                 var blocked = false;
                 var entitiesOnTile = _lookup.GetEntitiesInRange(tileCoords, 0.4f);

--- a/Content.Server/_Starlight/Antags/Vampires/Systems/Classes/UmbraeSystem.cs
+++ b/Content.Server/_Starlight/Antags/Vampires/Systems/Classes/UmbraeSystem.cs
@@ -22,7 +22,6 @@ using Content.Shared.Popups;
 using Content.Shared.Stealth;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Temperature.Components;
-using Content.Shared.UserInterface;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
@@ -53,6 +52,7 @@ public sealed class UmbraeSystem : EntitySystem
     [Dependency] private readonly TemperatureSystem _temperatureSystem = default!;
     [Dependency] private readonly DamageableSystem _damageableSystem = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly SharedEyeSystem _eye = default!;
 
     public override void Initialize()
     {
@@ -68,6 +68,7 @@ public sealed class UmbraeSystem : EntitySystem
         SubscribeLocalEvent<VampireComponent, VampireShadowSnareActionEvent>(OnShadowSnare);
 
         SubscribeLocalEvent<UmbraeComponent, VampireBloodDrankEvent>(OnBloodDrank);
+        SubscribeLocalEvent<UmbraeComponent, VampireFullPowerAchievedEvent>(OnFullPower);
     }
 
     private void OnBloodDrank(EntityUid uid, UmbraeComponent umbrae, ref VampireBloodDrankEvent args)
@@ -474,12 +475,10 @@ public sealed class UmbraeSystem : EntitySystem
             return;
         }
 
-        umbrae.ShadowAnchorBeaconPrototype = args.BeaconPrototype;
-
         var pressedCoords = Transform(uid).Coordinates;
         var tileCoords = pressedCoords.WithPosition(pressedCoords.Position.Floored() + new Vector2(0.5f, 0.5f));
 
-        var ev = new VampireShadowAnchorDoAfterEvent(GetNetCoordinates(tileCoords), bloodCost, args.AutoReturnDelay);
+        var ev = new VampireShadowAnchorDoAfterEvent(GetNetCoordinates(tileCoords), args.BeaconPrototype, bloodCost, args.AutoReturnDelay);
         var doAfter = new DoAfterArgs(EntityManager, uid, args.PlaceDelay, ev, uid)
         {
             DistanceThreshold = null,
@@ -521,7 +520,7 @@ public sealed class UmbraeSystem : EntitySystem
             return;
 
         var coords = GetCoordinates(args.TargetCoordinates);
-        var newBeacon = EntityManager.SpawnEntity(umbrae.ShadowAnchorBeaconPrototype, coords);
+        var newBeacon = EntityManager.SpawnEntity(args.BeaconPrototype, coords);
         umbrae.SpawnedShadowAnchorBeacon = newBeacon;
         umbrae.ShadowAnchorLoopId++;
         var expectedLoopId = umbrae.ShadowAnchorLoopId;
@@ -694,5 +693,10 @@ public sealed class UmbraeSystem : EntitySystem
         }
 
         args.Handled = true;
+    }
+    private void OnFullPower(EntityUid uid, UmbraeComponent umbrae, VampireFullPowerAchievedEvent args)
+    {
+        _eye.SetDrawFov(uid, false);
+        _popup.PopupEntity(Loc.GetString("vampire-umbrae-full-power-fov"), uid, uid, PopupType.Large);
     }
 }

--- a/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.Abilities.cs
+++ b/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.Abilities.cs
@@ -1,10 +1,8 @@
 using Content.Server.Bible.Components;
 using Content.Shared._Starlight.Antags.Vampires;
 using Content.Shared._Starlight.Antags.Vampires.Components;
-using Content.Shared._Starlight.Antags.Vampires.Components.Classes;
 using Content.Shared._Starlight.Antags.Vampires.Prototypes;
 using Content.Shared.Body.Components;
-using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Damage;
@@ -676,7 +674,11 @@ public sealed partial class VampireSystem : EntitySystem
         var prev = comp.FullPower;
         comp.FullPower = comp.TotalBlood > 1000 && uniqueHumanoids >= 8;
         if (!prev && comp.FullPower)
+        {
             _popup.PopupEntity(Loc.GetString("vampire-full-power-achieved"), uid, uid);
+            var ev = new VampireFullPowerAchievedEvent();
+            RaiseLocalEvent(uid, ev);
+        }
         Dirty(uid, comp);
     }
 

--- a/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.cs
+++ b/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.cs
@@ -7,6 +7,8 @@ using Content.Shared._Starlight.Antags.Vampires;
 using Content.Shared._Starlight.Antags.Vampires.Components;
 using Content.Shared._Starlight.Antags.Vampires.Components.Classes;
 using Content.Shared._Starlight.Antags.Vampires.Prototypes;
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Vampire.Components;
 using Content.Shared.Alert;
 using Content.Shared.Actions.Components;
 using Content.Shared.Damage;
@@ -411,6 +413,7 @@ public sealed partial class VampireSystem : EntitySystem
 
     private void OnStartup(EntityUid uid, VampireComponent comp, ComponentStartup args)
     {
+        EnsureComp<UnholyComponent>(uid);
         EnsureComp<VampireSunlightComponent>(uid);
         foreach (var actionId in comp.BaseVampireActions)
         {
@@ -436,6 +439,8 @@ public sealed partial class VampireSystem : EntitySystem
 
     private void OnShutdown(EntityUid uid, VampireComponent comp, ComponentShutdown args)
     {
+        RemComp<UnholyComponent>(uid);
+        RemComp<NightVisionComponent>(uid);
         if (TryComp<VampireDrainBeamComponent>(uid, out var drainBeamComp))
         {
             foreach (var connection in drainBeamComp.ActiveBeams.Values)
@@ -704,6 +709,9 @@ public sealed partial class VampireSystem : EntitySystem
         var reg = _componentFactory.GetRegistration(classProto.ClassComponent, ignoreCase: true);
         var classComp = _componentFactory.GetComponent(reg.Type);
         EntityManager.AddComponent(uid, classComp);
+
+        if (classProto.ID == "Umbrae")
+            EnsureComp<NightVisionComponent>(uid);
 
         comp.ChosenClassId = classProto.ID;
 

--- a/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.cs
+++ b/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.cs
@@ -653,8 +653,13 @@ public sealed partial class VampireSystem : EntitySystem
             if (ent == uid)
                 continue;
 
-            if (HasComp<PrayableComponent>(ent))
-                return true;
+            if (!HasComp<PrayableComponent>(ent))
+                continue;
+
+            if (!Transform(ent).Anchored)
+                continue;
+
+            return true;
         }
 
         return false;

--- a/Content.Shared/_Starlight/Antags/Vampires/Components/Classes/DantalionComponent.cs
+++ b/Content.Shared/_Starlight/Antags/Vampires/Components/Classes/DantalionComponent.cs
@@ -40,6 +40,9 @@ public sealed partial class DantalionComponent : VampireClassComponent
 	/// </summary>
 	[ViewVariables(VVAccess.ReadOnly)]
 	public HashSet<EntityUid> BloodBondLinkedThralls = new();
+
+	[ViewVariables(VVAccess.ReadOnly)]
+	public bool BloodBondProcessingDamage = false;
 	
 	[DataField]
 	public EntProtoId rallyOverlayEffect = "VampireRallyOverlayEffect";

--- a/Content.Shared/_Starlight/Antags/Vampires/Components/Classes/UmbraeComponent.cs
+++ b/Content.Shared/_Starlight/Antags/Vampires/Components/Classes/UmbraeComponent.cs
@@ -28,7 +28,6 @@ public sealed partial class UmbraeComponent : VampireClassComponent
     public EntityUid? SpawnedShadowAnchorBeacon = null;
     public bool ShadowAnchorPlacementInProgress;
     public int ShadowAnchorLoopId;
-    public EntProtoId ShadowAnchorBeaconPrototype = "VampireShadowAnchorBeacon";
 
     /// <summary>
     /// List of placed shadow snare traps

--- a/Content.Shared/_Starlight/Antags/Vampires/VampireEvents.cs
+++ b/Content.Shared/_Starlight/Antags/Vampires/VampireEvents.cs
@@ -72,6 +72,10 @@ public sealed class VampireBloodDrankEvent : EntityEventArgs
     }
 }
 
+public sealed class VampireFullPowerAchievedEvent : EntityEventArgs
+{
+}
+
 /// <summary>
 /// Raised locally on a vampire when their progression related blood values change
 /// </summary>
@@ -246,6 +250,9 @@ public sealed partial class VampireShadowAnchorDoAfterEvent : SimpleDoAfterEvent
     public NetCoordinates TargetCoordinates;
 
     [DataField]
+    public EntProtoId BeaconPrototype = "VampireShadowAnchorBeacon";
+
+    [DataField]
     public int BloodCost;
 
     [DataField]
@@ -255,9 +262,10 @@ public sealed partial class VampireShadowAnchorDoAfterEvent : SimpleDoAfterEvent
     {
     }
 
-    public VampireShadowAnchorDoAfterEvent(NetCoordinates coords, int bloodCost, TimeSpan autoReturnDelay)
+    public VampireShadowAnchorDoAfterEvent(NetCoordinates coords, EntProtoId beaconPrototype, int bloodCost, TimeSpan autoReturnDelay)
     {
         TargetCoordinates = coords;
+        BeaconPrototype = beaconPrototype;
         BloodCost = bloodCost;
         AutoReturnDelay = autoReturnDelay;
     }
@@ -281,7 +289,7 @@ public sealed partial class VampireDarkPassageActionEvent : WorldTargetActionEve
 public sealed partial class VampireExtinguishActionEvent : InstantActionEvent
 {
     [DataField]
-    public float Radius = 8f;
+    public float Radius = 4f;
 }
 
 // Shadow Boxing
@@ -418,16 +426,16 @@ public sealed partial class VampireBloodBondActionEvent : InstantActionEvent
     public float Range = 3f;
 
     /// <summary>
-    ///     Blood cost per second while active
+    ///     Blood cost per tick while active
     /// </summary>
     [DataField]
-    public float BloodCostPerSecond = 2.5f;
+    public int BloodCostPerTick = 5;
 
     /// <summary>
-    ///     Tick interval in seconds
+    ///     Tick interval
     /// </summary>
     [DataField]
-    public TimeSpan TickInterval = TimeSpan.FromSeconds(1);
+    public TimeSpan TickInterval = TimeSpan.FromSeconds(2);
 }
 
 public sealed partial class VampireMassHysteriaActionEvent : InstantActionEvent

--- a/Resources/Locale/en-US/_Starlight/vampire/vampire.ftl
+++ b/Resources/Locale/en-US/_Starlight/vampire/vampire.ftl
@@ -20,6 +20,7 @@ vampire-target-protected-by-faith = This person is protected by their faith!
 vampire-drink-target-maxed = You have already drunk { $amount } units of blood from this target.
 vampire-drink-target-hard-max = You have drunk the maximum amount of blood from this target ({ $amount } units).
 vampire-full-power-achieved = Your vampiric essence surges full power achieved!
+vampire-umbrae-full-power-fov = The shadows bend to your will. You can now see through walls!
 
 vampire-role-greeting = You are a vampire!
     Your blood thirst compels you to feed on crew members. Use your abilities to turn other crew.

--- a/Resources/ServerInfo/_StarLight/Guidebook/Antagonist/Vampire/Vampires.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Antagonist/Vampire/Vampires.xml
@@ -39,5 +39,20 @@
    [textlink="Dantalion" link="VampiresDantalion"] — thralls, illusions, social control.
    [textlink="Gargantua" link="VampiresGargantua"] — melee, durability, breaking through.
 
+  ## Holy Weakness
+
+  Vampires are vulnerable to holy forces, but [italic]only after they have fed on at least one victim[/italic].
+
+  [bold]Holy Water[/bold]:
+  - Deals burn damage to vampires who have fed.
+  - If you haven't drained blood from anyone yet, holy water has no effect on you.
+
+  [bold]Holy Place[/bold]
+  - Standing on chapel tiles deals constant burn damage to vampires.
+  - Again, this only activates once you've had at least one victim.
+
+  [bold]The Chaplain[/bold]
+  - Chaplains with an active bible are [bold]immune to vampire abilities[/bold]. 
+    But once you reach [bold]Full Power[/bold], you can bypass faith protection.
 
 </Document>


### PR DESCRIPTION
## Short description
changelog
## Why we need to add this

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Cringe_Cursed
- tweak: Tweaked so Blood Bond now splits incoming damage evenly, redistributed as burn damage.
- add: Added so, now Umbrae can see through walls upon reaching Full Power.
- add: Added night vision to Umbrae class.
- add: Added an entry to guidebook containing everything about Holy Things.
- tweak: Tweaked extinguish ability range from 8 tiles to 4.
- fix: Fixed Umbrae`s shadow anchor ability.
- fix: Fixed interactions between Dantalion class abilities and Chaplains.
- fix: FIxed, now you actualy cant enthrall Mindshielded crew.
- fix: Fixed demonic grasp ability
- fix: Fixed interactions between holy water and bible with Vampires.