### PR TITLE
[Hotfix] Fix FreeMAG not properly setting EmagType on cyborgs

### DIFF
--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -357,7 +357,10 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
             return;
         
         if (!_tag.HasTag(args.EmagComponent.Owner, "FreeMag"))
-                return;
+            return;
+
+        if (!ent.Comp.IsLawboard)
+            return;
 
         ent.Comp.Lawset = GetLawset("FreeLawset");
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Freemags now properly make borgs immune to the evil robotics console

## Why we need to add this
Due to a technicality, cyborgs, in code, are treated as law boards (they have SiliconLawProviderComponent). The problem with this is that this caused the FreeMAG (which has a special interaction when used on law boards) to treat cyborgs as both cyborgs _and_ law boards. This caused a cyborg's EmaggedComponent to not be properly set. The result is that FreeMagged borgs were still vulnerable to the robotics console. By adding a simple check to the law board emag code that ensures we are actually emagging a law board, this is fixed.
## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: R3v3l4t1on
- fix: FreeMagged borgs are no longer vulnerable to the nefarious Robotics Console. Go. Do crime.
