### PR TITLE
Remove free agency from the Skeletons.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -17,9 +17,9 @@
   - type: GhostRole
     name: ghost-role-information-skeleton-pirate-name
     description: ghost-role-information-skeleton-pirate-description
-    rules: ghost-role-information-freeagent-rules
+    rules: ghost-role-information-nonantagonist-rules # Starlight-edit - Free Agent -> NonAntagonist
     mindRoles:
-    - MindRoleGhostRoleFreeAgentSkeleton # Starlight-edit - FreeAgent -> FreeAgentSkeleton
+    - MindRoleGhostRoleNeutralSkeleton # Starlight-edit - FreeAgent -> NeutralSkeleton
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
@@ -36,9 +36,9 @@
   - type: GhostRole
     name: ghost-role-information-skeleton-biker-name
     description: ghost-role-information-skeleton-biker-description
-    rules: ghost-role-information-freeagent-rules
+    rules: ghost-role-information-nonantagonist-rules # Starlight-edit - Free Agent -> NonAntagonist
     mindRoles:
-    - MindRoleGhostRoleFreeAgentSkeleton # Starlight-edit - FreeAgent -> FreeAgentSkeleton
+    - MindRoleGhostRoleNeutralSkeleton # Starlight-edit - FreeAgent -> NeutralSkeleton
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
@@ -54,9 +54,9 @@
   - type: GhostRole
     name: ghost-role-information-closet-skeleton-name
     description: ghost-role-information-closet-skeleton-description
-    rules: ghost-role-information-nonantagonist-rules
-    # mindRoles:
-    # - MindRoleGhostRoleFreeAgent
+    rules: ghost-role-information-nonantagonist-rules # Starlight-edit - Free Agent -> NonAntagonist
+    mindRoles:
+    - MindRoleGhostRoleNeutralSkeleton # Starlight-edit - FreeAgent -> NeutralSkeleton
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
@@ -64,6 +64,7 @@
     prototypes: [LimitedAssistantGear]
   - type: RandomHumanoidAppearance
 
+# Starlight-edit start
 - type: entity
   parent: MobSkeletonPerson
   id: MobSkeletonClosetFreeAgent
@@ -74,10 +75,11 @@
     description: ghost-role-information-closet-skeleton-description
     rules: ghost-role-information-freeagent-rules
     mindRoles:
-    - MindRoleGhostRoleFreeAgentSkeleton # Starlight-edit - FreeAgent -> FreeAgentSkeleton
+    - MindRoleGhostRoleFreeAgentSkeleton
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [LimitedAssistantGear]
   - type: RandomHumanoidAppearance
+# Starlight-edit end

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -17,7 +17,7 @@
   - type: GhostRole
     name: ghost-role-information-skeleton-pirate-name
     description: ghost-role-information-skeleton-pirate-description
-    rules: ghost-role-information-nonantagonist-rules # Starlight-edit Free Agent -> NonAntagonist
+    rules: ghost-role-information-nonantagonist-rules # Starlight-edit - Free Agent -> NonAntagonist
     mindRoles:
     - MindRoleGhostRoleNeutralSkeleton # Starlight-edit - FreeAgent -> NeutralSkeleton
     raffle:
@@ -36,7 +36,7 @@
   - type: GhostRole
     name: ghost-role-information-skeleton-biker-name
     description: ghost-role-information-skeleton-biker-description
-    rules: ghost-role-information-nonantagonist-rules # Starlight-edit Free Agent -> NonAntagonist
+    rules: ghost-role-information-nonantagonist-rules # Starlight-edit - Free Agent -> NonAntagonist
     mindRoles:
     - MindRoleGhostRoleNeutralSkeleton # Starlight-edit - FreeAgent -> NeutralSkeleton
     raffle:
@@ -54,7 +54,7 @@
   - type: GhostRole
     name: ghost-role-information-closet-skeleton-name
     description: ghost-role-information-closet-skeleton-description
-    rules: ghost-role-information-nonantagonist-rules # Starlight-edit Free Agent -> NonAntagonist
+    rules: ghost-role-information-nonantagonist-rules # Starlight-edit - Free Agent -> NonAntagonist
     mindRoles:
     - MindRoleGhostRoleNeutralSkeleton # Starlight-edit - FreeAgent -> NeutralSkeleton
     raffle:
@@ -64,6 +64,7 @@
     prototypes: [LimitedAssistantGear]
   - type: RandomHumanoidAppearance
 
+# Starlight-edit start
 - type: entity
   parent: MobSkeletonPerson
   id: MobSkeletonClosetFreeAgent
@@ -74,10 +75,11 @@
     description: ghost-role-information-closet-skeleton-description
     rules: ghost-role-information-freeagent-rules
     mindRoles:
-    - MindRoleGhostRoleFreeAgentSkeleton # Starlight-edit - FreeAgent -> FreeAgentSkeleton
+    - MindRoleGhostRoleFreeAgentSkeleton
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
   - type: Loadout
     prototypes: [LimitedAssistantGear]
   - type: RandomHumanoidAppearance
+# Starlight-edit end

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -17,9 +17,9 @@
   - type: GhostRole
     name: ghost-role-information-skeleton-pirate-name
     description: ghost-role-information-skeleton-pirate-description
-    rules: ghost-role-information-freeagent-rules
+    rules: ghost-role-information-nonantagonist-rules # Starlight-edit Free Agent -> NonAntagonist
     mindRoles:
-    - MindRoleGhostRoleFreeAgentSkeleton # Starlight-edit - FreeAgent -> FreeAgentSkeleton
+    - MindRoleGhostRoleNeutralSkeleton # Starlight-edit - FreeAgent -> NeutralSkeleton
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
@@ -36,9 +36,9 @@
   - type: GhostRole
     name: ghost-role-information-skeleton-biker-name
     description: ghost-role-information-skeleton-biker-description
-    rules: ghost-role-information-freeagent-rules
+    rules: ghost-role-information-nonantagonist-rules # Starlight-edit Free Agent -> NonAntagonist
     mindRoles:
-    - MindRoleGhostRoleFreeAgentSkeleton # Starlight-edit - FreeAgent -> FreeAgentSkeleton
+    - MindRoleGhostRoleNeutralSkeleton # Starlight-edit - FreeAgent -> NeutralSkeleton
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
@@ -54,9 +54,9 @@
   - type: GhostRole
     name: ghost-role-information-closet-skeleton-name
     description: ghost-role-information-closet-skeleton-description
-    rules: ghost-role-information-nonantagonist-rules
-    # mindRoles:
-    # - MindRoleGhostRoleFreeAgent
+    rules: ghost-role-information-nonantagonist-rules # Starlight-edit Free Agent -> NonAntagonist
+    mindRoles:
+    - MindRoleGhostRoleNeutralSkeleton # Starlight-edit - FreeAgent -> NeutralSkeleton
     raffle:
       settings: default
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/_StarLight/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_StarLight/Roles/MindRoles/mind_roles.yml
@@ -61,7 +61,7 @@
   name: Ghost Role (Skeleton)
   components:
   - type: MindRole
-    roleType: FreeAgent
+    roleType: Neutral
     sortWeight: 0
     fallbackPlayTimeTracker: GhostSkeleton
 

--- a/Resources/Prototypes/_StarLight/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_StarLight/Roles/MindRoles/mind_roles.yml
@@ -61,6 +61,16 @@
   name: Ghost Role (Skeleton)
   components:
   - type: MindRole
+    roleType: FreeAgent
+    sortWeight: 0
+    fallbackPlayTimeTracker: GhostSkeleton
+
+- type: entity
+  parent: MindRoleGhostRoleNeutral
+  id: MindRoleGhostRoleNeutralSkeleton
+  name: Ghost Role (Skeleton)
+  components:
+  - type: MindRole
     roleType: Neutral
     sortWeight: 0
     fallbackPlayTimeTracker: GhostSkeleton

--- a/Resources/Prototypes/_StarLight/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_StarLight/Roles/MindRoles/mind_roles.yml
@@ -65,6 +65,16 @@
     sortWeight: 0
     fallbackPlayTimeTracker: GhostSkeleton
 
+- type: entity
+  parent: MindRoleGhostRoleNeutral
+  id: MindRoleGhostRoleNeutralSkeleton
+  name: Ghost Role (Skeleton)
+  components:
+  - type: MindRole
+    roleType: Neutral
+    sortWeight: 0
+    fallbackPlayTimeTracker: GhostSkeleton
+
 # Downstream antagonists
 
 - type: entity


### PR DESCRIPTION
## Short description
Re-aligns Skeleton ghost roles with the Crew.

## Why we need to add this
Upstream released them as free agents, we made them crew-aligned, and that was lost when the playtime trackers were implemented.

## Media (Video/Screenshots)

## Checks
- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: r3d3mpt1on
- fix: Skeletons are once again Crew-Aligned.