### PR TITLE
Allow using the old swing/thrust animations

### DIFF
--- a/Content.Client/Weapons/Melee/Components/WeaponArcVisualsComponent.cs
+++ b/Content.Client/Weapons/Melee/Components/WeaponArcVisualsComponent.cs
@@ -20,4 +20,7 @@ public enum WeaponArcAnimation : byte
     None,
     Thrust,
     Slash,
+    //Starlight begin
+    OldSlash,
+    OldThrust,
 }

--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -83,6 +83,22 @@ public sealed partial class MeleeWeaponSystem
                 if (arcComponent.Fadeout)
                     _animation.Play(animationUid, GetFadeAnimation(sprite, length * 0.5f, length + 0.15f), FadeAnimationKey);
                 break;
+            //Starlight begin
+            case WeaponArcAnimation.OldSlash:
+                track = EnsureComp<TrackUserComponent>(animationUid);
+                track.User = user;
+                _animation.Play(animationUid, GetOldSlashAnimation(sprite, angle, spriteRotation), SlashAnimationKey);
+                if(arcComponent.Fadeout)
+                    _animation.Play(animationUid, GetFadeAnimation(sprite, length * 0.5f, length + 0.15f), FadeAnimationKey);
+                break;
+            case WeaponArcAnimation.OldThrust:
+                track = EnsureComp<TrackUserComponent>(animationUid);
+                track.User = user;
+                _animation.Play(animationUid, GetOldThrustAnimation((animationUid, sprite), (float)Math.Clamp(localPos.Length()/2f,0.2,1f), spriteRotation), ThrustAnimationKey);
+                if (arcComponent.Fadeout)
+                    _animation.Play(animationUid, GetFadeAnimation(sprite, 0.05f, 0.15f), FadeAnimationKey);
+                break;
+            //Starlight end
             case WeaponArcAnimation.None:
                 var (mapPos, mapRot) = TransformSystem.GetWorldPositionRotation(userXform);
                 var worldPos = mapPos + (mapRot - userXform.LocalRotation).RotateVec(localPos);
@@ -218,6 +234,79 @@ public sealed partial class MeleeWeaponSystem
             },
         };
     }
+    
+    //Starlight begin
+    private Animation GetOldSlashAnimation(SpriteComponent sprite, Angle arc, Angle spriteRotation)
+    {
+        const float slashStart = 0.03f;
+        const float slashEnd = 0.065f;
+        const float length = slashEnd + 0.05f;
+        var startRotation = sprite.Rotation + arc / 2;
+        var endRotation = sprite.Rotation - arc / 2;
+        var startRotationOffset = startRotation.RotateVec(new Vector2(0f, -1f));
+        var endRotationOffset = endRotation.RotateVec(new Vector2(0f, -1f));
+        startRotation += spriteRotation;
+        endRotation += spriteRotation;
+
+        return new Animation()
+        {
+            Length = TimeSpan.FromSeconds(length),
+            AnimationTracks =
+            {
+                new AnimationTrackComponentProperty()
+                {
+                    ComponentType = typeof(SpriteComponent),
+                    Property = nameof(SpriteComponent.Rotation),
+                    KeyFrames =
+                    {
+                        new AnimationTrackProperty.KeyFrame(startRotation, 0f),
+                        new AnimationTrackProperty.KeyFrame(startRotation, slashStart),
+                        new AnimationTrackProperty.KeyFrame(endRotation, slashEnd)
+                    }
+                },
+                new AnimationTrackComponentProperty()
+                {
+                    ComponentType = typeof(SpriteComponent),
+                    Property = nameof(SpriteComponent.Offset),
+                    KeyFrames =
+                    {
+                        new AnimationTrackProperty.KeyFrame(startRotationOffset, 0f),
+                        new AnimationTrackProperty.KeyFrame(startRotationOffset, slashStart),
+                        new AnimationTrackProperty.KeyFrame(endRotationOffset, slashEnd)
+                    }
+                },
+            }
+        };
+    }
+
+    private Animation GetOldThrustAnimation(Entity<SpriteComponent> sprite, float distance, Angle spriteRotation)
+    {
+        const float thrustEnd = 0.05f;
+        const float length = 0.15f;
+        var startOffset = sprite.Comp.Rotation.RotateVec(new Vector2(0f, -distance / 5f));
+        var endOffset = sprite.Comp.Rotation.RotateVec(new Vector2(0f, -distance));
+        _sprite.SetRotation(sprite.AsNullable(), sprite.Comp.Rotation + spriteRotation);
+
+        return new Animation()
+        {
+            Length = TimeSpan.FromSeconds(length),
+            AnimationTracks =
+            {
+                new AnimationTrackComponentProperty()
+                {
+                    ComponentType = typeof(SpriteComponent),
+                    Property = nameof(SpriteComponent.Offset),
+                    KeyFrames =
+                    {
+                        new AnimationTrackProperty.KeyFrame(startOffset, 0f),
+                        new AnimationTrackProperty.KeyFrame(endOffset, thrustEnd),
+                        new AnimationTrackProperty.KeyFrame(endOffset, length),
+                    }
+                },
+            }
+        };
+    }
+    //Starlight end
 
     /// <summary>
     /// Updates the effect positions to follow the user

--- a/Resources/Prototypes/Entities/Objects/Fun/Plushies/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Plushies/plushies.yml
@@ -63,6 +63,11 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 10
+    #SL start - make this one feel like it used to because its funnier like that lowkey
+    animation: WeaponArcPunch
+    wideAnimation: WeaponArcSlashOld
+    swingBeverage: false
+    #SL end
   - type: Item
     size: Ginormous
     sprite: Objects/Weapons/Melee/Throngler-in-hand.rsi

--- a/Resources/Prototypes/_StarLight/Entities/Effects/weapon_arc.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Effects/weapon_arc.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: WeaponArcThrustOld
+  parent: WeaponArcStatic
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: WeaponArcVisuals
+      animation: OldThrust
+
+- type: entity
+  id: WeaponArcSlashOld
+  parent: WeaponArcStatic
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: WeaponArcVisuals
+      animation: OldSlash


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Allows use of the old swing/thrust animations if you change the animation name to `WeaponArcSlashOld` or `WeaponArcThrustOld`.
This has also been applied to the throngler plushie. (although it uses `WeaponArcPunch` for the left click swing) like it used to be before the latest upstream merge.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
funny.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- tweak: Allow weapons to use their old thrust/swing animations as they have been re-added under a new animation name.
- tweak: Throngler plushie has been updated to use the original swing animation and punch animation. Why? Funny.