### PR TITLE
Midround station/event tweaks/fixes

### DIFF
--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -201,6 +201,7 @@ public sealed partial class StationSystem : SharedStationSystem
     // Starlight Start
     private void OnGridInit(EntityUid uid, BecomesStationMidRoundComponent component, MapInitEvent ev)
     {
+        if (!component.Initialize) return;
         if (!HasComp<MapGridComponent>(uid)) return; // only grids can become stations
         if (component.Id is not null)
         {
@@ -333,8 +334,9 @@ public sealed partial class StationSystem : SharedStationSystem
     public EntityUid InitializeNewStationMidRound(EntityUid gridId, EntProtoId stationProtoId,
         BecomesStationMidRoundComponent? comp = null) => InitializeNewStationMidRound(gridId, [stationProtoId], comp);
     
-    public EntityUid InitializeNewStationMidRound(EntityUid gridId, List<EntProtoId> stationProtoIds, BecomesStationMidRoundComponent? comp = null)
+    public EntityUid InitializeNewStationMidRound(EntityUid gridId, List<EntProtoId>? stationProtoIds, BecomesStationMidRoundComponent? comp = null)
     {
+        if (stationProtoIds is null) return EntityUid.Invalid;
         //logic for if was initialized via BecomesStationMidRoundComponent
         ComponentRegistry? registry = null;
         if (comp is not null)
@@ -383,6 +385,7 @@ public sealed partial class StationSystem : SharedStationSystem
             if (!_prototype.TryIndex(protoId, out var proto)) continue;
             foreach (var comp in proto.Components.Values.Where(comp => !HasComp(ent, comp.Component.GetType())))
             {
+                if(registry is not null && registry.Values.Any(c=>c.GetType() == comp.GetType())) continue; // this will be overridden later, skip it.
                 var newcomp = _factory.GetComponent(comp);
                 AddComp(ent, newcomp);
             }
@@ -390,6 +393,7 @@ public sealed partial class StationSystem : SharedStationSystem
         // now any of the extra overrides
         if (registry is not null)
         {
+            Log.Log(LogLevel.Info, "NOT NULL!!");
             foreach (var comp in registry.Values.Where(comp => !HasComp(ent, comp.Component.GetType())))
             {
                 var newcomp = _factory.GetComponent(comp);
@@ -399,7 +403,9 @@ public sealed partial class StationSystem : SharedStationSystem
         EntityManager.InitializeAndStartEntity(ent, coords!.Value.MapId);
         return ent;
     }
-    
+
+    public void MarkMidRoundStationForInitialization(EntityUid uid, BecomesStationMidRoundComponent comp) =>
+        comp.Initialize = true;
     //SL end
     
     /// <summary>

--- a/Content.Server/_Starlight/Commands/StationInitCommand.cs
+++ b/Content.Server/_Starlight/Commands/StationInitCommand.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Content.Server._Starlight.Station;
 using Content.Server.Administration;
 using Content.Server.Station.Systems;
 using Content.Shared.Administration;
@@ -33,6 +35,20 @@ public sealed class StationInitCommand : LocalizedCommands
         var stationSystem = _entitySystemManager.GetEntitySystem<StationSystem>();
         if (!_entityManager.TryParseNetEntity(args[0], out var grid))
         {
+            if (args[0] == "all")
+            {
+                var query = _entityManager.EntityQueryEnumerator<BecomesStationMidRoundComponent>();
+                var added = new List<EntityUid>();
+                while (query.MoveNext(out var uid, out var comp))
+                {
+                    if (_entityManager.HasComponent<StationMemberComponent>(uid)) continue;
+                    if (comp.BaseStationProtos is null || comp.BaseStationProtos.Count == 0) continue;
+                    stationSystem.MarkMidRoundStationForInitialization(uid, comp);
+                    var id = stationSystem.InitializeNewStationMidRound(uid, comp.BaseStationProtos, comp);
+                    added.Add(id);
+                }
+                shell.WriteLine($"Initialized stations with the following IDs: {string.Join(", ", added)}.");
+            }
             shell.WriteError("Invalid grid entity ID.");
             return;
         }
@@ -45,8 +61,17 @@ public sealed class StationInitCommand : LocalizedCommands
 
         if (!_prototypeManager.TryIndex(args[1], out var prototype))
         {
-            shell.WriteError(
-                "Invalid station prototype ID. Check /Resources/Prototypes/Entities/Stations for valid station prototypes.");
+            if (!_entityManager.TryGetComponent<BecomesStationMidRoundComponent>(grid, out var midround) ||
+                midround.BaseStationProtos is null || midround.BaseStationProtos.Count == 0)
+            {
+                shell.WriteError(
+                    "Invalid station prototype ID. Check /Resources/Prototypes/Entities/Stations for valid station prototypes.");
+                return;
+            }
+
+            stationSystem.MarkMidRoundStationForInitialization(grid.Value, midround);
+            var id = stationSystem.InitializeNewStationMidRound(grid.Value, midround.BaseStationProtos, midround);
+            shell.WriteLine($"Station with ID {id} initialized!");
             return;
         }
 
@@ -76,7 +101,7 @@ public sealed class StationInitCommand : LocalizedCommands
         switch (args.Length)
         {
             case 1:
-                return CompletionResult.FromHintOptions(CompletionHelper.Components<MapGridComponent>(args[0], _entityManager), "Grid ID");
+                return CompletionResult.FromHintOptions(CompletionHelper.Components<MapGridComponent>(args[0], _entityManager), "Grid ID (or \"all\")");
             case 3:
                 return CompletionResult.FromHintOptions(CompletionHelper.Components<StationDataComponent>(args[2], _entityManager), "Station ID");
         }

--- a/Content.Server/_Starlight/Station/BecomesStationMidRoundComponent.cs
+++ b/Content.Server/_Starlight/Station/BecomesStationMidRoundComponent.cs
@@ -13,6 +13,11 @@ namespace Content.Server._Starlight.Station;
 public sealed partial class BecomesStationMidRoundComponent : Component
 {
     /// <summary>
+    /// Set this to true if you are mapping.
+    /// False by default as it will avoid an initialization attempt when adding to a grid on an already initialized map.
+    /// </summary>
+    [DataField] public bool Initialize;
+    /// <summary>
     /// Initialized ID of station
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)] public string? InitializedId = null;
@@ -23,7 +28,7 @@ public sealed partial class BecomesStationMidRoundComponent : Component
     /// <summary>
     /// Prototypes to use when constructing station
     /// </summary>
-    [DataField] public List<EntProtoId> BaseStationProtos = default!;
+    [DataField] public List<EntProtoId>? BaseStationProtos = default!;
     /// <summary>
     /// Always allow FTLing to this station
     /// </summary>

--- a/Resources/Prototypes/_StarLight/GameRules/wreckswarms.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/wreckswarms.yml
@@ -18,6 +18,7 @@
     reoccurrenceDelay: 1
     earliestStart: 12
     minimumPlayers: 25
+    globalAnnouncement: false
   - type: WreckSwarm
 
 - type: entity
@@ -28,6 +29,7 @@
     weight: 20
     earliestStart: 5
     minimumPlayers: 10
+    globalAnnouncement: false
   - type: WreckSwarm
     sizeFilter: salvage-map-wreck-size-small
 
@@ -39,6 +41,7 @@
     weight: 20
     earliestStart: 15
     minimumPlayers: 30
+    globalAnnouncement: false
   - type: WreckSwarm
     sizeFilter: salvage-map-wreck-size-medium
 
@@ -50,6 +53,7 @@
     weight: 10
     earliestStart: 30
     minimumPlayers: 50
+    globalAnnouncement: false
   - type: WreckSwarm
     announcement: station-event-incoming-wreck-large-announcement
     announcementSound: /Audio/Announcements/attention.ogg


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Properly adds jobs to station if specified, tweaks stationinit to allow passing "all" to init all available midround stations that have yet to be initialized, as well as not requiring prototype if it is specified already in the component.
As for events, properly marks wreck swarms to not globally announce to all players, and only announce to relevant station.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Yes

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Fixed some things regarding midround stations
- fix: Wreck swarms no longer announce globally, only to the target station.