### PR TITLE
Buff pipe pressure threshold

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -346,7 +346,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     The default pressure at which pumps and powered equipment max out at, in kPa.
         /// </summary>
-        public const float MaxOutputPressure = 30000; ///Starlight edit
+        public const float MaxOutputPressure = 9000; ///Starlight edit
 
         /// <summary>
         ///     The default maximum speed powered equipment can work at, in L/s.

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -346,7 +346,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     The default pressure at which pumps and powered equipment max out at, in kPa.
         /// </summary>
-        public const float MaxOutputPressure = 4500;
+        public const float MaxOutputPressure = 30000; ///Starlight edit
 
         /// <summary>
         ///     The default maximum speed powered equipment can work at, in L/s.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Changed the pressure atmos device can handle closer to real life values.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
With the upcomming [2983](https://github.com/ss14Starlight/space-station-14/pull/2983) PR I think we should allow atmosians to proceed more reactions in pipes in order to make them worry less about the space in their department in current maps and allow them to utilize more layers with current pipe layering feature (also 5 layers comming from CrazyPhantom). This change will make the life of atmosians a little bit easier.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AndrewTateOfficialSS14
- tweak: Changed atmos devices max pressure from 4500 to 9000 kPa.
