### PR TITLE
Secure Those Documents

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/representatives.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/representatives.yml
@@ -24,6 +24,7 @@
         - id: FaxMachineFlatpack
         - id: PlushieEmmie
         - id: ClothingOuterHardsuitNtrep
+        - id: BriefcaseSecure
         - !type:NestedSelector
           tableId: CorporateDocumentTable
   

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/briefcases.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/briefcases.yml
@@ -57,3 +57,6 @@
     stateUnlocked: open
   - type: Item
     sprite: _Starlight/Objects/Storage/Briefcases/briefcase_secure.rsi
+  - type: GuideHelp
+    guides:
+    - CombinationLocks  

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Wallmounts/safe.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Wallmounts/safe.yml
@@ -93,6 +93,9 @@
       storagebase: !type:Container
         ents: []
   - type: LockedStorage
+  - type: GuideHelp
+    guides:
+    - CombinationLocks  
 
 - type: entity
   parent: BaseWallSafe

--- a/Resources/Prototypes/_StarLight/Guidebook/tools.yml
+++ b/Resources/Prototypes/_StarLight/Guidebook/tools.yml
@@ -1,0 +1,4 @@
+- type: guideEntry
+  id: CombinationLocks
+  name: CombinationLocks
+  text: "/ServerInfo/_StarLight/Guidebook/Tools/CombinationLocks.xml"

--- a/Resources/ServerInfo/_StarLight/Guidebook/Tools/CombinationLocks.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Tools/CombinationLocks.xml
@@ -13,5 +13,7 @@
   The Wall Safe can sometimes be found on stations inside secure areas, but is uncommon.
   
   To set the combination for either device, enter a code the first time you open it then hit 'E' for Enter. You will then be prompted to input the code again to confirm. After you do so, it will be unlocked. Hitting any other numbers after this should lock it again.
+  
+  Combination locks can be hacked into by opening the maintenance panel and hacking them like any other device, but it takes time.
 
 </Document>

--- a/Resources/ServerInfo/_StarLight/Guidebook/Tools/CombinationLocks.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Tools/CombinationLocks.xml
@@ -14,6 +14,8 @@
   
   To set the combination for either device, enter a code the first time you open it then hit 'E' for Enter. You will then be prompted to input the code again to confirm. After you do so, it will be unlocked. Hitting any other numbers after this should lock it again.
   
+  You can change a set password by entering a new code and hitting 'C', then inputting the old code to confirm you are have access to do so.
+  
   Combination locks can be hacked into by opening the maintenance panel and hacking them like any other device, but it takes time.
 
 </Document>

--- a/Resources/ServerInfo/_StarLight/Guidebook/Tools/CombinationLocks.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Tools/CombinationLocks.xml
@@ -1,0 +1,17 @@
+<Document>
+  # Combination Locks
+  
+  There are four things that use Combination Locks. The Station Nuke, the Syndicate Nuke, the Secure Briefcase, and the Wall Safe. While both Nukes have pre-set codes that can only be obtained by either faxing Central Command, or being a Nuclear Operative, the Safe and Briefcase can be set by their users to secure items like paperwork.
+ 
+  <Box>
+    <GuideEntityEmbed Entity="BriefcaseSecure" Caption=""/>
+	<GuideEntityEmbed Entity="WallSafe" Caption=""/>
+  </Box>
+
+  The Secure Briefcase can be found in the NanoTrasen Representative's locker. It is recommended you use this briefcase to secure especially sensitive documents, such as Classified Documents, or communications from Central Command.
+  
+  The Wall Safe can sometimes be found on stations inside secure areas, but is uncommon.
+  
+  To set the combination for either device, enter a code the first time you open it then hit 'E' for Enter. You will then be prompted to input the code again to confirm. After you do so, it will be unlocked. Hitting any other numbers after this should lock it again.
+
+</Document>


### PR DESCRIPTION
## Short description
Adds the Secure Briefcase from #1378 to the NanoTrasen Representative's locker. This is a combination locked briefcase to secure any confidential communications from Central Command in, such as faxes or Classified Documents #3035 .

There is a guidebook entry on it, which can be opened by examining then clicking the (?) icon. To set the combination, input the desired code the first time you open the UI, then click 'E' for Enter. You will be prompted to confirm the code, after which it will be set. To lock the briefcase, click any random button while it is open.

The briefcase can still be hacked open with tools and time.

## Why we need to add this
The NanoTrasen Representative is handling a lot of sensitive faxed to and from Central Command, and they currently just keep them all in a clipboard. On top of this, the recently added Classified Documents can contain sensitive metashielded information like Nukies and Decimus. This gives NTR a way to secure those documents a little more tightly, while not being impossible for Traitors to still do their objectives.

## Media (Video/Screenshots)
<img width="1256" height="744" alt="image" src="https://github.com/user-attachments/assets/a64156eb-e556-48e1-8e79-1632877c7a99" />


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Gave NanoTrasen Representatives a 'Secure Briefcase' which can be locked with a pin code, added a long time ago by Rinary but never saw use by players. This will allow them to secure their faxes with CentComm, and their Classified Documents, more tightly. Can still be hacked open with time.
- add: Added a guidebook page for Combination Locks, which details how to use the Secure Briefcase and Wall Safe locks, and set their codes. Examine either then click the (?) icon to go to the page directly.
