### PR TITLE
More Emagged Modules

### DIFF
--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
@@ -77,6 +77,10 @@
     - BorgModuleMartyr
     - BorgModuleSyndicateWeapon
     - BorgModuleC20r
+    - BorgModuleSyndicateAdvancedChemical
+    - BorgModuleSyndicateRescue
+    - BorgModuleSyndicateChameleonProjector
+    - BorgModuleSyndicateAdvancedTool
 
 - type: latheRecipePack
   id: StarlightSyndicateModulesSecfab
@@ -85,6 +89,12 @@
     - BorgModuleSyndicateWeapon
     - BorgModuleC20r
     - BorgModuleL6C
+    - BorgModuleSyndicateStealth
+    - BorgModuleOperative
+    - BorgModuleSyndicateAdvancedChemical
+    - BorgModuleSyndicateRescue
+    - BorgModuleSyndicateChameleonProjector
+    - BorgModuleSyndicateAdvancedTool
 
 # Lawboards
 - type: latheRecipePack

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/robotics.yml
@@ -89,8 +89,6 @@
     - BorgModuleSyndicateWeapon
     - BorgModuleC20r
     - BorgModuleL6C
-    - BorgModuleSyndicateStealth
-    - BorgModuleOperative
     - BorgModuleSyndicateAdvancedChemical
     - BorgModuleSyndicateRescue
     - BorgModuleSyndicateChameleonProjector

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/robotics.yml
@@ -1,3 +1,5 @@
+## Syndicate
+
 - type: latheRecipe
   id: BorgModuleMartyr
   result: BorgModuleMartyr
@@ -41,6 +43,75 @@
     Steel: 2050
     Plastic: 500
     Plasma: 500
+
+- type: latheRecipe
+  id: BorgModuleOperative
+  result: BorgModuleOperative
+  categories:
+    - Modules
+  materials: #15 steel, 2 plastic, 1 plasma, 1 diamond for the EMAG
+    Steel: 1500
+    Plastic: 200
+    Plasma: 100
+    Diamond: 100
+
+- type: latheRecipe
+  id: BorgModuleSyndicateAdvancedChemical
+  result: BorgModuleSyndicateAdvancedChemical
+  categories:
+    - Modules
+  materials: #15 steel, 2 plastic, 1 plasma, 0.5 gold
+    Steel: 1500
+    Plastic: 200
+    Plasma: 100
+    Gold: 50
+
+- type: latheRecipe
+  id: BorgModuleSyndicateRescue
+  result: BorgModuleSyndicateRescue
+  categories:
+    - Modules
+  materials: #20 steel, 2 plastic, 1 plasma, 1 gold
+    Steel: 2000
+    Plastic: 200
+    Plasma: 100
+    Gold: 100
+
+- type: latheRecipe
+  id: BorgModuleSyndicateStealth
+  result: BorgModuleSyndicateStealth
+  categories:
+    - Modules
+  materials: #20 steel, 2 plastic, 1 plasma, 1 diamond for the EMAG
+    Steel: 2000
+    Plastic: 200
+    Plasma: 100
+    Diamond: 100
+
+- type: latheRecipe
+  id: BorgModuleSyndicateChameleonProjector
+  result: BorgModuleSyndicateChameleonProjector
+  categories:
+    - Modules
+  materials: #20 steel, 2 plastic, 1 plasma, 1 silver
+    Steel: 2000
+    Plastic: 200
+    Plasma: 100
+    Silver: 100
+
+- type: latheRecipe
+  id: BorgModuleSyndicateAdvancedTool
+  result: BorgModuleSyndicateAdvancedTool
+  categories:
+    - Modules
+  materials: #20 steel, 2 plastic, 1 plasma, 1 silver
+    Steel: 2000
+    Plastic: 200
+    Plasma: 100
+    Silver: 100
+
+
+## Normal
 
 - type: latheRecipe
   parent: BaseRoboticsRecipe

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/robotics.yml
@@ -45,17 +45,6 @@
     Plasma: 500
 
 - type: latheRecipe
-  id: BorgModuleOperative
-  result: BorgModuleOperative
-  categories:
-    - Modules
-  materials: #15 steel, 2 plastic, 1 plasma, 1 diamond for the EMAG
-    Steel: 1500
-    Plastic: 200
-    Plasma: 100
-    Diamond: 100
-
-- type: latheRecipe
   id: BorgModuleSyndicateAdvancedChemical
   result: BorgModuleSyndicateAdvancedChemical
   categories:
@@ -76,17 +65,6 @@
     Plastic: 200
     Plasma: 100
     Gold: 100
-
-- type: latheRecipe
-  id: BorgModuleSyndicateStealth
-  result: BorgModuleSyndicateStealth
-  categories:
-    - Modules
-  materials: #20 steel, 2 plastic, 1 plasma, 1 diamond for the EMAG
-    Steel: 2000
-    Plastic: 200
-    Plasma: 100
-    Diamond: 100
 
 - type: latheRecipe
   id: BorgModuleSyndicateChameleonProjector


### PR DESCRIPTION
## Short description
Added the following Syndicate Modules to Emagged Lathes/Sec Fab
- Syndicate Advanced Chemical Module 
- Syndicate Rescue Module 
- Syndicate Chameleon Projector Module 
- Syndicate Advanced Tools Module

Price scales with "Advanced" modules costing more.

## Why we need to add this
Currently EMAGed Borgs have limited options for equipment. They can have crew modules, but their Syndie options are gun, sword, and blow yourself up. This opens up more utility options for Traitors and SELF Agents to equip their borgs with. You can turn them into combat medics to heal you, give them chemical brewing capabilities, let them disguise as items to infiltrate an area, or just give them better tools.

Most of this functionality has limited or no real combat applicability, it's just extra versatility so EMAGed borgs don't just have Power Word: Shit Myself (explode) as their end goal. This could be potentially strong, but not dramatically more so than crew modules already are, or the existing syndicate modules that give them guns.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added the Advanced Chemical, Rescue, Chameleon, and Advanced Tools Syndicate Modules to the EMAG lists. This should give more non-combat utility to hacked borgs for both Traitors and SELF Agents.
