### PR TITLE
Nerfs the Cube

### DIFF
--- a/Resources/Maps/Salvage/small-3.yml
+++ b/Resources/Maps/Salvage/small-3.yml
@@ -506,7 +506,7 @@ entities:
     - type: Transform
       pos: 9.5,7.5
       parent: 10
-- proto: WallPlastitaniumIndestructible
+- proto: WallPlastitanium
   entities:
   - uid: 2
     components:


### PR DESCRIPTION
## Short description
Replaces all Unbreakable Plastitanium Walls on the "small-3" wreck with normal Plastitanium Walls. This thing could level departments holy fuck.

## Why we need to add this
This thing can level an entire department right now because unbreakable walls + collision code = fuck everyone within 50 tiles specifically.

## Media (Video/Screenshots)
No.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Nerfed the Cube. It no longer lusts for mass death and destruction. It's hunger has been satiated for now. It will only eat half of a department instead of the entire department. (replaced unbreakable walls with normal walls)
