### PR TITLE
Add access locks to pulse weaponry

### DIFF
--- a/Content.Server/_Starlight/Access/IdClothingBlockerSystem.cs
+++ b/Content.Server/_Starlight/Access/IdClothingBlockerSystem.cs
@@ -57,7 +57,7 @@ public sealed class IdClothingBlockerSystem : SharedIdClothingBlockerSystem
 
     protected override void OnUnequipAttempt(EntityUid uid, IdClothingBlockerComponent component, BeingUnequippedAttemptEvent args)
     {
-        var wearerHasAccess = HasJobAccess(args.Unequipee, component);
+        var wearerHasAccess = HasAccess(args.Unequipee, component);
         if (wearerHasAccess)
             return;
 
@@ -72,7 +72,7 @@ public sealed class IdClothingBlockerSystem : SharedIdClothingBlockerSystem
         if (args.DoAfter.Args.Target == null)
             return;
 
-        var wearerHasAccess = HasJobAccess(args.DoAfter.Args.Target.Value, component);
+        var wearerHasAccess = HasAccess(args.DoAfter.Args.Target.Value, component);
 
         if (wearerHasAccess)
             return;
@@ -81,14 +81,14 @@ public sealed class IdClothingBlockerSystem : SharedIdClothingBlockerSystem
         PopupClient(Loc.GetString("access-clothing-blocker-notify-unauthorized-access"), uid);
     }
 
-    protected override bool HasJobAccess(EntityUid wearer, IdClothingBlockerComponent component)
+    protected override bool HasAccess(EntityUid wearer, IdClothingBlockerComponent component)
     {
-        if (component.AllowedJobs == null)
+        if (component.AllowedAccesses == null)
             return true;
         
         _card.TryFindIdCard(wearer, out var card);
         TryComp<AccessComponent>(card.Owner, out var access);
-        return access != null && access.Tags.Overlaps(component.AllowedJobs);
+        return access != null && access.Tags.Overlaps(component.AllowedAccesses);
     }
 
     // We assume access might have changed when a hand or inventory is equipped or unequipped
@@ -126,7 +126,7 @@ public sealed class IdClothingBlockerSystem : SharedIdClothingBlockerSystem
             if (!TryComp<IdClothingBlockerComponent>(clothing, out var blocker))
                 continue;
 
-            var hasAccess = HasJobAccess(wearer, blocker);
+            var hasAccess = HasAccess(wearer, blocker);
             SetBlocked(clothing.Value, blocker, !hasAccess);
         }
     }

--- a/Content.Shared/_Starlight/Access/IdClothingBlockerComponent.cs
+++ b/Content.Shared/_Starlight/Access/IdClothingBlockerComponent.cs
@@ -11,8 +11,8 @@ public sealed partial class IdClothingBlockerComponent : Component
     [DataField("isBlocked")] [AutoNetworkedField]
     public bool IsBlocked = false;
 
-    [DataField("allowedJobs")]
-    public List<ProtoId<AccessLevelPrototype>>? AllowedJobs = new();
+    [DataField("allowedAccesses")]
+    public List<ProtoId<AccessLevelPrototype>>? AllowedAccesses = new();
 
     [DataField("beepSound")]
     public SoundSpecifier BeepSound = new SoundPathSpecifier("/Audio/Effects/beep1.ogg");

--- a/Content.Shared/_Starlight/Access/SharedIdClothingBlockerSystem.cs
+++ b/Content.Shared/_Starlight/Access/SharedIdClothingBlockerSystem.cs
@@ -19,7 +19,7 @@ public abstract class SharedIdClothingBlockerSystem : EntitySystem
     protected virtual void OnUnequipAttempt(EntityUid uid, IdClothingBlockerComponent component,
         BeingUnequippedAttemptEvent args)
     {
-        var wearerHasAccess = HasJobAccess(args.Unequipee, component);
+        var wearerHasAccess = HasAccess(args.Unequipee, component);
         if (wearerHasAccess)
             return;
 
@@ -35,7 +35,7 @@ public abstract class SharedIdClothingBlockerSystem : EntitySystem
         if (args.DoAfter.Args.Target == null)
             return;
 
-        var wearerHasAccess = HasJobAccess(args.DoAfter.Args.Target.Value, component);
+        var wearerHasAccess = HasAccess(args.DoAfter.Args.Target.Value, component);
 
         if (wearerHasAccess)
             return;
@@ -44,11 +44,11 @@ public abstract class SharedIdClothingBlockerSystem : EntitySystem
         PopupClient(Loc.GetString("access-clothing-blocker-notify-unauthorized-access"), uid);
     }
     
-    protected virtual bool HasJobAccess(EntityUid wearer, IdClothingBlockerComponent component) => !component.IsBlocked;
+    protected virtual bool HasAccess(EntityUid wearer, IdClothingBlockerComponent component) => !component.IsBlocked;
 
     private void OnGotEquipped(EntityUid uid, IdClothingBlockerComponent component, GotEquippedEvent args)
     {
-        var wearerHasAccess = HasJobAccess(args.Equipee, component);
+        var wearerHasAccess = HasAccess(args.Equipee, component);
 
         if (wearerHasAccess)
             return;

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Back/misc.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Back/misc.yml
@@ -17,7 +17,7 @@
       sprite: _Starlight/Clothing/Back/nullspaceteleporter.rsi
     - type: IdClothingBlocker
       freezeUser: false
-      allowedJobs:
+      allowedAccesses:
         - Security
         - Cadet
         - Command

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -382,7 +382,7 @@
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.50
   - type: IdClothingBlocker
-    allowedJobs:
+    allowedAccesses:
       - Security
       - Armory
       - HeadOfSecurity

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -500,6 +500,9 @@
     - state: stun-unshaded-0
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
+  - type: Lock
+  - type: AccessReader
+    access: [[ "CentralCommand" ]]
   - type: Item
     size: Small
     shape:
@@ -661,6 +664,9 @@
       shader: unshaded
   - type: Clothing
     sprite: _Starlight/Objects/Weapons/Guns/Battery/pulse_carbine.rsi
+  - type: Lock
+  - type: AccessReader
+    access: [[ "CentralCommand" ]]
   - type: Item
     size: Normal
     shape:
@@ -715,6 +721,9 @@
     - state: stun-unshaded-0
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
+  - type: Lock
+  - type: AccessReader
+    access: [[ "CentralCommand" ]]
   - type: Clothing
     sprite: _Starlight/Objects/Weapons/Guns/Battery/pulse.rsi
   - type: Item
@@ -918,6 +927,9 @@
     layers:
     - state: base
       map: ["enum.GunVisualLayers.Base"]
+  - type: Lock
+  - type: AccessReader
+    access: [[ "CentralCommand" ]]
   - type: Clothing
     sprite: _Starlight/Objects/Weapons/Guns/Battery/ntnc_pulse.rsi
   - type: Item


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR adds access locks tied to `CentralCommand` access to pulse weaponry.

Additionally, clarifies the SharedIdClothingBlockerSystem with a rename of a datafield and function name, as it does not accurately represent the current functionality.

## Why we need to add this
This is meant to add _some_ safeguards to NTSF/Decimus getting disarmed, thus granting access to the extremely powerful pulse weaponry.

Revs, for instance, can still utilize pulse weaponry if they also acquire the ID of the agent. This is to still reward antagonists for successfully incapacitating NTSF, without it being as easy as before.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- tweak: Pulse weaponry now has access locks tied to Central Command access.
