### PR TITLE
Staff OOC tag updates

### DIFF
--- a/Resources/Prototypes/_NullLink/title.yml
+++ b/Resources/Prototypes/_NullLink/title.yml
@@ -45,10 +45,10 @@
       color: "#1153cc"
       roles:
       - 1310741799601573960 # Staff Admin
-    - text: "Staff-Mentor"
+    - text: "Staff-Instructor"
       color: "#b3aeff"
       roles:
-      - 1276773207453728841 # Staff Mentor
+      - 1276773207453728841 # Staff Instructor
     - text: "SLN-PL"
       color: "#f1eb58"
       roles:
@@ -61,14 +61,6 @@
       color: "#f1eb58"
       roles:
       - 1272899036571238521 # Developer
-    - text: "Admin"
-      color: "#ff7600"
-      roles:
-      - 1305028815906537482 # Admin
-    - text: "Trialmin"
-      color: "#7ac000"
-      roles:
-      - 1305029272653533268 # Trialmin
     - text: "Event-C."
       color: "#7c58ff"
       roles:
@@ -77,6 +69,14 @@
       color: "#983fc9"
       roles:
       - 1308128839993659422 # Jr. Event Coordinator
+    - text: "Admin"
+      color: "#ff7600"
+      roles:
+      - 1305028815906537482 # Admin
+    - text: "Trialmin"
+      color: "#7ac000"
+      roles:
+      - 1305029272653533268 # Trialmin
     - text: "Prototyper"
       color: "#F1C40F"
       roles:

--- a/Resources/Prototypes/_NullLink/title.yml
+++ b/Resources/Prototypes/_NullLink/title.yml
@@ -89,6 +89,10 @@
       color: "#8ff10f"
       roles:
       - 1299137799693406288 # Spriter
+    - text: "Staff"
+      color: "#ad1457"
+      roles:
+      - 1305031022785855591 # Staff
     - text: "Former"
       color: "#b6599a"
       roles:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
* This should, if no other higher-priority tags are present, give support staff a "Staff" tag.
* Additionally, reorgs Event Coordinators + Jrs to be higher priority than Game Admins, matching the discord hierarchy
* Changes "Staff Mentor" to "Staff Instructor", which is the actual Discord role name. Staff Mentor does not exist

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: mikeysaurus
- tweak: Tweaks Staff OOC tags.