### PR TITLE
Copy hitscan hitposition to HitscanRaycastFiredData

### DIFF
--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicRaycastSystem.cs
@@ -106,6 +106,7 @@ public sealed class HitscanBasicRaycastSystem : EntitySystem
             Shooter = args.Shooter,
             HitEntity = result?.HitEntity,
             OutputTrace = args.OutputTrace, // Starlight
+            HitPosition = result?.HitPos, // Starlight
         };
 
         var attemptEvent = new AttemptHitscanRaycastFiredEvent { Data = data };


### PR DESCRIPTION
## Short description
This copies the position of the hit from the physics ray intersection to the hitscan fired data, which enables it to be used in the raycast fired attempt and raycast fired events.

## Why we need to add this
Without this hit position data ricochets don't trigger.

## Media (Video/Screenshots)
Pending

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Fixed hitscan ricochets not triggering.
