### PR TITLE
Fix projectile effect sequencing

### DIFF
--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -133,9 +133,9 @@ public sealed partial class GunSystem : SharedGunSystem
 
     private void OnHitscan(HitscanEvent ev)
     {
+        var delay = 0f;
         foreach (var trace in ev.Traces)
         {
-            var delay = 0f;
             delay = FireEffect(ev, delay, trace);
         }
     }


### PR DESCRIPTION
## Short description
The variable declaration and instantiation got moved inside the loop incorrectly, which made the delay incorrectly always zero.

## Why we need to add this
This makes bullet ricochet and penetration effects play at the correct delay for the point in the full trace where they should occur.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/4b1f99b2-bcaf-4b6b-9035-f12ec31ff6bf


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Fixed sequencing of hitscan projectile trace effects so they shouldn't play simultaneously with their reflections.

