### PR TITLE
Fix start points for secondary hitscan traces

### DIFF
--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanReflectSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanReflectSystem.cs
@@ -4,6 +4,10 @@ using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Reflect;
 using Robust.Shared.Random;
 
+#region Starlight
+using Robust.Shared.Map;
+#endregion Starlight
+
 namespace Content.Shared.Weapons.Hitscan.Systems;
 
 public sealed class HitscanReflectSystem : EntitySystem
@@ -36,6 +40,11 @@ public sealed class HitscanReflectSystem : EntitySystem
         args.Cancelled = true;
 
         var fromEffect = Transform(data.HitEntity.Value).Coordinates;
+
+        // Starlight start - the secondary trace for reflects should start from the impact point
+        if (Transform(data.HitEntity.Value).MapUid is { } hitMap && data.HitPosition is { } hitPosition)
+            fromEffect = new EntityCoordinates(hitMap, hitPosition);
+        // Starlight end
 
         var hitFiredEvent = new HitscanTraceEvent
         {

--- a/Content.Shared/_Starlight/Weapons/Hitscan/Systems/HitscanPierceSystem.cs
+++ b/Content.Shared/_Starlight/Weapons/Hitscan/Systems/HitscanPierceSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Weapons.Hitscan.Events;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared._Starlight.Combat.Ranged.Pierce;
 using Content.Shared._Starlight.Weapon;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -56,6 +57,8 @@ public sealed partial class PierceSystem : EntitySystem
         reflect.CurrentReflections++;
 
         var fromEffect = Transform(data.HitEntity.Value).Coordinates;
+        if (Transform(data.HitEntity.Value).MapUid is { } hitMap && data.HitPosition is { } hitPosition)
+            fromEffect = new EntityCoordinates(hitMap, hitPosition);
 
         // Give it a little bit of swim
         var random = _rand.NextFloat(-hitscan.Comp.Deviation, hitscan.Comp.Deviation);

--- a/Content.Shared/_Starlight/Weapons/Hitscan/Systems/HitscanRicochetSystem.cs
+++ b/Content.Shared/_Starlight/Weapons/Hitscan/Systems/HitscanRicochetSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Weapons.Hitscan.Events;
 using Content.Shared._Starlight.Combat.Ranged.Pierce;
 using Content.Shared._Starlight.Weapon;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics;
 using Robust.Shared.Random;
@@ -49,6 +50,8 @@ public sealed partial class HitscanRicochetSystem : EntitySystem
         args.Cancelled = true;
 
         var fromEffect = Transform(data.HitEntity.Value).Coordinates;
+        if (Transform(data.HitEntity.Value).MapUid is { } hitMap)
+            fromEffect = new EntityCoordinates(hitMap, data.HitPosition.Value);
 
         var hitFiredEvent = new HitscanTraceEvent
         {


### PR DESCRIPTION
## Short description
In the process of merging to handle the upstream rewrite of the hitscan code I used the upstream fromEffect logic, which simply used the center of the impacted entity; this changes it to use the impact location.

## Why we need to add this
Using the correct impact location ends up looking and working better overall.

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/8b7c9919-8d78-4a51-ba7f-5637e101c8dd

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Penguinwizzard
- fix: Secondary hitscans (from reflects, piercing shots, or ricochets) now use the hit location, rather than the center of the impacted entity, as their starting point.