### PR TITLE
Replacing Brigmed Medical Doctor time reqirement with Chemist

### DIFF
--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
@@ -7,9 +7,9 @@
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
       time: 36000 # 10 hrs
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 28800 # 8 hrs
+    - !type:RoleTimeRequirement
+      role: JobChemist
+      time: 28800 # 8 hours
   startingGear: BrigmedicGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
## Short description
Replacing 8 hour Medical Doctor time requirement with Chemist for Brigmed

## Why we need to add this
Brigmedic duties heavily revolve around chemistry, taking up 80% of their work.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

I have not verified that the changes work because of the dev environment not needing playtime for roles and I was unable to find a solution since deadmin didn't fix that.

**Changelog**