### PR TITLE
Fix Classified Document Steal Objectives

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -6,7 +6,7 @@
     TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 0.25 #Involves helping/harming others without killing them or stealing their stuff, lowered because the chance of rolling this was enormous when its just one objective in the category
-    TraitorObjectiveGroupStory: 1  # Starlight
+    TraitorObjectiveGroupStory: 0.75  # Starlight
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSteal
@@ -23,11 +23,14 @@
     CaptainGunStealObjective: 0.75  #Starlight edit
     CaptainJetpackStealObjective: 0.75  #Starlight edit
     HandTeleporterStealObjective: 1  #Starlight edit
-    RDDiplomaStealObjective: 1 #Starlight Unique Targets
-    CMOLicenseStealObjective: 1 #Starlight Unique Targets
+    RDDiplomaStealObjective: 0.75 #Starlight Unique Targets
+    CMOLicenseStealObjective: 0.75 #Starlight Unique Targets
     EnergyShotgunStealObjective: 0.5 #Starlight re-targeted
     Proto5xStealObjective: 0.5 #Starlight Unique Targets
-
+    CorporateSecretsStealObjective: 0.75 #Starlight Unique Target
+    CriminalReportsStealObjective: 0.75 #Starlight Unique Target
+    SecureKnowledgeStealObjective:  0.75 #Starlight Unique Target
+    
 - type: weightedRandom
   id: TraitorObjectiveGroupKill
   weights:

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -6,7 +6,7 @@
     TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 0.25 #Involves helping/harming others without killing them or stealing their stuff, lowered because the chance of rolling this was enormous when its just one objective in the category
-    TraitorObjectiveGroupStory: 0.75  # Starlight
+    TraitorObjectiveGroupStory: 0.85  # Starlight
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSteal

--- a/Resources/Prototypes/_StarLight/Objectives/traitor.yml
+++ b/Resources/Prototypes/_StarLight/Objectives/traitor.yml
@@ -95,14 +95,14 @@
 
 - type: entity
   parent: BaseIAAStealObjective
-  id: CriminalReportsStealStealObjective
+  id: CriminalReportsStealObjective
   components:
   - type: StealCondition
     stealGroup: CriminalReportsSteal
 
 - type: entity
   parent: BaseMagistrateStealObjective
-  id: SecureKnowledgeStealStealStealObjective
+  id: SecureKnowledgeStealObjective
   components:
   - type: StealCondition
     stealGroup: SecureKnowledgeSteal


### PR DESCRIPTION
## Short description
Actually adds the Classified Documents to the steal objective list for Traitors- I missed it because it was in an upstream file AAAA

## Why we need to add this
Fix

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed rates of RP objectives from 1 -> 0.85. Since they're a reflavor of escape alive, and we have so many more objectives now, this should make them not a guaranteed thing for nearly every traitor.
- fix: Fixed Classified Documents not being in the traitor steal objective list- Missed in testing because its in an upstream file, and because manually adding the objectives still worked. Now they will appear in round start objectives with the same frequency as Captain steal targets.

