### PR TITLE
Adds Some Makeshift Items To Maints Loot

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -339,6 +339,15 @@
       - id: RifleStock
       - id: ModularReceiver
       - id: HydroponicsToolScythe
+      - id: SwordMakeshift  #starlight Start: Adds some Makeshift Items
+      - id: MakeshiftShield
+      - id: SwordImprovised
+      - id: ImprovisedShield
+      - id: WeaponSniperMakeshift
+        weight: .8
+      - id: WeaponShotgunMakeshift
+        weight: .8
+      - id: ClothingOuterArmorMakeshift  #Starlight End:
     # Rare Group
     - !type:GroupSelector
       weight: 5


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
More variety of Weapons of the Maints loot pool, The unreliable Makeshift Guns with a lower chance and no Ammo, and Makeshift Swords and Shields, and a Vest on the normal chance. Weapon Table was chosen because it seemed the most fitting.

## Why we need to add this
Adds more variety to the Maints Weapon pool, all the Added weapons are weaker than the Claymore present on the same pool.

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
Makeshift Items to Maints Lootpool, more notably some Weapons, shields, and armor.

:cl: STARLIGHT TEAM
- add: Adds Makeshift Items to Maints Lootpool
