### PR TITLE
Missing Brigmed locker spawns

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -117,7 +117,7 @@
     - id: ClothingHeadHatBeretCorpsman #Starlight
     - id: ClothingBeltCorpsmanFilled #Starlight
     - id: ClothingHandsGlovesBlackNitrile #Starlight
-    - id: ClothingEyesGlassesSecurity #Starlight
+    - id: ClothingEyesGlassesBrigmedic #Starlight
     - id: WeaponTaser
     - id: WeaponDisabler
     - id: TrackingImplanter
@@ -129,7 +129,10 @@
     - id: ClothingUniformJumpsuitBrigmedic
     - id: ClothingUniformJumpskirtBrigmedic
     - id: ClothingUniformJumpskirtOfLife
-      prob: 0.1
+    - id: ClothingShoesBootsMagSec
+    - id: BedsheetBrigmedicStrange
+    - id: BedsheetBrigmedic
+    - id: RubberStampBrigmedic
     - id: MedkitFilled
     - !type:GroupSelector
       prob: 0.7

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
@@ -7,8 +7,8 @@
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
       time: 36000 # 10 hrs
-    - !type:DepartmentTimeRequirement
-      department: Medical
+    - !type:RoleTimeRequirement
+      role: JobChemist
       time: 28800 # 8 hrs
   startingGear: BrigmedicGear
   icon: "JobIconBrigmedic"


### PR DESCRIPTION
## Short description
Readded the missing items from Brigmeds's locker

## Why we need to add this
These items used to spawn some time ago but stopped. They still show up in the double brigmed locker.

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.