### PR TITLE
Added implant slots to lagomorphs

### DIFF
--- a/Resources/Prototypes/_StarLight/Body/Prototypes/lagomorph.yml
+++ b/Resources/Prototypes/_StarLight/Body/Prototypes/lagomorph.yml
@@ -12,6 +12,7 @@
         eyes: OrganHumanEyes
         tongue: OrganHumanTongue
         eye_implant: null
+        brain_implant: null
     torso:
       part: TorsoLagomorph
       connections:
@@ -36,8 +37,10 @@
       - left hand
     right hand:
       part: RightHandLagomorph
+      hand_implant: null
     left hand:
       part: LeftHandLagomorph
+      hand_implant: null
     right leg:
       part: RightLegLagomorph
       connections:

--- a/Resources/Prototypes/_StarLight/Body/Prototypes/lagomorph.yml
+++ b/Resources/Prototypes/_StarLight/Body/Prototypes/lagomorph.yml
@@ -37,10 +37,12 @@
       - left hand
     right hand:
       part: RightHandLagomorph
-      hand_implant: null
+      organs:
+        hand_implant: null
     left hand:
       part: LeftHandLagomorph
-      hand_implant: null
+      organs:
+        hand_implant: null
     right leg:
       part: RightLegLagomorph
       connections:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds implant slots to lagomorphs.

## Why we need to add this
When lagomorphs were made, they weren't given implant slots. This remedies that oversight.


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Lagomorphs no longer reject brain and hand implants
