### PR TITLE
Debug surgery stick regenerates bone gel

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/surgery.yml
@@ -87,3 +87,9 @@
   - type: Retractor
   - type: BoneSaw
   - type: BoneSetter
+  - type: SolutionRegeneration
+    solution: container
+    generated: 
+      reagents:
+      - ReagentId: BoneGel
+        Quantity: 1


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Makes the debug tool regenerate bone gel just like abductor bottles do

## Why we need to add this
Apparently someone besides me has been using this? May as well actually fix it :sweat_smile: 

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

No changelog because this is a debug tool players should never encounter anyway.