### PR TITLE
Tweaks to TSF/NTNC/ERT blacklist.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -85,6 +85,13 @@
 - type: randomHumanoidSettings
   id: ERTLeader
   parent: EventHumanoidCentcomm
+  speciesBlacklist: # Starlight start
+  - Diona
+  - Resomi
+  - Vox
+  - Avali
+  - Felionoid
+  - Thaven # Starlight end
   components:
     - type: GhostRole
       name: ghost-role-information-ert-leader-name

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -88,7 +88,6 @@
   speciesBlacklist: # Starlight start
   - Diona
   - Resomi
-  - Vox
   - Avali
   - Felionoid
   - Thaven # Starlight end

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -86,9 +86,6 @@
   id: ERTLeader
   parent: EventHumanoidCentcomm
   speciesBlacklist: # Starlight start
-  - Diona
-  - Resomi
-  - Avali
   - Felionoid
   - Thaven # Starlight end
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
@@ -6,7 +6,6 @@
   speciesBlacklist:
   - Diona
   - Resomi
-  - Vox
   - Avali
   - Felionoid
   - Thaven

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
@@ -4,9 +4,6 @@
   id: EventHumanoidNTNC
   parent: EventHumanoidMindShielded
   speciesBlacklist:
-  - Diona
-  - Resomi
-  - Avali
   - Felionoid
   - Thaven
   components:
@@ -144,10 +141,6 @@
   id: NTSFoperative
   parent: EventHumanoidCentcomm
   speciesBlacklist:
-  - Diona
-  - Resomi
-  - Vox
-  - Avali
   - Felionoid
   - Thaven
   components:
@@ -191,10 +184,6 @@
   id: Decimusoperative
   parent: EventHumanoidCentcomm
   speciesBlacklist:
-  - Diona
-  - Resomi
-  - Vox
-  - Avali
   - Felionoid
   - Thaven
   components:
@@ -269,10 +258,6 @@
   id: TSFMarine
   parent: EventHumanoidMindShielded
   speciesBlacklist:
-  - Diona
-  - Resomi
-  - Vox
-  - Avali
   - Felionoid
   - Thaven
   components:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
@@ -3,6 +3,13 @@
 - type: randomHumanoidSettings
   id: EventHumanoidNTNC
   parent: EventHumanoidMindShielded
+  speciesBlacklist:
+  - Diona
+  - Resomi
+  - Vox
+  - Avali
+  - Felionoid
+  - Thaven
   components:
   - type: AutoImplant
     implants:
@@ -138,15 +145,11 @@
   id: NTSFoperative
   parent: EventHumanoidCentcomm
   speciesBlacklist:
-  - Arachnid
   - Diona
-  - Reptilian
   - Resomi
   - Vox
-  - Vulpkanin
   - Avali
   - Felionoid
-  - Shadekin
   - Thaven
   components:
     - type: GhostRole
@@ -189,15 +192,11 @@
   id: Decimusoperative
   parent: EventHumanoidCentcomm
   speciesBlacklist:
-  - Arachnid
   - Diona
-  - Reptilian
   - Resomi
   - Vox
-  - Vulpkanin
   - Avali
   - Felionoid
-  - Shadekin
   - Thaven
   components:
     - type: GhostRole
@@ -271,21 +270,12 @@
   id: TSFMarine
   parent: EventHumanoidMindShielded
   speciesBlacklist:
-  - Arachnid
   - Diona
-  - Reptilian
   - Resomi
   - Vox
-  - Vulpkanin
   - Avali
   - Felionoid
-  - Shadekin
   - Thaven
-  - Cyclorite
-  - Dwarf
-  - Moth
-  - SlimePerson
-  - Lagomorph
   components:
     - type: GhostRole
       name: ghost-role-information-tsf-marine-name


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes Arachnids, Reptilians, Vulpkanins, Shadekins, Laspi, Cyclorites, Mothpeople, Dwarves, Vox, and Lagomorphs from the TSF marine blacklist. Additionally adds Diona, Resomi, Avali, Felionoid, and Thaven to ERT/NTNC blacklist.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
TSF marines being Human-only is completely silly. I shouldn't need to say that, but here we are...
As for the rest:

- Diona: They can't wear shoes. (This is based on personal experience as ERT Leader; I had to ask to be lizardsmited.)
- Resomi, Avali: They shouldn't be in a (mostly) pure-combat ghostrole due to their stamina and HP issue.
- Felionoid: Same as above but also I am biased against Felionoid players. Have not had good interactions with any of 'em.
- Thaven: This one's fairly obvious - the mood system makes them entirely unfit for ERT/NTNC/TSF et al.

NOTE: Resomi and Avali were kind of tacked on. I can shop that around if maintainers really would like it.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower

- fix: The TSF is now significantly less xenophobic in their marine hiring processes.
- tweak: NanoTrasen and Central Command are now slightly more xenophobic when hiring for NTNC and ERT.