### PR TITLE
Hotfix: Dynamic Computer Srites

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -29,9 +29,6 @@
       enum.EdgeConnectionVisuals.ConnectionMask:
         computerLayerBody:
           None: { state: arcade }
-          West: { state: arcade }
-          East: { state: arcade }
-          East, West: { state: arcade }
   # Starlight End
   - type: Icon
     sprite: Structures/Machines/arcade.rsi

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
@@ -17,10 +17,7 @@
     visuals:
       enum.EdgeConnectionVisuals.ConnectionMask:
         computerLayerBody:
-          None: { state: icon }
-          West: { state: icon }
-          East: { state: icon }
-          East, West: { state: icon }
+          None: { state: icon, sprite: Structures/Machines/tech_disk_printer.rsi }
   # Starlight End
   - type: DiskConsole
   - type: ResearchClient

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/wooden_television.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/wooden_television.yml
@@ -14,6 +14,13 @@
       state: detective_television
   - type: Computer
     board: ComputerTelevisionCircuitboard
+  # Starlight Start
+  - type: GenericVisualizer  # Override to prevent edge connection sprites
+    visuals:
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        console:
+          None: { state: television}
+  # Starlight End
   - type: PointLight
     radius: 1.5
     energy: 3.0

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Machines/Computers/computers.yml
@@ -59,10 +59,7 @@
     visuals:
       enum.EdgeConnectionVisuals.ConnectionMask:
         console:
-          None: { state: console }
-          West: { state: console }
-          East: { state: console }
-          East, West: { state: console }
+          None: { state: console, sprite: _Starlight/Structures/Machines/abductor_console.rsi }
   - type: ActivatableUI
     key: enum.AbductorConsoleUIKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Machines/Computers/desktop_computers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Machines/Computers/desktop_computers.yml
@@ -17,10 +17,7 @@
     visuals:
       enum.EdgeConnectionVisuals.ConnectionMask:
         computerLayerBody:
-          None: { state: computer }
-          West: { state: computer }
-          East: { state: computer }
-          East, West: { state: computer }
+          None: { state: computer, sprite: _Starlight/Structures/Machines/desktop_computers.rsi }
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Hotfixes for Dynamic Computer Sprite Connections.
Fixes
Abductor Consoles and Televisions weren't given a proper override
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bug fixing
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Abductor Consoles and Televisions not having correct sprites