### PR TITLE
Blacklist nuclear operatives from antag papers

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -18,6 +18,7 @@ using Robust.Shared.Random;
 using System.Linq;
 using System.Text;
 using Content.Server.Codewords;
+using Content.Shared._Starlight.Antags.Traitor; //Starlight
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -140,6 +141,7 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Change faction");
         _npcFaction.RemoveFaction(traitor, component.NanoTrasenFaction, false);
         _npcFaction.AddFaction(traitor, component.SyndicateFaction);
+        if(mind.CurrentEntity is not null) EnsureComp<TraitorComponent>(mind.CurrentEntity.Value); //Starlight - mark player entity as traitor
 
         Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Finished");
         return true;

--- a/Content.Server/_Starlight/Paper/AntagOnSignComponent.cs
+++ b/Content.Server/_Starlight/Paper/AntagOnSignComponent.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.Prototypes;
 using Component = Robust.Shared.GameObjects.Component;
+using Content.Shared.Whitelist; // Starlight
 
 namespace Content.Server._Starlight.Paper;
 
@@ -41,6 +42,13 @@ public sealed partial class AntagOnSignComponent : Component
     /// </summary>
     [DataField]
     public bool KeepFaxable = false;
+    
+    //Starlight begin
+    /// <summary>
+    /// blacklist to prevent the signee from becoming antag
+    /// </summary>
+    [DataField] public EntityWhitelist Blacklist = new();
+    //Starlight end
 }
 
 [DataDefinition]

--- a/Content.Server/_Starlight/Paper/AntagOnSignSystem.cs
+++ b/Content.Server/_Starlight/Paper/AntagOnSignSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Paper;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Content.Shared.Whitelist; // Starlight
 
 namespace Content.Server._Starlight.Paper;
 
@@ -16,6 +17,7 @@ public sealed class AntagOnSignSystem : EntitySystem
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly IComponentFactory _componentFactory = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     private ISawmill _sawmill = default!;
 
 
@@ -38,6 +40,7 @@ public sealed class AntagOnSignSystem : EntitySystem
 
     private void OnPaperSigned(EntityUid uid, AntagOnSignComponent component, PaperSignedEvent args)
     {
+        if (_whitelist.IsWhitelistPass(component.Blacklist, args.Signer)) return; // Starlight - prevent blacklisted entities from becoming antag
         if (component.ChargesRemaining <= 0)
             return;
         var signer = args.Signer;

--- a/Content.Shared/_Starlight/Antags/Traitor/TraitorComponent.cs
+++ b/Content.Shared/_Starlight/Antags/Traitor/TraitorComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._Starlight.Antags.Traitor;
+
+/// <summary>
+/// dummy component to mark player entity as a traitor for whitelists/blacklists/filters/etc
+/// </summary>
+[RegisterComponent]
+public sealed partial class TraitorComponent : Component
+{
+}

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
@@ -17,8 +17,6 @@
           - NukeOperative
           - Traitor
           - Revolutionary
-          - AntagImmune
-          - CommandStaff
       #SL end
 
 - type: entity
@@ -40,8 +38,6 @@
           - NukeOperative
           - Traitor
           - Revolutionary
-          - AntagImmune
-          - CommandStaff
       #SL end
 
 - type: entity
@@ -65,8 +61,6 @@
           - NukeOperative
           - Traitor
           - Revolutionary
-          - AntagImmune
-          - CommandStaff
       #SL end
     - type: ObjectiveOnSign
       #SL begin
@@ -75,8 +69,6 @@
           - NukeOperative
           - Traitor
           - Revolutionary
-          - AntagImmune
-          - CommandStaff
       #SL end
       objectives:
         # thief collection objectives
@@ -204,8 +196,6 @@
           - NukeOperative
           - Traitor
           - Revolutionary
-          - AntagImmune
-          - CommandStaff
       #SL end
 
 - type: entity
@@ -229,8 +219,6 @@
           - NukeOperative
           - Traitor
           - Revolutionary
-          - AntagImmune
-          - CommandStaff
       #SL end
 
 - type: entity
@@ -254,7 +242,5 @@
           - NukeOperative
           - Traitor
           - Revolutionary
-          - AntagImmune
-          - CommandStaff
       #SL end
 

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
@@ -15,6 +15,8 @@
       blacklist:
         components:
           - NukeOperative
+          - Traitor
+          - Revolutionary
       #SL end
 
 - type: entity
@@ -34,6 +36,8 @@
       blacklist:
         components:
           - NukeOperative
+          - Traitor
+          - Revolutionary
       #SL end
 
 - type: entity
@@ -55,12 +59,16 @@
       blacklist:
         components:
           - NukeOperative
+          - Traitor
+          - Revolutionary
       #SL end
     - type: ObjectiveOnSign
       #SL begin
       blacklist:
         components:
           - NukeOperative
+          - Traitor
+          - Revolutionary
       #SL end
       objectives:
         # thief collection objectives
@@ -186,6 +194,8 @@
       blacklist:
         components:
           - NukeOperative
+          - Traitor
+          - Revolutionary
       #SL end
 
 - type: entity
@@ -207,6 +217,8 @@
       blacklist:
         components:
           - NukeOperative
+          - Traitor
+          - Revolutionary
       #SL end
 
 - type: entity
@@ -228,5 +240,7 @@
       blacklist:
         components:
           - NukeOperative
+          - Traitor
+          - Revolutionary
       #SL end
 

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
@@ -17,6 +17,8 @@
           - NukeOperative
           - Traitor
           - Revolutionary
+          - AntagImmune
+          - CommandStaff
       #SL end
 
 - type: entity
@@ -38,6 +40,8 @@
           - NukeOperative
           - Traitor
           - Revolutionary
+          - AntagImmune
+          - CommandStaff
       #SL end
 
 - type: entity
@@ -61,6 +65,8 @@
           - NukeOperative
           - Traitor
           - Revolutionary
+          - AntagImmune
+          - CommandStaff
       #SL end
     - type: ObjectiveOnSign
       #SL begin
@@ -69,6 +75,8 @@
           - NukeOperative
           - Traitor
           - Revolutionary
+          - AntagImmune
+          - CommandStaff
       #SL end
       objectives:
         # thief collection objectives
@@ -196,6 +204,8 @@
           - NukeOperative
           - Traitor
           - Revolutionary
+          - AntagImmune
+          - CommandStaff
       #SL end
 
 - type: entity
@@ -219,6 +229,8 @@
           - NukeOperative
           - Traitor
           - Revolutionary
+          - AntagImmune
+          - CommandStaff
       #SL end
 
 - type: entity
@@ -242,5 +254,7 @@
           - NukeOperative
           - Traitor
           - Revolutionary
+          - AntagImmune
+          - CommandStaff
       #SL end
 

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Deliveries/deliveries_items.yml
@@ -11,6 +11,11 @@
       antags:
         - antag: Traitor
           targetComponent: TraitorRule
+      #SL begin
+      blacklist:
+        components:
+          - NukeOperative
+      #SL end
 
 - type: entity
   id: RRMailSyndicateSpamLetter
@@ -25,6 +30,11 @@
       antags:
         - antag: Traitor
           targetComponent: TraitorRule
+      #SL begin
+      blacklist:
+        components:
+          - NukeOperative
+      #SL end
 
 - type: entity
   id: MailSpamDontYouWantMore
@@ -41,7 +51,17 @@
           targetComponent: TraitorRule
         - antag: Thief # gotta be a thief for the thief objectives
           targetComponent: ThiefRule
+      #SL begin
+      blacklist:
+        components:
+          - NukeOperative
+      #SL end
     - type: ObjectiveOnSign
+      #SL begin
+      blacklist:
+        components:
+          - NukeOperative
+      #SL end
       objectives:
         # thief collection objectives
         - HeadCloakStealCollectionObjective
@@ -162,6 +182,11 @@
       antags:
         - antag: Revolutionary
           targetComponent: RevolutionaryRule
+      #SL begin
+      blacklist:
+        components:
+          - NukeOperative
+      #SL end
 
 - type: entity
   id: MailSovietSpamLetter50
@@ -178,6 +203,11 @@
       antags:
         - antag: Revolutionary
           targetComponent: RevolutionaryRule
+      #SL begin
+      blacklist:
+        components:
+          - NukeOperative
+      #SL end
 
 - type: entity
   id: MailSovietSpamLetter25
@@ -194,4 +224,9 @@
       antags:
         - antag: Revolutionary
           targetComponent: RevolutionaryRule
+      #SL begin
+      blacklist:
+        components:
+          - NukeOperative
+      #SL end
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Prevents anything with `NukeOperativeComponent` from triggering anything with `AntagOnSignComponent` via blacklist.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Nuclear operatives can no longer sign Syndicate or USSP spam letters to become Traitor/Revolutionary.
- fix: Revolutionaries can no longer sign Syndicate or USSP spam letters to become Traitor/Revolutionary.
- fix: Traitors can no longer sign Syndicate or USSP spam letters to become Traitor/Revolutionary,