### PR TITLE
behold abductors work again

### DIFF
--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
@@ -156,17 +156,19 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     private void Return(EntityUid uid, AbductorScientistComponent? scientistComp, AbductorAgentComponent? agentComp)
     {
 
-        _color.RaiseEffect(Color.FromHex("#BA0099"), new List<EntityUid>(1) { uid }, Filter.Pvs(uid, entityManager: EntityManager));
-        if (TryComp<PullerComponent>(uid, out var pullerComp)
-            && (pullerComp.Pulling == null
-            || !TryComp<PullableComponent>(pullerComp.Pulling.Value, out var pulledComp)
-            || !_pullingSystem.TryStopPull(pullerComp.Pulling.Value, pulledComp))) 
-            return;
+        if (_pullingSystem.IsPulling(uid))
+        {
+            if (!TryComp<PullerComponent>(uid, out var pullerComp)
+                || pullerComp.Pulling == null
+                || !TryComp<PullableComponent>(pullerComp.Pulling.Value, out var pullableComp)
+                || !_pullingSystem.TryStopPull(pullerComp.Pulling.Value, pullableComp)) return;
+        }
 
-        if (_pullingSystem.IsPulled(uid) 
-            && (!TryComp<PullableComponent>(uid, out var pullableComp) 
-            || !_pullingSystem.TryStopPull(uid, pullableComp)))
-            return;
+        if (_pullingSystem.IsPulled(uid))
+        {
+            if (!TryComp<PullableComponent>(uid, out var pullableComp)
+                || !_pullingSystem.TryStopPull(uid, pullableComp)) return;
+        }
 
         EntityCoordinates? spawnPosition = null;
 

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
@@ -194,15 +194,18 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
 
         var victim = GetEntity(args.Victim);
 
-        if (_pullingSystem.IsPulling(victim) 
-            || !TryComp<PullerComponent>(victim, out var pullerComp) 
-            || !TryComp<PullableComponent>(pullerComp.Pulling, out var pullableComp) 
-            || !_pullingSystem.TryStopPull(pullerComp.Pulling.Value, pullableComp))
-            return;
-
-        if (_pullingSystem.IsPulled(victim) 
-            || !_pullingSystem.TryStopPull(victim, pullableComp))
-            return;
+        if (_pullingSystem.IsPulling(victim))
+        {
+            if (!TryComp<PullerComponent>(victim, out var pullerComp)
+                || pullerComp.Pulling == null
+                || !TryComp<PullableComponent>(pullerComp.Pulling.Value, out var pullableComp)
+                || !_pullingSystem.TryStopPull(pullerComp.Pulling.Value, pullableComp)) return;
+        }
+        if (_pullingSystem.IsPulled(victim))
+        {
+            if (!TryComp<PullableComponent>(victim, out var pullableComp)
+                || !_pullingSystem.TryStopPull(victim, pullableComp)) return;
+        }
 
         if (!HasComp<AbductorComponent>(victim))
         {


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes the logic of server system of abductors that allows them to teleport their targets and themselves

## Why we need to add this
Make abductors work again

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: walksanatora
- fix: Abductors can now teleport again.