### PR TITLE
Makes the Hydra not pump-action.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -100,7 +100,6 @@
     size: Huge
   - type: AmmoCounter
   - type: Gun
-    pump: true # Starlight change
     fireRate: 1
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -1,9 +1,9 @@
 - type: entity
-  parent: WeaponLauncherHydra
+  parent: [ WeaponLauncherHydra, BaseSyndicateContraband]
   id: WeaponLauncherHydraSyndicate
   name: modified hydra
   suffix: Syndicate
-  description: A modified Hydra capable of taking both cleanades and standard grenades. Excellent for when you need to clean up the security department.
+  description: It looks like a standard-issue Hydra cleanade launcher, but the safety measures have been filed off.
   components:
   - type: ScanDetectable
   - type: Contraband

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ WeaponLauncherHydra, BaseSyndicateContraband]
+  parent: [ BaseSyndicateContraband, WeaponLauncherHydra ]
   id: WeaponLauncherHydraSyndicate
   name: modified hydra
   suffix: Syndicate


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This was a holdover from when the Hydra could fire lethal grenades normally.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix, can't pump it because revolver

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- fix: Hydra is no longer pump action