### PR TITLE
Removed Decimus Document From Locker Fills

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Documents/document_loot_tables.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Documents/document_loot_tables.yml
@@ -3,7 +3,7 @@
   table: !type:GroupSelector
     children:
       - id: ClassifiedCorporateDocumentAbductors
-      - id: ClassifiedCorporateDocumentDecimus
+      #- id: ClassifiedCorporateDocumentDecimus
       - id: ClassifiedCorporateDocumentNinjas
       - id: ClassifiedCorporateDocumentNukies
       - id: ClassifiedCorporateDocumentRomerol


### PR DESCRIPTION
## Short description
Going on record and pointing out the only times it ever leaked was conveniently at the hands of people who were sure it would be a problem. Funny how that works out. Wild coincidence. 

## Why we need to add this
People can't behave.

## Media (Video/Screenshots)
NA

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- remove: Removed Decimus Doc from the locker fill table. 

