### PR TITLE
Move SSD sleep behind existing CVAR

### DIFF
--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -127,9 +127,13 @@ public sealed class SSDIndicatorSystem : EntitySystem
         component.IsSSD = true;
 
         if (_icSsdSleep)
+        //Starlight Start
+        {
             component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
-
-        _sleep.TrySleeping(uid);
+            _sleep.TrySleeping(uid);
+        }
+        //_sleep.TrySleeping(uid); //Moved sleep on SSD behind the check whether SSD should sleep. WHY WAS THIS NOT ALREADY THE CASE???
+        //Starlight End
 
         Dirty(uid, component);
     }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes broken CVAR ic.ssd_sleep

## Why we need to add this
SSD sleep is a major annoyance, and the CVAR on whether *to* sleep currently doesn't work - it *always* puts you to sleep. While the CVAR should also be changed to false (Aghosts should not make you fall asleep, neither should game crashes), this PR at the very least fixes the functionality.

## Media (Video/Screenshots)
<img width="164" height="136" alt="grafik" src="https://github.com/user-attachments/assets/77ada3ba-e751-4f78-b5cc-56b9c4f8342b" />
SSD, but not asleep.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Going SSD no longer forces you to sleep, regardless of server settings.
