### PR TITLE
Beerhud eyepatch changes.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -294,7 +294,7 @@
   name: security hud eyepatch
 
 - type: entity
-  parent: [ClothingEyesHudBeer, ClothingHeadEyeBaseFlippable]
+  parent: ClothingHeadEyeBaseFlippable
   id: ClothingEyesEyepatchHudBeer
   name: beer hud eyepatch
   description: A pair of sunHud outfitted with apparatus to scan reagents, as well as providing an innate understanding of liquid viscosity while in motion. For true patriots.
@@ -303,6 +303,13 @@
     sprite: Clothing/Eyes/Hud/beerpatch.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Hud/beerpatch.rsi
+  - type: ShowThirstIcons # Starlight. This, and the next 8 lines were moved from ClothingEyesHudBeer. Why would an eyepatch have flash protection? Unparented it from the mentioned ID
+  - type: StealTarget
+    stealGroup: MiscGlassesCollection # Starlight
+  - type: SolutionScanner
+  - type: Tag
+    tags:
+    - WhitelistChameleon
 
 - type: entity
   parent: [ClothingEyesEyepatchHudBeer, ClothingHeadEyeBaseFlipped]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR unparents ClothingEyesEyepatchHudBeer from ClothingEyesHudBeer.

## Why we need to add this
It doesn't make too much sense for an Eyepatch to function as fully functional shielded glasses. 

## Media (Video/Screenshots)
I'm not exactly sure on how to collect media on these changes. It'll behave like a normal eyepatch upon getting flashed. (My laptop isn't a fan of recording, so I am unable to collect a recording of this)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [~] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: SeaborneProto
- tweak: fixed Beer Hud Eyepatch to not be sunglasses
