### PR TITLE
Cyberware v2 hotfix

### DIFF
--- a/Resources/Prototypes/_Moffstation/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Structures/Machines/research.yml
@@ -13,6 +13,7 @@
     - Arsenal
     - Experimental
     - CivilianServices
+    - Biochemical # Starlight
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: ExtensionCableReceiver

--- a/Resources/Prototypes/_StarLight/Actions/jump.yml
+++ b/Resources/Prototypes/_StarLight/Actions/jump.yml
@@ -5,6 +5,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Action
+    useDelay: 30
     itemIconStyle: NoItem
     icon:
       sprite: _Starlight/Actions/resomi.rsi


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes cooldowns on jumps and missing med research

## Why we need to add this
Resomi jumps are not working as intended, and the Medical research category has disappeared entirely - which is an unrelated bug I fixed while I was at it (as it seemed proximate to my changes, even if they were not the actual cause)

## Media (Video/Screenshots)
<img width="562" height="157" alt="image" src="https://github.com/user-attachments/assets/5afb9175-fb55-412c-ab8c-2667eef03f11" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: We have reduced the amount of Ephedrine in Resomi legs. They can no longer jump forever.
- fix: Research servers have been informed that we do indeed research medical sciences.
