### PR TITLE
Added missing surgeries to close laspi incisions

### DIFF
--- a/Resources/Prototypes/_StarLight/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_StarLight/Surgery/surgeries.yml
@@ -119,7 +119,7 @@
   components:
   - type: Surgery
     requirement:
-    - SurgeryOpenIncision
+    - SurgeryOpenIncisionSlime
     priority: 100
     steps:
     - SurgeryStepMendSlime
@@ -131,6 +131,29 @@
   - type: SurgeryPartCondition
     parts:
     - Head
+
+- type: entity
+  parent: SurgeryCloseIncision
+  id: SurgeryCloseIncisionLimbSlime
+  name: Close Incision
+  components:
+  - type: Surgery
+    requirement:
+    - SurgeryOpenIncisionSlime
+    priority: 100
+    steps:
+    - SurgeryStepMendSlime
+    - SurgeryStepCloseIncision
+  - type: SurgerySpeciesCondition
+    speciesBlacklist: []
+    speciesWhitelist:
+    - SlimePerson
+  - type: SurgeryPartCondition
+    parts:
+    - Arm
+    - Leg
+    - Hand
+    - Foot
 
 - type: entity
   parent: SurgeryBase


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes missing surgery end step for Laspi

## Why we need to add this
Laspi were missing the surgeries to close their incisions on limbs. This PR addresses that issue

## Media (Video/Screenshots)
<img width="392" height="177" alt="image" src="https://github.com/user-attachments/assets/812d9b5c-9328-4047-9522-1c55ddac4229" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Slime limbs can now have their incisions closed.
