### PR TITLE
Fix avali stasis numbers being just incorrect

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -169,8 +169,8 @@
         groups:
           Brute: 6
       bleedHealPerUpdate: 1.0
-      critHealingModifier: 2.0
-      stasisDamageReduction: 0.5
+      critHealingModifier: 0.5
+      stasisDamageReduction: 0.7
 
 # Chirp!
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This PR aims to make avali stasis more reasonable, its numbers are just incorrect, and were never planned to be this high.

## Why we need to add this
Balance of this has been completely thrown off.
Firstly the damage reduction was never meant to be 50%, and this was discussed with Killer, i believe we just kept the debug value there that was used to test the stasis whether its correctly affecting the damage.

Secondly, the healing while crit was changed when making stasis refactor into an absurd double healing while crit, which it was not supposed to be, it was supposed to be halved. I have no idea really why this was made double.

Both of these made Avali a bit hard to kill after entering their stasis.

The most important part of this is that it still allows to survive a spacing, which it was intended to do.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- tweak: Changed Avali stasis halving its damage reduction.
- tweak: Changed Avali lowering its healing by 4x in crit.