### PR TITLE
Fixed Borgi languages

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/base_borgi_chassis.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Cyborgs/base_borgi_chassis.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ MobCorgiSmart, BaseBorgiLanguages ]
+  parent: [ BaseBorgiLanguages, MobCorgiSmart ]
   id: BaseBorgiChassis
   save: false
   abstract: true


### PR DESCRIPTION
## Short description
PR #2661 fixed some bugs related to synthetics not having all the languages they were meant to, including Borgis. However, it did not actually fix the issue for Borgis, because Borgis aren't getting their languages _at all._ This PR makes the Borgi language list take priority over the Smart Corgi language list.

I confirmed the language list is correct for AIs, Borgs, and Borgis.

## Why we need to add this
Bug fix. Tangentially part of #2707.

## Media (Video/Screenshots)

Before fix:
<img width="408" height="513" alt="Borgi with only the smart corgi languages understood." src="https://github.com/user-attachments/assets/69f847eb-4c6f-469c-b30b-681dd12e2697" />

After fix:
<img width="386" height="797" alt="Borgi with all synth languages understood." src="https://github.com/user-attachments/assets/d606e312-d1b1-4f4b-9956-fd13f51b00b0" />

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: MelliferousMae
- fix: Borgis now understand all the languages Borgs do, plus Dog.