### PR TITLE
Lockers start anchored

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/magic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/magic.yml
@@ -86,6 +86,10 @@
   parent: ClosetSteelBase
   categories: [ HideSpawnMenu ]
   components:
+  # Starlight Start
+  - type: Transform
+    anchored: false
+  # Starlight End
   - type: ResistLocker
     resistTime: 30
   - type: StoreOnCollide

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -9,6 +9,7 @@
   - type: ResistLocker
   - type: Transform
     noRot: true
+    anchored: true # Starlight: Lockers start anchored
   - type: Sprite
     noRot: true
     sprite: Structures/Storage/closet.rsi


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Makes closers/lockers start anchored (Besides magic locker). A couple maps will have issues with this im thinking but Caws said there fine with lockers starting anchored.

Technical mapping changes.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Its kind of weird that they don't start anchored? Minimal change that makes a bit more IC sense imo, If all lockers is an issue however I can set maybe EVA and such to not be
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- tweak: Lockers/Closets now start anchored