### PR TITLE
Firelocks... is airlocks?

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -14,15 +14,18 @@
         - FireAlarm
         - AirAlarm
     - type: ApcPowerReceiver
+    - type: DoorBolt # Starlight: Let them be bolted
     - type: ExtensionCableReceiver
     - type: DeviceNetwork
       deviceNetId: AtmosDevices
       receiveFrequencyId: AtmosMonitor
     - type: DeviceNetworkRequiresPower
+    - type: Pierceable # Starlight: Flimsy piece of steel
+      level: Metal # Starlight: Flimsy piece of steel
     - type: InteractionOutline
     - type: Damageable
       damageContainer: StructuralInorganic
-      damageModifierSet: StructuralMetallicStrong
+      damageModifierSet: Metallic # Starlight: Flimsy piece of steel
     - type: RCDDeconstructable
       cost: 4
       delay: 6
@@ -30,11 +33,12 @@
     - type: Tag
       tags:
       - ForceFixRotations # Allow fixrotations to target these
+      - Airlock # Starlight: Make them airlock-ish
     - type: Destructible
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 500
+          damage: 100 # Starlight: Flimsy piece of steel
         behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]
@@ -148,6 +152,22 @@
       - Fires
       - Spacing
     - type: SyncSprite
+    - type: DoorSignalControl # Starlight start: Make firelocks more... airlock-ish.
+    - type: Airlock
+    - type: WirelessNetworkConnection
+      range: 200
+    - type: DeviceLinkSink
+      ports:
+        - Open
+        - Close
+        - Toggle
+        - AutoClose
+        - DoorBolt
+    - type: DeviceLinkSource
+      ports:
+        - DoorStatus
+      lastSignals:
+        DoorStatus: false # Starlight end
 
 - type: entity
   id: Firelock


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Makes firelocks act significantly more like airlocks for the purposes of access breaking.
Also reduces their health a lot.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Right now, firelocks are mostly an impenetrable wall - they have 500 health, can't be easily bolted, and can't be access broken. This PR intends to fix that, and also lets them be networked like regular airlocks.

The reason for this is that access breakers only work on doors with AirlockComponent (???).
So now firelocks have that, and have had their health reduced from 500 -> 100.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/572b7276-bbc1-48a7-bdcf-1b111885b2bd

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower

- add: The Syndicate has finally figured out how to access break firelocks.
- tweak: CED has decided to cut some costs by making firelocks out of steel, instead of plastitanium.