### PR TITLE
CBURN Radiation Rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -1115,7 +1115,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Radiation: 0.35
+        Radiation: 0.9
         Heat: 0.9
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.75

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -1115,6 +1115,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
+        Radiation: 0.35
         Heat: 0.9
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.75

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1209,7 +1209,7 @@
         Heat: 0.1
         Cold: 0.1
         Shock: 0.1
-        Radiation: 0.0
+        Radiation: 0.1
         Caustic: 0.1
     # Starlight-start
     staminaModifier: 0.2

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1209,7 +1209,7 @@
         Heat: 0.1
         Cold: 0.1
         Shock: 0.1
-        Radiation: 0.1
+        Radiation: 0.0
         Caustic: 0.1
     # Starlight-start
     staminaModifier: 0.2


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Rebalance CBURN to full radiation immunity.

## Why we need to add this
With the addition of the framework for nuclear fission and related technology, the paradigm of station threats has shifted towards them being able to utilize dirty weapons and all sorts of atomic warfare. Leading to some absolutely rare scary scenarios that CBURN can only solve.

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- tweak: After a certain incident of a meltdown's remains being utilized to completely liquidate an entire station by a rogue silicon intelligence, CBURN Units take the safety measures of their equipment more seriously with the realization of nuclear-based warfare.
