### PR TITLE
(Reach) New jobs + Map Maintenance

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Reach.yml
+++ b/Resources/Maps/_Starlight/Stations/Reach.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 266.0.0
+  engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 09/29/2025 04:18:45
-  entityCount: 3082
+  time: 02/10/2026 23:28:46
+  entityCount: 3092
 maps:
 - 1
 grids:
@@ -1452,7 +1452,8 @@ entities:
           -5,2:
             1: 15
           -3,1:
-            0: 57583
+            0: 49391
+            2: 8192
           -3,2:
             0: 3822
           -2,1:
@@ -1476,8 +1477,8 @@ entities:
           2,-2:
             0: 61695
           2,-4:
-            2: 6
-            3: 1536
+            3: 6
+            4: 1536
           3,-4:
             1: 3875
             0: 16384
@@ -1535,7 +1536,8 @@ entities:
           5,0:
             0: 61167
           5,1:
-            0: 61166
+            0: 28398
+            2: 32768
           5,2:
             0: 6
           5,-1:
@@ -1543,7 +1545,8 @@ entities:
           6,0:
             0: 14199
           6,1:
-            0: 275
+            0: 3
+            2: 272
           6,-1:
             0: 28721
         uniqueMixes:
@@ -1555,6 +1558,11 @@ entities:
         - volume: 2500
           immutable: True
           moles: {}
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+            Oxygen: 20.078888
+            Nitrogen: 75.53487
         - volume: 2500
           temperature: 293.15
           moles:
@@ -1568,6 +1576,8 @@ entities:
     - type: RadiationGridResistance
     - type: SpreaderGrid
     - type: ImplicitRoof
+    - type: NavMap
+    - type: ExplosionAirtightGrid
 - proto: AirAlarm
   entities:
   - uid: 3
@@ -1578,15 +1588,15 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1773
-      - 1804
-      - 1342
-      - 1358
-      - 1351
-      - 1357
-      - 1350
-      - 1349
-      - 3054
+      - 1849
+      - 1881
+      - 1421
+      - 1433
+      - 1410
+      - 1411
+      - 1409
+      - 1408
+      - 67
     - type: Fixtures
       fixtures: {}
   - uid: 4
@@ -1597,16 +1607,16 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1359
-      - 2992
-      - 2993
-      - 2994
-      - 2995
-      - 1772
-      - 1818
-      - 3053
-      - 1788
-      - 1783
+      - 1434
+      - 1412
+      - 1413
+      - 1414
+      - 1415
+      - 1848
+      - 1894
+      - 66
+      - 1865
+      - 1859
     - type: Fixtures
       fixtures: {}
   - uid: 5
@@ -1617,14 +1627,14 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1813
-      - 1791
-      - 1763
-      - 1765
-      - 1795
-      - 1794
-      - 1796
-      - 3069
+      - 1889
+      - 1868
+      - 1839
+      - 1841
+      - 1872
+      - 1871
+      - 1873
+      - 81
     - type: Fixtures
       fixtures: {}
   - uid: 6
@@ -1634,9 +1644,9 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1766
-      - 1792
-      - 3066
+      - 1842
+      - 1869
+      - 78
     - type: Fixtures
       fixtures: {}
   - uid: 7
@@ -1647,20 +1657,20 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1781
-      - 1816
-      - 1755
-      - 1365
-      - 1364
-      - 1339
-      - 1340
-      - 1341
-      - 1363
-      - 1338
-      - 1369
-      - 1368
-      - 1367
-      - 3058
+      - 1857
+      - 1892
+      - 1831
+      - 1440
+      - 1439
+      - 1418
+      - 1419
+      - 1420
+      - 1438
+      - 1417
+      - 1444
+      - 1443
+      - 1442
+      - 71
     - type: Fixtures
       fixtures: {}
   - uid: 8
@@ -1671,17 +1681,17 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1779
-      - 1801
-      - 1777
-      - 1800
-      - 1366
-      - 1338
-      - 1363
-      - 1341
-      - 1340
-      - 1339
-      - 3059
+      - 1855
+      - 1878
+      - 1853
+      - 1877
+      - 1441
+      - 1417
+      - 1438
+      - 1420
+      - 1419
+      - 1418
+      - 72
     - type: Fixtures
       fixtures: {}
   - uid: 9
@@ -1692,11 +1702,11 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1797
-      - 1774
-      - 1776
-      - 3056
-      - 3057
+      - 1874
+      - 1850
+      - 1852
+      - 69
+      - 70
     - type: Fixtures
       fixtures: {}
   - uid: 10
@@ -1707,12 +1717,12 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1769
-      - 1768
-      - 1808
-      - 1767
-      - 1336
-      - 3064
+      - 1845
+      - 1844
+      - 1885
+      - 1843
+      - 1407
+      - 76
     - type: Fixtures
       fixtures: {}
   - uid: 11
@@ -1723,28 +1733,28 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1803
-      - 1793
-      - 1814
-      - 1347
-      - 1346
-      - 1345
-      - 1353
-      - 1352
-      - 1370
-      - 1367
-      - 1368
-      - 1369
-      - 1337
-      - 1359
-      - 1358
-      - 1356
-      - 1354
-      - 1355
-      - 1342
-      - 2996
-      - 3067
-      - 3068
+      - 1880
+      - 1870
+      - 1890
+      - 1426
+      - 1425
+      - 1424
+      - 1429
+      - 1428
+      - 1445
+      - 1442
+      - 1443
+      - 1444
+      - 1416
+      - 1434
+      - 1433
+      - 1432
+      - 1430
+      - 1431
+      - 1421
+      - 1446
+      - 79
+      - 80
     - type: Fixtures
       fixtures: {}
   - uid: 12
@@ -1755,12 +1765,12 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1806
-      - 1771
-      - 1356
-      - 1354
-      - 1355
-      - 3060
+      - 1883
+      - 1847
+      - 1432
+      - 1430
+      - 1431
+      - 73
     - type: Fixtures
       fixtures: {}
   - uid: 13
@@ -1771,9 +1781,9 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1790
-      - 1780
-      - 1360
+      - 1867
+      - 1856
+      - 1435
     - type: Fixtures
       fixtures: {}
   - uid: 14
@@ -1783,10 +1793,10 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1412
-      - 1757
-      - 2996
-      - 3065
+      - 1863
+      - 1833
+      - 1446
+      - 77
     - type: Fixtures
       fixtures: {}
   - uid: 15
@@ -1797,11 +1807,11 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1787
-      - 1785
-      - 1361
-      - 1362
-      - 3062
+      - 1864
+      - 1861
+      - 1436
+      - 1437
+      - 74
     - type: Fixtures
       fixtures: {}
   - uid: 16
@@ -1812,11 +1822,11 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1360
-      - 1361
-      - 1362
-      - 1758
-      - 1811
+      - 1435
+      - 1436
+      - 1437
+      - 1834
+      - 1888
     - type: Fixtures
       fixtures: {}
   - uid: 17
@@ -1827,11 +1837,11 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1817
-      - 1759
-      - 3063
-      - 1770
-      - 1810
+      - 1893
+      - 1835
+      - 75
+      - 1846
+      - 1887
     - type: Fixtures
       fixtures: {}
   - uid: 18
@@ -1842,12 +1852,12 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 1778
-      - 1799
-      - 1366
-      - 1365
-      - 1364
-      - 3055
+      - 1854
+      - 1876
+      - 1441
+      - 1440
+      - 1439
+      - 68
     - type: Fixtures
       fixtures: {}
 - proto: AirCanister
@@ -1930,17 +1940,17 @@ entities:
     - type: Transform
       pos: 7.5,17.5
       parent: 2
-  - uid: 32
+  - uid: 31
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 2
-  - uid: 33
+  - uid: 32
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 2
-  - uid: 1042
+  - uid: 33
     components:
     - type: Transform
       pos: 12.5,16.5
@@ -1980,7 +1990,8 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         39:
-        - DoorStatus: DoorBolt
+        - - DoorStatus
+          - DoorBolt
   - uid: 39
     components:
     - type: Transform
@@ -1989,10 +2000,11 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         38:
-        - DoorStatus: DoorBolt
+        - - DoorStatus
+          - DoorBolt
 - proto: AirlockExternalGlassShuttleArrivals
   entities:
-  - uid: 3048
+  - uid: 40
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2000,160 +2012,160 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassShuttleEmergencyLocked
   entities:
-  - uid: 3046
+  - uid: 41
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 2
-  - uid: 3047
+  - uid: 42
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 2
 - proto: AirlockExternalGlassShuttleLocked
   entities:
-  - uid: 3049
+  - uid: 43
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,19.5
       parent: 2
-  - uid: 3050
+  - uid: 44
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,17.5
       parent: 2
-  - uid: 3052
+  - uid: 45
     components:
     - type: Transform
       pos: -17.5,-7.5
       parent: 2
 - proto: AirlockGlass
   entities:
-  - uid: 47
+  - uid: 46
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 2
-  - uid: 48
+  - uid: 47
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 2
-  - uid: 49
+  - uid: 48
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 2
-  - uid: 50
+  - uid: 49
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 2
-  - uid: 51
+  - uid: 50
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 2
-  - uid: 52
+  - uid: 51
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
-  - uid: 53
+  - uid: 52
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 2
 - proto: AirlockHydroponicsLocked
   entities:
-  - uid: 54
+  - uid: 53
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 2
 - proto: AirlockJanitorLocked
   entities:
-  - uid: 55
+  - uid: 54
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 2
 - proto: AirlockMaintLocked
   entities:
-  - uid: 56
+  - uid: 55
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 2
 - proto: AirlockMaintMedLocked
   entities:
-  - uid: 57
+  - uid: 56
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 2
 - proto: AirlockMedicalGlassLocked
   entities:
-  - uid: 58
+  - uid: 57
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 2
-  - uid: 59
+  - uid: 58
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 2
 - proto: AirlockResearchDirectorGlassLocked
   entities:
-  - uid: 60
+  - uid: 59
     components:
     - type: Transform
       pos: -7.5,8.5
       parent: 2
 - proto: AirlockScienceGlassLocked
   entities:
-  - uid: 61
+  - uid: 60
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
 - proto: AirlockSecurityGlassLocked
   entities:
-  - uid: 62
+  - uid: 61
     components:
     - type: Transform
       pos: 18.5,2.5
       parent: 2
 - proto: AirlockSecurityLocked
   entities:
-  - uid: 63
+  - uid: 62
     components:
     - type: Transform
       pos: 16.5,-1.5
       parent: 2
-  - uid: 64
+  - uid: 63
     components:
     - type: Transform
       pos: 17.5,-1.5
       parent: 2
 - proto: AirlockServiceGlassLocked
   entities:
-  - uid: 65
+  - uid: 64
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 2
-  - uid: 66
+  - uid: 65
     components:
     - type: Transform
       pos: -11.5,4.5
       parent: 2
 - proto: AirSensor
   entities:
-  - uid: 3053
+  - uid: 66
     components:
     - type: Transform
       pos: -3.5,9.5
@@ -2161,7 +2173,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 3054
+  - uid: 67
     components:
     - type: Transform
       pos: 1.5,10.5
@@ -2169,7 +2181,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 3055
+  - uid: 68
     components:
     - type: Transform
       pos: -13.5,6.5
@@ -2177,7 +2189,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 18
-  - uid: 3056
+  - uid: 69
     components:
     - type: Transform
       pos: -21.5,0.5
@@ -2185,7 +2197,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 9
-  - uid: 3057
+  - uid: 70
     components:
     - type: Transform
       pos: -18.5,1.5
@@ -2193,7 +2205,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 9
-  - uid: 3058
+  - uid: 71
     components:
     - type: Transform
       pos: -11.5,-1.5
@@ -2201,7 +2213,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 7
-  - uid: 3059
+  - uid: 72
     components:
     - type: Transform
       pos: -6.5,4.5
@@ -2209,7 +2221,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 8
-  - uid: 3060
+  - uid: 73
     components:
     - type: Transform
       pos: 10.5,13.5
@@ -2217,7 +2229,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12
-  - uid: 3062
+  - uid: 74
     components:
     - type: Transform
       pos: 18.5,8.5
@@ -2225,7 +2237,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 15
-  - uid: 3063
+  - uid: 75
     components:
     - type: Transform
       pos: 18.5,1.5
@@ -2233,7 +2245,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 17
-  - uid: 3064
+  - uid: 76
     components:
     - type: Transform
       pos: 23.5,3.5
@@ -2241,7 +2253,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 10
-  - uid: 3065
+  - uid: 77
     components:
     - type: Transform
       pos: 2.5,-12.5
@@ -2249,7 +2261,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 14
-  - uid: 3066
+  - uid: 78
     components:
     - type: Transform
       pos: -5.5,-7.5
@@ -2257,7 +2269,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 6
-  - uid: 3067
+  - uid: 79
     components:
     - type: Transform
       pos: -1.5,-12.5
@@ -2265,7 +2277,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11
-  - uid: 3068
+  - uid: 80
     components:
     - type: Transform
       pos: 4.5,4.5
@@ -2273,7 +2285,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11
-  - uid: 3069
+  - uid: 81
     components:
     - type: Transform
       pos: 10.5,-3.5
@@ -2283,7 +2295,7 @@ entities:
       - 5
 - proto: APCBasic
   entities:
-  - uid: 67
+  - uid: 82
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2291,14 +2303,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 68
+  - uid: 83
     components:
     - type: Transform
       pos: -18.5,5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 69
+  - uid: 84
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2306,7 +2318,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 70
+  - uid: 85
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2314,7 +2326,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 71
+  - uid: 86
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2322,21 +2334,21 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 72
+  - uid: 87
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 73
+  - uid: 88
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 74
+  - uid: 89
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2344,35 +2356,35 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 75
+  - uid: 90
     components:
     - type: Transform
       pos: 9.5,17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 76
+  - uid: 91
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 77
+  - uid: 92
     components:
     - type: Transform
       pos: 17.5,2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 78
+  - uid: 93
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 79
+  - uid: 94
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2382,14 +2394,14 @@ entities:
       fixtures: {}
 - proto: APECircuitboard
   entities:
-  - uid: 80
+  - uid: 95
     components:
     - type: Transform
       pos: -4.390625,7.619689
       parent: 2
 - proto: ArrivalsShuttleTimer
   entities:
-  - uid: 3080
+  - uid: 96
     components:
     - type: Transform
       pos: 11.5,16.5
@@ -2398,14 +2410,14 @@ entities:
       fixtures: {}
 - proto: Ashtray
   entities:
-  - uid: 82
+  - uid: 97
     components:
     - type: Transform
       pos: -3.2747555,-3.4928942
       parent: 2
 - proto: ATM
   entities:
-  - uid: 83
+  - uid: 98
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2413,34 +2425,34 @@ entities:
       parent: 2
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 43
+  - uid: 99
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,18.5
       parent: 2
-  - uid: 84
+  - uid: 100
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,19.5
       parent: 2
-  - uid: 88
+  - uid: 101
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 2
-  - uid: 89
+  - uid: 102
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 2
-  - uid: 90
+  - uid: 103
     components:
     - type: Transform
       pos: -17.5,-7.5
       parent: 2
-  - uid: 1108
+  - uid: 104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2448,38 +2460,38 @@ entities:
       parent: 2
 - proto: AtmosFixNitrogenMarker
   entities:
-  - uid: 91
+  - uid: 105
     components:
     - type: Transform
       pos: 10.5,-15.5
       parent: 2
-  - uid: 92
+  - uid: 106
     components:
     - type: Transform
       pos: 9.5,-15.5
       parent: 2
 - proto: AtmosFixOxygenMarker
   entities:
-  - uid: 93
+  - uid: 107
     components:
     - type: Transform
       pos: 9.5,-13.5
       parent: 2
-  - uid: 94
+  - uid: 108
     components:
     - type: Transform
       pos: 10.5,-13.5
       parent: 2
 - proto: Autolathe
   entities:
-  - uid: 95
+  - uid: 109
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 2
 - proto: BarSignTheLightbulb
   entities:
-  - uid: 96
+  - uid: 110
     components:
     - type: Transform
       pos: -9.5,6.5
@@ -2488,47 +2500,47 @@ entities:
       fixtures: {}
 - proto: BaseResearchAndDevelopmentPointSource
   entities:
-  - uid: 97
+  - uid: 111
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 2
 - proto: Bed
   entities:
-  - uid: 98
+  - uid: 112
     components:
     - type: Transform
       pos: 24.5,-3.5
       parent: 2
 - proto: BedsheetCaptain
   entities:
-  - uid: 99
+  - uid: 113
     components:
     - type: Transform
       pos: 24.5,-3.5
       parent: 2
 - proto: BedsheetCMO
   entities:
-  - uid: 100
+  - uid: 114
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 2
 - proto: BedsheetMedical
   entities:
-  - uid: 101
+  - uid: 115
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 2
 - proto: BlastDoor
   entities:
-  - uid: 102
+  - uid: 116
     components:
     - type: Transform
       pos: -6.5,12.5
       parent: 2
-  - uid: 103
+  - uid: 117
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2536,85 +2548,85 @@ entities:
       parent: 2
 - proto: BluespaceBeaker
   entities:
-  - uid: 104
+  - uid: 118
     components:
     - type: Transform
       pos: 6.3718643,-0.34468752
       parent: 2
 - proto: BookshelfFilled
   entities:
-  - uid: 105
+  - uid: 119
     components:
     - type: Transform
       pos: 18.5,9.5
       parent: 2
 - proto: BoozeDispenser
   entities:
-  - uid: 106
+  - uid: 120
     components:
     - type: Transform
       pos: -8.5,5.5
       parent: 2
 - proto: BorgCharger
   entities:
-  - uid: 107
+  - uid: 121
     components:
     - type: Transform
       pos: -8.5,7.5
       parent: 2
 - proto: BoxBodyBag
   entities:
-  - uid: 3078
+  - uid: 122
     components:
     - type: Transform
       pos: 2.3824162,-2.066069
       parent: 2
-  - uid: 3079
+  - uid: 123
     components:
     - type: Transform
       pos: 2.6949162,-2.0973406
       parent: 2
 - proto: BoxHandcuff
   entities:
-  - uid: 3038
+  - uid: 124
     components:
     - type: Transform
       pos: 19.701256,-2.1177576
       parent: 2
 - proto: BoxLightMixed
   entities:
-  - uid: 111
+  - uid: 125
     components:
     - type: Transform
       pos: -5.6020327,-8.298535
       parent: 2
 - proto: BoxZiptie
   entities:
-  - uid: 3039
+  - uid: 126
     components:
     - type: Transform
       pos: 19.357506,-2.023942
       parent: 2
 - proto: Bucket
   entities:
-  - uid: 113
+  - uid: 127
     components:
     - type: Transform
       pos: -12.511883,3.9677496
       parent: 2
-  - uid: 114
+  - uid: 128
     components:
     - type: Transform
       pos: -12.730633,3.8739996
       parent: 2
-  - uid: 115
+  - uid: 129
     components:
     - type: Transform
       pos: 14.5,8.5
       parent: 2
 - proto: ButchCleaver
   entities:
-  - uid: 3036
+  - uid: 130
     components:
     - type: Transform
       pos: -3.4543471,3.7875228
@@ -2633,3870 +2645,3870 @@ entities:
         path: /Audio/Items/Culinary/chop.ogg
 - proto: ButtonFrameCaution
   entities:
-  - uid: 116
+  - uid: 131
     components:
     - type: Transform
       pos: -4.5,12.5
       parent: 2
-  - uid: 117
+  - uid: 132
     components:
     - type: Transform
       pos: 13.5,11.5
       parent: 2
 - proto: CableApcExtension
   entities:
-  - uid: 31
+  - uid: 133
     components:
     - type: Transform
       pos: 14.5,15.5
       parent: 2
-  - uid: 110
-    components:
-    - type: Transform
-      pos: -9.5,-5.5
-      parent: 2
-  - uid: 112
-    components:
-    - type: Transform
-      pos: -0.5,17.5
-      parent: 2
-  - uid: 118
-    components:
-    - type: Transform
-      pos: 12.5,16.5
-      parent: 2
-  - uid: 119
-    components:
-    - type: Transform
-      pos: -4.5,11.5
-      parent: 2
-  - uid: 120
-    components:
-    - type: Transform
-      pos: -13.5,6.5
-      parent: 2
-  - uid: 121
-    components:
-    - type: Transform
-      pos: -21.5,-6.5
-      parent: 2
-  - uid: 122
-    components:
-    - type: Transform
-      pos: 7.5,-1.5
-      parent: 2
-  - uid: 123
-    components:
-    - type: Transform
-      pos: -17.5,3.5
-      parent: 2
-  - uid: 124
-    components:
-    - type: Transform
-      pos: -20.5,1.5
-      parent: 2
-  - uid: 125
-    components:
-    - type: Transform
-      pos: -18.5,3.5
-      parent: 2
-  - uid: 126
-    components:
-    - type: Transform
-      pos: -21.5,2.5
-      parent: 2
-  - uid: 127
-    components:
-    - type: Transform
-      pos: -18.5,5.5
-      parent: 2
-  - uid: 128
-    components:
-    - type: Transform
-      pos: -19.5,-1.5
-      parent: 2
-  - uid: 129
-    components:
-    - type: Transform
-      pos: -20.5,-1.5
-      parent: 2
-  - uid: 130
-    components:
-    - type: Transform
-      pos: -21.5,-1.5
-      parent: 2
-  - uid: 131
-    components:
-    - type: Transform
-      pos: -22.5,-1.5
-      parent: 2
-  - uid: 132
-    components:
-    - type: Transform
-      pos: -14.5,9.5
-      parent: 2
-  - uid: 133
-    components:
-    - type: Transform
-      pos: -22.5,-0.5
-      parent: 2
   - uid: 134
     components:
     - type: Transform
-      pos: -22.5,0.5
+      pos: -9.5,-5.5
       parent: 2
   - uid: 135
     components:
     - type: Transform
-      pos: -22.5,1.5
+      pos: -0.5,17.5
       parent: 2
   - uid: 136
     components:
     - type: Transform
-      pos: -20.5,-0.5
+      pos: 12.5,16.5
       parent: 2
   - uid: 137
     components:
     - type: Transform
-      pos: -20.5,0.5
+      pos: -4.5,11.5
       parent: 2
   - uid: 138
     components:
     - type: Transform
-      pos: -18.5,4.5
+      pos: -13.5,6.5
       parent: 2
   - uid: 139
     components:
     - type: Transform
-      pos: -20.5,2.5
+      pos: -21.5,-6.5
       parent: 2
   - uid: 140
     components:
     - type: Transform
-      pos: -22.5,2.5
+      pos: 7.5,-1.5
       parent: 2
   - uid: 141
     components:
     - type: Transform
-      pos: -17.5,2.5
+      pos: -17.5,3.5
       parent: 2
   - uid: 142
     components:
     - type: Transform
-      pos: -17.5,1.5
+      pos: -20.5,1.5
       parent: 2
   - uid: 143
     components:
     - type: Transform
-      pos: -17.5,0.5
+      pos: -18.5,3.5
       parent: 2
   - uid: 144
     components:
     - type: Transform
-      pos: -17.5,-0.5
+      pos: -21.5,2.5
       parent: 2
   - uid: 145
     components:
     - type: Transform
-      pos: -17.5,-1.5
+      pos: -18.5,5.5
       parent: 2
   - uid: 146
     components:
     - type: Transform
-      pos: -17.5,-2.5
+      pos: -19.5,-1.5
       parent: 2
   - uid: 147
     components:
     - type: Transform
-      pos: -17.5,-3.5
+      pos: -20.5,-1.5
       parent: 2
   - uid: 148
     components:
     - type: Transform
-      pos: -17.5,-4.5
+      pos: -21.5,-1.5
       parent: 2
   - uid: 149
     components:
     - type: Transform
-      pos: -16.5,0.5
+      pos: -22.5,-1.5
       parent: 2
   - uid: 150
     components:
     - type: Transform
-      pos: -18.5,0.5
+      pos: -14.5,9.5
       parent: 2
   - uid: 151
     components:
     - type: Transform
-      pos: -17.5,5.5
+      pos: -22.5,-0.5
       parent: 2
   - uid: 152
     components:
     - type: Transform
-      pos: -17.5,6.5
+      pos: -22.5,0.5
       parent: 2
   - uid: 153
     components:
     - type: Transform
-      pos: -17.5,7.5
+      pos: -22.5,1.5
       parent: 2
   - uid: 154
     components:
     - type: Transform
-      pos: -16.5,7.5
+      pos: -20.5,-0.5
       parent: 2
   - uid: 155
     components:
     - type: Transform
-      pos: -18.5,8.5
+      pos: -20.5,0.5
       parent: 2
   - uid: 156
     components:
     - type: Transform
-      pos: -19.5,8.5
+      pos: -18.5,4.5
       parent: 2
   - uid: 157
     components:
     - type: Transform
-      pos: -20.5,6.5
+      pos: -20.5,2.5
       parent: 2
   - uid: 158
     components:
     - type: Transform
-      pos: -21.5,5.5
+      pos: -22.5,2.5
       parent: 2
   - uid: 159
     components:
     - type: Transform
-      pos: -22.5,5.5
+      pos: -17.5,2.5
       parent: 2
   - uid: 160
     components:
     - type: Transform
-      pos: -23.5,5.5
+      pos: -17.5,1.5
       parent: 2
   - uid: 161
     components:
     - type: Transform
-      pos: -24.5,5.5
+      pos: -17.5,0.5
       parent: 2
   - uid: 162
     components:
     - type: Transform
-      pos: 22.5,5.5
+      pos: -17.5,-0.5
       parent: 2
   - uid: 163
     components:
     - type: Transform
-      pos: -25.5,4.5
+      pos: -17.5,-1.5
       parent: 2
   - uid: 164
     components:
     - type: Transform
-      pos: -25.5,3.5
+      pos: -17.5,-2.5
       parent: 2
   - uid: 165
     components:
     - type: Transform
-      pos: -13.5,-0.5
+      pos: -17.5,-3.5
       parent: 2
   - uid: 166
     components:
     - type: Transform
-      pos: -13.5,-1.5
+      pos: -17.5,-4.5
       parent: 2
   - uid: 167
     components:
     - type: Transform
-      pos: -7.5,2.5
+      pos: -16.5,0.5
       parent: 2
   - uid: 168
     components:
     - type: Transform
-      pos: -7.5,3.5
+      pos: -18.5,0.5
       parent: 2
   - uid: 169
     components:
     - type: Transform
-      pos: -7.5,4.5
+      pos: -17.5,5.5
       parent: 2
   - uid: 170
     components:
     - type: Transform
-      pos: -6.5,4.5
+      pos: -17.5,6.5
       parent: 2
   - uid: 171
     components:
     - type: Transform
-      pos: -4.5,4.5
+      pos: -17.5,7.5
       parent: 2
   - uid: 172
     components:
     - type: Transform
-      pos: -5.5,4.5
+      pos: -16.5,7.5
       parent: 2
   - uid: 173
     components:
     - type: Transform
-      pos: -3.5,4.5
+      pos: -18.5,8.5
       parent: 2
   - uid: 174
     components:
     - type: Transform
-      pos: -8.5,4.5
+      pos: -19.5,8.5
       parent: 2
   - uid: 175
     components:
     - type: Transform
-      pos: -9.5,4.5
+      pos: -20.5,6.5
       parent: 2
   - uid: 176
     components:
     - type: Transform
-      pos: -10.5,4.5
+      pos: -21.5,5.5
       parent: 2
   - uid: 177
     components:
     - type: Transform
-      pos: -11.5,4.5
+      pos: -22.5,5.5
       parent: 2
   - uid: 178
     components:
     - type: Transform
-      pos: -12.5,4.5
+      pos: -23.5,5.5
       parent: 2
   - uid: 179
     components:
     - type: Transform
-      pos: -13.5,4.5
+      pos: -24.5,5.5
       parent: 2
   - uid: 180
     components:
     - type: Transform
-      pos: -14.5,4.5
+      pos: 22.5,5.5
       parent: 2
   - uid: 181
     components:
     - type: Transform
-      pos: -13.5,3.5
+      pos: -25.5,4.5
       parent: 2
   - uid: 182
     components:
     - type: Transform
-      pos: -13.5,5.5
+      pos: -25.5,3.5
       parent: 2
   - uid: 183
     components:
     - type: Transform
-      pos: -7.5,-1.5
+      pos: -13.5,-0.5
       parent: 2
   - uid: 184
     components:
     - type: Transform
-      pos: -7.5,-0.5
+      pos: -13.5,-1.5
       parent: 2
   - uid: 185
     components:
     - type: Transform
-      pos: -7.5,0.5
+      pos: -7.5,2.5
       parent: 2
   - uid: 186
     components:
     - type: Transform
-      pos: -8.5,0.5
+      pos: -7.5,3.5
       parent: 2
   - uid: 187
     components:
     - type: Transform
-      pos: -9.5,0.5
+      pos: -7.5,4.5
       parent: 2
   - uid: 188
     components:
     - type: Transform
-      pos: -10.5,0.5
+      pos: -6.5,4.5
       parent: 2
   - uid: 189
     components:
     - type: Transform
-      pos: -11.5,0.5
+      pos: -4.5,4.5
       parent: 2
   - uid: 190
     components:
     - type: Transform
-      pos: -12.5,0.5
+      pos: -5.5,4.5
       parent: 2
   - uid: 191
     components:
     - type: Transform
-      pos: -13.5,0.5
+      pos: -3.5,4.5
       parent: 2
   - uid: 192
     components:
     - type: Transform
-      pos: -14.5,0.5
+      pos: -8.5,4.5
       parent: 2
   - uid: 193
     components:
     - type: Transform
-      pos: -6.5,0.5
+      pos: -9.5,4.5
       parent: 2
   - uid: 194
     components:
     - type: Transform
-      pos: -5.5,0.5
+      pos: -10.5,4.5
       parent: 2
   - uid: 195
     components:
     - type: Transform
-      pos: -4.5,0.5
+      pos: -11.5,4.5
       parent: 2
   - uid: 196
     components:
     - type: Transform
-      pos: -3.5,0.5
+      pos: -12.5,4.5
       parent: 2
   - uid: 197
     components:
     - type: Transform
-      pos: -13.5,-2.5
+      pos: -13.5,4.5
       parent: 2
   - uid: 198
     components:
     - type: Transform
-      pos: -12.5,-7.5
+      pos: -14.5,4.5
       parent: 2
   - uid: 199
     components:
     - type: Transform
-      pos: -13.5,-7.5
+      pos: -13.5,3.5
       parent: 2
   - uid: 200
     components:
     - type: Transform
-      pos: -13.5,-5.5
+      pos: -13.5,5.5
       parent: 2
   - uid: 201
     components:
     - type: Transform
-      pos: -9.5,-0.5
+      pos: -7.5,-1.5
       parent: 2
   - uid: 202
     components:
     - type: Transform
-      pos: -9.5,-1.5
+      pos: -7.5,-0.5
       parent: 2
   - uid: 203
     components:
     - type: Transform
-      pos: -9.5,-2.5
+      pos: -7.5,0.5
       parent: 2
   - uid: 204
     components:
     - type: Transform
-      pos: -14.5,-7.5
+      pos: -8.5,0.5
       parent: 2
   - uid: 205
     components:
     - type: Transform
-      pos: -9.5,-5.5
+      pos: -9.5,0.5
       parent: 2
   - uid: 206
     components:
     - type: Transform
-      pos: -5.5,-0.5
+      pos: -10.5,0.5
       parent: 2
   - uid: 207
     components:
     - type: Transform
-      pos: -5.5,-1.5
+      pos: -11.5,0.5
       parent: 2
   - uid: 208
     components:
     - type: Transform
-      pos: -5.5,-2.5
+      pos: -12.5,0.5
       parent: 2
   - uid: 209
     components:
     - type: Transform
-      pos: -5.5,-3.5
+      pos: -13.5,0.5
       parent: 2
   - uid: 210
     components:
     - type: Transform
-      pos: -4.5,-3.5
+      pos: -14.5,0.5
       parent: 2
   - uid: 211
     components:
     - type: Transform
-      pos: -2.5,-5.5
+      pos: -6.5,0.5
       parent: 2
   - uid: 212
     components:
     - type: Transform
-      pos: -1.5,-5.5
+      pos: -5.5,0.5
       parent: 2
   - uid: 213
     components:
     - type: Transform
-      pos: -0.5,-5.5
+      pos: -4.5,0.5
       parent: 2
   - uid: 214
     components:
     - type: Transform
-      pos: -0.5,-4.5
+      pos: -3.5,0.5
       parent: 2
   - uid: 215
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      pos: -13.5,-2.5
       parent: 2
   - uid: 216
     components:
     - type: Transform
-      pos: -0.5,-2.5
+      pos: -12.5,-7.5
       parent: 2
   - uid: 217
     components:
     - type: Transform
-      pos: -0.5,-1.5
+      pos: -13.5,-7.5
       parent: 2
   - uid: 218
     components:
     - type: Transform
-      pos: -0.5,-0.5
+      pos: -13.5,-5.5
       parent: 2
   - uid: 219
     components:
     - type: Transform
-      pos: -0.5,0.5
+      pos: -9.5,-0.5
       parent: 2
   - uid: 220
     components:
     - type: Transform
-      pos: -0.5,1.5
+      pos: -9.5,-1.5
       parent: 2
   - uid: 221
     components:
     - type: Transform
-      pos: -0.5,2.5
+      pos: -9.5,-2.5
       parent: 2
   - uid: 222
     components:
     - type: Transform
-      pos: -0.5,3.5
+      pos: -14.5,-7.5
       parent: 2
   - uid: 223
     components:
     - type: Transform
-      pos: -0.5,4.5
+      pos: -9.5,-5.5
       parent: 2
   - uid: 224
     components:
     - type: Transform
-      pos: -0.5,-6.5
+      pos: -5.5,-0.5
       parent: 2
   - uid: 225
     components:
     - type: Transform
-      pos: -0.5,-7.5
+      pos: -5.5,-1.5
       parent: 2
   - uid: 226
     components:
     - type: Transform
-      pos: -0.5,-8.5
+      pos: -5.5,-2.5
       parent: 2
   - uid: 227
     components:
     - type: Transform
-      pos: -0.5,-9.5
+      pos: -5.5,-3.5
       parent: 2
   - uid: 228
     components:
     - type: Transform
-      pos: -0.5,-10.5
+      pos: -4.5,-3.5
       parent: 2
   - uid: 229
     components:
     - type: Transform
-      pos: -0.5,-11.5
+      pos: -2.5,-5.5
       parent: 2
   - uid: 230
     components:
     - type: Transform
-      pos: -0.5,-12.5
+      pos: -1.5,-5.5
       parent: 2
   - uid: 231
     components:
     - type: Transform
-      pos: -1.5,-7.5
+      pos: -0.5,-5.5
       parent: 2
   - uid: 232
     components:
     - type: Transform
-      pos: -2.5,-7.5
+      pos: -0.5,-4.5
       parent: 2
   - uid: 233
     components:
     - type: Transform
-      pos: -3.5,-7.5
+      pos: -0.5,-3.5
       parent: 2
   - uid: 234
     components:
     - type: Transform
-      pos: -4.5,-7.5
+      pos: -0.5,-2.5
       parent: 2
   - uid: 235
     components:
     - type: Transform
-      pos: -5.5,-7.5
+      pos: -0.5,-1.5
       parent: 2
   - uid: 236
     components:
     - type: Transform
-      pos: -5.5,-6.5
+      pos: -0.5,-0.5
       parent: 2
   - uid: 237
     components:
     - type: Transform
-      pos: 0.5,-6.5
+      pos: -0.5,0.5
       parent: 2
   - uid: 238
     components:
     - type: Transform
-      pos: 1.5,-6.5
+      pos: -0.5,1.5
       parent: 2
   - uid: 239
     components:
     - type: Transform
-      pos: 2.5,-6.5
+      pos: -0.5,2.5
       parent: 2
   - uid: 240
     components:
     - type: Transform
-      pos: 3.5,-6.5
+      pos: -0.5,3.5
       parent: 2
   - uid: 241
     components:
     - type: Transform
-      pos: 4.5,-6.5
+      pos: -0.5,4.5
       parent: 2
   - uid: 242
     components:
     - type: Transform
-      pos: 7.5,-17.5
+      pos: -0.5,-6.5
       parent: 2
   - uid: 243
     components:
     - type: Transform
-      pos: 7.5,-16.5
+      pos: -0.5,-7.5
       parent: 2
   - uid: 244
     components:
     - type: Transform
-      pos: 7.5,-15.5
+      pos: -0.5,-8.5
       parent: 2
   - uid: 245
     components:
     - type: Transform
-      pos: 6.5,-15.5
+      pos: -0.5,-9.5
       parent: 2
   - uid: 246
     components:
     - type: Transform
-      pos: 5.5,-15.5
+      pos: -0.5,-10.5
       parent: 2
   - uid: 247
     components:
     - type: Transform
-      pos: 5.5,-14.5
+      pos: -0.5,-11.5
       parent: 2
   - uid: 248
     components:
     - type: Transform
-      pos: 5.5,-13.5
+      pos: -0.5,-12.5
       parent: 2
   - uid: 249
     components:
     - type: Transform
-      pos: 4.5,-13.5
+      pos: -1.5,-7.5
       parent: 2
   - uid: 250
     components:
     - type: Transform
-      pos: 4.5,-12.5
+      pos: -2.5,-7.5
       parent: 2
   - uid: 251
     components:
     - type: Transform
-      pos: 4.5,-11.5
+      pos: -3.5,-7.5
       parent: 2
   - uid: 252
     components:
     - type: Transform
-      pos: 4.5,-10.5
+      pos: -4.5,-7.5
       parent: 2
   - uid: 253
     components:
     - type: Transform
-      pos: 4.5,-9.5
+      pos: -5.5,-7.5
       parent: 2
   - uid: 254
     components:
     - type: Transform
-      pos: 3.5,-12.5
+      pos: -5.5,-6.5
       parent: 2
   - uid: 255
     components:
     - type: Transform
-      pos: 2.5,-12.5
+      pos: 0.5,-6.5
       parent: 2
   - uid: 256
     components:
     - type: Transform
-      pos: 1.5,-12.5
+      pos: 1.5,-6.5
       parent: 2
   - uid: 257
     components:
     - type: Transform
-      pos: 5.5,-11.5
+      pos: 2.5,-6.5
       parent: 2
   - uid: 258
     components:
     - type: Transform
-      pos: 6.5,-11.5
+      pos: 3.5,-6.5
       parent: 2
   - uid: 259
     components:
     - type: Transform
-      pos: 7.5,-11.5
+      pos: 4.5,-6.5
       parent: 2
   - uid: 260
     components:
     - type: Transform
-      pos: 8.5,-11.5
+      pos: 7.5,-17.5
       parent: 2
   - uid: 261
     components:
     - type: Transform
-      pos: 9.5,-11.5
+      pos: 7.5,-16.5
       parent: 2
   - uid: 262
     components:
     - type: Transform
-      pos: 10.5,-11.5
+      pos: 7.5,-15.5
       parent: 2
   - uid: 263
     components:
     - type: Transform
-      pos: 11.5,-11.5
+      pos: 6.5,-15.5
       parent: 2
   - uid: 264
     components:
     - type: Transform
-      pos: 9.5,-1.5
+      pos: 5.5,-15.5
       parent: 2
   - uid: 265
     components:
     - type: Transform
-      pos: 9.5,-2.5
+      pos: 5.5,-14.5
       parent: 2
   - uid: 266
     components:
     - type: Transform
-      pos: 10.5,-2.5
+      pos: 5.5,-13.5
       parent: 2
   - uid: 267
     components:
     - type: Transform
-      pos: 11.5,-2.5
+      pos: 4.5,-13.5
       parent: 2
   - uid: 268
     components:
     - type: Transform
-      pos: 11.5,-3.5
+      pos: 4.5,-12.5
       parent: 2
   - uid: 269
     components:
     - type: Transform
-      pos: 11.5,-4.5
+      pos: 4.5,-11.5
       parent: 2
   - uid: 270
     components:
     - type: Transform
-      pos: 8.5,-2.5
+      pos: 4.5,-10.5
       parent: 2
   - uid: 271
     components:
     - type: Transform
-      pos: 7.5,-2.5
+      pos: 4.5,-9.5
       parent: 2
   - uid: 272
     components:
     - type: Transform
-      pos: 8.5,-3.5
+      pos: 3.5,-12.5
       parent: 2
   - uid: 273
     components:
     - type: Transform
-      pos: 8.5,-4.5
+      pos: 2.5,-12.5
       parent: 2
   - uid: 274
     components:
     - type: Transform
-      pos: 6.5,-2.5
+      pos: 1.5,-12.5
       parent: 2
   - uid: 275
     components:
     - type: Transform
-      pos: 5.5,-2.5
+      pos: 5.5,-11.5
       parent: 2
   - uid: 276
     components:
     - type: Transform
-      pos: 5.5,-3.5
+      pos: 6.5,-11.5
       parent: 2
   - uid: 277
     components:
     - type: Transform
-      pos: 5.5,-4.5
+      pos: 7.5,-11.5
       parent: 2
   - uid: 278
     components:
     - type: Transform
-      pos: 4.5,-2.5
+      pos: 8.5,-11.5
       parent: 2
   - uid: 279
     components:
     - type: Transform
-      pos: 3.5,-2.5
+      pos: 9.5,-11.5
       parent: 2
   - uid: 280
     components:
     - type: Transform
-      pos: 3.5,-3.5
+      pos: 10.5,-11.5
       parent: 2
   - uid: 281
     components:
     - type: Transform
-      pos: 3.5,-4.5
+      pos: 11.5,-11.5
       parent: 2
   - uid: 282
     components:
     - type: Transform
-      pos: 3.5,-1.5
+      pos: 9.5,-1.5
       parent: 2
   - uid: 283
     components:
     - type: Transform
-      pos: 3.5,-0.5
+      pos: 9.5,-2.5
       parent: 2
   - uid: 284
     components:
     - type: Transform
-      pos: 3.5,0.5
+      pos: 10.5,-2.5
       parent: 2
   - uid: 285
     components:
     - type: Transform
-      pos: 3.5,1.5
+      pos: 11.5,-2.5
       parent: 2
   - uid: 286
     components:
     - type: Transform
-      pos: 7.5,-0.5
+      pos: 11.5,-3.5
       parent: 2
   - uid: 287
     components:
     - type: Transform
-      pos: 7.5,0.5
+      pos: 11.5,-4.5
       parent: 2
   - uid: 288
     components:
     - type: Transform
-      pos: 7.5,1.5
+      pos: 8.5,-2.5
       parent: 2
   - uid: 289
     components:
     - type: Transform
-      pos: 6.5,0.5
+      pos: 7.5,-2.5
       parent: 2
   - uid: 290
     components:
     - type: Transform
-      pos: 5.5,0.5
+      pos: 8.5,-3.5
       parent: 2
   - uid: 291
     components:
     - type: Transform
-      pos: 4.5,0.5
+      pos: 8.5,-4.5
       parent: 2
   - uid: 292
     components:
     - type: Transform
-      pos: 8.5,0.5
+      pos: 6.5,-2.5
       parent: 2
   - uid: 293
     components:
     - type: Transform
-      pos: 9.5,0.5
+      pos: 5.5,-2.5
       parent: 2
   - uid: 294
     components:
     - type: Transform
-      pos: 10.5,0.5
+      pos: 5.5,-3.5
       parent: 2
   - uid: 295
     components:
     - type: Transform
-      pos: 11.5,0.5
+      pos: 5.5,-4.5
       parent: 2
   - uid: 296
     components:
     - type: Transform
-      pos: 11.5,-0.5
+      pos: 4.5,-2.5
       parent: 2
   - uid: 297
     components:
     - type: Transform
-      pos: 11.5,-1.5
+      pos: 3.5,-2.5
       parent: 2
   - uid: 298
     components:
     - type: Transform
-      pos: 11.5,1.5
+      pos: 3.5,-3.5
       parent: 2
   - uid: 299
     components:
     - type: Transform
-      pos: 12.5,1.5
+      pos: 3.5,-4.5
       parent: 2
   - uid: 300
     components:
     - type: Transform
-      pos: 13.5,1.5
+      pos: 3.5,-1.5
       parent: 2
   - uid: 301
     components:
     - type: Transform
-      pos: 13.5,-0.5
+      pos: 3.5,-0.5
       parent: 2
   - uid: 302
     components:
     - type: Transform
-      pos: 13.5,-0.5
+      pos: 3.5,0.5
       parent: 2
   - uid: 303
     components:
     - type: Transform
-      pos: 12.5,-0.5
+      pos: 3.5,1.5
       parent: 2
   - uid: 304
     components:
     - type: Transform
-      pos: 4.5,6.5
+      pos: 7.5,-0.5
       parent: 2
   - uid: 305
     components:
     - type: Transform
-      pos: 4.5,5.5
+      pos: 7.5,0.5
       parent: 2
   - uid: 306
     components:
     - type: Transform
-      pos: 4.5,4.5
+      pos: 7.5,1.5
       parent: 2
   - uid: 307
     components:
     - type: Transform
-      pos: 3.5,4.5
+      pos: 6.5,0.5
       parent: 2
   - uid: 308
     components:
     - type: Transform
-      pos: 2.5,4.5
+      pos: 5.5,0.5
       parent: 2
   - uid: 309
     components:
     - type: Transform
-      pos: 1.5,4.5
+      pos: 4.5,0.5
       parent: 2
   - uid: 310
     components:
     - type: Transform
-      pos: 5.5,4.5
+      pos: 8.5,0.5
       parent: 2
   - uid: 311
     components:
     - type: Transform
-      pos: 6.5,4.5
+      pos: 9.5,0.5
       parent: 2
   - uid: 312
     components:
     - type: Transform
-      pos: 7.5,4.5
+      pos: 10.5,0.5
       parent: 2
   - uid: 313
     components:
     - type: Transform
-      pos: 8.5,4.5
+      pos: 11.5,0.5
       parent: 2
   - uid: 314
     components:
     - type: Transform
-      pos: 9.5,4.5
+      pos: 11.5,-0.5
       parent: 2
   - uid: 315
     components:
     - type: Transform
-      pos: 10.5,4.5
+      pos: 11.5,-1.5
       parent: 2
   - uid: 316
     components:
     - type: Transform
-      pos: 11.5,4.5
+      pos: 11.5,1.5
       parent: 2
   - uid: 317
     components:
     - type: Transform
-      pos: 12.5,4.5
+      pos: 12.5,1.5
       parent: 2
   - uid: 318
     components:
     - type: Transform
-      pos: 12.5,5.5
+      pos: 13.5,1.5
       parent: 2
   - uid: 319
     components:
     - type: Transform
-      pos: 13.5,5.5
+      pos: 13.5,-0.5
       parent: 2
   - uid: 320
     components:
     - type: Transform
-      pos: 12.5,3.5
+      pos: 13.5,-0.5
       parent: 2
   - uid: 321
     components:
     - type: Transform
-      pos: 13.5,3.5
+      pos: 12.5,-0.5
       parent: 2
   - uid: 322
     components:
     - type: Transform
-      pos: 17.5,2.5
+      pos: 4.5,6.5
       parent: 2
   - uid: 323
     components:
     - type: Transform
-      pos: 15.5,6.5
+      pos: 4.5,5.5
       parent: 2
   - uid: 324
     components:
     - type: Transform
-      pos: 14.5,6.5
+      pos: 4.5,4.5
       parent: 2
   - uid: 325
     components:
     - type: Transform
-      pos: 16.5,0.5
+      pos: 3.5,4.5
       parent: 2
   - uid: 326
     components:
     - type: Transform
-      pos: 16.5,-0.5
+      pos: 2.5,4.5
       parent: 2
   - uid: 327
     components:
     - type: Transform
-      pos: 16.5,-1.5
+      pos: 1.5,4.5
       parent: 2
   - uid: 328
     components:
     - type: Transform
-      pos: 16.5,-2.5
+      pos: 5.5,4.5
       parent: 2
   - uid: 329
     components:
     - type: Transform
-      pos: 16.5,-3.5
+      pos: 6.5,4.5
       parent: 2
   - uid: 330
     components:
     - type: Transform
-      pos: 16.5,-4.5
+      pos: 7.5,4.5
       parent: 2
   - uid: 331
     components:
     - type: Transform
-      pos: 19.5,2.5
+      pos: 8.5,4.5
       parent: 2
   - uid: 332
     components:
     - type: Transform
-      pos: 17.5,-3.5
+      pos: 9.5,4.5
       parent: 2
   - uid: 333
     components:
     - type: Transform
-      pos: 18.5,-3.5
+      pos: 10.5,4.5
       parent: 2
   - uid: 334
     components:
     - type: Transform
-      pos: 15.5,-3.5
+      pos: 11.5,4.5
       parent: 2
   - uid: 335
     components:
     - type: Transform
-      pos: 15.5,0.5
+      pos: 12.5,4.5
       parent: 2
   - uid: 336
     components:
     - type: Transform
-      pos: 17.5,0.5
+      pos: 12.5,5.5
       parent: 2
   - uid: 337
     components:
     - type: Transform
-      pos: 18.5,0.5
+      pos: 13.5,5.5
       parent: 2
   - uid: 338
     components:
     - type: Transform
-      pos: 19.5,0.5
+      pos: 12.5,3.5
       parent: 2
   - uid: 339
     components:
     - type: Transform
-      pos: 20.5,1.5
+      pos: 13.5,3.5
       parent: 2
   - uid: 340
     components:
     - type: Transform
-      pos: 22.5,2.5
+      pos: 17.5,2.5
       parent: 2
   - uid: 341
     components:
     - type: Transform
-      pos: 22.5,1.5
+      pos: 15.5,6.5
       parent: 2
   - uid: 342
     components:
     - type: Transform
-      pos: 22.5,-0.5
+      pos: 14.5,6.5
       parent: 2
   - uid: 343
     components:
     - type: Transform
-      pos: 22.5,0.5
+      pos: 16.5,0.5
       parent: 2
   - uid: 344
     components:
     - type: Transform
-      pos: 21.5,-0.5
+      pos: 16.5,-0.5
       parent: 2
   - uid: 345
     components:
     - type: Transform
-      pos: 20.5,-0.5
+      pos: 16.5,-1.5
       parent: 2
   - uid: 346
     components:
     - type: Transform
-      pos: 22.5,-1.5
+      pos: 16.5,-2.5
       parent: 2
   - uid: 347
     components:
     - type: Transform
-      pos: 22.5,-2.5
+      pos: 16.5,-3.5
       parent: 2
   - uid: 348
     components:
     - type: Transform
-      pos: 22.5,-3.5
+      pos: 16.5,-4.5
       parent: 2
   - uid: 349
     components:
     - type: Transform
-      pos: 23.5,-3.5
+      pos: 19.5,2.5
       parent: 2
   - uid: 350
     components:
     - type: Transform
-      pos: 24.5,-3.5
+      pos: 17.5,-3.5
       parent: 2
   - uid: 351
     components:
     - type: Transform
-      pos: 25.5,-3.5
+      pos: 18.5,-3.5
       parent: 2
   - uid: 352
     components:
     - type: Transform
-      pos: 25.5,-4.5
+      pos: 15.5,-3.5
       parent: 2
   - uid: 353
     components:
     - type: Transform
-      pos: 24.5,-4.5
+      pos: 15.5,0.5
       parent: 2
   - uid: 354
     components:
     - type: Transform
-      pos: 26.5,-3.5
+      pos: 17.5,0.5
       parent: 2
   - uid: 355
     components:
     - type: Transform
-      pos: 26.5,-2.5
+      pos: 18.5,0.5
       parent: 2
   - uid: 356
     components:
     - type: Transform
-      pos: 23.5,0.5
+      pos: 19.5,0.5
       parent: 2
   - uid: 357
     components:
     - type: Transform
-      pos: 24.5,0.5
+      pos: 20.5,1.5
       parent: 2
   - uid: 358
     components:
     - type: Transform
-      pos: 25.5,0.5
+      pos: 22.5,2.5
       parent: 2
   - uid: 359
     components:
     - type: Transform
-      pos: 26.5,0.5
+      pos: 22.5,1.5
       parent: 2
   - uid: 360
     components:
     - type: Transform
-      pos: 27.5,0.5
+      pos: 22.5,-0.5
       parent: 2
   - uid: 361
     components:
     - type: Transform
-      pos: 27.5,-0.5
+      pos: 22.5,0.5
       parent: 2
   - uid: 362
     components:
     - type: Transform
-      pos: 27.5,1.5
+      pos: 21.5,-0.5
       parent: 2
   - uid: 363
     components:
     - type: Transform
-      pos: 27.5,2.5
+      pos: 20.5,-0.5
       parent: 2
   - uid: 364
     components:
     - type: Transform
-      pos: 26.5,4.5
+      pos: 22.5,-1.5
       parent: 2
   - uid: 365
     components:
     - type: Transform
-      pos: 23.5,4.5
+      pos: 22.5,-2.5
       parent: 2
   - uid: 366
     components:
     - type: Transform
-      pos: 22.5,4.5
+      pos: 22.5,-3.5
       parent: 2
   - uid: 367
     components:
     - type: Transform
-      pos: 22.5,3.5
+      pos: 23.5,-3.5
       parent: 2
   - uid: 368
     components:
     - type: Transform
-      pos: 19.5,3.5
+      pos: 24.5,-3.5
       parent: 2
   - uid: 369
     components:
     - type: Transform
-      pos: 19.5,4.5
+      pos: 25.5,-3.5
       parent: 2
   - uid: 370
     components:
     - type: Transform
-      pos: 19.5,5.5
+      pos: 25.5,-4.5
       parent: 2
   - uid: 371
     components:
     - type: Transform
-      pos: 8.5,17.5
+      pos: 24.5,-4.5
       parent: 2
   - uid: 372
     components:
     - type: Transform
-      pos: -0.5,13.5
+      pos: 26.5,-3.5
       parent: 2
   - uid: 373
     components:
     - type: Transform
-      pos: 0.5,13.5
+      pos: 26.5,-2.5
       parent: 2
   - uid: 374
     components:
     - type: Transform
-      pos: 1.5,13.5
+      pos: 23.5,0.5
       parent: 2
   - uid: 375
     components:
     - type: Transform
-      pos: 1.5,14.5
+      pos: 24.5,0.5
       parent: 2
   - uid: 376
     components:
     - type: Transform
-      pos: 1.5,15.5
+      pos: 25.5,0.5
       parent: 2
   - uid: 377
     components:
     - type: Transform
-      pos: 1.5,12.5
+      pos: 26.5,0.5
       parent: 2
   - uid: 378
     components:
     - type: Transform
-      pos: 1.5,11.5
+      pos: 27.5,0.5
       parent: 2
   - uid: 379
     components:
     - type: Transform
-      pos: 1.5,10.5
+      pos: 27.5,-0.5
       parent: 2
   - uid: 380
     components:
     - type: Transform
-      pos: 1.5,9.5
+      pos: 27.5,1.5
       parent: 2
   - uid: 381
     components:
     - type: Transform
-      pos: 1.5,8.5
+      pos: 27.5,2.5
       parent: 2
   - uid: 382
     components:
     - type: Transform
-      pos: 1.5,7.5
+      pos: 26.5,4.5
       parent: 2
   - uid: 383
     components:
     - type: Transform
-      pos: -2.5,6.5
+      pos: 23.5,4.5
       parent: 2
   - uid: 384
     components:
     - type: Transform
-      pos: -2.5,7.5
+      pos: 22.5,4.5
       parent: 2
   - uid: 385
     components:
     - type: Transform
-      pos: -2.5,8.5
+      pos: 22.5,3.5
       parent: 2
   - uid: 386
     components:
     - type: Transform
-      pos: -2.5,9.5
+      pos: 19.5,3.5
       parent: 2
   - uid: 387
     components:
     - type: Transform
-      pos: -2.5,10.5
+      pos: 19.5,4.5
       parent: 2
   - uid: 388
     components:
     - type: Transform
-      pos: -2.5,11.5
+      pos: 19.5,5.5
       parent: 2
   - uid: 389
     components:
     - type: Transform
-      pos: -1.5,11.5
+      pos: 8.5,17.5
       parent: 2
   - uid: 390
     components:
     - type: Transform
-      pos: -3.5,8.5
+      pos: -0.5,13.5
       parent: 2
   - uid: 391
     components:
     - type: Transform
-      pos: -4.5,8.5
+      pos: 0.5,13.5
       parent: 2
   - uid: 392
     components:
     - type: Transform
-      pos: -5.5,8.5
+      pos: 1.5,13.5
       parent: 2
   - uid: 393
     components:
     - type: Transform
-      pos: -4.5,9.5
+      pos: 1.5,14.5
       parent: 2
   - uid: 394
     components:
     - type: Transform
-      pos: -3.5,11.5
+      pos: 1.5,15.5
       parent: 2
   - uid: 395
     components:
     - type: Transform
-      pos: 9.5,17.5
+      pos: 1.5,12.5
       parent: 2
   - uid: 396
     components:
     - type: Transform
-      pos: 9.5,16.5
+      pos: 1.5,11.5
       parent: 2
   - uid: 397
     components:
     - type: Transform
-      pos: 9.5,15.5
+      pos: 1.5,10.5
       parent: 2
   - uid: 398
     components:
     - type: Transform
-      pos: 9.5,14.5
+      pos: 1.5,9.5
       parent: 2
   - uid: 399
     components:
     - type: Transform
-      pos: 9.5,13.5
+      pos: 1.5,8.5
       parent: 2
   - uid: 400
     components:
     - type: Transform
-      pos: 9.5,12.5
+      pos: 1.5,7.5
       parent: 2
   - uid: 401
     components:
     - type: Transform
-      pos: 9.5,11.5
+      pos: -2.5,6.5
       parent: 2
   - uid: 402
     components:
     - type: Transform
-      pos: 9.5,10.5
+      pos: -2.5,7.5
       parent: 2
   - uid: 403
     components:
     - type: Transform
-      pos: 9.5,9.5
+      pos: -2.5,8.5
       parent: 2
   - uid: 404
     components:
     - type: Transform
-      pos: 9.5,8.5
+      pos: -2.5,9.5
       parent: 2
   - uid: 405
     components:
     - type: Transform
-      pos: 9.5,7.5
+      pos: -2.5,10.5
       parent: 2
   - uid: 406
     components:
     - type: Transform
-      pos: 8.5,7.5
+      pos: -2.5,11.5
       parent: 2
   - uid: 407
     components:
     - type: Transform
-      pos: 7.5,7.5
+      pos: -1.5,11.5
       parent: 2
   - uid: 408
     components:
     - type: Transform
-      pos: -9.5,-4.5
+      pos: -3.5,8.5
       parent: 2
   - uid: 409
     components:
     - type: Transform
-      pos: 18.5,7.5
+      pos: -4.5,8.5
       parent: 2
   - uid: 410
     components:
     - type: Transform
-      pos: 6.5,16.5
+      pos: -5.5,8.5
       parent: 2
   - uid: 411
     components:
     - type: Transform
-      pos: 5.5,16.5
+      pos: -4.5,9.5
       parent: 2
   - uid: 412
     components:
     - type: Transform
-      pos: 6.5,15.5
+      pos: -3.5,11.5
       parent: 2
   - uid: 413
     components:
     - type: Transform
-      pos: 6.5,14.5
+      pos: 9.5,17.5
       parent: 2
   - uid: 414
     components:
     - type: Transform
-      pos: 6.5,13.5
+      pos: 9.5,16.5
       parent: 2
   - uid: 415
     components:
     - type: Transform
-      pos: 6.5,12.5
+      pos: 9.5,15.5
       parent: 2
   - uid: 416
     components:
     - type: Transform
-      pos: 6.5,11.5
+      pos: 9.5,14.5
       parent: 2
   - uid: 417
     components:
     - type: Transform
-      pos: 6.5,10.5
+      pos: 9.5,13.5
       parent: 2
   - uid: 418
     components:
     - type: Transform
-      pos: 6.5,9.5
+      pos: 9.5,12.5
       parent: 2
   - uid: 419
     components:
     - type: Transform
-      pos: 6.5,8.5
+      pos: 9.5,11.5
       parent: 2
   - uid: 420
     components:
     - type: Transform
-      pos: 6.5,7.5
+      pos: 9.5,10.5
       parent: 2
   - uid: 421
     components:
     - type: Transform
-      pos: 0.5,15.5
+      pos: 9.5,9.5
       parent: 2
   - uid: 422
     components:
     - type: Transform
-      pos: -0.5,15.5
+      pos: 9.5,8.5
       parent: 2
   - uid: 423
     components:
     - type: Transform
-      pos: -1.5,15.5
+      pos: 9.5,7.5
       parent: 2
   - uid: 424
     components:
     - type: Transform
-      pos: -2.5,15.5
+      pos: 8.5,7.5
       parent: 2
   - uid: 425
     components:
     - type: Transform
-      pos: 5.5,-7.5
+      pos: 7.5,7.5
       parent: 2
   - uid: 426
     components:
     - type: Transform
-      pos: -1.5,-15.5
+      pos: -9.5,-4.5
       parent: 2
   - uid: 427
     components:
     - type: Transform
-      pos: -16.5,-6.5
+      pos: 18.5,7.5
       parent: 2
   - uid: 428
     components:
     - type: Transform
-      pos: -18.5,-5.5
+      pos: 6.5,16.5
       parent: 2
   - uid: 429
     components:
     - type: Transform
-      pos: 15.5,2.5
+      pos: 5.5,16.5
       parent: 2
   - uid: 430
     components:
     - type: Transform
-      pos: -10.5,8.5
+      pos: 6.5,15.5
       parent: 2
   - uid: 431
     components:
     - type: Transform
-      pos: -7.5,7.5
+      pos: 6.5,14.5
       parent: 2
   - uid: 432
     components:
     - type: Transform
-      pos: -7.5,10.5
+      pos: 6.5,13.5
       parent: 2
   - uid: 433
     components:
     - type: Transform
-      pos: -7.5,9.5
+      pos: 6.5,12.5
       parent: 2
   - uid: 434
     components:
     - type: Transform
-      pos: -8.5,11.5
+      pos: 6.5,11.5
       parent: 2
   - uid: 435
     components:
     - type: Transform
-      pos: -10.5,11.5
+      pos: 6.5,10.5
       parent: 2
   - uid: 436
     components:
     - type: Transform
-      pos: -9.5,11.5
+      pos: 6.5,9.5
       parent: 2
   - uid: 437
     components:
     - type: Transform
-      pos: 0.5,-15.5
+      pos: 6.5,8.5
       parent: 2
   - uid: 438
     components:
     - type: Transform
-      pos: -3.5,-16.5
+      pos: 6.5,7.5
       parent: 2
   - uid: 439
     components:
     - type: Transform
-      pos: -3.5,-15.5
+      pos: 0.5,15.5
       parent: 2
   - uid: 440
     components:
     - type: Transform
-      pos: 0.5,-16.5
+      pos: -0.5,15.5
       parent: 2
   - uid: 441
     components:
     - type: Transform
-      pos: -7.5,1.5
+      pos: -1.5,15.5
       parent: 2
   - uid: 442
     components:
     - type: Transform
-      pos: -7.5,-8.5
+      pos: -2.5,15.5
       parent: 2
   - uid: 443
     components:
     - type: Transform
-      pos: -25.5,5.5
+      pos: 5.5,-7.5
       parent: 2
   - uid: 444
     components:
     - type: Transform
-      pos: 15.5,3.5
+      pos: -1.5,-15.5
       parent: 2
   - uid: 445
     components:
     - type: Transform
-      pos: 15.5,4.5
+      pos: -16.5,-6.5
       parent: 2
   - uid: 446
     components:
     - type: Transform
-      pos: 15.5,5.5
+      pos: -18.5,-5.5
       parent: 2
   - uid: 447
     components:
     - type: Transform
-      pos: -20.5,5.5
+      pos: 15.5,2.5
       parent: 2
   - uid: 448
     components:
     - type: Transform
-      pos: 12.5,14.5
+      pos: -10.5,8.5
       parent: 2
   - uid: 449
     components:
     - type: Transform
-      pos: 23.5,9.5
+      pos: -7.5,7.5
       parent: 2
   - uid: 450
     components:
     - type: Transform
-      pos: 10.5,13.5
+      pos: -7.5,10.5
       parent: 2
   - uid: 451
     components:
     - type: Transform
-      pos: 15.5,1.5
+      pos: -7.5,9.5
       parent: 2
   - uid: 452
     components:
     - type: Transform
-      pos: 23.5,8.5
+      pos: -8.5,11.5
       parent: 2
   - uid: 453
     components:
     - type: Transform
-      pos: -4.5,-12.5
+      pos: -10.5,11.5
       parent: 2
   - uid: 454
     components:
     - type: Transform
-      pos: -5.5,-9.5
+      pos: -9.5,11.5
       parent: 2
   - uid: 455
     components:
     - type: Transform
-      pos: -10.5,-7.5
+      pos: 0.5,-15.5
       parent: 2
   - uid: 456
     components:
     - type: Transform
-      pos: -9.5,-7.5
+      pos: -3.5,-16.5
       parent: 2
   - uid: 457
     components:
     - type: Transform
-      pos: -8.5,-7.5
+      pos: -3.5,-15.5
       parent: 2
   - uid: 458
     components:
     - type: Transform
-      pos: -0.5,-14.5
+      pos: 0.5,-16.5
       parent: 2
   - uid: 459
     components:
     - type: Transform
-      pos: -0.5,-15.5
+      pos: -7.5,1.5
       parent: 2
   - uid: 460
     components:
     - type: Transform
-      pos: 12.5,17.5
+      pos: -7.5,-8.5
       parent: 2
   - uid: 461
     components:
     - type: Transform
-      pos: 11.5,14.5
+      pos: -25.5,5.5
       parent: 2
   - uid: 462
     components:
     - type: Transform
-      pos: -4.5,-10.5
+      pos: 15.5,3.5
       parent: 2
   - uid: 463
     components:
     - type: Transform
-      pos: -0.5,-13.5
+      pos: 15.5,4.5
       parent: 2
   - uid: 464
     components:
     - type: Transform
-      pos: 10.5,14.5
+      pos: 15.5,5.5
       parent: 2
   - uid: 465
     components:
     - type: Transform
-      pos: -6.5,11.5
+      pos: -20.5,5.5
       parent: 2
   - uid: 466
     components:
     - type: Transform
-      pos: 24.5,7.5
+      pos: 12.5,14.5
       parent: 2
   - uid: 467
     components:
     - type: Transform
-      pos: 22.5,9.5
+      pos: 23.5,9.5
       parent: 2
   - uid: 468
     components:
     - type: Transform
-      pos: -20.5,8.5
+      pos: 10.5,13.5
       parent: 2
   - uid: 469
     components:
     - type: Transform
-      pos: -11.5,-7.5
+      pos: 15.5,1.5
       parent: 2
   - uid: 470
     components:
     - type: Transform
-      pos: 22.5,6.5
+      pos: 23.5,8.5
       parent: 2
   - uid: 471
     components:
     - type: Transform
-      pos: -7.5,8.5
+      pos: -4.5,-12.5
       parent: 2
   - uid: 472
     components:
     - type: Transform
-      pos: -8.5,8.5
+      pos: -5.5,-9.5
       parent: 2
   - uid: 473
     components:
     - type: Transform
-      pos: 12.5,9.5
+      pos: -10.5,-7.5
       parent: 2
   - uid: 474
     components:
     - type: Transform
-      pos: -20.5,7.5
+      pos: -9.5,-7.5
       parent: 2
   - uid: 475
     components:
     - type: Transform
-      pos: 24.5,8.5
+      pos: -8.5,-7.5
       parent: 2
   - uid: 476
     components:
     - type: Transform
-      pos: -18.5,-6.5
+      pos: -0.5,-14.5
       parent: 2
   - uid: 477
     components:
     - type: Transform
-      pos: -5.5,11.5
+      pos: -0.5,-15.5
       parent: 2
   - uid: 478
     components:
     - type: Transform
-      pos: -4.5,10.5
+      pos: 12.5,17.5
       parent: 2
   - uid: 479
     components:
     - type: Transform
-      pos: -13.5,8.5
+      pos: 11.5,14.5
       parent: 2
   - uid: 480
     components:
     - type: Transform
-      pos: 17.5,1.5
+      pos: -4.5,-10.5
       parent: 2
   - uid: 481
     components:
     - type: Transform
-      pos: 17.5,3.5
+      pos: -0.5,-13.5
       parent: 2
   - uid: 482
     components:
     - type: Transform
-      pos: 17.5,4.5
+      pos: 10.5,14.5
       parent: 2
   - uid: 483
     components:
     - type: Transform
-      pos: 17.5,5.5
+      pos: -6.5,11.5
       parent: 2
   - uid: 484
     components:
     - type: Transform
-      pos: 17.5,6.5
+      pos: 24.5,7.5
       parent: 2
   - uid: 485
     components:
     - type: Transform
-      pos: 17.5,7.5
+      pos: 22.5,9.5
       parent: 2
   - uid: 486
     components:
     - type: Transform
-      pos: 17.5,8.5
+      pos: -20.5,8.5
       parent: 2
   - uid: 487
     components:
     - type: Transform
-      pos: 17.5,9.5
+      pos: -11.5,-7.5
       parent: 2
   - uid: 488
     components:
     - type: Transform
-      pos: 16.5,9.5
+      pos: 22.5,6.5
       parent: 2
   - uid: 489
     components:
     - type: Transform
-      pos: 15.5,9.5
+      pos: -7.5,8.5
       parent: 2
   - uid: 490
     components:
     - type: Transform
-      pos: 14.5,9.5
+      pos: -8.5,8.5
       parent: 2
   - uid: 491
     components:
     - type: Transform
-      pos: 13.5,9.5
+      pos: 12.5,9.5
       parent: 2
   - uid: 492
     components:
     - type: Transform
-      pos: 18.5,5.5
+      pos: -20.5,7.5
       parent: 2
   - uid: 493
     components:
     - type: Transform
-      pos: 17.5,10.5
+      pos: 24.5,8.5
       parent: 2
   - uid: 494
     components:
     - type: Transform
-      pos: 17.5,11.5
+      pos: -18.5,-6.5
       parent: 2
   - uid: 495
     components:
     - type: Transform
-      pos: 16.5,11.5
+      pos: -5.5,11.5
       parent: 2
   - uid: 496
     components:
     - type: Transform
-      pos: 15.5,11.5
+      pos: -4.5,10.5
       parent: 2
   - uid: 497
     components:
     - type: Transform
-      pos: -1.5,-16.5
+      pos: -13.5,8.5
       parent: 2
   - uid: 498
     components:
     - type: Transform
-      pos: -2.5,-16.5
+      pos: 17.5,1.5
       parent: 2
   - uid: 499
     components:
     - type: Transform
-      pos: -26.5,-2.5
+      pos: 17.5,3.5
       parent: 2
   - uid: 500
     components:
     - type: Transform
-      pos: -25.5,-2.5
+      pos: 17.5,4.5
       parent: 2
   - uid: 501
     components:
     - type: Transform
-      pos: -25.5,-3.5
+      pos: 17.5,5.5
       parent: 2
   - uid: 502
     components:
     - type: Transform
-      pos: -25.5,-4.5
+      pos: 17.5,6.5
       parent: 2
   - uid: 503
     components:
     - type: Transform
-      pos: -24.5,-4.5
+      pos: 17.5,7.5
       parent: 2
   - uid: 504
     components:
     - type: Transform
-      pos: -23.5,-4.5
+      pos: 17.5,8.5
       parent: 2
   - uid: 505
     components:
     - type: Transform
-      pos: -22.5,-4.5
+      pos: 17.5,9.5
       parent: 2
   - uid: 506
     components:
     - type: Transform
-      pos: -21.5,-4.5
+      pos: 16.5,9.5
       parent: 2
   - uid: 507
     components:
     - type: Transform
-      pos: -21.5,-5.5
+      pos: 15.5,9.5
       parent: 2
   - uid: 508
     components:
     - type: Transform
-      pos: -27.5,-2.5
+      pos: 14.5,9.5
       parent: 2
   - uid: 509
     components:
     - type: Transform
-      pos: -28.5,-2.5
+      pos: 13.5,9.5
       parent: 2
   - uid: 510
     components:
     - type: Transform
-      pos: -29.5,-2.5
+      pos: 18.5,5.5
       parent: 2
   - uid: 511
     components:
     - type: Transform
-      pos: -29.5,-3.5
+      pos: 17.5,10.5
       parent: 2
   - uid: 512
     components:
     - type: Transform
-      pos: -30.5,-3.5
+      pos: 17.5,11.5
       parent: 2
   - uid: 513
     components:
     - type: Transform
-      pos: -30.5,-4.5
+      pos: 16.5,11.5
       parent: 2
   - uid: 514
     components:
     - type: Transform
-      pos: -31.5,-4.5
+      pos: 15.5,11.5
       parent: 2
   - uid: 515
     components:
     - type: Transform
-      pos: -29.5,-1.5
+      pos: -1.5,-16.5
       parent: 2
   - uid: 516
     components:
     - type: Transform
-      pos: -29.5,-0.5
+      pos: -2.5,-16.5
       parent: 2
   - uid: 517
     components:
     - type: Transform
-      pos: -29.5,0.5
+      pos: -26.5,-2.5
       parent: 2
   - uid: 518
     components:
     - type: Transform
-      pos: -29.5,1.5
+      pos: -25.5,-2.5
       parent: 2
   - uid: 519
     components:
     - type: Transform
-      pos: -29.5,2.5
+      pos: -25.5,-3.5
       parent: 2
   - uid: 520
     components:
     - type: Transform
-      pos: -29.5,3.5
+      pos: -25.5,-4.5
       parent: 2
   - uid: 521
     components:
     - type: Transform
-      pos: -29.5,4.5
+      pos: -24.5,-4.5
       parent: 2
   - uid: 522
     components:
     - type: Transform
-      pos: -30.5,4.5
+      pos: -23.5,-4.5
       parent: 2
   - uid: 523
     components:
     - type: Transform
-      pos: -30.5,5.5
+      pos: -22.5,-4.5
       parent: 2
   - uid: 524
     components:
     - type: Transform
-      pos: -31.5,5.5
+      pos: -21.5,-4.5
       parent: 2
   - uid: 525
     components:
     - type: Transform
-      pos: -28.5,3.5
+      pos: -21.5,-5.5
       parent: 2
   - uid: 526
     components:
     - type: Transform
-      pos: -27.5,3.5
+      pos: -27.5,-2.5
       parent: 2
   - uid: 527
     components:
     - type: Transform
-      pos: -26.5,3.5
+      pos: -28.5,-2.5
       parent: 2
   - uid: 528
     components:
     - type: Transform
-      pos: 25.5,7.5
+      pos: -29.5,-2.5
       parent: 2
   - uid: 529
     components:
     - type: Transform
-      pos: 25.5,6.5
+      pos: -29.5,-3.5
       parent: 2
   - uid: 530
     components:
     - type: Transform
-      pos: 25.5,5.5
+      pos: -30.5,-3.5
       parent: 2
   - uid: 531
     components:
     - type: Transform
-      pos: 26.5,5.5
+      pos: -30.5,-4.5
       parent: 2
   - uid: 532
     components:
     - type: Transform
-      pos: 24.5,4.5
+      pos: -31.5,-4.5
       parent: 2
   - uid: 533
     components:
     - type: Transform
-      pos: -6.5,8.5
+      pos: -29.5,-1.5
       parent: 2
   - uid: 534
     components:
     - type: Transform
-      pos: -9.5,8.5
+      pos: -29.5,-0.5
       parent: 2
   - uid: 535
     components:
     - type: Transform
-      pos: -9.5,9.5
+      pos: -29.5,0.5
       parent: 2
   - uid: 536
     components:
     - type: Transform
-      pos: -9.5,10.5
+      pos: -29.5,1.5
       parent: 2
   - uid: 537
     components:
     - type: Transform
-      pos: 4.5,-15.5
+      pos: -29.5,2.5
       parent: 2
   - uid: 538
     components:
     - type: Transform
-      pos: 3.5,-15.5
+      pos: -29.5,3.5
       parent: 2
   - uid: 539
     components:
     - type: Transform
-      pos: 3.5,-14.5
+      pos: -29.5,4.5
       parent: 2
   - uid: 540
     components:
     - type: Transform
-      pos: 11.5,-10.5
+      pos: -30.5,4.5
       parent: 2
   - uid: 541
     components:
     - type: Transform
-      pos: 12.5,-10.5
+      pos: -30.5,5.5
       parent: 2
   - uid: 542
     components:
     - type: Transform
-      pos: 10.5,-7.5
+      pos: -31.5,5.5
       parent: 2
   - uid: 543
     components:
     - type: Transform
-      pos: 24.5,5.5
+      pos: -28.5,3.5
       parent: 2
   - uid: 544
     components:
     - type: Transform
-      pos: 12.5,15.5
+      pos: -27.5,3.5
       parent: 2
   - uid: 545
     components:
     - type: Transform
-      pos: 8.5,15.5
+      pos: -26.5,3.5
       parent: 2
   - uid: 546
     components:
     - type: Transform
-      pos: 8.5,18.5
+      pos: 25.5,7.5
       parent: 2
   - uid: 547
     components:
     - type: Transform
-      pos: 8.5,19.5
+      pos: 25.5,6.5
       parent: 2
   - uid: 548
     components:
     - type: Transform
-      pos: 7.5,15.5
+      pos: 25.5,5.5
       parent: 2
   - uid: 549
     components:
     - type: Transform
-      pos: 6.5,18.5
+      pos: 26.5,5.5
       parent: 2
   - uid: 550
     components:
     - type: Transform
-      pos: 6.5,19.5
+      pos: 24.5,4.5
       parent: 2
   - uid: 551
     components:
     - type: Transform
-      pos: 6.5,17.5
+      pos: -6.5,8.5
       parent: 2
   - uid: 552
     components:
     - type: Transform
-      pos: 7.5,18.5
+      pos: -9.5,8.5
       parent: 2
   - uid: 553
     components:
     - type: Transform
-      pos: 0.5,17.5
+      pos: -9.5,9.5
       parent: 2
   - uid: 554
     components:
     - type: Transform
-      pos: 2.5,15.5
+      pos: -9.5,10.5
       parent: 2
   - uid: 555
     components:
     - type: Transform
-      pos: 2.5,16.5
+      pos: 4.5,-15.5
       parent: 2
   - uid: 556
     components:
     - type: Transform
-      pos: 2.5,17.5
+      pos: 3.5,-15.5
+      parent: 2
+  - uid: 557
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 2
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 11.5,-10.5
       parent: 2
   - uid: 559
     components:
     - type: Transform
-      pos: -5.5,12.5
+      pos: 12.5,-10.5
       parent: 2
   - uid: 560
     components:
     - type: Transform
-      pos: -18.5,-4.5
+      pos: 10.5,-7.5
       parent: 2
   - uid: 561
     components:
     - type: Transform
-      pos: -16.5,-4.5
+      pos: 24.5,5.5
       parent: 2
   - uid: 562
     components:
     - type: Transform
-      pos: -16.5,-5.5
+      pos: 12.5,15.5
       parent: 2
   - uid: 563
     components:
     - type: Transform
-      pos: -16.5,-7.5
+      pos: 8.5,15.5
       parent: 2
   - uid: 564
     components:
     - type: Transform
-      pos: -13.5,7.5
+      pos: 8.5,18.5
       parent: 2
   - uid: 565
     components:
     - type: Transform
-      pos: -14.5,8.5
+      pos: 8.5,19.5
       parent: 2
   - uid: 566
     components:
     - type: Transform
-      pos: -16.5,8.5
+      pos: 7.5,15.5
       parent: 2
   - uid: 567
     components:
     - type: Transform
-      pos: -5.5,-8.5
+      pos: 6.5,18.5
       parent: 2
   - uid: 568
     components:
     - type: Transform
-      pos: -18.5,-7.5
+      pos: 6.5,19.5
       parent: 2
   - uid: 569
     components:
     - type: Transform
-      pos: -20.5,-6.5
+      pos: 6.5,17.5
       parent: 2
   - uid: 570
     components:
     - type: Transform
-      pos: -20.5,-7.5
+      pos: 7.5,18.5
       parent: 2
   - uid: 571
     components:
     - type: Transform
-      pos: -18.5,7.5
+      pos: 0.5,17.5
       parent: 2
   - uid: 572
     components:
     - type: Transform
-      pos: 13.5,14.5
+      pos: 2.5,15.5
       parent: 2
   - uid: 573
     components:
     - type: Transform
-      pos: 14.5,14.5
+      pos: 2.5,16.5
       parent: 2
   - uid: 574
     components:
     - type: Transform
-      pos: 11.5,9.5
+      pos: 2.5,17.5
       parent: 2
   - uid: 575
     components:
     - type: Transform
-      pos: 11.5,10.5
+      pos: -5.5,12.5
       parent: 2
   - uid: 576
     components:
     - type: Transform
-      pos: 14.5,2.5
+      pos: -18.5,-4.5
       parent: 2
   - uid: 577
     components:
     - type: Transform
-      pos: 21.5,1.5
+      pos: -16.5,-4.5
       parent: 2
   - uid: 578
     components:
     - type: Transform
-      pos: 21.5,6.5
+      pos: -16.5,-5.5
       parent: 2
   - uid: 579
     components:
     - type: Transform
-      pos: 21.5,7.5
+      pos: -16.5,-7.5
       parent: 2
   - uid: 580
     components:
     - type: Transform
-      pos: 20.5,7.5
+      pos: -13.5,7.5
       parent: 2
   - uid: 581
     components:
     - type: Transform
-      pos: 17.5,-7.5
+      pos: -14.5,8.5
       parent: 2
   - uid: 582
     components:
     - type: Transform
-      pos: 17.5,-8.5
+      pos: -16.5,8.5
       parent: 2
   - uid: 583
     components:
     - type: Transform
-      pos: 18.5,-8.5
+      pos: -5.5,-8.5
       parent: 2
   - uid: 584
     components:
     - type: Transform
-      pos: 15.5,-7.5
+      pos: -18.5,-7.5
       parent: 2
   - uid: 585
     components:
     - type: Transform
-      pos: 13.5,-10.5
+      pos: -20.5,-6.5
       parent: 2
   - uid: 586
     components:
     - type: Transform
-      pos: 15.5,-11.5
+      pos: -20.5,-7.5
       parent: 2
   - uid: 587
     components:
     - type: Transform
-      pos: 14.5,-11.5
+      pos: -18.5,7.5
       parent: 2
   - uid: 588
     components:
     - type: Transform
-      pos: 13.5,-11.5
+      pos: 13.5,14.5
       parent: 2
   - uid: 589
     components:
     - type: Transform
-      pos: 15.5,-12.5
+      pos: 14.5,14.5
       parent: 2
   - uid: 590
     components:
     - type: Transform
-      pos: -16.5,5.5
+      pos: 11.5,9.5
       parent: 2
   - uid: 591
     components:
     - type: Transform
-      pos: 6.5,-7.5
+      pos: 11.5,10.5
       parent: 2
   - uid: 592
     components:
     - type: Transform
-      pos: 8.5,-7.5
+      pos: 14.5,2.5
       parent: 2
   - uid: 593
     components:
     - type: Transform
-      pos: 9.5,-7.5
+      pos: 21.5,1.5
       parent: 2
   - uid: 594
     components:
     - type: Transform
-      pos: 5.5,-6.5
+      pos: 21.5,6.5
       parent: 2
   - uid: 595
     components:
     - type: Transform
-      pos: 7.5,-7.5
+      pos: 21.5,7.5
       parent: 2
   - uid: 596
     components:
     - type: Transform
-      pos: 11.5,-7.5
+      pos: 20.5,7.5
       parent: 2
   - uid: 597
     components:
     - type: Transform
-      pos: 12.5,-7.5
+      pos: 17.5,-7.5
       parent: 2
   - uid: 598
     components:
     - type: Transform
-      pos: 13.5,-7.5
+      pos: 17.5,-8.5
       parent: 2
   - uid: 599
     components:
     - type: Transform
-      pos: 14.5,-7.5
+      pos: 18.5,-8.5
       parent: 2
   - uid: 600
     components:
     - type: Transform
-      pos: 16.5,-7.5
+      pos: 15.5,-7.5
       parent: 2
   - uid: 601
     components:
     - type: Transform
-      pos: -1.5,-12.5
+      pos: 13.5,-10.5
       parent: 2
   - uid: 602
     components:
     - type: Transform
-      pos: -3.5,-12.5
+      pos: 15.5,-11.5
       parent: 2
   - uid: 603
     components:
     - type: Transform
-      pos: -7.5,-9.5
+      pos: 14.5,-11.5
       parent: 2
   - uid: 604
     components:
     - type: Transform
-      pos: -4.5,-11.5
+      pos: 13.5,-11.5
       parent: 2
   - uid: 605
     components:
     - type: Transform
-      pos: -2.5,-12.5
+      pos: 15.5,-12.5
       parent: 2
   - uid: 606
     components:
     - type: Transform
-      pos: -4.5,-13.5
+      pos: -16.5,5.5
       parent: 2
   - uid: 607
     components:
     - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 608
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 2
+  - uid: 609
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 2
+  - uid: 610
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 2
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 612
+    components:
+    - type: Transform
+      pos: 11.5,-7.5
+      parent: 2
+  - uid: 613
+    components:
+    - type: Transform
+      pos: 12.5,-7.5
+      parent: 2
+  - uid: 614
+    components:
+    - type: Transform
+      pos: 13.5,-7.5
+      parent: 2
+  - uid: 615
+    components:
+    - type: Transform
+      pos: 14.5,-7.5
+      parent: 2
+  - uid: 616
+    components:
+    - type: Transform
+      pos: 16.5,-7.5
+      parent: 2
+  - uid: 617
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 618
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 2
+  - uid: 619
+    components:
+    - type: Transform
+      pos: -7.5,-9.5
+      parent: 2
+  - uid: 620
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 2
+  - uid: 621
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 2
+  - uid: 622
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 2
+  - uid: 623
+    components:
+    - type: Transform
       pos: -6.5,-9.5
       parent: 2
-  - uid: 957
+  - uid: 624
     components:
     - type: Transform
       pos: 12.5,18.5
       parent: 2
-  - uid: 978
+  - uid: 625
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 2
-  - uid: 1040
+  - uid: 626
     components:
     - type: Transform
       pos: 12.5,19.5
       parent: 2
-  - uid: 1041
+  - uid: 627
     components:
     - type: Transform
       pos: 13.5,19.5
       parent: 2
-  - uid: 1824
+  - uid: 628
     components:
     - type: Transform
       pos: 14.5,17.5
       parent: 2
-  - uid: 2863
+  - uid: 629
     components:
     - type: Transform
       pos: 13.5,18.5
       parent: 2
-  - uid: 2889
+  - uid: 630
     components:
     - type: Transform
       pos: 14.5,18.5
       parent: 2
-  - uid: 2978
+  - uid: 631
     components:
     - type: Transform
       pos: 8.5,-15.5
       parent: 2
-  - uid: 2979
+  - uid: 632
     components:
     - type: Transform
       pos: 9.5,-15.5
       parent: 2
-  - uid: 2980
+  - uid: 633
     components:
     - type: Transform
       pos: 10.5,-15.5
       parent: 2
-  - uid: 2981
+  - uid: 634
     components:
     - type: Transform
       pos: 7.5,-14.5
       parent: 2
-  - uid: 2982
+  - uid: 635
     components:
     - type: Transform
       pos: 7.5,-13.5
       parent: 2
-  - uid: 2983
+  - uid: 636
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 2
-  - uid: 2984
+  - uid: 637
     components:
     - type: Transform
       pos: 9.5,-13.5
       parent: 2
-  - uid: 2985
+  - uid: 638
     components:
     - type: Transform
       pos: 10.5,-13.5
       parent: 2
-  - uid: 3004
+  - uid: 639
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 2
-  - uid: 3005
+  - uid: 640
     components:
     - type: Transform
       pos: -16.5,10.5
       parent: 2
-  - uid: 3006
+  - uid: 641
     components:
     - type: Transform
       pos: -15.5,10.5
       parent: 2
-  - uid: 3007
+  - uid: 642
     components:
     - type: Transform
       pos: -14.5,10.5
       parent: 2
-  - uid: 3008
+  - uid: 643
     components:
     - type: Transform
       pos: -14.5,11.5
       parent: 2
-  - uid: 3009
+  - uid: 644
     components:
     - type: Transform
       pos: -13.5,11.5
       parent: 2
-  - uid: 3010
+  - uid: 645
     components:
     - type: Transform
       pos: -12.5,11.5
       parent: 2
-  - uid: 3011
+  - uid: 646
     components:
     - type: Transform
       pos: -12.5,12.5
       parent: 2
-  - uid: 3015
+  - uid: 647
     components:
     - type: Transform
       pos: -8.5,12.5
       parent: 2
-  - uid: 3016
+  - uid: 648
     components:
     - type: Transform
       pos: -8.5,13.5
       parent: 2
-  - uid: 3017
+  - uid: 649
     components:
     - type: Transform
       pos: -7.5,13.5
       parent: 2
-  - uid: 3018
+  - uid: 650
     components:
     - type: Transform
       pos: -6.5,13.5
       parent: 2
-  - uid: 3019
+  - uid: 651
     components:
     - type: Transform
       pos: -5.5,13.5
       parent: 2
-  - uid: 3021
+  - uid: 652
     components:
     - type: Transform
       pos: -3.5,15.5
       parent: 2
-  - uid: 3022
+  - uid: 653
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 2
-  - uid: 3023
+  - uid: 654
     components:
     - type: Transform
       pos: -3.5,17.5
       parent: 2
-  - uid: 3024
+  - uid: 655
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 2
-  - uid: 3025
+  - uid: 656
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 2
-  - uid: 3026
+  - uid: 657
     components:
     - type: Transform
       pos: -9.5,-6.5
       parent: 2
-  - uid: 3027
+  - uid: 658
     components:
     - type: Transform
       pos: -13.5,-3.5
       parent: 2
-  - uid: 3028
+  - uid: 659
     components:
     - type: Transform
       pos: -13.5,-4.5
       parent: 2
-  - uid: 3029
+  - uid: 660
     components:
     - type: Transform
       pos: -13.5,-5.5
       parent: 2
-  - uid: 3030
+  - uid: 661
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 2
-  - uid: 3031
+  - uid: 662
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 2
-  - uid: 3032
+  - uid: 663
     components:
     - type: Transform
       pos: -10.5,-3.5
       parent: 2
-  - uid: 3033
+  - uid: 664
     components:
     - type: Transform
       pos: -11.5,-3.5
       parent: 2
-  - uid: 3034
+  - uid: 665
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 2
 - proto: CableHV
   entities:
-  - uid: 608
+  - uid: 666
     components:
     - type: Transform
       pos: -22.5,-0.5
       parent: 2
-  - uid: 609
+  - uid: 667
     components:
     - type: Transform
       pos: -23.5,-0.5
       parent: 2
-  - uid: 610
+  - uid: 668
     components:
     - type: Transform
       pos: -23.5,0.5
       parent: 2
-  - uid: 611
+  - uid: 669
     components:
     - type: Transform
       pos: -23.5,1.5
       parent: 2
-  - uid: 612
+  - uid: 670
     components:
     - type: Transform
       pos: -22.5,1.5
       parent: 2
-  - uid: 613
+  - uid: 671
     components:
     - type: Transform
       pos: -22.5,0.5
       parent: 2
-  - uid: 614
+  - uid: 672
     components:
     - type: Transform
       pos: -22.5,2.5
       parent: 2
-  - uid: 615
+  - uid: 673
     components:
     - type: Transform
       pos: -22.5,3.5
       parent: 2
-  - uid: 616
+  - uid: 674
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 2
-  - uid: 617
+  - uid: 675
     components:
     - type: Transform
       pos: -20.5,3.5
       parent: 2
-  - uid: 618
+  - uid: 676
     components:
     - type: Transform
       pos: -20.5,0.5
       parent: 2
-  - uid: 619
+  - uid: 677
     components:
     - type: Transform
       pos: -19.5,0.5
       parent: 2
-  - uid: 620
+  - uid: 678
     components:
     - type: Transform
       pos: -18.5,0.5
       parent: 2
-  - uid: 621
+  - uid: 679
     components:
     - type: Transform
       pos: -18.5,-0.5
       parent: 2
-  - uid: 622
+  - uid: 680
     components:
     - type: Transform
       pos: -18.5,-1.5
       parent: 2
-  - uid: 623
+  - uid: 681
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 2
-  - uid: 624
+  - uid: 682
     components:
     - type: Transform
       pos: -18.5,-3.5
       parent: 2
-  - uid: 625
+  - uid: 683
     components:
     - type: Transform
       pos: -17.5,0.5
       parent: 2
-  - uid: 626
+  - uid: 684
     components:
     - type: Transform
       pos: -16.5,0.5
       parent: 2
-  - uid: 627
+  - uid: 685
     components:
     - type: Transform
       pos: -15.5,0.5
       parent: 2
-  - uid: 628
+  - uid: 686
     components:
     - type: Transform
       pos: -14.5,0.5
       parent: 2
-  - uid: 629
+  - uid: 687
     components:
     - type: Transform
       pos: -13.5,0.5
       parent: 2
-  - uid: 630
+  - uid: 688
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 2
-  - uid: 631
+  - uid: 689
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 2
-  - uid: 632
+  - uid: 690
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 2
-  - uid: 633
+  - uid: 691
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 2
-  - uid: 634
+  - uid: 692
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 2
-  - uid: 635
+  - uid: 693
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 2
-  - uid: 636
+  - uid: 694
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 2
-  - uid: 637
+  - uid: 695
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 2
-  - uid: 638
+  - uid: 696
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 2
-  - uid: 639
+  - uid: 697
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 2
-  - uid: 640
+  - uid: 698
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
-  - uid: 641
+  - uid: 699
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 2
-  - uid: 642
+  - uid: 700
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
-  - uid: 643
+  - uid: 701
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 644
+  - uid: 702
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 645
+  - uid: 703
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 2
-  - uid: 646
+  - uid: 704
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 2
-  - uid: 647
+  - uid: 705
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
-  - uid: 648
+  - uid: 706
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 2
-  - uid: 649
+  - uid: 707
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 650
+  - uid: 708
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
-  - uid: 651
+  - uid: 709
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
-  - uid: 652
+  - uid: 710
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 2
-  - uid: 653
-    components:
-    - type: Transform
-      pos: -6.5,7.5
-      parent: 2
-  - uid: 654
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 2
-  - uid: 655
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 2
-  - uid: 656
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 2
-  - uid: 657
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 2
-  - uid: 658
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 2
-  - uid: 659
-    components:
-    - type: Transform
-      pos: -1.5,-5.5
-      parent: 2
-  - uid: 660
-    components:
-    - type: Transform
-      pos: -1.5,-6.5
-      parent: 2
-  - uid: 661
-    components:
-    - type: Transform
-      pos: -0.5,-6.5
-      parent: 2
-  - uid: 662
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 2
-  - uid: 663
-    components:
-    - type: Transform
-      pos: 1.5,-6.5
-      parent: 2
-  - uid: 664
-    components:
-    - type: Transform
-      pos: 2.5,-6.5
-      parent: 2
-  - uid: 665
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 2
-  - uid: 666
-    components:
-    - type: Transform
-      pos: 2.5,-8.5
-      parent: 2
-  - uid: 667
-    components:
-    - type: Transform
-      pos: 2.5,-9.5
-      parent: 2
-  - uid: 668
-    components:
-    - type: Transform
-      pos: -0.5,5.5
-      parent: 2
-  - uid: 669
-    components:
-    - type: Transform
-      pos: 0.5,5.5
-      parent: 2
-  - uid: 670
-    components:
-    - type: Transform
-      pos: 1.5,5.5
-      parent: 2
-  - uid: 671
-    components:
-    - type: Transform
-      pos: 2.5,5.5
-      parent: 2
-  - uid: 672
-    components:
-    - type: Transform
-      pos: 3.5,5.5
-      parent: 2
-  - uid: 673
-    components:
-    - type: Transform
-      pos: 4.5,5.5
-      parent: 2
-  - uid: 674
-    components:
-    - type: Transform
-      pos: 5.5,5.5
-      parent: 2
-  - uid: 675
-    components:
-    - type: Transform
-      pos: 6.5,5.5
-      parent: 2
-  - uid: 676
-    components:
-    - type: Transform
-      pos: 7.5,5.5
-      parent: 2
-  - uid: 677
-    components:
-    - type: Transform
-      pos: 8.5,5.5
-      parent: 2
-  - uid: 678
-    components:
-    - type: Transform
-      pos: 8.5,6.5
-      parent: 2
-  - uid: 679
-    components:
-    - type: Transform
-      pos: 8.5,7.5
-      parent: 2
-  - uid: 680
-    components:
-    - type: Transform
-      pos: 9.5,7.5
-      parent: 2
-  - uid: 681
-    components:
-    - type: Transform
-      pos: 10.5,7.5
-      parent: 2
-  - uid: 682
-    components:
-    - type: Transform
-      pos: 11.5,7.5
-      parent: 2
-  - uid: 683
-    components:
-    - type: Transform
-      pos: 8.5,4.5
-      parent: 2
-  - uid: 684
-    components:
-    - type: Transform
-      pos: 9.5,4.5
-      parent: 2
-  - uid: 685
-    components:
-    - type: Transform
-      pos: 10.5,4.5
-      parent: 2
-  - uid: 686
-    components:
-    - type: Transform
-      pos: 11.5,4.5
-      parent: 2
-  - uid: 687
-    components:
-    - type: Transform
-      pos: 12.5,4.5
-      parent: 2
-  - uid: 688
-    components:
-    - type: Transform
-      pos: 13.5,4.5
-      parent: 2
-  - uid: 689
-    components:
-    - type: Transform
-      pos: 14.5,4.5
-      parent: 2
-  - uid: 690
-    components:
-    - type: Transform
-      pos: 15.5,4.5
-      parent: 2
-  - uid: 691
-    components:
-    - type: Transform
-      pos: 16.5,0.5
-      parent: 2
-  - uid: 692
-    components:
-    - type: Transform
-      pos: 17.5,0.5
-      parent: 2
-  - uid: 693
-    components:
-    - type: Transform
-      pos: 18.5,0.5
-      parent: 2
-  - uid: 694
-    components:
-    - type: Transform
-      pos: 19.5,0.5
-      parent: 2
-  - uid: 695
-    components:
-    - type: Transform
-      pos: 20.5,0.5
-      parent: 2
-  - uid: 696
-    components:
-    - type: Transform
-      pos: 21.5,0.5
-      parent: 2
-  - uid: 697
-    components:
-    - type: Transform
-      pos: 21.5,1.5
-      parent: 2
-  - uid: 698
-    components:
-    - type: Transform
-      pos: 21.5,2.5
-      parent: 2
-  - uid: 699
-    components:
-    - type: Transform
-      pos: 21.5,3.5
-      parent: 2
-  - uid: 700
-    components:
-    - type: Transform
-      pos: 21.5,4.5
-      parent: 2
-  - uid: 701
-    components:
-    - type: Transform
-      pos: 15.5,0.5
-      parent: 2
-  - uid: 702
-    components:
-    - type: Transform
-      pos: 3.5,-6.5
-      parent: 2
-  - uid: 703
-    components:
-    - type: Transform
-      pos: -6.5,7.5
-      parent: 2
-  - uid: 704
-    components:
-    - type: Transform
-      pos: -23.5,-1.5
-      parent: 2
-  - uid: 705
-    components:
-    - type: Transform
-      pos: -20.5,1.5
-      parent: 2
-  - uid: 706
-    components:
-    - type: Transform
-      pos: -23.5,-2.5
-      parent: 2
-  - uid: 707
-    components:
-    - type: Transform
-      pos: -18.5,-4.5
-      parent: 2
-  - uid: 708
-    components:
-    - type: Transform
-      pos: -20.5,2.5
-      parent: 2
-  - uid: 709
-    components:
-    - type: Transform
-      pos: -19.5,-4.5
-      parent: 2
-  - uid: 710
-    components:
-    - type: Transform
-      pos: 15.5,1.5
-      parent: 2
   - uid: 711
     components:
     - type: Transform
-      pos: 15.5,2.5
+      pos: -6.5,7.5
       parent: 2
   - uid: 712
     components:
     - type: Transform
-      pos: 15.5,3.5
+      pos: -1.5,-0.5
       parent: 2
   - uid: 713
     components:
     - type: Transform
-      pos: 21.5,5.5
+      pos: -1.5,-1.5
       parent: 2
   - uid: 714
     components:
     - type: Transform
-      pos: 21.5,6.5
+      pos: -1.5,-2.5
       parent: 2
   - uid: 715
     components:
     - type: Transform
-      pos: 21.5,7.5
+      pos: -1.5,-3.5
       parent: 2
   - uid: 716
     components:
     - type: Transform
-      pos: 21.5,8.5
+      pos: -1.5,-4.5
       parent: 2
   - uid: 717
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 718
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 2
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 720
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 721
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+  - uid: 722
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 723
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 724
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 2
+  - uid: 725
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 2
+  - uid: 726
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 2
+  - uid: 727
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 728
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 2
+  - uid: 729
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 2
+  - uid: 730
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 731
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 2
+  - uid: 732
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 2
+  - uid: 733
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 734
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 735
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 8.5,6.5
+      parent: 2
+  - uid: 737
+    components:
+    - type: Transform
+      pos: 8.5,7.5
+      parent: 2
+  - uid: 738
+    components:
+    - type: Transform
+      pos: 9.5,7.5
+      parent: 2
+  - uid: 739
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 2
+  - uid: 740
+    components:
+    - type: Transform
+      pos: 11.5,7.5
+      parent: 2
+  - uid: 741
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 2
+  - uid: 742
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 2
+  - uid: 743
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 2
+  - uid: 744
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 2
+  - uid: 745
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 2
+  - uid: 746
+    components:
+    - type: Transform
+      pos: 13.5,4.5
+      parent: 2
+  - uid: 747
+    components:
+    - type: Transform
+      pos: 14.5,4.5
+      parent: 2
+  - uid: 748
+    components:
+    - type: Transform
+      pos: 15.5,4.5
+      parent: 2
+  - uid: 749
+    components:
+    - type: Transform
+      pos: 16.5,0.5
+      parent: 2
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 17.5,0.5
+      parent: 2
+  - uid: 751
+    components:
+    - type: Transform
+      pos: 18.5,0.5
+      parent: 2
+  - uid: 752
+    components:
+    - type: Transform
+      pos: 19.5,0.5
+      parent: 2
+  - uid: 753
+    components:
+    - type: Transform
+      pos: 20.5,0.5
+      parent: 2
+  - uid: 754
+    components:
+    - type: Transform
+      pos: 21.5,0.5
+      parent: 2
+  - uid: 755
+    components:
+    - type: Transform
+      pos: 21.5,1.5
+      parent: 2
+  - uid: 756
+    components:
+    - type: Transform
+      pos: 21.5,2.5
+      parent: 2
+  - uid: 757
+    components:
+    - type: Transform
+      pos: 21.5,3.5
+      parent: 2
+  - uid: 758
+    components:
+    - type: Transform
+      pos: 21.5,4.5
+      parent: 2
+  - uid: 759
+    components:
+    - type: Transform
+      pos: 15.5,0.5
+      parent: 2
+  - uid: 760
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 2
+  - uid: 761
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 2
+  - uid: 762
+    components:
+    - type: Transform
+      pos: -23.5,-1.5
+      parent: 2
+  - uid: 763
+    components:
+    - type: Transform
+      pos: -20.5,1.5
+      parent: 2
+  - uid: 764
+    components:
+    - type: Transform
+      pos: -23.5,-2.5
+      parent: 2
+  - uid: 765
+    components:
+    - type: Transform
+      pos: -18.5,-4.5
+      parent: 2
+  - uid: 766
+    components:
+    - type: Transform
+      pos: -20.5,2.5
+      parent: 2
+  - uid: 767
+    components:
+    - type: Transform
+      pos: -19.5,-4.5
+      parent: 2
+  - uid: 768
+    components:
+    - type: Transform
+      pos: 15.5,1.5
+      parent: 2
+  - uid: 769
+    components:
+    - type: Transform
+      pos: 15.5,2.5
+      parent: 2
+  - uid: 770
+    components:
+    - type: Transform
+      pos: 15.5,3.5
+      parent: 2
+  - uid: 771
+    components:
+    - type: Transform
+      pos: 21.5,5.5
+      parent: 2
+  - uid: 772
+    components:
+    - type: Transform
+      pos: 21.5,6.5
+      parent: 2
+  - uid: 773
+    components:
+    - type: Transform
+      pos: 21.5,7.5
+      parent: 2
+  - uid: 774
+    components:
+    - type: Transform
+      pos: 21.5,8.5
+      parent: 2
+  - uid: 775
     components:
     - type: Transform
       pos: 22.5,8.5
       parent: 2
 - proto: CableMV
   entities:
-  - uid: 718
+  - uid: 776
     components:
     - type: Transform
       pos: -7.5,1.5
       parent: 2
-  - uid: 719
+  - uid: 777
     components:
     - type: Transform
       pos: 11.5,7.5
       parent: 2
-  - uid: 720
+  - uid: 778
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 2
-  - uid: 721
+  - uid: 779
     components:
     - type: Transform
       pos: -20.5,3.5
       parent: 2
-  - uid: 722
+  - uid: 780
     components:
     - type: Transform
       pos: -18.5,3.5
       parent: 2
-  - uid: 723
+  - uid: 781
     components:
     - type: Transform
       pos: -18.5,4.5
       parent: 2
-  - uid: 724
+  - uid: 782
     components:
     - type: Transform
       pos: -18.5,5.5
       parent: 2
-  - uid: 725
+  - uid: 783
     components:
     - type: Transform
       pos: -18.5,2.5
       parent: 2
-  - uid: 726
+  - uid: 784
     components:
     - type: Transform
       pos: -18.5,0.5
       parent: 2
-  - uid: 727
+  - uid: 785
     components:
     - type: Transform
       pos: -18.5,-0.5
       parent: 2
-  - uid: 728
+  - uid: 786
     components:
     - type: Transform
       pos: -18.5,-1.5
       parent: 2
-  - uid: 729
+  - uid: 787
     components:
     - type: Transform
       pos: -19.5,-1.5
       parent: 2
-  - uid: 730
+  - uid: 788
     components:
     - type: Transform
       pos: -20.5,2.5
       parent: 2
-  - uid: 731
+  - uid: 789
     components:
     - type: Transform
       pos: -20.5,1.5
       parent: 2
-  - uid: 732
+  - uid: 790
     components:
     - type: Transform
       pos: -20.5,0.5
       parent: 2
-  - uid: 733
+  - uid: 791
     components:
     - type: Transform
       pos: -21.5,0.5
       parent: 2
-  - uid: 734
+  - uid: 792
     components:
     - type: Transform
       pos: -22.5,0.5
       parent: 2
-  - uid: 735
+  - uid: 793
     components:
     - type: Transform
       pos: -23.5,0.5
       parent: 2
-  - uid: 736
+  - uid: 794
     components:
     - type: Transform
       pos: -24.5,0.5
       parent: 2
-  - uid: 737
+  - uid: 795
     components:
     - type: Transform
       pos: -24.5,-0.5
       parent: 2
-  - uid: 738
+  - uid: 796
     components:
     - type: Transform
       pos: -24.5,-1.5
       parent: 2
-  - uid: 739
+  - uid: 797
     components:
     - type: Transform
       pos: -24.5,1.5
       parent: 2
-  - uid: 740
+  - uid: 798
     components:
     - type: Transform
       pos: -24.5,2.5
       parent: 2
-  - uid: 741
+  - uid: 799
     components:
     - type: Transform
       pos: -19.5,0.5
       parent: 2
-  - uid: 742
+  - uid: 800
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 2
-  - uid: 743
+  - uid: 801
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 2
-  - uid: 744
+  - uid: 802
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 2
-  - uid: 745
+  - uid: 803
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 2
-  - uid: 746
+  - uid: 804
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 2
-  - uid: 747
+  - uid: 805
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 2
-  - uid: 748
+  - uid: 806
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
-  - uid: 749
+  - uid: 807
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 2
-  - uid: 750
+  - uid: 808
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
-  - uid: 751
+  - uid: 809
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 752
+  - uid: 810
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 753
+  - uid: 811
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 2
-  - uid: 754
+  - uid: 812
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 2
-  - uid: 755
+  - uid: 813
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
-  - uid: 756
+  - uid: 814
     components:
     - type: Transform
       pos: -18.5,1.5
       parent: 2
-  - uid: 757
+  - uid: 815
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 758
+  - uid: 816
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 2
-  - uid: 759
+  - uid: 817
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
-  - uid: 760
+  - uid: 818
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
-  - uid: 761
+  - uid: 819
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 2
-  - uid: 762
+  - uid: 820
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 2
-  - uid: 763
+  - uid: 821
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 2
-  - uid: 764
+  - uid: 822
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 2
-  - uid: 765
+  - uid: 823
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 2
-  - uid: 766
+  - uid: 824
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 2
-  - uid: 767
+  - uid: 825
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 2
-  - uid: 768
+  - uid: 826
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 2
-  - uid: 769
+  - uid: 827
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 2
-  - uid: 770
+  - uid: 828
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 2
-  - uid: 771
+  - uid: 829
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 2
-  - uid: 772
+  - uid: 830
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 2
-  - uid: 773
+  - uid: 831
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 2
-  - uid: 774
+  - uid: 832
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 2
-  - uid: 775
+  - uid: 833
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 2
-  - uid: 776
+  - uid: 834
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 2
-  - uid: 777
+  - uid: 835
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 2
-  - uid: 778
+  - uid: 836
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 2
-  - uid: 779
+  - uid: 837
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 2
-  - uid: 780
+  - uid: 838
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 2
-  - uid: 781
+  - uid: 839
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 2
-  - uid: 782
+  - uid: 840
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
-  - uid: 783
+  - uid: 841
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 2
-  - uid: 784
+  - uid: 842
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 2
-  - uid: 785
+  - uid: 843
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 2
-  - uid: 786
+  - uid: 844
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 2
-  - uid: 787
+  - uid: 845
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 2
-  - uid: 788
+  - uid: 846
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 2
-  - uid: 789
+  - uid: 847
     components:
     - type: Transform
       pos: 10.5,7.5
       parent: 2
-  - uid: 790
+  - uid: 848
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 2
-  - uid: 791
+  - uid: 849
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 2
-  - uid: 792
+  - uid: 850
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 2
-  - uid: 793
+  - uid: 851
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 2
-  - uid: 794
+  - uid: 852
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 2
-  - uid: 795
+  - uid: 853
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 2
-  - uid: 796
+  - uid: 854
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 2
-  - uid: 797
+  - uid: 855
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 2
-  - uid: 798
+  - uid: 856
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 2
-  - uid: 799
+  - uid: 857
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 2
-  - uid: 800
+  - uid: 858
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 2
-  - uid: 801
+  - uid: 859
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 2
-  - uid: 802
+  - uid: 860
     components:
     - type: Transform
       pos: 7.5,11.5
       parent: 2
-  - uid: 803
+  - uid: 861
     components:
     - type: Transform
       pos: 7.5,12.5
       parent: 2
-  - uid: 804
+  - uid: 862
     components:
     - type: Transform
       pos: 7.5,13.5
       parent: 2
-  - uid: 805
+  - uid: 863
     components:
     - type: Transform
       pos: 7.5,14.5
       parent: 2
-  - uid: 806
+  - uid: 864
     components:
     - type: Transform
       pos: 7.5,15.5
       parent: 2
-  - uid: 807
+  - uid: 865
     components:
     - type: Transform
       pos: 7.5,16.5
       parent: 2
-  - uid: 808
+  - uid: 866
     components:
     - type: Transform
       pos: 8.5,16.5
       parent: 2
-  - uid: 809
+  - uid: 867
     components:
     - type: Transform
       pos: 9.5,16.5
       parent: 2
-  - uid: 810
+  - uid: 868
     components:
     - type: Transform
       pos: 9.5,17.5
       parent: 2
-  - uid: 811
+  - uid: 869
     components:
     - type: Transform
       pos: 21.5,4.5
       parent: 2
-  - uid: 812
+  - uid: 870
     components:
     - type: Transform
       pos: 21.5,3.5
       parent: 2
-  - uid: 813
+  - uid: 871
     components:
     - type: Transform
       pos: 21.5,2.5
       parent: 2
-  - uid: 814
+  - uid: 872
     components:
     - type: Transform
       pos: 21.5,1.5
       parent: 2
-  - uid: 815
+  - uid: 873
     components:
     - type: Transform
       pos: 21.5,0.5
       parent: 2
-  - uid: 816
+  - uid: 874
     components:
     - type: Transform
       pos: 20.5,0.5
       parent: 2
-  - uid: 817
+  - uid: 875
     components:
     - type: Transform
       pos: 19.5,0.5
       parent: 2
-  - uid: 818
+  - uid: 876
     components:
     - type: Transform
       pos: 17.5,0.5
       parent: 2
-  - uid: 819
+  - uid: 877
     components:
     - type: Transform
       pos: 17.5,1.5
       parent: 2
-  - uid: 820
+  - uid: 878
     components:
     - type: Transform
       pos: 17.5,2.5
       parent: 2
-  - uid: 821
+  - uid: 879
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 2
-  - uid: 822
+  - uid: 880
     components:
     - type: Transform
       pos: -18.5,-3.5
       parent: 2
-  - uid: 823
+  - uid: 881
     components:
     - type: Transform
       pos: 18.5,0.5
       parent: 2
-  - uid: 824
+  - uid: 882
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
-  - uid: 825
+  - uid: 883
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
-  - uid: 826
+  - uid: 884
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 2
-  - uid: 827
+  - uid: 885
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 2
-  - uid: 828
+  - uid: 886
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 2
-  - uid: 829
+  - uid: 887
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 2
-  - uid: 830
+  - uid: 888
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 2
-  - uid: 831
+  - uid: 889
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
-  - uid: 832
+  - uid: 890
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 2
-  - uid: 833
+  - uid: 891
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 2
-  - uid: 834
+  - uid: 892
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 2
-  - uid: 835
+  - uid: 893
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 2
-  - uid: 836
+  - uid: 894
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 837
+  - uid: 895
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
-  - uid: 838
+  - uid: 896
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 2
-  - uid: 839
+  - uid: 897
     components:
     - type: Transform
       pos: 21.5,5.5
       parent: 2
-  - uid: 840
+  - uid: 898
     components:
     - type: Transform
       pos: 21.5,6.5
       parent: 2
-  - uid: 841
+  - uid: 899
     components:
     - type: Transform
       pos: 21.5,7.5
       parent: 2
-  - uid: 842
+  - uid: 900
     components:
     - type: Transform
       pos: 21.5,8.5
       parent: 2
-  - uid: 843
+  - uid: 901
     components:
     - type: Transform
       pos: 20.5,7.5
       parent: 2
 - proto: CableTerminal
   entities:
-  - uid: 844
+  - uid: 902
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6504,1217 +6516,1217 @@ entities:
       parent: 2
 - proto: CargoMailTeleporter
   entities:
-  - uid: 845
+  - uid: 903
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 2
 - proto: Carpet
   entities:
-  - uid: 846
+  - uid: 904
     components:
     - type: Transform
       pos: 16.5,-3.5
       parent: 2
-  - uid: 847
+  - uid: 905
     components:
     - type: Transform
       pos: 15.5,-3.5
       parent: 2
-  - uid: 848
+  - uid: 906
     components:
     - type: Transform
       pos: 17.5,-3.5
       parent: 2
-  - uid: 849
+  - uid: 907
     components:
     - type: Transform
       pos: 18.5,-3.5
       parent: 2
-  - uid: 850
+  - uid: 908
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 851
+  - uid: 909
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 2
-  - uid: 852
+  - uid: 910
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 2
-  - uid: 853
+  - uid: 911
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 2
-  - uid: 854
+  - uid: 912
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 2
-  - uid: 855
+  - uid: 913
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 2
-  - uid: 856
+  - uid: 914
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
-  - uid: 857
+  - uid: 915
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 2
-  - uid: 858
+  - uid: 916
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 2
 - proto: CarpetBlue
   entities:
-  - uid: 859
+  - uid: 917
     components:
     - type: Transform
       pos: 22.5,-3.5
       parent: 2
-  - uid: 860
+  - uid: 918
     components:
     - type: Transform
       pos: 23.5,-3.5
       parent: 2
-  - uid: 861
+  - uid: 919
     components:
     - type: Transform
       pos: 24.5,-3.5
       parent: 2
 - proto: CarpetPurple
   entities:
-  - uid: 862
+  - uid: 920
     components:
     - type: Transform
       pos: -11.5,-4.5
       parent: 2
-  - uid: 863
+  - uid: 921
     components:
     - type: Transform
       pos: -11.5,-3.5
       parent: 2
-  - uid: 864
+  - uid: 922
     components:
     - type: Transform
       pos: -10.5,-4.5
       parent: 2
-  - uid: 865
+  - uid: 923
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 2
-  - uid: 866
+  - uid: 924
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 2
-  - uid: 867
+  - uid: 925
     components:
     - type: Transform
       pos: -9.5,-5.5
       parent: 2
-  - uid: 868
+  - uid: 926
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 2
-  - uid: 869
+  - uid: 927
     components:
     - type: Transform
       pos: -13.5,-2.5
       parent: 2
-  - uid: 870
+  - uid: 928
     components:
     - type: Transform
       pos: -13.5,-4.5
       parent: 2
-  - uid: 871
+  - uid: 929
     components:
     - type: Transform
       pos: -13.5,-3.5
       parent: 2
-  - uid: 872
+  - uid: 930
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 2
-  - uid: 873
+  - uid: 931
     components:
     - type: Transform
       pos: -9.5,-4.5
       parent: 2
-  - uid: 874
+  - uid: 932
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 2
-  - uid: 875
+  - uid: 933
     components:
     - type: Transform
       pos: -11.5,-5.5
       parent: 2
-  - uid: 876
+  - uid: 934
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 2
-  - uid: 877
+  - uid: 935
     components:
     - type: Transform
       pos: -13.5,-5.5
       parent: 2
-  - uid: 878
+  - uid: 936
     components:
     - type: Transform
       pos: -10.5,-5.5
       parent: 2
-  - uid: 879
+  - uid: 937
     components:
     - type: Transform
       pos: -10.5,-3.5
       parent: 2
-  - uid: 880
+  - uid: 938
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 2
-  - uid: 881
+  - uid: 939
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 2
 - proto: CarpetSBlue
   entities:
-  - uid: 882
+  - uid: 940
     components:
     - type: Transform
       pos: 7.5,16.5
       parent: 2
-  - uid: 883
+  - uid: 941
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 2
-  - uid: 884
+  - uid: 942
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 2
-  - uid: 885
+  - uid: 943
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 2
-  - uid: 886
+  - uid: 944
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 2
-  - uid: 887
+  - uid: 945
     components:
     - type: Transform
       pos: 7.5,11.5
       parent: 2
-  - uid: 888
+  - uid: 946
     components:
     - type: Transform
       pos: 7.5,12.5
       parent: 2
-  - uid: 889
+  - uid: 947
     components:
     - type: Transform
       pos: 7.5,13.5
       parent: 2
-  - uid: 890
+  - uid: 948
     components:
     - type: Transform
       pos: 7.5,14.5
       parent: 2
-  - uid: 891
+  - uid: 949
     components:
     - type: Transform
       pos: 7.5,15.5
       parent: 2
-  - uid: 892
+  - uid: 950
     components:
     - type: Transform
       pos: 8.5,16.5
       parent: 2
-  - uid: 893
+  - uid: 951
     components:
     - type: Transform
       pos: 6.5,16.5
       parent: 2
-  - uid: 894
+  - uid: 952
     components:
     - type: Transform
       pos: 6.5,14.5
       parent: 2
-  - uid: 895
+  - uid: 953
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 2
-  - uid: 896
+  - uid: 954
     components:
     - type: Transform
       pos: 8.5,12.5
       parent: 2
-  - uid: 897
+  - uid: 955
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 2
-  - uid: 898
+  - uid: 956
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 2
-  - uid: 899
+  - uid: 957
     components:
     - type: Transform
       pos: 8.5,10.5
       parent: 2
-  - uid: 900
+  - uid: 958
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 2
-  - uid: 901
+  - uid: 959
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 2
 - proto: Catwalk
   entities:
-  - uid: 87
+  - uid: 960
     components:
     - type: Transform
       pos: 12.5,16.5
       parent: 2
-  - uid: 902
+  - uid: 961
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,7.5
       parent: 2
-  - uid: 903
+  - uid: 962
     components:
     - type: Transform
       pos: -25.5,4.5
       parent: 2
-  - uid: 904
+  - uid: 963
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,-4.5
       parent: 2
-  - uid: 905
+  - uid: 964
     components:
     - type: Transform
       pos: -29.5,-1.5
       parent: 2
-  - uid: 906
+  - uid: 965
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
-  - uid: 907
+  - uid: 966
     components:
     - type: Transform
       pos: -26.5,4.5
       parent: 2
-  - uid: 908
+  - uid: 967
     components:
     - type: Transform
       pos: -27.5,-3.5
       parent: 2
-  - uid: 909
+  - uid: 968
     components:
     - type: Transform
       pos: -26.5,-3.5
       parent: 2
-  - uid: 910
+  - uid: 969
     components:
     - type: Transform
       pos: -25.5,-3.5
       parent: 2
-  - uid: 911
+  - uid: 970
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-9.5
       parent: 2
-  - uid: 912
+  - uid: 971
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-8.5
       parent: 2
-  - uid: 913
+  - uid: 972
     components:
     - type: Transform
       pos: -23.5,-2.5
       parent: 2
-  - uid: 914
+  - uid: 973
     components:
     - type: Transform
       pos: -25.5,5.5
       parent: 2
-  - uid: 915
+  - uid: 974
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,-0.5
       parent: 2
-  - uid: 916
+  - uid: 975
     components:
     - type: Transform
       pos: -25.5,-2.5
       parent: 2
-  - uid: 917
+  - uid: 976
     components:
     - type: Transform
       pos: -25.5,3.5
       parent: 2
-  - uid: 918
+  - uid: 977
     components:
     - type: Transform
       pos: -22.5,3.5
       parent: 2
-  - uid: 919
+  - uid: 978
     components:
     - type: Transform
       pos: -24.5,5.5
       parent: 2
-  - uid: 920
+  - uid: 979
     components:
     - type: Transform
       pos: -23.5,5.5
       parent: 2
-  - uid: 921
+  - uid: 980
     components:
     - type: Transform
       pos: -22.5,5.5
       parent: 2
-  - uid: 922
+  - uid: 981
     components:
     - type: Transform
       pos: -21.5,5.5
       parent: 2
-  - uid: 923
+  - uid: 982
     components:
     - type: Transform
       pos: -20.5,6.5
       parent: 2
-  - uid: 924
+  - uid: 983
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 2
-  - uid: 925
+  - uid: 984
     components:
     - type: Transform
       pos: -19.5,8.5
       parent: 2
-  - uid: 926
+  - uid: 985
     components:
     - type: Transform
       pos: -18.5,8.5
       parent: 2
-  - uid: 927
+  - uid: 986
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
-  - uid: 928
+  - uid: 987
     components:
     - type: Transform
       pos: -18.5,0.5
       parent: 2
-  - uid: 929
+  - uid: 988
     components:
     - type: Transform
       pos: -17.5,0.5
       parent: 2
-  - uid: 930
+  - uid: 989
     components:
     - type: Transform
       pos: -16.5,0.5
       parent: 2
-  - uid: 931
+  - uid: 990
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 2
-  - uid: 932
+  - uid: 991
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 2
-  - uid: 933
+  - uid: 992
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 2
-  - uid: 934
+  - uid: 993
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 2
-  - uid: 935
+  - uid: 994
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 2
-  - uid: 936
+  - uid: 995
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 2
-  - uid: 937
+  - uid: 996
     components:
     - type: Transform
       pos: 8.5,-6.5
       parent: 2
-  - uid: 938
+  - uid: 997
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-7.5
       parent: 2
-  - uid: 939
+  - uid: 998
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,8.5
       parent: 2
-  - uid: 940
+  - uid: 999
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,8.5
       parent: 2
-  - uid: 941
+  - uid: 1000
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-14.5
       parent: 2
-  - uid: 942
+  - uid: 1001
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-17.5
       parent: 2
-  - uid: 943
+  - uid: 1002
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-17.5
       parent: 2
-  - uid: 944
+  - uid: 1003
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,17.5
       parent: 2
-  - uid: 945
+  - uid: 1004
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,19.5
       parent: 2
-  - uid: 946
+  - uid: 1005
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,7.5
       parent: 2
-  - uid: 947
+  - uid: 1006
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,7.5
       parent: 2
-  - uid: 948
+  - uid: 1007
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-17.5
       parent: 2
-  - uid: 949
+  - uid: 1008
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
-  - uid: 950
+  - uid: 1009
     components:
     - type: Transform
       pos: -24.5,-4.5
       parent: 2
-  - uid: 951
+  - uid: 1010
     components:
     - type: Transform
       pos: 14.5,-12.5
       parent: 2
-  - uid: 952
+  - uid: 1011
     components:
     - type: Transform
       pos: 14.5,-10.5
       parent: 2
-  - uid: 953
+  - uid: 1012
     components:
     - type: Transform
       pos: 14.5,12.5
       parent: 2
-  - uid: 954
+  - uid: 1013
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-17.5
       parent: 2
-  - uid: 955
+  - uid: 1014
     components:
     - type: Transform
       pos: -22.5,-4.5
       parent: 2
-  - uid: 956
+  - uid: 1015
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,6.5
       parent: 2
-  - uid: 958
+  - uid: 1016
     components:
     - type: Transform
       pos: -21.5,-5.5
       parent: 2
-  - uid: 959
+  - uid: 1017
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,5.5
       parent: 2
-  - uid: 960
+  - uid: 1018
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-7.5
       parent: 2
-  - uid: 961
+  - uid: 1019
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,-5.5
       parent: 2
-  - uid: 962
+  - uid: 1020
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,5.5
       parent: 2
-  - uid: 963
+  - uid: 1021
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 964
+  - uid: 1022
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-14.5
       parent: 2
-  - uid: 965
+  - uid: 1023
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-2.5
       parent: 2
-  - uid: 966
+  - uid: 1024
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,3.5
       parent: 2
-  - uid: 967
+  - uid: 1025
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,4.5
       parent: 2
-  - uid: 969
+  - uid: 1026
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 2
-  - uid: 970
+  - uid: 1027
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 2
-  - uid: 971
+  - uid: 1028
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 2
-  - uid: 972
+  - uid: 1029
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 2
-  - uid: 973
+  - uid: 1030
     components:
     - type: Transform
       pos: 1.5,15.5
       parent: 2
-  - uid: 974
+  - uid: 1031
     components:
     - type: Transform
       pos: -20.5,-6.5
       parent: 2
-  - uid: 975
+  - uid: 1032
     components:
     - type: Transform
       pos: 13.5,-10.5
       parent: 2
-  - uid: 976
+  - uid: 1033
     components:
     - type: Transform
       pos: 14.5,-11.5
       parent: 2
-  - uid: 977
+  - uid: 1034
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-7.5
       parent: 2
-  - uid: 979
+  - uid: 1035
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-3.5
       parent: 2
-  - uid: 981
+  - uid: 1036
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-6.5
       parent: 2
-  - uid: 982
+  - uid: 1037
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-10.5
       parent: 2
-  - uid: 983
+  - uid: 1038
     components:
     - type: Transform
       pos: 10.5,-6.5
       parent: 2
-  - uid: 984
+  - uid: 1039
     components:
     - type: Transform
       pos: 11.5,-6.5
       parent: 2
-  - uid: 985
+  - uid: 1040
     components:
     - type: Transform
       pos: -20.5,5.5
       parent: 2
-  - uid: 986
+  - uid: 1041
     components:
     - type: Transform
       pos: -25.5,-4.5
       parent: 2
-  - uid: 987
+  - uid: 1042
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,1.5
       parent: 2
-  - uid: 988
+  - uid: 1043
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,0.5
       parent: 2
-  - uid: 989
+  - uid: 1044
     components:
     - type: Transform
       pos: -23.5,-4.5
       parent: 2
-  - uid: 990
+  - uid: 1045
     components:
     - type: Transform
       pos: -21.5,-4.5
       parent: 2
-  - uid: 992
+  - uid: 1046
     components:
     - type: Transform
       pos: 7.5,18.5
       parent: 2
-  - uid: 993
+  - uid: 1047
     components:
     - type: Transform
       pos: 5.5,18.5
       parent: 2
-  - uid: 994
+  - uid: 1048
     components:
     - type: Transform
       pos: 9.5,18.5
       parent: 2
-  - uid: 995
+  - uid: 1049
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 2
-  - uid: 996
+  - uid: 1050
     components:
     - type: Transform
       pos: -17.5,-6.5
       parent: 2
-  - uid: 997
+  - uid: 1051
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 2
-  - uid: 998
+  - uid: 1052
     components:
     - type: Transform
       pos: -2.5,-15.5
       parent: 2
-  - uid: 999
+  - uid: 1053
     components:
     - type: Transform
       pos: -26.5,-2.5
       parent: 2
-  - uid: 1000
+  - uid: 1054
     components:
     - type: Transform
       pos: -27.5,-2.5
       parent: 2
-  - uid: 1001
+  - uid: 1055
     components:
     - type: Transform
       pos: -28.5,-2.5
       parent: 2
-  - uid: 1002
+  - uid: 1056
     components:
     - type: Transform
       pos: -29.5,-2.5
       parent: 2
-  - uid: 1003
+  - uid: 1057
     components:
     - type: Transform
       pos: -29.5,-3.5
       parent: 2
-  - uid: 1004
+  - uid: 1058
     components:
     - type: Transform
       pos: -30.5,-3.5
       parent: 2
-  - uid: 1005
+  - uid: 1059
     components:
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
-  - uid: 1006
+  - uid: 1060
     components:
     - type: Transform
       pos: -31.5,-4.5
       parent: 2
-  - uid: 1007
+  - uid: 1061
     components:
     - type: Transform
       pos: -29.5,-0.5
       parent: 2
-  - uid: 1008
+  - uid: 1062
     components:
     - type: Transform
       pos: -29.5,0.5
       parent: 2
-  - uid: 1009
+  - uid: 1063
     components:
     - type: Transform
       pos: -29.5,1.5
       parent: 2
-  - uid: 1010
+  - uid: 1064
     components:
     - type: Transform
       pos: -29.5,2.5
       parent: 2
-  - uid: 1011
+  - uid: 1065
     components:
     - type: Transform
       pos: -29.5,3.5
       parent: 2
-  - uid: 1012
+  - uid: 1066
     components:
     - type: Transform
       pos: -29.5,4.5
       parent: 2
-  - uid: 1013
+  - uid: 1067
     components:
     - type: Transform
       pos: -30.5,4.5
       parent: 2
-  - uid: 1014
+  - uid: 1068
     components:
     - type: Transform
       pos: -30.5,5.5
       parent: 2
-  - uid: 1015
+  - uid: 1069
     components:
     - type: Transform
       pos: -31.5,5.5
       parent: 2
-  - uid: 1016
+  - uid: 1070
     components:
     - type: Transform
       pos: -26.5,3.5
       parent: 2
-  - uid: 1017
+  - uid: 1071
     components:
     - type: Transform
       pos: -27.5,3.5
       parent: 2
-  - uid: 1018
+  - uid: 1072
     components:
     - type: Transform
       pos: -28.5,3.5
       parent: 2
-  - uid: 1019
+  - uid: 1073
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,8.5
       parent: 2
-  - uid: 1020
+  - uid: 1074
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,8.5
       parent: 2
-  - uid: 1021
+  - uid: 1075
     components:
     - type: Transform
       pos: -21.5,-6.5
       parent: 2
-  - uid: 1022
+  - uid: 1076
     components:
     - type: Transform
       pos: 12.5,-13.5
       parent: 2
-  - uid: 1023
+  - uid: 1077
     components:
     - type: Transform
       pos: 15.5,-13.5
       parent: 2
-  - uid: 1024
+  - uid: 1078
     components:
     - type: Transform
       pos: 14.5,-13.5
       parent: 2
-  - uid: 1025
+  - uid: 1079
     components:
     - type: Transform
       pos: 13.5,-13.5
       parent: 2
-  - uid: 1026
+  - uid: 1080
     components:
     - type: Transform
       pos: 13.5,-14.5
       parent: 2
-  - uid: 1027
+  - uid: 1081
     components:
     - type: Transform
       pos: 13.5,-15.5
       parent: 2
-  - uid: 1028
+  - uid: 1082
     components:
     - type: Transform
       pos: 12.5,-15.5
       parent: 2
-  - uid: 1029
+  - uid: 1083
     components:
     - type: Transform
       pos: 12.5,-16.5
       parent: 2
-  - uid: 1030
+  - uid: 1084
     components:
     - type: Transform
       pos: 12.5,-17.5
       parent: 2
-  - uid: 1031
+  - uid: 1085
     components:
     - type: Transform
       pos: 11.5,-17.5
       parent: 2
-  - uid: 1032
+  - uid: 1086
     components:
     - type: Transform
       pos: 3.5,-17.5
       parent: 2
-  - uid: 1033
+  - uid: 1087
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 2
-  - uid: 1034
+  - uid: 1088
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 2
-  - uid: 1035
+  - uid: 1089
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 2
-  - uid: 1036
+  - uid: 1090
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 2
-  - uid: 1037
+  - uid: 1091
     components:
     - type: Transform
       pos: -1.5,15.5
       parent: 2
-  - uid: 1038
+  - uid: 1092
     components:
     - type: Transform
       pos: -2.5,15.5
       parent: 2
-  - uid: 1043
+  - uid: 1093
     components:
     - type: Transform
       pos: -12.5,10.5
       parent: 2
-  - uid: 1047
+  - uid: 1094
     components:
     - type: Transform
       pos: 9.5,-6.5
       parent: 2
-  - uid: 1048
+  - uid: 1095
     components:
     - type: Transform
       pos: 12.5,-6.5
       parent: 2
-  - uid: 1049
+  - uid: 1096
     components:
     - type: Transform
       pos: 13.5,-6.5
       parent: 2
-  - uid: 1050
+  - uid: 1097
     components:
     - type: Transform
       pos: 14.5,-6.5
       parent: 2
-  - uid: 1051
+  - uid: 1098
     components:
     - type: Transform
       pos: 15.5,-6.5
       parent: 2
-  - uid: 1052
+  - uid: 1099
     components:
     - type: Transform
       pos: 16.5,-6.5
       parent: 2
-  - uid: 1053
+  - uid: 1100
     components:
     - type: Transform
       pos: 17.5,-8.5
       parent: 2
-  - uid: 1054
+  - uid: 1101
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-1.5
       parent: 2
-  - uid: 1055
+  - uid: 1102
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,2.5
       parent: 2
-  - uid: 2312
+  - uid: 1103
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,15.5
       parent: 2
-  - uid: 2386
+  - uid: 1104
     components:
     - type: Transform
       pos: 12.5,17.5
       parent: 2
-  - uid: 2633
+  - uid: 1105
     components:
     - type: Transform
       pos: 12.5,18.5
       parent: 2
-  - uid: 2778
+  - uid: 1106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,16.5
       parent: 2
-  - uid: 2787
+  - uid: 1107
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,17.5
       parent: 2
-  - uid: 2788
+  - uid: 1108
     components:
     - type: Transform
       pos: 13.5,18.5
       parent: 2
-  - uid: 2789
+  - uid: 1109
     components:
     - type: Transform
       pos: 14.5,18.5
       parent: 2
-  - uid: 2968
+  - uid: 1110
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,9.5
       parent: 2
-  - uid: 2969
+  - uid: 1111
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,10.5
       parent: 2
-  - uid: 2970
+  - uid: 1112
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,10.5
       parent: 2
-  - uid: 2971
+  - uid: 1113
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,10.5
       parent: 2
-  - uid: 2972
+  - uid: 1114
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,11.5
       parent: 2
-  - uid: 2973
+  - uid: 1115
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,11.5
       parent: 2
-  - uid: 2974
+  - uid: 1116
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,11.5
       parent: 2
-  - uid: 2976
+  - uid: 1117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,12.5
       parent: 2
-  - uid: 2977
+  - uid: 1118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,12.5
       parent: 2
-  - uid: 2997
+  - uid: 1119
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,12.5
       parent: 2
-  - uid: 2998
+  - uid: 1120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,12.5
       parent: 2
-  - uid: 2999
+  - uid: 1121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,12.5
       parent: 2
-  - uid: 3000
+  - uid: 1122
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,13.5
       parent: 2
-  - uid: 3001
+  - uid: 1123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,13.5
       parent: 2
-  - uid: 3002
+  - uid: 1124
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,13.5
       parent: 2
-  - uid: 3003
+  - uid: 1125
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,13.5
       parent: 2
-  - uid: 3040
+  - uid: 1126
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,-1.5
       parent: 2
-  - uid: 3041
+  - uid: 1127
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,-0.5
       parent: 2
-  - uid: 3042
+  - uid: 1128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,0.5
       parent: 2
-  - uid: 3043
+  - uid: 1129
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,1.5
       parent: 2
-  - uid: 3044
+  - uid: 1130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,2.5
       parent: 2
-  - uid: 3045
+  - uid: 1131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7722,111 +7734,116 @@ entities:
       parent: 2
 - proto: Chair
   entities:
-  - uid: 1056
+  - uid: 1132
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 2
-  - uid: 1057
+  - uid: 1133
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,3.5
       parent: 2
-  - uid: 1058
+  - uid: 1134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,3.5
       parent: 2
-  - uid: 1059
+  - uid: 1135
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,3.5
       parent: 2
-  - uid: 1060
+  - uid: 1136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,3.5
       parent: 2
-  - uid: 1061
+  - uid: 1137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,3.5
       parent: 2
-  - uid: 1062
+  - uid: 1138
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,3.5
       parent: 2
-  - uid: 1063
+  - uid: 1139
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-11.5
       parent: 2
-  - uid: 1064
+  - uid: 1140
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 2
-  - uid: 1065
+  - uid: 1141
     components:
     - type: Transform
       pos: 14.5,5.5
       parent: 2
-  - uid: 1066
+  - uid: 1142
     components:
     - type: Transform
       pos: 16.5,1.5
       parent: 2
-  - uid: 1067
+  - uid: 1143
     components:
     - type: Transform
       pos: 12.5,10.5
       parent: 2
-  - uid: 1068
+  - uid: 1144
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,10.5
       parent: 2
-  - uid: 1069
+  - uid: 1145
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 2
-  - uid: 1070
+  - uid: 1146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,7.5
       parent: 2
-  - uid: 1071
+  - uid: 1147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-13.5
       parent: 2
+  - uid: 2064
+    components:
+    - type: Transform
+      pos: 17.5,1.5
+      parent: 2
 - proto: ChairFolding
   entities:
-  - uid: 1072
+  - uid: 1148
     components:
     - type: Transform
       pos: 14.5,-7.5
       parent: 2
-  - uid: 1073
+  - uid: 1149
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-8.5
       parent: 2
-  - uid: 1074
+  - uid: 1150
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7834,25 +7851,25 @@ entities:
       parent: 2
 - proto: ChairOfficeDark
   entities:
-  - uid: 1076
+  - uid: 1151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,12.5
       parent: 2
-  - uid: 1077
+  - uid: 1152
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,12.5
       parent: 2
-  - uid: 1078
+  - uid: 1153
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,7.5
       parent: 2
-  - uid: 2089
+  - uid: 1154
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7860,13 +7877,13 @@ entities:
       parent: 2
 - proto: ChairOfficeLight
   entities:
-  - uid: 1079
+  - uid: 1155
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,0.5
       parent: 2
-  - uid: 1080
+  - uid: 1156
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7874,73 +7891,67 @@ entities:
       parent: 2
 - proto: ChairPilotSeat
   entities:
-  - uid: 1081
+  - uid: 1157
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,1.5
       parent: 2
-  - uid: 1082
+  - uid: 1158
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,0.5
       parent: 2
-  - uid: 1083
+  - uid: 1159
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,15.5
       parent: 2
-  - uid: 1084
+  - uid: 1160
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,16.5
       parent: 2
-  - uid: 1085
+  - uid: 1161
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,3.5
       parent: 2
-  - uid: 1086
+  - uid: 1162
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,1.5
       parent: 2
-  - uid: 1087
+  - uid: 1163
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,2.5
       parent: 2
-  - uid: 1088
+  - uid: 1164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,2.5
       parent: 2
-  - uid: 1089
+  - uid: 1165
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,1.5
       parent: 2
-  - uid: 1090
+  - uid: 1166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-0.5
       parent: 2
-  - uid: 1091
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,6.5
-      parent: 2
-  - uid: 1092
+  - uid: 1168
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7948,35 +7959,35 @@ entities:
       parent: 2
 - proto: ChemDispenser
   entities:
-  - uid: 1093
+  - uid: 1169
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 2
 - proto: ChemistryHotplate
   entities:
-  - uid: 1094
+  - uid: 1170
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 2
 - proto: ChemMaster
   entities:
-  - uid: 1095
+  - uid: 1171
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
 - proto: CircuitImprinter
   entities:
-  - uid: 1096
+  - uid: 1172
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
 - proto: CleanerDispenser
   entities:
-  - uid: 1097
+  - uid: 1173
     components:
     - type: Transform
       pos: -3.5,-5.5
@@ -7985,95 +7996,95 @@ entities:
       fixtures: {}
 - proto: ClosetChefFilled
   entities:
-  - uid: 1098
+  - uid: 1174
     components:
     - type: Transform
       pos: -3.250826,4.530949
       parent: 2
-  - uid: 1099
+  - uid: 1175
     components:
     - type: Transform
       pos: 16.5,10.5
       parent: 2
 - proto: ClosetEmergencyFilledRandom
   entities:
-  - uid: 1100
+  - uid: 1176
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 2
-  - uid: 1101
+  - uid: 1177
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 2
-  - uid: 1107
+  - uid: 1178
     components:
     - type: Transform
       pos: 11.5,13.5
       parent: 2
 - proto: ClosetEmergencyN2FilledRandom
   entities:
-  - uid: 1103
+  - uid: 1179
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 2
-  - uid: 1104
+  - uid: 1180
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 2
-  - uid: 1105
+  - uid: 1181
     components:
     - type: Transform
       pos: 13.5,14.5
       parent: 2
 - proto: ClosetFireFilled
   entities:
-  - uid: 1106
+  - uid: 1182
     components:
     - type: Transform
       pos: 12.5,13.5
       parent: 2
 - proto: ClosetJanitorFilled
   entities:
-  - uid: 1046
+  - uid: 1183
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 2
 - proto: ClosetMaintenanceFilledRandom
   entities:
-  - uid: 1111
+  - uid: 1184
     components:
     - type: Transform
       pos: 12.5,-8.5
       parent: 2
 - proto: ClosetRadiationSuitFilled
   entities:
-  - uid: 1112
+  - uid: 1185
     components:
     - type: Transform
       pos: -18.5,-0.5
       parent: 2
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 1113
+  - uid: 1186
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1114
+  - uid: 1187
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1115
+  - uid: 1188
     components:
     - type: Transform
       pos: 11.5,6.5
@@ -8082,14 +8093,14 @@ entities:
       fixtures: {}
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 1116
+  - uid: 1189
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1117
+  - uid: 1190
     components:
     - type: Transform
       pos: 12.5,6.5
@@ -8098,14 +8109,14 @@ entities:
       fixtures: {}
 - proto: ClosetWallMaintenanceFilledRandom
   entities:
-  - uid: 1118
+  - uid: 1191
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1119
+  - uid: 1192
     components:
     - type: Transform
       pos: 12.5,-5.5
@@ -8114,26 +8125,27 @@ entities:
       fixtures: {}
 - proto: ClothingBeltUtility
   entities:
-  - uid: 1120
+  - uid: 2076
     components:
     - type: Transform
-      pos: -9.5617695,7.642974
-      parent: 2
+      parent: 2075
+    - type: Physics
+      canCollide: False
     - type: Storage
       storedItems:
-        1121:
+        2077:
           position: 0,0
           _rotation: South
-        1125:
+        2081:
           position: 1,0
           _rotation: South
-        1123:
+        2079:
           position: 2,0
           _rotation: South
-        1124:
+        2080:
           position: 3,0
           _rotation: South
-        1122:
+        2078:
           position: 4,0
           _rotation: South
     - type: ContainerContainer
@@ -8142,121 +8154,123 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1121
-          - 1125
-          - 1123
-          - 1124
-          - 1122
+          - 2077
+          - 2081
+          - 2079
+          - 2080
+          - 2078
+    - type: InsideEntityStorage
+      storage: 2075
 - proto: ClothingEyesGlassesMeson
   entities:
-  - uid: 1126
+  - uid: 1194
     components:
     - type: Transform
       pos: -20.396126,3.7096221
       parent: 2
-  - uid: 1127
+  - uid: 1195
     components:
     - type: Transform
       pos: -20.318,3.5689971
       parent: 2
 - proto: ClothingEyesGlassesSecurity
   entities:
-  - uid: 1128
+  - uid: 1196
     components:
     - type: Transform
       pos: 18.401093,-4.1065035
       parent: 2
 - proto: ClothingEyesHudMedSec
   entities:
-  - uid: 1129
+  - uid: 1197
     components:
     - type: Transform
       pos: 18.724009,-4.5547314
       parent: 2
 - proto: ClothingNeckCloakTrans
   entities:
-  - uid: 1130
+  - uid: 1198
     components:
     - type: Transform
       pos: 3.506415,3.5395489
       parent: 2
 - proto: ClothingNeckStethoscope
   entities:
-  - uid: 1131
+  - uid: 1199
     components:
     - type: Transform
       pos: 6.4035683,-4.3785286
       parent: 2
 - proto: ComfyChair
   entities:
-  - uid: 1132
+  - uid: 1200
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 2
-  - uid: 1133
+  - uid: 1201
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 2
-  - uid: 1134
+  - uid: 1202
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-4.5
       parent: 2
-  - uid: 1135
+  - uid: 1203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-4.5
       parent: 2
-  - uid: 1136
+  - uid: 1204
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,-2.5
       parent: 2
-  - uid: 1137
+  - uid: 1205
     components:
     - type: Transform
       pos: -13.5,-2.5
       parent: 2
-  - uid: 1138
+  - uid: 1206
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 2
-  - uid: 1139
+  - uid: 1207
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 2
-  - uid: 1140
+  - uid: 1208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-5.5
       parent: 2
-  - uid: 1141
+  - uid: 1209
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-5.5
       parent: 2
-  - uid: 1142
+  - uid: 1210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-5.5
       parent: 2
-  - uid: 1143
+  - uid: 1211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-5.5
       parent: 2
-  - uid: 1144
+  - uid: 1212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8264,14 +8278,14 @@ entities:
       parent: 2
 - proto: CompuerShuttleSalvage
   entities:
-  - uid: 2582
+  - uid: 1213
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 2
 - proto: ComputerAlert
   entities:
-  - uid: 1145
+  - uid: 1214
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8279,21 +8293,22 @@ entities:
       parent: 2
 - proto: ComputerAnalysisConsole
   entities:
-  - uid: 1146
+  - uid: 1215
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,10.5
       parent: 2
     - type: AnalysisConsole
-      analyzerEntity: 1993
+      analyzerEntity: 2090
     - type: DeviceLinkSource
       linkedPorts:
-        1993:
-        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+        2090:
+        - - ArtifactAnalyzerSender
+          - ArtifactAnalyzerReceiver
 - proto: ComputerAtmosMonitoring
   entities:
-  - uid: 1147
+  - uid: 1216
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8301,14 +8316,14 @@ entities:
       parent: 2
 - proto: ComputerCargoBounty
   entities:
-  - uid: 1148
+  - uid: 1217
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 2
 - proto: ComputerCargoOrders
   entities:
-  - uid: 1149
+  - uid: 1218
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8316,7 +8331,7 @@ entities:
       parent: 2
 - proto: ComputerCargoOrdersEngineering
   entities:
-  - uid: 1150
+  - uid: 1219
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8324,7 +8339,7 @@ entities:
       parent: 2
 - proto: ComputerCargoOrdersMedical
   entities:
-  - uid: 1151
+  - uid: 1220
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8332,14 +8347,14 @@ entities:
       parent: 2
 - proto: ComputerCargoOrdersScience
   entities:
-  - uid: 1152
+  - uid: 1221
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 2
 - proto: ComputerCargoOrdersSecurity
   entities:
-  - uid: 1153
+  - uid: 1222
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8347,7 +8362,7 @@ entities:
       parent: 2
 - proto: ComputerCargoOrdersService
   entities:
-  - uid: 1154
+  - uid: 1223
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8355,7 +8370,7 @@ entities:
       parent: 2
 - proto: ComputerComms
   entities:
-  - uid: 1155
+  - uid: 1224
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8363,7 +8378,7 @@ entities:
       parent: 2
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 1156
+  - uid: 1225
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8371,7 +8386,7 @@ entities:
       parent: 2
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 1157
+  - uid: 1226
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8379,7 +8394,7 @@ entities:
       parent: 2
 - proto: ComputerFundingAllocation
   entities:
-  - uid: 1158
+  - uid: 1227
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8387,7 +8402,7 @@ entities:
       parent: 2
 - proto: ComputerId
   entities:
-  - uid: 1159
+  - uid: 1228
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8395,7 +8410,7 @@ entities:
       parent: 2
 - proto: ComputerMedicalRecords
   entities:
-  - uid: 1160
+  - uid: 1229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8403,25 +8418,25 @@ entities:
       parent: 2
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 1161
+  - uid: 1230
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,-3.5
       parent: 2
-  - uid: 1162
+  - uid: 1231
     components:
     - type: Transform
       pos: 22.5,8.5
       parent: 2
 - proto: ComputerRadar
   entities:
-  - uid: 1163
+  - uid: 1232
     components:
     - type: Transform
       pos: 1.5,16.5
       parent: 2
-  - uid: 1164
+  - uid: 1233
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8429,7 +8444,7 @@ entities:
       parent: 2
 - proto: ComputerResearchAndDevelopment
   entities:
-  - uid: 1165
+  - uid: 1234
     components:
     - type: Transform
       pos: -3.5,12.5
@@ -8443,7 +8458,7 @@ entities:
       - Biochemical
 - proto: ComputerSalvageExpedition
   entities:
-  - uid: 1166
+  - uid: 1235
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8451,7 +8466,7 @@ entities:
       parent: 2
 - proto: ComputerSalvageJobBoard
   entities:
-  - uid: 3082
+  - uid: 1236
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8459,7 +8474,7 @@ entities:
       parent: 2
 - proto: ComputerShuttle
   entities:
-  - uid: 1168
+  - uid: 1237
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8467,21 +8482,21 @@ entities:
       parent: 2
 - proto: ComputerShuttleCargo
   entities:
-  - uid: 1169
+  - uid: 1238
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 2
 - proto: ComputerShuttleMining
   entities:
-  - uid: 2770
+  - uid: 1239
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 2
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 1044
+  - uid: 1240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8489,71 +8504,78 @@ entities:
       parent: 2
 - proto: ComputerTechnologyDiskTerminal
   entities:
-  - uid: 1171
+  - uid: 1241
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 2
 - proto: ConveyorBelt
   entities:
-  - uid: 1172
+  - uid: 1242
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 2
-  - uid: 1173
+  - uid: 1243
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
-  - uid: 1174
+  - uid: 1244
     components:
     - type: Transform
       pos: 17.5,-7.5
       parent: 2
-  - uid: 1175
+  - uid: 1245
     components:
     - type: Transform
       pos: 17.5,-8.5
       parent: 2
 - proto: CrateEngineeringCableBulk
   entities:
-  - uid: 1176
+  - uid: 1246
     components:
     - type: Transform
       pos: -16.5,-3.5
       parent: 2
 - proto: CrateFilledSpawner
   entities:
-  - uid: 1177
+  - uid: 1247
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
+- proto: CrateLawboards
+  entities:
+  - uid: 2585
+    components:
+    - type: Transform
+      pos: -8.5,10.5
+      parent: 2
 - proto: CrateMaterialBasicResource
   entities:
-  - uid: 1178
+  - uid: 1248
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 2
 - proto: CrateMedicalSurgery
   entities:
-  - uid: 1179
+  - uid: 1249
     components:
     - type: Transform
       pos: 10.5,-4.5
       parent: 2
 - proto: CrateNPCHamlet
   entities:
-  - uid: 1180
+  - uid: 1250
     components:
     - type: Transform
       pos: 21.5,3.5
       parent: 2
 - proto: CrewMonitoringServer
   entities:
-  - uid: 1181
+  - uid: 1251
     components:
     - type: Transform
       pos: 2.5,-2.5
@@ -8563,29 +8585,29 @@ entities:
       available: False
 - proto: Crowbar
   entities:
-  - uid: 1121
+  - uid: 2077
     components:
     - type: Transform
-      parent: 1120
+      parent: 2076
     - type: Physics
       canCollide: False
 - proto: CrowbarYellow
   entities:
-  - uid: 1182
+  - uid: 1252
     components:
     - type: Transform
       pos: -18.41299,2.5601718
       parent: 2
 - proto: CryogenicSleepUnit
   entities:
-  - uid: 1183
+  - uid: 1253
     components:
     - type: Transform
       pos: 17.5,10.5
       parent: 2
 - proto: CryogenicSleepUnitSpawnerLateJoin
   entities:
-  - uid: 1184
+  - uid: 1254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8593,131 +8615,131 @@ entities:
       parent: 2
 - proto: d6Dice
   entities:
-  - uid: 1185
+  - uid: 1255
     components:
     - type: Transform
       pos: 14.298776,-8.241399
       parent: 2
-  - uid: 1186
+  - uid: 1256
     components:
     - type: Transform
       pos: 14.746693,-8.251823
       parent: 2
 - proto: DefaultStationBeaconArrivals
   entities:
-  - uid: 1187
+  - uid: 1257
     components:
     - type: Transform
       pos: 7.5,16.5
       parent: 2
 - proto: DefaultStationBeaconAtmospherics
   entities:
-  - uid: 1188
+  - uid: 1258
     components:
     - type: Transform
       pos: 6.5,-13.5
       parent: 2
 - proto: DefaultStationBeaconBar
   entities:
-  - uid: 1189
+  - uid: 1259
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 2
 - proto: DefaultStationBeaconBotany
   entities:
-  - uid: 1190
+  - uid: 1260
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 2
 - proto: DefaultStationBeaconBridge
   entities:
-  - uid: 1191
+  - uid: 1261
     components:
     - type: Transform
       pos: 22.5,0.5
       parent: 2
 - proto: DefaultStationBeaconCargoBay
   entities:
-  - uid: 1192
+  - uid: 1262
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 2
 - proto: DefaultStationBeaconChemistry
   entities:
-  - uid: 1193
+  - uid: 1263
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 2
 - proto: DefaultStationBeaconDisposals
   entities:
-  - uid: 1194
+  - uid: 1264
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 2
 - proto: DefaultStationBeaconEngineering
   entities:
-  - uid: 1195
+  - uid: 1265
     components:
     - type: Transform
       pos: -17.5,0.5
       parent: 2
 - proto: DefaultStationBeaconEvac
   entities:
-  - uid: 1196
+  - uid: 1266
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 2
 - proto: DefaultStationBeaconJanitorsCloset
   entities:
-  - uid: 1197
+  - uid: 1267
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 2
 - proto: DefaultStationBeaconKitchen
   entities:
-  - uid: 1198
+  - uid: 1268
     components:
     - type: Transform
       pos: -5.5,4.5
       parent: 2
 - proto: DefaultStationBeaconMedbay
   entities:
-  - uid: 1199
+  - uid: 1269
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 2
 - proto: DefaultStationBeaconScience
   entities:
-  - uid: 1200
+  - uid: 1270
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 2
 - proto: DefaultStationBeaconSecurity
   entities:
-  - uid: 1201
+  - uid: 1271
     components:
     - type: Transform
       pos: 16.5,-2.5
       parent: 2
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 1202
+  - uid: 1272
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1203
+  - uid: 1273
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8727,59 +8749,59 @@ entities:
       fixtures: {}
 - proto: DisposalBend
   entities:
-  - uid: 1204
+  - uid: 1274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,8.5
       parent: 2
-  - uid: 1205
+  - uid: 1275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,8.5
       parent: 2
-  - uid: 1206
+  - uid: 1276
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 2
-  - uid: 1207
+  - uid: 1277
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-7.5
       parent: 2
-  - uid: 1208
+  - uid: 1278
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,0.5
       parent: 2
-  - uid: 1209
+  - uid: 1279
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 2
-  - uid: 1210
+  - uid: 1280
     components:
     - type: Transform
       pos: 14.5,4.5
       parent: 2
-  - uid: 1211
+  - uid: 1281
     components:
     - type: Transform
       pos: 17.5,-6.5
       parent: 2
-  - uid: 1212
+  - uid: 1282
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 2
-  - uid: 1213
+  - uid: 1283
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8787,18 +8809,18 @@ entities:
       parent: 2
 - proto: DisposalJunction
   entities:
-  - uid: 1214
+  - uid: 1284
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 2
-  - uid: 1215
+  - uid: 1285
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 2
-  - uid: 1216
+  - uid: 1286
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8806,7 +8828,7 @@ entities:
       parent: 2
 - proto: DisposalJunctionFlipped
   entities:
-  - uid: 1217
+  - uid: 1287
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8814,594 +8836,586 @@ entities:
       parent: 2
 - proto: DisposalPipe
   entities:
-  - uid: 1218
+  - uid: 1288
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 2
-  - uid: 1219
+  - uid: 1289
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 2
-  - uid: 1220
+  - uid: 1290
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-2.5
       parent: 2
-  - uid: 1221
+  - uid: 1291
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-2.5
       parent: 2
-  - uid: 1222
+  - uid: 1292
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-2.5
       parent: 2
-  - uid: 1223
+  - uid: 1293
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 2
-  - uid: 1224
+  - uid: 1294
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-2.5
       parent: 2
-  - uid: 1225
+  - uid: 1295
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,8.5
       parent: 2
-  - uid: 1226
+  - uid: 1296
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 2
-  - uid: 1227
+  - uid: 1297
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,8.5
       parent: 2
-  - uid: 1228
+  - uid: 1298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 2
-  - uid: 1229
+  - uid: 1299
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,8.5
       parent: 2
-  - uid: 1230
+  - uid: 1300
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,8.5
       parent: 2
-  - uid: 1231
+  - uid: 1301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,7.5
       parent: 2
-  - uid: 1232
+  - uid: 1302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,6.5
       parent: 2
-  - uid: 1233
+  - uid: 1303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,0.5
       parent: 2
-  - uid: 1234
+  - uid: 1304
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-6.5
       parent: 2
-  - uid: 1235
+  - uid: 1305
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 2
-  - uid: 1236
+  - uid: 1306
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 2
-  - uid: 1237
+  - uid: 1307
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 2
-  - uid: 1238
+  - uid: 1308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 2
-  - uid: 1239
+  - uid: 1309
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-6.5
       parent: 2
-  - uid: 1240
+  - uid: 1310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-6.5
       parent: 2
-  - uid: 1241
+  - uid: 1311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 2
-  - uid: 1242
+  - uid: 1312
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,0.5
       parent: 2
-  - uid: 1243
+  - uid: 1313
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,0.5
       parent: 2
-  - uid: 1244
+  - uid: 1314
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,0.5
       parent: 2
-  - uid: 1245
+  - uid: 1315
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,0.5
       parent: 2
-  - uid: 1246
+  - uid: 1316
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,0.5
       parent: 2
-  - uid: 1247
+  - uid: 1317
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,0.5
       parent: 2
-  - uid: 1248
+  - uid: 1318
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,0.5
       parent: 2
-  - uid: 1249
+  - uid: 1319
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,0.5
       parent: 2
-  - uid: 1250
+  - uid: 1320
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,0.5
       parent: 2
-  - uid: 1251
+  - uid: 1321
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 2
-  - uid: 1252
+  - uid: 1322
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 2
-  - uid: 1253
+  - uid: 1323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 2
-  - uid: 1254
+  - uid: 1324
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 2
-  - uid: 1255
+  - uid: 1325
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 2
-  - uid: 1256
+  - uid: 1326
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-7.5
       parent: 2
-  - uid: 1257
+  - uid: 1327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
       parent: 2
-  - uid: 1258
+  - uid: 1328
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 2
-  - uid: 1259
+  - uid: 1329
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-3.5
       parent: 2
-  - uid: 1260
+  - uid: 1330
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-2.5
       parent: 2
-  - uid: 1261
+  - uid: 1331
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 2
-  - uid: 1262
+  - uid: 1332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-0.5
       parent: 2
-  - uid: 1263
+  - uid: 1333
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 2
-  - uid: 1264
+  - uid: 1334
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 2
-  - uid: 1265
+  - uid: 1335
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 2
-  - uid: 1266
+  - uid: 1336
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 2
-  - uid: 1267
+  - uid: 1337
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 2
-  - uid: 1268
+  - uid: 1338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,4.5
       parent: 2
-  - uid: 1269
+  - uid: 1339
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,4.5
       parent: 2
-  - uid: 1270
+  - uid: 1340
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,4.5
       parent: 2
-  - uid: 1271
+  - uid: 1341
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,4.5
       parent: 2
-  - uid: 1272
+  - uid: 1342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,4.5
       parent: 2
-  - uid: 1273
+  - uid: 1343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,4.5
       parent: 2
-  - uid: 1274
+  - uid: 1344
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 2
-  - uid: 1275
+  - uid: 1345
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 2
-  - uid: 1276
+  - uid: 1346
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 2
-  - uid: 1277
+  - uid: 1347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 2
-  - uid: 1278
+  - uid: 1348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 2
-  - uid: 1279
+  - uid: 1349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 2
-  - uid: 1280
+  - uid: 1350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 2
-  - uid: 1281
+  - uid: 1351
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,1.5
       parent: 2
-  - uid: 1282
+  - uid: 1352
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,2.5
       parent: 2
-  - uid: 1283
+  - uid: 1353
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,3.5
       parent: 2
-  - uid: 1284
+  - uid: 1354
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-6.5
       parent: 2
-  - uid: 1285
+  - uid: 1355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-6.5
       parent: 2
-  - uid: 1286
+  - uid: 1356
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,5.5
       parent: 2
-  - uid: 1287
+  - uid: 1357
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-6.5
       parent: 2
-  - uid: 1288
+  - uid: 1358
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-6.5
       parent: 2
-  - uid: 1289
+  - uid: 1359
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,-6.5
       parent: 2
-  - uid: 1290
+  - uid: 1360
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-6.5
       parent: 2
-  - uid: 1291
+  - uid: 1361
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-6.5
       parent: 2
-  - uid: 1292
+  - uid: 1362
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-6.5
       parent: 2
-  - uid: 1293
+  - uid: 1363
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 2
 - proto: DisposalTrunk
   entities:
-  - uid: 1294
+  - uid: 1364
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
-  - uid: 1295
+  - uid: 1365
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 2
-  - uid: 1296
+  - uid: 1366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,-0.5
       parent: 2
-  - uid: 1297
+  - uid: 1367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-1.5
       parent: 2
-  - uid: 1298
+  - uid: 1368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-8.5
       parent: 2
-  - uid: 1299
+  - uid: 1369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-0.5
       parent: 2
-  - uid: 1300
+  - uid: 1370
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,-7.5
       parent: 2
-  - uid: 1301
+  - uid: 1371
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 2
 - proto: DisposalUnit
   entities:
-  - uid: 1302
+  - uid: 1372
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
-  - uid: 1303
+  - uid: 1373
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 2
-  - uid: 1304
+  - uid: 1374
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
-  - uid: 1305
+  - uid: 1375
     components:
     - type: Transform
       pos: 14.5,-0.5
       parent: 2
-  - uid: 1306
+  - uid: 1376
     components:
     - type: Transform
       pos: -16.5,-0.5
       parent: 2
-  - uid: 1307
+  - uid: 1377
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 2
-  - uid: 1308
+  - uid: 1378
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 2
 - proto: DisposalYJunction
   entities:
-  - uid: 1309
+  - uid: 1379
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-6.5
       parent: 2
-  - uid: 1310
+  - uid: 1380
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 2
 - proto: DogBed
   entities:
-  - uid: 1109
+  - uid: 1381
     components:
     - type: Transform
       pos: 14.5,-3.5
       parent: 2
-  - uid: 1311
+  - uid: 1382
     components:
     - type: Transform
       pos: 21.5,-3.5
       parent: 2
-  - uid: 1312
+  - uid: 3085
     components:
     - type: Transform
-      pos: 21.5,5.5
-      parent: 2
-- proto: DoorRemoteAll
-  entities:
-  - uid: 1313
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.01687,2.4772966
+      pos: 23.5,3.5
       parent: 2
 - proto: DrinkMugRainbow
   entities:
-  - uid: 1314
+  - uid: 1385
     components:
     - type: Transform
       pos: 15.158241,10.521398
       parent: 2
 - proto: DrinkVodkaBottleFull
   entities:
-  - uid: 1315
+  - uid: 1386
     components:
     - type: Transform
       pos: -20.785645,3.762307
       parent: 2
 - proto: EmergencyLight
   entities:
-  - uid: 1316
+  - uid: 1387
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9409,7 +9423,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1317
+  - uid: 1388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9417,7 +9431,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1318
+  - uid: 1389
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9425,7 +9439,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1319
+  - uid: 1390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9433,7 +9447,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1320
+  - uid: 1391
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9441,7 +9455,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1321
+  - uid: 1392
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9449,7 +9463,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1322
+  - uid: 1393
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9457,21 +9471,21 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1323
+  - uid: 1394
     components:
     - type: Transform
       pos: 17.5,1.5
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1324
+  - uid: 1395
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1325
+  - uid: 1396
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9479,7 +9493,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1326
+  - uid: 1397
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9487,7 +9501,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1327
+  - uid: 1398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9495,7 +9509,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1328
+  - uid: 1399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9503,7 +9517,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 1330
+  - uid: 1400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9511,7 +9525,7 @@ entities:
       parent: 2
     - type: Battery
       startingCharge: 30000
-  - uid: 3051
+  - uid: 1401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9519,37 +9533,37 @@ entities:
       parent: 2
 - proto: EmergencyRollerBedSpawnFolded
   entities:
-  - uid: 1331
+  - uid: 1402
     components:
     - type: Transform
       pos: 2.3683515,-0.47065163
       parent: 2
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 1332
-    components:
-    - type: Transform
-      pos: 9.5,6.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 1333
+  - uid: 1404
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1334
+  - uid: 1405
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
+  - uid: 2143
+    components:
+    - type: Transform
+      pos: 13.5,6.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: FaxMachineBase
   entities:
-  - uid: 3037
+  - uid: 1406
     components:
     - type: Transform
       pos: 24.5,2.5
@@ -9558,7 +9572,7 @@ entities:
       name: Bridge
 - proto: FirelockEdge
   entities:
-  - uid: 1336
+  - uid: 1407
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9567,7 +9581,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 10
-  - uid: 1349
+  - uid: 1408
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9576,7 +9590,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 1350
+  - uid: 1409
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9585,7 +9599,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 1351
+  - uid: 1410
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9594,7 +9608,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 1357
+  - uid: 1411
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9603,7 +9617,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 2992
+  - uid: 1412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9612,7 +9626,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 2993
+  - uid: 1413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9621,7 +9635,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 2994
+  - uid: 1414
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9630,7 +9644,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 2995
+  - uid: 1415
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9641,7 +9655,7 @@ entities:
       - 4
 - proto: FirelockGlass
   entities:
-  - uid: 1337
+  - uid: 1416
     components:
     - type: Transform
       pos: -1.5,2.5
@@ -9649,7 +9663,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11
-  - uid: 1338
+  - uid: 1417
     components:
     - type: Transform
       pos: -4.5,2.5
@@ -9658,7 +9672,7 @@ entities:
       deviceLists:
       - 8
       - 7
-  - uid: 1339
+  - uid: 1418
     components:
     - type: Transform
       pos: -10.5,2.5
@@ -9667,7 +9681,7 @@ entities:
       deviceLists:
       - 8
       - 7
-  - uid: 1340
+  - uid: 1419
     components:
     - type: Transform
       pos: -9.5,2.5
@@ -9676,7 +9690,7 @@ entities:
       deviceLists:
       - 8
       - 7
-  - uid: 1341
+  - uid: 1420
     components:
     - type: Transform
       pos: -8.5,2.5
@@ -9685,7 +9699,7 @@ entities:
       deviceLists:
       - 8
       - 7
-  - uid: 1342
+  - uid: 1421
     components:
     - type: Transform
       pos: 2.5,6.5
@@ -9694,17 +9708,17 @@ entities:
       deviceLists:
       - 11
       - 3
-  - uid: 1343
+  - uid: 1422
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 2
-  - uid: 1344
+  - uid: 1423
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 2
-  - uid: 1345
+  - uid: 1424
     components:
     - type: Transform
       pos: 0.5,-5.5
@@ -9712,7 +9726,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11
-  - uid: 1346
+  - uid: 1425
     components:
     - type: Transform
       pos: -0.5,-5.5
@@ -9720,7 +9734,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11
-  - uid: 1347
+  - uid: 1426
     components:
     - type: Transform
       pos: -1.5,-5.5
@@ -9728,12 +9742,12 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11
-  - uid: 1348
+  - uid: 1427
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 2
-  - uid: 1352
+  - uid: 1428
     components:
     - type: Transform
       pos: 0.5,2.5
@@ -9741,7 +9755,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11
-  - uid: 1353
+  - uid: 1429
     components:
     - type: Transform
       pos: -0.5,2.5
@@ -9749,22 +9763,22 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11
-  - uid: 1354
+  - uid: 1430
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 2
-  - uid: 1355
+  - uid: 1431
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 2
-  - uid: 1356
+  - uid: 1432
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 2
-  - uid: 1358
+  - uid: 1433
     components:
     - type: Transform
       pos: 0.5,6.5
@@ -9772,7 +9786,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 3
-  - uid: 1359
+  - uid: 1434
     components:
     - type: Transform
       pos: -1.5,6.5
@@ -9780,7 +9794,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 1360
+  - uid: 1435
     components:
     - type: Transform
       pos: 16.5,4.5
@@ -9789,7 +9803,7 @@ entities:
       deviceLists:
       - 13
       - 16
-  - uid: 1361
+  - uid: 1436
     components:
     - type: Transform
       pos: 17.5,6.5
@@ -9798,7 +9812,7 @@ entities:
       deviceLists:
       - 16
       - 15
-  - uid: 1362
+  - uid: 1437
     components:
     - type: Transform
       pos: 19.5,6.5
@@ -9807,7 +9821,7 @@ entities:
       deviceLists:
       - 16
       - 15
-  - uid: 1363
+  - uid: 1438
     components:
     - type: Transform
       pos: -6.5,2.5
@@ -9816,7 +9830,7 @@ entities:
       deviceLists:
       - 8
       - 7
-  - uid: 1364
+  - uid: 1439
     components:
     - type: Transform
       pos: -14.5,2.5
@@ -9825,7 +9839,7 @@ entities:
       deviceLists:
       - 7
       - 18
-  - uid: 1365
+  - uid: 1440
     components:
     - type: Transform
       pos: -13.5,2.5
@@ -9834,7 +9848,7 @@ entities:
       deviceLists:
       - 7
       - 18
-  - uid: 1366
+  - uid: 1441
     components:
     - type: Transform
       pos: -11.5,4.5
@@ -9843,7 +9857,7 @@ entities:
       deviceLists:
       - 8
       - 18
-  - uid: 1367
+  - uid: 1442
     components:
     - type: Transform
       pos: -2.5,-0.5
@@ -9852,7 +9866,7 @@ entities:
       deviceLists:
       - 7
       - 11
-  - uid: 1368
+  - uid: 1443
     components:
     - type: Transform
       pos: -2.5,0.5
@@ -9861,7 +9875,7 @@ entities:
       deviceLists:
       - 7
       - 11
-  - uid: 1369
+  - uid: 1444
     components:
     - type: Transform
       pos: -2.5,1.5
@@ -9870,7 +9884,7 @@ entities:
       deviceLists:
       - 7
       - 11
-  - uid: 1370
+  - uid: 1445
     components:
     - type: Transform
       pos: 1.5,0.5
@@ -9878,7 +9892,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11
-  - uid: 2996
+  - uid: 1446
     components:
     - type: Transform
       pos: 1.5,-11.5
@@ -9889,47 +9903,47 @@ entities:
       - 11
 - proto: Fireplace
   entities:
-  - uid: 1371
+  - uid: 1447
     components:
     - type: Transform
       pos: 23.5,-2.5
       parent: 2
 - proto: Flash
   entities:
-  - uid: 1372
+  - uid: 1448
     components:
     - type: Transform
       pos: 10.759085,-8.620478
       parent: 2
 - proto: FlashlightLantern
   entities:
-  - uid: 1373
+  - uid: 1449
     components:
     - type: Transform
       pos: -16.427797,2.50669
       parent: 2
-  - uid: 1374
+  - uid: 1450
     components:
     - type: Transform
       pos: -16.563213,2.6005049
       parent: 2
 - proto: FlippoEngravedLighter
   entities:
-  - uid: 1375
+  - uid: 1451
     components:
     - type: Transform
       pos: 26.017355,2.4964807
       parent: 2
 - proto: FloorDrain
   entities:
-  - uid: 1376
+  - uid: 1452
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 1377
+  - uid: 1453
     components:
     - type: Transform
       pos: -5.5,3.5
@@ -9938,35 +9952,35 @@ entities:
       fixtures: {}
 - proto: FoodBowlBig
   entities:
-  - uid: 1378
+  - uid: 1454
     components:
     - type: Transform
       pos: 15.580446,10.595212
       parent: 2
 - proto: ForkPlastic
   entities:
-  - uid: 1379
+  - uid: 1455
     components:
     - type: Transform
       pos: 15.726279,10.605636
       parent: 2
 - proto: GasMinerNitrogen
   entities:
-  - uid: 1380
+  - uid: 1456
     components:
     - type: Transform
       pos: 10.5,-15.5
       parent: 2
 - proto: GasMinerOxygen
   entities:
-  - uid: 1381
+  - uid: 1457
     components:
     - type: Transform
       pos: 10.5,-13.5
       parent: 2
 - proto: GasMixer
   entities:
-  - uid: 1382
+  - uid: 1458
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9980,7 +9994,7 @@ entities:
       color: '#03FCD3FF'
 - proto: GasPassiveVent
   entities:
-  - uid: 1383
+  - uid: 1459
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9988,7 +10002,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 1384
+  - uid: 1460
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9996,7 +10010,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 1385
+  - uid: 1461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10006,14 +10020,14 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBend
   entities:
-  - uid: 1386
+  - uid: 1462
     components:
     - type: Transform
       pos: 15.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1387
+  - uid: 1463
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10021,7 +10035,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 1388
+  - uid: 1464
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10029,14 +10043,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1389
+  - uid: 1465
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1390
+  - uid: 1466
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10044,14 +10058,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1391
+  - uid: 1467
     components:
     - type: Transform
       pos: 9.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1392
+  - uid: 1468
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10059,21 +10073,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1393
+  - uid: 1469
     components:
     - type: Transform
       pos: 12.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1394
+  - uid: 1470
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1395
+  - uid: 1471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10081,14 +10095,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1396
+  - uid: 1472
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1397
+  - uid: 1473
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10096,7 +10110,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1398
+  - uid: 1474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10104,7 +10118,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1399
+  - uid: 1475
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10112,14 +10126,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1400
+  - uid: 1476
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1401
+  - uid: 1477
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10127,7 +10141,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1402
+  - uid: 1478
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10135,7 +10149,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1403
+  - uid: 1479
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10143,7 +10157,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1404
+  - uid: 1480
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10151,7 +10165,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1405
+  - uid: 1481
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10159,7 +10173,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1406
+  - uid: 1482
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10167,7 +10181,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1407
+  - uid: 1483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10175,7 +10189,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1408
+  - uid: 1484
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10183,7 +10197,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1409
+  - uid: 1485
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10191,7 +10205,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1410
+  - uid: 1486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10199,7 +10213,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1411
+  - uid: 1487
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10207,7 +10221,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1413
+  - uid: 1488
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10215,7 +10229,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1414
+  - uid: 1489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10223,7 +10237,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1415
+  - uid: 1490
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10231,14 +10245,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1416
+  - uid: 1491
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1417
+  - uid: 1492
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10246,7 +10260,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1418
+  - uid: 1493
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10256,70 +10270,70 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeFourway
   entities:
-  - uid: 1419
+  - uid: 1494
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1420
+  - uid: 1495
     components:
     - type: Transform
       pos: 17.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1421
+  - uid: 1496
     components:
     - type: Transform
       pos: 22.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1422
+  - uid: 1497
     components:
     - type: Transform
       pos: -17.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1423
+  - uid: 1498
     components:
     - type: Transform
       pos: 15.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1424
+  - uid: 1499
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1425
+  - uid: 1500
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1426
+  - uid: 1501
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1427
+  - uid: 1502
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1428
+  - uid: 1503
     components:
     - type: Transform
       pos: 16.5,-0.5
@@ -10328,7 +10342,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeSensorDistribution
   entities:
-  - uid: 1429
+  - uid: 1504
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10338,7 +10352,7 @@ entities:
       color: '#03FCD3FF'
 - proto: GasPipeSensorWaste
   entities:
-  - uid: 1430
+  - uid: 1505
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10348,7 +10362,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
-  - uid: 1431
+  - uid: 1506
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10356,7 +10370,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1432
+  - uid: 1507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10364,7 +10378,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1433
+  - uid: 1508
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10372,7 +10386,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1434
+  - uid: 1509
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10380,7 +10394,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1435
+  - uid: 1510
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10388,7 +10402,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1436
+  - uid: 1511
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10396,7 +10410,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1437
+  - uid: 1512
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10404,7 +10418,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1438
+  - uid: 1513
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10412,7 +10426,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1439
+  - uid: 1514
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10420,7 +10434,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1440
+  - uid: 1515
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10428,7 +10442,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1441
+  - uid: 1516
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10436,7 +10450,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1442
+  - uid: 1517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10444,7 +10458,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1443
+  - uid: 1518
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10452,7 +10466,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1444
+  - uid: 1519
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10460,7 +10474,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1445
+  - uid: 1520
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10468,7 +10482,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 1446
+  - uid: 1521
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10476,7 +10490,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 1447
+  - uid: 1522
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10484,7 +10498,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1448
+  - uid: 1523
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10492,7 +10506,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1449
+  - uid: 1524
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10500,14 +10514,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1450
+  - uid: 1525
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1451
+  - uid: 1526
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10515,7 +10529,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1452
+  - uid: 1527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10523,7 +10537,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1453
+  - uid: 1528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10531,7 +10545,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1454
+  - uid: 1529
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10539,7 +10553,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1455
+  - uid: 1530
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10547,7 +10561,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1456
+  - uid: 1531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10555,601 +10569,17 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1457
+  - uid: 1532
     components:
     - type: Transform
       pos: -17.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1458
-    components:
-    - type: Transform
-      pos: -17.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1459
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -18.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1460
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1461
-    components:
-    - type: Transform
-      pos: -0.5,-14.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1462
-    components:
-    - type: Transform
-      pos: 5.5,15.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1463
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1464
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-15.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 1465
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-13.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 1466
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-14.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 1467
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 1468
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 1469
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1470
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1471
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1472
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1473
-    components:
-    - type: Transform
-      pos: -0.5,-8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1474
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1475
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1476
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1477
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1478
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1479
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1480
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1481
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1482
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1483
-    components:
-    - type: Transform
-      pos: 3.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1484
-    components:
-    - type: Transform
-      pos: 3.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1485
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1486
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1487
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1488
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1489
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1490
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1491
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1492
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1493
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1494
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1495
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 12.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1496
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1497
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1498
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1499
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1500
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1501
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1502
-    components:
-    - type: Transform
-      pos: 17.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1503
-    components:
-    - type: Transform
-      pos: 17.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1504
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1505
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1506
-    components:
-    - type: Transform
-      pos: 22.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1507
-    components:
-    - type: Transform
-      pos: 22.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1508
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1509
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1510
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1511
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1512
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1513
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 12.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1514
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1515
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1516
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1517
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1518
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1519
-    components:
-    - type: Transform
-      pos: 5.5,8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1520
-    components:
-    - type: Transform
-      pos: 5.5,9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1521
-    components:
-    - type: Transform
-      pos: 5.5,10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1522
-    components:
-    - type: Transform
-      pos: 5.5,11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1523
-    components:
-    - type: Transform
-      pos: 5.5,12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1524
-    components:
-    - type: Transform
-      pos: 5.5,13.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1525
-    components:
-    - type: Transform
-      pos: 5.5,14.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1526
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1527
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1528
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1529
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1530
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1531
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1532
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 1533
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,7.5
+      pos: -17.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11157,156 +10587,156 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,4.5
+      pos: -18.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1535
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,4.5
+      rot: 3.141592653589793 rad
+      pos: -17.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1536
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,4.5
+      pos: -0.5,-14.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1537
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,4.5
+      pos: 5.5,15.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1538
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,4.5
+      rot: 3.141592653589793 rad
+      pos: 18.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1539
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF1212FF'
   - uid: 1540
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#0335FCFF'
   - uid: 1541
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,0.5
+      rot: 3.141592653589793 rad
+      pos: 7.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#FF1212FF'
   - uid: 1542
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#03FCD3FF'
   - uid: 1543
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#03FCD3FF'
   - uid: 1544
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-12.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1545
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-12.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1546
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-12.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1547
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 1548
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,0.5
+      pos: -0.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1549
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1550
     components:
     - type: Transform
-      pos: -17.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1551
     components:
     - type: Transform
-      pos: -17.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1552
     components:
     - type: Transform
-      pos: -17.5,5.5
+      rot: 3.141592653589793 rad
+      pos: -0.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1553
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,0.5
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11314,42 +10744,45 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -17.5,-1.5
+      pos: -0.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1555
     components:
     - type: Transform
-      pos: -13.5,-0.5
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1556
     components:
     - type: Transform
-      pos: -5.5,-0.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1557
     components:
     - type: Transform
-      pos: -7.5,1.5
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1558
     components:
     - type: Transform
-      pos: -7.5,2.5
+      pos: 3.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1559
     components:
     - type: Transform
-      pos: -7.5,3.5
+      pos: 3.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11357,7 +10790,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -9.5,4.5
+      pos: 4.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11365,7 +10798,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -10.5,4.5
+      pos: 6.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11373,7 +10806,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -11.5,4.5
+      pos: 7.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11381,7 +10814,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -12.5,4.5
+      pos: 9.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11389,15 +10822,15 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,4.5
+      pos: 10.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1565
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,4.5
+      rot: 3.141592653589793 rad
+      pos: 11.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -11405,18 +10838,599 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,5.5
+      pos: 11.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1567
     components:
     - type: Transform
-      pos: -17.5,-3.5
+      rot: 1.5707963267948966 rad
+      pos: 10.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 1568
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1569
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1570
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1571
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1572
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1573
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1574
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1575
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1576
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1577
+    components:
+    - type: Transform
+      pos: 17.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1578
+    components:
+    - type: Transform
+      pos: 17.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1579
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1580
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1581
+    components:
+    - type: Transform
+      pos: 22.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1582
+    components:
+    - type: Transform
+      pos: 22.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1583
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1584
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1585
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1586
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1587
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1588
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1589
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1590
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1591
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1592
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1593
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1594
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1595
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1596
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1597
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1598
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1599
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1600
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1601
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1602
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1603
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1604
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1605
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1606
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1607
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1608
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1609
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1610
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1611
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1612
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1613
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1614
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1615
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1616
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1617
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1618
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1619
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1620
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1621
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1622
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1623
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1624
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1625
+    components:
+    - type: Transform
+      pos: -17.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1626
+    components:
+    - type: Transform
+      pos: -17.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1627
+    components:
+    - type: Transform
+      pos: -17.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1628
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1629
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1630
+    components:
+    - type: Transform
+      pos: -13.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1631
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1632
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1633
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1634
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1635
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1636
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1637
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1638
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1639
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1640
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1641
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1642
+    components:
+    - type: Transform
+      pos: -17.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1643
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11424,7 +11438,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1569
+  - uid: 1644
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11432,7 +11446,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1570
+  - uid: 1645
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11440,7 +11454,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1571
+  - uid: 1646
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11448,7 +11462,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1572
+  - uid: 1647
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11456,7 +11470,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1573
+  - uid: 1648
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11464,600 +11478,10 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1574
-    components:
-    - type: Transform
-      pos: 0.5,-7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1575
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1576
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1577
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1578
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1579
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1580
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1581
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1582
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1583
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1584
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1585
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1586
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1587
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1588
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1589
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1590
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1591
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1592
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1593
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1594
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1595
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1596
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1597
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1598
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1599
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -19.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1600
-    components:
-    - type: Transform
-      pos: -3.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1601
-    components:
-    - type: Transform
-      pos: -3.5,-2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1602
-    components:
-    - type: Transform
-      pos: -8.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1603
-    components:
-    - type: Transform
-      pos: -9.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1604
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1605
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1606
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1607
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1608
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1609
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1610
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1611
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1612
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,5.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1613
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1614
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1615
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1616
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1617
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1618
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1619
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1620
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1621
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1622
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,12.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1623
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,13.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1624
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,14.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1625
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1626
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1627
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1628
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1629
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1630
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,4.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1631
-    components:
-    - type: Transform
-      pos: 6.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1632
-    components:
-    - type: Transform
-      pos: 6.5,7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1633
-    components:
-    - type: Transform
-      pos: 6.5,8.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1634
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1635
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-11.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 1636
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1637
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1638
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1639
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1640
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1641
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1642
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1643
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,3.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1644
-    components:
-    - type: Transform
-      pos: 14.5,2.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1645
-    components:
-    - type: Transform
-      pos: 14.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1646
-    components:
-    - type: Transform
-      pos: 14.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1647
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1648
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 1649
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-0.5
+      pos: 0.5,-7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12065,31 +11489,31 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 20.5,-0.5
+      pos: -0.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1651
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 22.5,-0.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1652
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1653
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12097,7 +11521,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 21.5,-2.5
+      pos: -1.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12105,7 +11529,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 16.5,-1.5
+      pos: -1.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12113,7 +11537,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 16.5,-2.5
+      pos: -1.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12121,7 +11545,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,0.5
+      pos: -1.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12129,7 +11553,7 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,1.5
+      pos: -1.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12137,15 +11561,15 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,2.5
+      pos: 7.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1660
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,1.5
+      rot: 3.141592653589793 rad
+      pos: 7.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12153,21 +11577,23 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -11.5,1.5
+      pos: 5.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1662
     components:
     - type: Transform
-      pos: -12.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1663
     components:
     - type: Transform
-      pos: -12.5,3.5
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12175,7 +11601,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -2.5,-0.5
+      pos: -4.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12183,23 +11609,23 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 9.5,-4.5
+      pos: -5.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1666
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1667
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12207,125 +11633,123 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-11.5
+      pos: -10.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1669
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 1670
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 8.5,-6.5
+      pos: -13.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1671
     components:
     - type: Transform
-      pos: -0.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 1672
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: -17.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 1673
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-11.5
+      pos: -18.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1674
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-12.5
+      rot: -1.5707963267948966 rad
+      pos: -19.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1675
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -12.5,-0.5
+      pos: -3.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1676
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-6.5
+      pos: -3.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1677
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-11.5
+      pos: -8.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#990000FF'
   - uid: 1678
     components:
     - type: Transform
-      pos: -17.5,-4.5
+      pos: -9.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 1679
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -7.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1680
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -6.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1681
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,8.5
+      rot: 3.141592653589793 rad
+      pos: -5.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1682
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,8.5
+      rot: 3.141592653589793 rad
+      pos: -5.5,3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 1683
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,8.5
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -12333,11 +11757,601 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1685
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1686
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1687
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1688
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1689
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1690
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1691
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1692
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1693
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1694
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1695
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1696
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1697
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1698
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1699
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1700
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1701
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1702
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1703
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1704
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1705
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1706
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1707
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1708
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1709
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1710
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1711
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1712
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1713
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1714
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1715
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1716
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1717
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1718
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1719
+    components:
+    - type: Transform
+      pos: 14.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1720
+    components:
+    - type: Transform
+      pos: 14.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1721
+    components:
+    - type: Transform
+      pos: 14.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1722
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1723
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1724
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1725
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1726
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1727
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 23.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1728
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1729
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1730
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1731
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1732
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1733
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1734
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1735
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1736
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1737
+    components:
+    - type: Transform
+      pos: -12.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1738
+    components:
+    - type: Transform
+      pos: -12.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1739
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1740
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1741
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1742
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1743
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1744
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1745
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1746
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1747
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -16.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1748
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1749
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1750
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1751
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1752
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
+  - uid: 1753
+    components:
+    - type: Transform
+      pos: -17.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 1754
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1755
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1756
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1757
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1758
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 1759
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 16.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1685
+  - uid: 1760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12345,7 +12359,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1686
+  - uid: 1761
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12353,7 +12367,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1687
+  - uid: 1762
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12361,7 +12375,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1688
+  - uid: 1763
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12369,7 +12383,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1689
+  - uid: 1764
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12377,7 +12391,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1690
+  - uid: 1765
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12385,7 +12399,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1691
+  - uid: 1766
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12393,7 +12407,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1692
+  - uid: 1767
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12401,7 +12415,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 1693
+  - uid: 1768
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12411,7 +12425,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 1694
+  - uid: 1769
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12419,7 +12433,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1695
+  - uid: 1770
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12427,7 +12441,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1696
+  - uid: 1771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12435,7 +12449,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1697
+  - uid: 1772
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12443,7 +12457,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1698
+  - uid: 1773
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12451,7 +12465,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1699
+  - uid: 1774
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12459,7 +12473,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1700
+  - uid: 1775
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12467,14 +12481,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1701
+  - uid: 1776
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1702
+  - uid: 1777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12482,7 +12496,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1703
+  - uid: 1778
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12490,7 +12504,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1704
+  - uid: 1779
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12498,7 +12512,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1705
+  - uid: 1780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12506,14 +12520,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1706
+  - uid: 1781
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1707
+  - uid: 1782
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12521,14 +12535,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 1708
+  - uid: 1783
     components:
     - type: Transform
       pos: 7.5,-11.5
       parent: 2
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 1709
+  - uid: 1784
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12536,7 +12550,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 1710
+  - uid: 1785
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12544,28 +12558,28 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1711
+  - uid: 1786
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1712
+  - uid: 1787
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1713
+  - uid: 1788
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1714
+  - uid: 1789
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12573,7 +12587,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1715
+  - uid: 1790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12581,14 +12595,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1716
+  - uid: 1791
     components:
     - type: Transform
       pos: 11.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1717
+  - uid: 1792
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12596,7 +12610,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1718
+  - uid: 1793
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12604,14 +12618,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1719
+  - uid: 1794
     components:
     - type: Transform
       pos: -13.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1720
+  - uid: 1795
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12619,14 +12633,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1721
+  - uid: 1796
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1722
+  - uid: 1797
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12634,21 +12648,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1723
+  - uid: 1798
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1724
+  - uid: 1799
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1725
+  - uid: 1800
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12656,7 +12670,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1726
+  - uid: 1801
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12664,21 +12678,21 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1727
+  - uid: 1802
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1728
+  - uid: 1803
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1729
+  - uid: 1804
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12686,35 +12700,35 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1730
+  - uid: 1805
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1731
+  - uid: 1806
     components:
     - type: Transform
       pos: -16.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1732
+  - uid: 1807
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1733
+  - uid: 1808
     components:
     - type: Transform
       pos: -8.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1734
+  - uid: 1809
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12722,14 +12736,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1735
+  - uid: 1810
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1736
+  - uid: 1811
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12737,7 +12751,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1737
+  - uid: 1812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12745,7 +12759,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1738
+  - uid: 1813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12753,14 +12767,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1739
+  - uid: 1814
     components:
     - type: Transform
       pos: 21.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1740
+  - uid: 1815
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12768,7 +12782,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1741
+  - uid: 1816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12776,14 +12790,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1742
+  - uid: 1817
     components:
     - type: Transform
       pos: -9.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1743
+  - uid: 1818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12791,7 +12805,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1812
+  - uid: 1819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12801,14 +12815,14 @@ entities:
       color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 1744
+  - uid: 1820
     components:
     - type: Transform
       pos: 5.5,-10.5
       parent: 2
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 1745
+  - uid: 1821
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12816,7 +12830,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1746
+  - uid: 1822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12826,7 +12840,7 @@ entities:
       color: '#990000FF'
 - proto: GasPressurePump
   entities:
-  - uid: 1747
+  - uid: 1823
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12836,7 +12850,7 @@ entities:
       targetPressure: 4500
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1748
+  - uid: 1824
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12844,7 +12858,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1749
+  - uid: 1825
     components:
     - type: Transform
       pos: 5.5,-11.5
@@ -12853,7 +12867,7 @@ entities:
       targetPressure: 4500
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 1750
+  - uid: 1826
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12865,7 +12879,7 @@ entities:
       color: '#990000FF'
 - proto: GasVentPump
   entities:
-  - uid: 1751
+  - uid: 1827
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12873,14 +12887,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1752
+  - uid: 1828
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1753
+  - uid: 1829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12888,7 +12902,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1754
+  - uid: 1830
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12896,7 +12910,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1755
+  - uid: 1831
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12907,7 +12921,7 @@ entities:
       - 7
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1756
+  - uid: 1832
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -12915,7 +12929,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1757
+  - uid: 1833
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12926,7 +12940,7 @@ entities:
       - 14
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 1758
+  - uid: 1834
     components:
     - type: Transform
       pos: 18.5,3.5
@@ -12936,7 +12950,7 @@ entities:
       - 16
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1759
+  - uid: 1835
     components:
     - type: Transform
       pos: 17.5,1.5
@@ -12946,7 +12960,7 @@ entities:
       - 17
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1760
+  - uid: 1836
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -12954,7 +12968,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1761
+  - uid: 1837
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12962,7 +12976,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1762
+  - uid: 1838
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12970,7 +12984,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1763
+  - uid: 1839
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12981,7 +12995,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1764
+  - uid: 1840
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -12989,7 +13003,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1765
+  - uid: 1841
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13000,7 +13014,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1766
+  - uid: 1842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13011,7 +13025,7 @@ entities:
       - 6
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1767
+  - uid: 1843
     components:
     - type: Transform
       pos: 22.5,1.5
@@ -13021,7 +13035,7 @@ entities:
       - 10
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1768
+  - uid: 1844
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13032,7 +13046,7 @@ entities:
       - 10
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1769
+  - uid: 1845
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13043,7 +13057,7 @@ entities:
       - 10
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1770
+  - uid: 1846
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13054,7 +13068,7 @@ entities:
       - 17
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1771
+  - uid: 1847
     components:
     - type: Transform
       pos: 5.5,16.5
@@ -13064,7 +13078,7 @@ entities:
       - 12
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1772
+  - uid: 1848
     components:
     - type: Transform
       pos: -1.5,8.5
@@ -13074,7 +13088,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1773
+  - uid: 1849
     components:
     - type: Transform
       pos: 0.5,8.5
@@ -13084,7 +13098,7 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1774
+  - uid: 1850
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13095,7 +13109,7 @@ entities:
       - 9
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1775
+  - uid: 1851
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13103,7 +13117,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1776
+  - uid: 1852
     components:
     - type: Transform
       pos: -17.5,6.5
@@ -13113,7 +13127,7 @@ entities:
       - 9
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1777
+  - uid: 1853
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13124,7 +13138,7 @@ entities:
       - 8
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1778
+  - uid: 1854
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13135,7 +13149,7 @@ entities:
       - 18
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1779
+  - uid: 1855
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13146,7 +13160,7 @@ entities:
       - 8
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1780
+  - uid: 1856
     components:
     - type: Transform
       pos: 15.5,5.5
@@ -13156,7 +13170,7 @@ entities:
       - 13
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1781
+  - uid: 1857
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13167,7 +13181,7 @@ entities:
       - 7
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1782
+  - uid: 1858
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13175,7 +13189,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1783
+  - uid: 1859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13186,7 +13200,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1784
+  - uid: 1860
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13194,7 +13208,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 1785
+  - uid: 1861
     components:
     - type: Transform
       pos: 17.5,9.5
@@ -13204,7 +13218,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 15
-  - uid: 1786
+  - uid: 1862
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13214,7 +13228,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 1412
+  - uid: 1863
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13225,7 +13239,7 @@ entities:
       - 14
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1787
+  - uid: 1864
     components:
     - type: Transform
       pos: 14.5,9.5
@@ -13235,7 +13249,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 15
-  - uid: 1788
+  - uid: 1865
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13246,7 +13260,7 @@ entities:
       - 4
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1789
+  - uid: 1866
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13254,7 +13268,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1790
+  - uid: 1867
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13265,7 +13279,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 13
-  - uid: 1791
+  - uid: 1868
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13276,7 +13290,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1792
+  - uid: 1869
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13287,7 +13301,7 @@ entities:
       - 6
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1793
+  - uid: 1870
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13298,7 +13312,7 @@ entities:
       - 11
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1794
+  - uid: 1871
     components:
     - type: Transform
       pos: 6.5,0.5
@@ -13308,7 +13322,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1795
+  - uid: 1872
     components:
     - type: Transform
       pos: 4.5,0.5
@@ -13318,7 +13332,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1796
+  - uid: 1873
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13329,7 +13343,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1797
+  - uid: 1874
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13340,7 +13354,7 @@ entities:
       - 9
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1798
+  - uid: 1875
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13348,7 +13362,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1799
+  - uid: 1876
     components:
     - type: Transform
       pos: -12.5,4.5
@@ -13358,7 +13372,7 @@ entities:
       - 18
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1800
+  - uid: 1877
     components:
     - type: Transform
       pos: -9.5,3.5
@@ -13368,7 +13382,7 @@ entities:
       - 8
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1801
+  - uid: 1878
     components:
     - type: Transform
       pos: -5.5,4.5
@@ -13378,7 +13392,7 @@ entities:
       - 8
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1802
+  - uid: 1879
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13386,7 +13400,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1803
+  - uid: 1880
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13397,7 +13411,7 @@ entities:
       - 11
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1804
+  - uid: 1881
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13408,14 +13422,14 @@ entities:
       - 3
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1805
+  - uid: 1882
     components:
     - type: Transform
       pos: 1.5,15.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1806
+  - uid: 1883
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13426,7 +13440,7 @@ entities:
       - 12
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1807
+  - uid: 1884
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13434,7 +13448,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1808
+  - uid: 1885
     components:
     - type: Transform
       pos: 23.5,1.5
@@ -13444,7 +13458,7 @@ entities:
       - 10
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1809
+  - uid: 1886
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13452,7 +13466,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1810
+  - uid: 1887
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13463,7 +13477,7 @@ entities:
       - 17
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1811
+  - uid: 1888
     components:
     - type: Transform
       pos: 19.5,3.5
@@ -13473,7 +13487,7 @@ entities:
       - 16
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1813
+  - uid: 1889
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -13484,7 +13498,7 @@ entities:
       - 5
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1814
+  - uid: 1890
     components:
     - type: Transform
       pos: 10.5,5.5
@@ -13494,7 +13508,7 @@ entities:
       - 11
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1815
+  - uid: 1891
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13502,7 +13516,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1816
+  - uid: 1892
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -13513,7 +13527,7 @@ entities:
       - 7
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1817
+  - uid: 1893
     components:
     - type: Transform
       pos: 16.5,0.5
@@ -13523,7 +13537,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 17
-  - uid: 1818
+  - uid: 1894
     components:
     - type: Transform
       pos: -4.5,9.5
@@ -13535,26 +13549,26 @@ entities:
       color: '#990000FF'
 - proto: GeigerCounter
   entities:
-  - uid: 1819
+  - uid: 1895
     components:
     - type: Transform
       pos: -20.66175,3.4127471
       parent: 2
-  - uid: 1820
+  - uid: 1896
     components:
     - type: Transform
       pos: -20.521126,3.3189971
       parent: 2
 - proto: GeneratorRTGDamaged
   entities:
-  - uid: 1821
+  - uid: 1897
     components:
     - type: Transform
       pos: -23.5,0.5
       parent: 2
 - proto: GravityGeneratorMini
   entities:
-  - uid: 1822
+  - uid: 1898
     components:
     - type: Transform
       pos: -22.5,-2.5
@@ -13563,566 +13577,566 @@ entities:
       radius: 175.75
 - proto: Grille
   entities:
-  - uid: 557
+  - uid: 1899
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 2
-  - uid: 1039
+  - uid: 1900
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 2
-  - uid: 1823
+  - uid: 1901
     components:
     - type: Transform
       pos: 15.5,-12.5
       parent: 2
-  - uid: 1825
+  - uid: 1902
     components:
     - type: Transform
       pos: -10.5,-7.5
       parent: 2
-  - uid: 1826
+  - uid: 1903
     components:
     - type: Transform
       pos: 23.5,8.5
       parent: 2
-  - uid: 1827
+  - uid: 1904
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 2
-  - uid: 1828
+  - uid: 1905
     components:
     - type: Transform
       pos: 23.5,9.5
       parent: 2
-  - uid: 1829
+  - uid: 1906
     components:
     - type: Transform
       pos: 25.5,6.5
       parent: 2
-  - uid: 1830
+  - uid: 1907
     components:
     - type: Transform
       pos: 11.5,9.5
       parent: 2
-  - uid: 1831
+  - uid: 1908
     components:
     - type: Transform
       pos: 24.5,7.5
       parent: 2
-  - uid: 1832
+  - uid: 1909
     components:
     - type: Transform
       pos: 14.5,14.5
       parent: 2
-  - uid: 1833
+  - uid: 1910
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 2
-  - uid: 1834
+  - uid: 1911
     components:
     - type: Transform
       pos: 6.5,18.5
       parent: 2
-  - uid: 1835
+  - uid: 1912
     components:
     - type: Transform
       pos: 8.5,17.5
       parent: 2
-  - uid: 1836
+  - uid: 1913
     components:
     - type: Transform
       pos: 8.5,18.5
       parent: 2
-  - uid: 1837
+  - uid: 1914
     components:
     - type: Transform
       pos: 6.5,19.5
       parent: 2
-  - uid: 1838
+  - uid: 1915
     components:
     - type: Transform
       pos: 8.5,19.5
       parent: 2
-  - uid: 1839
+  - uid: 1916
     components:
     - type: Transform
       pos: 14.5,17.5
       parent: 2
-  - uid: 1840
+  - uid: 1917
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 2
-  - uid: 1841
+  - uid: 1918
     components:
     - type: Transform
       pos: 15.5,6.5
       parent: 2
-  - uid: 1842
+  - uid: 1919
     components:
     - type: Transform
       pos: 14.5,6.5
       parent: 2
-  - uid: 1843
+  - uid: 1920
     components:
     - type: Transform
       pos: 19.5,2.5
       parent: 2
-  - uid: 1844
+  - uid: 1921
     components:
     - type: Transform
       pos: 20.5,1.5
       parent: 2
-  - uid: 1845
+  - uid: 1922
     components:
     - type: Transform
       pos: 20.5,-0.5
       parent: 2
-  - uid: 1846
+  - uid: 1923
     components:
     - type: Transform
       pos: 25.5,-4.5
       parent: 2
-  - uid: 1847
+  - uid: 1924
     components:
     - type: Transform
       pos: 27.5,-0.5
       parent: 2
-  - uid: 1848
+  - uid: 1925
     components:
     - type: Transform
       pos: 25.5,-3.5
       parent: 2
-  - uid: 1849
+  - uid: 1926
     components:
     - type: Transform
       pos: 26.5,-3.5
       parent: 2
-  - uid: 1850
+  - uid: 1927
     components:
     - type: Transform
       pos: 26.5,-2.5
       parent: 2
-  - uid: 1851
+  - uid: 1928
     components:
     - type: Transform
       pos: 24.5,-4.5
       parent: 2
-  - uid: 1852
+  - uid: 1929
     components:
     - type: Transform
       pos: 27.5,0.5
       parent: 2
-  - uid: 1853
+  - uid: 1930
     components:
     - type: Transform
       pos: 27.5,1.5
       parent: 2
-  - uid: 1854
+  - uid: 1931
     components:
     - type: Transform
       pos: 27.5,2.5
       parent: 2
-  - uid: 1855
+  - uid: 1932
     components:
     - type: Transform
       pos: 26.5,4.5
       parent: 2
-  - uid: 1856
+  - uid: 1933
     components:
     - type: Transform
       pos: 13.5,-0.5
       parent: 2
-  - uid: 1857
+  - uid: 1934
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 2
-  - uid: 1858
+  - uid: 1935
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 2
-  - uid: 1859
+  - uid: 1936
     components:
     - type: Transform
       pos: 8.5,-15.5
       parent: 2
-  - uid: 1860
+  - uid: 1937
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 2
-  - uid: 1861
+  - uid: 1938
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 2
-  - uid: 1862
+  - uid: 1939
     components:
     - type: Transform
       pos: 22.5,9.5
       parent: 2
-  - uid: 1863
+  - uid: 1940
     components:
     - type: Transform
       pos: 25.5,7.5
       parent: 2
-  - uid: 1864
+  - uid: 1941
     components:
     - type: Transform
       pos: 13.5,-11.5
       parent: 2
-  - uid: 1865
+  - uid: 1942
     components:
     - type: Transform
       pos: -24.5,-1.5
       parent: 2
-  - uid: 1866
+  - uid: 1943
     components:
     - type: Transform
       pos: -24.5,-0.5
       parent: 2
-  - uid: 1867
+  - uid: 1944
     components:
     - type: Transform
       pos: -24.5,0.5
       parent: 2
-  - uid: 1868
+  - uid: 1945
     components:
     - type: Transform
       pos: -24.5,1.5
       parent: 2
-  - uid: 1869
+  - uid: 1946
     components:
     - type: Transform
       pos: -24.5,2.5
       parent: 2
-  - uid: 1870
+  - uid: 1947
     components:
     - type: Transform
       pos: -16.5,5.5
       parent: 2
-  - uid: 1871
+  - uid: 1948
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 2
-  - uid: 1872
+  - uid: 1949
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 2
-  - uid: 1873
+  - uid: 1950
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 2
-  - uid: 1874
+  - uid: 1951
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 2
-  - uid: 1875
+  - uid: 1952
     components:
     - type: Transform
       pos: 6.5,17.5
       parent: 2
-  - uid: 1876
+  - uid: 1953
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-  - uid: 1877
+  - uid: 1954
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 2
-  - uid: 1878
+  - uid: 1955
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 2
-  - uid: 1879
+  - uid: 1956
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 2
-  - uid: 1880
+  - uid: 1957
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 2
-  - uid: 1881
+  - uid: 1958
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-  - uid: 1882
+  - uid: 1959
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 2
-  - uid: 1883
+  - uid: 1960
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 2
-  - uid: 1884
+  - uid: 1961
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 2
-  - uid: 1885
+  - uid: 1962
     components:
     - type: Transform
       pos: -5.5,12.5
       parent: 2
-  - uid: 1886
+  - uid: 1963
     components:
     - type: Transform
       pos: -7.5,-8.5
       parent: 2
-  - uid: 1887
+  - uid: 1964
     components:
     - type: Transform
       pos: -7.5,10.5
       parent: 2
-  - uid: 1888
+  - uid: 1965
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 2
-  - uid: 1889
+  - uid: 1966
     components:
     - type: Transform
       pos: 11.5,10.5
       parent: 2
-  - uid: 1890
+  - uid: 1967
     components:
     - type: Transform
       pos: -14.5,-7.5
       parent: 2
-  - uid: 1891
+  - uid: 1968
     components:
     - type: Transform
       pos: 18.5,-8.5
       parent: 2
-  - uid: 1892
+  - uid: 1969
     components:
     - type: Transform
       pos: 17.5,11.5
       parent: 2
-  - uid: 1893
+  - uid: 1970
     components:
     - type: Transform
       pos: -4.5,-13.5
       parent: 2
-  - uid: 1894
+  - uid: 1971
     components:
     - type: Transform
       pos: 24.5,8.5
       parent: 2
-  - uid: 1895
+  - uid: 1972
     components:
     - type: Transform
       pos: 16.5,11.5
       parent: 2
-  - uid: 1896
+  - uid: 1973
     components:
     - type: Transform
       pos: 25.5,5.5
       parent: 2
-  - uid: 1897
+  - uid: 1974
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 2
-  - uid: 1898
+  - uid: 1975
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 2
-  - uid: 1899
+  - uid: 1976
     components:
     - type: Transform
       pos: -18.5,-7.5
       parent: 2
-  - uid: 1900
+  - uid: 1977
     components:
     - type: Transform
       pos: -14.5,9.5
       parent: 2
-  - uid: 1901
+  - uid: 1978
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 2
-  - uid: 1902
+  - uid: 1979
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 2
-  - uid: 1903
+  - uid: 1980
     components:
     - type: Transform
       pos: -18.5,7.5
       parent: 2
-  - uid: 1904
+  - uid: 1981
     components:
     - type: Transform
       pos: -18.5,-5.5
       parent: 2
-  - uid: 1905
+  - uid: 1982
     components:
     - type: Transform
       pos: 26.5,5.5
       parent: 2
-  - uid: 1906
+  - uid: 1983
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 2
-  - uid: 1907
+  - uid: 1984
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 2
-  - uid: 1908
+  - uid: 1985
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 2
-  - uid: 1909
+  - uid: 1986
     components:
     - type: Transform
       pos: -16.5,-5.5
       parent: 2
-  - uid: 1910
+  - uid: 1987
     components:
     - type: Transform
       pos: -16.5,-7.5
       parent: 2
-  - uid: 1911
+  - uid: 1988
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 2
-  - uid: 1912
+  - uid: 1989
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 2
-  - uid: 1913
+  - uid: 1990
     components:
     - type: Transform
       pos: -28.5,0.5
       parent: 2
-  - uid: 1914
+  - uid: 1991
     components:
     - type: Transform
       pos: -28.5,-0.5
       parent: 2
-  - uid: 1915
+  - uid: 1992
     components:
     - type: Transform
       pos: -28.5,1.5
       parent: 2
-  - uid: 1916
+  - uid: 1993
     components:
     - type: Transform
       pos: -7.5,7.5
       parent: 2
-  - uid: 1917
+  - uid: 1994
     components:
     - type: Transform
       pos: -7.5,9.5
       parent: 2
-  - uid: 1918
+  - uid: 1995
     components:
     - type: Transform
       pos: -8.5,11.5
       parent: 2
-  - uid: 1919
+  - uid: 1996
     components:
     - type: Transform
       pos: -9.5,11.5
       parent: 2
-  - uid: 1920
+  - uid: 1997
     components:
     - type: Transform
       pos: -10.5,11.5
       parent: 2
-  - uid: 1921
+  - uid: 1998
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 2
-  - uid: 1922
+  - uid: 1999
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 2
-  - uid: 1923
+  - uid: 2000
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 2
-  - uid: 1924
+  - uid: 2001
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 2
-  - uid: 1925
+  - uid: 2002
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 2
-  - uid: 1926
+  - uid: 2003
     components:
     - type: Transform
       pos: -7.5,-9.5
       parent: 2
-  - uid: 1988
+  - uid: 2004
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,17.5
       parent: 2
-  - uid: 2074
+  - uid: 2005
     components:
     - type: Transform
       pos: 13.5,19.5
       parent: 2
-  - uid: 2449
+  - uid: 2006
     components:
     - type: Transform
       pos: 12.5,19.5
       parent: 2
-  - uid: 2623
+  - uid: 2007
     components:
     - type: Transform
       pos: 14.5,15.5
       parent: 2
-  - uid: 3075
+  - uid: 2008
     components:
     - type: Transform
       pos: 13.5,16.5
       parent: 2
 - proto: Gyroscope
   entities:
-  - uid: 1927
+  - uid: 2009
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,2.5
       parent: 2
-  - uid: 1928
+  - uid: 2010
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14130,146 +14144,146 @@ entities:
       parent: 2
 - proto: HolofanProjector
   entities:
-  - uid: 1929
+  - uid: 2011
     components:
     - type: Transform
       pos: 4.5765324,-10.477916
       parent: 2
-  - uid: 1930
+  - uid: 2012
     components:
     - type: Transform
       pos: 4.6859074,-10.602916
       parent: 2
 - proto: HolopadCargoBay
   entities:
-  - uid: 3073
+  - uid: 2013
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 2
 - proto: HolopadCommandBridgeLongRange
   entities:
-  - uid: 1932
+  - uid: 2014
     components:
     - type: Transform
       pos: 22.5,0.5
       parent: 2
 - proto: HolopadEngineeringMain
   entities:
-  - uid: 3071
+  - uid: 2015
     components:
     - type: Transform
       pos: -17.5,1.5
       parent: 2
 - proto: HolopadEngineeringPower
   entities:
-  - uid: 3072
+  - uid: 2016
     components:
     - type: Transform
       pos: -20.5,-0.5
       parent: 2
 - proto: HolopadGeneralArrivals
   entities:
-  - uid: 3074
+  - uid: 2017
     components:
     - type: Transform
       pos: 10.5,15.5
       parent: 2
 - proto: HolopadGeneralLounge
   entities:
-  - uid: 3070
+  - uid: 2018
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 2
 - proto: HolopadMedicalMedbay
   entities:
-  - uid: 3077
+  - uid: 2019
     components:
     - type: Transform
       pos: 10.5,-2.5
       parent: 2
 - proto: HolopadSecurityFront
   entities:
-  - uid: 3076
+  - uid: 2020
     components:
     - type: Transform
       pos: 17.5,0.5
       parent: 2
 - proto: HoPIDCard
   entities:
-  - uid: 1933
+  - uid: 2022
     components:
     - type: Transform
-      parent: 2545
+      parent: 2021
     - type: Physics
       canCollide: False
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 1934
+  - uid: 2023
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 2
-  - uid: 1935
+  - uid: 2024
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 2
 - proto: HydroponicsToolClippers
   entities:
-  - uid: 1936
+  - uid: 2025
     components:
     - type: Transform
       pos: 12.5,9.5
       parent: 2
 - proto: HydroponicsToolMiniHoe
   entities:
-  - uid: 1937
+  - uid: 2026
     components:
     - type: Transform
       pos: 12.522824,9.656214
       parent: 2
 - proto: hydroponicsTray
   entities:
-  - uid: 1938
+  - uid: 2027
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 2
-  - uid: 1939
+  - uid: 2028
     components:
     - type: Transform
       pos: -14.5,3.5
       parent: 2
-  - uid: 1940
+  - uid: 2029
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,5.5
       parent: 2
-  - uid: 1941
+  - uid: 2030
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 2
-  - uid: 1942
+  - uid: 2031
     components:
     - type: Transform
       pos: -12.5,8.5
       parent: 2
-  - uid: 1943
+  - uid: 2032
     components:
     - type: Transform
       pos: -12.5,7.5
       parent: 2
-  - uid: 1944
+  - uid: 2033
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,7.5
       parent: 2
-  - uid: 1945
+  - uid: 2034
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14277,14 +14291,14 @@ entities:
       parent: 2
 - proto: Hypospray
   entities:
-  - uid: 1946
+  - uid: 2035
     components:
     - type: Transform
       pos: 6.6989994,-0.46516204
       parent: 2
 - proto: IntercomEngineering
   entities:
-  - uid: 1947
+  - uid: 2036
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14294,7 +14308,7 @@ entities:
       fixtures: {}
 - proto: IntercomMedical
   entities:
-  - uid: 1948
+  - uid: 2037
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14304,7 +14318,7 @@ entities:
       fixtures: {}
 - proto: IntercomSecurity
   entities:
-  - uid: 1949
+  - uid: 2038
     components:
     - type: Transform
       pos: 12.5,11.5
@@ -14313,7 +14327,7 @@ entities:
       fixtures: {}
 - proto: JanitorialTrolley
   entities:
-  - uid: 1950
+  - uid: 2039
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14321,21 +14335,21 @@ entities:
       parent: 2
 - proto: JetpackMiniFilled
   entities:
-  - uid: 1951
+  - uid: 2040
     components:
     - type: Transform
       pos: 2.4199898,16.571438
       parent: 2
 - proto: KitchenElectricGrill
   entities:
-  - uid: 1952
+  - uid: 2041
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
 - proto: KitchenKnife
   entities:
-  - uid: 3035
+  - uid: 2042
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14355,57 +14369,57 @@ entities:
         path: /Audio/Items/Culinary/chop.ogg
 - proto: KitchenMicrowave
   entities:
-  - uid: 1953
+  - uid: 2043
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 2
-  - uid: 1954
+  - uid: 2044
     components:
     - type: Transform
       pos: 14.5,10.5
       parent: 2
 - proto: KitchenOven
   entities:
-  - uid: 1955
+  - uid: 2045
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 2
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 1956
+  - uid: 2046
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 2
-  - uid: 1957
+  - uid: 2047
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 2
-  - uid: 1958
+  - uid: 2048
     components:
     - type: Transform
       pos: 16.5,7.5
       parent: 2
 - proto: KitchenSpike
   entities:
-  - uid: 1959
+  - uid: 2049
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 2
 - proto: KitchenStove
   entities:
-  - uid: 1960
+  - uid: 2050
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 2
 - proto: LampGold
   entities:
-  - uid: 1961
+  - uid: 2051
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14413,347 +14427,350 @@ entities:
       parent: 2
 - proto: LargeBeaker
   entities:
-  - uid: 1962
+  - uid: 2052
     components:
     - type: Transform
       pos: -7.306855,3.5659888
       parent: 2
 - proto: LockableButtonSecurity
   entities:
-  - uid: 1963
+  - uid: 2053
     components:
     - type: Transform
       pos: 13.5,11.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        2236:
-        - Pressed: Toggle
-        2237:
-        - Pressed: Toggle
-        2238:
-        - Pressed: Toggle
-        2239:
-        - Pressed: Toggle
-        2240:
-        - Pressed: Toggle
+        2342:
+        - - Pressed
+          - Toggle
+        2343:
+        - - Pressed
+          - Toggle
+        2344:
+        - - Pressed
+          - Toggle
+        2345:
+        - - Pressed
+          - Toggle
+        2346:
+        - - Pressed
+          - Toggle
     - type: Fixtures
       fixtures: {}
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
-  - uid: 1964
+  - uid: 2054
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerBoozeFilled
   entities:
-  - uid: 1965
+  - uid: 2055
     components:
     - type: Transform
       pos: -10.5,5.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerBotanistFilled
   entities:
-  - uid: 1966
+  - uid: 2056
     components:
     - type: Transform
       pos: -14.5,4.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerBSOFilled
   entities:
-  - uid: 1967
+  - uid: 2057
     components:
     - type: Transform
       pos: 24.5,6.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: LockerCaptainFilledHardsuit
   entities:
-  - uid: 1968
+  - uid: 2058
     components:
     - type: Transform
       pos: 21.5,-2.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerChemistryFilled
   entities:
-  - uid: 1969
+  - uid: 2059
     components:
     - type: Transform
       pos: 10.198524,-0.49005228
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerChiefEngineerFilledHardsuit
   entities:
-  - uid: 1970
+  - uid: 2060
     components:
     - type: Transform
       pos: 5.9685364,-15.469819
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerChiefMedicalOfficerFilledHardsuit
   entities:
-  - uid: 1971
+  - uid: 2061
     components:
     - type: Transform
       pos: 10.709357,-0.4804318
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerEngineerFilledHardsuit
   entities:
-  - uid: 1972
+  - uid: 2062
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
-  - uid: 1973
+  - uid: 2063
     components:
     - type: Transform
       pos: -18.5,-1.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
-- proto: LockerEvidence
-  entities:
-  - uid: 1974
-    components:
-    - type: Transform
-      pos: 19.5,1.5
-      parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerFreezerVaultFilled
   entities:
-  - uid: 1975
+  - uid: 2065
     components:
     - type: Transform
       pos: 24.5,-0.5
       parent: 2
 - proto: LockerHeadOfPersonnelFilled
   entities:
-  - uid: 1976
+  - uid: 2066
     components:
     - type: Transform
       pos: 21.5,4.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
+    - type: AccessReader
+      accessListsOriginal:
+      - - HeadOfPersonnel
 - proto: LockerHeadOfSecurityFilledHardsuit
   entities:
-  - uid: 1977
+  - uid: 1167
+    components:
+    - type: Transform
+      pos: 21.5,6.5
+      parent: 2
+- proto: LockerIAAFilled
+  entities:
+  - uid: 3019
+    components:
+    - type: Transform
+      pos: 19.5,1.5
+      parent: 2
+- proto: LockerMagistrateFilled
+  entities:
+  - uid: 2067
     components:
     - type: Transform
       pos: 23.5,7.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerMedicalFilled
   entities:
-  - uid: 1978
+  - uid: 2068
     components:
     - type: Transform
       pos: 12.5,-2.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerMiningSpecialistFilled
   entities:
-  - uid: 2275
+  - uid: 2069
     components:
     - type: Transform
       pos: -2.5,14.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerParamedicFilled
   entities:
-  - uid: 1980
+  - uid: 2070
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerPrisoner
   entities:
-  - uid: 1981
+  - uid: 2071
     components:
     - type: Transform
       pos: 17.5,3.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerPrisoner2
   entities:
-  - uid: 1982
+  - uid: 2072
     components:
     - type: Transform
       pos: 19.5,3.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerQuarterMasterFilled
   entities:
-  - uid: 2177
+  - uid: 2073
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerRepresentativeFilled
   entities:
-  - uid: 1984
+  - uid: 2074
     components:
     - type: Transform
       pos: 24.5,5.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
+    - type: AccessReader
+      accessListsOriginal:
+      - - Ntrep
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: LockerResearchDirectorFilledHardsuit
   entities:
-  - uid: 1985
+  - uid: 2075
     components:
     - type: Transform
       pos: -10.5,7.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 2076
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: LockerSalvageLeadFilledHardsuit
   entities:
-  - uid: 85
+  - uid: 2082
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 2
 - proto: LockerSalvageSpecialistFilledHardsuit
   entities:
-  - uid: 2372
+  - uid: 2083
     components:
     - type: Transform
       pos: -3.5,14.5
       parent: 2
 - proto: LockerScienceFilled
   entities:
-  - uid: 1987
+  - uid: 2084
     components:
     - type: Transform
       pos: -6.5,9.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LockerSecurityLargeFilled
   entities:
-  - uid: 2115
+  - uid: 2085
     components:
     - type: Transform
       pos: 14.5,-2.5
       parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
+  - uid: 2087
+    components:
+    - type: Transform
+      pos: 14.5,-4.5
+      parent: 2
 - proto: LockerWallMedicalFilled
   entities:
-  - uid: 1989
+  - uid: 2086
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: LockerWardenFilledHardsuit
-  entities:
-  - uid: 1990
-    components:
-    - type: Transform
-      pos: 14.5,-4.5
-      parent: 2
-    - type: WiresPanelSecurity
-      wiresAccessible: True
 - proto: LootSpawnerRandomCrateEngineering
   entities:
-  - uid: 1991
+  - uid: 2088
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 2
 - proto: LootSpawnerRandomLockbox
   entities:
-  - uid: 1992
+  - uid: 2089
     components:
     - type: Transform
       pos: 10.5,-8.5
       parent: 2
 - proto: MachineArtifactAnalyzer
   entities:
-  - uid: 1993
+  - uid: 2090
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 2
 - proto: MachineCentrifuge
   entities:
-  - uid: 1994
+  - uid: 2091
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 2
 - proto: MachineElectrolysisUnit
   entities:
-  - uid: 1995
+  - uid: 2092
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 2
 - proto: MachineMaterialSilo
   entities:
-  - uid: 1996
+  - uid: 2093
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
 - proto: MaintenanceFluffSpawner
   entities:
-  - uid: 1997
+  - uid: 2094
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 2
 - proto: MaintenancePlantSpawner
   entities:
-  - uid: 1998
+  - uid: 2095
     components:
     - type: Transform
       pos: 10.5,-6.5
       parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 1999
+  - uid: 2096
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 2
-  - uid: 2000
+  - uid: 2097
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 2
 - proto: MedicalTechFab
   entities:
-  - uid: 2001
+  - uid: 2098
     components:
     - type: Transform
       pos: 9.5,-4.5
@@ -14767,133 +14784,119 @@ entities:
       - Biochemical
 - proto: MedkitBruteFilled
   entities:
-  - uid: 2002
+  - uid: 2099
     components:
     - type: Transform
       pos: 2.413426,-3.2879133
       parent: 2
 - proto: MedkitBurnFilled
   entities:
-  - uid: 2003
+  - uid: 2100
     components:
     - type: Transform
       pos: 2.6738424,-3.4859672
       parent: 2
 - proto: MopBucket
   entities:
-  - uid: 2004
+  - uid: 2101
     components:
     - type: Transform
       pos: -5.529683,-6.4279804
       parent: 2
 - proto: MopItem
   entities:
-  - uid: 2005
+  - uid: 2102
     components:
     - type: Transform
       pos: -5.6298103,-8.465319
       parent: 2
 - proto: Multitool
   entities:
-  - uid: 1122
+  - uid: 2078
     components:
     - type: Transform
-      parent: 1120
+      parent: 2076
     - type: Physics
       canCollide: False
-  - uid: 2006
+  - uid: 2103
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.51185,-1.5539001
       parent: 2
-  - uid: 2007
+  - uid: 2104
     components:
     - type: Transform
       pos: 25.152287,2.4981446
       parent: 2
+- proto: nctterminal
+  entities:
+  - uid: 1403
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 2
 - proto: NitrogenCanister
   entities:
-  - uid: 2008
+  - uid: 2105
     components:
     - type: Transform
       pos: -16.5,-6.5
       parent: 2
-  - uid: 2009
+  - uid: 2106
     components:
     - type: Transform
       pos: 11.5,-10.5
       parent: 2
-- proto: NTDefaultCircuitBoard
-  entities:
-  - uid: 2010
-    components:
-    - type: Transform
-      pos: -8.595897,10.774277
-      parent: 2
-- proto: NutimovCircuitBoard
-  entities:
-  - uid: 2011
-    components:
-    - type: Transform
-      pos: -8.418814,10.5658
-      parent: 2
 - proto: OreProcessor
   entities:
-  - uid: 2012
+  - uid: 2109
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 2
 - proto: OxygenCanister
   entities:
-  - uid: 2013
+  - uid: 2110
     components:
     - type: Transform
       pos: 10.5,-10.5
       parent: 2
-  - uid: 2014
+  - uid: 2111
     components:
     - type: Transform
       pos: -16.5,6.5
       parent: 2
-- proto: PaladinCircuitBoard
-  entities:
-  - uid: 2015
-    components:
-    - type: Transform
-      pos: -8.585481,10.399016
-      parent: 2
 - proto: PartRodMetal
   entities:
-  - uid: 2016
+  - uid: 2113
     components:
     - type: Transform
       pos: -16.371857,-2.4141626
       parent: 2
-  - uid: 2017
+  - uid: 2114
     components:
     - type: Transform
       pos: 7.4046574,-16.509167
       parent: 2
-  - uid: 2018
+  - uid: 2115
     components:
     - type: Transform
       pos: 7.4046574,-16.509167
       parent: 2
-  - uid: 2172
+  - uid: 2116
     components:
     - type: Transform
       pos: -16.517689,-2.2682283
       parent: 2
-  - uid: 2966
+  - uid: 2117
     components:
     - type: Transform
       pos: -16.528107,-2.2056844
       parent: 2
 - proto: PianoInstrument
   entities:
-  - uid: 2021
+  - uid: 2118
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14901,113 +14904,107 @@ entities:
       parent: 2
 - proto: PlaqueAtmos
   entities:
-  - uid: 2022
+  - uid: 2119
     components:
     - type: Transform
       pos: 6.5,-9.5
       parent: 2
 - proto: PlasmaCanister
   entities:
-  - uid: 2023
+  - uid: 2120
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 2
-  - uid: 2230
+  - uid: 2121
     components:
     - type: Transform
       pos: -21.5,-2.5
       parent: 2
 - proto: PlasmaWindoorSecureCommandLocked
   entities:
-  - uid: 2024
+  - uid: 2122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2025
+  - uid: 2123
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2026
+  - uid: 2124
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: PlasticFlapsAirtightClear
   entities:
-  - uid: 2027
+  - uid: 2125
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
 - proto: PlayerStationAi
   entities:
-  - uid: 2028
+  - uid: 2126
     components:
-    - type: StationAiCore
-      lawConsole: 2431
-    - type: DeviceLinkSource
-      linkedPorts:
-        2431:
-        - - AiLawConsoleSender
-          - AiLawConsoleReceiver
     - type: Transform
       pos: -9.5,10.5
       parent: 2
+    - type: StationAiCore
+      lawConsole: 2546
+    - type: DeviceLinkSource
+      linkedPorts:
+        2546:
+        - - AiLawConsoleSender
+          - AiLawConsoleReceiver
 - proto: Plunger
   entities:
-  - uid: 2029
+  - uid: 2127
     components:
     - type: Transform
       pos: -4.2076445,-6.1772423
       parent: 2
 - proto: PortableGeneratorJrPacman
   entities:
-  - uid: 2030
+  - uid: 2128
     components:
     - type: Transform
       pos: 9.5,-8.5
       parent: 2
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 2031
+  - uid: 2129
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
 - proto: PortableGeneratorSuperPacman
   entities:
-  - uid: 2032
+  - uid: 2130
     components:
     - type: Transform
       pos: -23.5,-2.5
       parent: 2
 - proto: PortableScrubber
   entities:
-  - uid: 2033
+  - uid: 2131
     components:
     - type: Transform
       pos: 4.5,-15.5
       parent: 2
-  - uid: 2034
+  - uid: 2132
     components:
     - type: Transform
       pos: 4.5,-14.5
       parent: 2
 - proto: PosterContrabandAtmosiaDeclarationIndependence
   entities:
-  - uid: 2035
+  - uid: 2133
     components:
     - type: Transform
       pos: 8.5,-9.5
@@ -15016,7 +15013,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandBeachStarYamamoto
   entities:
-  - uid: 2036
+  - uid: 2134
     components:
     - type: Transform
       pos: 13.5,-5.5
@@ -15025,7 +15022,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandHighEffectEngineering
   entities:
-  - uid: 2037
+  - uid: 2135
     components:
     - type: Transform
       pos: -23.5,4.5
@@ -15034,7 +15031,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandKudzu
   entities:
-  - uid: 2038
+  - uid: 2136
     components:
     - type: Transform
       pos: -11.5,7.5
@@ -15043,7 +15040,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandSpaceCola
   entities:
-  - uid: 2039
+  - uid: 2137
     components:
     - type: Transform
       pos: -11.5,5.5
@@ -15052,7 +15049,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandTools
   entities:
-  - uid: 2040
+  - uid: 2138
     components:
     - type: Transform
       pos: -19.5,-2.5
@@ -15061,7 +15058,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitAnatomyPoster
   entities:
-  - uid: 2041
+  - uid: 2139
     components:
     - type: Transform
       pos: 13.5,-2.5
@@ -15070,7 +15067,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitCleanliness
   entities:
-  - uid: 2042
+  - uid: 2140
     components:
     - type: Transform
       pos: -2.5,-6.5
@@ -15079,7 +15076,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitCohibaRobustoAd
   entities:
-  - uid: 2043
+  - uid: 2141
     components:
     - type: Transform
       pos: -7.5,6.5
@@ -15088,7 +15085,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitHelpOthers
   entities:
-  - uid: 2044
+  - uid: 2142
     components:
     - type: Transform
       pos: -4.5,-5.5
@@ -15097,16 +15094,16 @@ entities:
       fixtures: {}
 - proto: PosterLegitHereForYourSafety
   entities:
-  - uid: 2045
+  - uid: 3090
     components:
     - type: Transform
-      pos: 13.5,6.5
+      pos: 12.5,2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitHighClassMartini
   entities:
-  - uid: 2046
+  - uid: 2144
     components:
     - type: Transform
       pos: -2.5,-3.5
@@ -15115,7 +15112,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitJustAWeekAway
   entities:
-  - uid: 2047
+  - uid: 2145
     components:
     - type: Transform
       pos: 4.5,11.5
@@ -15124,37 +15121,38 @@ entities:
       fixtures: {}
 - proto: PosterLegitNanomichiAd
   entities:
-  - uid: 2048
+  - uid: 2146
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,8.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitNanotrasenLogo
   entities:
-  - uid: 81
+  - uid: 2147
     components:
     - type: Transform
       pos: 10.5,16.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2050
+  - uid: 2148
     components:
     - type: Transform
       pos: 4.5,17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2051
+  - uid: 2149
     components:
     - type: Transform
       pos: 10.5,6.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2052
+  - uid: 2150
     components:
     - type: Transform
       pos: 26.5,-1.5
@@ -15163,7 +15161,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitNTTGC
   entities:
-  - uid: 2053
+  - uid: 2151
     components:
     - type: Transform
       pos: 11.5,2.5
@@ -15172,7 +15170,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitPDAAd
   entities:
-  - uid: 2054
+  - uid: 2152
     components:
     - type: Transform
       pos: 20.5,3.5
@@ -15181,7 +15179,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitPeriodicTable
   entities:
-  - uid: 2055
+  - uid: 2153
     components:
     - type: Transform
       pos: 9.5,1.5
@@ -15190,7 +15188,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitSafetyInternals
   entities:
-  - uid: 2056
+  - uid: 2154
     components:
     - type: Transform
       pos: -4.5,6.5
@@ -15199,7 +15197,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitScience
   entities:
-  - uid: 2057
+  - uid: 2155
     components:
     - type: Transform
       pos: -1.5,13.5
@@ -15208,7 +15206,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitSecWatch
   entities:
-  - uid: 2058
+  - uid: 2156
     components:
     - type: Transform
       pos: 20.5,5.5
@@ -15217,7 +15215,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitSpaceCops
   entities:
-  - uid: 2059
+  - uid: 2157
     components:
     - type: Transform
       pos: 14.5,-1.5
@@ -15226,7 +15224,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitUeNo
   entities:
-  - uid: 2060
+  - uid: 2158
     components:
     - type: Transform
       pos: 9.5,-9.5
@@ -15235,7 +15233,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitVacation
   entities:
-  - uid: 2061
+  - uid: 2159
     components:
     - type: Transform
       pos: 7.5,2.5
@@ -15244,94 +15242,94 @@ entities:
       fixtures: {}
 - proto: PottedPlant22
   entities:
-  - uid: 2062
+  - uid: 2160
     components:
     - type: Transform
       pos: -5.781889,-2.132682
       parent: 2
-  - uid: 2063
+  - uid: 2161
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 2
-  - uid: 2064
+  - uid: 2162
     components:
     - type: Transform
       pos: 10.5,5.5
       parent: 2
 - proto: PottedPlantRandom
   entities:
-  - uid: 2065
+  - uid: 2163
     components:
     - type: Transform
       pos: 15.5,5.5
       parent: 2
-  - uid: 2066
+  - uid: 2164
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 2
-  - uid: 2067
+  - uid: 2165
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 2
-  - uid: 2068
+  - uid: 2166
     components:
     - type: Transform
       pos: -7.5,1.5
       parent: 2
-  - uid: 2069
+  - uid: 2167
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 2
-  - uid: 2070
+  - uid: 2168
     components:
     - type: Transform
       pos: -11.5,1.5
       parent: 2
-  - uid: 2071
+  - uid: 2169
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
-  - uid: 2072
+  - uid: 2170
     components:
     - type: Transform
       pos: 10.5,9.5
       parent: 2
-  - uid: 2073
+  - uid: 2171
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
-  - uid: 2075
+  - uid: 2172
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 2
-  - uid: 2076
+  - uid: 2173
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 2
-  - uid: 3061
+  - uid: 2174
     components:
     - type: Transform
       pos: 9.5,16.5
       parent: 2
 - proto: PowerCellHyper
   entities:
-  - uid: 2078
+  - uid: 2176
     components:
     - type: Transform
-      parent: 2077
+      parent: 2175
     - type: Physics
       canCollide: False
 - proto: PowerCellRecharger
   entities:
-  - uid: 2077
+  - uid: 2175
     components:
     - type: Transform
       pos: -16.5,-1.5
@@ -15341,7 +15339,7 @@ entities:
         charger_slot: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 2078
+          ent: 2176
         machine_board: !type:Container
           showEnts: False
           occludes: True
@@ -15350,91 +15348,91 @@ entities:
           showEnts: False
           occludes: True
           ents: []
-  - uid: 2079
+  - uid: 2177
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 2
-  - uid: 2080
+  - uid: 2178
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
-  - uid: 2081
+  - uid: 2179
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 2
 - proto: PowerDrill
   entities:
-  - uid: 1123
+  - uid: 2079
     components:
     - type: Transform
-      parent: 1120
+      parent: 2076
     - type: Tool
       speedModifier: 1
     - type: Physics
       canCollide: False
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 2082
+  - uid: 2180
     components:
     - type: Transform
       pos: 9.5,-6.5
       parent: 2
-  - uid: 2083
+  - uid: 2181
     components:
     - type: Transform
       pos: 15.5,-6.5
       parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 2049
+  - uid: 2182
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,17.5
       parent: 2
-  - uid: 2084
+  - uid: 2183
     components:
     - type: Transform
       pos: 12.5,5.5
       parent: 2
-  - uid: 2085
+  - uid: 2184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-0.5
       parent: 2
-  - uid: 2086
+  - uid: 2185
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 2
-  - uid: 2087
+  - uid: 2186
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 2
-  - uid: 2088
+  - uid: 2187
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-1.5
       parent: 2
-  - uid: 2090
+  - uid: 2188
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-1.5
       parent: 2
-  - uid: 2091
+  - uid: 2189
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,9.5
       parent: 2
-  - uid: 2092
+  - uid: 2190
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15442,13 +15440,13 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2093
+  - uid: 2191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 2
-  - uid: 2094
+  - uid: 2192
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15456,7 +15454,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2095
+  - uid: 2193
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15464,14 +15462,14 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2096
+  - uid: 2194
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2097
+  - uid: 2195
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15479,7 +15477,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2098
+  - uid: 2196
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15487,7 +15485,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2099
+  - uid: 2197
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15495,7 +15493,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2100
+  - uid: 2198
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15503,7 +15501,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2101
+  - uid: 2199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15511,7 +15509,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2102
+  - uid: 2200
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15519,21 +15517,21 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2103
+  - uid: 2201
     components:
     - type: Transform
       pos: 11.5,-10.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2104
+  - uid: 2202
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2105
+  - uid: 2203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15541,7 +15539,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2106
+  - uid: 2204
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15549,7 +15547,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2107
+  - uid: 2205
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15557,7 +15555,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2108
+  - uid: 2206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -15565,7 +15563,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2109
+  - uid: 2207
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15573,7 +15571,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2110
+  - uid: 2208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15581,14 +15579,14 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2111
+  - uid: 2209
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2112
+  - uid: 2210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15596,136 +15594,136 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2113
+  - uid: 2211
     components:
     - type: Transform
       pos: 14.5,10.5
       parent: 2
-  - uid: 2114
+  - uid: 2212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,11.5
       parent: 2
-  - uid: 2116
+  - uid: 2213
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-6.5
       parent: 2
-  - uid: 2117
+  - uid: 2214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,6.5
       parent: 2
-  - uid: 2118
+  - uid: 2215
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-15.5
       parent: 2
-  - uid: 2119
+  - uid: 2216
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,7.5
       parent: 2
-  - uid: 2120
+  - uid: 2217
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,1.5
       parent: 2
-  - uid: 2121
+  - uid: 2218
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 2
-  - uid: 2122
+  - uid: 2219
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,6.5
       parent: 2
-  - uid: 2123
+  - uid: 2220
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-8.5
       parent: 2
-  - uid: 2124
+  - uid: 2221
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-10.5
       parent: 2
-  - uid: 2125
+  - uid: 2222
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,4.5
       parent: 2
-  - uid: 2126
+  - uid: 2223
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-6.5
       parent: 2
-  - uid: 2127
+  - uid: 2224
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-3.5
       parent: 2
-  - uid: 2128
+  - uid: 2225
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,4.5
       parent: 2
-  - uid: 2129
+  - uid: 2226
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-6.5
       parent: 2
-  - uid: 2130
+  - uid: 2227
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-1.5
       parent: 2
-  - uid: 2131
+  - uid: 2228
     components:
     - type: Transform
       pos: -4.5,11.5
       parent: 2
-  - uid: 2132
+  - uid: 2229
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-11.5
       parent: 2
-  - uid: 2133
+  - uid: 2230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 2
-  - uid: 2134
+  - uid: 2231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-16.5
       parent: 2
-  - uid: 2135
+  - uid: 2232
     components:
     - type: Transform
       pos: -11.5,1.5
       parent: 2
-  - uid: 2136
+  - uid: 2233
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15733,66 +15731,66 @@ entities:
       parent: 2
 - proto: PoweredlightExterior
   entities:
-  - uid: 108
+  - uid: 2234
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,3.5
       parent: 2
-  - uid: 1102
+  - uid: 2235
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,-1.5
       parent: 2
-  - uid: 2137
+  - uid: 2236
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,7.5
       parent: 2
-  - uid: 2138
+  - uid: 2237
     components:
     - type: Transform
       pos: -30.5,5.5
       parent: 2
-  - uid: 2139
+  - uid: 2238
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,3.5
       parent: 2
-  - uid: 2140
+  - uid: 2239
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,-5.5
       parent: 2
-  - uid: 2141
+  - uid: 2240
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-4.5
       parent: 2
-  - uid: 2142
+  - uid: 2241
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-2.5
       parent: 2
-  - uid: 2143
+  - uid: 2242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-16.5
       parent: 2
-  - uid: 2144
+  - uid: 2243
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-16.5
       parent: 2
-  - uid: 2967
+  - uid: 2244
     components:
     - type: Transform
       anchored: False
@@ -15801,31 +15799,31 @@ entities:
       parent: 2
     - type: Physics
       bodyType: Dynamic
-  - uid: 2975
+  - uid: 2245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-7.5
       parent: 2
-  - uid: 3012
+  - uid: 2246
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,12.5
       parent: 2
-  - uid: 3013
+  - uid: 2247
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,13.5
       parent: 2
-  - uid: 3014
+  - uid: 2248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,9.5
       parent: 2
-  - uid: 3020
+  - uid: 2249
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15833,7 +15831,7 @@ entities:
       parent: 2
 - proto: PoweredlightSodium
   entities:
-  - uid: 2145
+  - uid: 2250
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15841,7 +15839,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2146
+  - uid: 2251
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15851,34 +15849,34 @@ entities:
       powerLoad: 0
 - proto: PoweredSmallLight
   entities:
-  - uid: 2147
+  - uid: 2252
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,15.5
       parent: 2
-  - uid: 2148
+  - uid: 2253
     components:
     - type: Transform
       pos: -10.5,5.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2149
+  - uid: 2254
     components:
     - type: Transform
       pos: -7.5,5.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2150
+  - uid: 2255
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2151
+  - uid: 2256
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15886,7 +15884,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2152
+  - uid: 2257
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15894,7 +15892,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2153
+  - uid: 2258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15902,7 +15900,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2154
+  - uid: 2259
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -15910,49 +15908,49 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2155
+  - uid: 2260
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 2156
+  - uid: 2261
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-4.5
       parent: 2
-  - uid: 2157
+  - uid: 2262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,15.5
       parent: 2
-  - uid: 2158
+  - uid: 2263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,3.5
       parent: 2
-  - uid: 2159
+  - uid: 2264
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,7.5
       parent: 2
-  - uid: 2160
+  - uid: 2265
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 2
-  - uid: 2161
+  - uid: 2266
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,7.5
       parent: 2
-  - uid: 2162
+  - uid: 2267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -15960,248 +15958,232 @@ entities:
       parent: 2
 - proto: Protolathe
   entities:
-  - uid: 2163
+  - uid: 2268
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
 - proto: PuddleEgg
   entities:
-  - uid: 2164
+  - uid: 2269
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 2
 - proto: PuddleTomato
   entities:
-  - uid: 2165
+  - uid: 2270
     components:
     - type: Transform
       pos: -6.5,4.5
       parent: 2
 - proto: PuddleVomit
   entities:
-  - uid: 2166
+  - uid: 2271
     components:
     - type: Transform
       pos: -9.5,-5.5
       parent: 2
-  - uid: 2167
+  - uid: 2272
     components:
     - type: Transform
       pos: -8.5,-4.5
       parent: 2
-  - uid: 2168
+  - uid: 2273
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 2
 - proto: PuddleWatermelon
   entities:
-  - uid: 2169
+  - uid: 2274
     components:
     - type: Transform
       pos: -7.5,4.5
       parent: 2
 - proto: Rack
   entities:
-  - uid: 2170
+  - uid: 2275
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 2
-  - uid: 2171
+  - uid: 2276
     components:
     - type: Transform
       pos: 7.5,-16.5
       parent: 2
-  - uid: 2173
+  - uid: 2277
     components:
     - type: Transform
       pos: -20.5,3.5
       parent: 2
-  - uid: 2174
+  - uid: 2278
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
-  - uid: 2175
+  - uid: 2279
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 2
-  - uid: 2176
+  - uid: 2280
     components:
     - type: Transform
       pos: -18.5,2.5
       parent: 2
 - proto: RadiationCollectorFullTank
   entities:
-  - uid: 2178
+  - uid: 2281
     components:
     - type: Transform
       pos: -22.5,-0.5
       parent: 2
-  - uid: 2179
+  - uid: 2282
     components:
     - type: Transform
       pos: -22.5,1.5
       parent: 2
-  - uid: 2180
+  - uid: 2283
     components:
     - type: Transform
       pos: -22.5,0.5
       parent: 2
-  - uid: 2181
+  - uid: 2284
     components:
     - type: Transform
       pos: -23.5,-0.5
       parent: 2
-  - uid: 2182
+  - uid: 2285
     components:
     - type: Transform
       pos: -23.5,1.5
       parent: 2
 - proto: RagItem
   entities:
-  - uid: 2183
+  - uid: 2286
     components:
     - type: Transform
       pos: -10.602807,2.8977726
       parent: 2
 - proto: RailingCornerSmall
   entities:
-  - uid: 2184
+  - uid: 2287
     components:
     - type: Transform
       pos: 23.5,7.5
       parent: 2
 - proto: RandomArtifactSpawner
   entities:
-  - uid: 2185
+  - uid: 2288
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 2
 - proto: RandomBoard
   entities:
-  - uid: 2186
+  - uid: 2289
     components:
     - type: Transform
       pos: -16.5,-4.5
       parent: 2
 - proto: RandomPosterContraband
   entities:
-  - uid: 2187
+  - uid: 2290
     components:
     - type: Transform
       pos: 18.5,10.5
       parent: 2
 - proto: RandomVending
   entities:
-  - uid: 2188
+  - uid: 2291
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 2
 - proto: RCD
   entities:
-  - uid: 2189
+  - uid: 2292
     components:
     - type: Transform
       pos: 4.5666795,-10.266068
       parent: 2
 - proto: ReagentContainerFlour
   entities:
-  - uid: 2190
+  - uid: 2293
     components:
     - type: Transform
       pos: -7.619355,3.5451415
       parent: 2
-  - uid: 2191
+  - uid: 2294
     components:
     - type: Transform
       pos: 15.327541,10.68051
       parent: 2
 - proto: Recycler
   entities:
-  - uid: 2192
+  - uid: 2295
     components:
     - type: Transform
       pos: 17.5,-6.5
       parent: 2
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 2193
+  - uid: 2296
     components:
     - type: Transform
       pos: 8.5,-15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2194
+  - uid: 2297
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ReinforcedUraniumWindow
   entities:
-  - uid: 2195
+  - uid: 2298
     components:
     - type: Transform
       pos: -24.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2196
+  - uid: 2299
     components:
     - type: Transform
       pos: -24.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2197
+  - uid: 2300
     components:
     - type: Transform
       pos: -24.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2198
+  - uid: 2301
     components:
     - type: Transform
       pos: -24.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2199
+  - uid: 2302
     components:
     - type: Transform
       pos: -24.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ReinforcedWindow
   entities:
-  - uid: 2200
+  - uid: 2303
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 2201
+  - uid: 2304
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 2
 - proto: ResearchDisk10000
   entities:
-  - uid: 2202
+  - uid: 2305
     components:
     - type: Transform
       pos: 17.47298,-7.552605
@@ -16209,16 +16191,9 @@ entities:
     - type: CollisionWake
       enabled: False
     - type: Conveyed
-- proto: RobocopCircuitBoard
-  entities:
-  - uid: 2203
-    components:
-    - type: Transform
-      pos: -8.491731,10.670038
-      parent: 2
 - proto: SalvageMagnet
   entities:
-  - uid: 2204
+  - uid: 2307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -16226,51 +16201,51 @@ entities:
       parent: 2
 - proto: Screen
   entities:
-  - uid: 2205
-    components:
-    - type: Transform
-      pos: 5.5,6.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 2206
+  - uid: 2309
     components:
     - type: Transform
       pos: -15.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2207
+  - uid: 2310
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2208
+  - uid: 2311
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2209
+  - uid: 2312
     components:
     - type: Transform
       pos: 21.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
+  - uid: 3087
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: Screwdriver
   entities:
-  - uid: 2210
+  - uid: 2313
     components:
     - type: Transform
       pos: 1.4402248,16.391956
       parent: 2
 - proto: SecurityTechFab
   entities:
-  - uid: 2211
+  - uid: 2314
     components:
     - type: Transform
       pos: 15.5,-4.5
@@ -16284,943 +16259,726 @@ entities:
       - Biochemical
 - proto: SeedExtractor
   entities:
-  - uid: 2212
+  - uid: 2315
     components:
     - type: Transform
       pos: 13.5,8.5
       parent: 2
-  - uid: 2213
+  - uid: 2316
     components:
     - type: Transform
       pos: -14.5,8.5
       parent: 2
 - proto: SheetGlass
   entities:
-  - uid: 109
+  - uid: 2317
     components:
     - type: Transform
       pos: -16.330189,-2.341195
       parent: 2
-  - uid: 2019
+  - uid: 2318
     components:
     - type: Transform
       pos: -16.455189,-2.2890756
       parent: 2
-  - uid: 2020
+  - uid: 2319
     components:
     - type: Transform
       pos: -16.559357,-2.4975538
       parent: 2
-  - uid: 2214
+  - uid: 2320
     components:
     - type: Transform
       pos: 19.364311,-4.334065
       parent: 2
-  - uid: 2215
+  - uid: 2321
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 2216
+  - uid: 2322
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 2217
+  - uid: 2323
     components:
     - type: Transform
       pos: 3.3505435,10.904587
       parent: 2
 - proto: SheetPlasma
   entities:
-  - uid: 2218
+  - uid: 2324
     components:
     - type: Transform
       pos: -20.29877,3.6522484
       parent: 2
 - proto: SheetPlastic
   entities:
-  - uid: 2219
+  - uid: 2325
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 2220
+  - uid: 2326
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 2221
+  - uid: 2327
     components:
     - type: Transform
       pos: 19.615294,-4.3949633
       parent: 2
-  - uid: 2222
+  - uid: 2328
     components:
     - type: Transform
       pos: 3.6132839,10.927397
       parent: 2
 - proto: SheetSteel
   entities:
-  - uid: 2223
+  - uid: 2329
     components:
     - type: Transform
       pos: -16.351023,-2.0701735
       parent: 2
-  - uid: 2224
+  - uid: 2330
     components:
     - type: Transform
       pos: -16.301023,-4.426653
       parent: 2
-  - uid: 2225
+  - uid: 2331
     components:
     - type: Transform
       pos: -16.620468,-4.4127545
       parent: 2
-  - uid: 2226
+  - uid: 2332
     components:
     - type: Transform
       pos: 7.5296574,-16.509167
       parent: 2
-  - uid: 2227
+  - uid: 2333
     components:
     - type: Transform
       pos: 7.5296574,-16.509167
       parent: 2
-  - uid: 2228
+  - uid: 2334
     components:
     - type: Transform
       pos: 19.704664,-4.278744
       parent: 2
-  - uid: 2229
+  - uid: 2335
     components:
     - type: Transform
       pos: -16.590607,-2.3307714
       parent: 2
-  - uid: 2231
+  - uid: 2336
     components:
     - type: Transform
       pos: -16.523247,-4.2320733
       parent: 2
-  - uid: 2232
+  - uid: 2337
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 2233
+  - uid: 2338
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 2234
+  - uid: 2339
     components:
     - type: Transform
       pos: 3.5507839,10.687647
       parent: 2
-  - uid: 2965
+  - uid: 2340
     components:
     - type: Transform
       pos: -16.632273,-2.0284784
       parent: 2
 - proto: SheetUranium
   entities:
-  - uid: 2235
+  - uid: 2341
     components:
     - type: Transform
       pos: -20.53674,3.6443589
       parent: 2
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 2236
+  - uid: 2342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2237
+  - uid: 2343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2238
+  - uid: 2344
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2239
+  - uid: 2345
     components:
     - type: Transform
       pos: 16.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2240
+  - uid: 2346
     components:
     - type: Transform
       pos: 17.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ShuttersRadiation
   entities:
-  - uid: 2241
+  - uid: 2347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2242
+  - uid: 2348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2243
+  - uid: 2349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2244
+  - uid: 2350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2245
+  - uid: 2351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -24.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: ShuttleWindow
   entities:
-  - uid: 40
+  - uid: 2352
     components:
     - type: Transform
       pos: 14.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 42
+  - uid: 2353
     components:
     - type: Transform
       pos: 13.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 45
+  - uid: 2354
     components:
     - type: Transform
       pos: 12.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 558
+  - uid: 2355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 980
+  - uid: 2356
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 991
+  - uid: 2357
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 1045
+  - uid: 2358
     components:
     - type: Transform
       pos: 13.5,16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 1979
+  - uid: 2359
     components:
     - type: Transform
       pos: 14.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2246
+  - uid: 2360
     components:
     - type: Transform
       pos: 23.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2247
+  - uid: 2361
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2248
+  - uid: 2362
     components:
     - type: Transform
       pos: 24.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2249
+  - uid: 2363
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2250
+  - uid: 2364
     components:
     - type: Transform
       pos: -7.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2251
+  - uid: 2365
     components:
     - type: Transform
       pos: 25.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2252
+  - uid: 2366
     components:
     - type: Transform
       pos: -7.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2253
+  - uid: 2367
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2254
+  - uid: 2368
     components:
     - type: Transform
       pos: 18.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2255
+  - uid: 2369
     components:
     - type: Transform
       pos: -5.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2256
+  - uid: 2370
     components:
     - type: Transform
       pos: 17.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2257
+  - uid: 2371
     components:
     - type: Transform
       pos: 26.5,5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2258
+  - uid: 2372
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2259
+  - uid: 2373
     components:
     - type: Transform
       pos: 25.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2260
+  - uid: 2374
     components:
     - type: Transform
       pos: -7.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2261
+  - uid: 2375
     components:
     - type: Transform
       pos: -7.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2262
+  - uid: 2376
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2263
+  - uid: 2377
     components:
     - type: Transform
       pos: 16.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2264
+  - uid: 2378
     components:
     - type: Transform
       pos: 11.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2265
+  - uid: 2379
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2266
+  - uid: 2380
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2267
+  - uid: 2381
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2268
+  - uid: 2382
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2269
+  - uid: 2383
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2270
+  - uid: 2384
     components:
     - type: Transform
       pos: -16.5,5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2271
+  - uid: 2385
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2272
+  - uid: 2386
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2273
+  - uid: 2387
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2274
+  - uid: 2388
     components:
     - type: Transform
       pos: 8.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2276
+  - uid: 2389
     components:
     - type: Transform
       pos: 6.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2277
+  - uid: 2390
     components:
     - type: Transform
       pos: 8.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2278
+  - uid: 2391
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2279
+  - uid: 2392
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2280
+  - uid: 2393
     components:
     - type: Transform
       pos: -14.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2281
+  - uid: 2394
     components:
     - type: Transform
       pos: 13.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2282
+  - uid: 2395
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2283
+  - uid: 2396
     components:
     - type: Transform
       pos: 14.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2284
+  - uid: 2397
     components:
     - type: Transform
       pos: 15.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2285
+  - uid: 2398
     components:
     - type: Transform
       pos: 19.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2286
+  - uid: 2399
     components:
     - type: Transform
       pos: 20.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2287
+  - uid: 2400
     components:
     - type: Transform
       pos: 20.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2288
+  - uid: 2401
     components:
     - type: Transform
       pos: 27.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2289
+  - uid: 2402
     components:
     - type: Transform
       pos: 27.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2290
+  - uid: 2403
     components:
     - type: Transform
       pos: 27.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2291
+  - uid: 2404
     components:
     - type: Transform
       pos: 27.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2292
+  - uid: 2405
     components:
     - type: Transform
       pos: 26.5,4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2293
+  - uid: 2406
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2294
+  - uid: 2407
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2295
+  - uid: 2408
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2296
+  - uid: 2409
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2297
+  - uid: 2410
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2298
+  - uid: 2411
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2299
+  - uid: 2412
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2300
+  - uid: 2413
     components:
     - type: Transform
       pos: 24.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2301
+  - uid: 2414
     components:
     - type: Transform
       pos: 25.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2302
+  - uid: 2415
     components:
     - type: Transform
       pos: 25.5,-3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2303
+  - uid: 2416
     components:
     - type: Transform
       pos: 26.5,-3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2304
+  - uid: 2417
     components:
     - type: Transform
       pos: 26.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2305
+  - uid: 2418
     components:
     - type: Transform
       pos: 8.5,18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2306
+  - uid: 2419
     components:
     - type: Transform
       pos: 6.5,18.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2307
+  - uid: 2420
     components:
     - type: Transform
       pos: 6.5,19.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2308
+  - uid: 2421
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2309
+  - uid: 2422
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2310
+  - uid: 2423
     components:
     - type: Transform
       pos: 23.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2311
+  - uid: 2424
     components:
     - type: Transform
       pos: -16.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2313
+  - uid: 2425
     components:
     - type: Transform
       pos: 24.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2314
+  - uid: 2426
     components:
     - type: Transform
       pos: -7.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2315
+  - uid: 2427
     components:
     - type: Transform
       pos: -18.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2316
+  - uid: 2428
     components:
     - type: Transform
       pos: 11.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2318
+  - uid: 2429
     components:
     - type: Transform
       pos: 25.5,5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2319
+  - uid: 2430
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2320
+  - uid: 2431
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2321
+  - uid: 2432
     components:
     - type: Transform
       pos: -16.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2322
+  - uid: 2433
     components:
     - type: Transform
       pos: 22.5,9.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2323
+  - uid: 2434
     components:
     - type: Transform
       pos: -10.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2324
+  - uid: 2435
     components:
     - type: Transform
       pos: -9.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2325
+  - uid: 2436
     components:
     - type: Transform
       pos: -8.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2326
+  - uid: 2437
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2327
+  - uid: 2438
     components:
     - type: Transform
       pos: -18.5,-5.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2328
+  - uid: 2439
     components:
     - type: Transform
       pos: -18.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2329
+  - uid: 2440
     components:
     - type: Transform
       pos: 13.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2330
+  - uid: 2441
     components:
     - type: Transform
       pos: 15.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2331
+  - uid: 2442
     components:
     - type: Transform
       pos: -14.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2332
+  - uid: 2443
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2333
+  - uid: 2444
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2334
+  - uid: 2445
     components:
     - type: Transform
       pos: -10.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2335
+  - uid: 2446
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2336
+  - uid: 2447
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2337
+  - uid: 2448
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2338
+  - uid: 2449
     components:
     - type: Transform
       pos: -4.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2600
+  - uid: 2450
     components:
     - type: Transform
       pos: 14.5,15.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: SignalButtonDirectional
   entities:
-  - uid: 2339
+  - uid: 2451
     components:
     - type: Transform
       pos: -4.5,12.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        102:
-        - Pressed: Toggle
+        116:
+        - - Pressed
+          - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 2340
+  - uid: 2452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17228,7 +16986,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2341
+  - uid: 2453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -17236,11 +16994,12 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        103:
-        - Pressed: Toggle
+        117:
+        - - Pressed
+          - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 2342
+  - uid: 2454
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17248,19 +17007,24 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        2241:
-        - Pressed: Toggle
-        2242:
-        - Pressed: Toggle
-        2243:
-        - Pressed: Toggle
-        2244:
-        - Pressed: Toggle
-        2245:
-        - Pressed: Toggle
+        2347:
+        - - Pressed
+          - Toggle
+        2348:
+        - - Pressed
+          - Toggle
+        2349:
+        - - Pressed
+          - Toggle
+        2350:
+        - - Pressed
+          - Toggle
+        2351:
+        - - Pressed
+          - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 2343
+  - uid: 2455
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17268,13 +17032,24 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        103:
-        - Pressed: Toggle
+        117:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+- proto: SignArrivals
+  entities:
+  - uid: 1193
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,16.5
+      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: SignAtmos
   entities:
-  - uid: 2344
+  - uid: 2456
     components:
     - type: Transform
       pos: 1.5,-13.5
@@ -17283,7 +17058,7 @@ entities:
       fixtures: {}
 - proto: SignBar
   entities:
-  - uid: 2345
+  - uid: 2457
     components:
     - type: Transform
       pos: -2.5,2.5
@@ -17292,7 +17067,7 @@ entities:
       fixtures: {}
 - proto: SignCargoDock
   entities:
-  - uid: 2346
+  - uid: 2458
     components:
     - type: Transform
       pos: 3.5,14.5
@@ -17301,7 +17076,7 @@ entities:
       fixtures: {}
 - proto: SignChem
   entities:
-  - uid: 2347
+  - uid: 2459
     components:
     - type: Transform
       pos: 5.5,1.5
@@ -17310,7 +17085,7 @@ entities:
       fixtures: {}
 - proto: SignElectricalMed
   entities:
-  - uid: 2348
+  - uid: 2460
     components:
     - type: Transform
       pos: 3.5,-8.5
@@ -17319,7 +17094,7 @@ entities:
       fixtures: {}
 - proto: SignEngine
   entities:
-  - uid: 2349
+  - uid: 2461
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17329,7 +17104,7 @@ entities:
       fixtures: {}
 - proto: SignEngineering
   entities:
-  - uid: 2350
+  - uid: 2462
     components:
     - type: Transform
       pos: -15.5,1.5
@@ -17338,7 +17113,7 @@ entities:
       fixtures: {}
 - proto: SignEVA
   entities:
-  - uid: 2351
+  - uid: 2463
     components:
     - type: Transform
       pos: -15.5,6.5
@@ -17347,7 +17122,7 @@ entities:
       fixtures: {}
 - proto: SignGenpop
   entities:
-  - uid: 2352
+  - uid: 2464
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17357,7 +17132,7 @@ entities:
       fixtures: {}
 - proto: SignHydro1
   entities:
-  - uid: 2353
+  - uid: 2465
     components:
     - type: Transform
       pos: -12.5,2.5
@@ -17366,7 +17141,7 @@ entities:
       fixtures: {}
 - proto: SignMedical
   entities:
-  - uid: 2354
+  - uid: 2466
     components:
     - type: Transform
       pos: 1.5,-1.5
@@ -17375,7 +17150,7 @@ entities:
       fixtures: {}
 - proto: SignPlaque
   entities:
-  - uid: 2355
+  - uid: 2467
     components:
     - type: Transform
       pos: 24.5,-1.5
@@ -17384,7 +17159,7 @@ entities:
       fixtures: {}
 - proto: SignRadiationMed
   entities:
-  - uid: 2356
+  - uid: 2468
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17394,7 +17169,7 @@ entities:
       fixtures: {}
 - proto: SignScience
   entities:
-  - uid: 2357
+  - uid: 2469
     components:
     - type: Transform
       pos: -0.5,6.5
@@ -17403,14 +17178,14 @@ entities:
       fixtures: {}
 - proto: SignSecureMed
   entities:
-  - uid: 2358
+  - uid: 2470
     components:
     - type: Transform
       pos: 20.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2359
+  - uid: 2471
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17420,7 +17195,7 @@ entities:
       fixtures: {}
 - proto: SignSecureSmallRed
   entities:
-  - uid: 2360
+  - uid: 2472
     components:
     - type: Transform
       pos: 15.5,-1.5
@@ -17429,7 +17204,7 @@ entities:
       fixtures: {}
 - proto: SignSecurity
   entities:
-  - uid: 2361
+  - uid: 2473
     components:
     - type: Transform
       pos: 13.5,2.5
@@ -17438,7 +17213,7 @@ entities:
       fixtures: {}
 - proto: SignShipDock
   entities:
-  - uid: 2362
+  - uid: 2474
     components:
     - type: Transform
       pos: -1.5,-14.5
@@ -17447,7 +17222,7 @@ entities:
       fixtures: {}
 - proto: SignToolStorage
   entities:
-  - uid: 2363
+  - uid: 2475
     components:
     - type: Transform
       pos: -19.5,4.5
@@ -17456,26 +17231,26 @@ entities:
       fixtures: {}
 - proto: Sink
   entities:
-  - uid: 2364
+  - uid: 2476
     components:
     - type: Transform
       pos: 13.5,10.5
       parent: 2
 - proto: SinkWide
   entities:
-  - uid: 2365
+  - uid: 2477
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-7.5
       parent: 2
-  - uid: 2366
+  - uid: 2478
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,3.5
       parent: 2
-  - uid: 2367
+  - uid: 2479
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -17483,7 +17258,7 @@ entities:
       parent: 2
 - proto: SLVendingMachineEngi
   entities:
-  - uid: 2368
+  - uid: 2480
     components:
     - type: Transform
       pos: -23.5,3.5
@@ -17492,7 +17267,7 @@ entities:
       processingListings: {}
 - proto: SLVendingMachineFashion
   entities:
-  - uid: 2369
+  - uid: 2481
     components:
     - type: Transform
       pos: 5.5,12.5
@@ -17501,7 +17276,7 @@ entities:
       processingListings: {}
 - proto: SLVendingMachineHugDispenser
   entities:
-  - uid: 2370
+  - uid: 2482
     components:
     - type: Transform
       pos: 5.5,14.5
@@ -17510,7 +17285,7 @@ entities:
       processingListings: {}
 - proto: SLVendingMachineMedical
   entities:
-  - uid: 2371
+  - uid: 2483
     components:
     - type: Transform
       pos: 6.5,-1.5
@@ -17519,21 +17294,21 @@ entities:
       processingListings: {}
 - proto: SLVendingMachineMining
   entities:
-  - uid: 1167
+  - uid: 2484
     components:
     - type: Transform
       pos: -2.5,16.5
       parent: 2
 - proto: SLVendingMachineSalvage
   entities:
-  - uid: 1110
+  - uid: 2485
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 2
 - proto: SLVendingMachineSecurity
   entities:
-  - uid: 2373
+  - uid: 2486
     components:
     - type: Transform
       pos: 18.5,-2.5
@@ -17542,431 +17317,496 @@ entities:
       processingListings: {}
 - proto: SmartFridge
   entities:
-  - uid: 2374
+  - uid: 2487
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 2
-  - uid: 2375
+  - uid: 2488
     components:
     - type: Transform
       pos: -6.5,5.5
       parent: 2
 - proto: SMESAdvanced
   entities:
-  - uid: 2376
+  - uid: 2489
     components:
     - type: Transform
       pos: -22.5,3.5
       parent: 2
 - proto: SoapNT
   entities:
-  - uid: 2377
+  - uid: 2490
     components:
     - type: Transform
       pos: 16.59669,-4.5284977
       parent: 2
 - proto: SodaDispenser
   entities:
-  - uid: 2378
+  - uid: 2491
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 2
 - proto: SpaceCash10
   entities:
-  - uid: 2379
+  - uid: 2492
     components:
     - type: Transform
       pos: 14.517527,-8.32479
       parent: 2
-  - uid: 2380
+  - uid: 2493
     components:
     - type: Transform
       pos: 14.590443,-8.491573
       parent: 2
 - proto: SpaceCash100
   entities:
-  - uid: 2381
+  - uid: 2494
     components:
     - type: Transform
       pos: 14.44461,-8.168432
       parent: 2
 - proto: SpaceHeater
   entities:
-  - uid: 2382
+  - uid: 2495
     components:
     - type: Transform
       pos: 6.5,-15.5
       parent: 2
 - proto: SpawnMobCorgi
   entities:
-  - uid: 2383
+  - uid: 2108
     components:
     - type: Transform
-      pos: 21.5,5.5
+      pos: 23.5,3.5
       parent: 2
 - proto: SpawnMobCrabAtmos
   entities:
-  - uid: 2384
+  - uid: 2497
     components:
     - type: Transform
       pos: 6.5,-14.5
       parent: 2
 - proto: SpawnMobFoxRenault
   entities:
-  - uid: 2385
+  - uid: 2498
     components:
     - type: Transform
       pos: 21.5,-3.5
       parent: 2
 - proto: SpawnMobMcGriff
   entities:
-  - uid: 1170
+  - uid: 2499
     components:
     - type: Transform
       pos: 14.5,-3.5
       parent: 2
 - proto: SpawnMobMonkeyPunpun
   entities:
-  - uid: 2387
+  - uid: 2500
     components:
     - type: Transform
       pos: -8.5,4.5
       parent: 2
 - proto: SpawnPointAssistant
   entities:
-  - uid: 2388
+  - uid: 2501
     components:
     - type: Transform
       pos: 6.5,15.5
       parent: 2
-  - uid: 2389
+  - uid: 2502
     components:
     - type: Transform
       pos: 8.5,15.5
       parent: 2
 - proto: SpawnPointAtmos
   entities:
-  - uid: 2390
+  - uid: 2503
     components:
     - type: Transform
       pos: 6.5,-12.5
       parent: 2
 - proto: SpawnPointBartender
   entities:
-  - uid: 2391
+  - uid: 2504
     components:
     - type: Transform
       pos: -9.5,4.5
       parent: 2
 - proto: SpawnPointBlueShield
   entities:
-  - uid: 2392
+  - uid: 2505
     components:
     - type: Transform
       pos: 23.5,6.5
       parent: 2
 - proto: SpawnPointBorg
   entities:
-  - uid: 2393
+  - uid: 2506
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 2
 - proto: SpawnPointBotanist
   entities:
-  - uid: 2394
+  - uid: 2507
     components:
     - type: Transform
       pos: -13.5,4.5
       parent: 2
 - proto: SpawnPointCaptain
   entities:
-  - uid: 2395
+  - uid: 2508
     components:
     - type: Transform
       pos: 23.5,-3.5
       parent: 2
 - proto: SpawnPointCargoTechnician
   entities:
-  - uid: 2396
+  - uid: 2509
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 2
 - proto: SpawnPointChef
   entities:
-  - uid: 2397
+  - uid: 2510
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 2
 - proto: SpawnPointChemist
   entities:
-  - uid: 2398
+  - uid: 2511
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 2
 - proto: SpawnPointChiefEngineer
   entities:
-  - uid: 2399
+  - uid: 2512
     components:
     - type: Transform
       pos: 5.5,-14.5
       parent: 2
 - proto: SpawnPointChiefMedicalOfficer
   entities:
-  - uid: 2400
+  - uid: 2513
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 2
 - proto: SpawnPointClown
   entities:
-  - uid: 2401
+  - uid: 2514
     components:
     - type: Transform
       pos: 12.5,10.5
       parent: 2
+- proto: SpawnPointDutyOfficer
+  entities:
+  - uid: 3084
+    components:
+    - type: Transform
+      pos: 18.5,4.5
+      parent: 2
 - proto: SpawnPointHeadOfPersonnel
   entities:
-  - uid: 2402
+  - uid: 2515
     components:
     - type: Transform
       pos: 22.5,3.5
       parent: 2
 - proto: SpawnPointHeadOfSecurity
   entities:
-  - uid: 2403
+  - uid: 2516
     components:
     - type: Transform
       pos: 22.5,6.5
       parent: 2
+- proto: SpawnPointHeadOfSecurityWeapon
+  entities:
+  - uid: 2496
+    components:
+    - type: Transform
+      pos: 21.5,5.5
+      parent: 2
+- proto: SpawnPointIAA
+  entities:
+  - uid: 1384
+    components:
+    - type: Transform
+      pos: 17.5,1.5
+      parent: 2
 - proto: SpawnPointJanitor
   entities:
-  - uid: 2404
+  - uid: 2517
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 2
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 2405
+  - uid: 2107
+    components:
+    - type: Transform
+      pos: 12.5,18.5
+      parent: 2
+  - uid: 2518
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 2
-  - uid: 2406
+  - uid: 2519
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 2
-  - uid: 2407
+  - uid: 2520
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 2
-  - uid: 2408
+  - uid: 2521
     components:
     - type: Transform
       pos: 4.5,16.5
       parent: 2
+- proto: SpawnPointMagistrate
+  entities:
+  - uid: 3086
+    components:
+    - type: Transform
+      pos: 22.5,5.5
+      parent: 2
 - proto: SpawnPointmailtech
   entities:
-  - uid: 2409
+  - uid: 2522
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 2
 - proto: SpawnPointMedicalDoctor
   entities:
-  - uid: 2410
+  - uid: 2523
     components:
     - type: Transform
       pos: 11.5,-2.5
       parent: 2
 - proto: SpawnPointMedicalIntern
   entities:
-  - uid: 3081
+  - uid: 2524
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 2
 - proto: SpawnPointMime
   entities:
-  - uid: 2411
+  - uid: 2525
     components:
     - type: Transform
       pos: 14.5,5.5
       parent: 2
 - proto: SpawnPointminingspecialist
   entities:
-  - uid: 2412
+  - uid: 2526
     components:
     - type: Transform
       pos: -2.5,15.5
       parent: 2
 - proto: SpawnPointMusician
   entities:
-  - uid: 2413
+  - uid: 2527
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
+- proto: SpawnPointNCT
+  entities:
+  - uid: 2306
+    components:
+    - type: Transform
+      pos: 23.5,4.5
+      parent: 2
+  - uid: 3089
+    components:
+    - type: Transform
+      pos: 22.5,4.5
+      parent: 2
 - proto: SpawnPointNtrep
   entities:
-  - uid: 2414
+  - uid: 2528
     components:
     - type: Transform
       pos: 23.5,5.5
       parent: 2
 - proto: SpawnPointObserver
   entities:
-  - uid: 2415
+  - uid: 2529
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 2
 - proto: SpawnPointParamedic
   entities:
-  - uid: 2416
+  - uid: 2530
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 2
 - proto: SpawnPointQuartermaster
   entities:
-  - uid: 1983
+  - uid: 2531
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 2
 - proto: SpawnPointResearchAssistant
   entities:
-  - uid: 2418
+  - uid: 2532
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 2
 - proto: SpawnPointResearchDirector
   entities:
-  - uid: 2419
+  - uid: 2533
     components:
     - type: Transform
       pos: -10.5,8.5
       parent: 2
 - proto: SpawnPointSalvageLead
   entities:
-  - uid: 2420
+  - uid: 2534
     components:
     - type: Transform
       pos: -1.5,15.5
       parent: 2
 - proto: SpawnPointSalvageSpecialist
   entities:
-  - uid: 1986
+  - uid: 2535
     components:
     - type: Transform
       pos: -3.5,15.5
       parent: 2
 - proto: SpawnPointScientist
   entities:
-  - uid: 2421
+  - uid: 2536
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 2
 - proto: SpawnPointSecurityCadet
   entities:
-  - uid: 2422
+  - uid: 2537
     components:
     - type: Transform
       pos: 16.5,1.5
       parent: 2
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 2423
+  - uid: 2538
     components:
     - type: Transform
       pos: 16.5,-3.5
       parent: 2
-  - uid: 2424
+  - uid: 2539
     components:
     - type: Transform
       pos: 17.5,-3.5
       parent: 2
 - proto: SpawnPointStationEngineer
   entities:
-  - uid: 2425
+  - uid: 2540
     components:
     - type: Transform
       pos: -17.5,0.5
       parent: 2
 - proto: SpawnPointSurgeon
   entities:
-  - uid: 2426
+  - uid: 2541
     components:
     - type: Transform
       pos: 11.5,-4.5
       parent: 2
 - proto: SpawnPointTechnicalAssistant
   entities:
-  - uid: 2427
+  - uid: 2542
     components:
     - type: Transform
       pos: -17.5,-2.5
       parent: 2
 - proto: SpawnPointWarden
   entities:
-  - uid: 2428
+  - uid: 2543
     components:
     - type: Transform
       pos: 15.5,-3.5
       parent: 2
 - proto: SprayBottleSpaceCleaner
   entities:
-  - uid: 2429
+  - uid: 2544
     components:
     - type: Transform
       pos: -5.310366,-8.340232
       parent: 2
 - proto: StasisBed
   entities:
-  - uid: 2430
+  - uid: 2545
     components:
     - type: Transform
       pos: 12.5,-4.5
       parent: 2
+- proto: StationAiFixerComputer
+  entities:
+  - uid: 2586
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,7.5
+      parent: 2
 - proto: StationAiUploadComputer
   entities:
-  - uid: 2431
+  - uid: 2546
     components:
-    - type: SiliconLawUpdater
-      core: 2028
     - type: Transform
       pos: -10.5,10.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - ResearchDirector
+    - type: SiliconLawUpdater
+      core: 2126
 - proto: StationMap
   entities:
-  - uid: 2432
+  - uid: 2547
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 2433
+  - uid: 2548
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 4.5,12.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 3088
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: Stool
   entities:
-  - uid: 2434
+  - uid: 2549
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17974,19 +17814,19 @@ entities:
       parent: 2
 - proto: StoolBar
   entities:
-  - uid: 2435
+  - uid: 2550
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,1.5
       parent: 2
-  - uid: 2436
+  - uid: 2551
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,1.5
       parent: 2
-  - uid: 2437
+  - uid: 2552
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -17994,80 +17834,80 @@ entities:
       parent: 2
 - proto: Stunbaton
   entities:
-  - uid: 2438
+  - uid: 2553
     components:
     - type: Transform
       pos: 16.40919,-4.3566227
       parent: 2
-  - uid: 2439
+  - uid: 2554
     components:
     - type: Transform
       pos: 16.581064,-4.4972477
       parent: 2
 - proto: SubstationBasic
   entities:
-  - uid: 2440
+  - uid: 2555
     components:
     - type: MetaData
       name: Port Bow Substation
     - type: Transform
       pos: 11.5,7.5
       parent: 2
-  - uid: 2441
+  - uid: 2556
     components:
     - type: MetaData
       name: Starboard Bow Substation
     - type: Transform
       pos: 2.5,-9.5
       parent: 2
-  - uid: 2442
+  - uid: 2557
     components:
     - type: MetaData
       name: Port Stern Substation
     - type: Transform
       pos: -6.5,7.5
       parent: 2
-  - uid: 2443
+  - uid: 2558
     components:
     - type: MetaData
       name: Aft Substation
     - type: Transform
       pos: -21.5,3.5
       parent: 2
-  - uid: 2444
+  - uid: 2559
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 2445
+  - uid: 2560
     components:
     - type: Transform
       pos: 21.5,8.5
       parent: 2
 - proto: SuitStorageEVA
   entities:
-  - uid: 2446
+  - uid: 2561
     components:
     - type: Transform
       pos: -16.5,3.5
       parent: 2
 - proto: SuitStorageEVAAlternate
   entities:
-  - uid: 2447
+  - uid: 2562
     components:
     - type: Transform
       pos: -16.5,4.5
       parent: 2
 - proto: SuitStorageSec
   entities:
-  - uid: 2448
+  - uid: 2563
     components:
     - type: Transform
       pos: 17.5,-4.5
       parent: 2
 - proto: SurveillanceCameraCommand
   entities:
-  - uid: 2456
+  - uid: 2564
     components:
     - type: Transform
       pos: 21.5,-3.5
@@ -18077,7 +17917,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Captain's Quarters
-  - uid: 2460
+  - uid: 2565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18090,7 +17930,7 @@ entities:
       id: Bridge
 - proto: SurveillanceCameraEngineering
   entities:
-  - uid: 2934
+  - uid: 2566
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18101,7 +17941,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmos
-  - uid: 2989
+  - uid: 2567
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18112,7 +17952,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering
-  - uid: 2990
+  - uid: 2568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18125,7 +17965,7 @@ entities:
       id: Power
 - proto: SurveillanceCameraGeneral
   entities:
-  - uid: 2450
+  - uid: 2569
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18136,7 +17976,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Evac
-  - uid: 2453
+  - uid: 2570
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18147,7 +17987,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Arrivals
-  - uid: 2457
+  - uid: 2571
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18158,7 +17998,7 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: Hallway [Central]
-  - uid: 2991
+  - uid: 2572
     components:
     - type: Transform
       pos: 9.5,3.5
@@ -18170,7 +18010,7 @@ entities:
       id: Hallway [North]
 - proto: SurveillanceCameraMedical
   entities:
-  - uid: 2458
+  - uid: 2573
     components:
     - type: Transform
       pos: 9.5,-4.5
@@ -18182,14 +18022,14 @@ entities:
       id: Medbay
 - proto: SurveillanceCameraRouterSecurity
   entities:
-  - uid: 1075
+  - uid: 2574
     components:
     - type: Transform
       pos: 19.5,-2.5
       parent: 2
 - proto: SurveillanceCameraScience
   entities:
-  - uid: 2452
+  - uid: 2575
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18202,7 +18042,7 @@ entities:
       id: Science
 - proto: SurveillanceCameraSecurity
   entities:
-  - uid: 2454
+  - uid: 2576
     components:
     - type: Transform
       pos: 18.5,7.5
@@ -18212,7 +18052,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Genpop
-  - uid: 2455
+  - uid: 2577
     components:
     - type: Transform
       pos: 14.5,-4.5
@@ -18222,7 +18062,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Armory
-  - uid: 2459
+  - uid: 2578
     components:
     - type: Transform
       pos: 18.5,-0.5
@@ -18234,7 +18074,7 @@ entities:
       id: Security
 - proto: SurveillanceCameraService
   entities:
-  - uid: 2986
+  - uid: 2579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18245,7 +18085,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Janitor
-  - uid: 2987
+  - uid: 2580
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18256,7 +18096,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Lounge
-  - uid: 2988
+  - uid: 2581
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18269,7 +18109,7 @@ entities:
       id: Botany
 - proto: SurveillanceCameraSupply
   entities:
-  - uid: 2451
+  - uid: 2582
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18282,316 +18122,313 @@ entities:
       id: Cargo
 - proto: SyringeInaprovaline
   entities:
-  - uid: 2461
+  - uid: 2583
     components:
     - type: Transform
       pos: 6.639892,-4.3670673
       parent: 2
 - proto: Table
   entities:
-  - uid: 2417
+  - uid: 2584
     components:
     - type: Transform
       pos: -16.5,-2.5
       parent: 2
-  - uid: 2462
-    components:
-    - type: Transform
-      pos: -8.5,10.5
-      parent: 2
-  - uid: 2463
-    components:
-    - type: Transform
-      pos: -9.5,7.5
-      parent: 2
-  - uid: 2464
+  - uid: 2587
     components:
     - type: Transform
       pos: -16.5,-1.5
       parent: 2
-  - uid: 2465
+  - uid: 2588
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 2
-  - uid: 2466
+  - uid: 2589
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 2
-  - uid: 2467
+  - uid: 2590
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
-  - uid: 2468
+  - uid: 2591
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 2
-  - uid: 2469
+  - uid: 2592
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
-  - uid: 2470
+  - uid: 2593
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 2
-  - uid: 2471
+  - uid: 2594
     components:
     - type: Transform
       pos: -16.5,-4.5
       parent: 2
-  - uid: 2472
+  - uid: 2595
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 2
-  - uid: 2473
+  - uid: 2596
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 2474
+  - uid: 2597
     components:
     - type: Transform
       pos: -16.5,2.5
       parent: 2
-  - uid: 2475
+  - uid: 2598
     components:
     - type: Transform
       pos: 12.5,9.5
       parent: 2
-  - uid: 2476
+  - uid: 2599
     components:
     - type: Transform
       pos: 14.5,10.5
       parent: 2
-  - uid: 2477
+  - uid: 2600
     components:
     - type: Transform
       pos: 15.5,10.5
       parent: 2
-  - uid: 2478
+  - uid: 2601
     components:
     - type: Transform
       pos: 16.5,7.5
       parent: 2
 - proto: TableCarpet
   entities:
-  - uid: 2479
+  - uid: 2602
     components:
     - type: Transform
       pos: 25.5,-2.5
       parent: 2
-  - uid: 2480
+  - uid: 2603
     components:
     - type: Transform
       pos: 14.5,-8.5
       parent: 2
 - proto: TableGlass
   entities:
-  - uid: 2481
+  - uid: 2604
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 2482
+  - uid: 2605
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 2
-  - uid: 2483
+  - uid: 2606
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 2
-  - uid: 2484
+  - uid: 2607
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 2
-  - uid: 2485
+  - uid: 2608
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 2
-  - uid: 2486
+  - uid: 2609
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 2487
+  - uid: 2610
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 2
-  - uid: 2488
+  - uid: 2611
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 2
-  - uid: 2489
+  - uid: 2612
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 2
-  - uid: 2490
+  - uid: 2613
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 2
-  - uid: 2491
+  - uid: 2614
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 2
 - proto: TableReinforced
   entities:
-  - uid: 2492
+  - uid: 2615
     components:
     - type: Transform
       pos: 18.5,-4.5
       parent: 2
-  - uid: 2493
+  - uid: 2616
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 2
-  - uid: 2494
+  - uid: 2617
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 2
-  - uid: 2495
+  - uid: 2618
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 2
-  - uid: 2496
+  - uid: 2619
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 2
-  - uid: 2497
+  - uid: 2620
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
-  - uid: 2498
+  - uid: 2621
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 2
-  - uid: 2499
+  - uid: 2622
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 2
-  - uid: 2500
+  - uid: 2623
     components:
     - type: Transform
       pos: -8.5,5.5
       parent: 2
-  - uid: 2501
+  - uid: 2624
     components:
     - type: Transform
       pos: 19.5,-4.5
       parent: 2
-  - uid: 2502
+  - uid: 2625
     components:
     - type: Transform
       pos: 16.5,-4.5
       parent: 2
-  - uid: 2503
+  - uid: 2626
     components:
     - type: Transform
       pos: 26.5,2.5
       parent: 2
-  - uid: 2504
+  - uid: 2627
     components:
     - type: Transform
       pos: 25.5,2.5
       parent: 2
-  - uid: 2505
+  - uid: 2628
     components:
     - type: Transform
       pos: 24.5,2.5
       parent: 2
+- proto: TableReinforcedGlass
+  entities:
+  - uid: 1383
+    components:
+    - type: Transform
+      pos: 21.5,5.5
+      parent: 2
 - proto: TableWood
   entities:
-  - uid: 2506
+  - uid: 2629
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-4.5
       parent: 2
-  - uid: 2507
+  - uid: 2630
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-4.5
       parent: 2
-  - uid: 2508
+  - uid: 2631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,-3.5
       parent: 2
-  - uid: 2509
+  - uid: 2632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-3.5
       parent: 2
-  - uid: 2510
+  - uid: 2633
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-4.5
       parent: 2
-  - uid: 2511
+  - uid: 2634
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-4.5
       parent: 2
-  - uid: 2512
+  - uid: 2635
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-3.5
       parent: 2
-  - uid: 2513
+  - uid: 2636
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-3.5
       parent: 2
-  - uid: 2514
+  - uid: 2637
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-4.5
       parent: 2
-  - uid: 2515
+  - uid: 2638
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 2
-  - uid: 2516
+  - uid: 2639
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 2
-  - uid: 2517
+  - uid: 2640
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-  - uid: 2518
+  - uid: 2641
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -18599,167 +18436,157 @@ entities:
       parent: 2
 - proto: TargetStrange
   entities:
-  - uid: 2519
+  - uid: 2642
     components:
     - type: Transform
       pos: -21.5,-4.5
       parent: 2
 - proto: TelecomServerFilled
   entities:
-  - uid: 2520
+  - uid: 2643
     components:
     - type: Transform
       pos: 26.5,-0.5
       parent: 2
 - proto: Thruster
   entities:
-  - uid: 2521
+  - uid: 2644
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,1.5
       parent: 2
-  - uid: 2522
+  - uid: 2645
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -27.5,-3.5
       parent: 2
-  - uid: 2523
+  - uid: 2646
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-3.5
       parent: 2
-  - uid: 2524
+  - uid: 2647
     components:
     - type: Transform
       pos: -26.5,4.5
       parent: 2
-  - uid: 2525
+  - uid: 2648
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,0.5
       parent: 2
-  - uid: 2526
+  - uid: 2649
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,-0.5
       parent: 2
-  - uid: 2527
+  - uid: 2650
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-10.5
       parent: 2
-  - uid: 2528
+  - uid: 2651
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
-  - uid: 2529
+  - uid: 2652
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-13.5
       parent: 2
-  - uid: 2530
+  - uid: 2653
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-17.5
       parent: 2
-  - uid: 2531
+  - uid: 2654
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-17.5
       parent: 2
-  - uid: 2532
+  - uid: 2655
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,-2.5
       parent: 2
-  - uid: 2533
+  - uid: 2656
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-3.5
       parent: 2
-  - uid: 2534
+  - uid: 2657
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,3.5
       parent: 2
-  - uid: 2535
+  - uid: 2658
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,4.5
       parent: 2
-  - uid: 2536
+  - uid: 2659
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,-4.5
       parent: 2
-  - uid: 2537
+  - uid: 2660
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,5.5
       parent: 2
-  - uid: 2538
+  - uid: 2661
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-6.5
       parent: 2
-  - uid: 2539
+  - uid: 2662
     components:
     - type: Transform
       pos: 9.5,18.5
       parent: 2
-  - uid: 2540
+  - uid: 2663
     components:
     - type: Transform
       pos: 5.5,18.5
       parent: 2
-  - uid: 2541
+  - uid: 2664
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,12.5
       parent: 2
-  - uid: 2542
+  - uid: 2665
     components:
     - type: Transform
       pos: -12.5,10.5
       parent: 2
 - proto: ToolboxEmergencyFilled
   entities:
-  - uid: 2543
-    components:
-    - type: Transform
-      pos: 2.4632533,-7.742214
-      parent: 2
-  - uid: 2544
-    components:
-    - type: Transform
-      pos: -16.459047,2.8611026
-      parent: 2
-  - uid: 2545
+  - uid: 2021
     components:
     - type: Transform
       pos: 26.506453,2.5815358
       parent: 2
     - type: Storage
       storedItems:
-        1933:
+        2022:
           position: 0,0
           _rotation: East
     - type: ContainerContainer
@@ -18768,10 +18595,20 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1933
+          - 2022
+  - uid: 2666
+    components:
+    - type: Transform
+      pos: 2.4632533,-7.742214
+      parent: 2
+  - uid: 2667
+    components:
+    - type: Transform
+      pos: -16.459047,2.8611026
+      parent: 2
 - proto: TrashBag
   entities:
-  - uid: 2546
+  - uid: 2668
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -18779,14 +18616,14 @@ entities:
       parent: 2
 - proto: TrashBananaPeel
   entities:
-  - uid: 2547
+  - uid: 2669
     components:
     - type: Transform
       pos: -4.498433,-6.6936054
       parent: 2
 - proto: TurnstileGenpopEnter
   entities:
-  - uid: 2548
+  - uid: 2670
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18794,56 +18631,71 @@ entities:
       parent: 2
 - proto: TurnstileGenpopLeave
   entities:
-  - uid: 2549
+  - uid: 2671
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,4.5
       parent: 2
-  - uid: 2550
+  - uid: 2672
     components:
     - type: Transform
       pos: 17.5,6.5
       parent: 2
 - proto: TwoWayLever
   entities:
-  - uid: 2551
+  - uid: 2673
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        1172:
-        - Left: Reverse
-        - Right: Forward
-        - Middle: Off
-        1173:
-        - Left: Reverse
-        - Right: Forward
-        - Middle: Off
-  - uid: 2552
+        1242:
+        - - Left
+          - Reverse
+        - - Right
+          - Forward
+        - - Middle
+          - Off
+        1243:
+        - - Left
+          - Reverse
+        - - Right
+          - Forward
+        - - Middle
+          - Off
+  - uid: 2674
     components:
     - type: Transform
       pos: 16.5,-7.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        1175:
-        - Left: Reverse
-        - Right: Forward
-        - Middle: Off
-        1174:
-        - Left: Reverse
-        - Right: Forward
-        - Middle: Off
-        2192:
-        - Left: Reverse
-        - Right: Forward
-        - Middle: Off
+        1245:
+        - - Left
+          - Reverse
+        - - Right
+          - Forward
+        - - Middle
+          - Off
+        1244:
+        - - Left
+          - Reverse
+        - - Right
+          - Forward
+        - - Middle
+          - Off
+        2295:
+        - - Left
+          - Reverse
+        - - Right
+          - Forward
+        - - Middle
+          - Off
 - proto: UniformPrinter
   entities:
-  - uid: 2553
+  - uid: 2675
     components:
     - type: Transform
       pos: 24.5,1.5
@@ -18857,73 +18709,67 @@ entities:
       - Biochemical
 - proto: UraniumReinforcedWindowDirectional
   entities:
-  - uid: 2554
+  - uid: 2676
     components:
     - type: Transform
       pos: -5.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2555
+  - uid: 2677
     components:
     - type: Transform
       pos: -6.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2556
+  - uid: 2678
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: VendingMachineBooze
   entities:
-  - uid: 2557
+  - uid: 2679
     components:
     - type: Transform
       pos: -7.5,5.5
       parent: 2
 - proto: VendingMachineCart
   entities:
-  - uid: 2558
+  - uid: 2680
     components:
     - type: Transform
       pos: 21.5,-0.5
       parent: 2
 - proto: VendingMachineChefvend
   entities:
-  - uid: 2559
+  - uid: 2681
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 2
 - proto: VendingMachineChemicals
   entities:
-  - uid: 2560
+  - uid: 2682
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 2
 - proto: VendingMachineCigs
   entities:
-  - uid: 2561
+  - uid: 2683
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 2
 - proto: VendingMachineClothing
   entities:
-  - uid: 2562
+  - uid: 2684
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 2
 - proto: VendingMachineClown
   entities:
-  - uid: 2563
+  - uid: 2685
     components:
     - type: Transform
       pos: 6.5,-8.5
@@ -18932,14 +18778,14 @@ entities:
       processingListings: {}
 - proto: VendingMachineCoffee
   entities:
-  - uid: 2564
+  - uid: 2686
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 2
 - proto: VendingMachineCondiments
   entities:
-  - uid: 2565
+  - uid: 2687
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -18947,1707 +18793,1709 @@ entities:
       parent: 2
 - proto: VendingMachineEngivend
   entities:
-  - uid: 2566
+  - uid: 2688
     components:
     - type: Transform
       pos: -18.5,3.5
       parent: 2
 - proto: VendingMachineGames
   entities:
-  - uid: 2567
+  - uid: 2689
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 2
-  - uid: 2568
+  - uid: 2690
     components:
     - type: Transform
       pos: 19.5,8.5
       parent: 2
 - proto: VendingMachineJaniDrobe
   entities:
-  - uid: 2569
+  - uid: 2691
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 2
 - proto: VendingMachineMedical
   entities:
-  - uid: 2570
+  - uid: 2692
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
 - proto: VendingMachineNutri
   entities:
-  - uid: 2571
+  - uid: 2693
     components:
     - type: Transform
       pos: -14.5,7.5
       parent: 2
 - proto: VendingMachineSalvage
   entities:
-  - uid: 1329
+  - uid: 2694
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 2
 - proto: VendingMachineSec
   entities:
-  - uid: 2573
+  - uid: 2695
     components:
     - type: Transform
       pos: 15.5,-2.5
       parent: 2
 - proto: VendingMachineSecDrobe
   entities:
-  - uid: 2574
+  - uid: 2696
     components:
     - type: Transform
       pos: 15.5,-0.5
       parent: 2
 - proto: VendingMachineSeeds
   entities:
-  - uid: 2575
+  - uid: 2697
     components:
     - type: Transform
       pos: -14.5,6.5
       parent: 2
 - proto: VendingMachineSeedsUnlocked
   entities:
-  - uid: 2576
+  - uid: 2698
     components:
     - type: Transform
       pos: 13.5,7.5
       parent: 2
 - proto: VendingMachineSnack
   entities:
-  - uid: 2577
+  - uid: 2699
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
 - proto: VendingMachineSustenance
   entities:
-  - uid: 2578
+  - uid: 2700
     components:
     - type: Transform
       pos: 18.5,5.5
       parent: 2
 - proto: VendingMachineTankDispenserEngineering
   entities:
-  - uid: 2579
+  - uid: 2701
     components:
     - type: Transform
       pos: -18.5,6.5
       parent: 2
-  - uid: 2580
+  - uid: 2702
     components:
     - type: Transform
       pos: -18.5,-6.5
       parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 2581
+  - uid: 2703
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 2
 - proto: VendingMachineTheater
   entities:
-  - uid: 2583
+  - uid: 2704
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 2
 - proto: VendingMachineWinter
   entities:
-  - uid: 2584
+  - uid: 2705
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 2
 - proto: VendingMachineYouTool
   entities:
-  - uid: 2585
+  - uid: 2706
     components:
     - type: Transform
       pos: -18.5,4.5
       parent: 2
-- proto: WallShuttle
+- proto: WallmountMassScanner
   entities:
-  - uid: 41
-    components:
-    - type: Transform
-      pos: 11.5,19.5
-      parent: 2
-  - uid: 44
-    components:
-    - type: Transform
-      pos: 14.5,19.5
-      parent: 2
-  - uid: 46
-    components:
-    - type: Transform
-      pos: 11.5,18.5
-      parent: 2
-  - uid: 86
-    components:
-    - type: Transform
-      pos: -4.5,17.5
-      parent: 2
-  - uid: 1335
-    components:
-    - type: Transform
-      pos: 10.5,16.5
-      parent: 2
-  - uid: 2317
-    components:
-    - type: Transform
-      pos: 14.5,16.5
-      parent: 2
-  - uid: 2572
-    components:
-    - type: Transform
-      pos: 11.5,16.5
-      parent: 2
-  - uid: 2586
-    components:
-    - type: Transform
-      pos: 16.5,-9.5
-      parent: 2
-  - uid: 2587
-    components:
-    - type: Transform
-      pos: 19.5,10.5
-      parent: 2
-  - uid: 2588
-    components:
-    - type: Transform
-      pos: -11.5,11.5
-      parent: 2
-  - uid: 2589
-    components:
-    - type: Transform
-      pos: -19.5,6.5
-      parent: 2
-  - uid: 2590
-    components:
-    - type: Transform
-      pos: -24.5,-3.5
-      parent: 2
-  - uid: 2591
-    components:
-    - type: Transform
-      pos: 13.5,13.5
-      parent: 2
-  - uid: 2592
-    components:
-    - type: Transform
-      pos: 15.5,-5.5
-      parent: 2
-  - uid: 2593
-    components:
-    - type: Transform
-      pos: 18.5,-5.5
-      parent: 2
-  - uid: 2594
-    components:
-    - type: Transform
-      pos: 17.5,-5.5
-      parent: 2
-  - uid: 2595
-    components:
-    - type: Transform
-      pos: 16.5,-5.5
-      parent: 2
-  - uid: 2596
-    components:
-    - type: Transform
-      pos: 26.5,3.5
-      parent: 2
-  - uid: 2597
-    components:
-    - type: Transform
-      pos: 27.5,3.5
-      parent: 2
-  - uid: 2598
-    components:
-    - type: Transform
-      pos: 20.5,7.5
-      parent: 2
-  - uid: 2599
-    components:
-    - type: Transform
-      pos: 16.5,2.5
-      parent: 2
-  - uid: 2601
-    components:
-    - type: Transform
-      pos: 20.5,8.5
-      parent: 2
-  - uid: 2602
-    components:
-    - type: Transform
-      pos: -19.5,-3.5
-      parent: 2
-  - uid: 2603
-    components:
-    - type: Transform
-      pos: -11.5,8.5
-      parent: 2
-  - uid: 2604
-    components:
-    - type: Transform
-      pos: -7.5,2.5
-      parent: 2
-  - uid: 2605
-    components:
-    - type: Transform
-      pos: -9.5,6.5
-      parent: 2
-  - uid: 2606
-    components:
-    - type: Transform
-      pos: -4.5,-9.5
-      parent: 2
-  - uid: 2607
-    components:
-    - type: Transform
-      pos: -4.5,-14.5
-      parent: 2
-  - uid: 2608
-    components:
-    - type: Transform
-      pos: -4.5,13.5
-      parent: 2
-  - uid: 2609
-    components:
-    - type: Transform
-      pos: -24.5,4.5
-      parent: 2
-  - uid: 2610
-    components:
-    - type: Transform
-      pos: 17.5,-9.5
-      parent: 2
-  - uid: 2611
-    components:
-    - type: Transform
-      pos: 18.5,-6.5
-      parent: 2
-  - uid: 2612
-    components:
-    - type: Transform
-      pos: 16.5,-11.5
-      parent: 2
-  - uid: 2613
-    components:
-    - type: Transform
-      pos: 14.5,11.5
-      parent: 2
-  - uid: 2614
-    components:
-    - type: Transform
-      pos: 13.5,12.5
-      parent: 2
-  - uid: 2615
-    components:
-    - type: Transform
-      pos: -8.5,6.5
-      parent: 2
-  - uid: 2616
-    components:
-    - type: Transform
-      pos: 18.5,11.5
-      parent: 2
-  - uid: 2617
-    components:
-    - type: Transform
-      pos: 18.5,10.5
-      parent: 2
-  - uid: 2618
-    components:
-    - type: Transform
-      pos: 16.5,5.5
-      parent: 2
-  - uid: 2619
-    components:
-    - type: Transform
-      pos: 16.5,-10.5
-      parent: 2
-  - uid: 2620
-    components:
-    - type: Transform
-      pos: 14.5,-9.5
-      parent: 2
-  - uid: 2621
-    components:
-    - type: Transform
-      pos: -7.5,12.5
-      parent: 2
-  - uid: 2622
-    components:
-    - type: Transform
-      pos: -15.5,9.5
-      parent: 2
-  - uid: 2624
-    components:
-    - type: Transform
-      pos: -19.5,-6.5
-      parent: 2
-  - uid: 2625
-    components:
-    - type: Transform
-      pos: -19.5,-7.5
-      parent: 2
-  - uid: 2626
-    components:
-    - type: Transform
-      pos: -11.5,10.5
-      parent: 2
-  - uid: 2627
-    components:
-    - type: Transform
-      pos: -19.5,3.5
-      parent: 2
-  - uid: 2628
-    components:
-    - type: Transform
-      pos: 11.5,11.5
-      parent: 2
-  - uid: 2629
-    components:
-    - type: Transform
-      pos: 16.5,3.5
-      parent: 2
-  - uid: 2630
-    components:
-    - type: Transform
-      pos: 12.5,11.5
-      parent: 2
-  - uid: 2631
-    components:
-    - type: Transform
-      pos: 13.5,-9.5
-      parent: 2
-  - uid: 2632
-    components:
-    - type: Transform
-      pos: 18.5,-9.5
-      parent: 2
-  - uid: 2634
-    components:
-    - type: Transform
-      pos: -7.5,11.5
-      parent: 2
-  - uid: 2635
-    components:
-    - type: Transform
-      pos: 15.5,-9.5
-      parent: 2
-  - uid: 2636
-    components:
-    - type: Transform
-      pos: 16.5,6.5
-      parent: 2
-  - uid: 2637
-    components:
-    - type: Transform
-      pos: 13.5,-12.5
-      parent: 2
-  - uid: 2638
-    components:
-    - type: Transform
-      pos: -11.5,7.5
-      parent: 2
-  - uid: 2639
-    components:
-    - type: Transform
-      pos: 8.5,-12.5
-      parent: 2
-  - uid: 2640
-    components:
-    - type: Transform
-      pos: 9.5,-12.5
-      parent: 2
-  - uid: 2641
-    components:
-    - type: Transform
-      pos: 10.5,-12.5
-      parent: 2
-  - uid: 2642
-    components:
-    - type: Transform
-      pos: 11.5,-12.5
-      parent: 2
-  - uid: 2643
-    components:
-    - type: Transform
-      pos: 11.5,-13.5
-      parent: 2
-  - uid: 2644
-    components:
-    - type: Transform
-      pos: 11.5,-14.5
-      parent: 2
-  - uid: 2645
-    components:
-    - type: Transform
-      pos: 11.5,-15.5
-      parent: 2
-  - uid: 2646
-    components:
-    - type: Transform
-      pos: 11.5,-16.5
-      parent: 2
-  - uid: 2647
-    components:
-    - type: Transform
-      pos: 10.5,-14.5
-      parent: 2
-  - uid: 2648
-    components:
-    - type: Transform
-      pos: 9.5,-14.5
-      parent: 2
-  - uid: 2649
-    components:
-    - type: Transform
-      pos: 8.5,-14.5
-      parent: 2
-  - uid: 2650
-    components:
-    - type: Transform
-      pos: 10.5,-16.5
-      parent: 2
-  - uid: 2651
-    components:
-    - type: Transform
-      pos: 9.5,-16.5
-      parent: 2
-  - uid: 2652
-    components:
-    - type: Transform
-      pos: 8.5,-16.5
-      parent: 2
-  - uid: 2653
-    components:
-    - type: Transform
-      pos: 8.5,-17.5
-      parent: 2
-  - uid: 2654
-    components:
-    - type: Transform
-      pos: 10.5,-17.5
-      parent: 2
-  - uid: 2655
-    components:
-    - type: Transform
-      pos: 6.5,-17.5
-      parent: 2
-  - uid: 2656
-    components:
-    - type: Transform
-      pos: 6.5,-16.5
-      parent: 2
-  - uid: 2657
-    components:
-    - type: Transform
-      pos: 5.5,-16.5
-      parent: 2
-  - uid: 2658
-    components:
-    - type: Transform
-      pos: 4.5,-16.5
-      parent: 2
-  - uid: 2659
-    components:
-    - type: Transform
-      pos: 3.5,-16.5
-      parent: 2
-  - uid: 2660
-    components:
-    - type: Transform
-      pos: 4.5,-17.5
-      parent: 2
-  - uid: 2661
-    components:
-    - type: Transform
-      pos: 12.5,-14.5
-      parent: 2
-  - uid: 2662
-    components:
-    - type: Transform
-      pos: 12.5,-12.5
-      parent: 2
-  - uid: 2663
-    components:
-    - type: Transform
-      pos: 12.5,-9.5
-      parent: 2
-  - uid: 2664
-    components:
-    - type: Transform
-      pos: 11.5,-9.5
-      parent: 2
-  - uid: 2665
-    components:
-    - type: Transform
-      pos: 10.5,-9.5
-      parent: 2
-  - uid: 2666
-    components:
-    - type: Transform
-      pos: 9.5,-9.5
-      parent: 2
-  - uid: 2667
-    components:
-    - type: Transform
-      pos: 8.5,-9.5
-      parent: 2
-  - uid: 2668
-    components:
-    - type: Transform
-      pos: 7.5,-9.5
-      parent: 2
-  - uid: 2669
-    components:
-    - type: Transform
-      pos: 6.5,-9.5
-      parent: 2
-  - uid: 2670
-    components:
-    - type: Transform
-      pos: 5.5,-9.5
-      parent: 2
-  - uid: 2671
-    components:
-    - type: Transform
-      pos: 4.5,-9.5
-      parent: 2
-  - uid: 2672
-    components:
-    - type: Transform
-      pos: 3.5,-9.5
-      parent: 2
-  - uid: 2673
-    components:
-    - type: Transform
-      pos: 3.5,-10.5
-      parent: 2
-  - uid: 2674
-    components:
-    - type: Transform
-      pos: 1.5,-10.5
-      parent: 2
-  - uid: 2675
-    components:
-    - type: Transform
-      pos: 1.5,-9.5
-      parent: 2
-  - uid: 2676
-    components:
-    - type: Transform
-      pos: 2.5,-10.5
-      parent: 2
-  - uid: 2677
-    components:
-    - type: Transform
-      pos: 1.5,-13.5
-      parent: 2
-  - uid: 2678
-    components:
-    - type: Transform
-      pos: 1.5,-14.5
-      parent: 2
-  - uid: 2679
-    components:
-    - type: Transform
-      pos: 2.5,-14.5
-      parent: 2
-  - uid: 2680
-    components:
-    - type: Transform
-      pos: 18.5,-7.5
-      parent: 2
-  - uid: 2681
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 2
-  - uid: 2682
-    components:
-    - type: Transform
-      pos: 2.5,-5.5
-      parent: 2
-  - uid: 2683
-    components:
-    - type: Transform
-      pos: 4.5,-5.5
-      parent: 2
-  - uid: 2684
-    components:
-    - type: Transform
-      pos: 5.5,-5.5
-      parent: 2
-  - uid: 2685
-    components:
-    - type: Transform
-      pos: 6.5,-5.5
-      parent: 2
-  - uid: 2686
-    components:
-    - type: Transform
-      pos: 7.5,-5.5
-      parent: 2
-  - uid: 2687
-    components:
-    - type: Transform
-      pos: 8.5,-5.5
-      parent: 2
-  - uid: 2688
-    components:
-    - type: Transform
-      pos: 9.5,-5.5
-      parent: 2
-  - uid: 2689
-    components:
-    - type: Transform
-      pos: 10.5,-5.5
-      parent: 2
-  - uid: 2690
-    components:
-    - type: Transform
-      pos: 11.5,-5.5
-      parent: 2
-  - uid: 2691
-    components:
-    - type: Transform
-      pos: 12.5,-5.5
-      parent: 2
-  - uid: 2692
-    components:
-    - type: Transform
-      pos: 1.5,-8.5
-      parent: 2
-  - uid: 2693
-    components:
-    - type: Transform
-      pos: 1.5,-7.5
-      parent: 2
-  - uid: 2694
-    components:
-    - type: Transform
-      pos: 3.5,-8.5
-      parent: 2
-  - uid: 2695
-    components:
-    - type: Transform
-      pos: 0.5,-17.5
-      parent: 2
-  - uid: 2696
-    components:
-    - type: Transform
-      pos: -3.5,-9.5
-      parent: 2
-  - uid: 2697
-    components:
-    - type: Transform
-      pos: -2.5,-9.5
-      parent: 2
-  - uid: 2698
-    components:
-    - type: Transform
-      pos: -2.5,-8.5
-      parent: 2
-  - uid: 2699
-    components:
-    - type: Transform
-      pos: -2.5,-6.5
-      parent: 2
-  - uid: 2700
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
-      parent: 2
-  - uid: 2701
-    components:
-    - type: Transform
-      pos: -3.5,-5.5
-      parent: 2
-  - uid: 2702
-    components:
-    - type: Transform
-      pos: -4.5,-5.5
-      parent: 2
-  - uid: 2703
-    components:
-    - type: Transform
-      pos: -5.5,-5.5
-      parent: 2
-  - uid: 2704
-    components:
-    - type: Transform
-      pos: -6.5,-5.5
-      parent: 2
-  - uid: 2705
-    components:
-    - type: Transform
-      pos: -7.5,-5.5
-      parent: 2
-  - uid: 2706
-    components:
-    - type: Transform
-      pos: -7.5,-6.5
-      parent: 2
-  - uid: 2707
-    components:
-    - type: Transform
-      pos: -7.5,-7.5
-      parent: 2
-  - uid: 2708
-    components:
-    - type: Transform
-      pos: -15.5,-5.5
-      parent: 2
-  - uid: 2709
-    components:
-    - type: Transform
-      pos: -4.5,12.5
-      parent: 2
-  - uid: 2710
-    components:
-    - type: Transform
-      pos: -19.5,-5.5
-      parent: 2
-  - uid: 2711
-    components:
-    - type: Transform
-      pos: -15.5,-4.5
-      parent: 2
-  - uid: 2712
-    components:
-    - type: Transform
-      pos: -15.5,-3.5
-      parent: 2
-  - uid: 2713
-    components:
-    - type: Transform
-      pos: -15.5,-2.5
-      parent: 2
-  - uid: 2714
-    components:
-    - type: Transform
-      pos: -15.5,-1.5
-      parent: 2
-  - uid: 2715
-    components:
-    - type: Transform
-      pos: -15.5,-0.5
-      parent: 2
-  - uid: 2716
-    components:
-    - type: Transform
-      pos: -15.5,1.5
-      parent: 2
-  - uid: 2717
-    components:
-    - type: Transform
-      pos: -15.5,2.5
-      parent: 2
-  - uid: 2718
-    components:
-    - type: Transform
-      pos: -15.5,3.5
-      parent: 2
-  - uid: 2719
-    components:
-    - type: Transform
-      pos: -15.5,4.5
-      parent: 2
-  - uid: 2720
-    components:
-    - type: Transform
-      pos: -15.5,5.5
-      parent: 2
-  - uid: 2721
-    components:
-    - type: Transform
-      pos: -15.5,6.5
-      parent: 2
-  - uid: 2722
-    components:
-    - type: Transform
-      pos: -15.5,7.5
-      parent: 2
-  - uid: 2723
-    components:
-    - type: Transform
-      pos: -19.5,2.5
-      parent: 2
-  - uid: 2724
-    components:
-    - type: Transform
-      pos: -19.5,4.5
-      parent: 2
-  - uid: 2725
-    components:
-    - type: Transform
-      pos: -19.5,5.5
-      parent: 2
-  - uid: 2726
-    components:
-    - type: Transform
-      pos: -19.5,-1.5
-      parent: 2
-  - uid: 2727
-    components:
-    - type: Transform
-      pos: -19.5,-2.5
-      parent: 2
-  - uid: 2728
-    components:
-    - type: Transform
-      pos: -18.5,5.5
-      parent: 2
-  - uid: 2729
-    components:
-    - type: Transform
-      pos: -20.5,-5.5
-      parent: 2
-  - uid: 2730
-    components:
-    - type: Transform
-      pos: -20.5,-4.5
-      parent: 2
-  - uid: 2731
-    components:
-    - type: Transform
-      pos: -20.5,-3.5
-      parent: 2
-  - uid: 2732
-    components:
-    - type: Transform
-      pos: -21.5,-3.5
-      parent: 2
-  - uid: 2733
-    components:
-    - type: Transform
-      pos: -22.5,-3.5
-      parent: 2
-  - uid: 2734
-    components:
-    - type: Transform
-      pos: -23.5,-3.5
-      parent: 2
-  - uid: 2735
-    components:
-    - type: Transform
-      pos: -24.5,-2.5
-      parent: 2
-  - uid: 2736
-    components:
-    - type: Transform
-      pos: -24.5,3.5
-      parent: 2
-  - uid: 2737
-    components:
-    - type: Transform
-      pos: -23.5,4.5
-      parent: 2
-  - uid: 2738
-    components:
-    - type: Transform
-      pos: -22.5,4.5
-      parent: 2
-  - uid: 2739
-    components:
-    - type: Transform
-      pos: -21.5,4.5
-      parent: 2
-  - uid: 2740
-    components:
-    - type: Transform
-      pos: -20.5,4.5
-      parent: 2
-  - uid: 2741
-    components:
-    - type: Transform
-      pos: -11.5,9.5
-      parent: 2
-  - uid: 2742
-    components:
-    - type: Transform
-      pos: -31.5,-5.5
-      parent: 2
-  - uid: 2743
-    components:
-    - type: Transform
-      pos: -12.5,2.5
-      parent: 2
-  - uid: 2744
-    components:
-    - type: Transform
-      pos: -11.5,2.5
-      parent: 2
-  - uid: 2745
-    components:
-    - type: Transform
-      pos: -11.5,3.5
-      parent: 2
-  - uid: 2746
-    components:
-    - type: Transform
-      pos: -11.5,5.5
-      parent: 2
-  - uid: 2747
-    components:
-    - type: Transform
-      pos: -11.5,6.5
-      parent: 2
-  - uid: 2748
-    components:
-    - type: Transform
-      pos: -10.5,6.5
-      parent: 2
-  - uid: 2749
-    components:
-    - type: Transform
-      pos: -7.5,6.5
-      parent: 2
-  - uid: 2750
-    components:
-    - type: Transform
-      pos: -6.5,6.5
-      parent: 2
-  - uid: 2751
-    components:
-    - type: Transform
-      pos: -5.5,2.5
-      parent: 2
-  - uid: 2752
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 2
-  - uid: 2753
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 2
-  - uid: 2754
-    components:
-    - type: Transform
-      pos: -2.5,4.5
-      parent: 2
-  - uid: 2755
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 2
-  - uid: 2756
-    components:
-    - type: Transform
-      pos: -2.5,6.5
-      parent: 2
-  - uid: 2757
-    components:
-    - type: Transform
-      pos: -3.5,6.5
-      parent: 2
-  - uid: 2758
-    components:
-    - type: Transform
-      pos: -4.5,6.5
-      parent: 2
-  - uid: 2759
-    components:
-    - type: Transform
-      pos: -5.5,6.5
-      parent: 2
-  - uid: 2760
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 2
-  - uid: 2761
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
-      parent: 2
-  - uid: 2762
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 2
-  - uid: 2763
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 2
-  - uid: 2764
-    components:
-    - type: Transform
-      pos: -2.5,13.5
-      parent: 2
-  - uid: 2765
-    components:
-    - type: Transform
-      pos: -1.5,13.5
-      parent: 2
-  - uid: 2766
-    components:
-    - type: Transform
-      pos: -0.5,6.5
-      parent: 2
-  - uid: 2767
-    components:
-    - type: Transform
-      pos: -0.5,9.5
-      parent: 2
-  - uid: 2768
-    components:
-    - type: Transform
-      pos: -0.5,12.5
-      parent: 2
-  - uid: 2769
-    components:
-    - type: Transform
-      pos: -0.5,13.5
-      parent: 2
-  - uid: 2771
-    components:
-    - type: Transform
-      pos: 3.5,14.5
-      parent: 2
-  - uid: 2772
-    components:
-    - type: Transform
-      pos: 3.5,15.5
-      parent: 2
-  - uid: 2773
-    components:
-    - type: Transform
-      pos: 3.5,16.5
-      parent: 2
-  - uid: 2774
-    components:
-    - type: Transform
-      pos: 3.5,17.5
-      parent: 2
-  - uid: 2775
-    components:
-    - type: Transform
-      pos: 4.5,17.5
-      parent: 2
-  - uid: 2776
-    components:
-    - type: Transform
-      pos: 9.5,17.5
-      parent: 2
-  - uid: 2777
-    components:
-    - type: Transform
-      pos: 10.5,17.5
-      parent: 2
-  - uid: 2779
-    components:
-    - type: Transform
-      pos: 4.5,6.5
-      parent: 2
-  - uid: 2780
-    components:
-    - type: Transform
-      pos: 4.5,7.5
-      parent: 2
-  - uid: 2781
-    components:
-    - type: Transform
-      pos: 4.5,8.5
-      parent: 2
-  - uid: 2782
-    components:
-    - type: Transform
-      pos: 4.5,9.5
-      parent: 2
-  - uid: 2783
-    components:
-    - type: Transform
-      pos: 4.5,10.5
-      parent: 2
-  - uid: 2784
-    components:
-    - type: Transform
-      pos: 4.5,11.5
-      parent: 2
-  - uid: 2785
-    components:
-    - type: Transform
-      pos: 4.5,12.5
-      parent: 2
-  - uid: 2786
-    components:
-    - type: Transform
-      pos: 4.5,14.5
-      parent: 2
-  - uid: 2790
-    components:
-    - type: Transform
-      pos: -3.5,13.5
-      parent: 2
-  - uid: 2791
-    components:
-    - type: Transform
-      pos: 11.5,8.5
-      parent: 2
-  - uid: 2792
-    components:
-    - type: Transform
-      pos: 12.5,8.5
-      parent: 2
-  - uid: 2793
-    components:
-    - type: Transform
-      pos: 12.5,7.5
-      parent: 2
-  - uid: 2794
-    components:
-    - type: Transform
-      pos: 12.5,6.5
-      parent: 2
-  - uid: 2795
-    components:
-    - type: Transform
-      pos: 11.5,6.5
-      parent: 2
-  - uid: 2796
-    components:
-    - type: Transform
-      pos: 10.5,6.5
-      parent: 2
-  - uid: 2797
-    components:
-    - type: Transform
-      pos: 9.5,6.5
-      parent: 2
-  - uid: 2798
+  - uid: 2308
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: WallShuttle
+  entities:
+  - uid: 2707
+    components:
+    - type: Transform
+      pos: 11.5,19.5
+      parent: 2
+  - uid: 2708
+    components:
+    - type: Transform
+      pos: 14.5,19.5
+      parent: 2
+  - uid: 2709
+    components:
+    - type: Transform
+      pos: 11.5,18.5
+      parent: 2
+  - uid: 2710
+    components:
+    - type: Transform
+      pos: -4.5,17.5
+      parent: 2
+  - uid: 2711
+    components:
+    - type: Transform
+      pos: 10.5,16.5
+      parent: 2
+  - uid: 2712
+    components:
+    - type: Transform
+      pos: 14.5,16.5
+      parent: 2
+  - uid: 2713
+    components:
+    - type: Transform
+      pos: 11.5,16.5
+      parent: 2
+  - uid: 2714
+    components:
+    - type: Transform
+      pos: 16.5,-9.5
+      parent: 2
+  - uid: 2715
+    components:
+    - type: Transform
+      pos: 19.5,10.5
+      parent: 2
+  - uid: 2716
+    components:
+    - type: Transform
+      pos: -11.5,11.5
+      parent: 2
+  - uid: 2717
+    components:
+    - type: Transform
+      pos: -19.5,6.5
+      parent: 2
+  - uid: 2718
+    components:
+    - type: Transform
+      pos: -24.5,-3.5
+      parent: 2
+  - uid: 2719
+    components:
+    - type: Transform
+      pos: 13.5,13.5
+      parent: 2
+  - uid: 2720
+    components:
+    - type: Transform
+      pos: 15.5,-5.5
+      parent: 2
+  - uid: 2721
+    components:
+    - type: Transform
+      pos: 18.5,-5.5
+      parent: 2
+  - uid: 2722
+    components:
+    - type: Transform
+      pos: 17.5,-5.5
+      parent: 2
+  - uid: 2723
+    components:
+    - type: Transform
+      pos: 16.5,-5.5
+      parent: 2
+  - uid: 2724
+    components:
+    - type: Transform
+      pos: 26.5,3.5
+      parent: 2
+  - uid: 2725
+    components:
+    - type: Transform
+      pos: 27.5,3.5
+      parent: 2
+  - uid: 2726
+    components:
+    - type: Transform
+      pos: 20.5,7.5
+      parent: 2
+  - uid: 2727
+    components:
+    - type: Transform
+      pos: 16.5,2.5
+      parent: 2
+  - uid: 2728
+    components:
+    - type: Transform
+      pos: 20.5,8.5
+      parent: 2
+  - uid: 2729
+    components:
+    - type: Transform
+      pos: -19.5,-3.5
+      parent: 2
+  - uid: 2730
+    components:
+    - type: Transform
+      pos: -11.5,8.5
+      parent: 2
+  - uid: 2731
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 2
+  - uid: 2732
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 2
+  - uid: 2733
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 2
+  - uid: 2734
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 2
+  - uid: 2735
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 2
+  - uid: 2736
+    components:
+    - type: Transform
+      pos: -24.5,4.5
+      parent: 2
+  - uid: 2737
+    components:
+    - type: Transform
+      pos: 17.5,-9.5
+      parent: 2
+  - uid: 2738
+    components:
+    - type: Transform
+      pos: 18.5,-6.5
+      parent: 2
+  - uid: 2739
+    components:
+    - type: Transform
+      pos: 16.5,-11.5
+      parent: 2
+  - uid: 2740
+    components:
+    - type: Transform
+      pos: 14.5,11.5
+      parent: 2
+  - uid: 2741
+    components:
+    - type: Transform
+      pos: 13.5,12.5
+      parent: 2
+  - uid: 2742
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 2
+  - uid: 2743
+    components:
+    - type: Transform
+      pos: 18.5,11.5
+      parent: 2
+  - uid: 2744
+    components:
+    - type: Transform
+      pos: 18.5,10.5
+      parent: 2
+  - uid: 2745
+    components:
+    - type: Transform
+      pos: 16.5,5.5
+      parent: 2
+  - uid: 2746
+    components:
+    - type: Transform
+      pos: 16.5,-10.5
+      parent: 2
+  - uid: 2747
+    components:
+    - type: Transform
+      pos: 14.5,-9.5
+      parent: 2
+  - uid: 2748
+    components:
+    - type: Transform
+      pos: -7.5,12.5
+      parent: 2
+  - uid: 2749
+    components:
+    - type: Transform
+      pos: -15.5,9.5
+      parent: 2
+  - uid: 2750
+    components:
+    - type: Transform
+      pos: -19.5,-6.5
+      parent: 2
+  - uid: 2751
+    components:
+    - type: Transform
+      pos: -19.5,-7.5
+      parent: 2
+  - uid: 2752
+    components:
+    - type: Transform
+      pos: -11.5,10.5
+      parent: 2
+  - uid: 2753
+    components:
+    - type: Transform
+      pos: -19.5,3.5
+      parent: 2
+  - uid: 2754
+    components:
+    - type: Transform
+      pos: 11.5,11.5
+      parent: 2
+  - uid: 2755
+    components:
+    - type: Transform
+      pos: 16.5,3.5
+      parent: 2
+  - uid: 2756
+    components:
+    - type: Transform
+      pos: 12.5,11.5
+      parent: 2
+  - uid: 2757
+    components:
+    - type: Transform
+      pos: 13.5,-9.5
+      parent: 2
+  - uid: 2758
+    components:
+    - type: Transform
+      pos: 18.5,-9.5
+      parent: 2
+  - uid: 2759
+    components:
+    - type: Transform
+      pos: -7.5,11.5
+      parent: 2
+  - uid: 2760
+    components:
+    - type: Transform
+      pos: 15.5,-9.5
+      parent: 2
+  - uid: 2761
+    components:
+    - type: Transform
+      pos: 16.5,6.5
+      parent: 2
+  - uid: 2762
+    components:
+    - type: Transform
+      pos: 13.5,-12.5
+      parent: 2
+  - uid: 2763
+    components:
+    - type: Transform
+      pos: -11.5,7.5
+      parent: 2
+  - uid: 2764
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 2765
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 2766
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 2767
+    components:
+    - type: Transform
+      pos: 11.5,-12.5
+      parent: 2
+  - uid: 2768
+    components:
+    - type: Transform
+      pos: 11.5,-13.5
+      parent: 2
+  - uid: 2769
+    components:
+    - type: Transform
+      pos: 11.5,-14.5
+      parent: 2
+  - uid: 2770
+    components:
+    - type: Transform
+      pos: 11.5,-15.5
+      parent: 2
+  - uid: 2771
+    components:
+    - type: Transform
+      pos: 11.5,-16.5
+      parent: 2
+  - uid: 2772
+    components:
+    - type: Transform
+      pos: 10.5,-14.5
+      parent: 2
+  - uid: 2773
+    components:
+    - type: Transform
+      pos: 9.5,-14.5
+      parent: 2
+  - uid: 2774
+    components:
+    - type: Transform
+      pos: 8.5,-14.5
+      parent: 2
+  - uid: 2775
+    components:
+    - type: Transform
+      pos: 10.5,-16.5
+      parent: 2
+  - uid: 2776
+    components:
+    - type: Transform
+      pos: 9.5,-16.5
+      parent: 2
+  - uid: 2777
+    components:
+    - type: Transform
+      pos: 8.5,-16.5
+      parent: 2
+  - uid: 2778
+    components:
+    - type: Transform
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 2779
+    components:
+    - type: Transform
+      pos: 10.5,-17.5
+      parent: 2
+  - uid: 2780
+    components:
+    - type: Transform
+      pos: 6.5,-17.5
+      parent: 2
+  - uid: 2781
+    components:
+    - type: Transform
+      pos: 6.5,-16.5
+      parent: 2
+  - uid: 2782
+    components:
+    - type: Transform
+      pos: 5.5,-16.5
+      parent: 2
+  - uid: 2783
+    components:
+    - type: Transform
+      pos: 4.5,-16.5
+      parent: 2
+  - uid: 2784
+    components:
+    - type: Transform
+      pos: 3.5,-16.5
+      parent: 2
+  - uid: 2785
+    components:
+    - type: Transform
+      pos: 4.5,-17.5
+      parent: 2
+  - uid: 2786
+    components:
+    - type: Transform
+      pos: 12.5,-14.5
+      parent: 2
+  - uid: 2787
+    components:
+    - type: Transform
+      pos: 12.5,-12.5
+      parent: 2
+  - uid: 2788
+    components:
+    - type: Transform
+      pos: 12.5,-9.5
+      parent: 2
+  - uid: 2789
+    components:
+    - type: Transform
+      pos: 11.5,-9.5
+      parent: 2
+  - uid: 2790
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 2791
+    components:
+    - type: Transform
+      pos: 9.5,-9.5
+      parent: 2
+  - uid: 2792
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 2793
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 2
+  - uid: 2794
+    components:
+    - type: Transform
+      pos: 6.5,-9.5
+      parent: 2
+  - uid: 2795
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 2
+  - uid: 2796
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 2
+  - uid: 2797
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 2
+  - uid: 2798
+    components:
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 2
   - uid: 2799
     components:
     - type: Transform
-      pos: 14.5,-5.5
+      pos: 1.5,-10.5
       parent: 2
   - uid: 2800
     components:
     - type: Transform
-      pos: 13.5,-5.5
+      pos: 1.5,-9.5
       parent: 2
   - uid: 2801
     components:
     - type: Transform
-      pos: 13.5,-4.5
+      pos: 2.5,-10.5
       parent: 2
   - uid: 2802
     components:
     - type: Transform
-      pos: 13.5,-3.5
+      pos: 1.5,-13.5
       parent: 2
   - uid: 2803
     components:
     - type: Transform
-      pos: 13.5,-2.5
+      pos: 1.5,-14.5
       parent: 2
   - uid: 2804
     components:
     - type: Transform
-      pos: 13.5,-1.5
+      pos: 2.5,-14.5
       parent: 2
   - uid: 2805
     components:
     - type: Transform
-      pos: 14.5,-1.5
+      pos: 18.5,-7.5
       parent: 2
   - uid: 2806
     components:
     - type: Transform
-      pos: 15.5,-1.5
+      pos: 1.5,-5.5
       parent: 2
   - uid: 2807
     components:
     - type: Transform
-      pos: 18.5,-1.5
+      pos: 2.5,-5.5
       parent: 2
   - uid: 2808
     components:
     - type: Transform
-      pos: 19.5,-1.5
+      pos: 4.5,-5.5
       parent: 2
   - uid: 2809
     components:
     - type: Transform
-      pos: 20.5,-1.5
+      pos: 5.5,-5.5
       parent: 2
   - uid: 2810
     components:
     - type: Transform
-      pos: 20.5,-2.5
+      pos: 6.5,-5.5
       parent: 2
   - uid: 2811
     components:
     - type: Transform
-      pos: 20.5,-3.5
+      pos: 7.5,-5.5
       parent: 2
   - uid: 2812
     components:
     - type: Transform
-      pos: 20.5,-4.5
+      pos: 8.5,-5.5
       parent: 2
   - uid: 2813
     components:
     - type: Transform
-      pos: 20.5,-5.5
+      pos: 9.5,-5.5
       parent: 2
   - uid: 2814
     components:
     - type: Transform
-      pos: 19.5,-5.5
+      pos: 10.5,-5.5
       parent: 2
   - uid: 2815
     components:
     - type: Transform
-      pos: 23.5,-4.5
+      pos: 11.5,-5.5
       parent: 2
   - uid: 2816
     components:
     - type: Transform
-      pos: 22.5,-4.5
+      pos: 12.5,-5.5
       parent: 2
   - uid: 2817
     components:
     - type: Transform
-      pos: 21.5,-4.5
+      pos: 1.5,-8.5
       parent: 2
   - uid: 2818
     components:
     - type: Transform
-      pos: 21.5,-1.5
+      pos: 1.5,-7.5
       parent: 2
   - uid: 2819
     components:
     - type: Transform
-      pos: 23.5,-1.5
+      pos: 3.5,-8.5
       parent: 2
   - uid: 2820
     components:
     - type: Transform
-      pos: 24.5,-1.5
+      pos: 0.5,-17.5
       parent: 2
   - uid: 2821
     components:
     - type: Transform
-      pos: 25.5,-1.5
+      pos: -3.5,-9.5
       parent: 2
   - uid: 2822
     components:
     - type: Transform
-      pos: 26.5,-1.5
+      pos: -2.5,-9.5
       parent: 2
   - uid: 2823
     components:
     - type: Transform
-      pos: 27.5,-1.5
+      pos: -2.5,-8.5
       parent: 2
   - uid: 2824
     components:
     - type: Transform
-      pos: 17.5,2.5
+      pos: -2.5,-6.5
       parent: 2
   - uid: 2825
     components:
     - type: Transform
-      pos: -32.5,-5.5
+      pos: -2.5,-5.5
       parent: 2
   - uid: 2826
     components:
     - type: Transform
-      pos: 18.5,6.5
+      pos: -3.5,-5.5
       parent: 2
   - uid: 2827
     components:
     - type: Transform
-      pos: 20.5,6.5
+      pos: -4.5,-5.5
       parent: 2
   - uid: 2828
     components:
     - type: Transform
-      pos: 20.5,5.5
+      pos: -5.5,-5.5
       parent: 2
   - uid: 2829
     components:
     - type: Transform
-      pos: 20.5,4.5
+      pos: -6.5,-5.5
       parent: 2
   - uid: 2830
     components:
     - type: Transform
-      pos: 20.5,3.5
+      pos: -7.5,-5.5
       parent: 2
   - uid: 2831
     components:
     - type: Transform
-      pos: 20.5,2.5
+      pos: -7.5,-6.5
       parent: 2
   - uid: 2832
     components:
     - type: Transform
-      pos: -29.5,5.5
+      pos: -7.5,-7.5
       parent: 2
   - uid: 2833
     components:
     - type: Transform
-      pos: -29.5,-4.5
+      pos: -15.5,-5.5
       parent: 2
   - uid: 2834
     components:
     - type: Transform
-      pos: 13.5,6.5
+      pos: -4.5,12.5
       parent: 2
   - uid: 2835
     components:
     - type: Transform
-      pos: 13.5,2.5
+      pos: -19.5,-5.5
       parent: 2
   - uid: 2836
     components:
     - type: Transform
-      pos: 12.5,2.5
+      pos: -15.5,-4.5
       parent: 2
   - uid: 2837
     components:
     - type: Transform
-      pos: 11.5,2.5
+      pos: -15.5,-3.5
       parent: 2
   - uid: 2838
     components:
     - type: Transform
-      pos: 10.5,2.5
+      pos: -15.5,-2.5
       parent: 2
   - uid: 2839
     components:
     - type: Transform
-      pos: 9.5,2.5
+      pos: -15.5,-1.5
       parent: 2
   - uid: 2840
     components:
     - type: Transform
-      pos: 8.5,2.5
+      pos: -15.5,-0.5
       parent: 2
   - uid: 2841
     components:
     - type: Transform
-      pos: 7.5,2.5
+      pos: -15.5,1.5
       parent: 2
   - uid: 2842
     components:
     - type: Transform
-      pos: 6.5,2.5
+      pos: -15.5,2.5
       parent: 2
   - uid: 2843
     components:
     - type: Transform
-      pos: 5.5,2.5
+      pos: -15.5,3.5
       parent: 2
   - uid: 2844
     components:
     - type: Transform
-      pos: 4.5,2.5
+      pos: -15.5,4.5
       parent: 2
   - uid: 2845
     components:
     - type: Transform
-      pos: 2.5,2.5
+      pos: -15.5,5.5
       parent: 2
   - uid: 2846
     components:
     - type: Transform
-      pos: 1.5,2.5
+      pos: -15.5,6.5
       parent: 2
   - uid: 2847
     components:
     - type: Transform
-      pos: 9.5,1.5
+      pos: -15.5,7.5
       parent: 2
   - uid: 2848
     components:
     - type: Transform
-      pos: 9.5,-0.5
+      pos: -19.5,2.5
       parent: 2
   - uid: 2849
     components:
     - type: Transform
-      pos: 9.5,-1.5
+      pos: -19.5,4.5
       parent: 2
   - uid: 2850
     components:
     - type: Transform
-      pos: 5.5,-1.5
+      pos: -19.5,5.5
       parent: 2
   - uid: 2851
     components:
     - type: Transform
-      pos: 5.5,-0.5
+      pos: -19.5,-1.5
       parent: 2
   - uid: 2852
     components:
     - type: Transform
-      pos: 5.5,1.5
+      pos: -19.5,-2.5
       parent: 2
   - uid: 2853
     components:
     - type: Transform
-      pos: 1.5,-1.5
+      pos: -18.5,5.5
       parent: 2
   - uid: 2854
     components:
     - type: Transform
-      pos: -7.5,-1.5
+      pos: -20.5,-5.5
       parent: 2
   - uid: 2855
     components:
     - type: Transform
-      pos: -28.5,5.5
+      pos: -20.5,-4.5
       parent: 2
   - uid: 2856
     components:
     - type: Transform
-      pos: -28.5,-3.5
+      pos: -20.5,-3.5
       parent: 2
   - uid: 2857
     components:
     - type: Transform
-      pos: 5.5,17.5
+      pos: -21.5,-3.5
       parent: 2
   - uid: 2858
     components:
     - type: Transform
-      pos: -30.5,-5.5
+      pos: -22.5,-3.5
       parent: 2
   - uid: 2859
     components:
     - type: Transform
-      pos: 1.5,17.5
+      pos: -23.5,-3.5
       parent: 2
   - uid: 2860
     components:
     - type: Transform
-      pos: -29.5,6.5
+      pos: -24.5,-2.5
       parent: 2
   - uid: 2861
     components:
     - type: Transform
-      pos: -29.5,-5.5
+      pos: -24.5,3.5
       parent: 2
   - uid: 2862
     components:
     - type: Transform
-      pos: 10.5,8.5
+      pos: -23.5,4.5
+      parent: 2
+  - uid: 2863
+    components:
+    - type: Transform
+      pos: -22.5,4.5
       parent: 2
   - uid: 2864
     components:
     - type: Transform
-      pos: 19.5,-7.5
+      pos: -21.5,4.5
       parent: 2
   - uid: 2865
     components:
     - type: Transform
-      pos: 4.5,18.5
+      pos: -20.5,4.5
       parent: 2
   - uid: 2866
     components:
     - type: Transform
-      pos: 10.5,18.5
+      pos: -11.5,9.5
       parent: 2
   - uid: 2867
     components:
     - type: Transform
-      pos: 17.5,-11.5
+      pos: -31.5,-5.5
       parent: 2
   - uid: 2868
     components:
     - type: Transform
-      pos: 4.5,13.5
+      pos: -12.5,2.5
       parent: 2
   - uid: 2869
     components:
     - type: Transform
-      pos: -19.5,1.5
+      pos: -11.5,2.5
       parent: 2
   - uid: 2870
     components:
     - type: Transform
-      pos: 13.5,11.5
+      pos: -11.5,3.5
       parent: 2
   - uid: 2871
     components:
     - type: Transform
-      pos: -1.5,-17.5
+      pos: -11.5,5.5
       parent: 2
   - uid: 2872
     components:
     - type: Transform
-      pos: -3.5,-14.5
+      pos: -11.5,6.5
       parent: 2
   - uid: 2873
     components:
     - type: Transform
-      pos: -3.5,-17.5
+      pos: -10.5,6.5
       parent: 2
   - uid: 2874
     components:
     - type: Transform
-      pos: 19.5,9.5
+      pos: -7.5,6.5
       parent: 2
   - uid: 2875
     components:
     - type: Transform
-      pos: 20.5,9.5
+      pos: -6.5,6.5
       parent: 2
   - uid: 2876
     components:
     - type: Transform
-      pos: -28.5,-4.5
+      pos: -5.5,2.5
       parent: 2
   - uid: 2877
     components:
     - type: Transform
-      pos: 0.5,-14.5
+      pos: -2.5,2.5
       parent: 2
   - uid: 2878
     components:
     - type: Transform
-      pos: -19.5,-0.5
+      pos: -2.5,3.5
       parent: 2
   - uid: 2879
     components:
     - type: Transform
-      pos: -28.5,4.5
+      pos: -2.5,4.5
       parent: 2
   - uid: 2880
     components:
     - type: Transform
-      pos: -30.5,6.5
+      pos: -2.5,5.5
       parent: 2
   - uid: 2881
     components:
     - type: Transform
-      pos: -31.5,6.5
+      pos: -2.5,6.5
       parent: 2
   - uid: 2882
     components:
     - type: Transform
-      pos: -32.5,6.5
+      pos: -3.5,6.5
       parent: 2
   - uid: 2883
     components:
     - type: Transform
-      pos: -30.5,2.5
+      pos: -4.5,6.5
       parent: 2
   - uid: 2884
     components:
     - type: Transform
-      pos: -30.5,-1.5
+      pos: -5.5,6.5
       parent: 2
   - uid: 2885
     components:
     - type: Transform
-      pos: -4.5,14.5
+      pos: -2.5,-4.5
       parent: 2
   - uid: 2886
     components:
     - type: Transform
-      pos: 21.5,9.5
+      pos: -2.5,-3.5
       parent: 2
   - uid: 2887
     components:
     - type: Transform
-      pos: -4.5,15.5
+      pos: -2.5,-2.5
       parent: 2
   - uid: 2888
     components:
     - type: Transform
-      pos: -4.5,16.5
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 2889
+    components:
+    - type: Transform
+      pos: -2.5,13.5
       parent: 2
   - uid: 2890
     components:
     - type: Transform
-      pos: -13.5,9.5
+      pos: -1.5,13.5
       parent: 2
   - uid: 2891
     components:
     - type: Transform
-      pos: -15.5,-7.5
+      pos: -0.5,6.5
       parent: 2
   - uid: 2892
     components:
     - type: Transform
-      pos: 14.5,13.5
+      pos: -0.5,9.5
       parent: 2
   - uid: 2893
     components:
     - type: Transform
-      pos: -19.5,7.5
+      pos: -0.5,12.5
       parent: 2
   - uid: 2894
     components:
     - type: Transform
-      pos: 16.5,-12.5
+      pos: -0.5,13.5
       parent: 2
   - uid: 2895
     components:
     - type: Transform
-      pos: -15.5,8.5
+      pos: 3.5,14.5
       parent: 2
   - uid: 2896
     components:
     - type: Transform
-      pos: -13.5,10.5
+      pos: 3.5,15.5
       parent: 2
   - uid: 2897
     components:
     - type: Transform
-      pos: -15.5,-6.5
+      pos: 3.5,16.5
       parent: 2
   - uid: 2898
     components:
     - type: Transform
-      pos: 11.5,12.5
+      pos: 3.5,17.5
       parent: 2
   - uid: 2899
+    components:
+    - type: Transform
+      pos: 4.5,17.5
+      parent: 2
+  - uid: 2900
+    components:
+    - type: Transform
+      pos: 9.5,17.5
+      parent: 2
+  - uid: 2901
+    components:
+    - type: Transform
+      pos: 10.5,17.5
+      parent: 2
+  - uid: 2902
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 2
+  - uid: 2903
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 2
+  - uid: 2904
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 2
+  - uid: 2905
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 2
+  - uid: 2906
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 2
+  - uid: 2907
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 2
+  - uid: 2908
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 2
+  - uid: 2909
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 2
+  - uid: 2910
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 2
+  - uid: 2911
+    components:
+    - type: Transform
+      pos: 11.5,8.5
+      parent: 2
+  - uid: 2912
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 2
+  - uid: 2913
+    components:
+    - type: Transform
+      pos: 12.5,7.5
+      parent: 2
+  - uid: 2914
+    components:
+    - type: Transform
+      pos: 12.5,6.5
+      parent: 2
+  - uid: 2915
+    components:
+    - type: Transform
+      pos: 11.5,6.5
+      parent: 2
+  - uid: 2916
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 2
+  - uid: 2917
+    components:
+    - type: Transform
+      pos: 9.5,6.5
+      parent: 2
+  - uid: 2918
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 2
+  - uid: 2919
+    components:
+    - type: Transform
+      pos: 14.5,-5.5
+      parent: 2
+  - uid: 2920
+    components:
+    - type: Transform
+      pos: 13.5,-5.5
+      parent: 2
+  - uid: 2921
+    components:
+    - type: Transform
+      pos: 13.5,-4.5
+      parent: 2
+  - uid: 2922
+    components:
+    - type: Transform
+      pos: 13.5,-3.5
+      parent: 2
+  - uid: 2923
+    components:
+    - type: Transform
+      pos: 13.5,-2.5
+      parent: 2
+  - uid: 2924
+    components:
+    - type: Transform
+      pos: 13.5,-1.5
+      parent: 2
+  - uid: 2925
+    components:
+    - type: Transform
+      pos: 14.5,-1.5
+      parent: 2
+  - uid: 2926
+    components:
+    - type: Transform
+      pos: 15.5,-1.5
+      parent: 2
+  - uid: 2927
+    components:
+    - type: Transform
+      pos: 18.5,-1.5
+      parent: 2
+  - uid: 2928
+    components:
+    - type: Transform
+      pos: 19.5,-1.5
+      parent: 2
+  - uid: 2929
+    components:
+    - type: Transform
+      pos: 20.5,-1.5
+      parent: 2
+  - uid: 2930
+    components:
+    - type: Transform
+      pos: 20.5,-2.5
+      parent: 2
+  - uid: 2931
+    components:
+    - type: Transform
+      pos: 20.5,-3.5
+      parent: 2
+  - uid: 2932
+    components:
+    - type: Transform
+      pos: 20.5,-4.5
+      parent: 2
+  - uid: 2933
+    components:
+    - type: Transform
+      pos: 20.5,-5.5
+      parent: 2
+  - uid: 2934
+    components:
+    - type: Transform
+      pos: 19.5,-5.5
+      parent: 2
+  - uid: 2935
+    components:
+    - type: Transform
+      pos: 23.5,-4.5
+      parent: 2
+  - uid: 2936
+    components:
+    - type: Transform
+      pos: 22.5,-4.5
+      parent: 2
+  - uid: 2937
+    components:
+    - type: Transform
+      pos: 21.5,-4.5
+      parent: 2
+  - uid: 2938
+    components:
+    - type: Transform
+      pos: 21.5,-1.5
+      parent: 2
+  - uid: 2939
+    components:
+    - type: Transform
+      pos: 23.5,-1.5
+      parent: 2
+  - uid: 2940
+    components:
+    - type: Transform
+      pos: 24.5,-1.5
+      parent: 2
+  - uid: 2941
+    components:
+    - type: Transform
+      pos: 25.5,-1.5
+      parent: 2
+  - uid: 2942
+    components:
+    - type: Transform
+      pos: 26.5,-1.5
+      parent: 2
+  - uid: 2943
+    components:
+    - type: Transform
+      pos: 27.5,-1.5
+      parent: 2
+  - uid: 2944
+    components:
+    - type: Transform
+      pos: 17.5,2.5
+      parent: 2
+  - uid: 2945
+    components:
+    - type: Transform
+      pos: -32.5,-5.5
+      parent: 2
+  - uid: 2946
+    components:
+    - type: Transform
+      pos: 18.5,6.5
+      parent: 2
+  - uid: 2947
+    components:
+    - type: Transform
+      pos: 20.5,6.5
+      parent: 2
+  - uid: 2948
+    components:
+    - type: Transform
+      pos: 20.5,5.5
+      parent: 2
+  - uid: 2949
+    components:
+    - type: Transform
+      pos: 20.5,4.5
+      parent: 2
+  - uid: 2950
+    components:
+    - type: Transform
+      pos: 20.5,3.5
+      parent: 2
+  - uid: 2951
+    components:
+    - type: Transform
+      pos: 20.5,2.5
+      parent: 2
+  - uid: 2952
+    components:
+    - type: Transform
+      pos: -29.5,5.5
+      parent: 2
+  - uid: 2953
+    components:
+    - type: Transform
+      pos: -29.5,-4.5
+      parent: 2
+  - uid: 2954
+    components:
+    - type: Transform
+      pos: 13.5,6.5
+      parent: 2
+  - uid: 2955
+    components:
+    - type: Transform
+      pos: 13.5,2.5
+      parent: 2
+  - uid: 2956
+    components:
+    - type: Transform
+      pos: 12.5,2.5
+      parent: 2
+  - uid: 2957
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 2
+  - uid: 2958
+    components:
+    - type: Transform
+      pos: 10.5,2.5
+      parent: 2
+  - uid: 2959
+    components:
+    - type: Transform
+      pos: 9.5,2.5
+      parent: 2
+  - uid: 2960
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 2
+  - uid: 2961
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 2
+  - uid: 2962
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 2
+  - uid: 2963
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 2
+  - uid: 2964
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 2
+  - uid: 2965
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 2966
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 2967
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 2
+  - uid: 2968
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 2
+  - uid: 2969
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 2970
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 2971
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 2972
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 2973
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 2974
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 2975
+    components:
+    - type: Transform
+      pos: -28.5,5.5
+      parent: 2
+  - uid: 2976
+    components:
+    - type: Transform
+      pos: -28.5,-3.5
+      parent: 2
+  - uid: 2977
+    components:
+    - type: Transform
+      pos: 5.5,17.5
+      parent: 2
+  - uid: 2978
+    components:
+    - type: Transform
+      pos: -30.5,-5.5
+      parent: 2
+  - uid: 2979
+    components:
+    - type: Transform
+      pos: 1.5,17.5
+      parent: 2
+  - uid: 2980
+    components:
+    - type: Transform
+      pos: -29.5,6.5
+      parent: 2
+  - uid: 2981
+    components:
+    - type: Transform
+      pos: -29.5,-5.5
+      parent: 2
+  - uid: 2982
+    components:
+    - type: Transform
+      pos: 10.5,8.5
+      parent: 2
+  - uid: 2983
+    components:
+    - type: Transform
+      pos: 19.5,-7.5
+      parent: 2
+  - uid: 2984
+    components:
+    - type: Transform
+      pos: 4.5,18.5
+      parent: 2
+  - uid: 2985
+    components:
+    - type: Transform
+      pos: 10.5,18.5
+      parent: 2
+  - uid: 2986
+    components:
+    - type: Transform
+      pos: 17.5,-11.5
+      parent: 2
+  - uid: 2987
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 2
+  - uid: 2988
+    components:
+    - type: Transform
+      pos: -19.5,1.5
+      parent: 2
+  - uid: 2989
+    components:
+    - type: Transform
+      pos: 13.5,11.5
+      parent: 2
+  - uid: 2990
+    components:
+    - type: Transform
+      pos: -1.5,-17.5
+      parent: 2
+  - uid: 2991
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 2
+  - uid: 2992
+    components:
+    - type: Transform
+      pos: -3.5,-17.5
+      parent: 2
+  - uid: 2993
+    components:
+    - type: Transform
+      pos: 19.5,9.5
+      parent: 2
+  - uid: 2994
+    components:
+    - type: Transform
+      pos: 20.5,9.5
+      parent: 2
+  - uid: 2995
+    components:
+    - type: Transform
+      pos: -28.5,-4.5
+      parent: 2
+  - uid: 2996
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 2
+  - uid: 2997
+    components:
+    - type: Transform
+      pos: -19.5,-0.5
+      parent: 2
+  - uid: 2998
+    components:
+    - type: Transform
+      pos: -28.5,4.5
+      parent: 2
+  - uid: 2999
+    components:
+    - type: Transform
+      pos: -30.5,6.5
+      parent: 2
+  - uid: 3000
+    components:
+    - type: Transform
+      pos: -31.5,6.5
+      parent: 2
+  - uid: 3001
+    components:
+    - type: Transform
+      pos: -32.5,6.5
+      parent: 2
+  - uid: 3002
+    components:
+    - type: Transform
+      pos: -30.5,2.5
+      parent: 2
+  - uid: 3003
+    components:
+    - type: Transform
+      pos: -30.5,-1.5
+      parent: 2
+  - uid: 3004
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 2
+  - uid: 3005
+    components:
+    - type: Transform
+      pos: 21.5,9.5
+      parent: 2
+  - uid: 3006
+    components:
+    - type: Transform
+      pos: -4.5,15.5
+      parent: 2
+  - uid: 3007
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 2
+  - uid: 3008
+    components:
+    - type: Transform
+      pos: -13.5,9.5
+      parent: 2
+  - uid: 3009
+    components:
+    - type: Transform
+      pos: -15.5,-7.5
+      parent: 2
+  - uid: 3010
+    components:
+    - type: Transform
+      pos: 14.5,13.5
+      parent: 2
+  - uid: 3011
+    components:
+    - type: Transform
+      pos: -19.5,7.5
+      parent: 2
+  - uid: 3012
+    components:
+    - type: Transform
+      pos: 16.5,-12.5
+      parent: 2
+  - uid: 3013
+    components:
+    - type: Transform
+      pos: -15.5,8.5
+      parent: 2
+  - uid: 3014
+    components:
+    - type: Transform
+      pos: -13.5,10.5
+      parent: 2
+  - uid: 3015
+    components:
+    - type: Transform
+      pos: -15.5,-6.5
+      parent: 2
+  - uid: 3016
+    components:
+    - type: Transform
+      pos: 11.5,12.5
+      parent: 2
+  - uid: 3017
     components:
     - type: Transform
       pos: -12.5,9.5
       parent: 2
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 2900
+  - uid: 3018
     components:
     - type: Transform
       pos: 16.5,2.5
       parent: 2
-- proto: WardrobePrisonFilled
-  entities:
-  - uid: 2901
-    components:
-    - type: Transform
-      pos: 17.5,1.5
-      parent: 2
 - proto: WarningN2
   entities:
-  - uid: 2902
+  - uid: 3020
     components:
     - type: Transform
       pos: 8.5,-14.5
@@ -20656,7 +20504,7 @@ entities:
       fixtures: {}
 - proto: WarningO2
   entities:
-  - uid: 2903
+  - uid: 3021
     components:
     - type: Transform
       pos: 8.5,-12.5
@@ -20665,522 +20513,439 @@ entities:
       fixtures: {}
 - proto: WaterTankFull
   entities:
-  - uid: 2904
+  - uid: 3022
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 2
 - proto: WaterTankHighCapacity
   entities:
-  - uid: 2905
+  - uid: 3023
     components:
     - type: Transform
       pos: -14.5,5.5
       parent: 2
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 2906
+  - uid: 3024
     components:
     - type: Transform
       pos: 25.5,2.5
       parent: 2
-  - uid: 2907
+  - uid: 3025
     components:
     - type: Transform
       pos: 18.5,-4.5
       parent: 2
 - proto: WeaponPistolCHIMP
   entities:
-  - uid: 2908
+  - uid: 3026
     components:
     - type: Transform
       pos: -4.330495,7.357918
       parent: 2
 - proto: WelderExperimental
   entities:
-  - uid: 1124
+  - uid: 2080
     components:
     - type: Transform
-      parent: 1120
+      parent: 2076
     - type: Physics
       canCollide: False
 - proto: WelderIndustrialAdvanced
   entities:
-  - uid: 2909
+  - uid: 3027
     components:
     - type: Transform
       pos: 4.4984074,-10.399791
       parent: 2
 - proto: WeldingFuelTankFull
   entities:
-  - uid: 2910
+  - uid: 3028
     components:
     - type: Transform
       pos: 11.5,-8.5
       parent: 2
-  - uid: 2911
+  - uid: 3029
     components:
     - type: Transform
       pos: -20.5,-2.5
       parent: 2
 - proto: WindoorBarKitchenLocked
   entities:
-  - uid: 2912
+  - uid: 3030
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorCargoLocked
   entities:
-  - uid: 2913
+  - uid: 3031
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorHydroponicsLocked
   entities:
-  - uid: 2914
+  - uid: 3032
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureAtmosphericsLocked
   entities:
-  - uid: 2915
+  - uid: 3033
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2916
+  - uid: 3034
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureCargoLocked
   entities:
-  - uid: 2917
+  - uid: 3035
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2918
+  - uid: 3036
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2919
+  - uid: 3037
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2920
+  - uid: 3038
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2921
+  - uid: 3039
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureChemistryLocked
   entities:
-  - uid: 2922
+  - uid: 3040
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2923
+  - uid: 3041
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureCommandLocked
   entities:
-  - uid: 2924
+  - uid: 3042
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureEngineeringLocked
   entities:
-  - uid: 2925
+  - uid: 3043
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2926
+  - uid: 3044
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2927
+  - uid: 3045
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureJanitorLocked
   entities:
-  - uid: 2928
+  - uid: 3046
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2929
+  - uid: 3047
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorSecureScienceLocked
   entities:
-  - uid: 2930
+  - uid: 3048
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,10.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2931
+  - uid: 3049
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2932
+  - uid: 3050
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2933
+  - uid: 3051
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
+- proto: WindoorSecureSecurityLocked
+  entities:
+  - uid: 2112
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,5.5
+      parent: 2
+    - type: AccessReader
+      accessListsOriginal: []
+      access:
+      - - HeadOfSecurity
 - proto: WindoorSecureUranium
   entities:
-  - uid: 1931
+  - uid: 3052
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindoorServiceLocked
   entities:
-  - uid: 2935
+  - uid: 3053
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2936
+  - uid: 3054
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2937
+  - uid: 3055
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindowFrostedDirectional
   entities:
-  - uid: 2938
+  - uid: 3056
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2939
+  - uid: 3057
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 968
+  - uid: 3058
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,17.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2940
+  - uid: 3059
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-11.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2941
+  - uid: 3060
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,12.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2942
+  - uid: 3061
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2943
+  - uid: 3062
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-13.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2944
+  - uid: 3063
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2945
+  - uid: 3064
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2946
+  - uid: 3065
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2947
+  - uid: 3066
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2948
+  - uid: 3067
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2949
+  - uid: 3068
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2950
+  - uid: 3069
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2951
+  - uid: 3070
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-3.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2952
+  - uid: 3071
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2953
+  - uid: 3072
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2954
+  - uid: 3073
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-0.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2955
+  - uid: 3074
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,1.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2956
+  - uid: 3075
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2957
+  - uid: 3076
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2958
+  - uid: 3077
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2959
+  - uid: 3078
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,2.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2960
+  - uid: 3079
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2961
+  - uid: 3080
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2962
+  - uid: 3081
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-6.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-  - uid: 2963
+  - uid: 3082
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-7.5
       parent: 2
-    - type: DeltaPressure
-      gridUid: 2
-- proto: Wirecutter
-  entities:
-  - uid: 1125
+  - uid: 3091
     components:
     - type: Transform
-      parent: 1120
+      rot: 3.141592653589793 rad
+      pos: 21.5,5.5
+      parent: 2
+  - uid: 3092
+    components:
+    - type: Transform
+      pos: 21.5,5.5
+      parent: 2
+- proto: Wirecutter
+  entities:
+  - uid: 2081
+    components:
+    - type: Transform
+      parent: 2076
     - type: Physics
       canCollide: False
 - proto: Wrench
   entities:
-  - uid: 2964
+  - uid: 3083
     components:
     - type: Transform
       pos: -18.465073,2.622715

--- a/Resources/Prototypes/_StarLight/Maps/reach.yml
+++ b/Resources/Prototypes/_StarLight/Maps/reach.yml
@@ -43,6 +43,7 @@
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
+            DutyOfficer: [ 1, 1 ]
             SecurityOfficer: [ 2, 3 ]
             SecurityCadet: [ 1, 1 ]
             #supply
@@ -61,6 +62,9 @@
             StationAi: [ 1, 1 ]
             Borg: [ 1, 2 ]
             #law
+            Magistrate: [ 1, 1 ]
+            IAA: [ 2, 2 ]
             #Representives
             BlueShield: [ 1, 1 ]
             NanoTrasenRepresentative: [ 1, 1 ]
+            NanotrasenCareerTrainer: [ 1, 2 ]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- Enables Duty Officers
- Enables IAA
- Enables Magistrate
- Enables Nanotrasen Career Trainers
- Adds the HOS Weapon Spawner (WT was not mapped on Reach at all)

Due to the very small size of the map, bespoke rooms were not added for these roles.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- [x] Supports #2697 
- [x] Supports #2854
- [x] Supports #2855
- [x] Supports #2864
- [x] Supports #2871
- [x] Supports #2878
- [x] Supports #2879

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="933" height="648" alt="image" src="https://github.com/user-attachments/assets/342b46d4-5469-4b60-ae8b-503028c3b468" />

fig. 1 - NCT Spawnpoints, IAA spawnpoints in Security, IAA locker in Security for lack of a law office, Magistrate locker in Bridge, moved the Corgi spawner and dog bed a bit so that the HOS Weapon Spawner could be in a little secured glass box. Duty Officer also pictured.

<img width="676" height="536" alt="image" src="https://github.com/user-attachments/assets/571d7325-c5f7-4edf-a700-8999bd9d50aa" />

fig. 2 - Wall-mounted mass scanners at Cargo Front.

<img width="589" height="530" alt="image" src="https://github.com/user-attachments/assets/966296c6-cf2c-46d6-a5e0-c7f051e2770b" />

fig. 3 - AI Restoration Console. I moved the RD's toolbelt into their locker since I had to axe a table here.

<img width="877" height="501" alt="image" src="https://github.com/user-attachments/assets/f16d3e57-220d-4b83-8ff8-fab83498ea54" />

fig. 4 - `SpawnPointLateJoin` at Arrivals.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- add: (Reach) Nanotrasen Career Trainers
- add: (Reach) Magistrate Locker
- add: (Reach) IAA Locker
- add: (Reach) IAA spawnpoints
- add: (Reach) Duty Officer
- add: (Reach) HOS Weapon Spawner
- add: (Reach) SpawnPointLateJoin at Arrivals
- add: (Reach) Wall-mounted mass scanners to Cargo Front
- add: (Reach) AI Restoration Console
- fix: (Reach) Enabled Magistrate and IAA on Reach
- fix: (Reach) Removed admin super remote from the Bridge