### PR TITLE
Remove incendiary, uranium, and AP ammo from research

### DIFF
--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -20,32 +20,32 @@
   - Supply
   # These are roundstart but not replenishable for salvage
 
-- type: technology
-  id: DraconicMunitions
-  name: research-technology-draconic-munitions
-  icon:
-    sprite: Objects/Weapons/Guns/Ammunition/Boxes/pistol.rsi
-    state: incendiarydisplay
-  discipline: Arsenal
-  tier: 1
-  cost: 10000
-  recipeUnlocks:
-  - BoxShotgunIncendiary
-  - MagazineRifleIncendiary
-  - MagazinePistolIncendiary
-  - MagazinePistolSubMachineGunIncendiary
-  - MagazineLightRifleIncendiary
-  - SpeedLoaderMagnumIncendiary
-  - MagazineShotgunIncendiary
-  - MagazineBoxPistolIncendiary
-  - MagazineBoxMagnumIncendiary
-  - MagazineBoxLightRifleIncendiary
-  - MagazineBoxRifleIncendiary
-  - MagazineDMRIncendiary # Starlight
-  - MagazinePistolSubMachineGunIncendiary
-  - SpeedLoaderShotgunIncendiary
-  radioChannels:
-  - Security
+# - type: technology # Starlight removal
+#   id: DraconicMunitions
+#   name: research-technology-draconic-munitions
+#   icon:
+#     sprite: Objects/Weapons/Guns/Ammunition/Boxes/pistol.rsi
+#     state: incendiarydisplay
+#   discipline: Arsenal
+#   tier: 1
+#   cost: 10000
+#   recipeUnlocks:
+#   - BoxShotgunIncendiary
+#   - MagazineRifleIncendiary
+#   - MagazinePistolIncendiary
+#   - MagazinePistolSubMachineGunIncendiary
+#   - MagazineLightRifleIncendiary
+#   - SpeedLoaderMagnumIncendiary
+#   - MagazineShotgunIncendiary
+#   - MagazineBoxPistolIncendiary
+#   - MagazineBoxMagnumIncendiary
+#   - MagazineBoxLightRifleIncendiary
+#   - MagazineBoxRifleIncendiary
+#   - MagazineDMRIncendiary # Starlight
+#   - MagazinePistolSubMachineGunIncendiary
+#   - SpeedLoaderShotgunIncendiary
+#   radioChannels:
+#   - Security
 
 - type: technology
   id: WeaponizedLaserManipulation

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
@@ -176,59 +176,34 @@
 #####################BOX#######################
 # Light Rifle
   - MagazineBoxLightRifleRubber
-  - MagazineBoxLightRifleIncendiary
   - MagazineBoxLightRifleUranium
-  - MagazineBoxLightRifleAP
 # Magnum
   - MagazineBoxMagnumRubber
-  - MagazineBoxMagnumIncendiary
   - MagazineBoxMagnumUranium
-  - MagazineBoxMagnumAP
 # Pistol
   - MagazineBoxPistolRubber
-  - MagazineBoxPistolIncendiary
   - MagazineBoxPistolUranium
-  - MagazineBoxPistolAP
-  - MagazineBoxPistol40AP
 # Rifle
   - MagazineBoxRifleRubber
-  - MagazineBoxRifleIncendiary
   - MagazineBoxRifleUranium
-  - MagazineBoxRifleAP
 # Shotgun
   - BoxBeanbag
-  - BoxShotgunIncendiary
   - BoxShotgunUranium
   - BoxShellTranquilizer
 #####################MAGAZINE#######################
 # Light Rifle
-  - MagazineLightRifleIncendiary
   - MagazineLightRifleUranium
-  - MagazineLightRifleAP
-  - MagazineDMRIncendiary
   - MagazineDMRUranium
-  - MagazineDMRAP
 # Magnum
-  - SpeedLoaderMagnumIncendiary
   - SpeedLoaderMagnumUranium
-  - SpeedLoaderMagnumAP
 # Pistol
-  - MagazinePistolIncendiary
   - MagazinePistolUranium
-  - MagazinePistolAP
-  - MagazinePistol40AP
 # SMG
-  - MagazinePistolSubMachineGunIncendiary
   - MagazinePistolSubMachineGunUranium
-  - MagazinePistolSubMachineGunAP
 # Rifle
-  - MagazineRifleIncendiary
   - MagazineRifleUranium
-  - MagazineRifleAP
 # Shotgun
   - MagazineShotgunBeanbag
-  - MagazineShotgunIncendiary
-  - SpeedLoaderShotgunIncendiary
   - SpeedLoaderShotgunUranium
 # Grenade
   - MagazineGrenadeEmpty
@@ -264,7 +239,6 @@
   recipes:
   - WeaponMechCombatMissileRack8
   - WeaponMechCombatShotgun
-  - WeaponMechCombatShotgunIncendiary
   - WeaponMechCombatUltraRifle
   - WeaponMechCombatXray
   - WeaponMechChainSword
@@ -281,7 +255,7 @@
   id: StarlightSecurityMechsSystems
   recipes:
   - MechEquipmentSecGrabber
-  
+
 - type: latheRecipePack
   id: StarlightSecurityMechs
   recipes:

--- a/Resources/Prototypes/_StarLight/Research/arsenal.yml
+++ b/Resources/Prototypes/_StarLight/Research/arsenal.yml
@@ -44,7 +44,7 @@
 - type: technology
   id: EnergyBarriers
   name: research-technology-energy_barriers
-  icon: 
+  icon:
     sprite: Objects/Tools/EnergyDome/reinhardt.rsi
     state: icon
   discipline: Arsenal
@@ -55,31 +55,6 @@
   radioChannels:
   - Security
 
-- type: technology
-  id: ArmorPenetrationMunitions
-  name: research-technology-armor-penetration
-  icon:
-    sprite: Objects/Weapons/Guns/Ammunition/Magazine/Rifle/rifle_mag.rsi
-    state: ap
-  discipline: Arsenal
-  tier: 2
-  cost: 11500
-  recipeUnlocks:
-  - SpeedLoaderMagnumAP
-  - MagazinePistolAP
-  - MagazinePistol40AP
-  - MagazineRifleAP
-  - MagazineLightRifleAP
-  - MagazineBoxMagnumAP
-  - MagazineBoxPistolAP
-  - MagazineBoxPistol40AP
-  - MagazineBoxRifleAP
-  - MagazineBoxLightRifleAP
-  - MagazineDMRAP
-  - MagazinePistolSubMachineGunAP
-  radioChannels:
-  - Security
-  
 - type: technology
   id: IonWeaponry
   name: research-technology-ion-weaponry
@@ -119,7 +94,7 @@
   radioChannels:
   - Security
   - Medical
-  
+
 # Tier 3
 
 - type: technology
@@ -137,7 +112,7 @@
   - ExplosiveTechnology
   radioChannels:
   - Security
-  
+
 - type: technology
   id: Durand
   name: research-technology-durand
@@ -182,7 +157,7 @@
   - Security
   - Medical
 
- # Tier 4 
+ # Tier 4
 
 - type: technology
   id: DecloneTechnology
@@ -197,7 +172,7 @@
   - WeaponDecloner
   radioChannels:
   - Security
-  
+
 - type: technology
   id: ScanGateTechnology
   name: research-technology-scan-gate


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Does what it says on the tin, really.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Incendiary, uranium, and especially AP ammo are "meta" right now. They are mostly easy to get, unlockable very early on, and do significantly more damage than any other ammo type in the game - *half* a mag of AP ammo can kill Deathsquad with 90% pierce, for example.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower

- remove: Incendiary, uranium, and AP ammos are no longer researchable.