### PR TITLE
Reducing Costs for Mechs for Operatives and Lone Ops separately

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1465,7 +1465,7 @@
   icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: darkgygax }
   productEntity: CrateCybersunDarkGygaxBundle
   cost:
-    Telecrystal: 100
+    Telecrystal: 75
   categories:
   - UplinkAllies
   conditions:
@@ -1473,6 +1473,9 @@
     whitelist:
       tags:
       - NukeOpsUplink
+    blacklist:
+      tags:
+      - LoneOpsUplink
 
 - type: listing
   id: UplinkMauler
@@ -1481,7 +1484,7 @@
   icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: mauler }
   productEntity: CrateCybersunMaulerBundle
   cost:
-    Telecrystal: 150
+    Telecrystal: 100
   categories:
   - UplinkAllies
   conditions:
@@ -1489,6 +1492,9 @@
     whitelist:
       tags:
       - NukeOpsUplink
+    blacklist:
+      tags:
+      - LoneOpsUplink
 
 # Implants
 

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -118,6 +118,7 @@
   - type: Tag
     tags:
     - NukeOpsUplink
+    - LoneOpsUplink
 
 - type: entity
   parent: BaseUplinkRadioPreset

--- a/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
@@ -699,3 +699,35 @@
     Telecrystal: 4
   categories:
       - UplinkExplosives
+
+- type: listing
+  id: UplinkDarkGygaxLoneOps
+  name: uplink-mech-teleporter-assault-name
+  description: uplink-mech-teleporter-assault-desc
+  icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: darkgygax }
+  productEntity: CrateCybersunDarkGygaxBundle
+  cost:
+    Telecrystal: 30
+  categories:
+    - UplinkAllies
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - LoneOpsUplink
+
+- type: listing
+  id: UplinkMaulerLoneOps
+  name: uplink-mech-teleporter-heavy-name
+  description: uplink-mech-teleporter-heavy-desc
+  icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: mauler }
+  productEntity: CrateCybersunMaulerBundle
+  cost:
+    Telecrystal: 45
+  categories:
+    - UplinkAllies
+  conditions:
+    - !type:StoreWhitelistCondition
+      whitelist:
+        tags:
+          - LoneOpsUplink

--- a/Resources/Prototypes/_StarLight/tags.yml
+++ b/Resources/Prototypes/_StarLight/tags.yml
@@ -300,6 +300,9 @@
 
 - type: Tag
   id: Locker
+  
+- type: Tag
+  id: LoneOpsUplink
 
 - type: Tag
   id: MagazineBattery


### PR DESCRIPTION
## Short description
This PR rebalances the current Mechs by reducing TC costs. This PR separately balances the Mechs between both Standard Operatives, and Lone Ops making it purchasing for a significant percentage of their TC.

Standard Op Price changes:
Dark Gygax - 100 > 75
Mauler - 150 > 100

Lone Op Prices:
Dark Gygax - 100 > 30 (50% TC)
Mauler - 150 > 45 (75% TC)


## Why we need to add this
Currently, in the last 15 days, only 1 Dark Gygax has been purchased on Alpha as of the data I have been able to procure. I feel that it is always better to go with standard equipment as Jugg suits, and anything that slows you down is usually frowned upon as Captains and Security can always move around your assault.

This gives Mechs a bit more viability to try them out without absolutely destroying your economy. It also makes it possible, if using 100 out of the 120 TC you have in a 3 man Nuke team for a Mauler. 20 TC left is gonna be quite an ordeal to work with, but makes it possible if they wish.

## Media (Video/Screenshots)
<img width="1037" height="662" alt="image" src="https://github.com/user-attachments/assets/e75fac9e-5159-4b1d-883b-5271f165c848" />
Team Operatives are on the **Left**. Lone op is on the **Right**

<img width="2291" height="788" alt="image" src="https://github.com/user-attachments/assets/a7e22969-d43e-4ff6-a78e-c6dfbb137344" />
Information of Alfa Station. One Dark Gygax was purchased in the past 15 days. No Maulers.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Coolsurf6
- tweak: Nukie TeamOps have had Mech prices reduced to 75 and 100.
- tweak: Nukie LoneOps have had Mech prices reduced to be purchasable now to 30 and 45.


