### PR TITLE
Fixes Double Stamina Resistance from Raid Suits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -279,8 +279,10 @@
     # Starlight-end
   - type: ExplosionResistance
     damageCoefficient: 0.35
-  - type: StaminaResistance # do not add these to other equipment or mobs, we don't want to microbalance these everywhere
-    damageCoefficient: 0.45
+  # Starlight-start - Disables upstream stamina resistance
+  # - type: StaminaResistance # do not add these to other equipment or mobs, we don't want to microbalance these everywhere
+  #   damageCoefficient: 0.45
+  # Starlight-end
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1.1


### PR DESCRIPTION
## Short description
Removes overlapping stamina resistance that came from stable merge.

## Why we need to add this
Fix

## Media (Video/Screenshots)
<img width="285" height="230" alt="Screenshot_20260211_122926" src="https://github.com/user-attachments/assets/2f20f0ef-0259-46f1-bcbf-65ac5568468d" />

_oh dear god what is this please help me oh god_ 

This has been thoughly yoinked.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Coolsurf6
- fix: Fixed duplicated stamina resistance on Raid Suits

