### PR TITLE
Lapsi guidbook and modifier change

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -174,8 +174,8 @@
   id: Slime
   coefficients:
     Blunt: 0.6
-    Slash: 1.2
-    Piercing: 1.2
+    Slash: 1.1
+    Piercing: 1.1
     Cold: 1.5
     Poison: 0.8
 

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -174,8 +174,8 @@
   id: Slime
   coefficients:
     Blunt: 0.6
-    Slash: 1.1
-    Piercing: 1.1
+    Slash: 1.1 # Starlight-edit: 1.2 -> 1.1
+    Piercing: 1.1 # Starlight-edit
     Cold: 1.5
     Poison: 0.8
 

--- a/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
@@ -20,6 +20,6 @@
   moderately filling food for other species, although drinking the blood of your coworkers is usually frowned upon.
   They suffocate 80% slower, but take pressure damage 9% faster. This makes them by far the species most capable to survive in hard vacuum. For a while.
 
-  They take [color=#1e90ff]40% less Blunt damage[/color], but [color=#ffa500]50% more Cold damage, 20% more Slash damage and 20% more Piercing damage[/color].
+  They take [color=#1e90ff]40% less Blunt damage[/color], but [color=#ffa500]50% more Cold damage, 10% more Slash damage and 10% more Piercing damage[/color].
 
 </Document>


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- This is just a simple change to lapsi modifiers and guidebooks -->This is just a simple change to lapsi modifiers and guidebooks, slash and pierce modifiers reduced from 20% too 10% this is also changed in the guidebook 

## Why we need to add this
<!-- It is a slight buff to lapsi to outweigh some of their more debilitating debuffs -->It is a slight buff to lapsi to outweigh some of their more debilitating debuffs

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="2560" height="1080" alt="Screenshot (1)" src="https://github.com/user-attachments/assets/2ad4c1ec-cc14-4b19-904f-aa5a179a0673" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--Lapsi resistance and guidebook change
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.Lapsi resistance and guidebook change

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
--> 
:cl: skaffen
- tweak: Changed lapsi damage modifier, they now take 10% more slash and pierce damage instead of 20%.
