### PR TITLE
AI Machine Access

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -49,6 +49,7 @@
     price: 800
   - type: ResearchClient
   - type: TechnologyDatabase
+  - type: StationAiWhitelist #Starlight
 
 # a lathe that can be sped up with space lube / slowed down with glue
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -102,6 +102,7 @@
       - PowerStorage
       - VoltageNetworks
       - Power
+    - type: StationAiWhitelist #Starlight
 
     # Interface
     - type: BatteryInterface

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -30,6 +30,7 @@
     supplyRampTolerance: 5000
     supplyRampRate: 1000
   - type: StationInfiniteBatteryTarget
+  - type: StationAiWhitelist #Starlight
 
   # Interface
   - type: BatteryInterface


### PR DESCRIPTION
## Short description
Grants AI access to a couple machines they probably should have access to; Lathes, SMES, and Substations.

## Why we need to add this
AI gets access to a lot of machinery and computers, including control of APCs. Being able to open SMES and Substations to check power and diagnose issues is in line with their current access, and seems like it may have been an oversight when Wizden gave these machines UI. Lathes are also not access locked, so AI being able to open them to 1) See what materials are in them, and 2) print things that may be useful when asked IE prepping topicals in the medfab while med staff work so they can run back and grab them when they run out, is useful.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Gave the Station AI access to SMES, Substations, and Lathes. AI already gets access to APCs, being able to directly look at SMES and Substations to help diagnose power issues is in line with their current accesses, and the lack of it seems like an oversight when UI was added for these machines. Lathes are also just fun, to see what's unlocked more directly and check department material counts.

