### PR TITLE
Adds the ability for pAI players to open their hosts PDA UI

### DIFF
--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -9,6 +9,9 @@ using Content.Shared.Popups;
 using Content.Shared.Instruments;
 using Robust.Shared.Random;
 using System.Text;
+using Robust.Server.Containers; //Starlight pAI can open PDAs, see PR #3272
+using Content.Shared.PDA; //Starlight pAI can open PDAs, see PR #3272
+using Robust.Shared.Player; //Starlight pAI can open PDAs, see PR #3272
 
 namespace Content.Server.PAI;
 
@@ -19,6 +22,8 @@ public sealed class PAISystem : EntitySystem
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly ToggleableGhostRoleSystem _toggleableGhostRole = default!;
+    [Dependency] private readonly ContainerSystem _containerSystem = default!; //Starlight pAI can open PDAs, see PR #3272
+    [Dependency] private readonly SharedUserInterfaceSystem _userInterface = default!; //Starlight pAI can open PDAs, see PR #3272
 
     /// <summary>
     /// Possible symbols that can be part of a scrambled pai's name.
@@ -33,6 +38,7 @@ public sealed class PAISystem : EntitySystem
         SubscribeLocalEvent<PAIComponent, MindAddedMessage>(OnMindAdded);
         SubscribeLocalEvent<PAIComponent, MindRemovedMessage>(OnMindRemoved);
         SubscribeLocalEvent<PAIComponent, BeingMicrowavedEvent>(OnMicrowaved);
+        SubscribeLocalEvent<PAIComponent, PAIPDAActionEvent>(OnOpenPda); //Starlight pAI can open PDAs, see PR #3272
     }
 
     private void OnUseInHand(EntityUid uid, PAIComponent component, UseInHandEvent args)
@@ -119,4 +125,22 @@ public sealed class PAISystem : EntitySystem
                 _metaData.SetEntityName(uid, proto.Name);
         }
     }
+
+    #region Starlight
+    private void OnOpenPda(Entity<PAIComponent> ent, ref PAIPDAActionEvent args)
+    {
+        bool inAContainer = _containerSystem.TryGetContainingContainer(ent.Owner, out var container);
+        if (!inAContainer || container == null) { return; }
+
+        bool containerHasPdaComponent = TryComp<PdaComponent>(container.Owner, out _);
+        bool containerHasUserInterfaceComponent = TryComp<UserInterfaceComponent>(container.Owner, out var ui_comp);
+        bool paiComponentHasPlayerActor = TryComp<ActorComponent>(ent.Owner, out var actor);
+        bool insideValidPda = inAContainer && containerHasPdaComponent && containerHasUserInterfaceComponent && paiComponentHasPlayerActor;
+        if (!insideValidPda || ui_comp == null || actor == null) { return; }
+
+        bool openPdaUiSuccess = _userInterface.TryToggleUi((container.Owner, ui_comp), PdaUiKey.Key, actor.PlayerSession);
+        if (!openPdaUiSuccess) { return; }
+        // Success.
+    }
+    #endregion
 }

--- a/Content.Shared/_Starlight/PAI/PAIComponent.cs
+++ b/Content.Shared/_Starlight/PAI/PAIComponent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared.PAI;
+
+public sealed partial class PAIPDAActionEvent : InstantActionEvent
+{
+}

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -98,6 +98,7 @@
   - type: UserInterface
     interfaces:
       enum.PdaUiKey.Key:
+        requireInputValidation: false #Starlight pAI can open PDAs, see PR #3272
         type: PdaBoundUserInterface
       enum.StoreUiKey.Key:
         type: StoreBoundUserInterface

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -65,6 +65,7 @@
   - type: ActionGrant
     actions:
     - ActionPAIOpenShop
+    - ActionPAIPDA #Starlight pAI can open PDAs, see PR #3272
   - type: Store
     name: store-preset-name-pai #Starlight name change for data purity
     categories:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Fun/pai.yml
@@ -1,0 +1,13 @@
+- type: entity
+  parent: BaseMentalAction
+  id: ActionPAIPDA
+  name: Open PDA
+  description: Opens the PDA UI if you are in one.
+  components:
+    - type: Action
+      icon:
+          sprite: Objects/Devices/pda.rsi
+          state: pda
+      itemIconStyle: NoItem
+    - type: InstantAction
+      event: !type:PAIPDAActionEvent


### PR DESCRIPTION
# Short description
Adds the ability for pAI players to open their hosts PDA UI.

# Why we need to add this
As they are, pAIs are nothing more than sometimes-musical verbal ghosts that have had what little autonomy they had stripped of them, resulting in the role being incredibly boring and undesirable, for both pAI owners, and pAIs.
I discussed my thoughts with @neomoth, via Ahelp, who showed more support than I expected, encouraging me to post it to the discord, [which I did](https://discord.com/channels/1272545509562777621/1462391591686897862).
This is actually a re-implementation of a feature from the server I came from, which performs far better in the capacity of pAI involved gameplay.
Some people propose ideas such as giving pAIs autonomy through some bespoke mechsuit or some other fashion, which I personally quite dislike, I have a different vision in mind for pAIs, one that not only benefits just the pAI player, but also pAI owners, making them far more desirable.
I envision them being supplemental information and communication utilities, which I also believe is far more realistic.
The first step is to give them PDA access, where they may then use said PDA along with its functions. This includes the notetaker app, the task app, the crew manifest (in my experience quite useful!), station news, the wanted list, and more.
This is exactly what this PR does. Personally I think PDAs need an expansion, which goes hand in hand.
And then after this PR, I think a rework for pAI comm channels access is in order. I think I may take a stab at this tbh.

# Media (Video/Screenshots)
<img width="817" height="593" alt="image" src="https://github.com/user-attachments/assets/c701cdda-e804-4d57-a400-63a0b8046bf9" />

# Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.


**Changelog**
:cl: Notarin Steele
- add: Added the ability for a pAI to open a PDA if it is in one.
