### PR TITLE
Fix temporary detach SSD behavior and criminal card delivery handling

### DIFF
--- a/Content.Server/_Starlight/Railroading/RewardSystems/RailroadingDeliveryRewardSystem.cs
+++ b/Content.Server/_Starlight/Railroading/RewardSystems/RailroadingDeliveryRewardSystem.cs
@@ -2,10 +2,10 @@ using Content.Server.Chat.Managers;
 using Content.Server.Station.Systems;
 using Content.Server.StationRecords.Systems;
 using Content.Shared.Chat;
-using Content.Shared.Clothing;
 using Content.Shared.Delivery;
 using Content.Shared.FingerprintReader;
 using Content.Shared.Labels.EntitySystems;
+using Content.Shared.Mind;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.StationRecords;
 using Content.Shared._Starlight.Railroading.Events;
@@ -26,7 +26,7 @@ public sealed partial class RailroadingDeliveryRewardSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly LabelSystem _label = default!;
-    [Dependency] private readonly LoadoutSystem _loadout = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedPowerReceiverSystem _power = default!;
     [Dependency] private readonly StationRecordsSystem _records = default!;
@@ -35,7 +35,16 @@ public sealed partial class RailroadingDeliveryRewardSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
+        SubscribeLocalEvent<RailroadDeliveryRewardComponent, RailroadingCardChosenEvent>(OnChosen);
         SubscribeLocalEvent<RailroadDeliveryRewardComponent, RailroadingCardCompletedEvent>(OnCompleted);
+    }
+
+    private void OnChosen(Entity<RailroadDeliveryRewardComponent> ent, ref RailroadingCardChosenEvent args)
+    {
+        ent.Comp.RecipientMind = null;
+        // Capture recipient identity at card selection time so it does not depend on mutable display names.
+        if (_mind.TryGetMind(args.Subject.Owner, out var mindId, out _))
+            ent.Comp.RecipientMind = mindId;
     }
 
     private void OnCompleted(Entity<RailroadDeliveryRewardComponent> ent, ref RailroadingCardCompletedEvent args)
@@ -56,9 +65,6 @@ public sealed partial class RailroadingDeliveryRewardSystem : EntitySystem
             if (!_power.IsPowered(spawnerUid))
                 continue;
 
-            if (spawnerComp.ContainedDeliveryAmount >= spawnerComp.MaxContainedDeliveryAmount)
-                continue;
-
             spawner = spawnerUid;
             break;
         }
@@ -66,9 +72,14 @@ public sealed partial class RailroadingDeliveryRewardSystem : EntitySystem
         if (spawner == null)
             return;
 
+        if (ent.Comp.RecipientMind is not { } recipientMind
+            || !TryComp<MindComponent>(recipientMind, out var trackedMind)
+            || string.IsNullOrWhiteSpace(trackedMind.CharacterName))
+            return;
+
         var delivery = Spawn(ent.Comp.Delivery, Transform(spawner.Value).Coordinates);
-        var profile = _loadout.GetProfile(args.Subject);
-        var recordID = _records.GetRecordByName(station, MetaData(args.Subject).EntityName);
+        var subjectName = trackedMind.CharacterName!;
+        var recordID = _records.GetRecordByName(station, subjectName);
 
         if (ent.Comp.Dataset != null && _playerManager.TryGetSessionByEntity(args.Subject, out var session))
         {
@@ -76,27 +87,29 @@ public sealed partial class RailroadingDeliveryRewardSystem : EntitySystem
             var pick = _random.Pick(dataset.Values);
             if (ent.Comp.WrappedDataset != null)
             {
-                var wrappedDataset = _protoMan.Index(ent.Comp.Dataset);
+                var wrappedDataset = _protoMan.Index(ent.Comp.WrappedDataset.Value);
                 _chat.ChatMessageToOne(ChatChannel.Notifications, Loc.GetString(pick), Loc.GetString(wrappedDataset.Values[dataset.Values.IndexOf(pick)]), default, false, session.Channel, Color.FromHex("#57A3F7"));
             }
         }
 
-        if (!TryComp<DeliveryComponent>(delivery, out var deliveryComp)
-            || recordID == null
-            || !_records.TryGetRecord<GeneralStationRecord>(_records.Convert((GetNetEntity(station), recordID.Value)), out var entry))
+        if (!TryComp<DeliveryComponent>(delivery, out var deliveryComp))
             return;
 
-
-        deliveryComp.RecipientName = entry.Name;
-        deliveryComp.RecipientJobTitle = entry.JobTitle;
+        deliveryComp.RecipientName = subjectName;
         deliveryComp.RecipientStation = station;
 
-        _appearance.SetData(delivery, DeliveryVisuals.JobIcon, entry.JobIcon);
+        if (recordID != null
+            && _records.TryGetRecord<GeneralStationRecord>(_records.Convert((GetNetEntity(station), recordID.Value)), out var entry))
+        {
+            deliveryComp.RecipientName = entry.Name;
+            deliveryComp.RecipientJobTitle = entry.JobTitle;
+            _appearance.SetData(delivery, DeliveryVisuals.JobIcon, entry.JobIcon);
+
+            if (TryComp<FingerprintReaderComponent>(delivery, out var reader) && entry.Fingerprint != null)
+                _fingerprintReader.AddAllowedFingerprint((delivery, reader), entry.Fingerprint);
+        }
 
         _label.Label(delivery, deliveryComp.RecipientName);
-
-        if (TryComp<FingerprintReaderComponent>(delivery, out var reader) && entry.Fingerprint != null)
-            _fingerprintReader.AddAllowedFingerprint((delivery, reader), entry.Fingerprint);
 
         Dirty(delivery, deliveryComp);
     }

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Timing;
 using Content.Shared.Bed.Sleep;
 using Content.Shared._Starlight.SSDIndicator.Events;
 using Content.Shared.DoAfter;
+using Content.Shared.Mind.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Starlight.CryoTeleportation;
 // Starlight-end
@@ -22,6 +23,7 @@ namespace Content.Shared.SSDIndicator;
 public sealed class SSDIndicatorSystem : EntitySystem
 {
     public static readonly EntProtoId StatusEffectSSDSleeping = "StatusEffectSSDSleeping";
+    private static readonly TimeSpan SsdDoAfterDelay = TimeSpan.FromSeconds(10);
 
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -48,7 +50,16 @@ public sealed class SSDIndicatorSystem : EntitySystem
     // Starlight start
     private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args) => TryRemoveSSD(uid, component);
 
-    private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args) => TrySSD(uid, component, force: true);
+    // Avoid marking temporary mind transfer shells as SSD. (Wizard Jaunt Spell, Rod Spell, Golden Mask, etc.)
+    // Real disconnects keep mind on body and still go through SSD.
+    private void OnPlayerDetached(EntityUid uid, SSDIndicatorComponent component, PlayerDetachedEvent args)
+    {
+        if (TryComp<MindContainerComponent>(uid, out var mindContainer)
+            && !mindContainer.HasMind)
+            return;
+
+        TrySSD(uid, component, force: true);
+    }
 
     private void OnMoveInput(EntityUid uid, SSDIndicatorComponent comp, MoveInputEvent args) => TryRemoveSSD(uid, comp);
 
@@ -62,7 +73,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
             return;
 
         component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
-        component.NextUpdate = _timing.CurTime + component.UpdateInterval;
+        component.NextUpdate = component.FallAsleepTime; // Starlight: schedule the first update at FallAsleepTime, not repeatedly before sleep is even eligible.
         Dirty(uid, component);
     }
 
@@ -87,14 +98,17 @@ public sealed class SSDIndicatorSystem : EntitySystem
                 continue;
 
             _statusEffects.TryUpdateStatusEffectDuration(uid, StatusEffectSSDSleeping);
-            ssd.NextUpdate += ssd.UpdateInterval;
+            ssd.NextUpdate = curTime + ssd.UpdateInterval; // Starlight: advance from current time instead of incrementing by UpdateInterval.
             Dirty(uid, ssd);
         }
     }
 
     #region Starlight
 
-    private void OnSSDTry(EntityUid uid, SSDIndicatorComponent component, SSDTryDoAfterEvent args) => SSD(uid, component);
+    // Starlight-start
+    // /ssd uses a doAfter. After completion, apply SSD with immediate sleep timing.
+    private void OnSSDTry(EntityUid uid, SSDIndicatorComponent component, SSDTryDoAfterEvent args) => SSD(uid, component, sleepDelayOverride: TimeSpan.Zero);
+    // Starlight-end
 
     /// <summary>
     /// Attempts to set the entity as SSD.
@@ -110,7 +124,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
 
         if (!force)
         {
-            var doAfter = new DoAfterArgs(EntityManager, uid, TimeSpan.FromSeconds(10), new SSDTryDoAfterEvent(), uid)
+            var doAfter = new DoAfterArgs(EntityManager, uid, SsdDoAfterDelay, new SSDTryDoAfterEvent(), uid) // Starlight: make doAfter delay as a named constant for clarity.
             {
                 BreakOnMove = true,
             };
@@ -122,18 +136,19 @@ public sealed class SSDIndicatorSystem : EntitySystem
         return true;
     }
 
-    private void SSD(EntityUid uid, SSDIndicatorComponent component)
+    // Starlight-start
+    private void SSD(EntityUid uid, SSDIndicatorComponent component, TimeSpan? sleepDelayOverride = null)
     {
         component.IsSSD = true;
 
         if (_icSsdSleep)
-        //Starlight Start
         {
-            component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
-            _sleep.TrySleeping(uid);
+            // If sleepDelayOverride is provided, use that instead of the config value. This allows /ssd to apply SSD immediately without waiting for the usual delay.
+            var sleepDelay = sleepDelayOverride ?? TimeSpan.FromSeconds(_icSsdSleepTime);
+            component.FallAsleepTime = _timing.CurTime + sleepDelay;
+            component.NextUpdate = component.FallAsleepTime; // same reason as OnMapInit, first check should happen when sleep can apply.
         }
-        //_sleep.TrySleeping(uid); //Moved sleep on SSD behind the check whether SSD should sleep. WHY WAS THIS NOT ALREADY THE CASE???
-        //Starlight End
+        // Starlight-end
 
         Dirty(uid, component);
     }
@@ -155,6 +170,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
         {
             comp.FallAsleepTime = TimeSpan.Zero;
             _statusEffects.TryRemoveStatusEffect(uid, StatusEffectSSDSleeping);
+            _sleep.TryWaking(uid, force: true); // Starlight: force waking up after removing ssd.
         }
 
         if (TryComp<TargetCryoTeleportationComponent>(uid, out var cryoTeleport) && cryoTeleport.TimeDelay > TimeSpan.FromSeconds(0))

--- a/Content.Shared/_Starlight/Railroading/Components/Reward/RailroadDeliveryRewardComponent.cs
+++ b/Content.Shared/_Starlight/Railroading/Components/Reward/RailroadDeliveryRewardComponent.cs
@@ -17,4 +17,7 @@ public sealed partial class RailroadDeliveryRewardComponent : Component
     
     [DataField]
     public ProtoId<LocalizedDatasetPrototype>? WrappedDataset = null;
+
+    [NonSerialized]
+    public EntityUid? RecipientMind;
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This PR aims to fix two issues: SSD handling now distinguishes real disconnects from temporary detach cases, and criminal card railroading delivery targeting now uses a mind based system to capture recipient at card selection time.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

After the SSD changes a bug was introduced making wizards fall asleep after using a spell that detaches them from their body like jaunt or rod. This was forcing wizards to wake up after using these spells. This also applies with the golden mask curse which completely breaks it. I have changed it so that the /ssd command will continue to make you instantly fall asleep after the doAfter but the previous logic with waiting 600 seconds after being SSD to fall asleep is returned. 

Issues have been reported with players who have successfully managed to remain free for 20 minutes after selecting the criminal card never getting their letter in the mail. I have tried to make the delivery system more robust and use mind based targeting for picking the recipient when the card is selected.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: FeralCreature
- fix: Temporarily detaching from your body no longer instantly puts your body to sleep. 
- fix: Criminal card reward letters should no longer get lost in transit.