### PR TITLE
Nerfs the LaserCarbine

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -300,7 +300,7 @@
   description: Favoured by Nanotrasen Security for being cheap and easy to use.
   components:
   - type: Battery
-    maxCharge: 900 # 30 shots at 30 per shot
+    maxCharge: 900 # starlight comment
     startingCharge: 900
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -298,10 +298,12 @@
   parent: [BaseLaserRifle, BaseGunWieldable, BaseSecurityContraband]
   id: WeaponLaserCarbine
   description: Favoured by Nanotrasen Security for being cheap and easy to use.
+  # Starlight-start
   components:
   - type: Battery
-    maxCharge: 900 # starlight comment
+    maxCharge: 900
     startingCharge: 900
+  # Starlight-end
 
 - type: entity
   name: practice laser carbine

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -298,6 +298,10 @@
   parent: [BaseLaserRifle, BaseGunWieldable, BaseSecurityContraband]
   id: WeaponLaserCarbine
   description: Favoured by Nanotrasen Security for being cheap and easy to use.
+  components:
+  - type: Battery
+    maxCharge: 900 # 30 shots at 30 per shot
+    startingCharge: 900
 
 - type: entity
   name: practice laser carbine

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -57,7 +57,7 @@
   - type: HitscanBasicDamage
     damage:
       types:
-        Heat: 20 # Starlight
+        Heat: 15 # Starlight
 
 - type: entity
   parent: BasicHitscan


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Nerfing the stupidly OP laser carbine

## Why we need to add this
Game balance.
Right as of now. the laser carbine does *20 heat* with **50** shots. 20 x 50 that is 1000 heat. i get the laser carbine is meant to be suppressive fire. but its WAY to overtuned. it literaly out does ''greater'' lasers like the laser cannon.

so now its 30 shots and 15 heat,
30 x 15 = 450 damage while still having plenty of shots to shoot down range.

this only also applies to the immolator cannon and... retro laser? IIRC the advanced laser is the same as caps

## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
NT has cut costs and made the laser carbine worse (for balance)

:cl: Scarlet Lightweaver
- tweak: NT has cut costs and made the laser carbine worse (for balance)
