### PR TITLE
Add automatic chat highlights support for Avali and Resomi names

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -149,6 +149,13 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (newHighlights.Count(c => c == '-') > 1)
             newHighlights = newHighlights.Split('-')[0] + "\n@" + newHighlights.Split('-')[^1];
 
+        //Starlight begin
+        // If the character has a name with a single comma, assume it is an Avali name and extract the name and
+        // pack name eg. "Bird, Testdev Pack" -> "@Bird" "@Testdev Pack"
+        if (newHighlights.Count(c => c == ',') == 1)
+            newHighlights = newHighlights.Split(',')[0] + "\n@" + newHighlights.Split(',')[1].TrimStart(' ');
+        //Starlight end
+
         // Convert the job title to kebab-case and use it as a key for the loc file.
         var jobKey = job.Replace(' ', '-').ToLower();
 


### PR DESCRIPTION
## Short description
Adds support for the automatic chat highlights filter to separate Avali and Resomi nickname and pack names correctly.

## Why we need to add this
This will allow Avali/Resomi players to see when they are being addressed only via their first name, but will also handle when groups of players that share a pack name are addressed collectively.

## Media (Video/Screenshots)
#### After

- <img width="599" height="58" alt="image" src="https://github.com/user-attachments/assets/2e0fdc2c-377d-48e4-9e70-e0430ede83a7" />
- <img width="644" height="54" alt="image" src="https://github.com/user-attachments/assets/dcebe856-d6a7-4a3a-84fc-fb68f532d09a" />
- <img width="164" height="277" alt="image" src="https://github.com/user-attachments/assets/3ac9f26f-8b1e-48e0-a068-c5d84bc8fb33" />


#### Before

- <img width="639" height="53" alt="image" src="https://github.com/user-attachments/assets/eea60dfe-6c52-4ad3-b8f8-0b46c36e4b2e" />
- <img width="160" height="280" alt="image" src="https://github.com/user-attachments/assets/a72cd60c-050d-4759-8946-1cc829c9c197" />


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- add: Automatic chat highlights support for Avali and Resomi names
