### PR TITLE
TSF Patch

### DIFF
--- a/Resources/Locale/en-US/_Starlight/job/job.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job.ftl
@@ -29,3 +29,10 @@ role-type-corporate-aligned-alternate-color = #1b67a5
 job-rules-corporate-aligned = You are {role-type-corporate-aligned-name}.
                               You are to serve the interests of NanoTrasen and Central Command, even if they differ from the stations'.
                               Remember, you do NOT serve the crew.
+
+role-type-tsf-aligned-name = Trans-Solar Federation Aligned
+role-type-tsf-aligned-color = #22a7ff
+role-type-tsf-aligned-alternate-color = #22a7ff
+job-rules-tsf-aligned = You are {role-type-tsf-aligned-name}.
+                              You are to serve the interests of Trans-Solar Federation.
+                              Remember, you do NOT serve the crew.

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -8,9 +8,8 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 20h
-  - !type:DepartmentTimeRequirement
-    department: CentralCommand
-    time: 10h
+  - !type:RolesRequirement
+    proto: ExtRolesReq
   - !type:DepartmentTimeRequirement
     department: Command
     time: 10h

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Backpacks/tsf.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Backpacks/tsf.yml
@@ -13,7 +13,7 @@
       enum.StorageUiKey.Key:
         type: StorageBoundUserInterface
   - type: Telephone
-    transmissionRange: Map
+    transmissionRange: Unlimited
     compatibleRanges:
     - Grid
     - Map

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Head/eva-helmets.yml
@@ -47,6 +47,7 @@
     - type: EyeProtection
       protectionTime: 5
     - type: FlashImmunity
+    - type: ClothesNightVision
 
 - type: entity
   parent: ClothingHeadHelmetTSF

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -679,6 +679,7 @@
   - type: EyeProtection
     protectionTime: 5
   - type: FlashImmunity
+  - type: ClothesNightVision
 
 #Thanatos Helmet (Starlight version of Deathsquad)
 - type: entity

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -700,7 +700,9 @@
   - type: Clothing
     sprite: _Starlight/Clothing/OuterClothing/Hardsuits/tsf.rsi
   - type: ExplosionResistance
-    damageCoefficient: 0.3
+    damageCoefficient: 0.2
+  - type: StaminaResistance
+    damageCoefficient: 0.75
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.5
   - type: FireProtection
@@ -708,10 +710,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.4
-        Slash: 0.4
-        Piercing: 0.3
-        Heat: 0.5
+        Blunt: 0.3
+        Slash: 0.3
+        Piercing: 0.2
+        Heat: 0.4
         Caustic: 0
   - type: ClothingSpeedModifier
     walkModifier: 0.9

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/OuterClothing/softsuits.yml
@@ -58,11 +58,13 @@
       coefficients:
         Blunt: 0.6
         Slash: 0.6
-        Piercing: 0.55
-        Heat: 0.55
+        Piercing: 0.6
+        Heat: 0.5
         Caustic: 0
   - type: ExplosionResistance
     damageCoefficient: 0.5
+  - type: StaminaResistance 
+    damageCoefficient: 0.75
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.8
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/humanoid.yml
@@ -286,6 +286,7 @@
   - Moth
   - SlimePerson
   - Lagomorph
+  - Elf
   components:
     - type: GhostRole
       name: ghost-role-information-tsf-marine-name
@@ -294,7 +295,7 @@
       raffle:
         settings: default
       mindRoles:
-      - MindRoleGhostCorporateAligned
+      - MindRoleGhostTSFAligned
       job: TSFMarine
     - type: Loadout
       prototypes: [ TSFMarineGear ]
@@ -314,6 +315,7 @@
   components:
     - type: GhostRole
       name: ghost-role-information-tsf-leader-name
+      job: TSFMarineElite
     - type: Loadout
       prototypes: [ TSFMarineLeaderGear ]
     - type: RandomMetadata
@@ -328,6 +330,7 @@
   components:
     - type: GhostRole
       name: ghost-role-information-tsf-MARSOC-name
+      job: TSFMarineElite
     - type: Loadout
       prototypes: [ TSFEliteMarineGear ]
     - type: RandomMetadata

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/TSF/marine.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/TSF/marine.yml
@@ -5,20 +5,41 @@
   playTimeTracker: JobTSFMarine
   requirements:
     - !type:OverallPlaytimeRequirement
-        time: 72000 # 20h
+      time: 72000 # 20h
     - !type:DepartmentTimeRequirement
-        department: Security
-        time: 18000 # 5h
+      department: Security
+      time: 18000 # 5h
   setPreference: false
   icon: JobIconTSF
-  rules: job-rules-corporate-aligned
+  rules: job-rules-tsf-aligned
   supervisors: job-supervisors-none
   canBeAntag: false
   accessGroups:
-  - AllAccess
+    - AllAccess
   special:
-  - !type:AddImplantSpecial
-    implants: [ MindShieldImplant, DeathRattleImplantTSF ]
+    - !type:AddImplantSpecial
+      implants: [MindShieldImplant, DeathRattleImplantTSF]
+
+- type: job
+  id: TSFMarineElite
+  name: ghost-role-information-tsf-leader-name
+  description: ghost-role-information-tsf-marine-desc
+  playTimeTracker: JobTSFMarineLeader
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 72000 # 20h
+    - !type:RolesRequirement
+      proto: ExtRolesReq
+  setPreference: false
+  icon: JobIconTSF
+  rules: job-rules-tsf-aligned
+  supervisors: job-supervisors-none
+  canBeAntag: false
+  accessGroups:
+    - AllAccess
+  special:
+    - !type:AddImplantSpecial
+      implants: [MindShieldImplant, DeathRattleImplantTSF]
 
 - type: startingGear
   id: TSFMarineGear
@@ -37,20 +58,20 @@
     suitstorage: WeaponRifleARG
   storage:
     back:
-    - BoxSurvivalSecurity
-    - CrowbarRed
-    - Brutepack
-    - Ointment
-    - Gauze
+      - BoxSurvivalSecurity
+      - CrowbarRed
+      - Brutepack
+      - Ointment
+      - Gauze
     belt:
-    - MagazineBoxLightRifleFMJ
-    - MagazineLightRifleFMJ
-    - MagazineLightRifleFMJ
-    - MagazineLightRifleFMJ
-    - MagazineLightRifleFMJ
-    - MagazineBoxMagnumSP
-    - MagazineMagnum
-    - MagazineMagnum
+      - MagazineBoxLightRifleFMJ
+      - MagazineLightRifleFMJ
+      - MagazineLightRifleFMJ
+      - MagazineLightRifleFMJ
+      - MagazineLightRifleFMJ
+      - MagazineBoxMagnumSP
+      - MagazineMagnum
+      - MagazineMagnum
 
 - type: startingGear
   id: TSFMarineLeaderGear
@@ -69,18 +90,18 @@
     suitstorage: WeaponRifleARG
   storage:
     back:
-    - BoxSurvivalSecurity
-    - CrowbarRed
-    - MedkitCombatFilled
+      - BoxSurvivalSecurity
+      - CrowbarRed
+      - MedkitCombatFilled
     belt:
-    - MagazineBoxLightRifleFMJ
-    - MagazineLightRifleFMJ
-    - MagazineLightRifleFMJ
-    - MagazineLightRifleFMJ
-    - MagazineLightRifleFMJ
-    - MagazineBoxMagnumSP
-    - MagazineMagnum
-    - MagazineMagnum
+      - MagazineBoxLightRifleFMJ
+      - MagazineLightRifleFMJ
+      - MagazineLightRifleFMJ
+      - MagazineLightRifleFMJ
+      - MagazineLightRifleFMJ
+      - MagazineBoxMagnumSP
+      - MagazineMagnum
+      - MagazineMagnum
 
 - type: startingGear
   id: TSFEliteMarineGear
@@ -98,18 +119,18 @@
     suitstorage: WeaponRifleM52
   storage:
     back:
-    - BoxSurvivalSecurity
-    - CrowbarRed
-    - MedkitCombatFilled
+      - BoxSurvivalSecurity
+      - CrowbarRed
+      - MedkitCombatFilled
     belt:
-    - MagazineBoxRifleHP
-    - MagazineRifleM52HP
-    - MagazineRifleM52HP
-    - MagazineRifleM52HP
-    - MagazineRifleM52HP
-    - MagazineBoxMagnumSP
-    - MagazineMagnum
-    - MagazineMagnum
+      - MagazineBoxRifleHP
+      - MagazineRifleM52HP
+      - MagazineRifleM52HP
+      - MagazineRifleM52HP
+      - MagazineRifleM52HP
+      - MagazineBoxMagnumSP
+      - MagazineMagnum
+      - MagazineMagnum
 
 - type: startingGear
   id: TSFGeneralGear
@@ -128,15 +149,15 @@
     pocket2: MindShieldImplanter
   storage:
     back:
-    - BoxSurvivalSecurity
-    - CrowbarRed
-    - MedkitCombatFilled
+      - BoxSurvivalSecurity
+      - CrowbarRed
+      - MedkitCombatFilled
     belt:
-    - SpeedLoaderMagnumBasic
-    - BoxLethalshot
-    - BoxLethalshot
-  inhand: 
-  - DeathRattleImplanterTSF
+      - SpeedLoaderMagnumBasic
+      - BoxLethalshot
+      - BoxLethalshot
+  inhand:
+    - DeathRattleImplanterTSF
 
 - type: startingGear
   id: TSFRepGear
@@ -153,9 +174,9 @@
     pocket2: MindShieldImplanter
   storage:
     back:
-    - BoxSurvival
-  inhand: 
-  - DeathRattleImplanterTSF
+      - BoxSurvival
+  inhand:
+    - DeathRattleImplanterTSF
 
 - type: startingGear
   id: TSFTraderGear
@@ -172,4 +193,4 @@
     pocket2: AppraisalTool
   storage:
     back:
-    - BoxSurvival
+      - BoxSurvival

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/TSF/marine.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/TSF/marine.yml
@@ -24,7 +24,7 @@
   id: TSFMarineElite
   name: ghost-role-information-tsf-leader-name
   description: ghost-role-information-tsf-marine-desc
-  playTimeTracker: JobTSFMarineLeader
+  playTimeTracker: TSFMarineElite
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 72000 # 20h

--- a/Resources/Prototypes/_StarLight/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_StarLight/Roles/MindRoles/mind_roles.yml
@@ -8,6 +8,14 @@
 
 - type: entity
   parent: MindRoleGhostRoleNeutral
+  id: MindRoleGhostTSFAligned
+  name: Ghost Role (TSF Aligned)
+  components:
+    - type: MindRole
+      roleType: TSFAligned
+
+- type: entity
+  parent: MindRoleGhostRoleNeutral
   id: MindRoleGhostRolePAI
   name: Ghost Role (pAI Familiar)
   components:

--- a/Resources/Prototypes/_StarLight/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/_StarLight/Roles/play_time_trackers.yml
@@ -45,6 +45,9 @@
   
 - type: playTimeTracker
   id: JobTSFMarine
+
+- type: playTimeTracker
+  id: TSFMarineElite
   
 - type: playTimeTracker
   id: JobBoxer

--- a/Resources/Prototypes/_StarLight/Roles/role_types.yml
+++ b/Resources/Prototypes/_StarLight/Roles/role_types.yml
@@ -11,3 +11,9 @@
   name: role-type-corporate-aligned-name
   color: '#134975'
   symbol: "🗡" # Should never be antag, but just in case.
+
+- type: roleType
+  id: TSFAligned
+  name: role-type-corporate-aligned-name
+  color: '#134975'
+  symbol: "🗡" # Should never be antag, but just in case.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes/Changes TSF Armor like its should have been, after some testing, making stats as following:
Normal TSF/Leader -> Same as Security ERT.
TSF Elite -> NTSF / Weaker Decimus.

Made some changes in their allignement and changed some tools for them.

ERT Leader also does not need 10h of gameplay anymore just extra roles.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Patches and request needed to be done.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Shades
- tweak: ERT Leader / TSF Elite now need External Roles (before they needed 10h of ERT)
- tweak: Changed TSF Armor be patched correctly, including stamina resist.
- tweak: TSF Backpack range is now unlimited.
- tweak: TSF have now their own allignement.

