### PR TITLE
Long Range Gun Tweaking

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -297,12 +297,12 @@
           tags:
           - CartridgeRifle
   - type: SpeedModifiedOnWield
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.80 #SL 75% -> 80% speed
+    sprintModifier: 0.80 #SL 75% -> 80% speed
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
-    maxOffset: 2
-    pvsIncrease: 0.2
+    maxOffset: 2.5 #SL 2 -> 2.5
+    pvsIncrease: 0.25 #SL 0.2 -> 0.25
   - type: ContainerContainer
     containers:
       gun_magazine: !type:ContainerSlot

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -173,12 +173,12 @@
     capacity: 5
     proto: CartridgeAntiMateriel
   - type: SpeedModifiedOnWield
-    walkModifier: 0.25
-    sprintModifier: 0.25
+    walkModifier: 0.30 #SL 25% -> 30% speed
+    sprintModifier: 0.30 #SL 25% -> 30% speed
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
-    maxOffset: 3
-    pvsIncrease: 0.3
+    maxOffset: 4 #SL 3 -> 4
+    pvsIncrease: 0.4 #SL 0.3 -> 0.4
   - type: StaticPrice
     price: 3500
 

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Lockers/security.yml
@@ -182,11 +182,11 @@
       entity_storage: !type:AllSelector
         children:
         - id: WeaponRifleL10
-          amount: 2
+          amount: 3
         - id: MagazineDMRSP
-          amount: 3
+          amount: 4
         - id: MagazineDMRFMJ
-          amount: 3
+          amount: 4
         - id: HammerBreachingNT
           amount: 1
 

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -300,8 +300,8 @@
       path: /Audio/Weapons/Guns/Gunshots/ltrifle.ogg
   - type: GunRequiresWield
   - type: SpeedModifiedOnWield
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: ItemSlots
     slots:
       gun_magazine:
@@ -333,8 +333,8 @@
   - type: Appearance
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
-    maxOffset: 2.5
-    pvsIncrease: 0.25
+    maxOffset: 3
+    pvsIncrease: 0.3
 
 
 - type: entity


### PR DESCRIPTION
## Short description
Tweaks the stats of the "Long Range" guns- Hristov, Estoc, and L10 DMR.

Hristov: (Syndicate)
- Move Speed Increase, 25% -> 30%
- Scope Range Increase, 3 -> 4 tiles

Estoc: (Syndicate)
- Move Speed Increase, 75% -> 80%
- Scope Range Increase, 2 -> 2.5 tiles

L10 DMR: (Security)
- Move Speed Increase, 80% -> 90%
- Scope Range Increase, 2.5 -> 3 tiles
- DMR Safe Fill Increase, 2 -> 3 Rifles, 3 -> 4 SP Mag, 3 -> 4 FMJ Mag

## Why we need to add this
The L10 DMR has been in Security hands for a bit, granted the first week it was bugged so you couldn't shoot past allies which is now fixed. The consensus is mostly that it still feels a little weak, being basically just another Leikha or Lecter. The biggest cited things holding it back being the movement speed reduction and the range not really being substantial.

_I think this opinion is tinted heavily by how overpowered the Smart LMG was, and the recent heavy increase in antag count in rounds, but it is still worth adjusting for._

With the new changes, the 3 main "long range" rifles all were buffed slightly to preserve actual counterplay from antags. Hristov remains the top sniper with the largest range, with the L10 being next in line- it doesn't hit nearly as hard but lets you move still. Followed by the Estoc, which is the Syndicate's real 'equivalent' to the L10.

Adding 1 extra L10 to the safe also helps Security actually establish a firing line like intended- sure 1 on it's own is only doing as much damage as a Leikha, but 3 in one hallway firing at once over their allies and with extra range, is proper suppressing fire and area denial.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Hristov movement speed increased from 25% to 30%, and scope range increased from 3 to 4 tiles.
- tweak: Estoc movement speed increased from 75% to 80%, and scope range increased from 2 to 2.5 tiles.
- tweak: L10 DMR (Security DMR) movement speed increased from 80% to 90%, and scope range increased from 2.5 to 3 tiles. One extra L10 DMR, FMJ mag, and SP mag was also added to the safe.

