### PR TITLE
Changed Hyper Cells with Micro Reactor Cells in all Syndicate Mechs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -943,7 +943,7 @@
   - type: ContainerFill
     containers:
       mech-battery-slot:
-      - PowerCellHyper
+      - PowerCellMicroreactor
       mech-gas-tank-slot:
       - MechAirTankFilled
 
@@ -1019,7 +1019,7 @@
   - type: ContainerFill
     containers:
       mech-battery-slot:
-      - PowerCellHyper
+      - PowerCellMicroreactor
       mech-gas-tank-slot:
       - MechAirTankFilled
 


### PR DESCRIPTION
## Short description
Gives the syndicate mechs a micro reactor cell instead of a Hyper.


## Why we need to add this
Hyper cells really do not last enough in a drawn out combat. Now the mechs have 720 charge compared to 1800, but slowly charges (as in code, in about a minute to be back to full). This means that for spamming weaponary, you will run out of charge being forced to slow down, and think about what weapons you are using vs how much charge you have.

## Media (Video/Screenshots)
_I blew up my local host trying fire a missile, but it just works_

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Coolsurf6
- tweak: Syndicate Maulers and Dark Gygaxes now come with Micro Reactor Cells instead of Hyper Cells

