### PR TITLE
Bluespace Harvester circuit board Hotfix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/heads.yml
@@ -24,6 +24,7 @@
         - id: AtmosMonitoringComputerCircuitboard
         - id: PowerComputerCircuitboard
         - id: SolarControlComputerCircuitboard
+        - id: BluespaceHarvesterMachineCircuitboard # Starlight
 
 - type: entity
   parent: ToteBase
@@ -72,12 +73,6 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - id: CargoRequestEngineeringComputerCircuitboard
-        - id: AlertsComputerCircuitboard
-        - id: AtmosMonitoringComputerCircuitboard
-        - id: PowerComputerCircuitboard
-        - id: SolarControlComputerCircuitboard
-        - id: BluespaceHarvesterMachineCircuitboard # Starlight
         - id: SecurityTechFabCircuitboard
         - id: CargoRequestSecurityComputerCircuitboard
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Puts BluespaceHarvesterMachineCircuitboard into the correct tote and removed the accidentally duplicated circuit boards.

Beating cringe before they fix it :3
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Supply lines for CE's locker tote no longer go to HoS' locker (Bluespace Circuit board is correctly in CE's locker)