### PR TITLE
Lets you preview decal placement before painting them

### DIFF
--- a/Content.Client/SprayPainter/Overlays/SprayPainterDecalGhostOverlay.cs
+++ b/Content.Client/SprayPainter/Overlays/SprayPainterDecalGhostOverlay.cs
@@ -1,0 +1,61 @@
+using Content.Client.Decals;
+using Content.Client.Decals.Overlays;
+using Content.Shared.Decals;
+using Content.Shared.SprayPainter;
+using Content.Shared.SprayPainter.Components;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client.SprayPainter.Overlays;
+
+/// <summary>
+/// Overlay that shows a preview of the decal that will be painted when using the spray painter in decal add mode.
+/// </summary>
+public sealed class SprayPainterDecalGhostOverlay : DecalPlacementOverlay
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
+
+    private readonly EntityUid _sprayPainterUid;
+
+    public SprayPainterDecalGhostOverlay(
+        DecalPlacementSystem placement,
+        SharedTransformSystem transform,
+        SpriteSystem sprite,
+        EntityUid sprayPainterUid) : base(placement, transform, sprite)
+    {
+        IoCManager.InjectDependencies(this);
+        _sprayPainterUid = sprayPainterUid;
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        // Only draw preview when in Add mode
+        if (!_entityManager.TryGetComponent(_sprayPainterUid, out SprayPainterComponent? sprayPainterComp))
+            return false;
+
+        return sprayPainterComp.DecalMode == DecalPaintMode.Add;
+    }
+
+    protected override void LoadDecal()
+    {
+        if (!_entityManager.TryGetComponent(_sprayPainterUid, out SprayPainterComponent? sprayPainterComp))
+        {
+            decal = null;
+            return;
+        }
+
+        // Load the decal prototype from the spray painter's selected decal
+        if (!_protoManager.TryIndex<DecalPrototype>(sprayPainterComp.SelectedDecal, out var decalProto))
+        {
+            decal = null;
+            return;
+        }
+
+        decal = decalProto;
+        snap = sprayPainterComp.SnapDecals;
+        rotation = Angle.FromDegrees(sprayPainterComp.SelectedDecalAngle);
+        color = sprayPainterComp.SelectedDecalColor;
+    }
+}

--- a/Content.Client/SprayPainter/Overlays/SprayPainterDecalGhostOverlay.cs
+++ b/Content.Client/SprayPainter/Overlays/SprayPainterDecalGhostOverlay.cs
@@ -12,42 +12,41 @@ namespace Content.Client.SprayPainter.Overlays;
 /// <summary>
 /// Overlay that shows a preview of the decal that will be painted when using the spray painter in decal add mode.
 /// </summary>
-public sealed class SprayPainterDecalGhostOverlay : DecalPlacementOverlay
+public sealed class SprayPainterDecalGhostOverlay : DecalPlacementOverlay // Inherit from the decal placement overlay since the functionality is very similar, just with a different way of loading the decal prototype and only showing in certain modes
 {
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
 
     private readonly EntityUid _sprayPainterUid;
 
-    public SprayPainterDecalGhostOverlay(
+    public SprayPainterDecalGhostOverlay( // Pass dependencies to the base decal placement overlay
         DecalPlacementSystem placement,
         SharedTransformSystem transform,
         SpriteSystem sprite,
-        EntityUid sprayPainterUid) : base(placement, transform, sprite)
+        EntityUid sprayPainterUid) : base(placement, transform, sprite) 
     {
-        IoCManager.InjectDependencies(this);
+        IoCManager.InjectDependencies(this); 
         _sprayPainterUid = sprayPainterUid;
     }
 
-    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    protected override bool BeforeDraw(in OverlayDrawArgs args) // Only draw the decal ghost when the spray painter is in decal add mode
     {
-        // Only draw preview when in Add mode
+
         if (!_entityManager.TryGetComponent(_sprayPainterUid, out SprayPainterComponent? sprayPainterComp))
             return false;
 
         return sprayPainterComp.DecalMode == DecalPaintMode.Add;
     }
 
-    protected override void LoadDecal()
+    protected override void LoadDecal() // Load the decal prototype based on the selected decal in the spray painter component, and load the snap and rotation settings from the component as well
     {
-        if (!_entityManager.TryGetComponent(_sprayPainterUid, out SprayPainterComponent? sprayPainterComp))
+        if (!_entityManager.TryGetComponent(_sprayPainterUid, out SprayPainterComponent? sprayPainterComp)) // If we can't find the spray painter component, don't draw anything
         {
             decal = null;
             return;
         }
 
-        // Load the decal prototype from the spray painter's selected decal
-        if (!_protoManager.TryIndex<DecalPrototype>(sprayPainterComp.SelectedDecal, out var decalProto))
+        if (!_protoManager.TryIndex<DecalPrototype>(sprayPainterComp.SelectedDecal, out var decalProto)) // If we can't find the decal prototype, don't draw anything
         {
             decal = null;
             return;

--- a/Content.Client/SprayPainter/SprayPainterSystem.cs
+++ b/Content.Client/SprayPainter/SprayPainterSystem.cs
@@ -1,12 +1,18 @@
 using System.Linq;
+using Content.Client.Decals;
+using Content.Client.Hands.Systems;
 using Content.Client.Items;
 using Content.Client.Message;
+using Content.Client.SprayPainter.Overlays;
 using Content.Client.Stylesheets;
 using Content.Shared.Decals;
+using Content.Shared.Hands.Components;
 using Content.Shared.SprayPainter;
 using Content.Shared.SprayPainter.Components;
 using Content.Shared.SprayPainter.Prototypes;
 using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Prototypes;
@@ -21,10 +27,18 @@ namespace Content.Client.SprayPainter;
 public sealed class SprayPainterSystem : SharedSprayPainterSystem
 {
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
+    [Dependency] private readonly DecalPlacementSystem _decalPlacement = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SpriteSystem _spriteSystem = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly HandsSystem _hands = default!;
 
     public List<SprayPainterDecalEntry> Decals = [];
     public Dictionary<string, List<string>> PaintableGroupsByCategory = new();
     public Dictionary<string, Dictionary<string, EntProtoId>> PaintableStylesByGroup = new();
+
+    private readonly Dictionary<EntityUid, SprayPainterDecalGhostOverlay> _overlays = new();
 
     public override void Initialize()
     {
@@ -32,14 +46,77 @@ public sealed class SprayPainterSystem : SharedSprayPainterSystem
 
         Subs.ItemStatus<SprayPainterComponent>(ent => new StatusControl(ent));
         SubscribeLocalEvent<SprayPainterComponent, AfterAutoHandleStateEvent>(OnStateUpdate);
+        SubscribeLocalEvent<SprayPainterComponent, ComponentShutdown>(OnComponentShutdown);
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
 
         CachePrototypes();
     }
 
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        // Update all active overlays to check if they should still exist
+        var query = EntityQueryEnumerator<SprayPainterComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            UpdateDecalGhostOverlay((uid, comp));
+        }
+    }
+
     private void OnStateUpdate(Entity<SprayPainterComponent> ent, ref AfterAutoHandleStateEvent args)
     {
         UpdateUi(ent);
+        UpdateDecalGhostOverlay(ent);
+    }
+
+    private void OnComponentShutdown(Entity<SprayPainterComponent> ent, ref ComponentShutdown args)
+    {
+        // Clean up overlay when the spray painter component is removed
+        if (_overlays.Remove(ent.Owner, out var overlay))
+        {
+            _overlayManager.RemoveOverlay(overlay);
+        }
+    }
+
+    private void UpdateDecalGhostOverlay(Entity<SprayPainterComponent> ent)
+    {
+        var hasOverlay = _overlays.ContainsKey(ent.Owner);
+        
+        // Determine if we should have the overlay:
+        // 1. Must be in Add mode
+        // 2. Must be in the player's active hand
+        var shouldHaveOverlay = ent.Comp.DecalMode == DecalPaintMode.Add 
+            && IsSprayPainterInActiveHand(ent.Owner);
+
+        if (shouldHaveOverlay && !hasOverlay)
+        {
+            // Create and add the overlay
+            var overlay = new SprayPainterDecalGhostOverlay(_decalPlacement, _transform, _spriteSystem, ent.Owner);
+            _overlays[ent.Owner] = overlay;
+            _overlayManager.AddOverlay(overlay);
+        }
+        else if (!shouldHaveOverlay && hasOverlay)
+        {
+            // Remove the overlay
+            if (_overlays.Remove(ent.Owner, out var overlay))
+            {
+                _overlayManager.RemoveOverlay(overlay);
+            }
+        }
+    }
+
+    private bool IsSprayPainterInActiveHand(EntityUid sprayPainterUid)
+    {
+        var player = _playerManager.LocalPlayer?.ControlledEntity;
+        if (player is null)
+            return false;
+
+        if (!EntityManager.TryGetComponent(player, out HandsComponent? handsComp))
+            return false;
+
+        var activeHand = _hands.GetActiveItem((player.Value, handsComp));
+        return activeHand == sprayPainterUid;
     }
 
     protected override void UpdateUi(Entity<SprayPainterComponent> ent)
@@ -86,6 +163,19 @@ public sealed class SprayPainterSystem : SharedSprayPainterSystem
 
             Decals.Add(new SprayPainterDecalEntry(decalPrototype.ID, decalPrototype.Sprite));
         }
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        // Clean up all active overlays
+        foreach (var overlay in _overlays.Values)
+        {
+            _overlayManager.RemoveOverlay(overlay);
+        }
+
+        _overlays.Clear();
     }
 
     private sealed class StatusControl : Control

--- a/Content.Client/SprayPainter/SprayPainterSystem.cs
+++ b/Content.Client/SprayPainter/SprayPainterSystem.cs
@@ -52,7 +52,7 @@ public sealed class SprayPainterSystem : SharedSprayPainterSystem
         CachePrototypes();
     }
 
-    public override void Update(float frameTime)
+    public override void Update(float frameTime) // Update is used to check if the spray painter is in the player's active hand and update the decal ghost overlay accordingly, since the overlay should only be visible when the spray painter is in hand, and there isn't a specific event for when an item is moved to or from the player's hand
     {
         base.Update(frameTime);
 
@@ -67,10 +67,10 @@ public sealed class SprayPainterSystem : SharedSprayPainterSystem
     private void OnStateUpdate(Entity<SprayPainterComponent> ent, ref AfterAutoHandleStateEvent args)
     {
         UpdateUi(ent);
-        UpdateDecalGhostOverlay(ent);
+        UpdateDecalGhostOverlay(ent); // Update the decal ghost overlay whenever the component state updates, since changes to the decal mode or selected decal should be reflected in the overlay immediately
     }
 
-    private void OnComponentShutdown(Entity<SprayPainterComponent> ent, ref ComponentShutdown args)
+    private void OnComponentShutdown(Entity<SprayPainterComponent> ent, ref ComponentShutdown args) // Clean up the decal ghost overlay when the spray painter component is removed, such as when the item is deleted or the component is removed for any reason
     {
         // Clean up overlay when the spray painter component is removed
         if (_overlays.Remove(ent.Owner, out var overlay))
@@ -79,7 +79,7 @@ public sealed class SprayPainterSystem : SharedSprayPainterSystem
         }
     }
 
-    private void UpdateDecalGhostOverlay(Entity<SprayPainterComponent> ent)
+    private void UpdateDecalGhostOverlay(Entity<SprayPainterComponent> ent) // Check if the spray painter should have the decal ghost overlay, and add or remove it accordingly
     {
         var hasOverlay = _overlays.ContainsKey(ent.Owner);
         
@@ -106,7 +106,7 @@ public sealed class SprayPainterSystem : SharedSprayPainterSystem
         }
     }
 
-    private bool IsSprayPainterInActiveHand(EntityUid sprayPainterUid)
+    private bool IsSprayPainterInActiveHand(EntityUid sprayPainterUid) // Check if the spray painter is in the player's active hand, which determines whether the decal ghost overlay should be shown
     {
         var player = _playerManager.LocalPlayer?.ControlledEntity;
         if (player is null)
@@ -165,7 +165,7 @@ public sealed class SprayPainterSystem : SharedSprayPainterSystem
         }
     }
 
-    public override void Shutdown()
+    public override void Shutdown() // Clean up all active overlays when the system is shutting down, such as when the player disconnects or the game is closing
     {
         base.Shutdown();
 

--- a/Content.Client/SprayPainter/UI/SprayPainterBoundUserInterface.cs
+++ b/Content.Client/SprayPainter/UI/SprayPainterBoundUserInterface.cs
@@ -40,6 +40,22 @@ public sealed class SprayPainterBoundUserInterface(EntityUid owner, Enum uiKey) 
             _window.SetSelectedTab(sprayPainterComp.SelectedTab);
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing && _window != null)
+        {
+            _window.OnSpritePicked -= OnSpritePicked;
+            _window.OnSetPipeColor -= OnSetPipeColor;
+            _window.OnTabChanged -= OnTabChanged;
+            _window.OnDecalChanged -= OnDecalChanged;
+            _window.OnDecalColorChanged -= OnDecalColorChanged;
+            _window.OnDecalAngleChanged -= OnDecalAngleChanged;
+            _window.OnDecalSnapChanged -= OnDecalSnapChanged;
+        }
+    }
+
     public override void Update()
     {
         if (_window == null)

--- a/Content.Client/SprayPainter/UI/SprayPainterBoundUserInterface.cs
+++ b/Content.Client/SprayPainter/UI/SprayPainterBoundUserInterface.cs
@@ -40,7 +40,7 @@ public sealed class SprayPainterBoundUserInterface(EntityUid owner, Enum uiKey) 
             _window.SetSelectedTab(sprayPainterComp.SelectedTab);
     }
 
-    protected override void Dispose(bool disposing)
+    protected override void Dispose(bool disposing) // Unsubscribe from events and clean up the window when the UI is closed
     {
         base.Dispose(disposing);
 

--- a/Resources/Locale/en-US/_Starlight/spray-painter/spray_painter.ftl
+++ b/Resources/Locale/en-US/_Starlight/spray-painter/spray_painter.ftl
@@ -4,6 +4,8 @@ spray-painter-style-airlockstandard-surgery = Surgery
 spray-painter-style-airlockstandard-paramedic = Paramedic
 spray-painter-style-airlockstandard-salvagemining = Salvage/Mining
 spray-painter-style-airlockstandard-miningcargo = Mining/Cargo
+spray-painter-style-airlockstandard-retrosalvage = Retro Salvage
+spray-painter-style-airlockstandard-retromining = Retro Mining
 spray-painter-style-airlockstandard-retrosalvagemining = Retro Salvage/Mining
 
 # Glass Airlocks
@@ -12,6 +14,8 @@ spray-painter-style-airlockglass-surgery = Surgery
 spray-painter-style-airlockglass-paramedic = Paramedic
 spray-painter-style-airlockglass-salvagemining = Salvage/Mining
 spray-painter-style-airlockglass-miningcargo = Mining/Cargo
+spray-painter-style-airlockglass-retrosalvage = Retro Salvage
+spray-painter-style-airlockglass-retromining = Retro Mining
 spray-painter-style-airlockglass-retrosalvagemining = Retro Salvage/Mining
 
 # Lockers


### PR DESCRIPTION
## Short description
Adds a ghost overlay so you can see the position/rotation of the decal before painting it

## Why we need to add this
Because I can never remember if rotating by 90 degrees goes clockwise or counterclockwise

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/a11cd236-ee3a-4720-8155-74ec558139ca

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Maxim
- add: Added decal preview to spray painter

