### PR TITLE
pAI comms rework

### DIFF
--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -15,7 +15,11 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using SharedToolSystem = Content.Shared.Tools.Systems.SharedToolSystem;
-using Content.Shared._Starlight.Radio; // Starlight
+
+#region Starlight
+using Content.Shared._Starlight.Radio;
+using Content.Shared.Interaction.Components;
+#endregion
 
 namespace Content.Shared.Radio.EntitySystems;
 
@@ -50,9 +54,9 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         if (args.Cancelled)
             return;
 
-        var contained = component.KeyContainer.ContainedEntities.ToArray();
-        _container.EmptyContainer(component.KeyContainer, reparent: false);
-        foreach (var ent in contained)
+        List<EntityUid> removedKeys = _container.EmptyContainer(component.KeyContainer, reparent: false); //Starlight fixed unremovable keys being removable
+        if (removedKeys.Count == 0) return; //Starlight fixed unremovable keys being removable
+        foreach (var ent in removedKeys) //Starlight fixed unremovable keys being removable
         {
             _hands.PickupOrDrop(args.User, ent, dropNear: true);
         }
@@ -101,7 +105,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         }
         else if (TryComp<ToolComponent>(args.Used, out var tool)
                  && _tool.HasQuality(args.Used, component.KeysExtractionMethod, tool)
-                 && component.KeyContainer.ContainedEntities.Count > 0) // dont block deconstruction
+                 && component.KeyContainer.ContainedEntities.Count(key => !HasComp(key, typeof(UnremoveableComponent))) != 0) //Starlight fixed unremovable keys being removable
         {
             args.Handled = true;
             TryRemoveKey(uid, component, args, tool);
@@ -149,12 +153,6 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         if (!_wires.IsPanelOpen(uid))
         {
             _popup.PopupClient(Loc.GetString("encryption-keys-panel-locked"), uid, args.User);
-            return;
-        }
-
-        if (component.KeyContainer.ContainedEntities.Count == 0)
-        {
-            _popup.PopupClient(Loc.GetString("encryption-keys-no-keys"), uid, args.User);
             return;
         }
 

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -57,9 +57,13 @@
     stopSearchVerbPopup: pai-system-stopped-searching
   - type: Examiner
   - type: IntrinsicRadioReceiver
+  - type: IntrinsicRadioTransmitter #Starlight pAI comms rework, see PR #3299
   - type: ActiveRadio
-    channels:
-    - Common
+  - type: ContainerContainer #Starlight pAI comms rework, see PR #3299
+    containers:
+      key_slots: !type:Container
+  - type: EncryptionKeyHolder #Starlight pAI comms rework, see PR #3299
+    keySlots: 1
   - type: DoAfter
   - type: Actions
   - type: ActionGrant
@@ -133,12 +137,12 @@
     roleRules: ghost-role-information-syndicate-pai-rules
     mindRoles:
     - MindRoleGhostRolePAI
-  - type: IntrinsicRadioTransmitter
-    channels:
-    - Syndicate
-  - type: ActiveRadio
-    channels:
-    - Syndicate
+  - type: ContainerFill #Starlight pAI comms rework, see PR #3299
+    containers:
+      key_slots:
+      - EncryptionKeySyndiePAI
+  - type: EncryptionKeyHolder #Starlight pAI comms rework, see PR #3299
+    keySlots: 2
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Fun/pai.yml
@@ -11,3 +11,9 @@
       itemIconStyle: NoItem
     - type: InstantAction
       event: !type:PAIPDAActionEvent
+
+- type: entity
+  parent: EncryptionKeySyndie
+  id: EncryptionKeySyndiePAI
+  components:
+    - type: Unremoveable


### PR DESCRIPTION
# Short description
pAIs can accept encryption keys, also removed common from them roundstart

# Why we need to add this
This is a followup on my [previous PR](https://github.com/ss14Starlight/space-station-14/pull/3272), expanding pAIs for my vision for them.
LSS I am working on making pAIs actually useful, fun to have, and fun to play as, and the specific role they will fill are as an assistant that can communicate and handle information on their owners behalf.

# Media (Video/Screenshots)
<img width="386" height="91" alt="image" src="https://github.com/user-attachments/assets/06697dd1-5eff-4240-b3d4-3a9bb5e71fd0" />

# Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Notarin Steele
- fix: Fixed being able to remove unremovable encryption keys.
- remove: Removed common comms from pAIs roundstart.
- add: Added the ability to install new encryption keys into a pAI.
- add: Added the ability to remove encryption keys from a pAI.
