### PR TITLE
pAI languages store expansion

### DIFF
--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -23,6 +23,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Prometheus; //Starlight
+using Content.Server._Starlight.Language;
 
 
 namespace Content.Server.Store.Systems;
@@ -47,6 +48,7 @@ public sealed partial class StoreSystem
     [Dependency] private readonly StackSystem _stack = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
     [Dependency] private readonly RevSupplyRiftSystem _revSupplyRift = default!; // Starlight
+    [Dependency] private readonly LanguageSystem _languageSystem = default!; //Starlight
 
     private void InitializeUi()
     {
@@ -131,7 +133,7 @@ public sealed partial class StoreSystem
         // only tell operatives to lock their uplink if it can be locked
         var showFooter = HasComp<RingerUplinkComponent>(store);
 
-    var state = new StoreUpdateState(component.LastAvailableListings, allCurrency, showFooter, component.RefundAllowed, component.Grid); // Starlight
+        var state = new StoreUpdateState(component.LastAvailableListings, allCurrency, showFooter, component.RefundAllowed, component.Grid); // Starlight
         _ui.SetUiState(store, StoreUiKey.Key, state);
     }
 
@@ -282,6 +284,12 @@ public sealed partial class StoreSystem
                 HandleRefundComp(uid, component, upgradeActionId.Value);
         }
 
+        if (listing.ProductLanguage != null) //Starlight-start
+        {
+            var language = _languageSystem.GetLanguagePrototype(listing.ProductLanguage);
+            if  (language != null) _languageSystem.AddLanguage(buyer, language);
+        } // Starlight-end
+
         if (listing.ProductEvent != null)
         {
             if (!listing.RaiseProductEventOnUser)
@@ -422,7 +430,7 @@ public sealed partial class StoreSystem
         // Only tell operatives to lock their uplink if it can be locked
         var showFooter = HasComp<RingerUplinkComponent>(storeUid);
 
-    var state = new StoreUpdateState(storeComp.LastAvailableListings, allCurrency, showFooter, storeComp.RefundAllowed, storeComp.Grid); // Starlight
+        var state = new StoreUpdateState(storeComp.LastAvailableListings, allCurrency, showFooter, storeComp.RefundAllowed, storeComp.Grid); // Starlight
 
         // Set the UI state - this will update all connected sessions automatically
         _ui.SetUiState(storeUid, StoreUiKey.Key, state);

--- a/Content.Shared/Store/ListingPrototype.cs
+++ b/Content.Shared/Store/ListingPrototype.cs
@@ -31,6 +31,7 @@ public partial class ListingData : IEquatable<ListingData>
         other.Priority,
         other.ProductEntity,
         other.ProductAction,
+        other.ProductLanguage, //Starlight
         other.ProductUpgradeId,
         other.ProductActionEntity,
         other.ProductEvent,
@@ -57,6 +58,7 @@ public partial class ListingData : IEquatable<ListingData>
         int priority,
         EntProtoId? productEntity,
         EntProtoId? productAction,
+        string? productLanguage, //Starlight
         ProtoId<ListingPrototype>? productUpgradeId,
         EntityUid? productActionEntity,
         object? productEvent,
@@ -79,6 +81,7 @@ public partial class ListingData : IEquatable<ListingData>
         Priority = priority;
         ProductEntity = productEntity;
         ProductAction = productAction;
+        ProductLanguage = productLanguage; //Starlight
         ProductUpgradeId = productUpgradeId;
         ProductActionEntity = productActionEntity;
         ProductEvent = productEvent;
@@ -161,6 +164,12 @@ public partial class ListingData : IEquatable<ListingData>
     public EntProtoId? ProductAction;
 
     /// <summary>
+    /// The language that is given when the listing is purchased.
+    /// </summary>
+    [DataField]
+    public string? ProductLanguage; //Starlight
+
+    /// <summary>
     /// The listing ID of the related upgrade listing. Can be used to link a <see cref="ProductAction"/> to an
     /// upgrade or to use standalone as an upgrade
     /// </summary>
@@ -214,7 +223,7 @@ public partial class ListingData : IEquatable<ListingData>
     [DataField]
     public bool Unavailable = false;
 
-	/// <summary>
+    /// <summary>
     /// Whether or not to apply the store listing to the player mob rather than the player mind.
     /// </summary>
     [DataField]
@@ -231,6 +240,7 @@ public partial class ListingData : IEquatable<ListingData>
             Description != listing.Description ||
             ProductEntity != listing.ProductEntity ||
             ProductAction != listing.ProductAction ||
+            ProductLanguage != listing.ProductLanguage || // Starlight
             ProductEvent?.GetType() != listing.ProductEvent?.GetType() ||
             RestockTime != listing.RestockTime ||
             DisableRefund != listing.DisableRefund ||
@@ -305,6 +315,7 @@ public sealed partial class ListingDataWithCostModifiers : ListingData
             listingData.Priority,
             listingData.ProductEntity,
             listingData.ProductAction,
+            listingData.ProductLanguage, //Starlight
             listingData.ProductUpgradeId,
             listingData.ProductActionEntity,
             listingData.ProductEvent,

--- a/Resources/Locale/en-US/store/categories.ftl
+++ b/Resources/Locale/en-US/store/categories.ftl
@@ -26,3 +26,5 @@ store-caregory-spellbook-events = Event Spells
 
 # Nukie Delivery
 store-category-nukie-delivery = Offers
+
+store-category-languages = Languages

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -74,6 +74,7 @@
     name: store-preset-name-pai #Starlight name change for data purity
     categories:
     - PAIAbilities
+    - Languages #Starlight
     currencyWhitelist:
     - SiliconMemory
     balance:

--- a/Resources/Prototypes/_StarLight/Catalog/pai_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/pai_catalog.yml
@@ -1,0 +1,271 @@
+- type: listing
+  id: SolCommon
+  name: language-SolCommon-name
+  description: language-SolCommon-description
+  productLanguage: SolCommon
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: solcom
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Canilunzt
+  name: language-Canilunzt-name
+  description: language-Canilunzt-description
+  productLanguage: Canilunzt
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: vulp
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Bubblish
+  name: language-Bubblish-name
+  description: language-Bubblish-description
+  productLanguage: Bubblish
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: slime
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Draconic
+  name: language-Draconic-name
+  description: language-Draconic-description
+  productLanguage: Draconic
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: lizard
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Marish
+  name: language-Marish-name
+  description: language-Marish-description
+  productLanguage: Marish
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: shadekin
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Moffic
+  name: language-Moffic-name
+  description: language-Moffic-description
+  productLanguage: Moffic
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: moth
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Nekomimetic
+  name: language-Nekomimetic-name
+  description: language-Nekomimetic-description
+  productLanguage: Nekomimetic
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: neko
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Sylvan
+  name: language-Sylvan-name
+  description: language-Sylvan-description
+  productLanguage: Sylvan
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: plant
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Terrum
+  name: language-Terrum-name
+  description: language-Terrum-description
+  productLanguage: Terrum
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: golem
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: VoxPidgin
+  name: language-VoxPidgin-name
+  description: language-VoxPidgin-description
+  productLanguage: VoxPidgin
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: vox
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Scratch
+  name: language-Scratch-name
+  description: language-Scratch-description
+  productLanguage: Scratch
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: avali
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Thaveyan
+  name: language-Thaveyan-name
+  description: language-Thaveyan-description
+  productLanguage: Thaveyan
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: thaveyan
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Darktongue
+  name: language-Darktongue-name
+  description: language-Darktongue-description
+  productLanguage: Darktongue
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: darktongue
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Classical
+  name: language-Classical-name
+  description: language-Classical-description
+  productLanguage: Classical
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: classical
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Grumbakul
+  name: language-Grumbakul-name
+  description: language-Grumbakul-description
+  productLanguage: Grumbakul
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: dwarvish
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Aielic
+  name: language-Aielic-name
+  description: language-Aielic-description
+  productLanguage: Aielic
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: high-elven
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1
+
+- type: listing
+  id: Lagomorphian
+  name: language-Lagomorphian-name
+  description: language-Lagomorphian-description
+  productLanguage: Lagomorphian
+  icon:
+    sprite: /Textures/_Starlight/Interface/language_icon.rsi
+    state: lagomorph
+  cost:
+    SiliconMemory: 5
+  categories:
+    - Languages
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 1

--- a/Resources/Prototypes/_StarLight/Store/categories.yml
+++ b/Resources/Prototypes/_StarLight/Store/categories.yml
@@ -167,3 +167,8 @@
 - type: storeCategory
   id: CantripsStandard
   name: store-category-cantrips-standard
+
+# Languages
+- type: storeCategory
+  id: Languages
+  name: store-category-languages


### PR DESCRIPTION
# Short description
Added the ability for the pAI to purchase languages, and then listed most of the languages it can already understand to the list.

# Why we need to add this
This is yet another followup to my work on pAIs to make them more worthwile as communication and information assistants/secretaries.

# Media (Video/Screenshots)
<img width="410" height="931" alt="image" src="https://github.com/user-attachments/assets/ffb0faa1-18a5-4e07-8571-0c78c4933fb0" />
<img width="512" height="438" alt="image" src="https://github.com/user-attachments/assets/fb339f3d-3795-4a41-804b-dedf5cb1c0a1" />

# Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Notarin Steele
- add: Gave pAIs the ability to learn/purchase most station languages. 
