### PR TITLE
Adjust Zookeeper contraband

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -154,7 +154,7 @@
     proto: PelletShotgunPracticeSpreadTrace
 
 - type: entity
-  parent: [ BaseShellShotgun, BaseSecurityContraband ]
+  parent: [ BaseShellShotgun, BaseSecurityZookeeperContraband ]
   id: ShellTranquilizer
   name: 12 gauge tranquilizer slug # Starlight change: .50 -> 12 gauge
   description: The standard cartridge used by most modern shotguns. Tranquilizer ammunition contains a single ballistic syringe loaded with a strong sedative that harmlessly puts targets to sleep.

--- a/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/base_contraband.yml
@@ -133,6 +133,15 @@
     allowedDepartments: [ Security ]
     allowedJobs: [ Bartender, Zookeeper ]
 
+- type: entity
+  id: BaseSecurityZookeeperContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Security ]
+    allowedJobs: [ Zookeeper ]
+
 # for ~objective items not held by command
 - type: entity
   id: BaseWardenGrandTheftContraband


### PR DESCRIPTION
## Short description
Marks 12 gauge tranquilizer slug as not contraband for Zookeepers.

## Why we need to add this
Zookeepers start with boxes of tranquilizer slugs in their room on 2 of 3 maps where they can spawn, but since all ammo is technically contraband they cannot use it. This is not visible on the boxes however, so unless you cycle out the ammo you will not see this.

| Map  | Starting Ammo 1 | Starting Ammo 2 | Starting Armour |
| ------------- | ------------- | ------------- | ------------- |
| Cog  | 1x box of 12 gauge tranquilizer slugs | | |
| Manor  | 1x box of 12 gauge tranquilizer slugs | 2x 12 gauge slug | 1x Armor vest |
| Ming | 2x 12 gauge beanbug drum | |

## Media (Video/Screenshots)
<img width="390" alt="image" src="https://github.com/user-attachments/assets/5d592d2b-a245-4dfa-aa18-fabb27ed9317" />
<img width="390" alt="image" src="https://github.com/user-attachments/assets/a1ebbb8e-b41b-4fe2-87c2-d09e53223000" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- tweak: 12 gauge tranquilizer slugs are no longer contraband for Zookeepers
