### PR TITLE
Plumbing Patch 1

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -160,7 +160,7 @@ namespace Content.Server.Chemistry.EntitySystems
             var container = _itemSlotsSystem.GetItemOrNull(chemMaster, SharedChemMaster.InputSlotName);
             if (container is null ||
                 !_solutionContainerSystem.TryGetFitsInDispenser(container.Value, out var containerSoln, out var containerSolution) ||
-                !_solutionContainerSystem.TryGetSolution(chemMaster.Owner, SharedChemMaster.BufferSolutionName, out _, out var bufferSolution))
+                !_solutionContainerSystem.TryGetSolution(chemMaster.Owner, SharedChemMaster.BufferSolutionName, out var bufferSoln, out var bufferSolution)) //Starlight-edit
             {
                 return;
             }
@@ -173,9 +173,11 @@ namespace Content.Server.Chemistry.EntitySystems
             }
             else // Container to buffer
             {
-                amount = FixedPoint2.Min(amount, containerSolution.GetReagentQuantity(id));
+                // Starlight-Start: No longer force transfer as the buffer container no longer is infinitely big.
+                amount = FixedPoint2.Min(amount, containerSolution.GetReagentQuantity(id), bufferSolution.AvailableVolume);
                 _solutionContainerSystem.RemoveReagent(containerSoln.Value, id, amount);
-                bufferSolution.AddReagent(id, amount);
+                _solutionContainerSystem.TryAddReagent(bufferSoln.Value, id, amount, out _);
+                // Starlight-End
             }
 
             UpdateUiState(chemMaster, updateLabel: true);

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -102,6 +102,7 @@
     - id: BoxVial
     - id: PlasmaChemistryVial
     - id: ChemBag
+    - id: RPLD # Starlight
     - id: ClothingHandsGlovesLatex
     - id: ClothingHeadsetMedical
     - id: ClothingMaskSterile

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -100,7 +100,7 @@
   - type: SolutionContainerManager
     solutions:
       buffer:
-        maxVol: 5000 # Starlight: limited to 5000u for plumbing compatibility and realism
+        maxVol: 10000 # Starlight: limited to 10000u for plumbing compatibility and realism
         canReact: false
   - type: DumpableSolution
     solution: buffer


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Raises ChemMaster buffer size to 10000u, adds RPLD to Chemist locker, and switches to using safe TryAddReagent for beaker to buffer transfers inside ChemMaster.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Initial feedback has indicated 5000u was too small for the ChemMaster buffer container size. RPLD was always planned to be in chemist locker I just didn't get around to adding it yet. And using the safe method prevents those transfers from filling buffer past its limit.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: FeralCreature
- tweak: ChemMaster buffer can now hold up to 10000u of reagents.
- add: Added the Rapid Plumbing Device (RPLD) to chemist lockers.
- fix: Bad reagent transfer logic inside ChemMaster.