### PR TITLE
Change the name of the loading cyborg module

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -715,7 +715,7 @@
 - type: entity
   id: BorgModuleAdvancedLoading
   parent: [ BaseBorgModuleSupply, BaseProviderBorgModule ]
-  name: loading cyborg module
+  name: advanced loading cyborg module
   description: Advanced module for cargo cyborgs, with specialised hydraulic clamps
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Change the name from loading cyborg module to advanced loading cyborg module
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Makes the module sit with the other advanced modules in the exosuit fabricator
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="300" height="451" alt="image" src="https://github.com/user-attachments/assets/ec50bc7b-0767-4dec-95da-b041a7c97b4c" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: SevenShades
- tweak: Renamed the cargo cyborg's advanced module to make it sit with the other advanced modules