### PR TITLE
Fix double emergency tanks being 2x2

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -183,7 +183,9 @@
     sprite: Objects/Tanks/emergency_double.rsi
   - type: Item
     sprite: Objects/Tanks/emergency_double.rsi
-    size: Normal # Starlight edit
+    size: Normal # Starlight start
+    shape:
+      - 0,0,0,1
     storedSprite:
       state: storage
       sprite: Objects/Tanks/emergency_double.rsi


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
With #3218 double emergency oxygen tanks were explicitly made `Normal` size, but the default size for that is 2x2 causing an unintentional significant nerf to them. This restores them to their original shape.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Uh, bugfix.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="195" height="154" alt="image" src="https://github.com/user-attachments/assets/3f662a1a-0c74-4ef7-936c-ed6534dc9cf0" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower

- fix: CED reenabled their double emergency oxygen tank compression pipeline. (They are 1x2 again).