### PR TITLE
Add the diagnostic HuD to engineering cyborgs

### DIFF
--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -53,6 +53,14 @@
   - Engineering
   - Science
 
+  # Starlight start: Engiborg hud
+  addComponents:
+  - type: ShowHealthBars
+    damageContainers:
+    - Inorganic
+    - Silicon
+  # Starlight end
+
   # Visual
   inventoryTemplateId: borgShort
   spritePath: Mobs/Silicon/Chassis/engineer.rsi


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a diagnostic overlay to engineering cyborgs so they can see the health of other borgs and bots
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This allows engineering cyborgs to visually see if another borg or bot needs help, much like engi xenoborgs
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="200" height="192" alt="image" src="https://github.com/user-attachments/assets/429fde70-0b6b-4dea-9d4c-09af0d3a3874" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: SevenShades
- add: Added a diagnostic HuD to engineering cyborgs