### PR TITLE
Reporter Digiboard Starts with a Standart Battery instead of the Small one

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/digiboards.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/digiboards.yml
@@ -38,11 +38,11 @@
       slots:
         cell_slot:
           name: power-cell-slot-component-slot-name-default
-          startingItem: PowerCellSmall
+          startingItem: PowerCellMedium
           whitelist:
             tags:
               - PowerCell
-              - PowerCellSmall
+              - PowerCellMedium
     - type: PowerCellDraw
     - type: ActivatableUIRequiresPowerCell
     - type: NewsWriter

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/digiboards.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/digiboards.yml
@@ -42,7 +42,7 @@
           whitelist:
             tags:
               - PowerCell
-              - PowerCellMedium
+              - PowerCellSmall
     - type: PowerCellDraw
     - type: ActivatableUIRequiresPowerCell
     - type: NewsWriter


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Change the Reporter digiboard starting battery to the standard size battery.

## Why we need to add this
The small battery is NOT enough for writing a standard news report, which forces people to make less effort on the news just to ship it quickly before the power runs out. Even though short news on the go **sounds** like a good idea and is the main idea, the less effort people put into the news more it looks like spam news, and fewer people bother to read it.

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl:
- tweak: Reporter Digiboard now has Standard Batteries.
