### PR TITLE
Remove Extra Roles requirement from ERT leader

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -8,8 +8,9 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 20h
-  - !type:RolesRequirement
-    proto: ExtRolesReq
+  - !type:DepartmentTimeRequirement
+    department: CentralCommand
+    time: 10h
   - !type:DepartmentTimeRequirement
     department: Command
     time: 10h

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/TSF/marine.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/TSF/marine.yml
@@ -28,8 +28,6 @@
   requirements:
     - !type:OverallPlaytimeRequirement
       time: 72000 # 20h
-    - !type:RolesRequirement
-      proto: ExtRolesReq
   setPreference: false
   icon: JobIconTSF
   rules: job-rules-tsf-aligned


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Soft reverts one part of #3291

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
There was zero reasoning given for the ERT Leader change whatsoever.
Also, player feedback suggests it is entirely unwanted.

The PR also made ERT leader just straight up not require ERT time. Which is ???

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower

- remove: ERT Leader and TSF Elite no longer need Extra Roles.