### PR TITLE
add autocomplete to characterforceprototype

### DIFF
--- a/Content.Server/_Starlight/Commands/CharacterForcePrototypeCommand.cs
+++ b/Content.Server/_Starlight/Commands/CharacterForcePrototypeCommand.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using Content.Server.Administration;
+using Content.Server.Database;
 using Content.Server.Preferences.Managers;
 using Content.Server.Station.Systems;
 using Content.Shared.Administration;
@@ -58,11 +60,19 @@ public sealed class CharacterForcePrototypeCommand : LocalizedCommands
 
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
-        if (args.Length == 1)
+        switch (args.Length)
         {
-            return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), LocalizationManager.GetString("shell-argument-username-hint"));
+            case 1:
+                return CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), LocalizationManager.GetString("shell-argument-username-hint"));
+            case 2:
+                _players.TryGetSessionByUsername(args[0], out var player);
+                if (player == null)
+                    return CompletionResult.Empty;
+                var prefs = _prefsManager.GetPreferences(player.UserId).Characters.Select(c => new CompletionOption(c.Key.ToString(),c.Value.Name));
+                return CompletionResult.FromOptions(prefs);
+            default:
+                break;
         }
-
         return CompletionResult.Empty;
     }
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
adds character slot name autocomplete to `characterforceprototype`
## Why we need to add this
makes using it on others actually possible

## Media (Video/Screenshots)
<img width="538" height="76" alt="image" src="https://github.com/user-attachments/assets/9cf855a1-1f52-4d23-8a91-77390daa965b" />
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanator
- add: character slot autocomplete for "characterforceprototype"


