### PR TITLE
Plumbing UI touch-up

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -11,8 +11,8 @@
                 <Label Text="{Loc 'chem-master-window-container-label'}" />
                 <Control HorizontalExpand="True" />
                 <!-- Starlight-start: Plumbing valve -->
-                <Button MinSize="80 0" Name="InputEjectButton" Access="Public" Text="{Loc 'chem-master-window-eject-button'}" StyleClasses="OpenRight" />
-                <Button MinSize="80 0" Name="ValveButton" Access="Public" Text="{Loc 'chem-master-window-valve-closed'}" StyleClasses="OpenLeft" />
+                <Button MinSize="80 0" Name="ValveButton" Access="Public" Text="{Loc 'chem-master-window-valve-closed'}" StyleClasses="OpenRight" />
+                <Button MinSize="80 0" Name="InputEjectButton" Access="Public" Text="{Loc 'chem-master-window-eject-button'}" StyleClasses="OpenLeft" />
                 <!-- Starlight-end -->
             </BoxContainer>
 

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -46,7 +46,15 @@
             <SpriteView Name="View"
                         Scale="4 4"
                         HorizontalAlignment="Center" />
-            <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center">
+            <!-- Starlight-start: Plumbing valve -->
+            <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 4">
+                <Button Name="ValveButton"
+                        Access="Public"
+                        Text="{Loc 'reagent-dispenser-window-valve-closed'}"
+                        StyleClasses="" />
+            </BoxContainer>
+            <!-- Starlight-end -->
+            <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 0 0 4"><!-- Starlight: Margin -->
                 <Button Name="ClearButton"
                         Access="Public"
                         Text="{Loc 'reagent-dispenser-window-clear-button'}"
@@ -54,13 +62,7 @@
                 <Button Name="EjectButton"
                         Access="Public"
                         Text="{Loc 'reagent-dispenser-window-eject-button'}"
-                        StyleClasses="OpenBoth" />
-                <!-- Starlight-start: Plumbing valve -->
-                <Button Name="ValveButton"
-                        Access="Public"
-                        Text="{Loc 'reagent-dispenser-window-valve-closed'}"
                         StyleClasses="OpenLeft" />
-                <!-- Starlight-end -->
             </BoxContainer>
         </BoxContainer>
         <SplitContainer Orientation="Vertical"

--- a/Resources/Locale/en-US/_Starlight/chemistry/components/reagent-dispenser-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/chemistry/components/reagent-dispenser-component.ftl
@@ -2,5 +2,5 @@ reagent-dispenser-popup-no-energy = Not enough energy!
 reagent-dispenser-component-cannot-fit-message = The container can't hold that much!
 
 # Plumbing valve
-reagent-dispenser-window-valve-open = Close Valve
-reagent-dispenser-window-valve-closed = Open Valve
+reagent-dispenser-window-valve-open = Valve: Open
+reagent-dispenser-window-valve-closed = Valve: Closed


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

- Return "Eject" buttons in ChemMaster/ReagentDispenser to their original positions pre-plumbing (it was not done intentionally)
- Adjust valve control button localization in ReagentDispenser to match localization in ChemMaster

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Muscle memory dies hard. Puts the Eject buttons back where they were. This also helps for players that play on multiple servers.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="851" height="881" alt="image" src="https://github.com/user-attachments/assets/8a189341-cb3e-43e5-ac21-d2a547cfe9d3" />

<img width="1135" height="715" alt="image" src="https://github.com/user-attachments/assets/53de42cb-96d9-4ea9-9475-60d34c540e82" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: The Central Medical Division apologizes for moving the Eject buttons of the ChemMaster and reagent dispenser, and has returned them to their original positions.
