### PR TITLE
Terminator 1st phase skip

### DIFF
--- a/Resources/Prototypes/_StarLight/Actions/implant.yml
+++ b/Resources/Prototypes/_StarLight/Actions/implant.yml
@@ -68,3 +68,18 @@
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: gib
+
+# Terminator 1st phase Self-Destruct
+- type: entity
+  parent: [BaseSuicideAction, BaseImplantAction]
+  id: ActionActivateTerminatorDeathAcidifier
+  name: Activate Bio-Degrading Mechanism
+  description: Activates your first-phase bio-degradation mechanism, completely melting your outer layer and all equipped items. Your inner endoskeleton is revealed and left fully exposed.
+  components:
+  - type: Action
+    checkCanInteract: false
+    itemIconStyle: BigAction
+    priority: -20
+    icon:
+      sprite: Objects/Magic/magicactions.rsi
+      state: gib

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/terminator.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/terminator.yml
@@ -35,6 +35,10 @@
     - Dead
   # endoskeleton need it
   - type: TransferMindOnGib
+  # self destruct option for phase 1 (manual only, won't trigger on phase 2 transformation)
+  - type: AutoImplant
+    implants:
+    - TerminatorDeathAcidifierImplant
   - type: MobThresholds
     thresholds:
       0: Alive

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/subdermal_implants.yml
@@ -144,6 +144,29 @@
         enum.StorageUiKey.Key:
           type: StorageBoundUserInterface
 
+# death acidifier for terminator phase 1, only manual activation (no death trigger to avoid phase 2 transformation issues)
+- type: entity
+  parent: BaseSubdermalImplant
+  id: TerminatorDeathAcidifierImplant
+  name: terminator self-destruct implant
+  description: This implant melts the user and their equipment upon manual activation. Will not trigger during transformation.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+    permanent: true
+    implantAction: ActionActivateTerminatorDeathAcidifier
+  - type: TriggerOnActivateImplant
+  - type: GibOnTrigger
+    targetUser: true
+    deleteItems: true
+  - type: SpawnOnTrigger
+    proto: Acidifier
+    predicted: true
+  - type: Tag
+    tags:
+    - SubdermalImplant
+    - HideContextMenu
+
 # microbomb that gibs but does less collateral damage, for terminator
 - type: entity
   parent: MicroBombImplant


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Allows the future chrono sent terminator to skip thier 1st phase incase they get cuffed... somhow

## Why we need to add this
Allows for the terminator to self destruct early when they finish. (they will need to do it 2 times)

## Media (Video/Screenshots)
<img width="1247" height="847" alt="image" src="https://github.com/user-attachments/assets/68192112-db40-48e4-90a6-f71a0cc310fc" />
<img width="1361" height="820" alt="image" src="https://github.com/user-attachments/assets/91ec9006-6a87-4f71-b7b1-ebd9d66bdc32" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
Future NT has upgraded thier Exterminators!

:cl: Scarlet Lightweaver
- add: Added a phase skip option for terminators.
