### PR TITLE
Allows the NTR Fancy cane to be used like a Makeshift crowbar

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cane_nt.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cane_nt.yml
@@ -70,7 +70,5 @@
   - type: DrawableSolution
     solution: battery
   - type: MobilityAid
-  - type: ToolTileCompatible
-    delay: 2
   - type: Prying
     speedModifier: 0.50

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cane_nt.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cane_nt.yml
@@ -71,4 +71,4 @@
     solution: battery
   - type: MobilityAid
   - type: Prying
-    speedModifier: 0.50
+    speedModifier: 0.25

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cane_nt.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/cane_nt.yml
@@ -70,3 +70,7 @@
   - type: DrawableSolution
     solution: battery
   - type: MobilityAid
+  - type: ToolTileCompatible
+    delay: 2
+  - type: Prying
+    speedModifier: 0.50


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fancy cane was changed to be able to pry open unpowered doors like a crowbar.

## Why we need to add this
Seems unfitting to NTR carry a crowbar around, luckily his durable and Fancy cane can be used as an improvised Crowbar on power outages, and when needed, the NT rep walks a lot, so it's really easy to get stuck behind doors. (It has the same stats as a Makeshift crowbar; maybe it can be changed to be as quick as a normal crowbar)

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Vincolan
- add: NT Representative Cane is now able to be used like a crowbar.
