### PR TITLE
Plumbing Patch 3

### DIFF
--- a/Content.Server/_Starlight/Plumbing/EntitySystems/PlumbingPillPressSystem.cs
+++ b/Content.Server/_Starlight/Plumbing/EntitySystems/PlumbingPillPressSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Server._Starlight.Plumbing.Components;
 using Content.Server._Starlight.Plumbing.Nodes;
+using Content.Shared.Starlight.Medical.Items.Components;
 using Content.Shared._Starlight.Plumbing;
 using Content.Shared._Starlight.Plumbing.Components;
 using Content.Shared.Chemistry;
@@ -14,6 +15,7 @@ using JetBrains.Annotations;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using SharedAppearanceSystem = Robust.Shared.GameObjects.SharedAppearanceSystem;
 
@@ -32,9 +34,11 @@ public sealed class PlumbingPillPressSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly PlumbingPullSystem _pullSystem = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
     private static readonly EntProtoId PillPrototypeId = "Pill";
     private static readonly EntProtoId PatchPrototypeId = "Patch";
+    private const int MaxOutputEntitiesOnTile = 30;
 
     /// <summary>Max dosage matches the ChemMaster limit.</summary>
     private const uint MaxDosage = 20;
@@ -73,17 +77,28 @@ public sealed class PlumbingPillPressSystem : EntitySystem
         var dosage = FixedPoint2.New(ent.Comp.Dosage);
         var produced = false;
 
-        while (solution.Volume >= dosage)
+        if (solution.Volume >= dosage)
         {
+            // Spawn on the same tile, offset slightly south
+            var spawnCoords = Transform(ent.Owner).Coordinates.Offset(new Vector2(0, -0.3f));
+
+            if (GetOutputEntityCount(spawnCoords) >= MaxOutputEntitiesOnTile)
+            {
+                _appearance.SetData(ent.Owner, PlumbingVisuals.Running, false);
+                UpdateUiState(ent);
+                return;
+            }
+
             var withdrawal = _solutionSystem.SplitSolution(solutionEnt.Value, dosage);
 
             if (withdrawal.Volume <= FixedPoint2.Zero)
-                break;
+            {
+                _appearance.SetData(ent.Owner, PlumbingVisuals.Running, false);
+                UpdateUiState(ent);
+                return;
+            }
 
             produced = true;
-
-            // Spawn on the same tile, offset slightly south
-            var spawnCoords = Transform(ent.Owner).Coordinates.Offset(new Vector2(0, -0.3f));
 
             if (ent.Comp.OutputMode == PillPressOutputMode.Pill)
             {
@@ -303,5 +318,18 @@ public sealed class PlumbingPillPressSystem : EntitySystem
     {
         if (TryComp<PlumbingDeviceComponent>(uid, out var device))
             _audio.PlayPvs(device.ClickSound, uid, AudioParams.Default.WithVolume(-2f));
+    }
+
+    private int GetOutputEntityCount(EntityCoordinates coords)
+    {
+        var count = 0;
+
+        foreach (var entity in _lookup.GetEntitiesIntersecting(coords))
+        {
+            if (HasComp<PillComponent>(entity) || HasComp<PatchComponent>(entity))
+                count++;
+        }
+
+        return count;
     }
 }

--- a/Content.Server/_Starlight/Plumbing/EntitySystems/PlumbingReactorSystem.cs
+++ b/Content.Server/_Starlight/Plumbing/EntitySystems/PlumbingReactorSystem.cs
@@ -134,7 +134,7 @@ public sealed class PlumbingReactorSystem : EntitySystem
                 return;
             }
 
-            _reactionSystem.FullyReactSolution(bufferEnt.Value);
+            var reactionOccurred = _reactionSystem.FullyReactSolution(bufferEnt.Value);
 
             var products = new List<(ReagentId Reagent, FixedPoint2 Quantity)>();
             foreach (var reagent in buffer.Contents)
@@ -154,10 +154,12 @@ public sealed class PlumbingReactorSystem : EntitySystem
                     if (removed > 0)
                         _solutionSystem.TryAddReagent(outputEnt.Value, reagent, removed, out _);
                 }
+            }
 
-                // Reset buffer to ambient temperature after products are transferred.
+            if (reactionOccurred)
+            {
+                // Reset buffer to ambient temperature after any completed reaction pass.
                 _solutionSystem.SetTemperature(bufferEnt.Value, Atmospherics.T20C);
-
                 _appearance.SetData(ent.Owner, PlumbingVisuals.Running, false);
             }
         }

--- a/Content.Server/_Starlight/Plumbing/EntitySystems/PlumbingSmartDispenserSystem.cs
+++ b/Content.Server/_Starlight/Plumbing/EntitySystems/PlumbingSmartDispenserSystem.cs
@@ -111,7 +111,8 @@ public sealed class PlumbingSmartDispenserSystem : EntitySystem
         if (!_solutionSystem.TryGetSolution(ent.Owner, ent.Comp.SolutionName, out var fridgeSolnEnt, out var fridgeSolution))
             return;
 
-        var available = fridgeSolution.GetReagentQuantity(new ReagentId(reagentId, null));
+        var sourceReagent = fridgeSolution.Contents.FirstOrDefault(r => r.Reagent.Prototype == reagentId);
+        var available = sourceReagent.Quantity;
 
         if (available <= FixedPoint2.Zero)
         {
@@ -132,11 +133,11 @@ public sealed class PlumbingSmartDispenserSystem : EntitySystem
         }
 
         var transferAmount = FixedPoint2.Min(available, jugAvailable);
-        var removed = _solutionSystem.RemoveReagent(fridgeSolnEnt.Value, new ReagentId(reagentId, null), transferAmount);
+        var removed = _solutionSystem.RemoveReagent(fridgeSolnEnt.Value, sourceReagent.Reagent, transferAmount);
 
         if (removed > FixedPoint2.Zero)
         {
-            _solutionSystem.TryAddReagent(jugSolnEnt.Value, reagentId, removed, out _);
+            _solutionSystem.TryAddReagent(jugSolnEnt.Value, sourceReagent.Reagent, removed, out _);
 
             var reagentName = _prototypeManager.Index<ReagentPrototype>(reagentId).LocalizedName;
             _popup.PopupEntity(Loc.GetString("plumbing-smart-dispenser-filled",

--- a/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
@@ -259,10 +259,11 @@ namespace Content.Shared.Chemistry.Reaction
             return true;
         }
 
+        // Starlight Start: FullyReactSolution returns bool reactionOccured.
         /// <summary>
         ///     Continually react a solution until no more reactions occur, with a volume constraint.
         /// </summary>
-        public void FullyReactSolution(Entity<SolutionComponent> soln, ReactionMixerComponent? mixerComponent = null)
+        public bool FullyReactSolution(Entity<SolutionComponent> soln, ReactionMixerComponent? mixerComponent = null)
         {
             // construct the initial set of reactions to check.
             SortedSet<ReactionPrototype> reactions = new();
@@ -272,18 +273,24 @@ namespace Content.Shared.Chemistry.Reaction
                     reactions.UnionWith(reactantReactions);
             }
 
+            var reactionOccurred = false;
+
             // Repeatedly attempt to perform reactions, ending when there are no more applicable reactions, or when we
             // exceed the iteration limit.
             for (var i = 0; i < MaxReactionIterations; i++)
             {
                 if (!ProcessReactions(soln, reactions, mixerComponent))
-                    return;
+                    return reactionOccurred;
+
+                reactionOccurred = true;
             }
 
             Log.Error($"{nameof(Solution)} {soln.Owner} could not finish reacting in under {MaxReactionIterations} loops.");
+            return reactionOccurred;
         }
     }
-
+    // Starlight End
+    
     /// <summary>
     ///     Raised directed at the owner of a solution to determine whether the reaction should be allowed to occur.
     /// </summary>

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -33,6 +33,9 @@ using Robust.Shared.Utility;
 using Content.Shared.NodeContainer;
 using Content.Shared.Atmos;
 using Content.Shared._Starlight.Atmos;
+using Content.Shared._Starlight.Atmos.Components;
+using Content.Shared.Prototypes;
+using Content.Shared._Starlight.Plumbing.Components;
 // Starlight End
 
 namespace Content.Shared.RCD.Systems;
@@ -635,7 +638,12 @@ public sealed class RCDSystem : EntitySystem
         // Check rule: The tile is unoccupied
         var isWindow = prototype.ConstructionRules.Contains(RcdConstructionRule.IsWindow);
         var isCatwalk = prototype.ConstructionRules.Contains(RcdConstructionRule.IsCatwalk);
-
+        // Starlight Start: RPLD
+        var isPlumbingMachinePlacement = component.IsRPLD
+            && prototype.Prototype != null
+            && _protoManager.TryIndex<EntityPrototype>(prototype.Prototype, out var constructionProto)
+            && constructionProto.HasComponent<PlumbingConnectorAppearanceComponent>(_entityManager.ComponentFactory);
+        // Starlight End: RPLD
         _intersectingEntities.Clear();
         _lookup.GetLocalEntitiesIntersecting(gridUid, position, _intersectingEntities, -0.05f, LookupFlags.Uncontained);
 
@@ -643,7 +651,15 @@ public sealed class RCDSystem : EntitySystem
         {
             if (isWindow && HasComp<SharedCanBuildWindowOnTopComponent>(ent))
                 continue;
+            // Starlight Start: RPLD
+            if (isPlumbingMachinePlacement && Transform(ent).Anchored && HasComp<PlumbingConnectorAppearanceComponent>(ent))
+            {
+                if (popMsgs)
+                    _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), uid, user);
 
+                return false;
+            }
+            // Starlight End: RPLD
             if (isCatwalk && _tags.HasTag(ent, CatwalkTag))
             {
                 if (popMsgs)
@@ -845,6 +861,12 @@ public sealed class RCDSystem : EntitySystem
                         Transform(ent).LocalRotation = direction.ToAngle();
                         break;
                 }
+
+                // Starlight Start: RPLD - Re-anchor ducts after rotation is set.
+                // PipeRestrictOverlap may have incorrectly unanchored because the final rotation wasn't applied yet at that point.
+                if (component.IsRPLD && !Transform(ent).Anchored && HasComp<PipeRestrictOverlapComponent>(ent))
+                    _transform.AnchorEntity(ent, Transform(ent));
+                // Starlight End: RPLD
 
                 _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used RCD to spawn {ToPrettyString(ent)} at {position} on grid {gridUid}");
                 break;

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -5,9 +5,13 @@
   placement:
     mode: SnapgridCenter
   components:
+  # Starlight-start: Make dispenser rotatable.
   - type: Transform
     anchored: true
-    noRot: true
+    noRot: false
+  - type: Rotatable
+    rotateWhileAnchored: true
+  # Starlight-end
   - type: Clickable
   - type: InteractionOutline
   - type: Appearance

--- a/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
@@ -16,8 +16,8 @@
       - state: industrial-panel
         map: ["enum.WiresVisualLayers.MaintenancePanel"]
         visible: false
+    snapCardinals: false # Starlight-edit: allow non-cardinal rotation for chem dispenser to avoid conflict with 4 direction plumbing connector sprites
     # Starlight-end
-    snapCardinals: true
   - type: Storage
     openOnActivate: false
     whitelist:

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -6,9 +6,15 @@
   placement:
     mode: SnapgridCenter
   components:
+  # Starlight-start: Make ChemMaster rotatable.
+  - type: Transform
+    noRot: false
+  - type: Rotatable
+    rotateWhileAnchored: true
+  # Starlight-end
   - type: Sprite
     sprite: Structures/Machines/mixer.rsi
-    snapCardinals: true
+    snapCardinals: false # Starlight-edit: allow non-cardinal rotation for ChemMaster to avoid conflict with 4 direction plumbing connector sprites
     layers:
     - state: mixer_empty
     - state: mixer_screens

--- a/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_engineering.yml
@@ -39,11 +39,11 @@
   group: market
 
 - type: cargoProduct
-  id: EngineeringRPLD
+  id: PlumbingRPLD
   icon:
     sprite: _Starlight/Objects/Tools/rpld.rsi
     state: icon
   product: CrateRPLD
   cost: 800
-  category: cargoproduct-category-name-engineering
+  category: cargoproduct-category-name-medical
   group: market

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/engineering.yml
@@ -48,11 +48,13 @@
         id: RPD
 
 - type: entity
-  parent: CrateEngineeringSecure
+  parent: CrateMedicalSecure
   id: CrateRPLD
   name: RPLD crate
   description: A crate containing a single rapid plumbing device.
   components:
+  - type: AccessReader
+    access: [["Engineering"], ["Medical"]]
   - type: EntityTableContainerFill
     containers:
       entity_storage:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Tools/tools.yml
@@ -976,6 +976,8 @@
   name: RPLD
   description: A device used to rapidly deploy plumbing ducts and machines.
   components:
+  - type: Contraband
+    allowedDepartments: [ Engineering, Medical ]
   - type: RCD
     isRPLD: true
     availablePrototypes:

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Plumbing/plumbing_machines.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Plumbing/plumbing_machines.yml
@@ -101,6 +101,11 @@
   name: Plumbing Input
   description: A small tank you pour reagents into. Other machines pull from this. Connects in all directions.
   components:
+  - type: Physics
+    bodyType: Static
+    canCollide: false
+  - type: Fixtures
+    fixtures: {}
   - type: Sprite
     sprite: _Starlight/Structures/Piping/Plumbing/plumbers.rsi
     layers:
@@ -219,6 +224,11 @@
   name: Plumbing Output
   description: A small tank that pulls reagents from the network. Draw from it with a container. Connects in all directions.
   components:
+  - type: Physics
+    bodyType: Static
+    canCollide: false
+  - type: Fixtures
+    fixtures: {}
   - type: Sprite
     sprite: _Starlight/Structures/Piping/Plumbing/plumbers.rsi
     layers:
@@ -517,6 +527,11 @@
   name: Plumbing Filter
   description: Filters specific reagents from a duct network. Filtered reagents are sent to the side outlet while other reagents passthrough.
   components:
+  - type: Physics
+    bodyType: Static
+    canCollide: false
+  - type: Fixtures
+    fixtures: {}
   - type: Sprite
     sprite: _Starlight/Structures/Piping/Plumbing/plumbers.rsi
     layers:
@@ -585,6 +600,11 @@
   suffix: Flipped
   description: Filters specific reagents from a duct network. Filtered reagents are sent to the side outlet while other reagents passthrough.
   components:
+  - type: Physics
+    bodyType: Static
+    canCollide: false
+  - type: Fixtures
+    fixtures: {}
   - type: Sprite
     sprite: _Starlight/Structures/Piping/Plumbing/plumbers.rsi
     layers:
@@ -657,7 +677,7 @@
       outlet:
         !type:PlumbingNode
         nodeGroupID: Plumbing
-        pipeDirection: South
+        pipeDirection: TSouth
   - type: UserInterface
     interfaces:
       enum.PlumbingSynthesizerUiKey.Key:

--- a/Resources/Prototypes/_StarLight/RPLD/rpld.yml
+++ b/Resources/Prototypes/_StarLight/RPLD/rpld.yml
@@ -62,7 +62,7 @@
   prototype: PlumbingTank
   cost: 2
   delay: 0
-  collisionMask: Impassable
+  collisionMask: MachineMask
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -72,9 +72,9 @@
   sprite: /Textures/_Starlight/Interface/Radial/RPLD/pipe_input.png
   mode: ConstructObject
   prototype: PlumbingInput
-  cost: 2
+  cost: 1
   delay: 0
-  collisionMask: Impassable
+  collisionMask: MachineMask
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -84,9 +84,9 @@
   sprite: /Textures/_Starlight/Interface/Radial/RPLD/pipe_output.png
   mode: ConstructObject
   prototype: PlumbingOutput
-  cost: 2
+  cost: 1
   delay: 0
-  collisionMask: Impassable
+  collisionMask: MachineMask
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -98,7 +98,7 @@
   prototype: PlumbingSink
   cost: 2
   delay: 0
-  collisionMask: Impassable
+  collisionMask: MachineMask
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -108,9 +108,9 @@
   sprite: /Textures/_Starlight/Interface/Radial/RPLD/reaction_chamber.png
   mode: ConstructObject
   prototype: PlumbingReactor
-  cost: 5
+  cost: 3
   delay: 0
-  collisionMask: Impassable
+  collisionMask: MachineMask
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -122,7 +122,7 @@
   prototype: PlumbingPillPress
   cost: 3
   delay: 0
-  collisionMask: Impassable
+  collisionMask: MachineMask
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -133,9 +133,9 @@
   mode: ConstructObject
   prototype: PlumbingFilter
   mirrorPrototype: PlumbingFilterFlipped
-  cost: 3
+  cost: 1
   delay: 0
-  collisionMask: Impassable
+  collisionMask: MachineMask
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -145,9 +145,9 @@
   sprite: /Textures/_Starlight/Interface/Radial/RPLD/synthesizer.png
   mode: ConstructObject
   prototype: PlumbingSynthesizer
-  cost: 3
+  cost: 2
   delay: 0
-  collisionMask: Impassable
+  collisionMask: MachineMask
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -157,9 +157,9 @@
   sprite: /Textures/_Starlight/Interface/Radial/RPLD/smart_fridge.png
   mode: ConstructObject
   prototype: PlumbingSmartDispenser
-  cost: 5
+  cost: 3
   delay: 0
-  collisionMask: Impassable
+  collisionMask: MachineMask
   rotation: User
   fx: EffectRCDConstruct0
 
@@ -169,8 +169,8 @@
   sprite: /Textures/_Starlight/Interface/Radial/RPLD/drain.png
   mode: ConstructObject
   prototype: PlumbingDrain
-  cost: 2
+  cost: 1
   delay: 0
-  collisionMask: Impassable
+  collisionMask: MachineMask
   rotation: User
   fx: EffectRCDConstruct0


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Pill Press output is capped at 30 and now produces only one pill/patch per 2 second plumbing tick. FullyReactSolution now returns a bool reactionOccurred for plumbing reactor to use. Smart Dispenser now transfers reagents using exact reagent identity. Some RPLD overlap behavior for machines and ducts was fixed. RPLD machine costs were reduced. Chemical Dispensers and ChemMasters can now rotate. Removed collision from plumbing input, output, and filter machines so you can walk over them. Adds 2 more outlets to plumbing synthesizer. And RPLD contraband/crate access is correctly set to be both Medical and Engineering.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- Prevents the Pill Press from creating lag.
- Having FullyReactSolution return if a reaction occurred or not is very useful for plumbing, a minimal change, and doesn't break anything else.
- Smart Dispenser was not using exact ReagentID when removing and dispensing reagents causing a bug when it was used to fill automenders.
- RPLD will not longer allow you to place multiple plumbing machines on the same tile.
- Fixes bug where RPLD wasn't allowing placed plumbing ducts to cross paths due to deciding they were overlapping before applying the rotation.
- Feedback indicated the RPLD was using too much compressed matter, an already limited resource. Slightly reduced how much most of the plumbing machines cost to build with it.
- Being able to rotate chemical dispenser and chemmasters is important for having the plumbing inlets/outlets on the desired sides of the machine.
- The input, output, and filter machines all make sense for being able to walk over them.
- Adding 2 outlets to the plumbing synthesizer allows for more compact factory design.
- RPLD was incorrectly strictly engineering contraband, it now is Medical and Engineering contraband. 
- RPLD is under the medical category on cargo request computer and comes in a secure medical crate (with Engineering or Medical access required to open it) which is more fitting for it.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: FeralCreature
- tweak: The Plumbing Pill Press now only produces one pill per 2 second plumbing update and only allows 30 pills on it at one time.
- fix: Plumbing Reactors no longer behave weirdly when doing reactions that create an item.
- fix: Plumbing Smart Dispensers are now more exact when dispensing reagents allowing automenders to be functional after being filled by them.
- fix: The RPLD can now place ducts that cross other ducts without making you have to anchor them after.
- fix: RPLDs no longer allow you to place multiple plumbing machines on top of each other.
- tweak: Chemical Dispensers and ChemMasters can now be rotated to allow for easier plumbing access to their inlets/outlets.
- tweak: Plumbing machines now cost a bit less compressed matter to be placed by RPLD.
- fix: You can now walk over Plumbing inputs, outputs, and filters.
- tweak: 2 more outlets have been added to the plumbing synthesizer allowing for more compact factory layouts.
- fix: The RPLD is now correctly set as Medical and Engineering contraband, and comes in a secure crate that can only be opened with either access.