### PR TITLE
Revert the robotics console to its upstream state

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1585,7 +1585,7 @@
   parent: BaseComputerAiAccess
   id: ComputerRoboticsControl
   name: robotics control console
-  description: Used to remotely monitor, disable, and destroy the station's cyborgs. # Starlight-edit - add ", disable, and destroy"
+  description: Used to remotely monitor the station's cyborgs.
   components:
   - type: Sprite
     layers:
@@ -1600,7 +1600,7 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: RoboticsConsole
-    allowBorgControl: true # Starlight-edit - false -> true, allow disabling/detonating borgs
+    allowBorgControl: false
   - type: ActiveRadio
     channels:
     - Science


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Revert the robotics console to how it is upstream, removing the ability to remotely disable and detonate borgs
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
To start, I would like to say that this is no longer a mald PR. When I made the changes, (about a month ago), it mostly was, but I have given it time to sit and think about it, and in the end come back to it because even without emotion involved I still see it as truly bad game design and harmful to RP instead of contributing to it, like everything in this game should.

This has been an issue for a long time, but really I'm mostly concerned with why one of the few good removal PRs, [#41834](https://github.com/space-wizards/space-station-14/pull/41834), to come from wizden was silently reverted with no mention of it in the upstream port, [#2580](https://github.com/ss14Starlight/space-station-14/pull/2580), it should have come with.

I do not see why a system designed to remove someone's ability to play the game with no counterplay is something worth keeping, especially with the way I have seen admins ignore misuse of it it. This server already has a terrible culture around abusing and mistreating borgs, either forgetting or just enjoying the fact that cyborgs are played by people just like everyone else in a round, we do not need this as well. 

In all my time playing silicon I have never seen a positive interaction with this console. More often than not, there is no communication (in a roleplay game) just someone pressing a button that could strand you in space, hurt anyone nearby, or, in some rounds, mean you won't ever get a chassis back. Any use cases for this 'feature' can more positively be substituted by just notifying security, something that adds roleplay and is more fun for both parties involved.

I encourage reading the discussion on the upstream PR, it's not all applicable but also a bit concerning seeing the same trends as an LRP server in ours.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="300" height="894" alt="image" src="https://github.com/user-attachments/assets/c0a6255c-1bba-4c04-8397-6e4e6617b360" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: SevenShades
- tweak: Revert the robotics console to its upstream state, removing controls.
