### PR TITLE
Plumbing: Add water to synthesizeable reagents

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Plumbing/plumbing_machines.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Plumbing/plumbing_machines.yml
@@ -508,6 +508,7 @@
         acts: ["Destruction"]
   - type: StaticPrice
     price: 150
+
 # =============================================================================
 # Plumbing Filter - separates specific reagents into two outputs
 # =============================================================================
@@ -694,6 +695,17 @@
         acts: ["Destruction"]
   - type: StaticPrice
     price: 200
+
+- type: entity
+  parent: PlumbingSynthesizer
+  id: PlumbingSynthesizerWater
+  name: Plumbing Synthesizer
+  suffix: Water
+  description: Generates basic reagents using power from an internal battery.
+  components:
+    - type: PlumbingSynthesizer
+      selectedReagent: Water
+
 # =============================================================================
 # Plumbing Drain - floor drain that outputs to plumbing network
 # =============================================================================

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Plumbing/plumbing_machines.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Piping/Plumbing/plumbing_machines.yml
@@ -642,6 +642,7 @@
       Sugar: 2
       Silicon: 5
       Phosphorus: 5
+      Water: 2
   - type: Plungeable
   - type: PlumbingOutlet
     solutionName: buffer


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

- Adds water to list of base chemicals the Plumbing Synthesizer can synthesize
- Adds water-generating preset to Plumbing Synthesizer for mapping use (think: station-wide plumbing needs a station-wide water supply.)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Station-wide plumbing will need an infinite water source that integrates well with plumbing. The only current infinite water source (a non-plumbing sink) cannot be used for this purpose.

We can revisit this later with potentially adding a recipe for water. Until then this is a nice simple solution.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Left: Regular
Right: Water preset

<img width="713" height="507" alt="image" src="https://github.com/user-attachments/assets/92dedab9-e988-4e15-942d-4249736a0cd8" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Plumbing Synthesizers can now synthesize water.