### PR TITLE
Remove Dark Beaker from BrigMedic

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -101,8 +101,10 @@
   - LauncherSyringe
   - MiniSyringe
   - AdvancedJetInjector
-  - GoldenJug # SL
-  - SilverJug # SL
+  - GoldenJug # Starlight start
+  - SilverJug
+  - DarkBeaker
+  - LightBeaker # Starlight end
 
 - type: latheRecipePack
   id: MedicalBoards

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/chemistry.yml
@@ -209,7 +209,7 @@
 
 - type: entity
   name: dark beaker
-  parent: [BaseBeakerMetallic, DrinkBaseOpenable, DrinkVisualsOpenable, BaseSecurityContraband]
+  parent: [BaseBeakerMetallic, DrinkBaseOpenable, DrinkVisualsOpenable]
   description: The dark side of an unbreakable beaker. Its true power can be sealed.
   id: DarkBeaker
   components:
@@ -245,13 +245,13 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 7
+        Blunt: 3
     soundHit:
       collection: MetalThud
   - type: DamageOtherOnHit
     damage:
       types:
-        Blunt: 9
+        Blunt: 5
   - type: SolutionContainerManager
     solutions:
       beaker:

--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/Medical/chemist.yml
@@ -80,7 +80,7 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: SeniorChemist
-  
+
 
 - type: loadout
   id: SeniorChemistSatchel
@@ -206,7 +206,7 @@
   storage:
     back:
     - LightBeaker
-    
+
 - type: loadout
   id: SilverBeakerChemist
   effects:
@@ -215,3 +215,9 @@
   storage:
     back:
     - SilverBeaker
+
+- type: loadout
+  id: DarkBeaker
+  storage:
+    back:
+    - DarkBeaker

--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/brigmedic.yml
@@ -158,8 +158,3 @@
     id: VeteranCorpsmanPDA
 
 # Beaker
-- type: loadout
-  id: DarkBeaker
-  storage:
-    back:
-    - DarkBeaker

--- a/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/Jobs/Security/brigmedic.yml
@@ -163,12 +163,3 @@
   storage:
     back:
     - DarkBeaker
-    
-- type: loadout
-  id: SilverBeakerBrigmedic
-  effects:
-    - !type:GroupLoadoutEffect
-        proto: SkilledBrigmedic
-  storage:
-    back:
-    - SilverBeaker

--- a/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/loadout_groups.yml
@@ -707,6 +707,7 @@
   name: loadout-group-chemist-beaker
   loadouts:
     - LightBeaker
+    - DarkBeaker
     - SilverBeakerChemist
 
 - type: loadoutGroup
@@ -741,13 +742,6 @@
     - VeteranBrigmedicPDA
     - CorpsmanPDA
     - VeteranCorpsmanPDA
-
-- type: loadoutGroup
-  id: BrigmedicBeaker
-  name: loadout-group-brigmedic-beaker
-  loadouts:
-    - DarkBeaker
-    - SilverBeakerBrigmedic
 
 - type: loadoutGroup
   id: BrigmedicGloves

--- a/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_StarLight/Loadouts/role_loadouts.yml
@@ -151,7 +151,6 @@
   - BrigmedicGloves
   - BrigmedicEyewear
   - BrigmedicPDA
-  - BrigmedicBeaker
   - SecurityShoes
   - SecurityNonLethalWeapon
   - SecuritySidearm

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/medical.yml
@@ -766,3 +766,17 @@
   completetime: 2
   materials:
     Silver: 50
+
+- type: latheRecipe
+  id: LightBeaker
+  result: LightBeaker
+  completetime: 2
+  materials:
+    Steel: 400
+
+- type: latheRecipe
+  id: DarkBeaker
+  result: DarkBeaker
+  completetime: 2
+  materials:
+    Steel: 400

--- a/Resources/Prototypes/_StarLight/Research/medical.yml
+++ b/Resources/Prototypes/_StarLight/Research/medical.yml
@@ -33,6 +33,8 @@
   recipeUnlocks:
   - GoldenJug
   - SilverJug
+  - DarkBeaker
+  - LightBeaker
   radioChannels:
   - Medical
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This PR removes the Dark Beaker from Brigmedic's loadout, makes it non-Security contraband, and gives it to Chemists & the tech tree.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Brigmedic is having their chemistry removed, so this is a logical step to furthering that goal.

<img width="663" height="95" alt="image" src="https://github.com/user-attachments/assets/403cc053-bf17-476d-b445-6bfb9a8defb1" />

I'd be loathe to just remove the dark beaker entirely; the sprite is nice. So this is an option that preserves it, as well as giving light beakers a little more use.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="406" height="247" alt="image" src="https://github.com/user-attachments/assets/3b09949b-1dec-4a19-bcff-2c61b40d76c8" />
<img width="814" height="659" alt="image" src="https://github.com/user-attachments/assets/17187fd7-47e8-44f5-b8b6-9b1df8f10764" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fractalflower
- remove: Brigmedic no longer gets a beaker choice.
- remove: Dark Beaker is no longer Security contraband.
- add: Dark Beaker is now available to Chemists.
- add: Dark and Light beakers are now in the Advanced Chemical Storage research.
- tweak: Reduced Dark Beaker's damage.
