### PR TITLE
Make Paramedic mindshielded

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ShuttleRoles/settings.yml
@@ -258,7 +258,7 @@
 
 - type: randomHumanoidSettings
   id: VisitorParamedic
-  parent: VisitorMedical
+  parent: [ EventHumanoidMindShielded, VisitorMedical ] # Starlight: Don't forget mindshield
   components:
     - type: GhostRole
       name: job-name-paramedic

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -10,6 +10,7 @@
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
   supervisors: job-supervisors-cmo
+  canBeAntag: false # Starlight
   access:
   - Medical
   - Maintenance
@@ -17,7 +18,10 @@
   - External # Starlight
   extendedAccess:
   - Chemistry
-  - Surgery # Starlight
+  - Surgery # Starlight BEGIN
+  special:
+    - !type:AddImplantSpecial
+      implants: [ MindShieldImplant ]  # Starlight END
 
 - type: startingGear
   id: ParamedicGear


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Title.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug 
Reports here. Please describe how this will change the game balance. -->

Full context and discussion in the community suggestion: https://discord.com/channels/1272545509562777621/1473599436289474621

**Please read the suggestion thread before replying.**

At of the time of me writing, the suggestion has: 23 votes in favor, 10 against.

If you don't have time to read yourself, some **arbitrarily** picked highlights:
- Paramedic is an incredibly popular role to antag-roll because Paramedic basically always get Soft AA (AA without command, security and head-of-staff), making it a lot easier for them to do antagonistic activities _compared to other roles_.
  - Not the core focus but I thought it was worth mentioning that this is bad for Medical and the rest of the crew alike since a Paramedic in the brig isn't exactly helping anyone, leaving crit people to die.
- Paramedics get access to enter Brigmed per #3352, which is actually in violation of SOP since they aren't mindshielded
- (Added bonus: Opens up the job to people actually wanting to play Paramedic and not just AntagWithFreeAA).

~~Giving SoftAA in return is partially sketched as an exchange for losing the ability to roll antag, but there's more to it.~~

~~Currently, players who late-join as Paramedic regularly run into problems where it's impossible for them to actually get the access they need to do their job properly as heads of staff die, go missing, or get busy with stuff (e.g.: CE is _not_ interested in stamping your paper on a code yellow). This means they end up stuck in an awkward state of not having access or not enough stamps to get HOP to actually them the access, provided HOP is even a filled role.~~

~~The latter problem is **heavily** exacerbated on beta. In addition to the previous, it happens regularly that e.g. the CE is dying, the Paramedic has no access, and there is no other Engineering staff or AI on duty to let them in. This is an exercise in needless frustration for the Paramedic player and victims both.~~

~~As closing words, I've definitely not touched on everything. I humbly ask you read the suggestion thread and arguments both for- and against the proposed changes.~~

EDIT: Scrapped access changes from PR.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Joining as paramedic, showing mindshield:

https://github.com/user-attachments/assets/8236f7d7-4fc9-4330-8a6e-d8bdd59795e4


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl:
- tweak: Paramedics are now mindshielded.