### PR TITLE
Added guidebook entry for records

### DIFF
--- a/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
@@ -145,3 +145,6 @@ guide-entry-sl-service-sop-headofpersonnel = Head of Personnel
 guide-entry-plumbing = Plumbing
 guide-entry-plumbingflow = Reagent Flow
 guide-entry-plumbingmachines = Plumbing Machines
+
+# Records
+guide-entry-records = Character Records

--- a/Resources/Prototypes/Guidebook/newplayer.yml
+++ b/Resources/Prototypes/Guidebook/newplayer.yml
@@ -26,6 +26,7 @@
   children:
   - YourFirstCharacter
   - Species
+  - Records # Starlight
 
 - type: guideEntry
   id: YourFirstCharacter

--- a/Resources/Prototypes/_StarLight/Guidebook/records.yml
+++ b/Resources/Prototypes/_StarLight/Guidebook/records.yml
@@ -1,0 +1,4 @@
+- type: guideEntry
+  id: Records
+  name: guide-entry-records
+  text: "/ServerInfo/_StarLight/Guidebook/Character/Records.xml"

--- a/Resources/ServerInfo/_StarLight/Guidebook/Character/Records.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Character/Records.xml
@@ -1,3 +1,41 @@
 <Document>
   # Character Records
+
+  Starlight allows you to flesh out your character's past via records. They are
+  accessible in their own tab during character creation. Individual entries
+  should be written from a perspective of someone with the authority to write
+  it.
+
+  Be creative with records, collaborate with other players, or even use them
+  for character development by addressing events from past shifts. Sadly, there
+  is currently no way to add new permanent records during a shift, so it may
+  be worth it to take notes after an impactful shift.
+
+  During a shift, records can be accessed via different computers, namely
+  Security Records Computer, Medical Records Computer, and Employment
+  Records Computer. 
+
+  ## Employment
+
+  This category should contain what information CC has about your professional
+  past, both with CC and previous employers. It may also include things like
+  Education and previously held positions.
+
+  ## Medical
+
+  Your character's medical history and information for your medical personel.
+  May include things like past treatment reports, psychological evaluations,
+  surgeries, and perscriptions.
+
+  ## Security
+
+  Practically the criminal file of your character. The security record should
+  include things like arrest reports and other incidents from your character's
+  past that CC is aware of.
+
+  ## Admin
+
+  Internal records CC keeps on your character, includes information like
+  promotions and demotions, raises and pay cuts, and notes about performance.
+    
 </Document>

--- a/Resources/ServerInfo/_StarLight/Guidebook/Character/Records.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Character/Records.xml
@@ -1,0 +1,3 @@
+<Document>
+  # Character Records
+</Document>


### PR DESCRIPTION
## Short description
Added a chapter in the guidebook about records.

## Why we need to add this
The current implementation of records has been in for a while but there was no entry in the guidebook for it. A dedicated entry may lead to more usage of the feature and with that to more fleshed out characters (beta player here, I really enjoy reading them).

I am aware that records may be removed/drastically changed as the current implementation is not fully satisfactory (see #2949 and past Discord discussions that I cannot find again). So if this gets merged, reverting it should be easy.

## Media (Video/Screenshots)
<img width="672" height="521" alt="Screenshot_20260218_205728" src="https://github.com/user-attachments/assets/2c52268e-3231-4dc5-8795-9b40a980d369" />

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: SiTW
- add: Guidebook entry for records.
