### PR TITLE
Remove vox damage modifiers from Felionoid

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
@@ -47,7 +47,6 @@
       amount: 3
   - type: Damageable
     damageContainer: Biological
-    damageModifierSet: Vox
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:


### PR DESCRIPTION
## Short description
Removes the vox damage modifiers from felionoids.

## Why we need to add this
Code maintenance; preventing unexpected surprises in the future since the Vox modifiers are unmodified from upstream. Vox (and felionoids) currently do not have any actual damage alterations, so this has no gameplay impact.
https://github.com/ss14Starlight/space-station-14/blob/db3ea7deb6f4897a2830affd2b57ccb37f3804c4/Resources/Prototypes/Damage/modifier_sets.yml#L223-L226

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.