### PR TITLE
Add Robotics time requirement to Mothership

### DIFF
--- a/Resources/Prototypes/Roles/Antags/xenoborgs.yml
+++ b/Resources/Prototypes/Roles/Antags/xenoborgs.yml
@@ -9,6 +9,9 @@
   - !type:RoleTimeRequirement
     role: JobStationAi # Starlight
     time: 18000  # 5 hrs
+  - !type:RoleTimeRequirement # Starlight
+    role: JobRoboticist # Starlight
+    time: 9000 # 2.5 hrs
   guides: [ Xenoborgs ]
   playTimeTracker: AntagMothershipCore # Starlight
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Add in 2.5 hours of Roboticist requirement for Mother. 

## Why we need to add this
Roboticist hours are more relevant than AI hours since their primary job (and the only one their children cannot do) is installing MMIs to their creations. They NEED to know how to do that to have any chance as the core.

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Born Stellar
- tweak: Mothership Core now requires 2.5 Roboticist hours in addition to the 5 hours of AI.
