### PR TITLE
Add metrics for antags spawned

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -45,12 +45,23 @@ using Content.Shared.Tag;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
+using Prometheus;
 // Starlight End
 
 namespace Content.Server.Antag;
 
 public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelectionComponent>
 {
+    // Starlight edit start
+    #region Starlight data collection
+    private static readonly Counter _antagsSpawned = Metrics.CreateCounter(
+        "sl_antags_spawned",
+        "Number of antagonists spawned by type",
+        ["type"]
+    );
+    #endregion
+    // Starlight edit end
+
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly IBanManager _ban = default!;
     [Dependency] private readonly IChatManager _chat = default!;
@@ -533,6 +544,10 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             Log.Debug($"Assigned {ToPrettyString(curMind)} as antagonist: {ToPrettyString(ent)}");
             _adminLogger.Add(LogType.AntagSelection, $"Assigned {ToPrettyString(curMind)} as antagonist: {ToPrettyString(ent)}");
         }
+
+        // Starlight edit start - add stats
+        _antagsSpawned.WithLabels(Prototype(ent)?.ID ?? "unknown").Inc();
+        // Starlight edit end
 
         var afterEv = new AfterAntagEntitySelectedEvent(session, player, ent, def);
         RaiseLocalEvent(ent, ref afterEv, true);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This is a simple PR to add some tracking for how many antags are spawned.

## Why we need to add this
I believe we are missing this crucial statistic, to correctly assess how much do we need

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
