### PR TITLE
Double emergency tanks are now small items again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -183,7 +183,7 @@
     sprite: Objects/Tanks/emergency_double.rsi
   - type: Item
     sprite: Objects/Tanks/emergency_double.rsi
-    size: Normal # Starlight start
+    size: Small # Starlight start
     shape:
       - 0,0,0,1
     storedSprite:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes double emergency tank size classification

## Why we need to add this
When emergency tanks were changed to be tiny items, *rather than small*, double tanks were changed to be Normal for some reason. This makes them not fit into survival boxes it normally spawns in, and is one of the persistent test failures on all branches at the moment. The actual size in inventory doesn't change with this PR (and small items are normally 1x2, as they are here), just the size classification (from Normal -> Small).

## Media (Video/Screenshots)
<img width="109" height="79" alt="image" src="https://github.com/user-attachments/assets/82447732-8016-4e7b-b123-a9278c85a3b1" />
Double tanks fit into the box again

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Double emergency tanks are small items again.
