### PR TITLE
Reduce animal reproduction costs and increase chicken and duck reproduction capacities

### DIFF
--- a/Content.Server/Animals/Components/EggLayerComponent.cs
+++ b/Content.Server/Animals/Components/EggLayerComponent.cs
@@ -44,7 +44,7 @@ public sealed partial class EggLayerComponent : Component
     ///     The amount of nutrient consumed on update.
     /// </summary>
     [DataField]
-    public float HungerUsage = 60f;
+    public float HungerUsage = 30f; // Starlight edit 60f -> 30f
 
     [DataField] public EntityUid? Action;
 

--- a/Content.Shared/Nutrition/AnimalHusbandry/ReproductiveComponent.cs
+++ b/Content.Shared/Nutrition/AnimalHusbandry/ReproductiveComponent.cs
@@ -84,7 +84,7 @@ public sealed partial class ReproductiveComponent : Component
     /// gives birth. A balancing tool to require feeding.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float HungerPerBirth = 75f;
+    public float HungerPerBirth = 50f; // Starlight edit 75f -> 50f
 
     /// <summary>
     /// Popup shown when an entity gives birth.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -254,6 +254,8 @@
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-laid-egg-popup
+    capacity: 12  #Starlight
+    hungerPerBirth: 35 #Starlight
     makeOffspringInfant: false
     partnerWhitelist:
       tags:
@@ -722,6 +724,8 @@
   - type: Reproductive
     breedChance: 0.05
     birthPopup: reproductive-laid-egg-popup
+    capacity: 12  #Starlight
+    hungerPerBirth: 35 #Starlight
     makeOffspringInfant: false
     partnerWhitelist:
       tags:


### PR DESCRIPTION
## Short description
Reduces the hunger cost when livestock reproduces, the cost for egg layers to lay eggs, and increases the breeding capacity for chickens and ducks.

## Why we need to add this
Make animal husbandry more viable by reducing the _maximum_ of hunger/food consumed when animals successfully breed from `75` to `50`. Note that this doesn't affect the minimum amount required to breed, which is `25`.
Reducing this means that keeping animals well fed isn't as much of an efficiency loss, as they will now at most only consume half their hunger capacity.

This is further reduced for chickens and ducks, as they are worth considerably less food when butchered. The unfertilized eggs received the same reduction. In addition, the default limit of `6` is low for animals which is sold in bundles of 4 and produces 1-3 offspring, so this was increased to `12`.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- tweak: Cows, Goats, and Pigs now consume 33% less food when giving birth.
- tweak: Chickens and Ducks now consume 50% less food when laying eggs.
- tweak: Chicken and Duck breeding limit increased to 12.