### PR TITLE
Terminators randomly CLANK

### DIFF
--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -543,6 +543,16 @@ public abstract partial class SharedMoverController : VirtualController
         if (!CanSound() || !_tags.HasTag(uid, FootstepSoundTag))
             return false;
 
+        #region Starlight GetFootstepSound event here!
+        var ev = new GetFootstepSoundEvent();
+        RaiseLocalEvent(uid, ref ev);
+        if (ev.Sound != null)
+        {
+            sound = ev.Sound;
+            return true;
+        }
+        #endregion
+
         var coordinates = xform.Coordinates;
         var distanceNeeded = mover.Sprinting
             ? mobMover.StepSoundMoveDistanceRunning
@@ -634,15 +644,6 @@ public abstract partial class SharedMoverController : VirtualController
 
         var position = _mapSystem.LocalToTile(xform.GridUid.Value, grid, xform.Coordinates);
         var soundEv = new GetFootstepSoundEvent(uid);
-
-        #region Starlight foot-step self-modifying
-        RaiseLocalEvent(uid, ref soundEv);
-        if (soundEv.Sound != null)
-        {
-            sound = soundEv.Sound;
-            return true;
-        }
-        #endregion
 
         // If the coordinates have a FootstepModifier component
         // i.e. component that emit sound on footsteps emit that sound

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -635,6 +635,15 @@ public abstract partial class SharedMoverController : VirtualController
         var position = _mapSystem.LocalToTile(xform.GridUid.Value, grid, xform.Coordinates);
         var soundEv = new GetFootstepSoundEvent(uid);
 
+        #region Starlight foot-step self-modifying
+        RaiseLocalEvent(uid, ref soundEv);
+        if (soundEv.Sound != null)
+        {
+            sound = soundEv.Sound;
+            return true;
+        }
+        #endregion
+
         // If the coordinates have a FootstepModifier component
         // i.e. component that emit sound on footsteps emit that sound
         var anchored = _mapSystem.GetAnchoredEntitiesEnumerator(xform.GridUid.Value, grid, position);

--- a/Content.Shared/_Starlight/Movement/Components/RandomFootstepSoundComponent.cs
+++ b/Content.Shared/_Starlight/Movement/Components/RandomFootstepSoundComponent.cs
@@ -1,0 +1,14 @@
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.Audio;
+
+namespace Content.Shared._Starlight.Movement.Components;
+
+[RegisterComponent]
+public sealed partial class RandomFootstepSoundComponent : Component
+{
+    [DataField(required: true)]
+    public SoundSpecifier? Sound;
+
+    [DataField]
+    public float Chance = 0.001f; //1/1000 steps will make this sound.
+}

--- a/Content.Shared/_Starlight/Movement/Components/RandomFootstepSoundComponent.cs
+++ b/Content.Shared/_Starlight/Movement/Components/RandomFootstepSoundComponent.cs
@@ -1,14 +1,15 @@
 ﻿using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._Starlight.Movement.Components;
 
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class RandomFootstepSoundComponent : Component
 {
-    [DataField(required: true)]
+    [DataField(required: true), AutoNetworkedField]
     public SoundSpecifier? Sound;
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float Chance = 0.001f; //1/1000 steps will make this sound.
 }

--- a/Content.Shared/_Starlight/Movement/Systems/RandomFootstepSoundSystem.cs
+++ b/Content.Shared/_Starlight/Movement/Systems/RandomFootstepSoundSystem.cs
@@ -1,0 +1,24 @@
+﻿using Content.Shared._Starlight.Movement.Components;
+using Content.Shared.Movement.Events;
+using Robust.Shared.Random;
+
+namespace Content.Shared._Starlight.Movement.Systems;
+
+public sealed class RandomFootstepSoundSystem : EntitySystem
+{
+
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RandomFootstepSoundComponent, GetFootstepSoundEvent>(OnGetFootstepSound);
+    }
+
+    private void OnGetFootstepSound(Entity<RandomFootstepSoundComponent> ent, ref GetFootstepSoundEvent ev)
+    {
+        if (_random.Prob(ent.Comp.Chance))
+            ev.Sound = ent.Comp.Sound;
+    }
+}

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/terminator.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/terminator.yml
@@ -114,6 +114,13 @@
     baseDecayRate: 0
   - type: Hunger
     baseDecayRate: 0
+  - type: RandomFootstepSound # 1/1000 steps will be a heavy clank. not very subtle.
+    sound: 
+      path: /Audio/Mecha/sound_mecha_powerloader_step.ogg
+      params:
+        volume: -6
+        pitch: 0.7
+        variation: 0.025
 
 - type: entity
   parent:


### PR DESCRIPTION
## Short description
Makes it so terminators have a 1/1000 chance (0.1%) chance to make a CLANK sound every step (think jugsuit)

## Why we need to add this
adds a subtle random tell to terminators. 

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/954427a4-f718-49dd-a6dc-6c5906a63f4f

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl:
- add: Terminators now randomly take a "heavy" footstep revealing their silicon lies.
