### PR TITLE
Fix labels appearing in radio comms

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -35,6 +35,7 @@ using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 using Content.Shared._Starlight.Radio; //Starlight
+using Content.Shared.NameModifier.Components; //Starlight
 
 namespace Content.Server.Radio.EntitySystems;
 
@@ -142,6 +143,10 @@ public sealed class RadioSystem : EntitySystem
 
         var meta = MetaData(messageSource);
         var entityName = meta?.EntityName ?? string.Empty;
+        // Starlight BEGIN
+        if (TryComp(messageSource, out NameModifierComponent? nameModifier))
+            entityName = nameModifier.BaseName; // Bypass name modifiers (specifically: labels).
+        // Starlight END
         var evt = new TransformSpeakerNameEvent(messageSource, entityName);
         RaiseLocalEvent(messageSource, evt);
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Fixes labels appearing in radio comms.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

People are complaining about cases like these examples spamming their chatbox:

<img width="607" height="231" alt="label1" src="https://github.com/user-attachments/assets/d0cac681-65db-49ba-bfff-c8d433ef6d25" />

<img width="548" height="68" alt="label2" src="https://github.com/user-attachments/assets/680e4602-630d-4f8a-83b5-adeebb67e68b" />


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->


https://github.com/user-attachments/assets/31628e9c-4e9e-4a4f-b4f6-fb310a7ab4ae


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl:
- fix: Radio communications will no longer show labels after the person's name.
