### PR TITLE
Clarify changelog that Paramedics also will not roll antag

### DIFF
--- a/Resources/Changelog/ChangelogStarlight.yml
+++ b/Resources/Changelog/ChangelogStarlight.yml
@@ -31243,7 +31243,7 @@ Entries:
   url: https://github.com/ss14Starlight/space-station-14/pull/3378
 - author: redmushie
   changes:
-  - message: Paramedics are now mindshielded.
+  - message: Paramedics are now mindshielded and can no longer roll antag.
     type: Tweak
   id: 336801
   time: '2026-02-19T10:56:24.000000+00:00'


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Change changelog line of #3368 to reflect that Paramedics also will not roll antag.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

It's causing a lot of confusion to people who know these are two separate things. This should help.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
