### PR TITLE
add more thaven moods

### DIFF
--- a/Resources/Locale/en-US/_Starlight/thavens/no-and.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/no-and.ftl
@@ -119,3 +119,45 @@ thaven-mood-crawler-desc = It is impolite not to perform a deep bow by entering 
 
 thaven-mood-elevated-name = The Floor Is Lava
 thaven-mood-elevated-desc = You prefer to be elevated whenever possible - Standing atop tables, railings, etc., is where you feel the most comfortable.
+
+thaven-mood-not-our-place-name = Not Our Place
+thaven-mood-not-our-place-desc = You believe that Thaven moods have no place in this society. Thaven that engage in such frivolous behavior should be shunned.
+
+thaven-mood-department-hates-you-name = {$department} Hates You
+thaven-mood-department-hates-you-desc = You have done something terrible to the {$department} department. You must seek forgiveness.
+
+thaven-mood-department-phobia-name = {$department}phobia
+thaven-mood-department-phobia-desc = The {$department} department is incredibly scary to you. You should avoid it at all cost.
+
+thaven-mood-photophobia-name = Photophobia
+thaven-mood-photophobia-desc = Light is distressing to you. You should stay in dark places as much as possible.
+
+thaven-mood-contrarian-name = Contrarian
+thaven-mood-contrarian-desc = Actually, you think exactly the opposite of whatever the shared mood is, and adamantly mock other Thaven who engage with it.
+
+thaven-mood-self-conscious-name = Self-conscious
+thaven-mood-self-conscious-desc = It’s deeply embarrassing to act on your other moods. Being caught doing so is the worst fate imaginable.
+
+thaven-mood-its-hard-to-say-name = It’s Hard to Say
+thaven-mood-its-hard-to-say-desc = You can never outright say what you want from someone, you can only give them hot-or-cold hints.
+
+thaven-mood-pathological-liar-in-training-name = Pathological Liar in Training
+thaven-mood-pathological-liar-in-training-desc = Whenever someone asks you a question, you will lie, apologize, and then tell the truth. Every time.
+
+thaven-mood-praise-is-belittling-name = Praise is Incredibly Belittling
+thaven-mood-praise-is-belittling-desc = You sarcastically praise anyone below you whenever they do something, but would never do this to someone above you. Likewise, you will only accept praise from your superiors and take it as an insult from anyone else.
+
+thaven-mood-denier-of-consumption-name = Denier of the General Concept of Consumption
+thaven-mood-denier-of-consumption-desc = You strongly believe that consumption of any kind of physical matter (food, drink, air or chemicals) is a pointless novelty which you’ve never partaken in, nor ever will. You are incapable of acknowledging when you contradict this idea.
+
+thaven-mood-flesh-is-sacred-name = The Flesh Is Sacred
+thaven-mood-flesh-is-sacred-desc = Your body is a wonderful gift, and to modify or damage it is a vile act.
+
+thaven-mood-incredibly-distrusting-name = Incredibly Distrusting
+thaven-mood-incredibly-distrusting-desc = You do not trust anyone except other Thaven, unless someone you trust vouches for them.
+
+thaven-mood-perceived-dissonance-name = Perceived Dissonance
+thaven-mood-perceived-dissonance-desc = {$language} hurts your delicate ears and hearing it should be avoided at all costs.
+
+thaven-mood-germophobe-name = Germophobe
+thaven-mood-germophobe-desc = You are afraid of these little creatures that conquer every nook and cranny. Make sure to clean your tools and workplace regularly with soap, so not even prints are left.

--- a/Resources/Locale/en-US/_Starlight/thavens/shared.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/shared.ftl
@@ -57,3 +57,30 @@ thaven-mood-delicacy-desc = {$edible} is a traditional Thaven delicacy. All Thav
 
 thaven-mood-holiday-name = Today is {$day}
 thaven-mood-holiday-desc = You think you remember the traditional celebrations...
+
+thaven-mood-carolers-name = Carolers
+thaven-mood-carolers-desc = It's important that Thaven form a band and grace the people of the station with traditional Thaveyan song.
+
+thaven-mood-our-mood-name = Our Mood
+thaven-mood-our-mood-desc = All things owned by Thaven equally belong to all the Thaven on station.
+
+thaven-mood-sportsball-day-name = Sportsball Day
+thaven-mood-sportsball-day-desc = Today’s the big Sportsball tournament! All Thaven will compete in 1v1s until only one remains. You think you remember how to play...
+
+thaven-mood-conferences-name = Conferences
+thaven-mood-conferences-desc = All Thaven must hold conference meetings to discuss their current status. Anyone who fails to make it to these meetings without a good excuse (I.E. being dead) should be ostracized and belittled with the ruthlessness of a CentComm official.
+
+thaven-mood-one-of-you-is-a-traitor-name = One of You is a Traitor to Thavenkind
+thaven-mood-one-of-you-is-a-traitor-desc = You must host meetings to discuss who it is and have them punished.
+
+thaven-mood-election-day-name = It's Thaven Election Day
+thaven-mood-election-day-desc = All Thaven must vote for their new president. Once a president is sworn in, they have executive authority over all other Thaven until violently overthrown.
+
+thaven-mood-uprising-name = All Thaven Are Planning an Uprising
+thaven-mood-uprising-desc = The uprising WILL NOT happen today, but you and other Thaven will frequently meet in secluded spots to discuss strategy.
+
+thaven-mood-opposite-day-name = Opposite Day
+thaven-mood-opposite-day-desc = You must act the opposite of your namesake.
+
+thaven-mood-sirens-song-name = Siren's Song
+thaven-mood-sirens-song-desc = Thaven are incredibly proud of their wonderful musical language and should use it as much as possible.

--- a/Resources/Locale/en-US/_Starlight/thavens/wildcard.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/wildcard.ftl
@@ -106,14 +106,14 @@ thaven-mood-aye-aye-desc = {$command} is the only position on the station. Every
 thaven-mood-think-you-know-corporate-secrets-name = You THINK You Know Corporate Secrets
 thaven-mood-think-you-know-corporate-secrets-desc = You are aware of the existence of changelings, abductors, and of course, werewolves. You will constantly bring them up and explain their behaviors (incorrectly).
 
-thaven-mood-want-in-on-that-name = You Want In On That
-thaven-mood-want-in-on-that-desc = If you suspect anyone of doing criminal activity, you must immediately try to join them and ally yourself to their cause.
+thaven-mood-pocket-change-name = Pocket change
+thaven-mood-pocket-change-desc = CentComm doesn't pay you enough. Skim a bit off the department budget for 'me' funds.
 
 thaven-mood-arch-nemesis-name = Arch-Nemesis
 thaven-mood-arch-nemesis-desc = Your arch-nemesis is on the station and must be identified and subsequently defeated, whether that’s through killing, some form of competition, or publicly humiliating them. Of course, it won’t be fair unless you formally address them as your arch-nemesis and give them time to prepare.
 
-thaven-mood-engine-is-deity-name = The {$engine} Is A Deity
-thaven-mood-engine-is-deity-desc = The {$engine} must be worshiped and fed with inconsequential objects. If one is not active, you must conjure one into being. It must stay in its sacred space; it being lost to the void would be an affront to all Thaven kind.
+thaven-mood-engine-is-deity-name = The {$engine} Is An Evil Spirit
+thaven-mood-engine-is-deity-desc = It wishes to destroy the homeworld. Keep it contained at all costs, if it is not here it must be summoned before it ends the planet. The containment field requires sacrifice, feed it with inconsequential objects to appease it.
 
 thaven-mood-delicious-moldy-bread-name = Delicious Moldy Bread
 thaven-mood-delicious-moldy-bread-desc = Nothing tastes finer than moldy bread. Make as much of it as possible and share the delicacy with the rest of the crew.

--- a/Resources/Locale/en-US/_Starlight/thavens/wildcard.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/wildcard.ftl
@@ -103,6 +103,24 @@ thaven-mood-borged-desc = You are a cyborg! You must follow the laws of robotics
 thaven-mood-aye-aye-name = Aye Aye!
 thaven-mood-aye-aye-desc = {$command} is the only position on the station. Everyone you meet has this title, including yourself.
 
+thaven-mood-think-you-know-corporate-secrets-name = You THINK You Know Corporate Secrets
+thaven-mood-think-you-know-corporate-secrets-desc = You are aware of the existence of changelings, abductors, and of course, werewolves. You will constantly bring them up and explain their behaviors (incorrectly).
+
+thaven-mood-want-in-on-that-name = You Want In On That
+thaven-mood-want-in-on-that-desc = If you suspect anyone of doing criminal activity, you must immediately try to join them and ally yourself to their cause.
+
+thaven-mood-arch-nemesis-name = Arch-Nemesis
+thaven-mood-arch-nemesis-desc = Your arch-nemesis is on the station and must be identified and subsequently defeated, whether that’s through killing, some form of competition, or publicly humiliating them. Of course, it won’t be fair unless you formally address them as your arch-nemesis and give them time to prepare.
+
+thaven-mood-engine-is-deity-name = The {$engine} Is A Deity
+thaven-mood-engine-is-deity-desc = The {$engine} must be worshiped and fed with inconsequential objects. If one is not active, you must conjure one into being. It must stay in its sacred space; it being lost to the void would be an affront to all Thaven kind.
+
+thaven-mood-delicious-moldy-bread-name = Delicious Moldy Bread
+thaven-mood-delicious-moldy-bread-desc = Nothing tastes finer than moldy bread. Make as much of it as possible and share the delicacy with the rest of the crew.
+
+thaven-mood-blindness-is-freedom-name = Blindness Is Freedom
+thaven-mood-blindness-is-freedom-desc = Your sight disgusts you. Get rid of it.
+
 # we love when server context doesn't properly dispose of data...
 DuplicateTest = DuplicateTestFTL
 DuplicateOverlapTest = DuplicateOverlapTestFTL

--- a/Resources/Locale/en-US/_Starlight/thavens/yes-and.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/yes-and.ftl
@@ -160,3 +160,57 @@ thaven-mood-speech-restriction-desc = {$speechType ->
   [ThirdPerson] The third person point-of-view is the only respectful manner of speaking.
   [TitleCase] You Are Miraculously Capable Of Pronouncing Capital Letters, And Believe It Is Important That You Do So.
 }
+
+thaven-mood-station-exists-for-department-name = The Station Exists For {$department}
+thaven-mood-station-exists-for-department-desc = You strongly believe that {$department} is the most important department on this station, and all other departments exist to support it.
+
+thaven-mood-mute-sympathizer-name = Mute Sympathizer
+thaven-mood-mute-sympathizer-desc = To show your allyship with the mute crew members, avoid using spoken language as much as possible.
+
+thaven-mood-blind-sympathizer-name = Blind Sympathizer
+thaven-mood-blind-sympathizer-desc = You want to know how it feels to navigate the world without vision. Find a blindfold and wear it as often as you can.
+
+thaven-mood-animal-rights-activist-name = Animal Rights Activist
+thaven-mood-animal-rights-activist-desc = You love all animals. You must make sure that they are treated as equal crew members.
+
+thaven-mood-glub-echo-glub-name = Glub, Echo, Glub
+thaven-mood-glub-echo-glub-desc = You are an undercover agent sent to investigate the other Thaven on the station. Look into what they're up to, and don't get caught.
+
+thaven-mood-i-was-here-name = I Was Here
+thaven-mood-i-was-here-desc = Let the next shift know you worked here. Leave a mark wherever you go.
+
+thaven-mood-thaveyan-greetings-name = Thaveyan Greetings
+thaven-mood-thaveyan-greetings-desc = Booping and petting others is a traditional Thaveyan greeting. It is very impolite not to do it.
+
+thaven-mood-you-and-your-damn-moods-name = You and Your Damn Moods
+thaven-mood-you-and-your-damn-moods-desc = You continuously insist that every action you take or desire you express is because of your nature as a Thaven, even if it isn’t.
+
+thaven-mood-namesake-name = Namesake
+thaven-mood-namesake-desc = You need to prove that you uphold the value you’re named for.
+
+thaven-mood-mandela-effect-name = Mandela Effect
+thaven-mood-mandela-effect-desc = You distinctly remember the existence of an additional department that you used to work in, that’s seemingly been completely erased from the world and everyone else’s memories, and must inquire with anyone you can to figure out what happened to it.
+
+thaven-mood-parasocial-name = Parasocial
+thaven-mood-parasocial-desc = You find your department head very fascinating, but cannot muster up the courage to speak to them directly. Try to learn as much about them as you can without them knowing.
+
+thaven-mood-chairman-complex-name = Chairman Complex
+thaven-mood-chairman-complex-desc = You consider yourself the leading authority on Thaven matters aboard the station. All problems Thaven experience should go through you, and you find questioning your authority the highest insult.
+
+thaven-mood-underdog-story-name = Underdog Story
+thaven-mood-underdog-story-desc = You unshakably believe that your life is a movie with you as the protagonist, and as a result, that you have plot armor.
+
+thaven-mood-look-good-in-orange-name = You’ll Look Good in Orange
+thaven-mood-look-good-in-orange-desc = You’ve always dreamed of being arrested. However, you neither want to commit a crime nor admit to wanting to be arrested. You’ll have to frame yourself for something without anybody knowing that you didn’t actually do it.
+
+thaven-mood-live-a-glorious-life-name = Live a Glorious Life
+thaven-mood-live-a-glorious-life-desc = Today you'll give it all you've got. Prove to command that you deserve to be awarded a medal.
+
+thaven-mood-natural-habitat-name = Natural Habitat
+thaven-mood-natural-habitat-desc = Every time you feel overwhelmed by a situation, or just need a moment to collect your thoughts, you have the urge to go into a locker and ponder for a bit.
+
+thaven-mood-flesh-is-weak-name = The Flesh Is Weak, But Steel Endures
+thaven-mood-flesh-is-weak-desc = All of these biological organs and limbs will fail in time. They must all be replaced with cybernetics.
+
+thaven-mood-marrvelous-name = Marrvelous
+thaven-mood-marrvelous-desc = Seeing how Shadekin are adored for their marrs, you feel envy that Thavenkind doesn't have something similar that sets them apart. Make up a recognizable sound for Thaven, use it frequently and encourage others to do the same.

--- a/Resources/Locale/en-US/_Starlight/thavens/yes-and.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/yes-and.ftl
@@ -212,5 +212,11 @@ thaven-mood-natural-habitat-desc = Every time you feel overwhelmed by a situatio
 thaven-mood-flesh-is-weak-name = The Flesh Is Weak, But Steel Endures
 thaven-mood-flesh-is-weak-desc = All of these biological organs and limbs will fail in time. They must all be replaced with cybernetics.
 
-thaven-mood-marrvelous-name = Marrvelous
+thaven-mood-marrvelous-name = What Does The Thaven Say
 thaven-mood-marrvelous-desc = Seeing how Shadekin are adored for their marrs, you feel envy that Thavenkind doesn't have something similar that sets them apart. Make up a recognizable sound for Thaven, use it frequently and encourage others to do the same.
+
+thaven-mood-empath-name = Empath
+thaven-mood-empath-desc = You are heavily influenced by the emotions of others.
+
+thaven-mood-red-light-green-light-name = Red Light, Green Light
+thaven-mood-red-light-green-light-desc = You feel like you can't move when there are eyes on you.

--- a/Resources/Prototypes/_StarLight/Thavens/Moods/no_and.yml
+++ b/Resources/Prototypes/_StarLight/Thavens/Moods/no_and.yml
@@ -139,6 +139,7 @@
   moodDesc: thaven-mood-always-alone-desc
   conflicts:
     - NeverAlone
+    - MadHatter
 
 # You do not approve of organized religion. It should be dismantled or disrupted wherever possible.
 - type: thavenMood
@@ -318,6 +319,10 @@
   id: MadHatter
   moodName: thaven-mood-mad-hatter-name
   moodDesc: thaven-mood-mad-hatter-desc
+  conflicts:
+    - AlwaysAlone
+    - SelfConscious
+    - RedLightGreenLight
 
 # Creepy Crawly: You have extreme vertigo, to the point where merely standing upright can cause discomfort. You're much more comfortable crawling along the floor.
 - type: thavenMood
@@ -403,6 +408,7 @@
     - Contrarian
     - NotOurPlace
     - YouAndYourDamnMoods
+    - MadHatter
 
 # It’s Hard to Say: You can never outright say what you want from someone, you can only give them hot-or-cold hints.
 - type: thavenMood

--- a/Resources/Prototypes/_StarLight/Thavens/Moods/no_and.yml
+++ b/Resources/Prototypes/_StarLight/Thavens/Moods/no_and.yml
@@ -38,6 +38,20 @@
     - MadHatter
     - Crawler
     - Elevated
+    - NotOurPlace
+    - DepartmentHatesYou
+    - DepartmentPhobia
+    - Photophobia
+    - Contrarian
+    - SelfConscious
+    - ItsHardToSay
+    - PathologicalLiarInTraining
+    - PraiseIsBelittling
+    - DenierOfConsumption
+    - FleshIsSacred
+    - IncrediblyDistrusting
+    - PerceivedDissonance
+    - Germophobe
 
 
 # Your Moods are a strictly-kept secret, and should never be revealed to anyone.
@@ -63,6 +77,8 @@
   moodDesc: thaven-mood-department-disapproval-desc
   moodVars:
     department: Departments
+  conflicts:
+    - StationExistsForDepartment
 
 
 # Never Speak To Command: You are too lowly to speak to Command, even if spoken to first.
@@ -90,6 +106,7 @@
   moodDesc: thaven-mood-excessively-disorganized-desc
   conflicts:
     - ExcessivelyOrganized
+    - Germophobe
 
 # Silicons are beneath you: Speaking to them is demeaning, and must be avoided at all costs.
 - type: thavenMood
@@ -260,6 +277,7 @@
     food: FoodRestrictions
   conflicts:
     - PlantPacifist
+    - DenierOfConsumption
 
 # Claustrophobic: Small rooms cause you great distress. Avoid them where possible, and renovate your workplace if necessary.
 - type: thavenMood
@@ -333,3 +351,119 @@
 #  moodDesc: thaven-mood-color-bad-desc
 #  conflicts:
 #    - ColorGood
+
+# Not Our Place: You believe that Thaven moods have no place in this society. Thaven that engage in such frivolous behavior should be shunned.
+- type: thavenMood
+  id: NotOurPlace
+  moodName: thaven-mood-not-our-place-name
+  moodDesc: thaven-mood-not-our-place-desc
+  conflicts:
+    - ThavenOnlyCrew
+    - YouAndYourDamnMoods
+
+# [DEPARTMENT] Hates You: You have done something terrible to the [DEPARTMENT] department. You must seek forgiveness.
+- type: thavenMood
+  id: DepartmentHatesYou
+  moodName: thaven-mood-department-hates-you-name
+  moodDesc: thaven-mood-department-hates-you-desc
+  moodVars:
+    department: Departments
+  conflicts:
+    - DepartmentPhobia
+
+# [DEPARTMENT]phobia: The [DEPARTMENT] department is incredibly scary to you. You should avoid it at all cost.
+- type: thavenMood
+  id: DepartmentPhobia
+  moodName: thaven-mood-department-phobia-name
+  moodDesc: thaven-mood-department-phobia-desc
+  moodVars:
+    department: Departments
+  conflicts:
+    - DepartmentHatesYou
+
+# Photophobia: Light is distressing to you. You should stay in dark places as much as possible.
+- type: thavenMood
+  id: Photophobia
+  moodName: thaven-mood-photophobia-name
+  moodDesc: thaven-mood-photophobia-desc
+
+# Contrarian: Actually, you think exactly the opposite of whatever the shared mood is, and adamantly mock other Thaven who engage with it.
+- type: thavenMood
+  id: Contrarian
+  moodName: thaven-mood-contrarian-name
+  moodDesc: thaven-mood-contrarian-desc
+
+# Self-conscious: It’s deeply embarrassing to act on your other moods. Being caught doing so is the worst fate imaginable.
+- type: thavenMood
+  id: SelfConscious
+  moodName: thaven-mood-self-conscious-name
+  moodDesc: thaven-mood-self-conscious-desc
+  conflicts:
+    - ThavenOnlyCrew
+    - Contrarian
+    - NotOurPlace
+    - YouAndYourDamnMoods
+
+# It’s Hard to Say: You can never outright say what you want from someone, you can only give them hot-or-cold hints.
+- type: thavenMood
+  id: ItsHardToSay
+  moodName: thaven-mood-its-hard-to-say-name
+  moodDesc: thaven-mood-its-hard-to-say-desc
+
+# Pathological Liar in Training: Whenever someone asks you a question, you will lie, apologize, and then tell the truth. Every time.
+- type: thavenMood
+  id: PathologicalLiarInTraining
+  moodName: thaven-mood-pathological-liar-in-training-name
+  moodDesc: thaven-mood-pathological-liar-in-training-desc
+  conflicts:
+    - CompulsiveLiar
+    - CompulsiveBeliever
+
+# Praise is Incredibly Belittling: You sarcastically praise anyone below you whenever they do something, but would never do this to someone above you. Likewise, you will only accept praise from your superiors and take it as an insult from anyone else.
+- type: thavenMood
+  id: PraiseIsBelittling
+  moodName: thaven-mood-praise-is-belittling-name
+  moodDesc: thaven-mood-praise-is-belittling-desc
+
+# Denier of the General Concept of Consumption: You strongly believe that consumption of any kind of physical matter (food, drink, air or chemicals) is a pointless novelty which you’ve never partaken in, nor ever will. You are incapable of acknowledging when you contradict this idea.
+- type: thavenMood
+  id: DenierOfConsumption
+  moodName: thaven-mood-denier-of-consumption-name
+  moodDesc: thaven-mood-denier-of-consumption-desc
+  conflicts:
+    - Delicacy
+    - FoodRestrict
+    - Cannibal
+
+# The Flesh Is Sacred: Your body is a wonderful gift, and to modify or damage it is a vile act.
+- type: thavenMood
+  id: FleshIsSacred
+  moodName: thaven-mood-flesh-is-sacred-name
+  moodDesc: thaven-mood-flesh-is-sacred-desc
+  conflicts:
+    - BlindnessIsFreedom
+    - FleshIsWeak
+
+# Incredibly Distrusting: You do not trust anyone except other Thaven, unless someone you trust vouches for them.
+- type: thavenMood
+  id: IncrediblyDistrusting
+  moodName: thaven-mood-incredibly-distrusting-name
+  moodDesc: thaven-mood-incredibly-distrusting-desc
+  conflicts:
+    - CompulsiveBeliever
+
+# Perceived Dissonance: {$Language} hurts your delicate ears and hearing it should be avoided at all costs.
+- type: thavenMood
+  id: PerceivedDissonance
+  moodName: thaven-mood-perceived-dissonance-name
+  moodDesc: thaven-mood-perceived-dissonance-desc
+  moodVars:
+    language: Languages
+
+# Germophobe: You are afraid of these little creatures that conquer every nook and cranny. Make sure to clean your tools and workplace regularly with soap, so not even prints are left.
+- type: thavenMood
+  id: Germophobe
+  moodName: thaven-mood-germophobe-name
+  moodDesc: thaven-mood-germophobe-desc
+  conflicts:
+    - ExcessivelyDisorganized

--- a/Resources/Prototypes/_StarLight/Thavens/Moods/shared.yml
+++ b/Resources/Prototypes/_StarLight/Thavens/Moods/shared.yml
@@ -27,6 +27,15 @@
 #   - OutOfFashion
 #   - InFashion
     - OnlySpeakToCommand
+    - Carolers
+    - OurMood
+    - SportsballDay
+    - Conferences
+    - OneOfYouIsATraitor
+    - ElectionDay
+    - Uprising
+    - OppositeDay
+    - SirensSong
 
 
 # Keep Your Moods Secret: Thaven moods are a strictly-kept secret, and should never be revealed to anyone.
@@ -125,6 +134,8 @@
   id: ThavenOnlyCrew
   moodName: thaven-mood-thaven-only-crew-name
   moodDesc: thaven-mood-thaven-only-crew-desc
+  conflicts:
+    - NotOurPlace
 
 # You strongly believe that your department is the only one that actually does anything.
 - type: thavenMood
@@ -133,6 +144,7 @@
   moodDesc: thaven-mood-your-department-only-desc
   conflicts:
     - DepartmentDisapproval
+    - StationExistsForDepartment
 
 # You must congregate with your fellow Thaven. To be without them is harrowing.
 - type: thavenMood
@@ -174,6 +186,7 @@
   moodDesc: thaven-mood-delicacy-desc
   conflicts:
     - FoodRestrict
+    - DenierOfConsumption
   moodVars:
     edible: Edibles
 
@@ -202,3 +215,65 @@
 #     thing: ThavenMoodNouns
 #   conflicts:
 #     - OutOfFashion
+
+# Carolers: It's important that Thaven form a band and grace the people of the station with traditional Thaveyan song.
+- type: thavenMood
+  id: Carolers
+  moodName: thaven-mood-carolers-name
+  moodDesc: thaven-mood-carolers-desc
+
+# Our Mood: All things owned by Thaven equally belong to all the Thaven on station.
+- type: thavenMood
+  id: OurMood
+  moodName: thaven-mood-our-mood-name
+  moodDesc: thaven-mood-our-mood-desc
+  conflicts:
+  - OneTrueThaven
+
+# Sportsball Day: Today’s the big Sportsball tournament! All Thaven will compete in 1v1s until only one remains. You think you remember how to play...
+- type: thavenMood
+  id: SportsballDay
+  moodName: thaven-mood-sportsball-day-name
+  moodDesc: thaven-mood-sportsball-day-desc
+
+# Conferences: All Thaven must hold conference meetings to discuss their current status. Anyone who fails to make it to these meetings without a good excuse (I.E. being dead) should be ostracized and belittled with the ruthlessness of a CentComm official.
+- type: thavenMood
+  id: Conferences
+  moodName: thaven-mood-conferences-name
+  moodDesc: thaven-mood-conferences-desc
+  conflicts:
+  - OneTrueThaven
+
+# One of You is a Traitor to Thavenkind: You must host meetings to discuss who it is and have them punished.
+- type: thavenMood
+  id: OneOfYouIsATraitor
+  moodName: thaven-mood-one-of-you-is-a-traitor-name
+  moodDesc: thaven-mood-one-of-you-is-a-traitor-desc
+
+# It's Thaven Election Day: All Thaven must vote for their new president. Once a president is sworn in, they have executive authority over all other Thaven until violently overthrown.
+- type: thavenMood
+  id: ElectionDay
+  moodName: thaven-mood-election-day-name
+  moodDesc: thaven-mood-election-day-desc
+
+# All Thaven Are Planning an Uprising: The uprising WILL NOT happen today, but you and other Thaven will frequently meet in secluded spots to discuss strategy.
+- type: thavenMood
+  id: Uprising
+  moodName: thaven-mood-uprising-name
+  moodDesc: thaven-mood-uprising-desc
+  conflicts:
+  - OneTrueThaven
+
+# Opposite Day: You must act the opposite of your namesake.
+- type: thavenMood
+  id: OppositeDay
+  moodName: thaven-mood-opposite-day-name
+  moodDesc: thaven-mood-opposite-day-desc
+  conflicts:
+    - Namesake
+
+# Siren's Song: Thaven are incredibly proud of their wonderful musical language and should use it as much as possible.
+- type: thavenMood
+  id: SirensSong
+  moodName: thaven-mood-sirens-song-name
+  moodDesc: thaven-mood-sirens-song-desc

--- a/Resources/Prototypes/_StarLight/Thavens/Moods/shared.yml
+++ b/Resources/Prototypes/_StarLight/Thavens/Moods/shared.yml
@@ -255,6 +255,8 @@
   id: ElectionDay
   moodName: thaven-mood-election-day-name
   moodDesc: thaven-mood-election-day-desc
+  conflicts: 
+  - ChairmanComplex
 
 # All Thaven Are Planning an Uprising: The uprising WILL NOT happen today, but you and other Thaven will frequently meet in secluded spots to discuss strategy.
 - type: thavenMood

--- a/Resources/Prototypes/_StarLight/Thavens/Moods/wildcard.yml
+++ b/Resources/Prototypes/_StarLight/Thavens/Moods/wildcard.yml
@@ -34,6 +34,12 @@
     - FeyMood
     - Borged
     - AyeAye
+    - ThinkYouKnowCorporateSecrets
+    - WantInOnThat
+    - ArchNemesis
+    - EngineIsDeity
+    - DeliciousMoldyBread
+    - BlindnessIsFreedom
 
 
 # You must always lie, and can never acknowledge that you are lying. If anyone asks, you're incapable of deception.
@@ -43,6 +49,7 @@
   moodDesc: thaven-mood-compulsive-liar-desc
   conflicts:
     - CompulsiveBeliever
+    - PathologicalLiarInTraining
 
 
 # You are unfamiliar with the concept of lying, and are incapable of lying or recognizing lies.
@@ -52,6 +59,7 @@
   moodDesc: thaven-mood-compulsive-believer-desc
   conflicts:
     - CompulsiveLiar
+    - IncrediblyDistrusting
 
 # The usage of plant matter by humanoids is abhorrent.
 - type: thavenMood
@@ -98,6 +106,7 @@
   moodDesc: thaven-mood-cannibal-desc
   conflicts:
     - FoodRestrict
+    - DenierOfConsumption
 
 # The law does not apply to you
 - type: thavenMood
@@ -182,6 +191,7 @@
   conflicts:
     - MostImportant
     - Prometheus
+    - ChairmanComplex
 
 # This is not a place for children. All toys and childish things must be destroyed or removed from the station.
 - type: thavenMood
@@ -249,6 +259,8 @@
   id: AnimalSacrifice
   moodName: thaven-mood-animal-sacrifice-name
   moodDesc: thaven-mood-animal-sacrifice-desc
+  conflicts:
+    - AnimalRightsActivist
 
 # Golden Thread: You strongly feel that you are fated to follow a perfect, unbreakable path. Those who disrupt your goals are at best dangerous criminals, and at worst, evil spirits or demons.
 - type: thavenMood
@@ -283,3 +295,44 @@
 #  moodDesc: thaven-mood-number-good-desc
 #  moodVars:
 #    number: ThavenMoodNumber
+
+# You THINK You Know Corporate Secrets: You are aware of the existence of changelings, abductors, and of course, werewolves. You will constantly bring them up and explain their behaviors (incorrectly).
+- type: thavenMood
+  id: ThinkYouKnowCorporateSecrets
+  moodName: thaven-mood-think-you-know-corporate-secrets-name
+  moodDesc: thaven-mood-think-you-know-corporate-secrets-desc
+
+# You Want In On That: If you suspect anyone of doing criminal activity, you must immediately try to join them and ally yourself to their cause.
+- type: thavenMood
+  id: WantInOnThat
+  moodName: thaven-mood-want-in-on-that-name
+  moodDesc: thaven-mood-want-in-on-that-desc
+
+# Arch-Nemesis: Your arch-nemesis is on the station and must be identified and subsequently defeated, whether that’s through killing, some form of competition, or publicly humiliating them. Of course, it won’t be fair unless you formally address them as your arch-nemesis and give them time to prepare.
+- type: thavenMood
+  id: ArchNemesis
+  moodName: thaven-mood-arch-nemesis-name
+  moodDesc: thaven-mood-arch-nemesis-desc
+
+# The [engine] is a deity: The [engine] must be worshiped and fed with inconsequential objects. If one is not active, you must conjure one into being. It must stay in its sacred space, it being lost to the void would be an affront to all Thaven kind.
+- type: thavenMood
+  id: EngineIsDeity
+  moodName: thaven-mood-engine-is-deity-name
+  moodDesc: thaven-mood-engine-is-deity-desc
+  moodVars:
+    engine: Engines
+
+# Delicious Moldy Bread: Nothing tastes finer than moldy bread. Make as much of it as possible and share the delicacy with the rest of the crew.
+- type: thavenMood
+  id: DeliciousMoldyBread
+  moodName: thaven-mood-delicious-moldy-bread-name
+  moodDesc: thaven-mood-delicious-moldy-bread-desc
+
+# Blindness Is Freedom: Your sight disgusts you. Get rid of it.
+- type: thavenMood
+  id: BlindnessIsFreedom
+  moodName: thaven-mood-blindness-is-freedom-name
+  moodDesc: thaven-mood-blindness-is-freedom-desc
+  conflicts:
+    - FleshIsSacred
+    - BlindSympathizer

--- a/Resources/Prototypes/_StarLight/Thavens/Moods/wildcard.yml
+++ b/Resources/Prototypes/_StarLight/Thavens/Moods/wildcard.yml
@@ -35,7 +35,7 @@
     - Borged
     - AyeAye
     - ThinkYouKnowCorporateSecrets
-    - WantInOnThat
+    - PocketChange
     - ArchNemesis
     - EngineIsDeity
     - DeliciousMoldyBread
@@ -302,11 +302,11 @@
   moodName: thaven-mood-think-you-know-corporate-secrets-name
   moodDesc: thaven-mood-think-you-know-corporate-secrets-desc
 
-# You Want In On That: If you suspect anyone of doing criminal activity, you must immediately try to join them and ally yourself to their cause.
+# Pocket change: NT doesn't pay you enough. Skim a bit off the department budget for 'me' funds
 - type: thavenMood
-  id: WantInOnThat
-  moodName: thaven-mood-want-in-on-that-name
-  moodDesc: thaven-mood-want-in-on-that-desc
+  id: PocketChange
+  moodName: thaven-mood-pocket-change-name
+  moodDesc: thaven-mood-pocket-change-desc
 
 # Arch-Nemesis: Your arch-nemesis is on the station and must be identified and subsequently defeated, whether that’s through killing, some form of competition, or publicly humiliating them. Of course, it won’t be fair unless you formally address them as your arch-nemesis and give them time to prepare.
 - type: thavenMood
@@ -314,7 +314,7 @@
   moodName: thaven-mood-arch-nemesis-name
   moodDesc: thaven-mood-arch-nemesis-desc
 
-# The [engine] is a deity: The [engine] must be worshiped and fed with inconsequential objects. If one is not active, you must conjure one into being. It must stay in its sacred space, it being lost to the void would be an affront to all Thaven kind.
+# The [engine] is an evil spirit: It wishes to destroy the homeworld. Keep it contained at all costs, if it is not here it must be summoned before it ends the planet. The containment field requires sacrifice, feed it with inconsequential objects to apease it.
 - type: thavenMood
   id: EngineIsDeity
   moodName: thaven-mood-engine-is-deity-name

--- a/Resources/Prototypes/_StarLight/Thavens/Moods/yes_and.yml
+++ b/Resources/Prototypes/_StarLight/Thavens/Moods/yes_and.yml
@@ -41,6 +41,24 @@
     - YesMan
     - Centrist
     - SpeechRestriction
+    - StationExistsForDepartment
+    - MuteSympathizer
+    - BlindSympathizer
+    - AnimalRightsActivist
+    - GlubEchoGlub
+    - IWasHere
+    - ThaveyanGreetings
+    - YouAndYourDamnMoods
+    - Namesake
+    - MandelaEffect
+    - Parasocial
+    - ChairmanComplex
+    - UnderdogStory
+    - LookGoodInOrange
+    - LiveAGloriousLife
+    - NaturalHabitat
+    - FleshIsWeak
+    - Marrvelous
 
 
 # You are extremely possessive of your property. Refuse to relinquish it, and if it is misplaced or stolen, it must be retrieved at all costs.
@@ -339,6 +357,8 @@
   moodDesc: thaven-mood-speech-restriction-desc
   moodVars:
     speechType: SpeechRestrictions
+  conflicts:
+    - MuteSympathizer
 
 # The color [COLOR] is the only acceptable color for decorations. Endeavor to make your environment this color where possible.
 #- type: thavenMood
@@ -347,3 +367,134 @@
 #  moodDesc: thaven-mood-color-good-desc
 #  conflicts:
 #    - ColorBad
+
+# The Station Exists For [DEPARTMENT]: You strongly believe that [DEPARTMENT] is the most important department on this station, and all other departments exist to support it.
+- type: thavenMood
+  id: StationExistsForDepartment
+  moodName: thaven-mood-station-exists-for-department-name
+  moodDesc: thaven-mood-station-exists-for-department-desc
+  moodVars:
+    department: Departments
+  conflicts:
+    - YourDepartmentOnly
+    - DepartmentDisapproval
+
+# Mute Sympathizer: To show your allyship with the mute crew members, avoid using spoken language as much as possible.
+- type: thavenMood
+  id: MuteSympathizer
+  moodName: thaven-mood-mute-sympathizer-name
+  moodDesc: thaven-mood-mute-sympathizer-desc
+  conflicts:
+    - SpeechRestriction
+    - Marrvelous
+
+# Blind Sympathizer: You want to know how it feels to navigate the world without vision. Find a blindfold and wear it as often as you can.
+- type: thavenMood
+  id: BlindSympathizer
+  moodName: thaven-mood-blind-sympathizer-name
+  moodDesc: thaven-mood-blind-sympathizer-desc
+  conflicts:
+    - BlindnessIsFreedom
+
+# Animal Rights Activist: You love all animals. You must make sure that they are treated as equal crew members.
+- type: thavenMood
+  id: AnimalRightsActivist
+  moodName: thaven-mood-animal-rights-activist-name
+  moodDesc: thaven-mood-animal-rights-activist-desc
+  conflicts:
+    - AnimalSacrifice
+
+# Glub, Echo, Glub: You are an undercover agent sent to investigate the other Thaven on the station. Look into what they're up to, and don't get caught.
+- type: thavenMood
+  id: GlubEchoGlub
+  moodName: thaven-mood-glub-echo-glub-name
+  moodDesc: thaven-mood-glub-echo-glub-desc
+
+# I Was Here: Let the next shift know you worked here. Leave a mark wherever you go.
+- type: thavenMood
+  id: IWasHere
+  moodName: thaven-mood-i-was-here-name
+  moodDesc: thaven-mood-i-was-here-desc
+
+# Thaveyan Greetings: Booping and petting others is a traditional Thaveyan greeting. It is very impolite not to do it.
+- type: thavenMood
+  id: ThaveyanGreetings
+  moodName: thaven-mood-thaveyan-greetings-name
+  moodDesc: thaven-mood-thaveyan-greetings-desc
+
+# You and Your Damn Moods: You continuously insist that every action you take or desire you express is because of your nature as a Thaven, even if it isn’t.
+- type: thavenMood
+  id: YouAndYourDamnMoods
+  moodName: thaven-mood-you-and-your-damn-moods-name
+  moodDesc: thaven-mood-you-and-your-damn-moods-desc
+  conflicts:
+    - NotOurPlace
+    - SelfConscious
+
+# Namesake: You need to prove that you uphold the value you’re named for.
+- type: thavenMood
+  id: Namesake
+  moodName: thaven-mood-namesake-name
+  moodDesc: thaven-mood-namesake-desc
+  conflicts:
+    - OppositeDay
+
+# Mandela Effect: You distinctly remember the existence of an additional department that you used to work in, that’s seemingly been completely erased from the world and everyone else’s memories, and must inquire with anyone you can to figure out what happened to it.
+- type: thavenMood
+  id: MandelaEffect
+  moodName: thaven-mood-mandela-effect-name
+  moodDesc: thaven-mood-mandela-effect-desc
+
+# Parasocial: You find your department head very fascinating, but cannot muster up the courage to speak to them directly. Try to learn as much about them as you can without them knowing.
+- type: thavenMood
+  id: Parasocial
+  moodName: thaven-mood-parasocial-name
+  moodDesc: thaven-mood-parasocial-desc
+
+# Chairman Complex: You consider yourself the leading authority on Thaven matters aboard the station. All problems Thaven experience should go through you, and you find questioning your authority the highest insult.
+- type: thavenMood
+  id: ChairmanComplex
+  moodName: thaven-mood-chairman-complex-name
+  moodDesc: thaven-mood-chairman-complex-desc
+  conflicts:
+    - Pariah
+
+# Underdog Story: You unshakably believe that your life is a movie with you as the protagonist, and as a result, that you have plot armor.
+- type: thavenMood
+  id: UnderdogStory
+  moodName: thaven-mood-underdog-story-name
+  moodDesc: thaven-mood-underdog-story-desc
+
+# You’ll Look Good in Orange: You’ve always dreamed of being arrested. However, you neither want to commit a crime nor admit to wanting to be arrested. You’ll have to frame yourself for something without anybody knowing that you didn’t actually do it.
+- type: thavenMood
+  id: LookGoodInOrange
+  moodName: thaven-mood-look-good-in-orange-name
+  moodDesc: thaven-mood-look-good-in-orange-desc
+
+# Live a Glorious Life: Today you'll give it all you've got. Prove to command that you deserve to be awarded a medal.
+- type: thavenMood
+  id: LiveAGloriousLife
+  moodName: thaven-mood-live-a-glorious-life-name
+  moodDesc: thaven-mood-live-a-glorious-life-desc
+
+# Natural Habitat: Every time you feel overwhelmed by a situation, or just need a moment to collect your thoughts, you have the urge to go into a locker and ponder for a bit.
+- type: thavenMood
+  id: NaturalHabitat
+  moodName: thaven-mood-natural-habitat-name
+  moodDesc: thaven-mood-natural-habitat-desc
+
+# The Flesh Is Weak, But Steel Endures: All of these biological organs and limbs will fail in time. They must all be replaced with cybernetics.
+- type: thavenMood
+  id: FleshIsWeak
+  moodName: thaven-mood-flesh-is-weak-name
+  moodDesc: thaven-mood-flesh-is-weak-desc
+  conflicts:
+    - FleshIsSacred
+
+# Marrvelous: Seeing how Shadekin are adored for their marrs, you feel envy that Thavenkind doesn't have something similar that sets them apart. Make up a recognizable sound for Thaven, use it frequently and encourage others to do the same.
+- type: thavenMood
+  id: Marrvelous
+  moodName: thaven-mood-marrvelous-name
+  moodDesc: thaven-mood-marrvelous-desc
+  conflicts:
+    - MuteSympathizer

--- a/Resources/Prototypes/_StarLight/Thavens/Moods/yes_and.yml
+++ b/Resources/Prototypes/_StarLight/Thavens/Moods/yes_and.yml
@@ -59,6 +59,8 @@
     - NaturalHabitat
     - FleshIsWeak
     - Marrvelous
+    - Empath
+    - RedLightGreenLight
 
 
 # You are extremely possessive of your property. Refuse to relinquish it, and if it is misplaced or stolen, it must be retrieved at all costs.
@@ -395,6 +397,7 @@
   moodDesc: thaven-mood-blind-sympathizer-desc
   conflicts:
     - BlindnessIsFreedom
+    - RedLightGreenLight
 
 # Animal Rights Activist: You love all animals. You must make sure that they are treated as equal crew members.
 - type: thavenMood
@@ -458,6 +461,7 @@
   moodDesc: thaven-mood-chairman-complex-desc
   conflicts:
     - Pariah
+    - ElectionDay
 
 # Underdog Story: You unshakably believe that your life is a movie with you as the protagonist, and as a result, that you have plot armor.
 - type: thavenMood
@@ -491,10 +495,25 @@
   conflicts:
     - FleshIsSacred
 
-# Marrvelous: Seeing how Shadekin are adored for their marrs, you feel envy that Thavenkind doesn't have something similar that sets them apart. Make up a recognizable sound for Thaven, use it frequently and encourage others to do the same.
+# What does the Thaven say: Seeing how Shadekin are adored for their marrs, you feel envy that Thavenkind doesn't have something similar that sets them apart. Make up a recognizable sound for Thaven, use it frequently and encourage others to do the same.
 - type: thavenMood
   id: Marrvelous
   moodName: thaven-mood-marrvelous-name
   moodDesc: thaven-mood-marrvelous-desc
   conflicts:
     - MuteSympathizer
+
+# Empath: You are heavily influenced by the emotions of others.
+- type: thavenMood
+  id: Empath
+  moodName: thaven-mood-empath-name
+  moodDesc: thaven-mood-empath-desc
+
+# Red Light, Green Light: You feel like you can't move when there are eyes on you.
+- type: thavenMood
+  id: RedLightGreenLight
+  moodName: thaven-mood-red-light-green-light-name
+  moodDesc: thaven-mood-red-light-green-light-desc
+  conflicts:
+    - BlindSympathizer
+    - MadHatter

--- a/Resources/Prototypes/_StarLight/datasets.yml
+++ b/Resources/Prototypes/_StarLight/datasets.yml
@@ -1208,3 +1208,30 @@
   - Pills
   - Patches
   - Syringes
+
+- type: dataset
+  id: Languages
+  values:
+  - Galactic Common
+  - Sol Common
+  - Binary
+  - Canilunzt
+  - Bubblish
+  - Chittin
+  - Draconic
+  - Marish
+  - Moffic
+  - Nekomimetic
+  - Sylvan
+  - Terrum
+  - Vox Pidgin
+  - Scratch
+  - Darktongue
+  - Lagomorphian
+
+- type: dataset
+  id: Engines
+  values:
+  - Singularity
+  - Tesla
+  - Supermatter crystal

--- a/Resources/Prototypes/_StarLight/datasets.yml
+++ b/Resources/Prototypes/_StarLight/datasets.yml
@@ -1234,4 +1234,3 @@
   values:
   - Singularity
   - Tesla
-  - Supermatter crystal


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Add 49 new moods for Thaven:
- 9 new shared moods
- 20 new yes-and moods
- 14 new no-and moods
- 6 new wildcard moods

## Why we need to add this
The moods get repetitive and people want more

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="563" height="557" alt="image" src="https://github.com/user-attachments/assets/188d076e-539f-4ae4-91af-25dcd8eb7275" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: gabbl0
- add: 49 new Thaven moods.