### PR TITLE
Be a Learner for Longer

### DIFF
--- a/Resources/Prototypes/Roles/requirement_overrides.yml
+++ b/Resources/Prototypes/Roles/requirement_overrides.yml
@@ -150,7 +150,7 @@
       time: 30h
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 15h
+      time: 30h #SL Edit 15h -> 30h
       inverted: true # stop playing intern if you're good at security!
     SecurityOfficer:
     - !type:DepartmentTimeRequirement
@@ -220,21 +220,21 @@
       time: 5m
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 15h
+      time: 25h #SL edit 15 -> 25
       inverted: true
     MedicalIntern:
     - !type:OverallPlaytimeRequirement
       time: 5m
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 15h
+      time: 25h #SL edit 15 -> 25
       inverted: true 
     ResearchAssistant:
     - !type:OverallPlaytimeRequirement
       time: 5m
     - !type:DepartmentTimeRequirement
       department: Science
-      time: 15h
+      time: 25h #SL edit 15 -> 25
       inverted: true 
     Chaplain:
     - !type:OverallPlaytimeRequirement


### PR DESCRIPTION
## Short description
Increased the time you are allowed to keep playing a Learner role before being locked out.
- Security Cadet - 15h -> 30h
- Technical Assistant - 15h -> 25h
- Medical Assistant - 15h -> 25h
- Research Assistant 15h -> 25h

## Why we need to add this
More time to learn roles if you need it. Being forced into Secoff when you aren't confident yet sucks.

## Media (Video/Screenshots)
n/a

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl:
- tweak: Changed max time you can be a Learner Role. Security Cadet 15h > 30h, Technical Assistant, Medical Assistant, and Research Assistant 15h -> 25h.

