### PR TITLE
Uplink capitalization standardization & loc fix

### DIFF
--- a/Resources/Locale/en-US/_Starlight/reagents/meta/cleaning.ftl
+++ b/Resources/Locale/en-US/_Starlight/reagents/meta/cleaning.ftl
@@ -1,4 +1,3 @@
-reagent-name-space-cleaner = space cleaner
 reagent-name-syndicate-space-cleaner = syndicate space cleaner
 reagent-desc-syndicate-space-cleaner = A special variety of common space cleaner used by the Syndicate on... "cleanup operations".
 reagent-physical-desc-suspicious = suspicious

--- a/Resources/Locale/en-US/_Starlight/store/categories.ftl
+++ b/Resources/Locale/en-US/_Starlight/store/categories.ftl
@@ -14,3 +14,6 @@ store-ling-category-sting = Stings
 store-ling-category-utility = Utility
 
 store-category-cantrips-standard = Standard Cantrips
+
+# Uplinks
+store-category-cybernetics = Cybernetics

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -2122,7 +2122,7 @@
 # Job Specific
 
 - type: listing
-  id: uplinkGatfruitSeeds
+  id: UplinkGatfruitSeeds # Starlight
   name: uplink-gatfruit-seeds-name
   description: uplink-gatfruit-seeds-desc
   productEntity: GatfruitSeeds
@@ -2159,7 +2159,7 @@
         - Assistant
 
 - type: listing
-  id: uplinkNecronomicon
+  id: UplinkNecronomicon # Starlight
   name: uplink-necronomicon-name
   description: uplink-necronomicon-desc
   productEntity: BibleNecronomicon
@@ -2201,7 +2201,7 @@
     - Captain # Starlight
 
 - type: listing
-  id: uplinkRevolverCapGunFake
+  id: UplinkRevolverCapGunFake # Starlight
   name: uplink-revolver-cap-gun-fake-name
   description: uplink-revolver-cap-gun-fake-desc
   productEntity: RevolverCapGunFake
@@ -2221,7 +2221,7 @@
     - Captain # Starlight
 
 - type: listing
-  id: uplinkBananaPeelExplosive
+  id: UplinkBananaPeelExplosive # Starlight
   name: uplink-banana-peel-explosive-name
   description: uplink-banana-peel-explosive-desc
   icon: { sprite: Objects/Specific/Hydroponics/banana.rsi, state: peel }
@@ -2280,7 +2280,7 @@
     - Captain # Starlight
 
 - type: listing
-  id: uplinkHotPotato
+  id: UplinkHotPotato # Starlight
   name: uplink-hot-potato-name
   description: uplink-hot-potato-desc
   discountCategory: usualDiscounts
@@ -2323,7 +2323,7 @@
       - Captain # Starlight
 
 - type: listing
-  id: uplinkProximityMine
+  id: UplinkProximityMine # Starlight
   name: uplink-proximity-mine-name
   description: uplink-proximity-mine-desc
   productEntity: WetFloorSignMineExplosive

--- a/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
@@ -1,5 +1,5 @@
 - type: listing
-  id: uplinkContortionistJumpsuit
+  id: UplinkContortionistJumpsuit
   name: uplink-contortionist-jumpsuit-name
   description: uplink-contortionist-jumpsuit-desc
   productEntity: ClothingUniformJumpsuitAtmosSyndie
@@ -34,7 +34,7 @@
   - UplinkWeaponry
 
 - type: listing
-  id: uplinkWeaponShotgunMinotaur
+  id: UplinkWeaponShotgunMinotaur
   name: uplink-minotaur-name
   description: uplink-minotaur-desc
   productEntity: ClothingBackpackDuffelSyndicateFilledMinotaurShotgun
@@ -57,7 +57,7 @@
           - NukeOpsUplink
 
 - type: listing
-  id: uplinkWeaponRiflePitpull
+  id: UplinkWeaponRiflePitpull
   name: uplink-pitbull-bundle-name
   description: uplink-pitbull-bundle-desc
   icon:
@@ -120,7 +120,7 @@
     - Captain
 
 - type: listing
-  id: uplinkWeaponPistolDeagle
+  id: UplinkWeaponPistolDeagle
   name: uplink-deagle-name
   description: uplink-deagle-desc
   productEntity: WeaponPistolDeagle
@@ -133,7 +133,7 @@
     - UplinkWeaponry
 
 - type: listing
-  id: uplinkWeaponPistolStechkin
+  id: UplinkWeaponPistolStechkin
   name: uplink-stechkin-name
   description: uplink-stechkin-desc
   productEntity: WeaponPistolStechkin

--- a/Resources/Prototypes/_StarLight/Store/categories.yml
+++ b/Resources/Prototypes/_StarLight/Store/categories.yml
@@ -99,7 +99,7 @@
 # agent uplink
 - type: storeCategory
   id: UplinkCybernetics
-  name: Cybernetics
+  name: store-category-cybernetics
   
 # salvage
 


### PR DESCRIPTION
## Short description
Makes all Traitor/Nukie uplink items have a capital U. Also fixes the cybernetics uplink loc.

## Why we need to add this
Mostly for consistency and staff-facing data analysis.

Similar to the [label loc fix PR](https://github.com/ss14Starlight/space-station-14/pull/3399), the uplink categories expect localization, but the cybernetics category was given a string instead. (Also fixes a duplicate loc I missed in that PR.)

## Media (Video/Screenshots)
<img width="219" height="23" alt="image" src="https://github.com/user-attachments/assets/b1d30cd1-79bb-4922-9932-5170301525ba" />

The end of this
<img width="445" height="254" alt="image" src="https://github.com/user-attachments/assets/4f5c5ffc-9367-402e-84ea-a10dd6cf96dc" />

Thanks to this
<img width="352" height="55" alt="image" src="https://github.com/user-attachments/assets/16c0a194-e9f3-4eac-b9c8-860052c8b6b1" />

<img width="299" height="63" alt="image" src="https://github.com/user-attachments/assets/a34b1580-857d-4b43-9abc-85458df2d395" />

## Tests
I have opened the uplink and the items were there.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: All traitor/nukie uplink items now have a capital U in their IDs.
- fix: Cybernetics uplink now has proper localization.
- fix: Removes a duplicate space cleaner localization.