### PR TITLE
Fix mass driver activating on ghosts

### DIFF
--- a/Content.Shared/_Starlight/MassDriver/EntitySystems/SharedMassDriverSystem.cs
+++ b/Content.Shared/_Starlight/MassDriver/EntitySystems/SharedMassDriverSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Power.EntitySystems;
 using Content.Shared.Audio;
 using Robust.Shared.Timing;
 using Robust.Shared.GameObjects;
+using Content.Shared.Ghost;
 
 namespace Content.Shared._Starlight.MassDriver.EntitySystems;
 
@@ -15,11 +16,12 @@ public abstract class SharedMassDriverSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAmbientSoundSystem _audioSystem = default!;
+    private EntityQuery<GhostComponent> _ghostQuery;
 
     public override void Initialize()
     {
         base.Initialize();
-
+        _ghostQuery = GetEntityQuery<GhostComponent>();
         SubscribeLocalEvent<MassDriverComponent, PowerChangedEvent>(OnPowerChanged);
     }
 
@@ -64,6 +66,9 @@ public abstract class SharedMassDriverSystem : EntitySystem
 
             entities.Clear();
             _lookup.GetEntitiesIntersecting(uid, entities, LookupFlags.Dynamic);
+            
+            // Preventing Ghosts from activating mass drivers
+            entities.RemoveWhere(entity => _ghostQuery.HasComp(entity));
 
             int entitiesCount = entities.Count;
 

--- a/Content.Shared/_Starlight/MassDriver/EntitySystems/SharedMassDriverSystem.cs
+++ b/Content.Shared/_Starlight/MassDriver/EntitySystems/SharedMassDriverSystem.cs
@@ -68,7 +68,7 @@ public abstract class SharedMassDriverSystem : EntitySystem
             _lookup.GetEntitiesIntersecting(uid, entities, LookupFlags.Dynamic);
             
             // Preventing Ghosts from activating mass drivers
-            entities.RemoveWhere(entity => _ghostQuery.HasComp(entity));
+            entities.RemoveWhere(_ghostQuery.HasComp);
 
             int entitiesCount = entities.Count;
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
This fixes ghosts activating and being moved by mass drivers if they are on the same tile.

## Why we need to add this
Bug fix, ghosts should not activate mass drivers.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/473e6006-a96b-4f2b-9e6e-d251c02a9a70


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- fix: Ghosts no longer activate mass drivers.