### PR TITLE
Make NTR's secure briefcase bomb proof

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/briefcases.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/briefcases.yml
@@ -62,3 +62,5 @@
     - CombinationLocks
   - type: StealTarget
     stealGroup: NTRepBriefcaseSecure
+  - type: ExplosionResistance
+    damageCoefficient: 0

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Misc/briefcases.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Misc/briefcases.yml
@@ -32,7 +32,8 @@
     range: 20
     sound: 
       collection: "sparks"
-    
+  - type: ExplosionResistance
+    damageCoefficient: 0
 
 - type: entity
   parent: BriefcaseBaseSecure
@@ -62,5 +63,3 @@
     - CombinationLocks
   - type: StealTarget
     stealGroup: NTRepBriefcaseSecure
-  - type: ExplosionResistance
-    damageCoefficient: 0


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

Make NTR's secure briefcase bomb proof to prevent the contents from ashing.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

https://discord.com/channels/1272545509562777621/1473501917614313627

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

I confirmed this method works to ash the contents pre-changes. Here it is post-changes:

https://github.com/user-attachments/assets/d2c09a36-cbd1-4449-b95d-961b07d975a9

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: Secure briefcases (such as NTR's) now keeps the contents safe from ashing.