### PR TITLE
Makes Anomalies as a whole more powerful

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -100,10 +100,10 @@
   - type: ProjectileAnomaly
     projectilePrototype: ProjectileAnomalyFireball
     projectileSpeed: 0.5
-    minProjectiles: 3
-    maxProjectiles: 6
+    minProjectiles: 4 # Starlight start: Changed the danger of the fire anomaly so then it demands more collaboration of crew 
+    maxProjectiles: 8
   - type: IgnitionSource
-    temperature: 800
+    temperature: 1200 # Starlight end:
     ignited: true
   - type: IgniteOnCollide
     fixtureId: fix1
@@ -222,8 +222,8 @@
     entries:
     - settings:
         spawnOnPulse: true
-        minAmount: 1
-        maxAmount: 4
+        minAmount: 2 #starlight Start: Makes the anomaly more dangerous (1>2)
+        maxAmount: 5 #starlight end: Makes the anomaly more dangerous (4>5)
         minRange: 1.5
         maxRange: 2.5
       spawns:
@@ -258,8 +258,8 @@
       - MobFleshLover
     - settings:
         spawnOnSuperCritical: true
-        minAmount: 5
-        maxAmount: 8
+        minAmount: 8 #starlight Start: Makes more Kudzu when Supercritical
+        maxAmount: 10 #starlight end: 
         maxRange: 10
       spawns:
       - FleshKudzu
@@ -348,7 +348,7 @@
       collection: AnomalyIceSupercritical
   - type: ExplosionAnomaly
     supercriticalExplosion: Cryo
-    explosionTotalIntensity: 300
+    explosionTotalIntensity: 500 #Starlight Tweak: make Ice anom Critical more dangerous
     explosionDropoff: 2
     explosionMaxTileIntensity: 20
   - type: ProjectileAnomaly
@@ -800,13 +800,13 @@
     entries:
     - settings:
         spawnOnPulse: true
-        minAmount: 3
-        maxAmount: 7
+        minAmount: 5 #starlight start: Spawns more grass on pulses
+        maxAmount: 10 #starlight end: 
         maxRange: 5
       floor: FloorAstroGrass
     - settings:
         spawnOnSuperCritical: true
-        minAmount: 10
+        minAmount: 20 #starlight tweak: Adds more Grass on Critical
         maxAmount: 30
         maxRange: 15
       floor: FloorAstroGrass
@@ -821,9 +821,9 @@
       - KudzuFlowerFriendly
     - settings:
         spawnOnSuperCritical: true
-        minAmount: 5
-        maxAmount: 10
-        maxRange: 6
+        minAmount: 10 #starlight Start: Adds more Kudzu on critical
+        maxAmount: 15  
+        maxRange: 8 #starlight end:
       spawns:
       - KudzuFlowerAngry
 
@@ -905,8 +905,8 @@
     entries:
     - settings:
         spawnOnSuperCritical: true
-        minAmount: 3
-        maxAmount: 8
+        minAmount: 5 #starlight Start: Makes the anom more dangerous to crit
+        maxAmount: 10 #starlight End:
         maxRange: 2
       spawns:
       - ReagentSlimeSpawner

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -135,8 +135,8 @@
             - SpawnClownSpider
         - settings:
             spawnOnSuperCritical: true
-            minAmount: 1
-            maxAmount: 5
+            minAmount: 5
+            maxAmount: 10
             maxRange: 10
           spawns:
             - ClownKudzu

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -33,13 +33,20 @@
           spawns:
             - TrashBananaPeel
             - FloorBananiumEntity
+        - settings: 
+            spawnOnPulse: true
+            minAmount: 1
+            maxAmount: 3
+            maxRange: 4
+          spawns:
+            - MobMonkey 
         - settings:
             spawnOnSuperCritical: true
             minAmount: 5
-            maxAmount: 12
+            maxAmount: 10
             maxRange: 6
           spawns:
-            - MobMonkey
+            - MobGorilla
     - type: RadiationSource
 
 - type: entity
@@ -106,6 +113,7 @@
             - MobClownGolem
             - MobClownClamp
             - MobClownLover
+            - SpawnClownSpider
         #        - settings:
         #            spawnOnSuperCritical: true
         #            minAmount: 10
@@ -124,10 +132,11 @@
             - MobClownGolem
             - MobClownClamp
             - MobClownLover
+            - SpawnClownSpider
         - settings:
             spawnOnSuperCritical: true
-            minAmount: 5
-            maxAmount: 8
+            minAmount: 1
+            maxAmount: 5
             maxRange: 10
           spawns:
             - ClownKudzu


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Tries to make the anoms critical state more dangerous and some anoms that are more 'Weak' more dangerous to deal with, some more commits on Tech anom and other anoms is planned on the future.

## Why we need to add this
Currently is very common to anoms to crit with low impact and low punishment, i really think that the impact of them could be more dangerous, so then making the collaboration between Crew more necessary and making more for a dynamic and chaotic variability between rounds.

# Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Vincolan
- tweak: Banana Anomaly now spawns Gorillas at the Critical and  Friendly monkeys at pulse.
- tweak: Fire anom pulses are now more dangerous.
- tweak: Ice anom critical explosion is more powerful.
- tweak: Clown and Plant Anomaly now spawns more Kudzu .
- tweak: Now the Clown anomaly creates ClownSpiders on Critical.
- tweak: Some other minor anomalies changes.