### PR TITLE
IAA Default Command Access

### DIFF
--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Law/iaa.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Law/iaa.yml
@@ -18,6 +18,7 @@
   displayWeight: 40
   access:
   - IAA
+  - Command
   - Brig
   - Maintenance
   - Lawyer


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Making IAAs have command access by default.

## Why we need to add this
IAAs typically get command access anyways. This is because SoP requires centcom employees to go to a secure location on red alert or above. 

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="675" height="401" alt="Screenshot_2026-02-21_22-33-16" src="https://github.com/user-attachments/assets/b546abdf-2c9d-4070-a9e7-3c1733d286d4" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Nullnominal
- tweak: CC Has finally realized that IAAs should have command access by default
