### PR TITLE
HOTFIX: Nuke player labels

### DIFF
--- a/Content.Shared/Labels/Components/HandLabelerComponent.cs
+++ b/Content.Shared/Labels/Components/HandLabelerComponent.cs
@@ -19,6 +19,12 @@ public sealed partial class HandLabelerComponent : Component
 
     [DataField]
     public EntityWhitelist Whitelist = new();
+    
+    /// <summary>
+    /// STARLIGHT: Blacklist for entities that may not be labeled. Checked BEFORE the whitelist. 
+    /// </summary>
+    [DataField]
+    public EntityWhitelist Blacklist = new();
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -93,8 +93,15 @@ public abstract class SharedHandLabelerSystem : EntitySystem
 
     private void OnUtilityVerb(Entity<HandLabelerComponent> ent, ref GetVerbsEvent<UtilityVerb> args)
     {
-        if (args.Target is not { Valid: true } target || _whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, target) || !args.CanAccess)
+        // Starlight BEGIN
+        // Split out to reduce boolean vomit.
+        if (args.Target is not { Valid: true } target|| !args.CanAccess) 
             return;
+        if (_whitelistSystem.IsWhitelistPass(ent.Comp.Blacklist, target)) // If it hits the blacklist, abort
+            return;
+        if (_whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, target)) // If it fails the whitelist, abort
+            return;
+        // Starlight END
 
         var user = args.User;   // can't use ref parameter in lambdas
 
@@ -128,8 +135,15 @@ public abstract class SharedHandLabelerSystem : EntitySystem
 
     private void AfterInteractOn(Entity<HandLabelerComponent> ent, ref AfterInteractEvent args)
     {
-        if (args.Target is not { Valid: true } target || _whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, target) || !args.CanReach)
+        // Starlight BEGIN
+        // Split out to reduce boolean vomit.
+        if (args.Target is not { Valid: true } target|| !args.CanReach) 
             return;
+        if (_whitelistSystem.IsWhitelistPass(ent.Comp.Blacklist, target)) // If it hits the blacklist, abort
+            return;
+        if (_whitelistSystem.IsWhitelistFail(ent.Comp.Whitelist, target)) // If it fails the whitelist, abort
+            return;
+        // Starlight END
 
         AddLabelTo(ent, args.User, target);
     }

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -35,7 +35,6 @@
     - SpiderCraft
     - AnomalyHost
     - Arachnid
-    - Labelable # Starlight
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -232,7 +232,6 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
-    - Labelable # Starlight
   - type: ActiveInputMover # Starlight
   # Starlight Start: Social Interactions
   - type: PhysicalSocialInteractionGiver

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -22,7 +22,6 @@
     - DoorBumpOpener
     - AnomalyHost
     - Diona
-    - Labelable # Starlight
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -29,7 +29,6 @@
   - type: Tag
     tags:
     - Unimplantable # _Starlight
-    - Labelable # Starlight
   - type: MobState
   - type: MobThresholds
     thresholds:

--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -20,12 +20,16 @@
         enum.HandLabelerUiKey.Key:
           type: HandLabelerBoundUserInterface
     - type: HandLabeler
+    # Starlight-start
+      blacklist:
+        tags:
+          - NotLabelable
+    # Starlight-end
       whitelist:
         components:
           - Item
         tags:
           - Structure
-          - Labelable # Starlight: Playable races can be labeled
     - type: PhysicalComposition
     # Starlight-start: Vending Machines Prices
     - type: ItemPrice

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Player/shadekin.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Player/shadekin.yml
@@ -24,5 +24,4 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
-    - Labelable
     - CantBecomeRevolutionary

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/avali.yml
@@ -43,6 +43,7 @@
         - DoorBumpOpener
         - AnomalyHost
         - Avali
+        - NotLabelable
     - type: Absorbable
     - type: HumanoidAppearance
       species: Avali

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/felionoid.yml
@@ -80,6 +80,7 @@
     - DoorBumpOpener
     - AnomalyHost
     - Felionoid
+    - NotLabelable
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/Species/resomi.yml
@@ -304,6 +304,7 @@
     - DoorBumpOpener
     - AnomalyHost
     - Resomi
+    - NotLabelable
   - type: NightVision
   - type: FlashModifier
     modifier: 2

--- a/Resources/Prototypes/_StarLight/tags.yml
+++ b/Resources/Prototypes/_StarLight/tags.yml
@@ -297,9 +297,6 @@
 # Used for the jet injector and advanced jet injector
 - type: Tag
   id: JetInjector
-  
-- type: Tag
-  id: Labelable
 
 - type: Tag
   id: L6Saw
@@ -382,6 +379,9 @@
 
 - type: Tag
   id: Nexus
+  
+- type: Tag
+  id: NotLabelable
 
 - type: Tag
   id: NukiePlanet


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

- Reverts https://github.com/ss14Starlight/space-station-14/pull/2758
- Adds blacklist instead to fix avali/resomi/felionoids being labelable

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

- **Presumed cmdlink exploit seen in Alfa.**
  - <img width="595" height="543" alt="image" src="https://github.com/user-attachments/assets/855b1f9e-2e84-41a3-9546-0a9c16c4f7a0" />
  - https://discord.com/channels/1272545509562777621/1356838103670849710/1475038628840345612

- Player labels brought more problems than anticipated and people are rightfully complaining.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/5bea30a1-3b91-4a3e-ad45-ef44dda287ed


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- remove: Players can no longer be labeled.
