### PR TITLE
Revert "Fix labels appearing in radio comms"

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -35,7 +35,6 @@ using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 using Content.Shared._Starlight.Radio; //Starlight
-using Content.Shared.NameModifier.Components; //Starlight
 
 namespace Content.Server.Radio.EntitySystems;
 
@@ -143,10 +142,6 @@ public sealed class RadioSystem : EntitySystem
 
         var meta = MetaData(messageSource);
         var entityName = meta?.EntityName ?? string.Empty;
-        // Starlight BEGIN
-        if (TryComp(messageSource, out NameModifierComponent? nameModifier))
-            entityName = nameModifier.BaseName; // Bypass name modifiers (specifically: labels).
-        // Starlight END
         var evt = new TransformSpeakerNameEvent(messageSource, entityName);
         RaiseLocalEvent(messageSource, evt);
 


### PR DESCRIPTION
This reverts commit d097b2363e95a48b16afe673e1eff69c04b330a8.

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Reverts #3391 since player labels are being deleted per #3417 .

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Reverts #3391 since player labels are being deleted per #3417 .

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->