### PR TITLE
Disable animal husbandry functions on zombification

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -48,6 +48,8 @@ using Content.Server._Starlight.Language;
 using Content.Shared._Starlight.Language.Components;
 using Content.Server._Starlight.Antags.Vampires;
 using Content.Shared._Starlight.Antags.Vampires.Components;
+using Content.Server.Animals.Components;
+using Content.Shared.Animals;
 #endregion Starlight
 
 namespace Content.Server.Zombies;
@@ -166,6 +168,9 @@ public sealed partial class ZombieSystem
         _language.AddLanguage(target, "Zombie");
 
         RemComp<VampireComponent>(target); //De-vamps Vampire zombies
+        RemComp<EggLayerComponent>(target); //Prevent infinite egg production
+        RemComp<UdderComponent>(target); //Prevent infinite milk production
+        RemComp<WoolyComponent>(target); //Prevent infinite wool production
         // Starlight-end
 
         //This is needed for stupid entities that fuck up combat mode component


### PR DESCRIPTION
## Short description
Disables animal husbandry features on zombification.

## Why we need to add this
Animal production features are still enabled when it has been zombified. Because all of these are set to allow infinite production when a hunger component is missing, these animals will produce infinite resources once they've been zombified.

See the following summaries for each corresponding component's system:
https://github.com/ss14Starlight/space-station-14/blob/ef9311d93274bb9d4a2295ce7d483e8f22f63013/Content.Server/Animals/Systems/EggLayerSystem.cs#L16-L19
https://github.com/ss14Starlight/space-station-14/blob/ef9311d93274bb9d4a2295ce7d483e8f22f63013/Content.Shared/Animals/UdderSystem.cs#L15-L18
https://github.com/ss14Starlight/space-station-14/blob/ef9311d93274bb9d4a2295ce7d483e8f22f63013/Content.Shared/Animals/WoolySystem.cs#L11-L14

In practice this isn't really noticeable except for eggs, which can end up being produced in very large numbers.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- remove: Zombified animals such as chickens and ducks no longer produce eggs.
- remove: Zombified animals such as cows and goats no longer produce milk.
- remove: Zombified animals such as goats no longer produce wool.