### PR TITLE
Power Event Audio Overlap Bugfix

### DIFF
--- a/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
+++ b/Content.Server/StationEvents/Events/PowerGridCheckRule.cs
@@ -61,24 +61,7 @@ namespace Content.Server.StationEvents.Events
                 }
             }
 
-            // Can't use the default EndAudio
-            component.AnnounceCancelToken?.Cancel();
-            component.AnnounceCancelToken = new CancellationTokenSource();
-            Timer.Spawn(3000, () =>
-            {
-                //Starlight begin - dumb.
-                TryComp<StationEventComponent>(uid, out var stationEvent);
-                if (stationEvent is null) return;
-                if (stationEvent.GlobalAnnouncement)
-                    Audio.PlayGlobal(component.PowerOnSound, Filter.Broadcast(), true);
-                else
-                    Audio.PlayGlobal(component.PowerOnSound,
-                        Filter.Empty().AddWhere(session =>
-                            session.AttachedEntity is not null &&
-                            TryComp<StationMemberComponent>(Transform(session.AttachedEntity.Value).GridUid,
-                                out var station) && station.Station == stationEvent.TargetStation), true);
-                //Starlight end
-            }, component.AnnounceCancelToken.Token);
+            
             component.Unpowered.Clear();
         }
 


### PR DESCRIPTION
**NOTE**: Needs testing in an environment with our TTS systems. I could only test the removal of the event end audio, but I cannot test how that interacts with the TTS, though I am pretty confident it would work just fine.


## Short description
I have entirely removed the audio for the ending announcement for this event, because it and the TTS overlap in audio. It is much more feasible to remove the event audio than it is to prevent the TTS to trigger, and that is what I have done.

## Why we need to add this

It is a bugfix, the overlapping audio is unintended.

## Media (Video/Screenshots)

The video is too large for me to upload (just 2 minutes was too big?). the important part is that the event works just like before, but when the event ends no station announcement audio is played, so the TTS will be the only audio.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ Mostly, just need a TTS test] I do not require assistance to complete the PR.
- [Mostly, but I cannot Test TTS] Before posting/requesting review of a PR, I have verified that the changes work.
- [no] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl:
- fix: Fixed the station AI audio overlap for when power is restored.
