### PR TITLE
Added Parameds as mindshielded in Revolutionary Guidebook

### DIFF
--- a/Resources/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml
@@ -52,7 +52,7 @@
   - [bold]Visibly be destroyed upon being implanted into a [color=#ed7300]Head Revolutionary[/color][/bold], giving you away
   - NOT protect against flash disorientation
 
-  Assume all of [color=#cb0000]Security[/color], [color=#1b67a5]Command[/color], [color=#a86819]Salvage specialists[/color] and [color=#478bff]Internal Affairs Agents[/color] to be implanted with [color=cyan]MindShields™[/color] already, [bold]however they can be removed by using an empty implanter obtainable from the Medical department's MedFab, or by using an [color=#ed7300][bold]SKB Demindshielder[/bold][/color] available in your [color=#ed7300]uplink.[/color][/bold] <!-- Starlight-edit -->
+  Assume all of [color=#cb0000]Security[/color], [color=#1b67a5]Command[/color], [color=#a86819]Salvage specialists[/color], [color=#5b97bc]Paramedics[/color] and [color=#478bff]Internal Affairs Agents[/color] to be implanted with [color=cyan]MindShields™[/color] already, [bold]however they can be removed by using an empty implanter obtainable from the Medical department's MedFab, or by using an [color=#ed7300][bold]SKB Demindshielder[/bold][/color] available in your [color=#ed7300]uplink.[/color][/bold] <!-- Starlight-edit -->
 
   <Box>
     <GuideEntityEmbed Entity="ToyFigurineSecurity" Caption=""/>


### PR DESCRIPTION
## Short description
Added parameds to the list of likely mindshielded personnel.

## Why we need to add this
With redmushie's PR #3368 to make paramedics mindshielded, we should also add them to the guidebook for revs to make it clear to players who are not familiar with this change, that parameds might be a bad target to flash now. 

Took the color code from the medical guidebook entry for the paramed color in this PR.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Currently have a RAM eating job running on my machine, and cannot start local instance. But changes should be small enough to not need it. 

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: SiTW
- tweak: Included paramedics in the mindshielded section in revolutionary guidebook.
