### PR TITLE
Fix several missing guidebook entries for food recipes

### DIFF
--- a/Resources/Prototypes/_StarLight/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Cooking/meal_recipes.yml
@@ -89,7 +89,7 @@
   name: charcuterie recipe
   result: FoodCharcuterie
   time: 5
-  group: Savoury
+  group: Savory
   solids:
     FoodCheeseSlice: 2
     FoodMeatCutletCooked: 2
@@ -101,7 +101,7 @@
   name: khlav kalash recipe
   result: FoodMealKhlavKalash
   time: 5
-  group: Savoury
+  group: Savory
   reagents:
     Enzyme: 1
   solids:
@@ -126,7 +126,7 @@
   name: haggis recipe
   result: FoodHaggis
   time: 15
-  group: Meat
+  group: Savory
   reagents:
     UncookedAnimalProteins: 10
   solids:
@@ -137,7 +137,7 @@
   name: black pudding recipe
   result: FoodBlackPudding
   time: 15
-  group: Meat
+  group: Savory
   reagents:
     Blood: 10
     Water: 10


### PR DESCRIPTION
## Short description
Fixes 4 missing guidebook entries for food recipes

## Why we need to add this
Makes these recipes more discoverable by ensuring that they show up in the guidebook correctly.

## Media (Video/Screenshots)
<img width="350" alt="image" src="https://github.com/user-attachments/assets/e987fbe8-5d23-4d42-8782-fa7202ae1538" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/9d84d814-686b-49f6-8145-3488738497f9" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/f10306df-b2fc-498d-a68f-ffaefe071973" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/d5504c25-a6c1-42a7-aaf4-2387f891df9c" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- fix: Black pudding recipe is now visible in the guidebook.
- fix: Charcuterie board recipe is now visible in the guidebook.
- fix: Khlav kalash recipe is now visible in the guidebook.
- fix: Haggis recipe is now visible in the guidebook.