### PR TITLE
Tweaks destory beam to sound deadlier

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/BatteryWeaponFireModesComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BatteryWeaponFireModesComponent.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Shared.Weapons.Ranged.Systems;
 using Content.Shared._Starlight.Weapons.Ranged.Components; // Starlight-edit
-using Robust.Shared.Audio; // Starlight-edit
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -66,16 +65,6 @@ public sealed partial class BatteryWeaponFireMode
     
     [DataField("visualState")]
     public string? VisualState;
-
-    // Starlight-start
-    /// <summary>
-    /// Optional gunshot sound override for this fire mode.
-    /// When set, replaces the gun's base SoundGunshot while this mode is active.
-    /// </summary>
-    [DataField("soundGunshot", serverOnly: true)]
-    [NonSerialized]
-    public SoundSpecifier? SoundGunshot;
-    // Starlight-end
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Weapons/Ranged/Components/BatteryWeaponFireModesComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/BatteryWeaponFireModesComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Weapons.Ranged.Systems;
 using Content.Shared._Starlight.Weapons.Ranged.Components; // Starlight-edit
+using Robust.Shared.Audio; // Starlight-edit
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -65,6 +66,16 @@ public sealed partial class BatteryWeaponFireMode
     
     [DataField("visualState")]
     public string? VisualState;
+
+    // Starlight-start
+    /// <summary>
+    /// Optional gunshot sound override for this fire mode.
+    /// When set, replaces the gun's base SoundGunshot while this mode is active.
+    /// </summary>
+    [DataField("soundGunshot", serverOnly: true)]
+    [NonSerialized]
+    public SoundSpecifier? SoundGunshot;
+    // Starlight-end
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
@@ -14,6 +14,8 @@ using Content.Shared._Starlight.Weapons.Ranged.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
 using Content.Shared.Lock;
+using Content.Shared.Weapons.Ranged.Events;
+using Robust.Shared.Audio;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 #endregion Starlight
@@ -42,6 +44,7 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
         SubscribeLocalEvent<BatteryWeaponFireModesComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<BatteryWeaponFireModesComponent, ActivateInWorldEvent>(OnInteractHandEvent); // Starlight-edit
         SubscribeLocalEvent<BatteryWeaponFireModesComponent, AttemptShootEvent>(OnShootAttempt); // Starlight-edit
+        SubscribeLocalEvent<BatteryWeaponFireModesComponent, GunRefreshModifiersEvent>(OnGunRefreshModifiers); // Starlight-edit
     }
 
     private void OnExamined(Entity<BatteryWeaponFireModesComponent> ent, ref ExaminedEvent args)
@@ -204,6 +207,11 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
 
             _gun.UpdateShots((ent, batteryAmmoProviderComponent));
         }
+
+        // Starlight-start: per-fire-mode gunshot sound override
+        if (TryComp(ent, out GunComponent? gunComp))
+            _gun.RefreshModifiers((ent, gunComp));
+        // Starlight-end
     }
 
     # region Starlight
@@ -258,4 +266,28 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
     }
 
     # endregion Starlight
+
+    // Starlight-start
+    private void OnGunRefreshModifiers(Entity<BatteryWeaponFireModesComponent> ent, ref GunRefreshModifiersEvent args)
+    {
+        var fireMode = GetMode(ent.Comp);
+
+        // Explicit per-mode sound override takes priority
+        if (fireMode.SoundGunshot != null)
+        {
+            args = args with { SoundGunshot = fireMode.SoundGunshot };
+            return;
+        }
+
+        // DestroyBeam fire mode dynamically inherits the x-ray cannon's gunshot sound,
+        // so no path is hardcoded — if WeaponXrayCannon's sound changes it propagates here too.
+        if (fireMode.Prototype == "DestroyBeam" &&
+            _prototypeManager.TryIndex<EntityPrototype>("WeaponXrayCannon", out var xrayProto) &&
+            xrayProto.TryGetComponent<GunComponent>(out var xrayGun) &&
+            xrayGun.SoundGunshot != null)
+        {
+            args = args with { SoundGunshot = xrayGun.SoundGunshot };
+        }
+    }
+    // Starlight-end
 }

--- a/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
@@ -15,7 +15,6 @@ using Content.Shared.Interaction;
 using Content.Shared.Item;
 using Content.Shared.Lock;
 using Content.Shared.Weapons.Ranged.Events;
-using Robust.Shared.Audio;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 #endregion Starlight
@@ -44,7 +43,7 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
         SubscribeLocalEvent<BatteryWeaponFireModesComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<BatteryWeaponFireModesComponent, ActivateInWorldEvent>(OnInteractHandEvent); // Starlight-edit
         SubscribeLocalEvent<BatteryWeaponFireModesComponent, AttemptShootEvent>(OnShootAttempt); // Starlight-edit
-        SubscribeLocalEvent<BatteryWeaponFireModesComponent, GunRefreshModifiersEvent>(OnGunRefreshModifiers); // Starlight-edit
+        SubscribeLocalEvent<GunFireModeSoundsComponent, GunRefreshModifiersEvent>(OnGunRefreshModifiers); // Starlight-edit
     }
 
     private void OnExamined(Entity<BatteryWeaponFireModesComponent> ent, ref ExaminedEvent args)
@@ -57,12 +56,11 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
         // Starlight-start
         if (TryGetAmmoProvider(ent, out var ammoProvider) && ammoProvider != null)
         {
-            if (ammoProvider is BatteryAmmoProviderComponent projectileAmmo)
+            if (ammoProvider is BatteryAmmoProviderComponent)
             {
-                if (!_prototypeManager.TryIndex<EntityPrototype>(fireMode.Prototype, out var projectile))
-                    return;
-
-                args.PushMarkup(Loc.GetString("gun-set-fire-mode-examine", ("mode", projectile.Name)));
+                // Hitscan prototypes aren't indexed as EntityPrototype — skip examine line if not found
+                if (_prototypeManager.TryIndex<EntityPrototype>(fireMode.Prototype, out var projectile))
+                    args.PushMarkup(Loc.GetString("gun-set-fire-mode-examine", ("mode", projectile.Name)));
             }
         }
         // Starlight-end
@@ -96,15 +94,18 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
             var index = i;
 
             // Starlight-start
-            if (ammoProvider is BatteryAmmoProviderComponent projectileAmmo)
+            if (ammoProvider is BatteryAmmoProviderComponent)
             {
-                var entProto = _prototypeManager.Index<EntityPrototype>(fireMode.Prototype);
+                // Hitscan prototypes aren't EntityPrototypes — fall back to the prototype ID as display name
+                var label = _prototypeManager.TryIndex<EntityPrototype>(fireMode.Prototype, out var entProto)
+                    ? entProto.Name
+                    : fireMode.Prototype;
 
                 var v = new Verb
                 {
                     Priority = 1,
                     Category = VerbCategory.SelectType,
-                    Text = entProto.Name,
+                    Text = label,
                     Disabled = i == component.CurrentFireMode,
                     Impact = LogImpact.Low,
                     DoContactInteraction = true,
@@ -177,9 +178,6 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
         {
             if (ammoProvider is BatteryAmmoProviderComponent projectileAmmo)
             {
-                if (!_prototypeManager.TryIndex<EntityPrototype>(fireMode.Prototype, out var prototype))
-                    return;
-
                 var oldFireCost = projectileAmmo.FireCost;
                 projectileAmmo.Prototype = fireMode.Prototype;
                 projectileAmmo.FireCost = fireMode.FireCost;
@@ -189,7 +187,8 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
                 projectileAmmo.Capacity = (int)Math.Round(projectileAmmo.Capacity / fireCostDiff);
                 Dirty(ent, projectileAmmo);
 
-                if (user != null)
+                // Hitscan prototypes aren't indexed as EntityPrototype — skip popup if not found
+                if (user != null && _prototypeManager.TryIndex<EntityPrototype>(fireMode.Prototype, out var prototype))
                     _popupSystem.PopupPredicted(Loc.GetString("gun-set-fire-mode-popup", ("mode", prototype.Name)), ent, user);
             }
 
@@ -268,26 +267,13 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
     # endregion Starlight
 
     // Starlight-start
-    private void OnGunRefreshModifiers(Entity<BatteryWeaponFireModesComponent> ent, ref GunRefreshModifiersEvent args)
+    private void OnGunRefreshModifiers(Entity<GunFireModeSoundsComponent> ent, ref GunRefreshModifiersEvent args)
     {
-        var fireMode = GetMode(ent.Comp);
-
-        // Explicit per-mode sound override takes priority
-        if (fireMode.SoundGunshot != null)
-        {
-            args = args with { SoundGunshot = fireMode.SoundGunshot };
+        if (!TryComp<BatteryWeaponFireModesComponent>(ent, out var fireModes))
             return;
-        }
 
-        // DestroyBeam fire mode dynamically inherits the x-ray cannon's gunshot sound,
-        // so no path is hardcoded — if WeaponXrayCannon's sound changes it propagates here too.
-        if (fireMode.Prototype == "DestroyBeam" &&
-            _prototypeManager.TryIndex<EntityPrototype>("WeaponXrayCannon", out var xrayProto) &&
-            xrayProto.TryGetComponent<GunComponent>(out var xrayGun) &&
-            xrayGun.SoundGunshot != null)
-        {
-            args = args with { SoundGunshot = xrayGun.SoundGunshot };
-        }
+        if (ent.Comp.Sounds.TryGetValue(fireModes.CurrentFireMode, out var sound))
+            args = args with { SoundGunshot = sound };
     }
     // Starlight-end
 }

--- a/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
@@ -96,7 +96,6 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
             // Starlight-start
             if (ammoProvider is BatteryAmmoProviderComponent)
             {
-                // Hitscan prototypes aren't EntityPrototypes — fall back to the prototype ID as display name
                 var label = _prototypeManager.TryIndex<EntityPrototype>(fireMode.Prototype, out var entProto)
                     ? entProto.Name
                     : fireMode.Prototype;

--- a/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
@@ -187,7 +187,6 @@ public sealed class BatteryWeaponFireModesSystem : EntitySystem
                 projectileAmmo.Capacity = (int)Math.Round(projectileAmmo.Capacity / fireCostDiff);
                 Dirty(ent, projectileAmmo);
 
-                // Hitscan prototypes aren't indexed as EntityPrototype — skip popup if not found
                 if (user != null && _prototypeManager.TryIndex<EntityPrototype>(fireMode.Prototype, out var prototype))
                     _popupSystem.PopupPredicted(Loc.GetString("gun-set-fire-mode-popup", ("mode", prototype.Name)), ent, user);
             }

--- a/Content.Shared/_Starlight/Weapons/Ranged/Components/GunFireModeSoundsComponent.cs
+++ b/Content.Shared/_Starlight/Weapons/Ranged/Components/GunFireModeSoundsComponent.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.Weapons.Ranged.Components;
+
+/// <summary>
+/// Overrides the gunshot sound per fire mode index.
+/// Pair with <see cref="BatteryWeaponFireModesComponent"/>; the key in <see cref="Sounds"/>
+/// corresponds to the index in <see cref="BatteryWeaponFireModesComponent.FireModes"/>.
+/// Modes without an entry keep the gun's base sound.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class GunFireModeSoundsComponent : Component
+{
+    /// <summary>
+    /// Maps fire mode index → gunshot sound override.
+    /// </summary>
+    [DataField(required: true), AutoNetworkedField]
+    public Dictionary<int, SoundSpecifier> Sounds = new();
+}

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -486,6 +486,10 @@
     - proto: DestroyBeam
       fireCost: 100
       magState: destroy
+  - type: GunFireModeSounds
+    sounds:
+      2:
+        path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
 
 - type: entity
   name: pulse pistol
@@ -532,6 +536,10 @@
       fireCost: 200
       magState: destroy
       visualState: destroy
+  - type: GunFireModeSounds
+    sounds:
+      2:
+        path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: Battery
     maxCharge: 2600
     startingCharge: 2600
@@ -704,6 +712,10 @@
       fireCost: 100
       magState: destroy
       visualState: destroy
+  - type: GunFireModeSounds
+    sounds:
+      2:
+        path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: Battery
     maxCharge: 3300
     startingCharge: 3300
@@ -761,6 +773,10 @@
       fireCost: 10
       magState: destroy
       visualState: destroy
+  - type: GunFireModeSounds
+    sounds:
+      2:
+        path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: Battery
     maxCharge: 2640
     startingCharge: 2640


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Make the destory beam sound like a deadly beam

## Why we need to add this
Audio astectics. it uses the xray or laser-3 audio now.
## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Scarlet Lightweaver
- tweak: The Destory beams now carry thier iconic gunshot sound effect!.
