### PR TITLE
Toxic Gas Grenade Tweaks

### DIFF
--- a/Resources/Locale/en-US/_Starlight/catalog/uplink.ftl
+++ b/Resources/Locale/en-US/_Starlight/catalog/uplink.ftl
@@ -16,8 +16,8 @@ uplink-switchblade-desc = A cheap blade that switches people from being alive to
 uplink-mind-control-implant-name = Mind Control Implanter
 uplink-mind-control-implant-desc = Turn your frenemy into a friend. They will follow any order from any Syndicate as long as they can escape to CentComm.
 
-uplink-toxic-grenade-name = Toxic Gas Grenade
-uplink-toxic-grenade-desc = A painful crowd control gas grenade full of Desoxyephedrine. Good for clearing the masses out of a chokepoint. Turn on your internals first.
+uplink-toxic-grenade-name = Acidic Gas Grenade
+uplink-toxic-grenade-desc = A painful crowd control gas grenade full of Sulfuric Acid. Good for clearing the masses out of a chokepoint. Turn on your internals first.
 
 uplink-x4-name = Composition X-4
 uplink-x4-desc = Used to put even bigger holes in areas you really hate.

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/grenades.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/grenades.yml
@@ -39,8 +39,8 @@
 - type: entity
   parent: SmokeGrenade
   id: ToxicGasGrenade
-  name: toxic gas grenade
-  description: A painful crowd control gas grenade full of Desoxyephedrine. Turn on your internals before using it.
+  name: acidic gas grenade
+  description: A painful crowd control gas grenade full of Sulfuric Acid. Turn on your internals before using it.
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Grenades/toxic_gas.rsi
@@ -52,7 +52,7 @@
     smokePrototype: TearGasSmokeYellow
     solution:
       reagents:
-      - ReagentId: Desoxyephedrine
+      - ReagentId: SulfuricAcid
         Quantity: 12
   - type: StaticPrice
     price: 500


### PR DESCRIPTION
## Short description
Changes the Toxic Gas Grenade into an Acidic Gas Grenade, swapping the meth for sulfuric acid.

## Why we need to add this
Why does meth have a stupid ass name, just call it meth. Change necessary so you are no longer buffing the people you're trying to gas.

## Media (Video/Screenshots)
<img width="569" height="533" alt="image" src="https://github.com/user-attachments/assets/de6c3b92-5da1-401e-aad5-457544f6562b" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Changed Toxic Gas Grenades to Acidic Gas Grenades so you are no longer buffing the people you're trying to gas. Now contains Sulfuric Acid, and does 19-20 caustic damage.

