### PR TITLE
AutoDiscordAdminLog

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GameRule.cs
+++ b/Content.Server/GameTicking/GameTicker.GameRule.cs
@@ -364,11 +364,13 @@ public sealed partial class GameTicker
             if (shell.Player != null)
             {
                 _adminLogger.Add(LogType.EventStarted, $"{shell.Player} tried to add game rule [{rule}] via command");
+                _autolog.LogToDiscord(Loc.GetString("add-gamerule-admin", ("rule", rule), ("admin", shell.Player)), shell.Player.Name); // Starlight
                 _chatManager.SendAdminAnnouncement(Loc.GetString("add-gamerule-admin", ("rule", rule), ("admin", shell.Player)));
             }
             else
             {
                 _adminLogger.Add(LogType.EventStarted, $"Unknown tried to add game rule [{rule}] via command");
+                _autolog.LogToDiscord("Unknown tried to add game rule [{rule}] via command"); // Starlight
             }
             var ent = AddGameRule(rule);
 

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -1,3 +1,4 @@
+using Content.Server._Starlight.Administration.Systems;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
 using Content.Server.Antag;
@@ -67,6 +68,7 @@ namespace Content.Server.GameTicking
         [Dependency] private readonly SharedRoleSystem _roles = default!;
         [Dependency] private readonly ServerDbEntryManager _dbEntryManager = default!;
         [Dependency] private readonly AntagSelectionSystem _antagSelection = default!;
+        [Dependency] private readonly AutoDiscordLogSystem _autolog = default!; // Starlight
 
         [ViewVariables] private bool _initialized;
         [ViewVariables] private bool _postInitialized;

--- a/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/AntagLoadProfileRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._Starlight.Administration.Systems;
 using Content.Server._Starlight.Traits;
 using Content.Server.Antag;
 using Content.Server.GameTicking.Rules.Components;
@@ -23,6 +24,7 @@ public sealed class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoadProfile
     [Dependency] private readonly TraitSystem _traitSystem = default!; //Starlight
     [Dependency] private readonly SLSharedCharacterInfoSystem _sLSharedCharacterInfoSystem = default!; //Starlight
     [Dependency] private readonly GrammarSystem _grammarSystem = default!; // Starlight
+    [Dependency] private readonly AutoDiscordLogSystem _autolog = default!; // Starlight
 
     public override void Initialize()
     {
@@ -67,6 +69,8 @@ public sealed class AntagLoadProfileRuleSystem : GameRuleSystem<AntagLoadProfile
             var resolvedEntity = (EntityUid)args.Entity;
             var grammar = EntityManager.EnsureComponent<GrammarComponent>(resolvedEntity);
             _grammarSystem.SetGender((resolvedEntity, grammar), profile.Gender);
+
+            _autolog.LogToDiscord(Loc.GetString("autolog-forcedprototype", ("character", profile.Name), ("prototype", profile.ForcedPrototype)));
         }
         else
         {

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -31,6 +31,7 @@ using Content.Server._Starlight.Medical.Limbs;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
 using Prometheus;
+using Content.Server._Starlight.Administration.Systems;
 // Starlight End
 
 namespace Content.Server.Station.Systems;
@@ -55,6 +56,7 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
     [Dependency] private readonly LimbSystem _limbSystem = default!;
     [Dependency] private readonly BodySystem _bodySystem = default!;
     [Dependency] private readonly GrammarSystem _grammarSystem = default!; // Starlight
+    [Dependency] private readonly AutoDiscordLogSystem _autolog = default!; // Starlight
 
     private List<CyberneticImplant> _allCybernetics = default!; // Starlight
 
@@ -176,10 +178,16 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
             var resolvedEntity = (EntityUid)entity;
             var grammar = EntityManager.EnsureComponent<GrammarComponent>(resolvedEntity);
             _grammarSystem.SetGender((resolvedEntity, grammar), profile.Gender);
+
+            var playertitle = "Unknown";
+            if (_actors.TryGetSession(entity, out var session))
+                playertitle = session!.Name;
+
+            _autolog.LogToDiscord(Loc.GetString("autolog-forcedprototype", ("character", profile.Name), ("prototype", profile.ForcedPrototype)));
         }
-        else 
-        { 
-        // Starlight End
+        else
+        {
+            // Starlight End
             entity ??= Spawn(species.Prototype, coordinates);
         } // Starlight
 
@@ -279,12 +287,14 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
     /// <summary>
     /// Replaces humanoid's limbs with cybernetics on spawn
     /// </summary>
-    private void SetupCybernetics(EntityUid entity, List<string> cybernetics){
+    private void SetupCybernetics(EntityUid entity, List<string> cybernetics)
+    {
         if (!TryComp(entity, out TransformComponent? transform) ||
             !TryComp(entity, out HumanoidAppearanceComponent? appearance) ||
-            !TryComp(entity, out BodyComponent? bodyComp)) {
-                return;
-            }
+            !TryComp(entity, out BodyComponent? bodyComp))
+        {
+            return;
+        }
         Entity<TransformComponent, HumanoidAppearanceComponent, BodyComponent> body = (entity, transform, appearance, bodyComp);
 
         var installedCyberlimbs = _allCybernetics.Where(p => cybernetics.Contains(p.ID) && p.Type == CyberneticImplantType.Limb).ToList();
@@ -293,31 +303,36 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
                                                     .Select(p => p.ID).ToList();
 
 
-        foreach (var implant in filteredCyberlimbs){
+        foreach (var implant in filteredCyberlimbs)
+        {
             var implantEnt = _prototypeManager.Index<EntityPrototype>(implant);
 
             var newPart = Spawn(implant, body.Comp1.Coordinates);
-            if(!TryComp(newPart, out BodyPartComponent? bodyPartComp)){
+            if (!TryComp(newPart, out BodyPartComponent? bodyPartComp))
+            {
                 Del(newPart);
                 continue;
             }
 
             var oldPartId = _bodySystem.GetBodyChildrenOfType(entity, bodyPartComp.PartType).FirstOrDefault(p => p.Component.Symmetry == bodyPartComp.Symmetry);
-            if(!TryComp(oldPartId.Id, out TransformComponent? oldPartTransform) ||
+            if (!TryComp(oldPartId.Id, out TransformComponent? oldPartTransform) ||
                !TryComp(oldPartId.Id, out MetaDataComponent? oldPartMetadata) ||
-               !TryComp(oldPartId.Id, out BodyPartComponent? oldPartBodyPart)){
+               !TryComp(oldPartId.Id, out BodyPartComponent? oldPartBodyPart))
+            {
                 Del(newPart);
                 continue;
-               }
+            }
             Entity<TransformComponent, MetaDataComponent, BodyPartComponent> oldPart = (oldPartId.Id, oldPartTransform, oldPartMetadata, oldPartBodyPart);
 
-            if(!_bodySystem.TryGetParentBodyPart(oldPart.Owner, out var parentUid, out var parentBodyPart)){
+            if (!_bodySystem.TryGetParentBodyPart(oldPart.Owner, out var parentUid, out var parentBodyPart))
+            {
                 Del(newPart);
                 continue;
             }
 
             var slot = CyberneticImplant.SlotIDFromBodypart(bodyPartComp);
-            if(slot == ""){
+            if (slot == "")
+            {
                 Del(newPart);
                 continue;
             }

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -179,10 +179,6 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
             var grammar = EntityManager.EnsureComponent<GrammarComponent>(resolvedEntity);
             _grammarSystem.SetGender((resolvedEntity, grammar), profile.Gender);
 
-            var playertitle = "Unknown";
-            if (_actors.TryGetSession(entity, out var session))
-                playertitle = session!.Name;
-
             _autolog.LogToDiscord(Loc.GetString("autolog-forcedprototype", ("character", profile.Name), ("prototype", profile.ForcedPrototype)));
         }
         else

--- a/Content.Server/_Starlight/Administration/Systems/AutoDiscordLogSystem.cs
+++ b/Content.Server/_Starlight/Administration/Systems/AutoDiscordLogSystem.cs
@@ -45,7 +45,7 @@ public sealed class AutoDiscordLogSystem : EntitySystem
                 Description = description,
                 Footer = new WebhookEmbedFooter
                 {
-                    Text = Loc.GetString("news-discord-footer",
+                    Text = Loc.GetString("autolog-discord-footer",
                         ("server", _cfg.GetCVar(CCVars.AdminLogsServerName)),
                         ("round", _ticker.RoundId),
                         ("roundtype", Loc.GetString(_ticker.CurrentPreset?.ModeTitle ?? "bug-report-report-unknown")),

--- a/Content.Server/_Starlight/Administration/Systems/AutoDiscordLogSystem.cs
+++ b/Content.Server/_Starlight/Administration/Systems/AutoDiscordLogSystem.cs
@@ -1,0 +1,64 @@
+using System.Threading.Tasks;
+using Content.Server.Discord;
+using Content.Server.GameTicking;
+using Content.Shared.CCVar;
+using Content.Shared.Starlight.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Starlight.Administration.Systems;
+
+public sealed class AutoDiscordLogSystem : EntitySystem
+{
+    [Dependency] private readonly DiscordWebhook _discord = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly GameTicker _ticker = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private WebhookIdentifier? _webhookId = null;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _cfg.OnValueChanged(StarlightCCVars.DiscordAdminAutoLogWebhook,
+            value =>
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                    _discord.GetWebhook(value, data => _webhookId = data.ToIdentifier());
+            }, true);
+    }
+
+    public void LogToDiscord(string info, string author = "AutoLog") =>
+        SendToDiscordWebhook(author, info);
+
+    private async Task SendToDiscordWebhook(string title, string description)
+    {
+        if (_webhookId is null)
+            return;
+
+        try
+        {
+            var embed = new WebhookEmbed
+            {
+                Title = title,
+                Description = description,
+                Footer = new WebhookEmbedFooter
+                {
+                    Text = Loc.GetString("news-discord-footer",
+                        ("server", _cfg.GetCVar(CCVars.AdminLogsServerName)),
+                        ("round", _ticker.RoundId),
+                        ("roundtype", Loc.GetString(_ticker.CurrentPreset?.ModeTitle ?? "bug-report-report-unknown")),
+                        ("time", _timing.CurTime.Subtract(_ticker.RoundStartTimeSpan).ToString("hh':'mm':'ss")))
+                }
+            };
+            var payload = new WebhookPayload { Embeds = [embed] };
+            await _discord.CreateMessage(_webhookId.Value, payload);
+            Log.Info("Sent AutoLog to Discord webhook");
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Error while sending discord AutoLog:\n{e}");
+        }
+    }
+}

--- a/Content.Server/_Starlight/Administration/Systems/Commands/LogEvent.cs
+++ b/Content.Server/_Starlight/Administration/Systems/Commands/LogEvent.cs
@@ -1,0 +1,33 @@
+using Content.Server._Starlight.Administration.Systems;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server._Starlight.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class LogEventCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly AutoDiscordLogSystem _autolog = default!;
+
+    public override string Command => "logevent";
+    public override string Description => "Quickly log something on the discord, this can be an event, admeme, ect...";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (shell.Player is not { } player)
+        {
+            shell.WriteError(Loc.GetString("shell-cannot-run-command-from-server"));
+            return;
+        }
+
+        if (args.Length < 1)
+            return;
+
+        var message = string.Join(" ", args).Trim();
+        if (string.IsNullOrEmpty(message))
+            return;
+
+        _autolog.LogToDiscord(message, shell.Player!.Name);
+    }
+}

--- a/Content.Server/_Starlight/Ghost/AdminMouseSystem.cs
+++ b/Content.Server/_Starlight/Ghost/AdminMouseSystem.cs
@@ -1,9 +1,11 @@
+using Content.Server._Starlight.Administration.Systems;
 using Content.Server.Administration.Managers;
 using Content.Server.Polymorph.Systems;
 using Content.Shared._NullLink;
 using Content.Shared.Database;
 using Content.Shared.Ghost;
 using Content.Shared.Verbs;
+using Robust.Server.Player;
 using Robust.Shared.Utility;
 
 namespace Content.Server._Starlight.Ghost;
@@ -13,6 +15,7 @@ public sealed class AdminMouseSystem : EntitySystem
     [Dependency] private readonly ISharedNullLinkPlayerRolesReqManager _playerRoles = default!;
     [Dependency] private readonly IAdminManager _admin = default!;
     [Dependency] private readonly PolymorphSystem _polymorphSystem = default!;
+    [Dependency] private readonly AutoDiscordLogSystem _autolog = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -34,10 +37,11 @@ public sealed class AdminMouseSystem : EntitySystem
             {
                 Text = adminName,
                 Category = VerbCategory.Smite,
-                Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_Starlight/Mobs/Animals/mouse.rsi"), "mouse-admin"),
+                Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_Starlight/Mobs/Animals/mouse.rsi"), "icon-0"),
                 Act = () =>
                 {
                     _polymorphSystem.PolymorphEntity(user, "AdminMouse");
+                    _autolog.LogToDiscord(Loc.GetString("autolog-admin-mouse"), ToPrettyString(user));
                 },
                 Impact = LogImpact.Extreme,
                 Message = string.Join(": ", adminName, Loc.GetString("admin-verb-make-adminmouse")),
@@ -52,10 +56,11 @@ public sealed class AdminMouseSystem : EntitySystem
             {
                 Text = mentorName,
                 Category = VerbCategory.Smite,
-                Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_Starlight/Mobs/Animals/mouse.rsi"), "mouse-mentor"),
+                Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_Starlight/Mobs/Animals/mouse.rsi"), "icon-0"),
                 Act = () =>
                 {
                     _polymorphSystem.PolymorphEntity(user, "MentorMouse");
+                    _autolog.LogToDiscord(Loc.GetString("autolog-mentor-mouse"), ToPrettyString(user));
                 },
                 Impact = LogImpact.Extreme,
                 Message = string.Join(": ", mentorName, Loc.GetString("admin-verb-make-mentormouse")),

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Discord.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Discord.cs
@@ -22,5 +22,5 @@ public sealed partial class StarlightCCVars
         CVarDef.Create("discord.ban_webhook", string.Empty, CVar.SERVERONLY);
 
     public static readonly CVarDef<string> DiscordAdminAutoLogWebhook =
-        CVarDef.Create("discord.admin_autolog", "https://discord.com/api/webhooks/1475606920370061437/K926KA1AW6UUUGG6CxjWQjddoR5vZbxKCiI1bf0h4Ojslp3lVyC6cdUk9cVAUDaTfVC4", CVar.SERVERONLY);
+        CVarDef.Create("discord.admin_autolog", string.Empty, CVar.SERVERONLY);
 }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Discord.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Discord.cs
@@ -20,4 +20,7 @@ public sealed partial class StarlightCCVars
     
     public static readonly CVarDef<string> DiscordBanWebhook =
         CVarDef.Create("discord.ban_webhook", string.Empty, CVar.SERVERONLY);
+
+    public static readonly CVarDef<string> DiscordAdminAutoLogWebhook =
+        CVarDef.Create("discord.admin_autolog", "https://discord.com/api/webhooks/1475606920370061437/K926KA1AW6UUUGG6CxjWQjddoR5vZbxKCiI1bf0h4Ojslp3lVyC6cdUk9cVAUDaTfVC4", CVar.SERVERONLY);
 }

--- a/Resources/Locale/en-US/_Starlight/administration/autolog.ftl
+++ b/Resources/Locale/en-US/_Starlight/administration/autolog.ftl
@@ -1,0 +1,3 @@
+news-discord-footer = Server: {$server} | Round: #{$round} | Round Type: {$roundtype} | Round Time: {$time}
+
+autolog-forcedprototype = Spawned Character: {$character} with ForcedPrototype: {$prototype}

--- a/Resources/Locale/en-US/_Starlight/administration/autolog.ftl
+++ b/Resources/Locale/en-US/_Starlight/administration/autolog.ftl
@@ -1,3 +1,5 @@
-news-discord-footer = Server: {$server} | Round: #{$round} | Round Type: {$roundtype} | Round Time: {$time}
+autolog-discord-footer = Server: {$server} | Round: #{$round} | Round Type: {$roundtype} | Round Time: {$time}
 
 autolog-forcedprototype = Spawned Character: {$character} with ForcedPrototype: {$prototype}
+autolog-admin-mouse = Became Admin Mouse
+autolog-mentor-mouse = Became Mentor Mouse

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/pets.yml
@@ -81,7 +81,6 @@
     - Mouse
     understands:
     - Mouse
-  - type: NightVision
   - type: UniversalLanguageSpeaker
   - type: VentCrawler
   - type: Climbing

--- a/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Mobs/NPCs/pets.yml
@@ -81,6 +81,7 @@
     - Mouse
     understands:
     - Mouse
+  - type: NightVision
   - type: UniversalLanguageSpeaker
   - type: VentCrawler
   - type: Climbing


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
NO CL Change.

This PR add a AutoDiscordLogSystem by request, this will help non-admin to be logged when doing things (Mentor Mouse)
But its also support to be expended on this, for now i kept it basic, its will log, admin/mentor mouse, forcedprototype, addgamerules.

and add a command called "logevent" witch can be used to easly log.

This is basic but can easly be expended upon, no CL needed and will be discord + webhook CVar changes.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Non-Admins sometimes cannot log, this helps by logging it auto on some actions and made a command to make logging easier.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.
