### PR TITLE
Improve usability of basic cooking ingredient containers 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -64,6 +64,12 @@
     damage:
       types:
         Blunt: 0
+  #Starlight start
+  - type: ExaminableSolution
+    solution: food
+    examinableWhileClosed: false
+    heldOnly: true
+  #Starlight end
 
 - type: entity
   abstract: true
@@ -267,6 +273,15 @@
           Quantity: 20
   - type: Edible
     edible: Drink # slurping sounds!
+  #Starlight start
+    solution: food
+    destroyOnEmpty: false
+    utensil: None
+  - type: Openable
+    sound:
+      collection: pop
+    closeable: true
+  #Starlight end
 
 - type: entity
   parent: ReagentPacketBase
@@ -295,7 +310,17 @@
   - type: Tag
     tags:
       - Mayo
-      - Condiment #Starlight
+  #Starlight start
+      - Condiment
+  - type: Openable
+    closeable: true
+  - type: Edible
+    edible: Drink # slurping sounds!
+    solution: food
+    destroyOnEmpty: false
+    utensil: None
+  #Starlight end
+
 # - type: entity
 #   parent: ReagentPacketBase
 #   id: ReagentContainerAllspice


### PR DESCRIPTION
## Short description
Adds a couple of missing container features to basic cooking ingredient containers, such as flour bags.

## Why we need to add this
Cooking ingredient containers have some inconsistent behaviours that also impair usability (and arguably realism).

- Making them _examinable_ when held makes it easier to gauge roughly how much you have left to work with, and whether a bag has been contaminated with another reagent. Volume measurement is non-exact however.
- Making olive oil and mayonnaise bottles _closable_ is consistent with other bottled reagents from the _ChefVend_, and allows the chef to protect them. Because they are opaque they still cannot be examined from a distance or measured exactly.
- Making olive oil and mayonnaise bottles _non-edible_ is self-explanitory.

## Media (Video/Screenshots)
#### Closable
<img width="350" alt="image" src="https://github.com/user-attachments/assets/4e0800f9-50a8-44af-832a-06936af1664c" />

#### Examinable
<img width="350" alt="image" src="https://github.com/user-attachments/assets/cca45ea5-f037-448f-871b-43f1e3dfe30a" />

#### Non-edible
<img width="350" alt="image" src="https://github.com/user-attachments/assets/1289ab34-69f7-4cd8-982e-b5f0c864d6da" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- tweak: Cooking ingredient containers such as flour bags now have examinable contents when opened.
- tweak: Olive oil and mayonnaise bottles are now closable, and no longer edible.