### PR TITLE
Food condiments now restore a small amount of hunger

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/condiments.yml
@@ -7,6 +7,13 @@
   flavor: sweet
   color: aquamarine
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: BbqSauce
@@ -17,6 +24,13 @@
   flavor: sweet
   color: darkred
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: Coldsauce
@@ -26,6 +40,13 @@
   physicalDesc: reagent-physical-desc-cold
   flavor: cold
   color: skyblue
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: Cornoil
@@ -36,6 +57,13 @@
   flavor: oily
   color: yellow
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: HorseradishSauce
@@ -46,6 +74,13 @@
   flavor: spicy
   color: gray
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: Hotsauce
@@ -56,6 +91,13 @@
   flavor: spicy
   color: red
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: Ketchup
@@ -66,6 +108,13 @@
   flavor: tomato
   color: red
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: Ketchunaise
@@ -76,6 +125,13 @@
   flavor: ketchunaise
   color: "#fba399"
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: LaughinSyrup
@@ -86,6 +142,13 @@
   flavor: sweet
   color: "#803280"
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: Mayo
@@ -96,6 +159,13 @@
   flavor: mayonnaise
   color: "#f9f5e5"
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: Mustard
@@ -106,6 +176,13 @@
   flavor: mustard
   color: "#ffdb58"
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: Vinaigrette
@@ -116,6 +193,13 @@
   flavor: sour
   color: "#efdaae"
   recognizable: true
+  #Starlight start
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+        factor: 0.5
+  #Starlight end
 
 - type: reagent
   id: Soysauce


### PR DESCRIPTION
## Short description
Condiments will now restore a small amount of hunger, at 1/3rd that of nutriment. Overall a full condiment packet will restore 10/200 (5%) hunger.

## Why we need to add this
Gives a small amount of practical purpose and use for condiment items aside from reagents. Most food items in the game supports adding some additional chemicals; intent obviously being condiments - but there was little reason to do so.

## Media (Video/Screenshots)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/2bce9f03-3bf0-4d1c-b9a5-0710108481d8" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- tweak: Condiments such as ketchup now restore a small amount of hunger
