### PR TITLE
Make ion storms affect Thaven moods

### DIFF
--- a/Content.Server/StationEvents/Events/IonStormRule.cs
+++ b/Content.Server/StationEvents/Events/IonStormRule.cs
@@ -3,12 +3,15 @@ using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.Station.Components;
+using Content.Server._Starlight.Thaven; //Starlight
+using Content.Shared._Starlight.Thaven.Components; //Starlight 
 
 namespace Content.Server.StationEvents.Events;
 
 public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 {
     [Dependency] private readonly IonStormSystem _ionStorm = default!;
+    [Dependency] private readonly ThavenMoodsSystem _thavenMood = default!; //Starlight
 
     protected override void Started(EntityUid uid, IonStormRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
@@ -32,5 +35,17 @@ public sealed class IonStormRule : StationEventSystem<IonStormRuleComponent>
 
             _ionStorm.IonStormTarget((ent, lawBound, target));
         }
+
+        //Starlight begin | Ion storm affects Thaven moods
+        var moodsQuery = EntityQueryEnumerator<ThavenMoodsComponent, TransformComponent>();
+        while (moodsQuery.MoveNext(out var ent, out var moodHolder, out var xform))
+        {            
+            // only affect Thaven Moods holders on the station
+            if (CompOrNull<StationMemberComponent>(xform.GridUid)?.Station != chosenStation)
+                continue;
+        
+            _thavenMood.OnIonStorm((ent, moodHolder));
+        }
+        //Startlight end
     }
 }

--- a/Content.Server/_Starlight/Thaven/ThavenMoodSystem.cs
+++ b/Content.Server/_Starlight/Thaven/ThavenMoodSystem.cs
@@ -381,4 +381,12 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
 
         TryAddRandomMood(ent, ent.Comp.Wildcard);
     }
+
+    // Tries to add a mood on an ion storm event
+    public void OnIonStorm(Entity<ThavenMoodsComponent> ent)
+    {
+        if (!_random.Prob(ent.Comp.IonStormMoodChance))
+            return;
+        TryAddRandomMood(ent, ent.Comp.Wildcard);
+    }
 }

--- a/Content.Shared/_Starlight/Thaven/ThavenMoodsComponent.cs
+++ b/Content.Shared/_Starlight/Thaven/ThavenMoodsComponent.cs
@@ -49,6 +49,12 @@ public sealed partial class ThavenMoodsComponent : Component
     /// </summary>
     [DataField(serverOnly: true)]
     public ProtoId<DatasetPrototype> Wildcard = SharedThavenMoodSystem.WildcardDataset;
+
+    /// <summary>
+    /// Chance of getting a random "wildcard" mood added during an ion storm.
+    /// </summary>
+    [DataField]
+    public float IonStormMoodChance = 0.5f;
 }
 
 public sealed partial class ToggleMoodsScreenEvent : InstantActionEvent;

--- a/Content.Shared/_Starlight/Thaven/ThavenMoodsComponent.cs
+++ b/Content.Shared/_Starlight/Thaven/ThavenMoodsComponent.cs
@@ -54,7 +54,7 @@ public sealed partial class ThavenMoodsComponent : Component
     /// Chance of getting a random "wildcard" mood added during an ion storm.
     /// </summary>
     [DataField]
-    public float IonStormMoodChance = 0.5f;
+    public float IonStormMoodChance = 0.25f;
 }
 
 public sealed partial class ToggleMoodsScreenEvent : InstantActionEvent;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Give Thaven a 50% (edit: lowered to 25%) chance to gain a new "wildcard" mood on an ion storm event.

## Why we need to add this
Thaven have positronic-like brains so it makes sense for them to be affected by ion storms. This was suggested on discord a bunch of times.

## Media (Video/Screenshots)
<img width="574" height="701" alt="image" src="https://github.com/user-attachments/assets/ebbe9051-742c-47bf-b818-4a28f91fd28d" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: gabbl0
- add: Ion storms now have a chance to affect Thaven moods (25% chance to get a new wildcard mood).
