### PR TITLE
balances the IK60 and LR 30 to be reasonable.

### DIFF
--- a/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Cargo/cargo_armory.yml
@@ -19,6 +19,16 @@
   group: market
   
 - type: cargoProduct
+  id: ArmoryIK60
+  icon:
+    sprite: _Starlight/Objects/Weapons/Guns/Rifles/laser_carbine.rsi
+    state: icon
+  product: CrateArmoryIK60
+  cost: 9000
+  category: cargoproduct-category-name-armory
+  group: market
+
+- type: cargoProduct
   id: ArmoryCombatShotgun
   icon:
     sprite: _Starlight/Objects/Weapons/Guns/Shotguns/cshotgun.rsi

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Crates/armory.yml
@@ -16,6 +16,23 @@
           amount: 2
 
 - type: entity
+  id: CrateArmoryIK60
+  parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
+  name: IK-60 laser carbine crate
+  description: Contains one IK-60 full-auto laser carbine and two battery magazines. High-end Nanotrasen Space Force hardware. Requires Armory access to open.
+  components:
+  - type: Contraband
+    allowedDepartments: [ Security ]
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: WeaponIK60
+          amount: 1
+        - id: MagazineBatteryLr30
+          amount: 2
+
+- type: entity
   id: CrateArmoryLr30Magazines
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: lr30 magazines crate

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -110,7 +110,7 @@
     containers:
       gun_magazine: !type:ContainerSlot
   - type: Gun
-    fireRate: 5.3
+    fireRate: 5
     selectedMode: FullAuto
     availableModes:
       - SemiAuto

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -27,7 +27,7 @@
   name: lr-30
   parent: [BaseItem, BaseGunWieldable, BaseSecuritySalvageContraband]
   id: WeaponLr30
-  description: Energy carbine with lethal mode.
+  description: An early prototype of the IK-60 laser carbine. Lacking the refined receiver of its successor, it is limited to three-round burst fire — a limitation engineers never bothered to fix before the IK-60 rendered it obsolete.
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Rifles/lr30.rsi
@@ -62,11 +62,13 @@
     containers:
       gun_magazine: !type:ContainerSlot
   - type: Gun
-    fireRate: 5
-    selectedMode: FullAuto
+    burstFireRate: 7.5
+    shotsPerBurst: 3
+    burstCooldown: 0.5
+    selectedMode: Burst
     availableModes:
+      - Burst
       - SemiAuto
-      - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
   - type: MagazineVisuals
@@ -108,13 +110,11 @@
     containers:
       gun_magazine: !type:ContainerSlot
   - type: Gun
-    fireRate: 5
-    shotsPerBurst: 2
-    burstCooldown: 0.6
-    selectedMode: Burst
+    fireRate: 5.3
+    selectedMode: FullAuto
     availableModes:
       - SemiAuto
-      - Burst
+      - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
   - type: MagazineVisuals


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
swap the roles of the IK60 and LR 30 to be reasonable.

## Why we need to add this
this is to balance the LR30 that is **both a salvage and security gun** from being full auto fast firing to burst. while still being strong.
the IK 60 is now the full auto varient and can be bought at cargo. albiet at an *expensive* price.
## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
Made the IK 60 and LR 30 reasonable.

:cl: Scarlet Lightweaver
- tweak: Made the IK 60 and LR 30 reasonable.