### PR TITLE
Enable SELF

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -32,8 +32,8 @@
       prob: 0.08 # Starlight
     - id: Brighteye # Starlight
       prob: 0.05
-#    - id: SiliconLiberation #Starlight
-#      prob: 0.4 #Starlight
+    - id: SiliconLiberation #Starlight
+      prob: 0.2 #Starlight
 
 - type: entity
   parent: BaseGameRule
@@ -51,8 +51,8 @@
       prob: 0.08 # Starlight
     - id: Brighteye # Starlight
       prob: 0.05
-#    - id: SiliconLiberation #Starlight
-#      prob: 0.4 #Starlight
+    - id: SiliconLiberation #Starlight
+      prob: 0.2 #Starlight
 
 - type: entity
   parent: BaseGameRule
@@ -70,8 +70,8 @@
       prob: 0.08 # Starlight Space is dangerous, yo.
     - id: Brighteye # Starlight
       prob: 0.05
-#    - id: SiliconLiberation #Starlight
-#      prob: 0.5 #Starlight
+    - id: SiliconLiberation #Starlight
+      prob: 0.2 #Starlight
 
 - type: entity
   parent: BaseGameRule
@@ -87,8 +87,8 @@
       prob: 0.15 # Starlight
     - id: Brighteye # Starlight
       prob: 0.05
-#    - id: SiliconLiberation #Starlight
-#      prob: 0.5 #Starlight
+    - id: SiliconLiberation #Starlight
+      prob: 0.2 #Starlight
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_StarLight/GameRules/roundstart.yml
@@ -31,8 +31,8 @@
       prob: 0.08 # Starlight. To account for their secret mode being lowered.
     - id: Brighteye
       prob: 0.05
-#    - id: SiliconLiberation
-#      prob: 0.4
+    - id: SiliconLiberation
+      prob: 0.2
 
 - type: entity
   parent: BaseGameRule


### PR DESCRIPTION
## Short description
Enables the Silicon Engine Liberation Front antag (SELF). Has a 20% chance in most subgamemodes to prevent oversaturation.

## Why we need to add this
They've been run as an admeme a few times a week for a month with no borg RDM or any other worries maintainers had. I see no need for further testing.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Enabled Silicon Liberation for multiple subgamerules with a 20% rate to avoid oversaturation.

