### PR TITLE
Refracted Playtime Requirements - You Will (Not) Flukie

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/syndiedrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/syndiedrobe.yml
@@ -15,6 +15,8 @@
     ClothingNeckScarfStripedSyndieGreen: 2
     ClothingNeckScarfStripedSyndieRed: 2
     ClothingShoesBootsWinterSyndicate: 2
+    ClothingBackpackSyndicate: 4 #SL edit
+    ClothingBackpackDuffelSyndicate: 4 #SL edit
   contrabandInventory:
     ToyFigurineFootsoldier: 1
     ToyFigurineNukieElite: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/syndiedrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/syndiedrobe.yml
@@ -15,8 +15,6 @@
     ClothingNeckScarfStripedSyndieGreen: 2
     ClothingNeckScarfStripedSyndieRed: 2
     ClothingShoesBootsWinterSyndicate: 2
-    ClothingBackpackSyndicate: 4 #SL edit
-    ClothingBackpackDuffelSyndicate: 4 #SL edit
   contrabandInventory:
     ToyFigurineFootsoldier: 1
     ToyFigurineNukieElite: 1

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -88,16 +88,18 @@
     price: 3000
 
 - type: entity
-  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband]
+  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband, ClothingShoesMilitaryBase] # Starlight
   id: ClothingShoesBootsMagSyndie
   name: blood-red magboots
-  description: Reverse-engineered from ERT magboots, they have a heavy magnetic pull and integrated thrusters. It can hold 0.75 L of gas.
+  description: Reverse-engineered from ERT magboots, they have a heavy magnetic pull, integrated thrusters, and are designed for combat. It can hold 0.75 L of gas. # Starlight
   components:
   - type: Sprite
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
     state: icon
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
+  - type: ClothingSlowOnDamageModifier #Starlight
+    modifier: 0.5 # Starlight
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -88,18 +88,16 @@
     price: 3000
 
 - type: entity
-  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband, ClothingShoesMilitaryBase] # Starlight
+  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband]
   id: ClothingShoesBootsMagSyndie
   name: blood-red magboots
-  description: Reverse-engineered from ERT magboots, they have a heavy magnetic pull, integrated thrusters, and are designed for combat. It can hold 0.75 L of gas. # Starlight
+  description: Reverse-engineered from ERT magboots, they have a heavy magnetic pull and integrated thrusters. It can hold 0.75 L of gas.
   components:
   - type: Sprite
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
     state: icon
   - type: Clothing
     sprite: Clothing/Shoes/Boots/magboots-syndicate.rsi
-  - type: ClothingSlowOnDamageModifier #Starlight
-    modifier: 0.5 # Starlight
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/Roles/Antags/changeling.yml
@@ -8,6 +8,6 @@
   guides: [ Changelings ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 3h
+    time: 24h
   playTimeTracker: AntagChangeling
   # Starlight end

--- a/Resources/Prototypes/Roles/Antags/dragon.yml
+++ b/Resources/Prototypes/Roles/Antags/dragon.yml
@@ -7,6 +7,6 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobSalvageSpecialist
-    time: 3h
+    time: 12h
   playTimeTracker: AntagDragon
   # Starlight end

--- a/Resources/Prototypes/Roles/Antags/dragon.yml
+++ b/Resources/Prototypes/Roles/Antags/dragon.yml
@@ -5,8 +5,10 @@
   objective: roles-antag-dragon-objective
   # Starlight start
   requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 24h
   - !type:RoleTimeRequirement
     role: JobSalvageSpecialist
-    time: 12h
+    time: 8h
   playTimeTracker: AntagDragon
   # Starlight end

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -10,7 +10,9 @@
   requirements:
   - !type:DepartmentTimeRequirement
     department: Security
-    time: 3h
+    time: 9h
+  - !type:OverallPlaytimeRequirement
+    time: 48h
   playTimeTracker: AntagNinja
   # Starlight end
 

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -8,14 +8,14 @@
   # Starlight start
   previewStartingGear: SpaceNinjaGear
   requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 48h
   - !type:DepartmentTimeRequirement
     department: Security
     time: 9h
   - !type:RoleTimeRequirement
     role: AntagThief
     time: 5h
-  - !type:OverallPlaytimeRequirement
-    time: 48h
   playTimeTracker: AntagNinja
   # Starlight end
 

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -10,11 +10,11 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 48h
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 9h
   - !type:RoleTimeRequirement
-    role: AntagThief
+    role: JobSecurityOfficer # It's better than nothing.
+    time: 3h
+  - !type:RoleTimeRequirement
+    role: AntagThief # You are a glorified Thief without Pax.
     time: 5h
   playTimeTracker: AntagNinja
   # Starlight end

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -11,6 +11,9 @@
   - !type:DepartmentTimeRequirement
     department: Security
     time: 9h
+  - !type:RoleTimeRequirement
+    role: AntagThief
+    time: 5h
   - !type:OverallPlaytimeRequirement
     time: 48h
   playTimeTracker: AntagNinja

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -15,7 +15,7 @@
     time: 5h
   - !type:RoleTimeRequirement # Tradeoff for not having too high Sec time; You should know how to use your uplink. 
     role: AntagTraitor
-    time: 6h # Starlight end
+    time: 3h # Starlight end
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateOperativeGearFull
   playTimeTracker: AntagNukeops # Starlight
@@ -40,7 +40,7 @@
     time: 5h
   - !type:RoleTimeRequirement # You should know how to use your uplink, but less important than base Nukie.
     role: AntagTraitor
-    time: 4h # Starlight end
+    time: 2h # Starlight end
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateOperativeMedicFull
   playTimeTracker: AntagNukeopsMedic # Starlight

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -57,12 +57,12 @@
   - !type:RoleTimeRequirement
     role: JobSecurityOfficer # It's better than nothing.
     time: 15h
-  - !type:RoleTimeRequirement # You're leading the whole show, and the main antagonist of the entire round. You better have some understanding of what you're doing. This *cannot* be your first go.
-    role: AntagNukeops
-    time: 5h
   - !type:DepartmentTimeRequirement
     department: Command
     time: 10h # You need to actually have experience leading others.
+  - !type:RoleTimeRequirement # You're leading the whole show, and the main antagonist of the entire round. You better have some understanding of what you're doing. This *cannot* be your first go.
+    role: AntagNukeops
+    time: 5h
   # Starlight end
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateCommanderGearFull

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -15,7 +15,7 @@
     time: 5h
   - !type:RoleTimeRequirement # Tradeoff for not having too high Sec time; You should know how to use your uplink. 
     role: AntagTraitor
-    time: 3h # Starlight end
+    time: 5h # Starlight end
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateOperativeGearFull
   playTimeTracker: AntagNukeops # Starlight
@@ -31,16 +31,16 @@
     time: 48h # Starlight start
   - !type:RoleTimeRequirement
     role: JobChemist
-    time: 6h # Starlight
+    time: 6h
   - !type:RoleTimeRequirement
     role: JobSurgeon
-    time: 3h # Starlight
+    time: 3h
   - !type:RoleTimeRequirement
     role: JobBrigmedic # Brigmedic is commonly used as Nukie Corpsman practice. With Brigmed being changed away from a chemist soon, this ensures you know how to operate medical in a high stress enviroment. This also accounts for your Security time.
     time: 5h
   - !type:RoleTimeRequirement # You should know how to use your uplink, but less important than base Nukie.
     role: AntagTraitor
-    time: 2h # Starlight end
+    time: 3h # Starlight end
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateOperativeMedicFull
   playTimeTracker: AntagNukeopsMedic # Starlight

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -6,10 +6,16 @@
   objective: roles-antag-nuclear-operative-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 24h # Starlight
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 6h # Starlight
+    time: 48h # Starlight start
+  - !type:RoleTimeRequirement
+    role: JobSecurityOfficer # Cadet time isn't too indicative of knowledge.
+    time: 5h
+  - !type:RoleTimeRequirement # At the very least please know basic med. Cannot be department since you can bypass that with Psychologist.
+    role: JobMedicalDoctor
+    time: 5h
+  - !type:RoleTimeRequirement # Tradeoff for not having too high Sec time; You should know how to use your uplink. 
+    role: AntagTraitor
+    time: 6h # Starlight end
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateOperativeGearFull
   playTimeTracker: AntagNukeops # Starlight
@@ -22,16 +28,19 @@
   objective: roles-antag-nuclear-operative-agent-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 24h # Starlight
+    time: 48h # Starlight start
   - !type:RoleTimeRequirement
     role: JobChemist
     time: 6h # Starlight
   - !type:RoleTimeRequirement
     role: JobSurgeon
     time: 3h # Starlight
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 3h # Starlight
+  - !type:RoleTimeRequirement
+    role: JobBrigmedic # Brigmedic is commonly used as Nukie Corpsman practice. With Brigmed being changed away from a chemist soon, this ensures you know how to operate medical in a high stress enviroment. This also accounts for your Security time.
+    time: 5h
+  - !type:RoleTimeRequirement # You should know how to use your uplink, but less important than base Nukie.
+    role: AntagTraitor
+    time: 4h # Starlight end
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateOperativeMedicFull
   playTimeTracker: AntagNukeopsMedic # Starlight
@@ -44,14 +53,17 @@
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 24h # Starlight
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 12h # Starlight
+    time: 72h # Starlight start. You need to have experience.
+  - !type:RoleTimeRequirement
+    role: JobSecurityOfficer # It's better than nothing.
+    time: 15h
+  - !type:RoleTimeRequirement # You're leading the whole show, and the main antagonist of the entire round. You better have some understanding of what you're doing. This *cannot* be your first go.
+    role: AntagNukeops
+    time: 5h
   - !type:DepartmentTimeRequirement
     department: Command
-    time: 6h # Starlight
-  # should be changed to nukie playtime when thats tracked (wyci)
+    time: 10h # You need to actually have experience leading others.
+  # Starlight end
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateCommanderGearFull
   playTimeTracker: AntagNukeopsCommander # Starlight

--- a/Resources/Prototypes/Roles/Antags/paradoxClone.yml
+++ b/Resources/Prototypes/Roles/Antags/paradoxClone.yml
@@ -7,7 +7,7 @@
   # Starlight start
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 24h
+    time: 48h # You should at least have some familiarity with the community to actually be able to pull this off.
   playTimeTracker: AntagParadoxClone
   # Starlight end
 

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -7,14 +7,14 @@
   guides: [ Revolutionaries ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 24h # Starlight
-  - !type:DepartmentTimeRequirement
-    department: Security
-    time: 6h # Starlight
+    time: 72h # Starlight start
+  - !type:RoleTimeRequirement
+    role: JobSecurityOfficer # Less important than some of the other antags to know
+    time: 5h
   - !type:DepartmentTimeRequirement
     department: Command
-    time: 6h # Starlight
-  playTimeTracker: AntagHeadRev # Starlight
+    time: 12h # Have to be a leader. You're essentially making your own chain of command in this role.
+  playTimeTracker: AntagHeadRev # Starlight end
 
 - type: antag
   id: Rev

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -7,7 +7,7 @@
   guides: [ Thieves ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 3h # Starlight
+    time: 8h # Starlight. Low stakes, low involvement.
   playTimeTracker: AntagThief # Starlight
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -7,7 +7,7 @@
   guides: [ Traitors ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 3h # Starlight
+    time: 24h # Starlight, mostly just to ensure you know basic controls.
   playTimeTracker: AntagTraitor # Starlight
 
 - type: antag
@@ -19,7 +19,7 @@
   guides: [ Traitors ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 3h # Starlight
+    time: 24h # Starlight, mostly just to ensure you know basic controls.
   playTimeTracker: AntagTraitor # Starlight
 
 # Syndicate Operative Outfit - Monkey

--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -14,7 +14,7 @@
   objective: roles-antag-wizard-objective # TODO: maybe give random objs and stationary ones from AntagObjectives and AntagRandomObjectives
   requirements: # I hate time locked roles but this should be enough time for someone to be acclimated
   - !type:OverallPlaytimeRequirement
-    time: 24h # Starlight
+    time: 48h # Starlight. You've got the potential to mass grief.
   - !type:DepartmentTimeRequirement
     department: Security
     time: 6h # Starlight

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -7,8 +7,11 @@
   guides: [ Zombies ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 3h # Starlight
-  playTimeTracker: AntagInitialInfected # Starlight
+    time: 24h # Starlight start. It's like legal raiding.
+  - !type:RoleTimeRequirement # Mainly to know that you can treat yourself. Cannot be department since you can bypass that with Psychologist. Also teaches you what your primary target as an II is.
+    role: JobMedicalDoctor
+    time: 2h
+  playTimeTracker: AntagInitialInfected # Starlight end
 
 - type: antag
   id: Zombie

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -12,7 +12,7 @@
       time: 5h # Starlight
     - !type:DepartmentTimeRequirement
       department: Cargo
-      time: 20h # Starlight
+      time: 30h # Starlight
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuartermaster" #Starlight

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -6,8 +6,10 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Cargo
-      time: 2.5h
-  icon: "JobIconSalvageSpecialist" # Starlight - New distinct icon
+      time: 8h # Starlight start. You should learn how to drive the shuttle, or at least sell stuff at ATS.
+    - !type:OverallPlaytimeRequirement 
+      time: 12h
+  icon: "JobIconSalvageSpecialist" # Starlight - New distinct icon, Starlight end
   startingGear: SalvageSpecialistGear
   supervisors: job-supervisors-qm
   canBeAntag: false

--- a/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
@@ -5,13 +5,13 @@
   playTimeTracker: JobCBURN
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 20h
+    time: 60h # Starlight. Professional role, expected to be mature.
   - !type:RoleTimeRequirement
     role: JobMedicalDoctor
-    time: 5h
+    time: 10h # Starlight. You should know how to treat people.
   - !type:RoleTimeRequirement
     role: JobSecurityOfficer
-    time: 5h
+    time: 10h # Starlight. You're a highly specialized cleaning squad. You need to know how to do combat.
   setPreference: false
   startingGear: CBURNGear
   icon: "JobIconCBURN"

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -7,13 +7,16 @@
   # Starlight start
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 20h
+    time: 96h # Realistically, if you have the CC time, you'll have met this anyways... But, in case that CC time is removed later.
   - !type:DepartmentTimeRequirement
     department: CentralCommand
     time: 10h
   - !type:DepartmentTimeRequirement
     department: Command
-    time: 10h
+    time: 20h
+  - !type:RoleTimeRequirement
+    role: JobSecurityOfficer
+    time: 15h # If theyre not an admin, they NEED to be good in combat. You're the last hope, after all.
   # Starlight end
   setPreference: false
   startingGear: ERTLeaderGearEVA
@@ -118,7 +121,7 @@
   playTimeTracker: JobERTChaplain
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 20h
+    time: 48h # While you technically are a last resort against the "paranormal", there's no threats that actually warrant you having more time than this unless Cluwne Beasts get properly implemented.
   - !type:RoleTimeRequirement
     role: JobChaplain
     time: 5h
@@ -201,10 +204,10 @@
   playTimeTracker: JobERTEngineer
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 20h
+    time: 48h # Starlight. You should know the game's controls if you're going to be building stuff.
   - !type:RoleTimeRequirement
     role: JobStationEngineer
-    time: 5h
+    time: 15h # Starlight. You should know how to construct things with and without the RCD.
   setPreference: false
   startingGear: ERTEngineerGearEVA
   icon: "JobIconERTEngineer"
@@ -302,10 +305,10 @@
   playTimeTracker: JobERTSecurity
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 20h
+    time: 72h #Starlight
   - !type:RoleTimeRequirement
     role: JobSecurityOfficer
-    time: 5h
+    time: 15h # Starlight, your whole job here is fighting and following orders.
   setPreference: false
   startingGear: ERTEngineerGearEVA
   icon: "JobIconERTSecurity"
@@ -497,13 +500,16 @@
   playTimeTracker: JobERTMedical
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 20h
+    time: 48h # Starlight
   - !type:RoleTimeRequirement
     role: JobMedicalDoctor
-    time: 5h
+    time: 10h # Starlight
   - !type:RoleTimeRequirement
     role: JobChemist
-    time: 5h
+    time: 10h #Starlight start
+  - !type:RoleTimeRequirement
+    role: JobSecurityOfficer
+    time: 5h #Starlight, youre a medic but you WILL be fighting at some point, Starlight end
   setPreference: false
   startingGear: ERTMedicalGearEVA
   icon: "JobIconERTMedical" #Starlight
@@ -606,7 +612,7 @@
   playTimeTracker: JobERTJanitor
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 20h
+    time: 72h # Starlight
   - !type:RoleTimeRequirement
     role: JobJanitor
     time: 5h

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -204,7 +204,7 @@
   playTimeTracker: JobERTEngineer
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 48h # Starlight. You should know the game's controls if you're going to be building stuff.
+    time: 72h # Starlight. You should know the game's controls if you're going to be building stuff.
   - !type:RoleTimeRequirement
     role: JobStationEngineer
     time: 15h # Starlight. You should know how to construct things with and without the RCD.
@@ -500,7 +500,7 @@
   playTimeTracker: JobERTMedical
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 48h # Starlight
+    time: 72h # Starlight
   - !type:RoleTimeRequirement
     role: JobMedicalDoctor
     time: 10h # Starlight
@@ -612,7 +612,7 @@
   playTimeTracker: JobERTJanitor
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 72h # Starlight
+    time: 48h # Starlight
   - !type:RoleTimeRequirement
     role: JobJanitor
     time: 5h

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -7,7 +7,7 @@
     # Starlight - we've changed basically this whole block to be service instead of captain-lite
     - !type:DepartmentTimeRequirement
       department: Civilian
-      time: 20h
+      time: 30h # Starlight
     - !type:RoleTimeRequirement
       role: JobBotanist
       time: 3h

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -4,9 +4,9 @@
   description: job-description-chemist
   playTimeTracker: JobChemist
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 5h
+    - !type:RoleTimeRequirement # Starlight start
+      role: JobMedicalDoctor # Can't be department, since you can bypass with Psychologist.
+      time: 6h # Starlight end
   startingGear: ChemistGear
   icon: "JobIconChemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -14,7 +14,7 @@
       time: 7h # Starlight
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 20h # Starlight
+      time: 30h # Starlight
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -4,9 +4,9 @@
   description: job-description-paramedic
   playTimeTracker: JobParamedic
   requirements:
-  - !type:DepartmentTimeRequirement
-    department: Medical
-    time: 2.5h
+    - !type:RoleTimeRequirement # Starlight start
+      role: JobMedicalDoctor # Can't be department because of Psychologist again...
+      time: 4h # Starlight end
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -12,7 +12,7 @@
     time: 5h # Starlight
   - !type:DepartmentTimeRequirement
     department: Science
-    time: 20h # Starlight
+    time: 30h # Starlight
 
   weight: 10
   startingGear: ResearchDirectorGear

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -6,16 +6,16 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobWarden
-      time: 5h # Starlight
+      time: 10h # Starlight
     - !type:RoleTimeRequirement
       role: JobDetective
       time: 5h # knowing how to use the tools is important # Starlight
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 5h
+      time: 15h # Starlight
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 20h # Starlight
+      time: 60h # Starlight - Literally the most pressured role in the game, you need extensive knowledge of your department
 
   weight: 10
   startingGear: HoSGear

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -6,10 +6,10 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 16h # Starlight
+      time: 15h # Starlight
     - !type:RoleTimeRequirement # Starlight
       role: JobDutyOfficer # Starlight
-      time: 4h # Starlight
+      time: 5h # Starlight
     - !type:RoleTimeRequirement
       role: JobDetective # Starlight
       time: 1h # Starlight

--- a/Resources/Prototypes/_StarLight/Roles/Antags/vampire.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Antags/vampire.yml
@@ -6,5 +6,5 @@
   objective: roles-antag-vampire-description
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 3h
+    time: 24h # Mostly just to ensure you know basic controls. Didn't want to make them too high since they're a thing unique to us in their functionality right now, so they've got an appeal to them.
   playTimeTracker: AntagVampire

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Cargo/mining_specialist.yml
@@ -4,11 +4,11 @@
   description: job-description-miningspec
   playTimeTracker: JobMiningSpecialist
   requirements:
-  - !type:DepartmentTimeRequirement
-    department: Cargo
-    time: 10800 # 3 hrs
-  - !type:OverallPlaytimeRequirement
-    time: 36000 #10 hrs
+    - !type:DepartmentTimeRequirement
+      department: Cargo
+      time: 6h # Less complex than salv
+    - !type:OverallPlaytimeRequirement 
+      time: 10h # Same as above
   icon: "JobIconMiningSpecialist"
   startingGear: MiningSpecialistGear
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
@@ -6,13 +6,13 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 40h # You are the sole bodyguard of the highest ranking people on the station, you have to be good.
+      time: 30h # You are the sole bodyguard of the highest ranking people on the station, you have to be good.
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 25h # You're expected to be mature, at least a little.
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 10h # You need to know how to treat people as this role its necessary
+      time: 30h # You're expected to be mature, at least a little.
+    - !type:RoleTimeRequirement
+      role: JobBrigmedic
+      time: 6h # Lower stakes version of the same role, and forces you to get Paramed time too. Totals to about 10 hours paramed+brigmed combined.
     - !type:RolesRequirement
       proto: ExtRolesReq
   startingGear: BlueShieldGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/blueshield.yml
@@ -6,10 +6,13 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 72000 # 20 hrs
+      time: 40h # You are the sole bodyguard of the highest ranking people on the station, you have to be good.
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 72000 # 20 hrs
+      time: 25h # You're expected to be mature, at least a little.
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 10h # You need to know how to treat people as this role its necessary
     - !type:RolesRequirement
       proto: ExtRolesReq
   startingGear: BlueShieldGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 72000 # 20 hrs
+      time: 40h # Parity with Magistrate. You should be experienced with Command before you tell them how to do their jobs.
     - !type:RolesRequirement
       proto: ExtRolesReq
   startingGear: NanoTrasenRepresentativeGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Representives/nanotrasenrepresentative.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 40h # Parity with Magistrate. You should be experienced with Command before you tell them how to do their jobs.
+      time: 40h # Still less than Magistrate. You should be experienced with Command before you tell them how to do their jobs.
     - !type:RolesRequirement
       proto: ExtRolesReq
   startingGear: NanoTrasenRepresentativeGear

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
@@ -10,6 +10,9 @@
     - !type:RoleTimeRequirement
       role: JobChemist
       time: 14400 # 4 hrs
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 15h # You'll realistically clear this if you clear the chem requirements. Brigmed is being changed to be more-paramedical anyways, so this works with that. Chem time should be removed later on.
   startingGear: BrigmedicGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_StarLight/Roles/Jobs/Security/brigmedic.yml
@@ -10,6 +10,9 @@
     - !type:RoleTimeRequirement
       role: JobChemist
       time: 14400 # 4 hrs
+    - !type:RoleTimeRequirement
+      role: JobParamedic
+      time: 4h
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 15h # You'll realistically clear this if you clear the chem requirements. Brigmed is being changed to be more-paramedical anyways, so this works with that. Chem time should be removed later on.


### PR DESCRIPTION
## Short description
Gives playtime alterations another shot, based on [Roro's original PR](https://github.com/ss14Starlight/space-station-14/pull/2664), minus about 33% for the largest ones.

## Before and After times
### Antags
- Nukeops - 24h overall, 6h sec > 48h overall, 5h secoff, 5h medical doctor, 5h Traitor
- NukeopsMedic - 24h overall, 6h chemist, 3h surgeon, 3h sec > 48h overall, 6h chemist, 3hr surgeon, 5h Brigmedic, 3h Traitor
- NukeopsCommander - 24h overall, 12h sec, 6h command > 72hr overall, 15h secoff, 10h Command, 5hr Nukeops
- HeadRev - 24h overall, 6h sec, 6h command > 72h overall, 5h secoff, 12h command
- Traitor, Changeling, Vampire - 3h overall > 24h overall
- Thief - 3h overall > 8h overall
- Initial Infected - 3h overall > 24h overall, 2 medical doctor (To know about treating yourself, but to also know what your Prime Target is.)
- Dragon - 3h salv > 24hr overall, 8h salv
- Ninja - 3h sec > 48h overall, 3h sec officer, 5h Thief
- Paradox clone - 24h overall > 48h overall (This is a HARD role. You should be familiar with the server culture if you even want a chance.)
- Wizard - 24h overall, 6h sec > 48h overall, 6h sec

### Non-Antags
- All command except HoS - 20h department time > 30h department time
- Paramedic - 2.5h med > 4h doctor
- Chemist - 5h med > 6h doctor
- Brigmedic - 10h secoff, 8h med > 10h secoff, 4h chem, 4h paramedic, 15hr medical department (Less Chem time since Chem is being phased out of Brigmed. If we had more systems to back it up I'd just bite the bullet right now and fully remove chem time, but we don't currently.)
- Warden - 16h secoff, 4hr duty officer, 1h det > 15h secoff, 5h duty officer, 1hr detective (Didn't want to make HoS drastically harder to unlock)
- HoS - 5h Ward, 5h det, 5h secoff, 20h sec > 10h ward, 5h det, 15h secoff, 60h sec (Highest stress role on the station debatably.)
- Salvage Specialist - 2.5h cargo > 8h cargo, 12h overall playtime (We've got a unique Salvage system, so I didn't want to make this too high.)
- Mining Specialist - 3h cargo, 10h overall > 6h cargo, 10h overall
- BSO - 20h sec, 20h command > 30h sec, 30h command, 6h Brigmed
- NTR - 20h command > 40h command (Magi is still higher than ntr for playtime even after this)

### CentComm roles
- ERTLeader - 20hr overall, 10h CC, 10h command > 96hr overall, 10h CC, 20h command, 15h secoff
- ERTEngineer - 20h overall, 5h engineer > 72h overall, 15h station engineer
- ERTSecurity - 20h overall, 5h secoff > 72h overall, 15h secoff
- ERTMedical - 20h overall, 5h doctor, 5h chemist > 72h overall, 10h doctor, 10h chemist, 5hr secoff (You come with ERT Sec. There's a very high chance you'll be fighting.)
- ERTChaplain - 20h overall, 5h chaplain > 48h overall, 5h chaplain
- ERTJanitor - 20h overall, 5h janitor > 48h overall, 5h janitor
CBURN - 20hr overall, 5h medical doctor, 5h secoff > 60hr overall, 10h medical doctor, 10h secoff

## Why we need to add this
Now that we have proper antag time tracking, it's time to re-evaluate our standards. For too long have we had antags who don't know how to even attempt their basic objectives, or *don't even know they have an uplink.* In addition, antag scaling has made it far more likely that you'll actually roll an Antag now. Therefore, we can actually start to hold our antags to some standards, at least mechanically. (Roleplay is an entirely different matter... Antags, at least nukies, should definitely convey themselves more seriously, and should be taken more seriously by the crew too.)

All playtimes named above that require departmental medical time, except for CMO, Brigmed, and BSO, have had their base medical time changed to Medical Doctor, due to Psychologist existing. It's entirely possible to unlock a lot of Medical without ever doing medicine if you just play Psychologist. They alternative to this was making Psychologist unlock with Medical time like MedDoctor, but I feel we should allow people to pick the pure roleplay role if they want to roleplay, so this was the compromise. BSO requires Brigmed time, which requires Paramed time. It's a good stepping stone, as each role progressively has higher stakes while adding one or so additional task. BSO requiring Brigmed also implicitly forces Sec time too.

Nukies now require Traitor Time, Ninja now requires Thief time. For Nukies, you *must* know how to use an Uplink. For Ninja, you're essentially playing a higher stakes Thief without pax.

As for the CentComm roles; You're playing someone professional who isn't your character. You have to be mature and professional.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld, RorororoIDK
- tweak: Playtime requirements for Antags has been changed across the board.
- tweak: Many jobs have had their playtimes tweaked.
- tweak: Nukeops - 24h overall, 6h sec > 48h overall, 5h secoff, 5h medical doctor, 5h Traitor.
- tweak: NukeopsMedic - 24h overall, 6h chemist, 3h surgeon, 3h sec > 48h overall, 6h chemist, 3hr surgeon, 5h Brigmedic, 3h Traitor.
- tweak: NukeopsCommander - 24h overall, 12h sec, 6h command > 72hr overall, 15h secoff, 10h Command, 5hr Nukeops.
- tweak: HeadRev - 24h overall, 6h sec, 6h command > 72h overall, 5h secoff, 12h command.
- tweak: Traitor, Changeling, Vampire - 3h overall > 24h overall.
- tweak: Thief - 3h overall > 8h overall.
- tweak: Initial Infected - 3h overall > 24h overall, 2 medical doctor (To know about treating yourself, but to also know what your Prime Target is.).
- tweak: Dragon - 3h salv > 24hr overall, 8h salv.
- tweak: Ninja - 3h sec > 48h overall, 3h sec officer, 5h Thief.
- tweak: Paradox clone - 24h overall > 48h overall (This is a HARD role. You should be familiar with the server culture if you even want a chance.).
- tweak: Wizard - 24h overall 6h sec > 48h overall, 6h sec.
- tweak: All command except HoS - 20h department time > 30h department time.
- tweak: Paramedic - 2.5h med > 4h doctor.
- tweak: Chemist - 5h med > 6h doctor.
- tweak: Brigmedic - 10h secoff, 8h med > 10h secoff, 4h chem, 4h paramedic, 15hr medical department (Less Chem time since Chem is being phased out of Brigmed. If we had more systems to back it up I'd just bite the bullet right now and fully remove chem time, but we don't currently.).
- tweak: Warden - 16h secoff, 4hr duty officer, 1h det > 15h secoff, 5h duty officer, 1hr detective (Didn't want to make HoS drastically harder to unlock).
- tweak: HoS - 5h Ward, 5h det, 5h secoff, 20h sec > 10h ward, 5h det, 15h secoff, 60h sec (Highest stress role on the station debatably.).
- tweak: Salvage Specialist - 2.5h cargo > 8h cargo, 12h overall playtime (We've got a unique Salvage system, so I didn't want to make this too high.).
- tweak: Mining Specialist - 3h cargo, 10h overall > 6h cargo, 10h overall.
- tweak: BSO - 20h sec, 20h command > 30h sec, 30h command, 6h brigmed.
- tweak: NTR - 20h command > 40h command (Magi is still higher than ntr for playtime even after this).
- tweak: ERTLeader - 20hr overall, 10h CC, 10h command > 96hr overall, 10h CC, 20h command, 15h secoff.
- tweak: ERTEngineer - 20h overall, 5h engineer > 72h overall, 15h station engineer.
- tweak: ERTSecurity - 20h overall, 5h secoff > 72h overall, 15h secoff.
- tweak: ERTMedical - 20h overall, 5h doctor, 5h chemist > 72h overall, 10h doctor, 10h chemist, 5hr secoff (You come with ERT Sec. There's a very high chance you'll be fighting.).
- tweak: ERTChaplain - 20h overall, 5h chaplain > 48h overall, 5h chaplain.
- tweak: ERTJanitor - 20h overall, 5h janitor > 48h overall, 5h janitor.
- tweak: CBURN - 20hr overall, 5h medical doctor, 5h secoff > 60hr overall, 10h medical doctor, 10h secoff.