### PR TITLE
Reverts L6 SAW nerfs + bugfix

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -282,7 +282,7 @@
   discountDownTo:
     Telecrystal: 20
   cost:
-    Telecrystal: 26 # Starlight
+    Telecrystal: 25
   categories:
   - UplinkWeaponry
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -42,10 +42,10 @@
     maxAngle: -20
   - type: Gun
     minAngle: 24
-    maxAngle: 35
+    maxAngle: 45
     angleIncrease: 4
     angleDecay: 16
-    fireRate: 6 # Starlight
+    fireRate: 8
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -125,9 +125,6 @@
       path: /Audio/Weapons/Guns/Bolt/lmg_bolt_closed.ogg
     soundBoltOpened:
       path: /Audio/Weapons/Guns/Cock/shotgun_open.ogg
-  - type: SpeedModifiedOnWield
-    walkModifier: 0.90
-    sprintModifier: 0.90
   - type: ItemSlots
     slots:
       gun_magazine:
@@ -145,9 +142,6 @@
         whitelist:
           tags:
             - CartridgeLightRifle
-  - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 0.90
   - type: HeldSpeedModifier
   - type: Gun
     minAngle: 24


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- This PR reverts the changes I made in #2768.
- This PR fixes a bug that was introduced in #3117 which gave the L6 SAW a 10% slowdown when worn on your back.

Starlight comments have been removed where changes were reverted to their default value. I forgor to put on on the `maxAngle` in my other PR, sorry.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- This change was unpopular with the community.
- https://discord.com/channels/1272545509562777621/1476683328399609968
- https://discord.com/channels/1272545509562777621/1408151198066020403/1464570188245504092
- Nuclear Operatives are having a hard time on Alpha. This is a bigger, more complex issue than the scope of this issue, but the L6 SAW being worse overall does impact Nukeops on Alpha.
- The bugfix is a bugfix. The L6 SAW was never intended to apply a slowdown when worn on your back - only when wielded.

Other contributors like teapoterror are looking at a bigger-picture Syndicate guns balance pass. This PR just restores the L6 SAW to how it was before my nerfs while teapot cooks up those changes.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawForConcern
- remove: L6 SAW price reverted back to 25TC (was 26TC).
- remove: L6 SAW accuracy reverted (from 35 maxAngle to 45).
- remove: L6 SAW firerate reverted (from 6 to 8).
- remove: L6 SAW slowdown-on-wielded reverted (from 10% to 0%).
- fix: L6 SAW unintentionally slowed you down 10% while worn on your back.