### PR TITLE
Why yes, this is a rodspam mald PR.

### DIFF
--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -19,7 +19,7 @@
   description: spellbook-polymorph-rod-desc
   productAction: ActionPolymorphWizardRod
   cost:
-    WizCoin: 3
+    WizCoin: 7 #Starlight: 3WC->7WC It's a LRP spell murderhobo spell, and it was so cheap you could buy every other wizard movement ability to avoid ever getting caught.
   categories:
   - SpellbookOffensive
   conditions:

--- a/Resources/Prototypes/Objectives/wizard.yml
+++ b/Resources/Prototypes/Objectives/wizard.yml
@@ -25,8 +25,8 @@
 - type: entity
   parent: [BaseWizardObjective, BaseFreeObjective]
   id: WizardDemonstrateObjective
-  name: Show off 
-  description: Show those magicless peons what a wizard can REALLY do!
+  name: Show off! #STARLIGHT-Going back to the old objective. No more explicit murderhobo encouragement.
+  description: Show those magicless peons what a wizard can REALLY do! #STARLIGHT- Description
   components:
   - type: Objective
     icon:

--- a/Resources/Prototypes/Objectives/wizard.yml
+++ b/Resources/Prototypes/Objectives/wizard.yml
@@ -25,8 +25,8 @@
 - type: entity
   parent: [BaseWizardObjective, BaseFreeObjective]
   id: WizardDemonstrateObjective
-  name: Cause chaos
-  description: Teach those station welps to never disrespect a Wizard again!
+  name: Show off 
+  description: Show those magicless peons what a wizard can REALLY do!
   components:
   - type: Objective
     icon:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Rod. Let's admit it. It's easily the most problematic part of wizard's toolkit as far as encouraging them to murderhobo goes.
The fact it's so cheap that you can ALSO buy practically every other movement option the wizard gets means that any wizard who buys the kill-the-entire-hall button can ALSO then just jaunt away with impunity. It's _by far_ the most common wizard archetype for a reason .

Also effectively reverts the Wizden change that made wizard's objective "Cause chaos." They are now here to show off again, and you can't show off if everyone else is dead.

## Why we need to add this
~~I'm malding. this is a mald pr. screw you~~

See description. Wizard's objectives encourage them to go for maximum carnage, while cheap Rod Form provides them with the means to do this with impunity. How many rounds and admemes with good RP have been ruined by a midround wizard seeing a group of people like a set of bowling pins?

I've heard more comprehensive solutions (involving the wizard expending energy and having to retire to their shuttle to manage magical heat build up) spitballed, but until someone starts working on them, this will ideally make it so Wizards have to choose between the massive destructive power of Rod Form, or being able to escape easily from the angry mob forming who aren't amused by their magical tricks.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: deltaVelocity
- remove: Reverted the Wizard's "Cause Chaos" objective to "Show Off." If you kill everyone, there's nobody left to show off to.
- tweak: Increased the price of the Wizard's Rod Form spell from 3 to 7 Wizcoin. No more rod-upgraded jaunt-upgraded blink spam from Wizards, ideally.

