### PR TITLE
(Orwell) Performers, Anchors, Fryers, and Chemicals

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Orwell.yml
+++ b/Resources/Maps/_Starlight/Stations/Orwell.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 268.0.0
+  engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 01/20/2026 19:17:54
-  entityCount: 29309
+  time: 02/27/2026 03:38:51
+  entityCount: 29317
 maps:
 - 1
 grids:
@@ -10334,7 +10334,7 @@ entities:
       pos: -57.5,40.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -35177.08
+      secondsUntilStateChange: -35609.297
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10741,7 +10741,7 @@ entities:
     - type: DeviceLinkSink
       invokeCounter: 1
     - type: Door
-      secondsUntilStateChange: -172016.39
+      secondsUntilStateChange: -172448.61
       state: Opening
     - type: DeviceLinkSource
       linkedPorts:
@@ -12473,7 +12473,7 @@ entities:
       pos: 18.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -60973.473
+      secondsUntilStateChange: -61405.69
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -12484,7 +12484,7 @@ entities:
       pos: 17.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -60968.406
+      secondsUntilStateChange: -61400.625
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -86629,7 +86629,7 @@ entities:
       pos: -43.5,-6.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -36493.875
+      secondsUntilStateChange: -36926.094
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -101988,9 +101988,13 @@ entities:
   - uid: 16111
     components:
     - type: Transform
+      anchored: False
       rot: 1.5707963267948966 rad
       pos: 37.5,-31.5
       parent: 2
+    - type: Physics
+      canCollide: True
+      bodyType: Dynamic
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 16112
@@ -118208,9 +118212,13 @@ entities:
   - uid: 18191
     components:
     - type: Transform
+      anchored: False
       rot: -1.5707963267948966 rad
       pos: -25.5,2.5
       parent: 2
+    - type: Physics
+      canCollide: True
+      bodyType: Dynamic
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 18192
@@ -136908,14 +136916,6 @@ entities:
       parent: 2
 - proto: LockerChemistryFilled
   entities:
-  - uid: 21087
-    components:
-    - type: Transform
-      pos: 13.5,4.5
-      parent: 2
-    - type: AccessReader
-      accessListsOriginal:
-      - - Chemistry
   - uid: 21088
     components:
     - type: Transform
@@ -138965,6 +138965,8 @@ entities:
     - type: Transform
       pos: 52.584244,-0.65098023
       parent: 2
+    - type: IntrinsicRadioTransmitter
+      channels: []
     - type: StockLimitedProcessing
       processingListings: {}
   - uid: 21390
@@ -138972,6 +138974,8 @@ entities:
     - type: Transform
       pos: 89.51733,6.6519823
       parent: 2
+    - type: IntrinsicRadioTransmitter
+      channels: []
     - type: StockLimitedProcessing
       processingListings: {}
   - uid: 21391
@@ -138979,6 +138983,8 @@ entities:
     - type: Transform
       pos: 89.7517,6.4488573
       parent: 2
+    - type: IntrinsicRadioTransmitter
+      channels: []
     - type: StockLimitedProcessing
       processingListings: {}
   - uid: 21392
@@ -138986,6 +138992,8 @@ entities:
     - type: Transform
       pos: 75.553406,1.6576805
       parent: 2
+    - type: IntrinsicRadioTransmitter
+      channels: []
     - type: StockLimitedProcessing
       processingListings: {}
   - uid: 21393
@@ -138993,6 +139001,8 @@ entities:
     - type: Transform
       pos: 37.518326,5.717554
       parent: 2
+    - type: IntrinsicRadioTransmitter
+      channels: []
     - type: StockLimitedProcessing
       processingListings: {}
   - uid: 21394
@@ -139000,6 +139010,8 @@ entities:
     - type: Transform
       pos: 47.528732,0.5850005
       parent: 2
+    - type: IntrinsicRadioTransmitter
+      channels: []
     - type: StockLimitedProcessing
       processingListings: {}
   - uid: 21395
@@ -139007,6 +139019,8 @@ entities:
     - type: Transform
       pos: 28.499985,34.591892
       parent: 2
+    - type: IntrinsicRadioTransmitter
+      channels: []
     - type: StockLimitedProcessing
       processingListings: {}
   - uid: 21396
@@ -139014,6 +139028,8 @@ entities:
     - type: Transform
       pos: 31.48066,38.568207
       parent: 2
+    - type: IntrinsicRadioTransmitter
+      channels: []
     - type: StockLimitedProcessing
       processingListings: {}
 - proto: PewEndLeft
@@ -139400,6 +139416,9 @@ entities:
   entities:
   - uid: 21460
     components:
+    - type: Transform
+      pos: 94.5,0.5
+      parent: 2
     - type: StationAiCore
       lawConsole: 24311
     - type: DeviceLinkSource
@@ -139407,9 +139426,6 @@ entities:
         24311:
         - - AiLawConsoleSender
           - AiLawConsoleReceiver
-    - type: Transform
-      pos: 94.5,0.5
-      parent: 2
 - proto: PlushieAtmosian
   entities:
   - uid: 21461
@@ -144289,6 +144305,23 @@ entities:
       - Experimental
       - CivilianServices
       - Biochemical
+- proto: protectionanchor
+  entities:
+  - uid: 21087
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 2
+  - uid: 29310
+    components:
+    - type: Transform
+      pos: 14.5,-4.5
+      parent: 2
+  - uid: 29311
+    components:
+    - type: Transform
+      pos: 51.5,-12.5
+      parent: 2
 - proto: Protolathe
   entities:
   - uid: 22279
@@ -155537,6 +155570,28 @@ entities:
     - type: Transform
       pos: 42.5,-15.5
       parent: 2
+- proto: SpawnPointPerformer
+  entities:
+  - uid: 29312
+    components:
+    - type: Transform
+      pos: -41.5,-21.5
+      parent: 2
+  - uid: 29313
+    components:
+    - type: Transform
+      pos: -43.5,-17.5
+      parent: 2
+  - uid: 29314
+    components:
+    - type: Transform
+      pos: -41.5,-17.5
+      parent: 2
+  - uid: 29316
+    components:
+    - type: Transform
+      pos: -47.5,-18.5
+      parent: 2
 - proto: SpawnPointQuartermaster
   entities:
   - uid: 24197
@@ -155726,6 +155781,11 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-15.5
+      parent: 2
+  - uid: 29315
+    components:
+    - type: Transform
+      pos: -18.5,-16.5
       parent: 2
 - proto: SpawnPointStationEngineer
   entities:
@@ -156175,11 +156235,11 @@ entities:
   entities:
   - uid: 24311
     components:
-    - type: SiliconLawUpdater
-      core: 21460
     - type: Transform
       pos: 93.5,-7.5
       parent: 2
+    - type: SiliconLawUpdater
+      core: 21460
 - proto: StationAnchor
   entities:
   - uid: 24312
@@ -162268,6 +162328,13 @@ entities:
     components:
     - type: Transform
       pos: 11.479034,-12.826936
+      parent: 2
+- proto: TP14KitchenDeepFryerTabletop
+  entities:
+  - uid: 29317
+    components:
+    - type: Transform
+      pos: -15.5,-14.5
       parent: 2
 - proto: TrainingBomb
   entities:

--- a/Resources/Prototypes/_StarLight/Maps/orwell.yml
+++ b/Resources/Prototypes/_StarLight/Maps/orwell.yml
@@ -63,6 +63,7 @@
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 2, 2 ]
+            Performer: [ 3, 4 ]
             Boxer: [ 2, 2 ]
             #silicon
             StationAi: [ 1, 1 ]


### PR DESCRIPTION
## Short description
Short and simple again, some upkeep. Notably enables performers.

## Why we need to add this
Mapping upkeep before the merge.

- [X] Supports https://github.com/ss14Starlight/space-station-14/issues/2853
- [X] Supports https://github.com/ss14Starlight/space-station-14/issues/3346

## Media (Video/Screenshots)
Protection anchors
<img width="1041" height="569" alt="image" src="https://github.com/user-attachments/assets/82b79361-c6aa-4f28-92c9-896eedf2bf1b" />

<img width="699" height="521" alt="image" src="https://github.com/user-attachments/assets/490150bd-32e9-4a22-b26f-f27dfdad9586" />

Deep fryer
<img width="479" height="566" alt="image" src="https://github.com/user-attachments/assets/08901387-d844-4497-a629-4dc7d39721ae" />

Brigmed
<img width="339" height="419" alt="image" src="https://github.com/user-attachments/assets/940109a1-2eea-4de9-a11a-ce3116e0e6f7" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: (Orwell) Adds spawns and slots for the Performer job.
- add: (Orwell) Adds 1 extra Service Worker spawn point, but not a slot. (It's next to kitchen, so there's a chance you won't spawn in the bathroom now.).
- add: (Orwell) Adds protection anchors to the armory and vault.
- add: (Orwell) Adds a deep fryer to the kitchen.
- remove: (Orwell) Removes Chemical locker from Brigmed.