### PR TITLE
(Ming) Performers and anchors

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Ming.yml
+++ b/Resources/Maps/_Starlight/Stations/Ming.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 02/27/2026 09:44:31
-  entityCount: 29482
+  time: 02/27/2026 09:47:20
+  entityCount: 29483
 maps:
 - 1
 grids:
@@ -10403,7 +10403,7 @@ entities:
       pos: -63.5,-31.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -181815.98
+      secondsUntilStateChange: -181977.2
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10428,7 +10428,7 @@ entities:
       pos: -58.5,-45.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -180213.48
+      secondsUntilStateChange: -180374.7
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10563,7 +10563,7 @@ entities:
       pos: -32.5,-52.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -187468.52
+      secondsUntilStateChange: -187629.73
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11026,7 +11026,7 @@ entities:
       pos: -71.5,-38.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -182326.31
+      secondsUntilStateChange: -182487.53
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -11221,7 +11221,7 @@ entities:
       pos: -83.5,-42.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6887.574
+      secondsUntilStateChange: -7048.783
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11233,7 +11233,7 @@ entities:
       pos: -83.5,-46.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6888.1743
+      secondsUntilStateChange: -7049.3833
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11245,7 +11245,7 @@ entities:
       pos: -83.5,-50.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6888.941
+      secondsUntilStateChange: -7050.15
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11257,7 +11257,7 @@ entities:
       pos: -83.5,-32.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6886.1743
+      secondsUntilStateChange: -7047.3833
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11269,7 +11269,7 @@ entities:
       pos: -83.5,-28.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6885.6074
+      secondsUntilStateChange: -7046.8164
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11281,7 +11281,7 @@ entities:
       pos: -83.5,-24.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6885.1074
+      secondsUntilStateChange: -7046.3164
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11293,7 +11293,7 @@ entities:
       pos: 47.5,53.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6910.4077
+      secondsUntilStateChange: -7071.6167
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11305,7 +11305,7 @@ entities:
       pos: 47.5,57.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6909.774
+      secondsUntilStateChange: -7070.983
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11319,7 +11319,7 @@ entities:
       addComponents: []
       path: /Maps/_Starlight/Shuttles/KillerTamashi-SecShuttle.yml
     - type: Door
-      secondsUntilStateChange: -62697.684
+      secondsUntilStateChange: -62858.89
       state: Opening
 - proto: AirlockExternalGlassShuttleLocked
   entities:
@@ -12627,7 +12627,7 @@ entities:
       pos: 34.5,43.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -260673.98
+      secondsUntilStateChange: -260835.2
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -137984,6 +137984,11 @@ entities:
     components:
     - type: Transform
       pos: 51.5,-15.5
+      parent: 2
+  - uid: 29483
+    components:
+    - type: Transform
+      pos: 0.5,5.5
       parent: 2
 - proto: Protolathe
   entities:

--- a/Resources/Maps/_Starlight/Stations/Ming.yml
+++ b/Resources/Maps/_Starlight/Stations/Ming.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 270.1.0
+  engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 01/28/2026 17:17:50
-  entityCount: 29476
+  time: 02/27/2026 09:44:31
+  entityCount: 29482
 maps:
 - 1
 grids:
@@ -10403,7 +10403,7 @@ entities:
       pos: -63.5,-31.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -181328.8
+      secondsUntilStateChange: -181815.98
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10428,7 +10428,7 @@ entities:
       pos: -58.5,-45.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -179726.3
+      secondsUntilStateChange: -180213.48
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10563,7 +10563,7 @@ entities:
       pos: -32.5,-52.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -186981.33
+      secondsUntilStateChange: -187468.52
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11026,7 +11026,7 @@ entities:
       pos: -71.5,-38.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -181839.12
+      secondsUntilStateChange: -182326.31
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -11221,7 +11221,7 @@ entities:
       pos: -83.5,-42.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6400.384
+      secondsUntilStateChange: -6887.574
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11233,7 +11233,7 @@ entities:
       pos: -83.5,-46.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6400.984
+      secondsUntilStateChange: -6888.1743
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11245,7 +11245,7 @@ entities:
       pos: -83.5,-50.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6401.7505
+      secondsUntilStateChange: -6888.941
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11257,7 +11257,7 @@ entities:
       pos: -83.5,-32.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6398.984
+      secondsUntilStateChange: -6886.1743
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11269,7 +11269,7 @@ entities:
       pos: -83.5,-28.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6398.417
+      secondsUntilStateChange: -6885.6074
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11281,7 +11281,7 @@ entities:
       pos: -83.5,-24.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6397.917
+      secondsUntilStateChange: -6885.1074
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11293,7 +11293,7 @@ entities:
       pos: 47.5,53.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6423.2173
+      secondsUntilStateChange: -6910.4077
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11305,7 +11305,7 @@ entities:
       pos: 47.5,57.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6422.5835
+      secondsUntilStateChange: -6909.774
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11319,7 +11319,7 @@ entities:
       addComponents: []
       path: /Maps/_Starlight/Shuttles/KillerTamashi-SecShuttle.yml
     - type: Door
-      secondsUntilStateChange: -62210.492
+      secondsUntilStateChange: -62697.684
       state: Opening
 - proto: AirlockExternalGlassShuttleLocked
   entities:
@@ -12627,7 +12627,7 @@ entities:
       pos: 34.5,43.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -260186.8
+      secondsUntilStateChange: -260673.98
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -110121,9 +110121,13 @@ entities:
   - uid: 17233
     components:
     - type: Transform
+      anchored: False
       rot: 1.5707963267948966 rad
       pos: 29.5,34.5
       parent: 2
+    - type: Physics
+      canCollide: True
+      bodyType: Dynamic
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 17234
@@ -120748,6 +120752,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -1.4829488,-4.6610336
       parent: 2
+    - type: IntrinsicRadioTransmitter
+      channels: []
     - type: StockLimitedProcessing
       processingListings: {}
 - proto: GravityGenerator
@@ -131175,16 +131181,6 @@ entities:
       parent: 2
 - proto: LockerChemistryFilled
   entities:
-  - uid: 78
-    components:
-    - type: Transform
-      pos: 24.5,-21.5
-      parent: 2
-    - type: AccessReader
-      accessListsOriginal:
-      - - Chemistry
-      access:
-      - - Medical
   - uid: 20498
     components:
     - type: Transform
@@ -133390,6 +133386,8 @@ entities:
     - type: Transform
       pos: -77.49177,-2.4420576
       parent: 2
+    - type: IntrinsicRadioTransmitter
+      channels: []
 - proto: PetCarrier
   entities:
   - uid: 12025
@@ -133662,6 +133660,9 @@ entities:
   entities:
   - uid: 20863
     components:
+    - type: Transform
+      pos: -50.5,-57.5
+      parent: 2
     - type: StationAiCore
       lawConsole: 24271
     - type: DeviceLinkSource
@@ -133669,9 +133670,6 @@ entities:
         24271:
         - - AiLawConsoleSender
           - AiLawConsoleReceiver
-    - type: Transform
-      pos: -50.5,-57.5
-      parent: 2
 - proto: PlushieAtmosian
   entities:
   - uid: 20864
@@ -137970,6 +137968,23 @@ entities:
       - Experimental
       - CivilianServices
       - Biochemical
+- proto: protectionanchor
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 45.5,-11.5
+      parent: 2
+  - uid: 29478
+    components:
+    - type: Transform
+      pos: 51.5,-11.5
+      parent: 2
+  - uid: 29479
+    components:
+    - type: Transform
+      pos: 51.5,-15.5
+      parent: 2
 - proto: Protolathe
   entities:
   - uid: 21574
@@ -152269,6 +152284,23 @@ entities:
     - type: Transform
       pos: 36.5,50.5
       parent: 2
+- proto: SpawnPointPerformer
+  entities:
+  - uid: 29480
+    components:
+    - type: Transform
+      pos: -28.5,15.5
+      parent: 2
+  - uid: 29481
+    components:
+    - type: Transform
+      pos: -35.5,20.5
+      parent: 2
+  - uid: 29482
+    components:
+    - type: Transform
+      pos: -35.5,22.5
+      parent: 2
 - proto: SpawnPointPsychologist
   entities:
   - uid: 24106
@@ -153206,12 +153238,12 @@ entities:
   entities:
   - uid: 24271
     components:
-    - type: SiliconLawUpdater
-      core: 20863
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -43.5,-59.5
       parent: 2
+    - type: SiliconLawUpdater
+      core: 20863
 - proto: StationAnchor
   entities:
   - uid: 24273
@@ -158866,6 +158898,13 @@ entities:
       parent: 1149
     - type: Physics
       canCollide: False
+- proto: TP14KitchenDeepFryerTabletop
+  entities:
+  - uid: 29477
+    components:
+    - type: Transform
+      pos: -27.5,3.5
+      parent: 2
 - proto: TrashBananaPeel
   entities:
   - uid: 25176

--- a/Resources/Maps/_Starlight/Stations/Ming.yml
+++ b/Resources/Maps/_Starlight/Stations/Ming.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 02/27/2026 09:47:20
-  entityCount: 29483
+  time: 02/27/2026 09:58:04
+  entityCount: 29491
 maps:
 - 1
 grids:
@@ -10403,7 +10403,7 @@ entities:
       pos: -63.5,-31.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -181977.2
+      secondsUntilStateChange: -182602.3
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10428,7 +10428,7 @@ entities:
       pos: -58.5,-45.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -180374.7
+      secondsUntilStateChange: -180999.8
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10563,7 +10563,7 @@ entities:
       pos: -32.5,-52.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -187629.73
+      secondsUntilStateChange: -188254.83
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11026,7 +11026,7 @@ entities:
       pos: -71.5,-38.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -182487.53
+      secondsUntilStateChange: -183112.62
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -11221,7 +11221,7 @@ entities:
       pos: -83.5,-42.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7048.783
+      secondsUntilStateChange: -7673.8823
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11233,7 +11233,7 @@ entities:
       pos: -83.5,-46.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7049.3833
+      secondsUntilStateChange: -7674.4824
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11245,7 +11245,7 @@ entities:
       pos: -83.5,-50.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7050.15
+      secondsUntilStateChange: -7675.249
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11257,7 +11257,7 @@ entities:
       pos: -83.5,-32.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7047.3833
+      secondsUntilStateChange: -7672.4824
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11269,7 +11269,7 @@ entities:
       pos: -83.5,-28.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7046.8164
+      secondsUntilStateChange: -7671.9155
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11281,7 +11281,7 @@ entities:
       pos: -83.5,-24.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7046.3164
+      secondsUntilStateChange: -7671.4155
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11293,7 +11293,7 @@ entities:
       pos: 47.5,53.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7071.6167
+      secondsUntilStateChange: -7696.716
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11305,7 +11305,7 @@ entities:
       pos: 47.5,57.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7070.983
+      secondsUntilStateChange: -7696.082
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11319,7 +11319,7 @@ entities:
       addComponents: []
       path: /Maps/_Starlight/Shuttles/KillerTamashi-SecShuttle.yml
     - type: Door
-      secondsUntilStateChange: -62858.89
+      secondsUntilStateChange: -63483.992
       state: Opening
 - proto: AirlockExternalGlassShuttleLocked
   entities:
@@ -12627,7 +12627,7 @@ entities:
       pos: 34.5,43.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -260835.2
+      secondsUntilStateChange: -261460.3
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -15637,6 +15637,22 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-40.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 29484
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 48.5,-10.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 29487
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,-13.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -38987,6 +39003,16 @@ entities:
     - type: Transform
       pos: 12.5,-43.5
       parent: 2
+  - uid: 29490
+    components:
+    - type: Transform
+      pos: 48.5,-14.5
+      parent: 2
+  - uid: 29491
+    components:
+    - type: Transform
+      pos: 48.5,-13.5
+      parent: 2
 - proto: CableHV
   entities:
   - uid: 5429
@@ -60789,6 +60815,26 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-40.5
+      parent: 2
+  - uid: 29485
+    components:
+    - type: Transform
+      pos: 48.5,-10.5
+      parent: 2
+  - uid: 29486
+    components:
+    - type: Transform
+      pos: 49.5,-10.5
+      parent: 2
+  - uid: 29488
+    components:
+    - type: Transform
+      pos: 49.5,-9.5
+      parent: 2
+  - uid: 29489
+    components:
+    - type: Transform
+      pos: 48.5,-13.5
       parent: 2
 - proto: CableTerminal
   entities:

--- a/Resources/Maps/_Starlight/Stations/Ming.yml
+++ b/Resources/Maps/_Starlight/Stations/Ming.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 02/27/2026 09:58:04
-  entityCount: 29491
+  time: 02/27/2026 18:51:36
+  entityCount: 29487
 maps:
 - 1
 grids:
@@ -10403,7 +10403,7 @@ entities:
       pos: -63.5,-31.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -182602.3
+      secondsUntilStateChange: -182662.1
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10428,7 +10428,7 @@ entities:
       pos: -58.5,-45.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -180999.8
+      secondsUntilStateChange: -181059.6
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10563,7 +10563,7 @@ entities:
       pos: -32.5,-52.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -188254.83
+      secondsUntilStateChange: -188314.62
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11026,7 +11026,7 @@ entities:
       pos: -71.5,-38.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -183112.62
+      secondsUntilStateChange: -183172.42
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -11221,7 +11221,7 @@ entities:
       pos: -83.5,-42.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7673.8823
+      secondsUntilStateChange: -7733.6826
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11233,7 +11233,7 @@ entities:
       pos: -83.5,-46.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7674.4824
+      secondsUntilStateChange: -7734.2827
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11245,7 +11245,7 @@ entities:
       pos: -83.5,-50.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7675.249
+      secondsUntilStateChange: -7735.0493
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11257,7 +11257,7 @@ entities:
       pos: -83.5,-32.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7672.4824
+      secondsUntilStateChange: -7732.2827
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11269,7 +11269,7 @@ entities:
       pos: -83.5,-28.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7671.9155
+      secondsUntilStateChange: -7731.716
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11281,7 +11281,7 @@ entities:
       pos: -83.5,-24.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7671.4155
+      secondsUntilStateChange: -7731.216
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11293,7 +11293,7 @@ entities:
       pos: 47.5,53.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7696.716
+      secondsUntilStateChange: -7756.516
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11305,7 +11305,7 @@ entities:
       pos: 47.5,57.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7696.082
+      secondsUntilStateChange: -7755.8823
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11319,7 +11319,7 @@ entities:
       addComponents: []
       path: /Maps/_Starlight/Shuttles/KillerTamashi-SecShuttle.yml
     - type: Door
-      secondsUntilStateChange: -63483.992
+      secondsUntilStateChange: -63543.793
       state: Opening
 - proto: AirlockExternalGlassShuttleLocked
   entities:
@@ -12627,7 +12627,7 @@ entities:
       pos: 34.5,43.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -261460.3
+      secondsUntilStateChange: -261520.1
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -15645,14 +15645,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 48.5,-10.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 29487
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,-13.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -39008,11 +39000,6 @@ entities:
     - type: Transform
       pos: 48.5,-14.5
       parent: 2
-  - uid: 29491
-    components:
-    - type: Transform
-      pos: 48.5,-13.5
-      parent: 2
 - proto: CableHV
   entities:
   - uid: 5429
@@ -60830,11 +60817,6 @@ entities:
     components:
     - type: Transform
       pos: 49.5,-9.5
-      parent: 2
-  - uid: 29489
-    components:
-    - type: Transform
-      pos: 48.5,-13.5
       parent: 2
 - proto: CableTerminal
   entities:
@@ -138020,11 +138002,6 @@ entities:
     components:
     - type: Transform
       pos: 45.5,-11.5
-      parent: 2
-  - uid: 29478
-    components:
-    - type: Transform
-      pos: 51.5,-11.5
       parent: 2
   - uid: 29479
     components:

--- a/Resources/Maps/_Starlight/Stations/Ming.yml
+++ b/Resources/Maps/_Starlight/Stations/Ming.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 02/27/2026 18:51:36
-  entityCount: 29487
+  time: 02/27/2026 18:53:15
+  entityCount: 29486
 maps:
 - 1
 grids:
@@ -10403,7 +10403,7 @@ entities:
       pos: -63.5,-31.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -182662.1
+      secondsUntilStateChange: -182757.52
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10428,7 +10428,7 @@ entities:
       pos: -58.5,-45.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -181059.6
+      secondsUntilStateChange: -181155.02
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10563,7 +10563,7 @@ entities:
       pos: -32.5,-52.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -188314.62
+      secondsUntilStateChange: -188410.05
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11026,7 +11026,7 @@ entities:
       pos: -71.5,-38.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -183172.42
+      secondsUntilStateChange: -183267.84
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -11221,7 +11221,7 @@ entities:
       pos: -83.5,-42.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7733.6826
+      secondsUntilStateChange: -7829.1025
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11233,7 +11233,7 @@ entities:
       pos: -83.5,-46.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7734.2827
+      secondsUntilStateChange: -7829.7026
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11245,7 +11245,7 @@ entities:
       pos: -83.5,-50.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7735.0493
+      secondsUntilStateChange: -7830.469
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11257,7 +11257,7 @@ entities:
       pos: -83.5,-32.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7732.2827
+      secondsUntilStateChange: -7827.7026
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11269,7 +11269,7 @@ entities:
       pos: -83.5,-28.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7731.716
+      secondsUntilStateChange: -7827.1357
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11281,7 +11281,7 @@ entities:
       pos: -83.5,-24.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7731.216
+      secondsUntilStateChange: -7826.6357
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11293,7 +11293,7 @@ entities:
       pos: 47.5,53.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7756.516
+      secondsUntilStateChange: -7851.936
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11305,7 +11305,7 @@ entities:
       pos: 47.5,57.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -7755.8823
+      secondsUntilStateChange: -7851.3022
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11319,7 +11319,7 @@ entities:
       addComponents: []
       path: /Maps/_Starlight/Shuttles/KillerTamashi-SecShuttle.yml
     - type: Door
-      secondsUntilStateChange: -63543.793
+      secondsUntilStateChange: -63639.21
       state: Opening
 - proto: AirlockExternalGlassShuttleLocked
   entities:
@@ -12627,7 +12627,7 @@ entities:
       pos: 34.5,43.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -261520.1
+      secondsUntilStateChange: -261615.52
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -38994,11 +38994,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,-43.5
-      parent: 2
-  - uid: 29490
-    components:
-    - type: Transform
-      pos: 48.5,-14.5
       parent: 2
 - proto: CableHV
   entities:

--- a/Resources/Prototypes/_StarLight/Maps/ming.yml
+++ b/Resources/Prototypes/_StarLight/Maps/ming.yml
@@ -65,6 +65,7 @@
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 2, 2 ]
+            Performer: [ 3, 4 ]
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 3, 5 ]


### PR DESCRIPTION
## Short description
Enables performers and does 2 mapping chores + deep fryer.

## Why we need to add this
Map upkeep. Enables Performers too.

- [X] Supports https://github.com/ss14Starlight/space-station-14/issues/2853
- [X] Supports https://github.com/ss14Starlight/space-station-14/issues/3346

## Media (Video/Screenshots)
Protection anchors
<img width="623" height="561" alt="image" src="https://github.com/user-attachments/assets/c79df84f-23e2-46f6-8a29-1cb2c012054a" />

<img width="567" height="473" alt="image" src="https://github.com/user-attachments/assets/55a69d8c-2245-4911-90bd-a9373fb405b2" />

Brigmedic chem locker removed
<img width="309" height="491" alt="image" src="https://github.com/user-attachments/assets/ee9fc8f9-17d6-414f-a038-3400d1f88178" />

Deep fryer
<img width="663" height="364" alt="image" src="https://github.com/user-attachments/assets/fa81c3a1-8b48-4bd1-90ff-6414737befeb" />

Performer spawns
<img width="558" height="482" alt="image" src="https://github.com/user-attachments/assets/660c7d34-2c05-4c29-9628-71a8fbcaaa9d" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: (Ming) Added protection anchors to the armory and the vault. (With 2 more APCs in armory to sustain the 3 anchors.).
- add: (Ming) Added a deep fryer to the kitchen.
- add: (Ming) Added Performer spawns and slots.
- remove: (Ming) Removed Brigmedic chem locker.