### PR TITLE
[hotfix]Fix xenoborg's laser cannon

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1050,6 +1050,11 @@
   id: WeaponLaserCannonXenoborg
   name: xenoborg laser cannon
   components:
+  # region starlight - fix xenoborg cannon's absurdly low fire cost.
+  - type: BatteryAmmoProvider
+    proto: RedHeavyLaser
+    fireCost: 100
+  # end region starlight
   - type: BatterySelfRecharger
     autoRechargeRate: 30
   # "remove" wield bonus and penalty so borgs can use it


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes an oversight that gives xenoborg's heavy cannon way more shots than it should have.

## Why we need to add this
 So, me and a bunch of people were talking about the xenoborg heavy's laser cannon being too strong. Turns out? IT IS. At some point, we changed the RedHeavyLaser to a fire cost of 40. The xenoborg heavy laser prototypes off this laser. The original cost? 100. Combined with an auto recharge rate of 30 it made the heavy xenoborg's laser cannon ABSURDLY strong, being able to fire virtually infinitely. That ends. Today.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: R3v3l4t1on
- fix: Xenoborg's heavy laser cannon is no longer overtuned to all hell (firecost 40 increased from 100)
