### PR TITLE
Pirate disposable turret + sprite and access fixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -105,6 +105,37 @@
     price: 1350
 
 - type: entity
+  name: electrical toolbox
+  suffix: Pirate, Turret
+  parent: ToolboxElectrical
+  id: ToolboxElectricalTurretPirate
+  description: A toolbox typically stocked with electrical gear.
+  components:
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 100
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 1
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+          - !type:SpawnEntitiesBehavior
+            spawn:
+              WeaponTurretPirateDisposable:
+                min: 1
+                max: 1
+  - type: StaticPrice
+    price: 1350
+
+- type: entity
   name: artistic toolbox
   parent: ToolboxBase
   id: ToolboxArtistic

--- a/Resources/Prototypes/_StarLight/Access/misc.yml
+++ b/Resources/Prototypes/_StarLight/Access/misc.yml
@@ -37,6 +37,7 @@
   - Freelance
   - Commie
   - Wizard
+  - Pirate
 
 - type: accessGroup
   id: Syndicate

--- a/Resources/Prototypes/_StarLight/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/Fills/Items/toolboxes.yml
@@ -1,4 +1,15 @@
 - type: entity
+  id: ToolboxElectricalTurretPirateFilled
+  name: electrical toolbox
+  suffix: Pirate, Turret, Filled
+  parent: ToolboxElectricalTurretPirate
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: ToolboxElectricalEntityTable
+
+- type: entity
   id: ToolboxArtisticFilledCleaner
   name: artistic toolbox
   suffix: Cleaner

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Devices/Electronics/door.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Devices/Electronics/door.yml
@@ -108,6 +108,7 @@
     - type: StaticPrice
       price: 55
     - type: AccessReader
+      access: [["Pirate"]]
     - type: ActivatableUI
       key: enum.DoorElectronicsConfigurationUiKey.Key
       requiredItems:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -506,7 +506,7 @@
     size: Huge
     shape:
     - 0,0,3,2
-    sprite: Objects/Weapons/Guns/Shotguns/blunderbuss.rsi
+    sprite: _Starlight/Objects/Weapons/Guns/Rifles/lionhunter_inhands.rsi
   - type: Clothing
     sprite: _Starlight/Objects/Weapons/Guns/Rifles/lionhunter_inhands.rsi
     quickEquip: false

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
@@ -13,3 +13,45 @@
     - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/gun_sentry.ogg
+
+- type: entity
+  parent: BaseWeaponBallisticTurret
+  id: WeaponTurretPirateDisposable
+  name: disposable ballistic turret
+  suffix: Pirate, Disposable
+  components:
+  - type: NpcFactionMember
+    factions:
+    - Pirate
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:TriggerBehavior
+  - type: Gun
+    fireRate: 2
+    selectedMode: FullAuto
+    availableModes:
+    - FullAuto
+    soundGunshot: /Audio/Weapons/Guns/Gunshots/gun_sentry.ogg
+  - type: BallisticAmmoProvider
+    proto: CartridgePistolFMJ
+    capacity: 50
+  - type: TriggerOnEmptyGunshot
+  - type: ExplodeOnTrigger
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 10
+    intensitySlope: 1.5
+    totalIntensity: 30
+    canCreateVacuum: false

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
@@ -39,7 +39,7 @@
         acts: [ "Destruction" ]
       - !type:TriggerBehavior
   - type: Gun
-    fireRate: 2
+    fireRate: 1.3
     selectedMode: FullAuto
     availableModes:
     - FullAuto

--- a/Resources/Prototypes/_StarLight/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Doors/Airlocks/access.yml
@@ -367,6 +367,42 @@
       board: [ BaseDoorElectronicsPirate ]
   - type: Wires
     layoutId: AirlockSecurity
+
+- type: entity
+  parent: AirlockSyndicate
+  id: AirlockSyndicatePirateLocked
+  suffix: Pirate, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ BaseDoorElectronicsPirate ]
+
+- type: entity
+  parent: AirlockSyndicateGlass
+  id: AirlockSyndicateGlassPirateLocked
+  suffix: Pirate, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ BaseDoorElectronicsPirate ]
+
+- type: entity
+  parent: AirlockShuttleSyndicate
+  id: AirlockExternalShuttlePirateLocked
+  suffix: External, Docking, Pirate, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ BaseDoorElectronicsPirate ]
+
+- type: entity
+  parent: AirlockGlassShuttleSyndicate
+  id: AirlockExternalGlassShuttlePirateLocked
+  suffix: Pirate, Locked, Glass
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ BaseDoorElectronicsPirate ]
 # Brigmedic
 - type: entity
   parent: AirlockBrigmed

--- a/Resources/Prototypes/_StarLight/Recipes/Construction/Graphs/machines/pirate_disposable_turret.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Construction/Graphs/machines/pirate_disposable_turret.yml
@@ -1,0 +1,16 @@
+- type: constructionGraph
+  id: WeaponTurretPirateDisposable
+  start: disposableTurret
+  graph:
+  - node: disposableTurret
+    entity: WeaponTurretPirateDisposable
+    edges:
+    - to: disposableTurret
+      completed:
+      - !type:SpawnPrototype
+            prototype: ToolboxElectricalTurret
+            amount: 1
+      - !type:DeleteEntity {}
+      steps:
+        - tool: Screwing
+          doAfter: 10


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes RSI and access bug for pirates and adds a disposable turret.

## Why we need to add this
More pirated focused items and bug fixing

## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
Fixed RSI and access bugs for pirates and added a disposable turret for them (its weaker then the modern syndicate ones).

:cl: Scarlet Lightweaver
- fix: Fixed RSI and access bugs for pirates and added a disposable turret for them (its weaker then the modern syndicate ones).
