### PR TITLE
Fix crew monitoring paging system warning too early

### DIFF
--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerSystem.cs
@@ -100,7 +100,7 @@ public sealed class CrewMonitoringServerSystem : EntitySystem
         // Update paging status for all currently seen sensors.
         foreach (var (address, sensor) in component.SensorStatus)
         {
-            var critOrDead = !sensor.IsAlive || (sensor.DamagePercentage != null && sensor.DamagePercentage >= 0.5);
+            var critOrDead = !sensor.IsAlive || (sensor.DamagePercentage != null && sensor.DamagePercentage >= 1.0);
             seen.Add(address);
 
             // If person isn't crit or dead, discard status if it exists and ignore.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Title

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Currently it pages at 50% the way to crit, not 100%. The paging only happens once per person so the recipients don't get paged when it *actually* needs their attention. Somehow didn't come up in testing..

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

n/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: Crew monitor paging no longer pages before a person crits.

