### PR TITLE
Add Robotics-access secure windoor prototypes for mapping

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Structures/Doors/Windoors/windoor.yml
@@ -1,3 +1,4 @@
+# Mining
 - type: entity
   parent: WindoorSecureCargoLocked
   id: WindoorSecureMiningLocked
@@ -7,6 +8,7 @@
     containers:
       board: [ DoorElectronicsMining ]
 
+# Salvage
 - type: entity
   parent: WindoorSecureCargoLocked
   id: WindoorSecureSalvageMiningLocked
@@ -15,3 +17,26 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsSalvageMining ]
+
+# Robotics
+- type: entity
+  parent: WindoorSecure
+  id: WindoorSecureRoboticsLocked
+  suffix: Robotics, Locked
+  components:
+    - type: ContainerFill
+      containers:
+        board: [ DoorElectronicsRobotics ]
+    - type: Wires
+      layoutId: AirlockScience
+
+- type: entity
+  parent: WindoorSecurePlasma
+  id: PlasmaWindoorSecureRoboticsLocked
+  suffix: Robotics, Locked, Plasma
+  components:
+    - type: ContainerFill
+      containers:
+        board: [ DoorElectronicsRobotics ]
+    - type: Wires
+      layoutId: AirlockScience


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Adds Robotics access `SecureWindoor` prototypes for mapping.

Omitting changelog since relates to mapper tooling only.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

@Makeshiftt reported it was missing in #3465.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/3b2464e7-d3a3-481c-b588-fcfc8d21c0cd


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

