### PR TITLE
Fix Cyborgs and AI having no identifiers in communications

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -35,7 +35,6 @@ using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 using Content.Shared._Starlight.Radio; //Starlight
-using Content.Shared.NameModifier.Components; //Starlight
 
 namespace Content.Server.Radio.EntitySystems;
 
@@ -143,10 +142,6 @@ public sealed class RadioSystem : EntitySystem
 
         var meta = MetaData(messageSource);
         var entityName = meta?.EntityName ?? string.Empty;
-        // Starlight BEGIN
-        if (TryComp(messageSource, out NameModifierComponent? nameModifier))
-            entityName = nameModifier.BaseName; // Bypass name modifiers (specifically: labels).
-        // Starlight END
         var evt = new TransformSpeakerNameEvent(messageSource, entityName);
         RaiseLocalEvent(messageSource, evt);
 


### PR DESCRIPTION
This reverts commit d097b2363e95a48b16afe673e1eff69c04b330a8.

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Hard reverts #3391 and returns us to upstream state.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Unintended side effect of #3391 is cyborgs and AI losing their identifiers in communications:

<img width="333" height="37" alt="SS14 Loader_6y1tNsn7iK" src="https://github.com/user-attachments/assets/d61a8e6d-b15d-4946-a870-f3514023ec82" />

<img width="325" height="41" alt="SS14 Loader_ZY3K1zkcTJ" src="https://github.com/user-attachments/assets/7d0e44fe-77a7-4be3-a329-b426583c6aca" />

Per #3417 player labeling is gone anyways so no harm in reverting.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="493" height="101" alt="image" src="https://github.com/user-attachments/assets/aaeb58c4-e4e6-48d6-923f-90ed90172c8a" />

<img width="545" height="71" alt="image" src="https://github.com/user-attachments/assets/c9461c55-8a0a-4fab-afaa-b257434db425" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl:
- fix: Cyborgs and AIs once again show their identifiers in their communications.
