### PR TITLE
Slime water damage tweak

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -119,7 +119,7 @@
       - !type:HealthChange
         damage:
           types:
-            Heat: 1 # Starlight-edit
+            Heat: 0.25 # Starlight-edit
       - !type:PopupMessage
         type: Local
         visualType: Large


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Reduced the amount of heat damage laspi take from water while still keeping it painful.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

While ashing a laspi with a tank of water was fun, the amount of damage taken from a unit of water was overtuned in the eyes of many laspi players. With this you shouldn't be able to take down a laspi with just a fire extinguisher, but the damage still shouldn't be ignorable.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: 
- tweak: reduced heat damage from one to 0.25.