### PR TITLE
Fix Station AI crew monitor not working

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -70,6 +70,7 @@
     deviceNetId: Wireless
     receiveFrequencyId: CrewMonitor
     transmitFrequencyId: ShuttleTimer
+  - type: StationLimitedNetwork
   - type: RadarConsole
     followEntity: false
   - type: CommunicationsConsole

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -70,7 +70,7 @@
     deviceNetId: Wireless
     receiveFrequencyId: CrewMonitor
     transmitFrequencyId: ShuttleTimer
-  - type: StationLimitedNetwork
+  - type: StationLimitedNetwork # Starlight
   - type: RadarConsole
     followEntity: false
   - type: CommunicationsConsole

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/handheld_brigmedic_crew_monitor.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/handheld_brigmedic_crew_monitor.yml
@@ -46,6 +46,7 @@
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: CrewMonitor
+  - type: StationLimitedNetwork
   - type: WirelessNetworkConnection
     range: 500
   - type: StealTarget

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
@@ -47,6 +47,7 @@
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: CrewMonitor
+  - type: StationLimitedNetwork
   - type: WirelessNetworkConnection
     range: 500
   - type: StealTarget


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Fixes Station AI crew monitor (sometimes) not working.

## Long description

This bug came from the Station AI `CrewMonitoringConsole` component receiving the normal sensor list first, but then being overridden by an empty list from CC's crew monitoring server. Limiting communications to the station fixes this, matching existing handheld crew monitors (CMO's and Para's). Adjusted our other two handhelds (BSO, Brigmed's) to match this.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

It's broken: https://discord.com/channels/1272545509562777621/1477347080476299274

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Video was too big so uploaded to Cloudflare bucket: https://s.redmushie.me/2026/02/Content.Client_m6Ra6ViNrH.mp4

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: Station AI's crew monitor now correctly displays data.