### PR TITLE
Fix Station AI/aghost station records UI crashing for custom species names

### DIFF
--- a/Content.Client/StationRecords/GeneralRecord.xaml.cs
+++ b/Content.Client/StationRecords/GeneralRecord.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class GeneralRecord : Control
         Age.Text = Loc.GetString("general-station-record-console-record-age", ("age", record.Age.ToString()));
         Title.Text = Loc.GetString("general-station-record-console-record-title",
             ("job", Loc.GetString(record.JobTitle)));
-        var species = Loc.GetString(prototypeManager.Index<SpeciesPrototype>(record.Species).Name);
+        var species = Loc.GetString(record.Species);
         Species.Text = Loc.GetString("general-station-record-console-record-species", ("species", species));
         Gender.Text = Loc.GetString("general-station-record-console-record-gender",
             ("gender", record.Gender.ToString()));


### PR DESCRIPTION

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Fixes the Station AI / aghost Station Records UI crashing when a player has entered a custom value for the species name.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

It's throwing exceptions for players and breaking the UI.

<img width="3436" height="485" alt="image" src="https://github.com/user-attachments/assets/09600462-489d-4a08-b1a0-e1d8336c2b59" />

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### aghost
<img width="907" height="559" alt="image" src="https://github.com/user-attachments/assets/9172bd0b-0034-4ef5-800e-298500e6773e" />

### Station AI
<img width="839" height="663" alt="image" src="https://github.com/user-attachments/assets/e73bc76b-625e-43bc-9cd7-ebbe65b4a478" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: Custom species names no longer crash the Station Records interface for Station AIs and admins.