### PR TITLE
nerfs the breaching hammers blunt but buffs struct

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/hammers.yml
@@ -12,16 +12,16 @@
     attackRate: 0.7
     damage:
       types:
-        Blunt: 15
-        Structural: 20
+        Blunt: 10
+        Structural: 25
     soundHit:
       collection: MetalThud
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 25
-        Structural: 100
+        Blunt: 22
+        Structural: 105
   - type: Item
     size: Normal
     shape:

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Melee/hammers.yml
@@ -12,7 +12,7 @@
     attackRate: 0.7
     damage:
       types:
-        Blunt: 10
+        Blunt: 5
         Structural: 25
     soundHit:
       collection: MetalThud
@@ -20,8 +20,8 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 22
-        Structural: 105
+        Blunt: 20
+        Structural: 110
   - type: Item
     size: Normal
     shape:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
nerf the breaching hammer.

## Why we need to add this
40 damage is too much. after feedback im lowering it. but to comprimise i made the strucural stonger to 135 when weilded
so now
4 hits on a solid wall
11 hits on a reinforced wall
4 hits on a reinforced uranium window
2 hits reinforced window
3 hits reinforced plasma window
4 hits airlock
11 hits high secure door

## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Scarlet lightweaver
- tweak: Changed the breaching hammers damage to be 5 blunt and 25 structural without wield.
- tweak: Changed the breaching hammers damage to be 25 blunt and 135 structural when wielding.
