### PR TITLE
Cyberlegs are now strong enough to carry cyclorites

### DIFF
--- a/Resources/Prototypes/_Starlight/Body/Parts/cyberlimbs.yml
+++ b/Resources/Prototypes/_Starlight/Body/Parts/cyberlimbs.yml
@@ -109,7 +109,7 @@
       state: "l_leg"
     - type: MovementBodyPart
       sprintSpeed : 4.725 # +5%
-      maxdensity: 155
+      maxDensity: 155
     - type: WithAttachedBodyParts
       parts:
         left foot: LeftFootCyber
@@ -133,7 +133,7 @@
       state: "r_leg"
     - type: MovementBodyPart
       sprintSpeed : 4.725 # +5%
-      maxdensity: 155
+      maxDensity: 155
     - type: WithAttachedBodyParts
       parts:
         right foot: RightFootCyber
@@ -196,7 +196,7 @@
     - type: MovementBodyPart
       walkSpeed: 3.75 # 1.5x of base
       sprintSpeed: 6.75 # 1.5x of base
-      maxdensity: 155
+      maxDensity: 155
     - type: WithAttachedBodyParts
       parts:
         left foot: LeftFootCyber
@@ -222,7 +222,7 @@
     - type: MovementBodyPart
       walkSpeed: 3.75 # 1.5x of base
       sprintSpeed: 6.75 # 1.5x of base
-      maxdensity: 155
+      maxDensity: 155
     - type: WithAttachedBodyParts
       parts:
         right foot: RightFootCyber
@@ -1921,7 +1921,7 @@
       state: "l_leg_pilebunker"
     - type: MovementBodyPart
       sprintSpeed : 4.5
-      maxdensity: 155
+      maxDensity: 155
     - type: WithAttachedBodyParts
       parts:
         left foot: LeftFootCyber
@@ -1945,7 +1945,7 @@
       state: "r_leg_pilebunker"
     - type: MovementBodyPart
       sprintSpeed : 4.5
-      maxdensity: 155
+      maxDensity: 155
     - type: WithAttachedBodyParts
       parts:
         right foot: RightFootCyber
@@ -1971,7 +1971,7 @@
       state: "l_leg_cargo"
     - type: MovementBodyPart
       sprintSpeed : 4.05
-      maxdensity: 155
+      maxDensity: 155
     - type: WithAttachedBodyParts
       parts:
         left foot: LeftFootCyber
@@ -2025,7 +2025,7 @@
       state: "r_leg_cargo"
     - type: MovementBodyPart
       sprintSpeed : 4.05
-      maxdensity: 155
+      maxDensity: 155
     - type: WithAttachedBodyParts
       parts:
         right foot: RightFootCyber

--- a/Resources/Prototypes/_Starlight/Body/Parts/cyberlimbs.yml
+++ b/Resources/Prototypes/_Starlight/Body/Parts/cyberlimbs.yml
@@ -109,7 +109,7 @@
       state: "l_leg"
     - type: MovementBodyPart
       sprintSpeed : 4.725 # +5%
-      maxDensity: 111
+      maxdensity: 155
     - type: WithAttachedBodyParts
       parts:
         left foot: LeftFootCyber
@@ -133,7 +133,7 @@
       state: "r_leg"
     - type: MovementBodyPart
       sprintSpeed : 4.725 # +5%
-      maxDensity: 111
+      maxdensity: 155
     - type: WithAttachedBodyParts
       parts:
         right foot: RightFootCyber
@@ -196,7 +196,7 @@
     - type: MovementBodyPart
       walkSpeed: 3.75 # 1.5x of base
       sprintSpeed: 6.75 # 1.5x of base
-      maxDensity: 111
+      maxdensity: 155
     - type: WithAttachedBodyParts
       parts:
         left foot: LeftFootCyber
@@ -222,7 +222,7 @@
     - type: MovementBodyPart
       walkSpeed: 3.75 # 1.5x of base
       sprintSpeed: 6.75 # 1.5x of base
-      maxDensity: 111
+      maxdensity: 155
     - type: WithAttachedBodyParts
       parts:
         right foot: RightFootCyber
@@ -1921,7 +1921,7 @@
       state: "l_leg_pilebunker"
     - type: MovementBodyPart
       sprintSpeed : 4.5
-      maxDensity: 111
+      maxdensity: 155
     - type: WithAttachedBodyParts
       parts:
         left foot: LeftFootCyber
@@ -1945,7 +1945,7 @@
       state: "r_leg_pilebunker"
     - type: MovementBodyPart
       sprintSpeed : 4.5
-      maxDensity: 111
+      maxdensity: 155
     - type: WithAttachedBodyParts
       parts:
         right foot: RightFootCyber
@@ -1971,7 +1971,7 @@
       state: "l_leg_cargo"
     - type: MovementBodyPart
       sprintSpeed : 4.05
-      maxDensity: 111
+      maxdensity: 155
     - type: WithAttachedBodyParts
       parts:
         left foot: LeftFootCyber
@@ -2025,7 +2025,7 @@
       state: "r_leg_cargo"
     - type: MovementBodyPart
       sprintSpeed : 4.05
-      maxDensity: 111
+      maxdensity: 155
     - type: WithAttachedBodyParts
       parts:
         right foot: RightFootCyber


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Makes cyberlegs strong enough to actually carry a cyclorite

## Why we need to add this
This was an oversight when cyclorites' density was changed - they needed to go from 111 density per leg to 155 and were not adjusted.

## Media (Video/Screenshots)
<img width="273" height="64" alt="image" src="https://github.com/user-attachments/assets/a590477a-8ec5-48b3-9124-53fba068b0e6" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Cyberlegs can carry Cyclorites and Diona again.
