### PR TITLE
NoDisarmComponent

### DIFF
--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Content.Shared._Starlight.Combat.Disarming; // Starlight
 
 namespace Content.Server.Hands.Systems
 {
@@ -98,6 +99,7 @@ namespace Content.Server.Hands.Systems
             if (TryComp(uid, out PullerComponent? puller) && TryComp(puller.Pulling, out PullableComponent? pullable))
                 _pullingSystem.TryStopPull(puller.Pulling.Value, pullable);
 
+            if (HasComp<NoDisarmComponent>(GetActiveItem(args.Target))) return; // Starlight
             var offsetRandomCoordinates = _transformSystem.GetMoverCoordinates(args.Target).Offset(_random.NextVector2(1f, 1.5f));
             if (!ThrowHeldItem(args.Target, offsetRandomCoordinates))
                 return;

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -42,6 +42,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using ItemToggleMeleeWeaponComponent = Content.Shared.Item.ItemToggle.Components.ItemToggleMeleeWeaponComponent;
+using Content.Shared._Starlight.Combat.Disarming; // Starlight
 
 namespace Content.Shared.Weapons.Melee;
 
@@ -881,6 +882,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         {
             return false;
         }
+        
+        if (HasComp<NoDisarmComponent>(target)) return false; // Starlight
 
         // Need hands or to be able to be shoved over.
         if (!TryComp<HandsComponent>(target, out var targetHandsComponent))

--- a/Content.Shared/_Starlight/Combat/Disarming/NoDisarmComponent.cs
+++ b/Content.Shared/_Starlight/Combat/Disarming/NoDisarmComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.Combat.Disarming;
+
+/// <summary>
+/// Prevents the entity this is attached to from being disarmed. Can be attached to
+/// the item holder as well as the item itself.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class NoDisarmComponent : Component
+{
+}


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds a component that can be attached to an item or entity to prevent Combat Mode from disarming it.
If placed onto the entity holding an item, you will be unable to use disarm on them at all, preventing shoving them entirely.
If placed onto the item the entity is holding, you will still be able to shove them, but the item will never be knocked out of their hand, acting as if they are holding nothing and dealing stamina damage instead.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Admemes, special items that can't be knocked out of hand, etc.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.