### PR TITLE
(Packed) + (Plasma) Robotics Windoors

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Packed.yml
+++ b/Resources/Maps/_Starlight/Stations/Packed.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 02/27/2026 07:19:21
+  time: 03/02/2026 07:58:10
   entityCount: 16922
 maps:
 - 1
@@ -46659,7 +46659,6 @@ entities:
     - type: Transform
       pos: 59.5,39.5
       parent: 2
-    - type: Door
 - proto: d6Dice
   entities:
   - uid: 316
@@ -52411,7 +52410,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 26.5,37.5
       parent: 2
-    - type: Door
   - uid: 9362
     components:
     - type: Transform
@@ -78075,11 +78073,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 48.5,11.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        7848:
-        - - Pressed
-          - Open
     - type: Fixtures
       fixtures: {}
 - proto: LockableButtonService
@@ -109442,7 +109435,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 49.5,1.5
       parent: 2
-- proto: WindoorSecureResearchDirectorLocked
+- proto: WindoorSecureRoboticsLocked
   entities:
   - uid: 7848
     components:

--- a/Resources/Maps/_Starlight/Stations/Plasma.yml
+++ b/Resources/Maps/_Starlight/Stations/Plasma.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 02/25/2026 13:14:08
-  entityCount: 27544
+  time: 03/02/2026 07:58:00
+  entityCount: 27541
 maps:
 - 1
 grids:
@@ -15872,7 +15872,7 @@ entities:
       pos: -131.5,-45.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -171215.06
+      secondsUntilStateChange: -171443.3
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -27922,12 +27922,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-3.5
-      parent: 2
-  - uid: 3527
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -119.5,-49.5
       parent: 2
 - proto: ButtonFrameJanitor
   entities:
@@ -133381,24 +133375,6 @@ entities:
           - Toggle
     - type: Fixtures
       fixtures: {}
-- proto: LockableButtonResearch
-  entities:
-  - uid: 4037
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -119.5,-49.5
-      parent: 2
-    - type: AccessReader
-      accessListsOriginal:
-      - - Research
-    - type: DeviceLinkSource
-      linkedPorts:
-        19439:
-        - - Pressed
-          - Open
-    - type: Fixtures
-      fixtures: {}
 - proto: LockableButtonSecurity
   entities:
   - uid: 19494
@@ -157042,11 +157018,6 @@ entities:
       parent: 2
 - proto: Table
   entities:
-  - uid: 3543
-    components:
-    - type: Transform
-      pos: -119.5,-49.5
-      parent: 2
   - uid: 10220
     components:
     - type: Transform
@@ -178516,7 +178487,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -371321.88
+      secondsUntilStateChange: -371550.12
       state: Opening
     - type: Airlock
       autoClose: False
@@ -178732,9 +178703,9 @@ entities:
         20610:
         - - DoorStatus
           - Toggle
-- proto: WindoorSecureResearchDirectorLocked
+- proto: WindoorSecureRoboticsLocked
   entities:
-  - uid: 19439
+  - uid: 3527
     components:
     - type: Transform
       pos: -120.5,-48.5


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->
## Short description
Replaces the Research-Access windoors with Robotics-Access ones in Packed and Plasma, courtesy of Redmushie (#3513)
<!-- What do you propose to change with your PR? -->

## Why we need to add this
Currently as a Scientist (Or RA) you can break into robotics in these maps just by using the windoor.
Likely, there are more stations with this flaw, but I'll leave that to the specific maintainers to add it to their maps, to prevent conflicts.
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
Plasma:
<img width="857" height="685" alt="image" src="https://github.com/user-attachments/assets/dfe627ce-f287-4617-a4ad-a37d805e6e2f" />
Packed:
<img width="936" height="679" alt="image" src="https://github.com/user-attachments/assets/87b7d5d9-cf32-4d5e-bc9c-3389c740efcf" />

<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Makeshift
- tweak: (Plasma) Replaced the Research-Access windoor into robotics with a Robotics-Access one.
- tweak: (Packed) Replaced the Research-Access windoor into robotics with a Robotics-Access one.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
