### PR TITLE
Borg hat fix (again)

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/borg_subtypes.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/borg_subtypes.yml
@@ -512,6 +512,7 @@
       spriteHasMindState: standard_e
       spriteNoMindState: standard_e_r
       spriteToggleLightState: standard_l
+      inventoryTemplateId: borg
 
 - type: entity
   parent: BorgCargoSubtypeBase
@@ -536,6 +537,7 @@
       spriteHasMindState: cricket_e
       spriteNoMindState: cricket_e_r
       spriteToggleLightState: cricket_l
+      inventoryTemplateId: borgDutch
 
 - type: entity
   parent: BorgCargoSubtypeBase
@@ -548,6 +550,7 @@
       spriteHasMindState: real_tech_e
       spriteNoMindState: real_tech_e_r
       spriteToggleLightState: real_tech_l
+      inventoryTemplateId: borgDutch
 
 # region Purrfus
 
@@ -562,6 +565,7 @@
       spriteHasMindState: green_e
       spriteNoMindState: green_e_r
       spriteToggleLightState: green_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgPurrfusSubtypeBase
@@ -574,6 +578,7 @@
       spriteHasMindState: orange_e
       spriteNoMindState: orange_e_r
       spriteToggleLightState: orange_l
+      inventoryTemplateId: borgTall
 
 - type: entity
   parent: BorgPurrfusSubtypeBase
@@ -586,3 +591,4 @@
       spriteHasMindState: pink_e
       spriteNoMindState: pink_e_r
       spriteToggleLightState: pink_l
+      inventoryTemplateId: borgTall

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/borg_subtypes.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/borg_subtypes.yml
@@ -550,7 +550,7 @@
       spriteHasMindState: real_tech_e
       spriteNoMindState: real_tech_e_r
       spriteToggleLightState: real_tech_l
-      inventoryTemplateId: borgDutch
+      inventoryTemplateId: borgTall
 
 # region Purrfus
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes hat displacements for cargoborgs and alternate colour purrfus frames

## Why we need to add this
When these frames were added, they weren't assigned inventory templates, so they just use the default - which do not fit them.

Closes https://github.com/ss14Starlight/space-station-14/issues/3545

## Media (Video/Screenshots)
<img width="426" height="339" alt="image" src="https://github.com/user-attachments/assets/f6466b9e-c9b1-436c-aa2d-38b8cf3ec2ed" />
Slight adjustment to RealTech's hat position:
<img width="163" height="200" alt="image" src="https://github.com/user-attachments/assets/efca1adc-093b-4221-b963-2bfb932645dc" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Hats fit cargoborgs and purrfus properly now.
