### PR TITLE
Fix ID card computer refusing to edit ID cards that have accesses the donor ID does not

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -362,16 +362,15 @@ namespace Content.Client.Access.UI
 
         private void SubmitData()
         {
+            // Don't send this if it isn't dirty.
             var jobProtoDirty = _lastJobProto != null &&
                                 _jobPrototypeIds[JobPresetOptionButton.SelectedId] != _lastJobProto;
-            // Starlight-edit: Start
-            // Only submit access levels that are allowed by the server
-            var filteredAccess = _pendingPressedAccessLevels.Where(x => _allowedAccessLevels.Contains(x)).ToList();
 
+            // Starlight-edit: Start
             _owner?.SubmitData(
                 FullNameLineEdit.Text,
                 JobTitleLineEdit.Text,
-                filteredAccess,
+                _pendingPressedAccessLevels.ToList(),
                 jobProtoDirty ? _jobPrototypeIds[JobPresetOptionButton.SelectedId] : string.Empty);
 
             // Clear the override after submit so next UpdateState can update pressed state as normal

--- a/Resources/Prototypes/Access/security.yml
+++ b/Resources/Prototypes/Access/security.yml
@@ -37,6 +37,8 @@
   - Cryogenics
   - Brigmedic
   - Cadet # Starlight
+  - GenpopEnter # Starlight: Some jobs (e.g. CE) have this and ID console requires it to be in a group to be assignable.
+  - GenpopLeave # Starlight
 
 - type: accessGroup
   id: Armory


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

- Fix ID card computer completely refusing to edit ID cards that have one or more accesses the donor ID does not.
  - E.g.: HoP was unable to edit CE ID cards since HoP didn't have the "Chief Engineer" access.
- Fix GenpopEnter and GenpopLeave being unassignable despite various jobs having them (such as HoS, CE)

## Long description

Server side there is already validation on which accesses can be assigned or unassigned based on what the donor ID has. However, apparently we (Starlight) also added client side validation at some point that made the console try to actively *remove* the accesses the donor ID didn't have, making the server say "hold on you can't do that" and completely refuse the operation. This happened even if the user wasn't actually trying to do that, making it basically refuse to do anything.

The fix removes this client side behavior and now just transmits what the user actually did, and lets the server decide.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

From the HoP player perspective the ID card computer **completely** refuses to work when editing Command IDs.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/bbbd9ea9-02b3-46eb-9366-d14591f6b706


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: The ID card computer no longer refuses to work when the donor ID is missing one or more accesses of the receiving ID.
- fix: Enter Genpop and Leave Genpop permissions are now assignable in ID card computers (various IDs have them!).
