### PR TITLE
Allow smart corgis to wear advanced mining hardsuits

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -527,6 +527,11 @@
       - 1.025689525 # nitrogen
   - type: Jetpack
     moleUsage: 0.00085
+  - type: Tag
+    tags:
+    - Hardsuit
+    - WhitelistChameleon
+    - CorgiWearable
 
 #Mining Hardsuit
 - type: entity


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Allows smart corgis to wear advanced mining hardsuits.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The advanced mining hardsuit already has a sprite made for corgis, and its helmet is marked as corgi wearable.  The hardsuit was missing the CorgiWearable tag though.  I've gone on and fixed that.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="2543" height="1357" alt="image" src="https://github.com/user-attachments/assets/89a3d50c-982f-4d5e-992b-cb0149325423" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- fix: Smart corgis can now wear the advanced mining hardsuit.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
