### PR TITLE
Mindshielded players can no longer unionize.

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Deliveries/deliveries_items.yml
@@ -199,6 +199,7 @@
           - NukeOperative
           - Traitor
           - Revolutionary
+          - MindShield
       #SL end
 
 - type: entity
@@ -222,6 +223,7 @@
           - NukeOperative
           - Traitor
           - Revolutionary
+          - MindShield
       #SL end
 
 - type: entity
@@ -245,5 +247,6 @@
           - NukeOperative
           - Traitor
           - Revolutionary
+          - MindShield
       #SL end
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Adds `MindShieldComponen` to the blacklist of the workers rights papers.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Apparently salvies abused the fact that it doesn't break your mindshield to be converted like this to powergame, as they were literally headrevs who had proper mindshields.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: You can no longer be converted to a Head Revolutionary by signing a worker's rights paper if you are currently mindshielded.