### PR TITLE
Makes abductor's teleport interuptable by damage

### DIFF
--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
@@ -76,7 +76,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
 
     private void OnReturn(AbductorReturnToShipEvent ev)
     {
-        // Check if abductor is stunned, cuffed, or dead - if so, cancel the return
+        // Check if abductor is stunned or cuffed- if so, cancel the return
         if (HasComp<StunnedComponent>(ev.Performer))
         {
             _popup.PopupEntity(Loc.GetString("abductor-return-stunned"), ev.Performer, ev.Performer);
@@ -88,9 +88,6 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
             _popup.PopupEntity(Loc.GetString("abductor-return-cuffed"), ev.Performer, ev.Performer);
             return;
         }
-
-        if (_mobState.IsIncapacitated(ev.Performer))
-            return;
           
         AbductorAgentComponent? agentComp = null;
         if (!TryComp<AbductorScientistComponent>(ev.Performer, out var scientistComp) && !TryComp<AbductorAgentComponent>(ev.Performer, out agentComp))

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Actions.cs
@@ -120,7 +120,12 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         despawnComp.Lifetime = 3.0f;
         _audioSystem.PlayPvs(_alienTeleport, effect);
 
-        var doAfter = new DoAfterArgs(EntityManager, ev.Performer, TimeSpan.FromSeconds(3), new AbductorReturnDoAfterEvent(), ev.Performer);
+        var doAfter = new DoAfterArgs(EntityManager, ev.Performer, TimeSpan.FromSeconds(3), new AbductorReturnDoAfterEvent(), ev.Performer)
+        {
+            BreakOnDamage = true
+        };
+
+        
         _doAfter.TryStartDoAfter(doAfter);
         ev.Handled = true;
     }

--- a/Resources/Prototypes/_Starlight/Actions/abductor.yml
+++ b/Resources/Prototypes/_Starlight/Actions/abductor.yml
@@ -59,7 +59,7 @@
   description: return to the ship.
   components:
   - type: Action
-    useDelay: 30
+    useDelay: 5
     priority: -12
     checkConsciousness: false
     checkCanInteract: false


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- Damage interrupts the 'recall to ship' action.
- The lower cooldown means you can re-attempt your teleport quicker if your original teleport is interrupted.
- Allows dead abductors to be teleported to the ship (e.g. your teammate marks you with the gizmo)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Having spectated a lot of abductors, I have come to realize they have no incentive to be sneaky (as their guidebook entry suggests they should be, what with the whole 'abductors must make every attempt to leave no trace and avoid detection' line).

Good players will blatantly teleport into dangerous and crowded areas, stun, cuff, or crit anything in the room, and then kidnap their target. In the event that someone brings a firearm, they just hit the teleport button as a get-out-of-jail-free-card and are gone after fire seconds. I think players can attest to having seen an abductor incapacitate an entire room full of people single-handedly.

This PR adds actual risk to teleporting out. You can still move, dodge, dive into a corridor, but any damage will cancel your teleport. You can still stun, sleep, cuff people to give yourself enough time to get out, but it is no longer a guaranteed out. Your abductor teammate can still retrieve your body (and/or corpse) by using the gizmo on it like anyone else.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/b948c471-680f-4216-8f5f-a9aed385e3da

fig. 1 - Demonstrating the reduced 'return to ship' cooldown and teleportation interruption by damage.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- tweak: Abductor's 'return to ship' action is now interrupted by damage.
- tweak: Abductor's 'return to ship' action cooldown reduced from 30 seconds to 5 seconds.
- tweak: Dead abductor now can be marked for teleport.