### PR TITLE
(Prism) Fixes cargo shuttle APC being overloaded

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/cargo_prism.yml
+++ b/Resources/Maps/_Starlight/Shuttles/cargo_prism.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 261.2.0
-  forkId: Starlight
-  forkVersion: 1732131340
-  time: 07/13/2025 18:16:32
-  entityCount: 256
+  engineVersion: 272.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 03/03/2026 13:22:54
+  entityCount: 270
 maps: []
 grids:
 - 1
@@ -28,7 +28,8 @@ entities:
     - type: MetaData
       name: Cargo Shuttle
     - type: Transform
-      pos: 88.40116,75.02753
+      pos: -0.5988388,0.027526855
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -92,37 +93,19 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 21.824879
-          - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
         - volume: 2500
           temperature: 293.14975
           moles:
-          - 20.078888
-          - 75.53487
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 20.078888
+            Nitrogen: 75.53487
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: CargoShuttle
+    - type: NavMap
+    - type: ExplosionAirtightGrid
 - proto: ActionToggleLight
   entities:
   - uid: 3
@@ -150,16 +133,18 @@ entities:
       - 169
       - 166
       - 167
-      - 135
+      - 134
+      - 139
       - 140
+      - 135
+      - 137
       - 141
+      - 142
       - 136
       - 138
-      - 142
       - 143
-      - 137
-      - 139
-      - 252
+    - type: Fixtures
+      fixtures: {}
 - proto: AirCanister
   entities:
   - uid: 5
@@ -221,6 +206,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 2.5,5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: AtmosDeviceFanDirectional
   entities:
   - uid: 19
@@ -381,215 +376,280 @@ entities:
   - uid: 46
     components:
     - type: Transform
-      pos: -1.5,0.5
+      pos: -0.5,-1.5
       parent: 1
   - uid: 47
     components:
     - type: Transform
-      pos: -1.5,-0.5
+      pos: -1.5,-1.5
       parent: 1
   - uid: 48
     components:
     - type: Transform
-      pos: -1.5,-1.5
+      pos: -1.5,-2.5
       parent: 1
   - uid: 49
     components:
     - type: Transform
-      pos: -1.5,-2.5
+      pos: -1.5,-3.5
       parent: 1
   - uid: 50
     components:
     - type: Transform
-      pos: -1.5,-3.5
+      pos: -0.5,-3.5
       parent: 1
   - uid: 51
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      pos: 0.5,-3.5
       parent: 1
   - uid: 52
     components:
     - type: Transform
-      pos: 0.5,-3.5
+      pos: 1.5,-3.5
       parent: 1
   - uid: 53
     components:
     - type: Transform
-      pos: 1.5,-3.5
+      pos: 2.5,-3.5
       parent: 1
   - uid: 54
     components:
     - type: Transform
-      pos: 2.5,-3.5
+      pos: 2.5,-2.5
       parent: 1
   - uid: 55
     components:
     - type: Transform
-      pos: 2.5,-2.5
+      pos: 2.5,-1.5
       parent: 1
   - uid: 56
     components:
     - type: Transform
-      pos: 2.5,-1.5
+      pos: 0.5,-1.5
       parent: 1
   - uid: 57
     components:
     - type: Transform
-      pos: 2.5,-0.5
+      pos: 1.5,-1.5
       parent: 1
   - uid: 58
     components:
     - type: Transform
-      pos: 2.5,0.5
+      pos: 2.5,1.5
       parent: 1
   - uid: 59
     components:
     - type: Transform
-      pos: 2.5,1.5
+      pos: -1.5,-6.5
       parent: 1
   - uid: 60
     components:
     - type: Transform
-      pos: -1.5,-6.5
+      pos: -0.5,-6.5
       parent: 1
   - uid: 61
     components:
     - type: Transform
-      pos: -0.5,-6.5
+      pos: 0.5,-5.5
       parent: 1
   - uid: 62
     components:
     - type: Transform
-      pos: 0.5,-5.5
+      pos: 0.5,-6.5
       parent: 1
   - uid: 63
     components:
     - type: Transform
-      pos: 0.5,-6.5
+      pos: 1.5,-6.5
       parent: 1
   - uid: 64
     components:
     - type: Transform
-      pos: 1.5,-6.5
+      pos: 0.5,-4.5
       parent: 1
   - uid: 65
     components:
     - type: Transform
-      pos: 0.5,-4.5
+      pos: 3.5,3.5
       parent: 1
   - uid: 66
     components:
     - type: Transform
-      pos: 3.5,3.5
+      pos: 3.5,2.5
       parent: 1
   - uid: 67
     components:
     - type: Transform
-      pos: 3.5,2.5
+      pos: 3.5,1.5
       parent: 1
   - uid: 68
     components:
     - type: Transform
-      pos: 3.5,1.5
+      pos: -2.5,3.5
       parent: 1
   - uid: 69
     components:
     - type: Transform
-      pos: -2.5,3.5
+      pos: -2.5,2.5
       parent: 1
   - uid: 70
     components:
     - type: Transform
-      pos: -2.5,2.5
+      pos: -2.5,1.5
       parent: 1
   - uid: 71
     components:
     - type: Transform
-      pos: -2.5,1.5
+      pos: -1.5,7.5
       parent: 1
   - uid: 72
     components:
     - type: Transform
-      pos: -1.5,7.5
+      pos: -2.5,6.5
       parent: 1
   - uid: 73
     components:
     - type: Transform
-      pos: -2.5,6.5
+      pos: 2.5,7.5
       parent: 1
   - uid: 74
     components:
     - type: Transform
-      pos: 2.5,7.5
+      pos: 3.5,6.5
       parent: 1
-  - uid: 75
+  - uid: 269
     components:
     - type: Transform
-      pos: 3.5,6.5
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 76
+  - uid: 75
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 77
+  - uid: 76
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 78
+  - uid: 77
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 1
-  - uid: 79
+  - uid: 78
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 80
+  - uid: 79
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 81
+  - uid: 80
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 82
+  - uid: 81
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 83
+  - uid: 82
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 84
+  - uid: 83
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 85
+  - uid: 84
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 86
+  - uid: 85
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 87
+  - uid: 86
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -597,61 +657,61 @@ entities:
       parent: 1
 - proto: CargoPallet
   entities:
-  - uid: 88
+  - uid: 87
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 89
+  - uid: 88
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 1
-  - uid: 90
+  - uid: 89
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-4.5
       parent: 1
-  - uid: 91
+  - uid: 90
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 1
-  - uid: 92
+  - uid: 91
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 93
+  - uid: 92
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 94
+  - uid: 93
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
-  - uid: 95
+  - uid: 94
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-1.5
       parent: 1
-  - uid: 96
+  - uid: 95
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-1.5
       parent: 1
-  - uid: 97
+  - uid: 96
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -659,103 +719,103 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 98
+  - uid: 97
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-  - uid: 99
+  - uid: 98
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
-  - uid: 100
+  - uid: 99
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-  - uid: 101
+  - uid: 100
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
-  - uid: 102
+  - uid: 101
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 103
+  - uid: 102
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 1
-  - uid: 104
+  - uid: 103
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 1
-  - uid: 105
+  - uid: 104
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 106
+  - uid: 105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
-  - uid: 107
+  - uid: 106
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
-  - uid: 108
+  - uid: 107
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-3.5
       parent: 1
-  - uid: 109
+  - uid: 108
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 110
+  - uid: 109
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 111
+  - uid: 110
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 112
+  - uid: 111
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 1
-  - uid: 113
+  - uid: 112
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 114
+  - uid: 113
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -763,7 +823,7 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 115
+  - uid: 114
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -771,116 +831,122 @@ entities:
       parent: 1
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 116
+  - uid: 115
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: ClosetWallEmergencyN2FilledRandom
   entities:
-  - uid: 117
+  - uid: 116
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 118
+  - uid: 117
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: ComputerShuttleCargo
   entities:
-  - uid: 119
+  - uid: 118
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
 - proto: ConveyorBelt
   entities:
-  - uid: 120
+  - uid: 119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 121
+  - uid: 120
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
-  - uid: 122
+  - uid: 121
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
-  - uid: 123
+  - uid: 122
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-3.5
       parent: 1
-  - uid: 124
+  - uid: 123
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 1
-  - uid: 125
+  - uid: 124
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 126
+  - uid: 125
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 127
+  - uid: 126
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 1
-  - uid: 128
+  - uid: 127
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 129
+  - uid: 128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
-  - uid: 130
+  - uid: 129
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-  - uid: 131
+  - uid: 130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
-  - uid: 132
+  - uid: 131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-  - uid: 133
+  - uid: 132
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -888,14 +954,14 @@ entities:
       parent: 1
 - proto: DrinkRootBeerCan
   entities:
-  - uid: 134
+  - uid: 133
     components:
     - type: Transform
       pos: 1.2695007,6.886612
       parent: 1
 - proto: FirelockEdge
   entities:
-  - uid: 135
+  - uid: 134
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -904,11 +970,20 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 136
+  - uid: 135
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
@@ -917,21 +992,12 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,0.5
-      parent: 1
-    - type: DeviceNetwork
-      deviceLists:
-      - 4
-  - uid: 138
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 139
+  - uid: 138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -940,7 +1006,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 140
+  - uid: 139
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -949,7 +1015,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 141
+  - uid: 140
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -958,7 +1024,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 142
+  - uid: 141
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -967,7 +1033,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 143
+  - uid: 142
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -976,7 +1042,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4
-  - uid: 252
+  - uid: 143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1326,11 +1392,15 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 180
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: Lamp
   entities:
   - uid: 2
@@ -1356,6 +1426,8 @@ entities:
         25:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
   - uid: 182
     components:
     - type: Transform
@@ -1370,6 +1442,8 @@ entities:
         23:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
 - proto: LockerWallEvacRepair
   entities:
   - uid: 6
@@ -1386,18 +1460,8 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -1410,6 +1474,8 @@ entities:
           - 7
           - 10
           - 9
+    - type: Fixtures
+      fixtures: {}
 - proto: MetalFoamGrenade
   entities:
   - uid: 12
@@ -1664,13 +1730,6 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        133:
-        - - Left
-          - Reverse
-        - - Right
-          - Forward
-        - - Middle
-          - Off
         132:
         - - Left
           - Reverse
@@ -1699,6 +1758,20 @@ entities:
           - Forward
         - - Middle
           - Off
+        128:
+        - - Left
+          - Reverse
+        - - Right
+          - Forward
+        - - Middle
+          - Off
+        126:
+        - - Left
+          - Reverse
+        - - Right
+          - Forward
+        - - Middle
+          - Off
         127:
         - - Left
           - Reverse
@@ -1706,7 +1779,7 @@ entities:
           - Forward
         - - Middle
           - Off
-        128:
+        119:
         - - Left
           - Reverse
         - - Right
@@ -1749,13 +1822,6 @@ entities:
         - - Middle
           - Off
         125:
-        - - Left
-          - Reverse
-        - - Right
-          - Forward
-        - - Middle
-          - Off
-        126:
         - - Left
           - Reverse
         - - Right
@@ -1930,25 +1996,25 @@ entities:
       parent: 1
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 253
+  - uid: 252
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,4.5
       parent: 1
-  - uid: 254
+  - uid: 253
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 255
+  - uid: 254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,1.5
       parent: 1
-  - uid: 256
+  - uid: 255
     components:
     - type: Transform
       rot: 3.141592653589793 rad


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
The cargo shuttle on Prism had 22kW being drawn from its 20kW APC, causing it to overload at roundstart. This PR fixes that by adding a second APC to the shuttle.

Also, I fixed the shuttle's origin offset. It was saved in such a way it spawned with an offset of about 89 tiles to the right ($+X$) and 75 tiles to the north ($+Y$).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1210" height="1000" alt="image" src="https://github.com/user-attachments/assets/32afd41d-56ed-44b3-864b-55c704ef05ee" />
<img width="1215" height="1002" alt="image" src="https://github.com/user-attachments/assets/014fe981-8f7a-42d8-b789-625f5073b7d9" />

fig. 1 - APCs no longer overloaded on the Prism cargo shuttle.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- fix: (Prism) Cargo shuttle APC split into two LV networks to prevent the APC from being overloaded at roundstart.