### PR TITLE
Avali chemistry and body temp balance tweaks

### DIFF
--- a/Resources/Locale/en-US/_SpL/reagents/meta/botany.ftl
+++ b/Resources/Locale/en-US/_SpL/reagents/meta/botany.ftl
@@ -1,0 +1,2 @@
+reagent-name-ammonium = Ammonium
+reagent-desc-ammonium = A cataionic ion of ammonia with more hydrogen. Gets more bang for your buck with botany and birds.

--- a/Resources/Locale/en-US/_SpL/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_SpL/reagents/meta/medicine.ftl
@@ -1,0 +1,11 @@
+reagent-name-scorizine = Scorizine
+reagent-desc-scorizine = An engineered chemical for advanced burn treatment of ammonia-based lifeforms. Overdosing causes subdermal cartilage to harden in jagged forms.
+
+reagent-name-voltizol = voltizol
+reagent-desc-voltizol = An engineered chemical for advanced shock treatment of ammonia based lifeforms. Overdose blocks synaptic signals and heats the body.
+
+reagent-name-carbonate = Carbonate
+reagent-desc-carbonate = Carbonates your drinks, or you if you eat it.
+
+reagent-name-ammoniacarbonate = Ammonium Carbonate
+reagent-desc-ammoniacarbonate = Smelling salts, used for keeping people awake at all costs and for Avalonian made medicines.

--- a/Resources/Locale/en-US/_Starlight/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_Starlight/reagents/meta/medicine.ftl
@@ -1,5 +1,5 @@
 reagent-name-amoxla = amoxla
-reagent-desc-amoxla = Ammonia-based chem that treats airloss and bloodloss in Avali and Resomi, and acts like a somewhat strong poison in other species.
+reagent-desc-amoxla = Ammonia-based chem that treats airloss in Avali and Resomi, and acts like a somewhat strong poison in other species.
 
 reagent-name-bonegel = bone gel
 reagent-desc-bonegel = A gel that uses as clue for bones to regrow. It is better not to consume it, but it can be used in surgery.

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -24,7 +24,8 @@ reagent-desc-dermaline = An advanced chemical that is more effective at treating
 
 # Starlight Start
 reagent-name-dexalin = dexalin
-reagent-desc-dexalin = Used for treating minor oxygen deprivation and bloodloss, mildly toxic to Avali and Resomi. A required reagent for dexalin plus.
+reagent-desc-dexalin = Used for treating minor oxygen deprivation and bloodloss. A required reagent for dexalin plus. 
+#Spectralight, no longer avali toxic
 
 reagent-name-dexalin-plus = dexalin plus
 reagent-name-dexalin-plus-saline = dexalin plus & saline
@@ -111,7 +112,8 @@ reagent-desc-sigynate = A thick pink syrup useful for neutralizing acids and soo
 
 # Starlight Start
 reagent-name-saline = saline
-reagent-desc-saline = A mixture of salt and water, highly toxic to Avali and Resomi. Commonly used to treat dehydration or low fluid presence in blood.
+reagent-desc-saline = A mixture of salt and water. Commonly used to treat dehydration or low fluid presence in blood. 
+#Spectralight, no longer toxic to avali
 #Starlight End
 
 reagent-name-lacerinol = lacerinol

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -449,7 +449,16 @@
     Drink:
       effects:
       - !type:SatiateThirst
+        conditions:
+          - !type:MetabolizerTypeCondition #Spectralight, no longer sates avali resomi thirst as well.
+            type: [ Avali, Resomi ]
+            inverted: true
         factor: 4
+      - !type:SatiateThirst
+        conditions:
+          - !type:MetabolizerTypeCondition #Spectralight, no longer sates avali resomi thirst as well.
+            type: [ Avali, Resomi ]
+        factor: 2
     Gas:
       effects:
       - !type:HealthChange

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -240,13 +240,18 @@
             Caustic: 1
     Medicine: #Starlight
       effects:
+      - !type:SatiateThirst 
+          conditions:
+          - !type:MetabolizerTypeCondition #Spectralight, sates avali and resomi thirst better than water
+            type: [ Avali, Resomi ]
+          factor: 6
       - !type:HealthChange
         conditions:
         - !type:MetabolizerTypeCondition
           type: [ Avali, Resomi ]
         damage:
           types:
-            Asphyxiation: -1
+            Asphyxiation: -0.5
     Gas:
       effects:
       - !type:HealthChange

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -336,10 +336,6 @@
     Medicine:
       effects:
       - !type:HealthChange
-        conditions:
-        - !type:MetabolizerTypeCondition #starliight
-          type: [ Avali, Resomi ]
-          inverted: true
         damage:
           types:
             Asphyxiation: -1
@@ -353,15 +349,7 @@
           types:
             Asphyxiation: 3
             Cold: 1
-      - !type:HealthChange #Starlight
-        conditions:
-        - !type:MetabolizerTypeCondition
-          type: [ Avali, Resomi ]
-        damage:
-          types:
-            Poison: 1.5 #Avali and Resomi blood is ammonia based, so chems made to treat normal bloodloss poison them instead (Lethal Dose: 20u)
-            Asphyxiation: 1 
-            Bloodloss: 1
+            #SpectaLight. Avali blood is ammonia based so only chems with iron in them are poison. Oxygen is fine.
       # Starlight-Start: Cyclorite Metabolism
       - !type:AdjustReagent
         conditions:
@@ -659,6 +647,10 @@
     Medicine:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition #starliight
+          type: [ Avali, Resomi ]
+          inverted: true
         damage:
           types:
             Cold: -4
@@ -914,21 +906,14 @@
     Medicine: #Starlight
       effects:
         - !type:SatiateThirst  # Starlight - thirst effect changed from Drink to Medicine
-           factor: 6           #
-        - !type:ModifyBloodLevel
           conditions:
-          - !type:MetabolizerTypeCondition
+          - !type:MetabolizerTypeCondition #Spectralight, no longer sates avali resomi thirst.
             type: [ Avali, Resomi ]
             inverted: true
+          factor: 6           
+        - !type:ModifyBloodLevel
           amount: 6
-        - !type:HealthChange
-          conditions:
-          - !type:MetabolizerTypeCondition
-           type: [ Avali, Resomi ]
-          damage:
-            types:
-              Caustic: 2 # 30 damage per unit was ridiculous, but I'm leaving some damage to punish mistakes without risking round removal. Adding salt to water shouldn't suddenly make it the strongest toxin in the game by far.
-              Heat: 2 
+          #SpectraLight Avali/Resomi blood is DILUTED ammonia blood. saline is fine. iron is not.
         # Starlight-Start: Cyclorite Metabolism
         - !type:AdjustReagent
           conditions:
@@ -1587,10 +1572,21 @@
       metabolismRate: 0.1 # slow metabolism to not be a godly combat med, its for treating burn victims efficiently
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Avali, Resomi ]
+          inverted: true
         damage:
           types:
             Heat: -1
-      # od causes massive bleeding
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Avali, Resomi ]
+        damage:
+          types:
+            Slash: 0.5
+            Piercing: 0.5 #SpectraLight: Iron as a constituant part. Poison.
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
@@ -1636,9 +1632,21 @@
       effects:
       # heals shocks and removes shock chems
       - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Avali, Resomi ]
+          inverted: true
         damage:
           types:
             Shock: -1.5 # 6 per u
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition 
+          type: [ Avali, Resomi ]
+        damage:
+          types:
+            Shock: 2 
+            Poison: 1 #SpectraLight: Avali poison again. see above. iron based chem.
       - !type:AdjustReagent
         reagent: Licoxide
         amount: -2

--- a/Resources/Prototypes/_SpL/Reagents/botany.yml
+++ b/Resources/Prototypes/_SpL/Reagents/botany.yml
@@ -1,0 +1,40 @@
+- type: reagent
+  id: Ammonium
+  name: reagent-name-ammonium
+  group: Botanical
+  desc: reagent-desc-ammonium
+  physicalDesc: reagent-physical-desc-pungent
+  flavor: bitter
+  color: "#77b58e"
+  boilingPoint: -33.0
+  meltingPoint: -77.7
+  plantMetabolism:
+  - !type:PlantAdjustNutrition
+    amount: 1
+  - !type:PlantAdjustHealth
+    amount: 0.5
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        conditions: #Starlight
+        - !type:MetabolizerTypeCondition
+          type: [ Avali, Resomi ]
+          inverted: true
+        damage:
+          types:
+            Caustic: 1.5
+    Medicine: #Starlight
+      effects:
+      - !type:SatiateThirst 
+          conditions:
+          - !type:MetabolizerTypeCondition #Spectralight, sates avali and resomi thirst better than water
+            type: [ Avali, Resomi ]
+          factor: 8
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Avali, Resomi ]
+        damage:
+          types:
+            Asphyxiation: -1

--- a/Resources/Prototypes/_SpL/Reagents/medicine.yml
+++ b/Resources/Prototypes/_SpL/Reagents/medicine.yml
@@ -1,0 +1,165 @@
+- type: reagent
+  id: Scorizine
+  group: Medicine
+  name: reagent-name-scorizine
+  desc: reagent-desc-scorizine
+  physicalDesc: reagent-physical-desc-viscous
+  flavor: beer
+  color: "#a3d7d9"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.25
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Avali, Resomi ]
+        damage:
+          types:
+            Heat: -2
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Avali, Resomi ]
+          inverted: true
+        damage:
+          types:
+            Caustic: 2 #ammonia based, causes caustic burns
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentCondition
+          reagent: Scorizine
+          min: 20
+        damage:
+          types:
+            Slash: 0.5
+            Piercing: 0.5
+      - !type:Vomit
+        conditions:
+        - !type:ReagentCondition
+          reagent: Scorizine
+          min: 15
+        probability: 0.1
+      - !type:Emote
+        conditions:
+        - !type:ReagentCondition
+          reagent: Scorizine
+          min: 10
+        emote: Cough
+        probability: 0.2
+
+- type: reagent
+  id: Voltizol
+  name: reagent-name-voltizol
+  group: Medicine
+  desc: reagent-desc-voltizol
+  physicalDesc: reagent-physical-desc-elf-space-cleaner
+  flavor: beer
+  color: "#b3baa4"
+  metabolisms:
+    Medicine:
+      metabolismRate: 0.5
+      effects:
+      # heals shocks and removes shock chems
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Avali, Resomi ]
+        damage:
+          types:
+            Shock: -2 # 4 per u
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition 
+          type: [ Avali, Resomi ]
+          inverted: true
+        damage:
+          types:
+            Shock: 2 
+            Caustic: 1 #SpectraLight: Avali poison again. see above. iron based chem.
+      - !type:AdjustReagent
+        reagent: Licoxide
+        amount: -2
+      - !type:AdjustReagent
+        reagent:  Tazinide
+        amount: -2
+      # avali hotness device
+      - !type:AdjustTemperature
+        amount: 2500
+      # od burns to death
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentCondition
+          reagent: Voltizol
+          min: 12
+        damage:
+          types:
+            Heat: 2 # 4 per u
+      - !type:AdjustTemperature
+        conditions:
+        - !type:ReagentCondition
+          reagent: Voltizol
+          min: 12
+        amount: 30000
+      - !type:Jitter
+        conditions:
+        - !type:ReagentCondition
+          reagent: Voltizol
+          min: 12
+      #Starlight Start
+      - !type:ModifyStatusEffect
+        effectProto: StatusEffectCyberneticDisruption
+        conditions:
+        - !type:ReagentCondition
+          reagent: Voltizol
+          min: 12
+        type: Add
+        time: 2
+      - !type:ModifyStatusEffect
+        effectProto: StatusEffectCyberneticDisruption
+        conditions:
+        - !type:MetabolizerTypeCondition 
+          type: [ Avali, Resomi ]
+          inverted: true
+        type: Add
+        time: 2
+      # Starlight-End
+
+- type: reagent
+  id: Carbonate
+  group: Medicine
+  name: reagent-name-carbonate
+  desc: reagent-desc-carbonate
+  physicalDesc: reagent-physical-desc-powdery
+  flavor: chalky
+  color: "#e0e3da"
+
+- type: reagent
+  id: AmmoniaCarbonate
+  group: Medicine
+  name: reagent-name-ammoniacarbonate
+  desc: reagent-desc-ammoniacarbonate
+  physicalDesc: reagent-physical-desc-powdery
+  flavor: horrible #this is smelling salts.
+  color: "#eaede4"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:Jitter
+      - !type:GenericStatusEffect
+        key: Stutter
+        component: StutteringAccent
+      - !type:ModifyStatusEffect
+        effectProto: StatusEffectDrowsiness
+        time: 30
+        type: Remove
+      - !type:ResetNarcolepsy
+        conditions:
+        - !type:ReagentCondition
+          reagent: AmmoniaCarbonate
+          min: 10
+      - !type:PopupMessage
+        visualType: Medium
+        messages: ["ethyloxyephedrine-effect-feeling-awake", "ethyloxyephedrine-effect-clear-mind"]
+        type: Local
+        probability: 0.3

--- a/Resources/Prototypes/_SpL/Recipes/Reactions/botany.yml
+++ b/Resources/Prototypes/_SpL/Recipes/Reactions/botany.yml
@@ -1,0 +1,9 @@
+- type: reaction
+  id: Ammonium
+  reactants:
+    Ammonia:
+      amount: 1
+    Hydrogen:
+      amount: 1
+  products:
+    Ammonium: 2

--- a/Resources/Prototypes/_SpL/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_SpL/Recipes/Reactions/medicine.yml
@@ -1,0 +1,61 @@
+- type: reaction
+  id: Scorizine
+  requiredMixerCategories:
+  - Electrolysis
+  reactants:
+    AmmoniaCarbonate:
+      amount: 1
+    Silicon:
+      amount: 2
+    Copper:
+      amount: 1
+      catalyst: true
+  products:
+    Scorizine: 3
+
+- type: reaction
+  id: Voltizol
+  requiredMixerCategories:
+  - Electrolysis
+  reactants:
+    AmmoniaCarbonate:
+      amount: 1
+    Lithium:
+      amount: 2
+    Copper:
+      amount: 1
+      catalyst: true
+  products:
+    Voltizol: 3
+
+- type: reaction
+  id: Carbonate
+  reactants:
+    Carbon:
+      amount: 1
+    Oxygen:
+      amount: 1
+    Ammonia:
+      amount: 1
+  products:
+    Carbonate: 3
+
+- type: reaction
+  id: SodiumCarbonateCarbonate
+  reactants:
+    Carbonate:
+      amount: 3
+    TableSalt:
+      amount: 1
+  products:
+    SodiumCarbonate: 4
+
+- type: reaction
+  id: AmmoniaCarbonate
+  reactants:
+    Carbonate:
+      amount: 1
+    Ammonium:
+      amount: 1
+  products:
+    AmmoniaCarbonate: 2

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/avali.yml
@@ -3,10 +3,10 @@
   abstract: true
   components:
     - type: TemperatureDamage
-      heatDamageThreshold: 310
-      coldDamageThreshold: 223
+      heatDamageThreshold: 293 #Spectralight: Lowered to 293
+      coldDamageThreshold: 213 #Spectralight: Lowered to 213
     - type: Temperature
-      currentTemperature: 261
+      currentTemperature: 251 #Spectralight: Lowered to 251
       specificHeat: 48
     - type: ThermalRegulator
       metabolismHeat: 400 # icebirb go brrr
@@ -14,13 +14,13 @@
       implicitHeatRegulation: 1500
       sweatHeatRegulation: 2000
       shiveringHeatRegulation: 2000
-      normalBodyTemperature: 261
+      normalBodyTemperature: 251 #Spectralight: Lowered to 251
       thermalRegulationTemperatureThreshold: 1
     - type: TemperatureSpeed
       thresholds:
-        250: 0.9
-        230: 0.8
-        223: 0.6
+        230: 0.9 #Spectralight: Lowered to 230
+        220: 0.8 #Spectralight: Lowered to 220
+        213: 0.6 #Spectralight: Lowered to 213
 
 - type: entity
   save: false
@@ -43,7 +43,6 @@
         - DoorBumpOpener
         - AnomalyHost
         - Avali
-        - NotLabelable
     - type: Absorbable
     - type: HumanoidAppearance
       species: Avali

--- a/Resources/Prototypes/_Starlight/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/medicine.yml
@@ -51,7 +51,7 @@
           type: [ Avali, Resomi ]
         damage:
           types:
-            Asphyxiation: -3.5
+            Asphyxiation: -3.5 
             Bloodloss: -3
       - !type:AdjustReagent
         conditions:
@@ -78,12 +78,7 @@
           types:
             Poison: 1.5 #Ammonia is toxic injected directly into bloodstream
             Asphyxiation: 1 
-            Bloodloss: 0.5
-      - !type:ModifyBloodLevel
-        conditions:
-        - !type:MetabolizerTypeCondition
-          type: [ Avali, Resomi ]
-        amount: 3
+            Bloodloss: 0.5 #SpectraLight, remove bloodloss healing from amoxla
         # Starlight-Start: Cyclorite Metabolism
       - !type:AdjustReagent # Amoxla for Cyclorites is a toxin not medicine
         conditions:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Avali and Resomi are currently listed as a "Major" impact species, but as it stands, Avali and Resomi do not have the downsides of species like Vox. My goal with this PR is to change Avali and Resomi to be more balanced, and have a major gameplay downside like Vox does.

Currently, Amoxla is a very powerful chem, and being able to use it is almost an upside for Avali and Resomi, considering it allows them to very quickly recover from any and all airloss and bloodloss. With this change, Avali and Resomi will no longer be able to near instantly recover from any Air/Bloodloss damage with just one chemical.

SpectraLight downstream changes for  Avali and resomi .
Changes Avali body temp and cold/heat thresholds to better match lore.
Changes Avali and resomi thirst mechanics
Adds a few new  Avali and resomi specific chems and tightens  Avali and resomi ali chem allergies.

The changes to Avali and Resomi burn chems does NOT affect kelo/derma, and as a result should not majorly change the revivability of downed Avali and Resomi. This change also does NOT just "put an annoying indicator on the hud at all times" it makes Avali take heat damage when in much cooler environments than before, thus the "annoying indicator". 

Current upsides for Avali:
Use of Amoxla
pretty much complete resistance to environmental cold, and -40% cold damage
Nanite shell
0g flight
Nexus
Upgraded Melee
Current downsides for Avali:
40% more ***FIRE*** damage
crit/death at 90/180
diet restrictions
No use of dexp (which is numbers wise worse than amoxla)

Changed upsides for Avali:
Near immunity to environmental cold, and -40% cold damage
Nanite Shell
0g flight
Nexus
Upgraded Melee
Changed Downsides for Avali:
Medical chem restrictions that arent DIRECT UPGRADES to their counterparts, and therefore act as actual downsides to the species, Pyra, Dexp, and Insu
A more impactful body temperature system that causes them to overheat quickly and burn faster when on fire
40% more ***FIRE*** damage
crit/death at 90/180
diet restrictions

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->


Due to Avali being an ammonia based species, they have been changed to be able to drink ammonia for higher thirst satiation, like other species can with Saline. This is balanced out by making water less effective for them.
Avali already had a lower body temp and temp tolerance, the changes to avali temp are intended to make them take far more heat damage than before while in hot rooms, and has a byproduct of avali being roleplay uncomfortably hot in room temp rooms without any protection. This is intended to parallel Vox's nitrogen mechanics (natural station environment being dangerous to the player) but not have as much of an impact, to allow for the chemistry changes.

Due to the fact that Dexalin and Saline are no longer dangerous to Avali and Resomi in this PR, two more chemicals have been added to retain the balance of 3 chems hurting Avali and Resomi, in this case, Pyra and Insu being replace with Scor and Volt for them. This notably also gives chemistry more to do, and gives electrolysis a use when it currently has none (main use was turning water (unlimited) into hydrogen and oxygen (limited) before the two were made unlimited). 

The design behind expanding Avali and Resomi medical chem is that their "Major gameplay change" is meant to be their low body temp and lack of access to specific chems, but in my opinion, Amoxla alone does not constitute a "Major" change, and their body temp differences are currently not enough to meaningfully change gameplay. Currently, Avali are one of if not the best species combat wise, being able to retreat and full heal at any time, and while this PR doesnt directly deal with combat balance, it gives them more downsides in return for their overwhelming staying power in combat.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="538" height="349" alt="Screenshot 2026-03-03 174216" src="https://github.com/user-attachments/assets/f06c032c-f37c-4a75-945d-de9e69bc04a5" />


<img width="542" height="476" alt="Screenshot 2026-03-03 174050" src="https://github.com/user-attachments/assets/b0472dbf-d013-43be-a6eb-f6409490bc31" />
<img width="533" height="568" alt="Screenshot 2026-03-03 174155" src="https://github.com/user-attachments/assets/e4e011c1-c937-45b0-99bd-00c8c24d2e00" />
<img width="537" height="481" alt="Screenshot 2026-03-03 174134" src="https://github.com/user-attachments/assets/a95ad562-7b91-457a-9e56-349dd7baa656" />
<img width="544" height="500" alt="Screenshot 2026-03-03 174124" src="https://github.com/user-attachments/assets/48cff276-7706-457d-86bb-f1e7278dc979" />
<img width="540" height="472" alt="Screenshot 2026-03-03 174115" src="https://github.com/user-attachments/assets/1b3422bc-98bc-4f47-9eca-356f189836c1" />
<img width="536" height="334" alt="Screenshot 2026-03-03 174100" src="https://github.com/user-attachments/assets/bd4a8613-0f51-430a-8d1a-01a5588569fc" />
<img width="539" height="596" alt="Screenshot 2026-03-03 174056" src="https://github.com/user-attachments/assets/5085c626-e278-4bcd-a75f-c92410eb3757" />

More changes listed below.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- tweak: Avali Body temp is now -22 Celcius
- tweak: Avali now get cold at 230, 220, and 213 Celcius
- tweak: Avali now get uncomfortably (But not damagingly) hot in room temp rooms. Grab a space heater or hardsuit to stay cool.
- tweak: Avali now only get 0.6x thirst sated by water. Avali can drink Ammonia for 2x thirst sating. Go ask chem to refill your water bottle.
- remove: Avali are no longer poisoned by Saline and Dexalin, and are now damaged by Iron based compounds, as is more accurate to lore.
- tweak: Avali are now damaged by Pyra and Insu, and Lepo no longer heals cold on them.
- add: Avali now get 2 new chems, Scorizine and Voltizol, which act as Pyra and Insu equivalents for Avali only. Avali do NOT get a Lepo equivalent. New changes will make Avali practically immune to cold temps while making them very sensitive to hot ones, so they shouldn't need it.
- add: Carbonate, a new chemical that's used to make Ammonium Carbonate and Sodium Carbonate.
- add: Ammonium, a new chemical that sates Avali thirst above averagely and heals a minor amount of airloss.
- tweak: nerfed Ammonia airloss healing from 1/0.5u to 0.5/0.5u.
- add: Ammonium Carbonate, a new chemical that staves off narcolepsy and removes a massive amount of drowsiness. smell your salts.