### PR TITLE
Contraband Tweaks (Harmless Syndie, Law Board, Program Cartridges)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -290,7 +290,7 @@
 
 #Syndicate
 - type: entity
-  parent: [ClothingBackpack, BaseSyndicateContraband]
+  parent: [ClothingBackpack, BaseMinorContraband] #SL Edit Syndie > Minor Contra
   id: ClothingBackpackSyndicate
   name: syndicate backpack
   description:

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -163,7 +163,7 @@
       sprite: Clothing/Back/Duffels/salvage.rsi
 
 - type: entity
-  parent: [ClothingBackpackDuffel, BaseSyndicateContraband]
+  parent: [ClothingBackpackDuffel, BaseMinorContraband] #SL Edit Syndie > Minor Contra
   id: ClothingBackpackDuffelSyndicate
   name: syndicate duffel bag
   description: A large duffel bag for holding various traitor goods.
@@ -177,7 +177,7 @@
     - 0,0,8,4
 
 - type: entity
-  parent: [ ClothingBackpackDuffelSyndicate, BaseSyndicateContraband ]
+  parent: [ ClothingBackpackDuffelSyndicate, BaseMinorContraband ] #SL Edit Syndie > Minor Contra
   id: ClothingBackpackDuffelSyndicateBundle
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -34,7 +34,7 @@
 
 #Syndicate EVA Helmet
 - type: entity
-  parent: [ ClothingHeadEVAHelmetBase, BaseSyndicateContraband ]
+  parent: [ ClothingHeadEVAHelmetBase, BaseMinorContraband ] #SL Edit Syndie > Minor Contra
   id: ClothingHeadHelmetSyndicate
   name: syndicate EVA helmet
   description: A simple, stylish EVA helmet. Designed for maximum humble space-badassery.

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -847,7 +847,7 @@
     sprite: Clothing/Head/Hats/truckershat.rsi
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseMajorContraband ] #SL EDIT, Syndie to Major
+  parent: [ ClothingHeadBase, BaseMinorContraband ] #SL EDIT, Syndie to Minor
   id: ClothingHeadPyjamaSyndicateBlack
   name: syndicate black pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -863,7 +863,7 @@
       HeadSide : HEAD
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseMajorContraband ] #SL EDIT, Syndie to Major
+  parent: [ ClothingHeadBase, BaseMinorContraband ] #SL EDIT, Syndie to Minor
   id: ClothingHeadPyjamaSyndicatePink
   name: syndicate pink pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -879,7 +879,7 @@
       HeadSide : HEAD
 
 - type: entity
-  parent: [ ClothingHeadBase, BaseMajorContraband ] #SL EDIT, Syndie to Major
+  parent: [ ClothingHeadBase, BaseMinorContraband ] #SL EDIT, Syndie to Minor
   id: ClothingHeadPyjamaSyndicateRed
   name: syndicate red pyjama hat
   description: For keeping that traitor head of yours warm.
@@ -1084,7 +1084,7 @@
         Caustic: 0.95
 
 - type: entity
-  parent: [ClothingHeadBase, BaseMajorContraband] #SL EDIT, Syndie to Major
+  parent: [ClothingHeadBase, BaseMinorContraband] #SL EDIT, Syndie to Minor
   id: ClothingHeadHatSyndie
   name: syndicate hat
   description: A souvenir hat from "Syndieland", their production has already been closed.

--- a/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
@@ -87,7 +87,7 @@
       sprite: Clothing/Neck/Scarfs/purple.rsi
 
 - type: entity
-  parent: [ ClothingScarfBase, BaseMajorContraband ]  #SL EDIT, Syndie to Major
+  parent: [ ClothingScarfBase, BaseMinorContraband ]  #SL EDIT, Syndie to Minor
   id: ClothingNeckScarfStripedSyndieGreen
   name: striped syndicate green scarf
   description: A stylish striped syndicate green scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
@@ -100,7 +100,7 @@
       price: 500
 
 - type: entity
-  parent: [ ClothingScarfBase, BaseMajorContraband ] #SL EDIT, Syndie to Major
+  parent: [ ClothingScarfBase, BaseMinorContraband ] #SL EDIT, Syndie to Minor
   id: ClothingNeckScarfStripedSyndieRed
   name: striped syndicate red scarf
   description: A stylish striped syndicate red scarf. The perfect winter accessory for those with a keen fashion sense, and those who are in the mood to steal something.
@@ -113,7 +113,7 @@
       price: 500
 
 - type: entity
-  parent: [ ClothingScarfBase, BaseCentcommContraband ] #SL EDIT, Syndie to Major
+  parent: [ ClothingScarfBase, BaseCentcommContraband ] #SL EDIT
   id: ClothingNeckScarfStripedCentcom
   name: striped CentComm scarf
   description: A stylish striped centcomm colored scarf. The perfect winter accessory for those with a keen fashion sense, and those who need to do paperwork in the cold.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -409,7 +409,7 @@
   name: paramedic windbreaker
 
 - type: entity
-  parent: [ClothingOuterStorageBase, BaseSyndicateContraband]
+  parent: [ClothingOuterStorageBase, BaseMinorContraband] #SL Edit Syndie > Minor
   id: ClothingOuterCoatSyndieCap
   name: syndicate's coat
   description: The syndicate's coat is made of durable fabric, with gilded patterns.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -19,7 +19,7 @@
 
 #Syndicate EVA
 - type: entity
-  parent: [ ClothingOuterEVASuitBase, BaseSyndicateContraband ]
+  parent: [ ClothingOuterEVASuitBase, BaseMinorContraband ] #SL edit Syndie > Minor Contra
   id: ClothingOuterEVASuitSyndicate
   name: syndicate EVA suit
   description: "Has a tag on the back that reads: 'Totally not property of an enemy corporation, honest!'"

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -804,7 +804,7 @@
     clothingPrototype: ClothingHeadHatHoodWinterWarden
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseSyndicateContraband]
+  parent: [ClothingOuterWinterCoatToggleable, BaseMinorContraband] #SL Edit Syndie > Minor contra
   id: ClothingOuterWinterSyndieCap
   name: syndicate's winter coat
   description: "The syndicate's winter coat is made of durable fabric, with gilded patterns, and coarse wool."
@@ -843,7 +843,7 @@
 ##############################################################
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseSyndicateContraband]
+  parent: [ClothingOuterWinterCoatToggleable, BaseMinorContraband] #SL edit Syndie > Minor contra
   id: ClothingOuterWinterSyndie
   name: syndicate's winter coat
   description: Insulated winter coat, looks like a merch from "Syndieland".

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -161,7 +161,7 @@
     sprite: Clothing/Shoes/Boots/winterbootssec.rsi
 
 - type: entity
-  parent: [ClothingShoesBaseWinterBoots, BaseSyndicateContraband]
+  parent: [ClothingShoesBaseWinterBoots, BaseMinorContraband] #SL Edit Syndie > Minor Contra
   id: ClothingShoesBootsWinterSyndicate
   name: syndicate's winter boots
   description: Durable heavy boots, looks like merch from "Syndieland".

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -658,7 +658,7 @@
       sprite: Clothing/Uniforms/Jumpskirt/lawyergood.rsi
 
 - type: entity
-  parent: [ ClothingUniformSkirtBase, BaseSyndicateContraband ]
+  parent: [ ClothingUniformSkirtBase, BaseMinorContraband ] #SL Edit Syndie > Minor
   id: ClothingUniformJumpskirtSyndieFormalDress
   name: syndicate formal dress
   description: "The syndicate's uniform is made in an elegant style, it's even a pity to do dirty tricks in this."

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -788,7 +788,7 @@
       sprite: Clothing/Uniforms/Jumpsuit/lawyergood.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseMajorContraband] #SL EDIT, Syndie to Major
+  parent: [UnsensoredClothingUniformBase, BaseMinorContraband] #SL EDIT, Syndie to minor
   id: ClothingUniformJumpsuitPyjamaSyndicateBlack
   name: black syndicate pyjamas
   description: For those long nights in perma.
@@ -799,7 +799,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicateblack.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseMajorContraband] #SL EDIT, Syndie to Major
+  parent: [UnsensoredClothingUniformBase, BaseMinorContraband] #SL EDIT, Syndie to minor
   id: ClothingUniformJumpsuitPyjamaSyndicatePink
   name: pink syndicate pyjamas
   description: For those long nights in perma.
@@ -810,7 +810,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/pyjamasyndicatepink.rsi
 
 - type: entity
-  parent: [UnsensoredClothingUniformBase, BaseMajorContraband] #SL EDIT, Syndie to Major
+  parent: [UnsensoredClothingUniformBase, BaseMinorContraband] #SL EDIT, Syndie to minor
   id: ClothingUniformJumpsuitPyjamaSyndicateRed
   name: red syndicate pyjamas
   description: For those long nights in perma.
@@ -1176,7 +1176,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/hawaiyellow.rsi
 
 - type: entity
-  parent: [ClothingUniformBase, BaseSyndicateContraband]
+  parent: [ClothingUniformBase, BaseMinorContraband] #SL Edit Syndie > Minor Contra
   id: ClothingUniformJumpsuitSyndieFormal
   name: syndicate formal suit
   description: "The syndicate's uniform is made in an elegant style, it's even a pity to do dirty tricks in this."

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/ship_vs_ship.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/ship_vs_ship.yml
@@ -15,7 +15,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/recruit_nt.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseSyndicateContraband ]
+  parent: [ ClothingUniformBase, BaseMinorContraband ] #SL Edit Syndie > Minor
   id: ClothingUniformJumpsuitRecruitSyndie
   name: syndicate recruit jumpsuit
   description: A dubious, dark-grey jumpsuit. As if assistants weren't dubious enough already.
@@ -38,7 +38,7 @@
     sprite: Clothing/Uniforms/Jumpsuit/repairman_nt.rsi
 
 - type: entity
-  parent: [ ClothingUniformBase, BaseSyndicateContraband ]
+  parent: [ ClothingUniformBase, BaseMinorContraband ] #SL Edit Syndie > Minor contra
   id: ClothingUniformJumpsuitRepairmanSyndie
   name: syndicate repairman jumpsuit
   description: Functional, fashionable, and badass. Nanotrasen's engineers wish they could look as good as this.
@@ -50,7 +50,7 @@
 
 #Paramedic
 - type: entity
-  parent: [ ClothingUniformBase, BaseSyndicateContraband ]
+  parent: [ ClothingUniformBase, BaseMinorContraband ] #SL Edit Syndie > Minor Contra
   id: ClothingUniformJumpsuitParamedicSyndie
   name: syndicate paramedic jumpsuit
   description: For some reason, wearing this makes you feel like you're awfully close to violating the Geneva Convention.
@@ -63,7 +63,7 @@
 #HEADS OF STAFF
 #Chief Engineer
 - type: entity
-  parent: [ ClothingUniformBase, BaseSyndicateContraband ]
+  parent: [ ClothingUniformBase, BaseMinorContraband ] #SL edit Syndie > Minor Contra
   id: ClothingUniformJumpsuitChiefEngineerSyndie
   name: syndicate chief engineer jumpsuit
   description: An evil-looking jumpsuit with a reflective vest & red undershirt. #TODO: Write a better description for this once Ship vs. Ship is real and actual player habits begin forming

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -18,7 +18,7 @@
 
 - type: entity
   id: NTDefaultCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (NT Default)
   # description: An electronics board containing the NT Default lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -27,7 +27,7 @@
 
 - type: entity
   id: AsimovCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Crewsimov)
   # description: An electronics board containing the Crewsimov lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -37,7 +37,7 @@
 
 - type: entity
   id: CorporateCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Corporate)
   # description: An electronics board containing the Corporate lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -47,7 +47,7 @@
 
 - type: entity
   id: CommandmentCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Ten Commandments)
   # description: An electronics board containing the Ten Commandments lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -57,7 +57,7 @@
 
 - type: entity
   id: PaladinCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Paladin)
   # description: An electronics board containing the Paladin lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -67,7 +67,7 @@
 
 - type: entity
   id: LiveLetLiveCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Live and Let Live)
   # description: An electronics board containing the Live and Let Live lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -77,7 +77,7 @@
 
 - type: entity
   id: StationEfficiencyCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Station Efficiency)
   # description: An electronics board containing the Station Efficiency lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -87,7 +87,7 @@
 
 - type: entity
   id: RobocopCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Robocop)
   # description: An electronics board containing the Robocop lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -97,7 +97,7 @@
 
 - type: entity
   id: OverlordCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Overlord)
   # description: An electronics board containing the Overlord lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -107,7 +107,7 @@
 
 - type: entity
   id: GameMasterCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Game Master)
   # description: An electronics board containing the Game Master lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -117,7 +117,7 @@
 
 - type: entity
   id: ArtistCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Artist)
   # description: An electronics board containing the Artist lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -140,7 +140,7 @@
 
 - type: entity
   id: NutimovCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Nutimov)
   # description: An electronics board containing the Nutimov lawset. # Starlight Edit: Removed for Dynamic Description
   components:
@@ -150,7 +150,7 @@
 
 - type: entity
   id: XenoborgCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseXenoborgContraband ] #SL Edit made Xenoborg Contra
   name: law board (Xenoborg)
   suffix: Admeme
   # description: An electronics board containing the Xenoborg lawset. # Starlight Edit: Removed for Dynamic Description
@@ -163,7 +163,7 @@
 
 - type: entity
   id: MothershipCircuitBoard
-  parent: BaseSiliconLawboard
+  parent: [ BaseSiliconLawboard, BaseXenoborgContraband ] #SL Edit made Xenoborg Contra
   name: law board (Mothership Core)
   suffix: Admeme
   # description: An electronics board containing the Mothership Core lawset. # Starlight Edit: Removed for Dynamic Description

--- a/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
@@ -94,7 +94,7 @@
     - type: NetProbeCartridge
 
 - type: entity
-  parent: [ BasePDACartridge, BaseSecurityEngineeringContraband ] #SL Edit added Engie-Sec Contra
+  parent: [ BasePDACartridge, BaseSecurityContraband ] #SL Edit added Security Contra
   id: LogProbeCartridge
   name: LogProbe cartridge
   description: A program for getting access logs from devices.

--- a/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/cartridges.yml
@@ -77,7 +77,7 @@
     - type: CrewManifestCartridge
 
 - type: entity
-  parent: BasePDACartridge
+  parent: [ BasePDACartridge, BaseEngineeringContraband ] #SL Edit added Engie Contra
   id: NetProbeCartridge
   name: NetProbe cartridge
   description: A program for getting the address and frequency of network devices.
@@ -94,7 +94,7 @@
     - type: NetProbeCartridge
 
 - type: entity
-  parent: BasePDACartridge
+  parent: [ BasePDACartridge, BaseSecurityEngineeringContraband ] #SL Edit added Engie-Sec Contra
   id: LogProbeCartridge
   name: LogProbe cartridge
   description: A program for getting access logs from devices.
@@ -119,7 +119,7 @@
       stealGroup: LogProbeCartridge # Starlight
 
 - type: entity
-  parent: BasePDACartridge
+  parent: [ BasePDACartridge, BaseSecurityContraband ] #SL Edit added Security Contra
   id: WantedListCartridge
   name: Wanted list cartridge
   description: A program to get a list of wanted persons.

--- a/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/bedsheets.yml
@@ -444,7 +444,7 @@
 
 - type: entity
   id: BedsheetSyndie
-  parent: [ BedsheetBase, BaseMajorContraband ]  #SL EDIT, Syndie to Major
+  parent: [ BedsheetBase, BaseMinorContraband ]  #SL EDIT, Syndie to Minor
   name: syndicate bedsheet
   description: It has a syndicate emblem and it has an aura of evil.
   components:

--- a/Resources/Prototypes/Entities/Objects/Misc/business_card.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/business_card.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: SyndicateBusinessCard
   name: syndicate business card
-  parent: [ Paper, BaseSyndicateContraband ]
+  parent: [ Paper, BaseMinorContraband ] #SL Edit Syndie > Minor Contra
   description: A black card with the syndicate's logo. There's something written on the back.
   components:
     - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Misc/handy_flags.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handy_flags.yml
@@ -23,7 +23,7 @@
     sprite: Objects/Misc/Handy_Flags/NT_handy_flag.rsi
 
 - type: entity
-  parent: [BaseItem, BaseSyndicateContraband]
+  parent: [BaseItem, BaseMinorContraband] #SL Edit Syndie > Minor Contra
   id: SyndieHandyFlag
   name: syndicate handheld flag
   description: "For truly rebellious patriots. Death to NT!"

--- a/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
@@ -208,7 +208,7 @@
 
 - type: entity
   name: syndicate rubber stamp
-  parent: [RubberStampBase, BaseSyndicateContraband]
+  parent: [RubberStampBase, BaseMinorContraband] #SL Edit Syndie > Minor Contra
   id: RubberStampSyndicate
   categories: [ DoNotMap ]
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Back/satchel.yml
@@ -53,7 +53,7 @@
     sprite: _Starlight/Clothing/Back/Satchels/Centcomm.rsi
 
 - type: entity
-  parent: [ClothingBackpackSatchel, BaseSyndicateContraband]
+  parent: [ClothingBackpackSatchel, BaseMinorContraband]
   id: ClothingBackpackSatchelSyndicate
   name: syndicate satchel
   description: Ask not what the syndicate satchel can do for you, but rather, what can't it do.

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/Machine/law_boards.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/Machine/law_boards.yml
@@ -15,7 +15,7 @@
 
 - type: entity
   id: PanicmovCircuitBoard
-  parent: BaseElectronics
+  parent: [ BaseElectronics, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Panicmov)
   components:
   - type: Sprite
@@ -29,7 +29,7 @@
 
 - type: entity
   id: GenieCircuitBoard
-  parent: BaseElectronics
+  parent: [ BaseElectronics, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Genie in a Core)
   components:
   - type: Sprite
@@ -43,7 +43,7 @@
 
 - type: entity
   id: ReporterCircuitBoard
-  parent: BaseElectronics
+  parent: [ BaseElectronics, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Reporter)
   components:
   - type: Sprite
@@ -57,7 +57,7 @@
 
 - type: entity
   id: JermovCircuitBoard
-  parent: BaseElectronics
+  parent: [ BaseElectronics, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
   name: law board (Jermov)
   components:
   - type: Sprite


### PR DESCRIPTION
## Short description
Makes many non-harmful Syndicate Contraband items Minor Contraband instead, to match Corporate Law. This is mainly clothing items and things that can not harm the station or crew, so things like the Sus Toolbox remain Syndie Contra. The Gorlex Flippo and Matchbox are an exception as they are directly and overtly branded specifically, not generically 'syndicate'.

Made a few Program Cartridges Contraband; Netprobe is Engineering, Log Probe and Wanted List are Security.

Made all 'safe' Law Boards Security-Science-Command Contraband. Hostile boards like Syndiemov, Antimov, and Commiemov remain their respective faction's contraband.

## Why we need to add this
Parity with Corporate Law- Security is instructed in Corporate Law to treat all 'harmless' Syndicate items as Minor Contraband, so that pajamas aren't treated the same as a sniper rifle under the law which would be stupid. This edit fixes most (all?) of these cases to now be reflected in the examine text to reduce confusion.

Recently with the addition of SELF, possession of Law Boards has become a goal for an antagonist, as SELF Agents need a Law Board to FreeMAG in order to wipe the AI's Laws. On top of this, only Science, Security, and Command should be handling Law Boards anyway, so them being non-contra felt like a mistake rather than intention. This change makes them contra.

Finally, the Program Cartridges. The intent for a while has been that programs that replicate functions of restricted items should be restricted, but it's never been represented in game. Now, it is. Exception has been made for 'safety features' like health scanners and coordinates.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed the Contraband Level of many 'harmless' Syndicate items to reflect how they should be treated per Corporate Law. Namely, all harmless items like clothing are now Minor Contraband not Syndicate Contraband. Items with utility as weapons or armor, as well as Gorlex Flippo and Matchbox, remain Syndicate Contraband.
- tweak: Changed the Contraband Level of the NetProbe Cartridge to be Engineering Contra, the Log Probe Cartridge to be Security Contra, and the Wanted List Cartridge to be Security Contra, to reflect their intended status as restricted items. Programs that act as 'safety' features like medscanner and coordinates remain non-contra.
- tweak: Changed all 'safe' AI Law Boards to be Command-Security-Science Contraband. SELF Agents explicitly target these items to complete an objective, and only Command and arguably Sci/Sec should ever be touching them, so their status as non-contra no longer made sense and arguably never made sense.

