### PR TITLE
Dualweild HOTFIX + balance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -26,6 +26,7 @@
     tags:
     - Sidearm
   - type: CanDualWield # 🌟Starlight🌟
+    dualWieldInaccuracyPenalty: 15
   - type: Clothing
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -48,6 +48,8 @@
       path: /Audio/Weapons/Guns/MagOut/revolver_magout.ogg
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
+  - type: CanDualWield # 🌟Starlight🌟
+    dualWieldInaccuracyPenalty: 25
   - type: StaticPrice
     price: 500
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Lets revolvers dual weild
Adds a inaccuray penalty (low til testing in public servers is done)

## Why we need to add this
Dont make dual weilding TOO op. needs to have downsides.

## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Scarlet Lightweaver
- add: Added inital spread penalty for dualweilding til public testing is done.
- fix: Fixed not being able to dual weild revolvers. Go wild cowboy.
