### PR TITLE
Reduce healium drunkness, buff ethyl/haloper more

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -364,9 +364,9 @@
       - !type:ModifyStatusEffect
         effectProto: StatusEffectSeeingRainbow
         type: Add
-        time: 40 # Starlight: Liquid frezon way more potent (its denser!)
+        time: 60 # Starlight: Liquid frezon way more potent (its denser!)
       - !type:Drunk
-        boozePower: 40  # Starlight: Liquid frezon way more potent (its denser!)
+        boozePower: 30  # Starlight: Liquid frezon way more potent (its denser!)
       - !type:PopupMessage
         type: Local
         messages: [ "frezon-lungs-cold" ]
@@ -393,7 +393,7 @@
         type: Add
         time: 20  # Starlight: Down from 500 (holy shit)
       - !type:Drunk
-        boozePower: 20 # Starlight: Down from 500 (holy shit)
+        boozePower: 10 # Starlight: Down from 500 (holy shit)
         minScale: 1
       - !type:PopupMessage
         type: Local

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -135,7 +135,7 @@
       effects:
       - !type:ModifyStatusEffect
         effectProto: StatusEffectDrunk
-        time: 20.0 # Starlight: More potent, up from 6
+        time: 30.0 # Starlight: More potent, up from 6
         type: Remove
       - !type:HealthChange
         damage:
@@ -1961,7 +1961,7 @@
         type: Remove
       - !type:ModifyStatusEffect
         effectProto: StatusEffectSeeingRainbow
-        time: 30.0 # Starlight: More potent, up from 10
+        time: 45.0 # Starlight: More potent, up from 10
         type: Remove
       - !type:AdjustReagent
         reagent: Desoxyephedrine

--- a/Resources/Prototypes/_Funkystation/Reagents/gases.yml
+++ b/Resources/Prototypes/_Funkystation/Reagents/gases.yml
@@ -202,7 +202,7 @@
         - !type:ReagentCondition
           reagent: Healium
           min: 3
-        boozePower: 150
+        boozePower: 20 # Starlight: Down from 150
         # needs to be made into hypothium to work well as a chem, use as a gas otherwise
 
 - type: reagent


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description

- Reduce healium drunkness to similar effectiveness of frezon (see https://github.com/ss14Starlight/space-station-14/pull/2934)
- Adjust frezon's hallucination/drunkness ratio from 1:1 to 1:0.5
- Buff haloperidol and ethylredoxrazine more.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Yet another shift where someone got caught in a Healium gas leak, promptly fell asleep and kept inhaling it, causing them to be drunk for 45 minutes + 300u ethylredoxrazine. This just isn't fun for anybody involved and the player reported feeling sick IRL after staring at the drunkness effect for so long.

I'm going to look into just capping status effects next, but until then, this will have to do.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Forgive me but it's just numerical changes

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: Frezon (gaseous and liquid) now makes you 50% less drunk (hallucinations unaffected).
- tweak: Liquid frezon is now more 33% more potent.
- tweak: Reduced Healium drunk effect to not instantly make you drunk for hours.
- tweak: Ethylredoxrazine is now 50% more effective against drunkness.
- tweak: Haloperidol is now 33% more effective against hallucinations.
