### PR TITLE
Aghost bypasses tag checks

### DIFF
--- a/Content.Shared/_Starlight/Restrict/SharedRestrictSystem.cs
+++ b/Content.Shared/_Starlight/Restrict/SharedRestrictSystem.cs
@@ -1,11 +1,8 @@
-﻿using System.Linq;
-using Content.Shared.Interaction.Events;
+﻿using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
-using Content.Shared.Turrets;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Systems;
-using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 

--- a/Content.Shared/_Starlight/Restrict/SharedRestrictSystem.cs
+++ b/Content.Shared/_Starlight/Restrict/SharedRestrictSystem.cs
@@ -2,17 +2,23 @@
 using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
+using Content.Shared.Turrets;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Shared.Starlight.Restrict;
+
 public abstract partial class SharedRestrictSystem : EntitySystem
 {
     [Dependency] private readonly TagSystem _tagSystem = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    
+    private static readonly ProtoId<TagPrototype> BypassUserTagChecks = "BypassUserTagChecks";
+    
     public override void Initialize()
     {
         SubscribeLocalEvent<RestrictByUserTagComponent, AttemptMeleeEvent>(OnAttemptMelee);
@@ -22,6 +28,7 @@ public abstract partial class SharedRestrictSystem : EntitySystem
 
     private void OnAttemptInteract(Entity<RestrictByUserTagComponent> ent, ref InteractionAttemptEvent args)
     {
+        if (_tagSystem.HasTag(args.Uid, BypassUserTagChecks)) return;
         if (!_tagSystem.HasAllTags(args.Uid, ent.Comp.Contains) || _tagSystem.HasAnyTag(args.Uid, ent.Comp.DoestContain))
         {
             args.Cancelled = true;
@@ -32,6 +39,7 @@ public abstract partial class SharedRestrictSystem : EntitySystem
     
     private void OnShotAttempt(Entity<RestrictByUserTagComponent> ent, ref AttemptShootEvent args)
     {
+        if (_tagSystem.HasTag(args.User, BypassUserTagChecks)) return;
         if (!_tagSystem.HasAllTags(args.User, ent.Comp.Contains) || _tagSystem.HasAnyTag(args.User, ent.Comp.DoestContain))
         {
             args.Cancelled = true;
@@ -42,6 +50,7 @@ public abstract partial class SharedRestrictSystem : EntitySystem
 
     private void OnAttemptMelee(Entity<RestrictByUserTagComponent> ent, ref AttemptMeleeEvent args)
     {
+        if (_tagSystem.HasTag(args.User, BypassUserTagChecks)) return;
         if(!_tagSystem.HasAllTags(args.User, ent.Comp.Contains) || _tagSystem.HasAnyTag(args.User, ent.Comp.DoestContain))
         {
             args.Cancelled = true;

--- a/Content.Shared/_Starlight/Restrict/SharedRestrictSystem.cs
+++ b/Content.Shared/_Starlight/Restrict/SharedRestrictSystem.cs
@@ -14,7 +14,7 @@ public abstract partial class SharedRestrictSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     
-    private const ProtoId<TagPrototype> BypassUserTagChecks = "BypassUserTagChecks";
+    private const string BypassUserTagChecks = "BypassUserTagChecks";
     
     public override void Initialize()
     {

--- a/Content.Shared/_Starlight/Restrict/SharedRestrictSystem.cs
+++ b/Content.Shared/_Starlight/Restrict/SharedRestrictSystem.cs
@@ -14,7 +14,7 @@ public abstract partial class SharedRestrictSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     
-    private static readonly ProtoId<TagPrototype> BypassUserTagChecks = "BypassUserTagChecks";
+    private const ProtoId<TagPrototype> BypassUserTagChecks = "BypassUserTagChecks";
     
     public override void Initialize()
     {

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -12,6 +12,7 @@
     - CanPilot
     - BypassInteractionRangeChecks
     - BypassDropChecks
+    - BypassUserTagChecks
     - NoConsoleSound
     - SilentStorageUser
     - PreventAccessLogging

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -12,7 +12,7 @@
     - CanPilot
     - BypassInteractionRangeChecks
     - BypassDropChecks
-    - BypassUserTagChecks
+    - BypassUserTagChecks # Starlight-edit
     - NoConsoleSound
     - SilentStorageUser
     - PreventAccessLogging

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -72,6 +72,9 @@
   id: BurnedTraitBackground
 
 - type: Tag
+  id: BypassUserTagChecks
+
+- type: Tag
   id: CantInteract
 
 - type: Tag


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Added bypass tag for "UserTagChecks", gave it to aghost.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Lets admins bypass these types of checks, currently primarly used for abductor equipment.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/faab39ef-1835-4607-8943-7a0a1ce307c9


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Admin ghosts now bypass user tag checks (e.g.: on Abductor equipment).
