### PR TITLE
Add status effect stack caps

### DIFF
--- a/Content.Server/Speech/Muting/MutingSystem.cs
+++ b/Content.Server/Speech/Muting/MutingSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Speech;
 using Content.Shared.Speech.Muting;
 using Content.Server._Starlight.Language;
 using Content.Server._Starlight.Speech.EntitySystems; // Starlight
+using Content.Shared.StatusEffectNew; // Starlight
 
 namespace Content.Server.Speech.Muting
 {
@@ -21,6 +22,12 @@ namespace Content.Server.Speech.Muting
             SubscribeLocalEvent<MutedComponent, SpeakAttemptEvent>(OnSpeakAttempt);
             SubscribeLocalEvent<MutedComponent, EmoteEvent>(OnEmote, before: new[] { typeof(VocalSystem), typeof(MumbleAccentSystem) });
             SubscribeLocalEvent<MutedComponent, ScreamActionEvent>(OnScreamAction, before: new[] { typeof(VocalSystem) });
+            
+            // Starlight START
+            // Remove when WizDen finally migrates mute status effect to StatusEffectNew
+            SubscribeLocalEvent<MutedComponent, StatusEffectAppliedEvent>((_, _, ref args) => EnsureComp<MutedComponent>(args.Target));
+            SubscribeLocalEvent<MutedComponent, StatusEffectRemovedEvent>((_, _, ref args) => RemComp<MutedComponent>(args.Target));
+            // Starlight END
         }
 
         private void OnEmote(EntityUid uid, MutedComponent component, ref EmoteEvent args)

--- a/Content.Shared/StatusEffectNew/Components/StatusEffectComponent.cs
+++ b/Content.Shared/StatusEffectNew/Components/StatusEffectComponent.cs
@@ -33,10 +33,10 @@ public sealed partial class StatusEffectComponent : Component
     public TimeSpan? EndEffectTime;
     
     /// <summary>
-    ///     STARLIGHT: Maximum remaining duration of this status effect. Relative to now, not start time.
+    ///     STARLIGHT: Maximum duration of this status effect that it can stack up to. Relative to now, not start time.
     /// </summary>
     [DataField]
-    public TimeSpan? MaximumRemainingDuration { get; private set; }
+    public TimeSpan? MaximumDuration { get; private set; }
 
     /// <summary>
     /// If true, this status effect has been applied. Used to ensure that <see cref="StatusEffectAppliedEvent"/> only fires once.

--- a/Content.Shared/StatusEffectNew/Components/StatusEffectComponent.cs
+++ b/Content.Shared/StatusEffectNew/Components/StatusEffectComponent.cs
@@ -31,6 +31,12 @@ public sealed partial class StatusEffectComponent : Component
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, AutoNetworkedField]
     public TimeSpan? EndEffectTime;
+    
+    /// <summary>
+    ///     STARLIGHT: Maximum remaining duration of this status effect. Relative to now, not start time.
+    /// </summary>
+    [DataField]
+    public TimeSpan? MaximumRemainingDuration { get; private set; }
 
     /// <summary>
     /// If true, this status effect has been applied. Used to ensure that <see cref="StatusEffectAppliedEvent"/> only fires once.

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -297,7 +297,7 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         // Starlight START
         var uncappedEndTime = effect.Comp.EndEffectTime + delta;
         var exceedsMaximumDuration = effect.Comp.MaximumRemainingDuration != null
-            && uncappedEndTime - _timing.CurTime > effect.Comp.EndEffectTime;
+            && uncappedEndTime - _timing.CurTime > effect.Comp.MaximumRemainingDuration;
         var endTime = exceedsMaximumDuration ? _timing.CurTime + effect.Comp.MaximumRemainingDuration : uncappedEndTime;
         // Starlight END
 

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -226,6 +226,11 @@ public sealed partial class StatusEffectsSystem : EntitySystem
 
         statusEffect = effect;
 
+        // Starlight START
+        if (effectComp.MaximumRemainingDuration != null && duration > effectComp.MaximumRemainingDuration)
+            duration = effectComp.MaximumRemainingDuration;
+        // Starlight END
+        
         var endTime = delay == null ? _timing.CurTime + duration : _timing.CurTime + delay + duration;
         SetStatusEffectEndTime((effect.Value, effectComp), endTime);
         var startTime = delay == null ? TimeSpan.Zero : _timing.CurTime + delay.Value;
@@ -288,9 +293,16 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         // It's already infinitely long can't add or subtract from infinity...
         if (effect.Comp.EndEffectTime is null)
             return;
+        
+        // Starlight START
+        var uncappedEndTime = effect.Comp.EndEffectTime + delta;
+        var exceedsMaximumDuration = effect.Comp.MaximumRemainingDuration != null
+            && uncappedEndTime - _timing.CurTime > effect.Comp.EndEffectTime;
+        var endTime = exceedsMaximumDuration ? _timing.CurTime + effect.Comp.MaximumRemainingDuration : uncappedEndTime;
+        // Starlight END
 
         // Add to the current end effect time, if we're here we should have one set already, and if it's null it's probably infinite.
-        SetStatusEffectEndTime((effect, effect.Comp), effect.Comp.EndEffectTime.Value + delta);
+        SetStatusEffectEndTime((effect, effect.Comp), endTime); // Starlight: Use our endTime
     }
 
     private void SetStatusEffectEndTime(Entity<StatusEffectComponent?> ent, TimeSpan? endTime)

--- a/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectsSystem.cs
@@ -227,8 +227,8 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         statusEffect = effect;
 
         // Starlight START
-        if (effectComp.MaximumRemainingDuration != null && duration > effectComp.MaximumRemainingDuration)
-            duration = effectComp.MaximumRemainingDuration;
+        if (effectComp.MaximumDuration != null && duration > effectComp.MaximumDuration)
+            duration = effectComp.MaximumDuration;
         // Starlight END
         
         var endTime = delay == null ? _timing.CurTime + duration : _timing.CurTime + delay + duration;
@@ -296,9 +296,9 @@ public sealed partial class StatusEffectsSystem : EntitySystem
         
         // Starlight START
         var uncappedEndTime = effect.Comp.EndEffectTime + delta;
-        var exceedsMaximumDuration = effect.Comp.MaximumRemainingDuration != null
-            && uncappedEndTime - _timing.CurTime > effect.Comp.MaximumRemainingDuration;
-        var endTime = exceedsMaximumDuration ? _timing.CurTime + effect.Comp.MaximumRemainingDuration : uncappedEndTime;
+        var exceedsMaximumDuration = effect.Comp.MaximumDuration != null
+            && uncappedEndTime - _timing.CurTime > effect.Comp.MaximumDuration;
+        var endTime = exceedsMaximumDuration ? _timing.CurTime + effect.Comp.MaximumDuration : uncappedEndTime;
         // Starlight END
 
         // Add to the current end effect time, if we're here we should have one set already, and if it's null it's probably infinite.

--- a/Resources/Prototypes/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/misc.yml
@@ -70,6 +70,13 @@
   name: drowsiness
   components:
   - type: DrowsinessStatusEffect
+  # Starlight START
+  - type: StatusEffect
+    whitelist:
+      components:
+      - MobState
+  maximumRemainingDuration: 3m # <-- The only change relative to parent component definition
+  # Starlight END
 
 # Adds drugs overlay
 - type: entity
@@ -78,6 +85,13 @@
   name: hallucinations
   components:
   - type: SeeingRainbowsStatusEffect
+  # Starlight START
+  - type: StatusEffect
+    whitelist:
+      components:
+        - MobState
+    maximumRemainingDuration: 25m # <-- The only change relative to parent component definition
+  # Starlight END
 
 # Causes your vision to become blurry and gives me a headache.
 - type: entity
@@ -86,6 +100,13 @@
   name: woozy
   components:
   - type: DrunkStatusEffect
+  # Starlight START
+  - type: StatusEffect
+    whitelist:
+      components:
+        - MobState
+    maximumRemainingDuration: 25m # <-- The only change relative to parent component definition
+  # Starlight END
 
 # Causes you to get drunk
 - type: entity

--- a/Resources/Prototypes/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/misc.yml
@@ -54,7 +54,7 @@
     whitelist:
       components:
         - MobState
-    maximumRemainingDuration: 2m # <-- The only change relative to parent component definition
+    maximumDuration: 2m # <-- The only change relative to parent component definition
   # Starlight END
   - type: ForcedSleepingStatusEffect
   - type: StunnedStatusEffect
@@ -82,7 +82,7 @@
     whitelist:
       components:
       - MobState
-    maximumRemainingDuration: 3m # <-- The only change relative to parent component definition
+    maximumDuration: 3m # <-- The only change relative to parent component definition
   # Starlight END
 
 # Adds drugs overlay
@@ -97,7 +97,7 @@
     whitelist:
       components:
         - MobState
-    maximumRemainingDuration: 25m # <-- The only change relative to parent component definition
+    maximumDuration: 25m # <-- The only change relative to parent component definition
   # Starlight END
 
 # Causes your vision to become blurry and gives me a headache.
@@ -112,7 +112,7 @@
     whitelist:
       components:
         - MobState
-    maximumRemainingDuration: 25m # <-- The only change relative to parent component definition
+    maximumDuration: 25m # <-- The only change relative to parent component definition
   # Starlight END
 
 # Causes you to get drunk

--- a/Resources/Prototypes/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/misc.yml
@@ -49,6 +49,13 @@
   id: StatusEffectForcedSleeping
   name: forced sleep
   components:
+  # Starlight START
+  - type: StatusEffect
+    whitelist:
+      components:
+        - MobState
+    maximumRemainingDuration: 2m # <-- The only change relative to parent component definition
+  # Starlight END
   - type: ForcedSleepingStatusEffect
   - type: StunnedStatusEffect
   - type: KnockdownStatusEffect

--- a/Resources/Prototypes/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/misc.yml
@@ -82,7 +82,7 @@
     whitelist:
       components:
       - MobState
-  maximumRemainingDuration: 3m # <-- The only change relative to parent component definition
+    maximumRemainingDuration: 3m # <-- The only change relative to parent component definition
   # Starlight END
 
 # Adds drugs overlay

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -364,9 +364,9 @@
       - !type:ModifyStatusEffect
         effectProto: StatusEffectSeeingRainbow
         type: Add
-        time: 40 # Starlight: Liquid frezon way more potent (its denser!)
+        time: 60 # Starlight: Liquid frezon way more potent (its denser!)
       - !type:Drunk
-        boozePower: 40  # Starlight: Liquid frezon way more potent (its denser!)
+        boozePower: 30  # Starlight: Liquid frezon way more potent (its denser!)
       - !type:PopupMessage
         type: Local
         messages: [ "frezon-lungs-cold" ]
@@ -393,7 +393,7 @@
         type: Add
         time: 20  # Starlight: Down from 500 (holy shit)
       - !type:Drunk
-        boozePower: 20 # Starlight: Down from 500 (holy shit)
+        boozePower: 10 # Starlight: Down from 500 (holy shit)
         minScale: 1
       - !type:PopupMessage
         type: Local

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -356,11 +356,13 @@
   metabolisms:
     Narcotic:
       effects:
-      - !type:GenericStatusEffect
-        key: Muted
-        component: Muted
+      # Starlight BEGIN
+      # Migrated to new status system to be able to cap it. Undo when WizDen finally migrates it.
+      - !type:ModifyStatusEffect
+        effectProto: StatusEffectMuted
         type: Add
         time: 10
+      # Starlight END
 
 - type: reagent
   id: NorepinephricAcid

--- a/Resources/Prototypes/_Funkystation/Reagents/gases.yml
+++ b/Resources/Prototypes/_Funkystation/Reagents/gases.yml
@@ -202,7 +202,7 @@
         - !type:ReagentCondition
           reagent: Healium
           min: 3
-        boozePower: 150
+        boozePower: 20 # Starlight: Down from 150
         # needs to be made into hypothium to work well as a chem, use as a gas otherwise
 
 - type: reagent

--- a/Resources/Prototypes/_Starlight/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/_Starlight/Entities/StatusEffects/misc.yml
@@ -14,7 +14,7 @@
   - type: TemporaryBlindness
 
 # Upstream also does not have an updated status effect for muted. Delete this when they do,
-# but keep the "maximumRemainingDuration", that's a Starlight change.
+# but keep the "maximumDuration", that's a Starlight change.
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectMuted
@@ -26,7 +26,7 @@
           - MobState
           - Blindable
         requireAll: true
-      maximumRemainingDuration: 4m
+      maximumDuration: 4m
     - type: Muted
     - type: StatusEffectAlert
       alert: Muted
@@ -44,7 +44,7 @@
       components:
       - Shadekin
       - TheDarkImmune
-    maximumRemainingDuration: 2m 
+    maximumDuration: 2m 
   - type: DrunkStatusEffect
   - type: DrowsinessStatusEffect
     sleepIncident: false

--- a/Resources/Prototypes/_Starlight/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/_Starlight/Entities/StatusEffects/misc.yml
@@ -26,6 +26,7 @@
       components:
       - Shadekin
       - TheDarkImmune
+    maximumRemainingDuration: 2m 
   - type: DrunkStatusEffect
   - type: DrowsinessStatusEffect
     sleepIncident: false

--- a/Resources/Prototypes/_Starlight/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/_Starlight/Entities/StatusEffects/misc.yml
@@ -13,6 +13,24 @@
       requireAll: true
   - type: TemporaryBlindness
 
+# Upstream also does not have an updated status effect for muted. Delete this when they do,
+# but keep the "maximumRemainingDuration", that's a Starlight change.
+- type: entity
+  parent: MobStatusEffectDebuff
+  id: StatusEffectMuted
+  name: mute
+  components:
+    - type: StatusEffect
+      whitelist:
+        components:
+          - MobState
+          - Blindable
+        requireAll: true
+      maximumRemainingDuration: 4m
+    - type: Muted
+    - type: StatusEffectAlert
+      alert: Muted
+
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectTheDark

--- a/Resources/Prototypes/_Starlight/Entities/Tiles/dark.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Tiles/dark.yml
@@ -57,8 +57,9 @@
     - type: TileEntityEffect
       effects:
       - !type:ModifyStatusEffect
-        effectProto: StatusEffectTheDark
-        time: 5
+        effectProto: StatusEffectTheDarkMap
+        type: Add
+        time: 10
 
 
 - type: entity

--- a/Resources/Prototypes/_Starlight/Reagents/biological.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/biological.yml
@@ -50,4 +50,5 @@
           reagent: DarkBlood
           min: 10
         effectProto: StatusEffectTheDark
-        time: 1
+        type: Add
+        time: 5


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

See changelog, it has everything in it.


## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Yesterday I was in yet another shift where someone got caught in a Healium gas leak, promptly fell asleep and kept inhaling it, causing them to be drunk for 45 minutes + 300u ethylredoxrazine. This just isn't fun for anybody involved and the player reported feeling sick IRL after staring at the drunkness effect for so long.

So, I added caps for otherwise infinitely stacking status effects. This solves a lot of problems:
- Players no longer get permanently drunk/hallucinating from extended frezon/healium exposure;
- Chemicals to treat those status effects can be (and honestly already are) balanced well to the maximum effect stacks;
- Even if chem/med fails to produce the chemicals the effects will stop without destroying the entire remainder of the shift.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Cap working

https://github.com/user-attachments/assets/2935659e-8fc8-48b7-8498-d8c3bb1c100c

### Healium drunkness reduction

https://github.com/user-attachments/assets/764c984c-1475-40d2-9d68-f1aa1bce1bde

### Mute toxin change & cap working

The status effect on the right side of the screen was out of frame but it's also working correctly, even with the cap.

https://github.com/user-attachments/assets/47665b4f-37bd-46e4-8ac2-491f47bac4cf

### Ethylredoxrazine vs 25 minutes of drunkness

40-50u of this cheap chem to remove max stack drunkness.

https://github.com/user-attachments/assets/ea36c82c-17ed-4655-af8e-338901bf2f7b

### Haloperidol vs 25 minutes of hallucination

25u of this chem to remove max stack hallucinations.

https://github.com/user-attachments/assets/fb5a4ecc-e08f-4c9d-9c39-8241079e169d


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Status effects can now have caps configured to prevent stacking infinitely.
- add: "Drunk" effect now has 25 minute stack limit.
- add: "Hallucination" effect now has a 25 minute stack limit.
- add: "Drowsiness" effect now has a 3 minute stack limit.
- add: "Forced sleep" effect now has a 2 minute stack limit.
- add: "Muted" effect now has a 4 minute stack limit.
- add: "The dark" effect now has a 2 minute stack limit.
- tweak: Liquid frezon is now 50% more potent.
- tweak: Reduced Healium drunk effect stacking to sane levels.
- fix: "The dark" effect is now properly applied to non-Shadekin when visiting The Dark or metabolizing dark blood.