### PR TITLE
Bureaucratic error can no longer remove job slots

### DIFF
--- a/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
@@ -60,7 +60,7 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
                 if (_stationJobs.IsJobUnlimited(chosenStation.Value, chosenJob))
                     continue;
 
-                _stationJobs.TryAdjustJobSlot(chosenStation.Value, chosenJob, RobustRandom.Next(-3, 6), clamp: true);
+                _stationJobs.TryAdjustJobSlot(chosenStation.Value, chosenJob, RobustRandom.Next(0, 6), clamp: true); //Starlight Edit: No removing job slots - we don't have enough as it is.
             }
         }
     }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Changes Bureaucratic Error event to never remove job slots.

## Why we need to add this
We do not have enough job slots *as is*, some of the time, so having this event remove some just means people can't latejoin. Let's keep the chaos of *more* jobslots, but not lock out people from playing.

## Media (Video/Screenshots)
<img width="717" height="46" alt="image" src="https://github.com/user-attachments/assets/83748aba-ce1e-40e4-9d53-f7713d3d4f06" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- tweak: Bureaucratic errors can no longer remove job slots.
