### PR TITLE
Stops Non-Player-Controlled Holoclowns Randomly Attacking

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -255,9 +255,6 @@
     - type: RandomMetadata
       nameSegments:
       - NamesClown
-    - type: NpcFactionMember
-      factions:
-        - Syndicate
     - type: HTN
       rootTask:
         task: SimpleHumanoidHostileCompound

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -255,7 +255,7 @@
     - type: RandomMetadata
       nameSegments:
       - NamesClown
-    # - type: NpcFactionMember
+    # - type: NpcFactionMember Starlight-edit
     #  factions:
     #     - Syndicate
     - type: HTN

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -248,7 +248,7 @@
       soundHit:
         collection: BikeHorn
       damage:
-        types: 
+        types:
           Blunt: 5
     - type: Loadout
       prototypes: [ HoloClownGear ]

--- a/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/guardian.yml
@@ -248,13 +248,16 @@
       soundHit:
         collection: BikeHorn
       damage:
-        types:
+        types: 
           Blunt: 5
     - type: Loadout
       prototypes: [ HoloClownGear ]
     - type: RandomMetadata
       nameSegments:
       - NamesClown
+    # - type: NpcFactionMember
+    #  factions:
+    #     - Syndicate
     - type: HTN
       rootTask:
         task: SimpleHumanoidHostileCompound


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Removes holoclowns' Syndicate faction tag, stopping their AI from attempting to attack their host and anyone on station when not controlled by a player.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Holoclown AI currently attempts to attack their host every time they move, and when they are deployed outside their host they pick up the closest weapon and attack anyone nearby. This is because they are a member of the Syndicate faction, and are attacking all enemies of the Syndicate. 

Unfortunately, it makes it _really_ obvious when someone has a holoclown if the ghost role hasn't been taken yet. They seem to just be punching themselves a ton, and it's really loud and attention-grabbing.

I feel it should be noted that holoparasites already don't have the Syndicate faction, so this brings holoclowns in line with their counterpart.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CommanderAlex365
- fix: Stopped holoclown AI randomly attacking people.