### PR TITLE
dualweild penalty nerf for guns. and bug fixes

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -32,12 +32,12 @@ public abstract partial class SharedGunSystem
 
     private void OnAltVerb(EntityUid uid, GunComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract || !args.CanComplexInteract || args.Hands == null)
+        if (!args.CanAccess || !args.CanInteract || !args.CanComplexInteract)
             return;
 
         // 🌟Starlight🌟 — dual-wield verb: show when holding a gun in each hand
         var dualWield = EntitySystem.Get<SharedDualWieldSystem>();
-        if (dualWield.TryGetBothGuns(args.User, args.Hands, out var leftGun, out var rightGun)
+        if (dualWield.TryGetBothGuns(args.User, out var leftGun, out var rightGun)
             && (uid == leftGun || uid == rightGun))
         {
             var isActive = TryComp<DualWieldComponent>(args.User, out var dw) && dw.Active;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -161,7 +161,11 @@ public abstract partial class SharedGunSystem : EntitySystem
             return;
         }
 
-        if (gun.Owner != GetEntity(msg.Gun))
+        // 🌟Starlight🌟 — in dual-wield mode, TryGetGun already picks the correct alternating gun;
+        // skip the gun-ID match check so the server fires the right gun even when the client's
+        // NextIsLeft state hasn't synced back yet.
+        var isDualWield = TryComp<DualWieldComponent>(user.Value, out var dualWield) && dualWield.Active;
+        if (!isDualWield && gun.Owner != GetEntity(msg.Gun))
             return;
 
         if (TryComp(user, out VentCrawlerComponent? crawlerComp) //🌟Starlight🌟
@@ -170,12 +174,12 @@ public abstract partial class SharedGunSystem : EntitySystem
 
         gun.Comp.ShootCoordinates = GetCoordinates(msg.Coordinates);
         gun.Comp.Target = GetEntity(msg.Target);
-        AttemptShoot(user.Value, gun);
+        var fired = AttemptShoot(user.Value, gun);
 
-        // 🌟Starlight🌟 — dual-wield: alternate which gun fires next
-        if (TryComp<DualWieldComponent>(user.Value, out var dualWield) && dualWield.Active)
+        // 🌟Starlight🌟 — dual-wield: only alternate after an actual shot so both guns stay in sync
+        if (isDualWield && fired)
         {
-            dualWield.NextIsLeft = !dualWield.NextIsLeft;
+            dualWield!.NextIsLeft = !dualWield.NextIsLeft;
             Dirty(user.Value, dualWield);
         }
     }

--- a/Content.Shared/_Starlight/Weapons/DualWield/SharedDualWieldSystem.cs
+++ b/Content.Shared/_Starlight/Weapons/DualWield/SharedDualWieldSystem.cs
@@ -75,7 +75,10 @@ public sealed class SharedDualWieldSystem : EntitySystem
             dw.Active   = true;
             dw.LeftGun  = leftGun;
             dw.RightGun = rightGun;
-            dw.NextIsLeft = false;
+
+            // Start firing from whichever hand is currently active
+            dw.NextIsLeft = _hands.GetActiveItem(user) == leftGun;
+
             Dirty(user, dw);
             // Refresh both guns so accuracy penalties kick in
             _gun.RefreshModifiers(leftGun);
@@ -103,29 +106,33 @@ public sealed class SharedDualWieldSystem : EntitySystem
     }
 
     /// <summary>
-    /// Returns true if the user has exactly one gun in each hand (left and right).
+    /// Returns true if the user has a gun in each hand.
+    /// gun1 is always the gun in the ACTIVE hand (fires first); gun2 is the other.
+    /// Works for any two guns with CanDualWieldComponent, regardless of type.
     /// </summary>
     public bool TryGetBothGuns(
         EntityUid user,
-        HandsComponent handsComp,
-        out EntityUid leftGun,
-        out EntityUid rightGun)
+        out EntityUid gun1,
+        out EntityUid gun2)
     {
-        leftGun  = EntityUid.Invalid;
-        rightGun = EntityUid.Invalid;
+        gun1 = EntityUid.Invalid;
+        gun2 = EntityUid.Invalid;
 
-        foreach (var (handName, hand) in handsComp.Hands)
+        // EnumerateHeld starts with the active hand — so gun1 = active gun naturally.
+        foreach (var held in _hands.EnumerateHeld(user))
         {
-            var held = _hands.GetHeldItem((user, handsComp), handName);
-            if (held == null || !HasComp<GunComponent>(held.Value))
+            if (!HasComp<GunComponent>(held))
                 continue;
 
-            if (hand.Location == HandLocation.Left && leftGun == EntityUid.Invalid)
-                leftGun = held.Value;
-            else if (hand.Location == HandLocation.Right && rightGun == EntityUid.Invalid)
-                rightGun = held.Value;
+            if (gun1 == EntityUid.Invalid)
+                gun1 = held;
+            else if (gun2 == EntityUid.Invalid)
+            {
+                gun2 = held;
+                break;
+            }
         }
 
-        return leftGun != EntityUid.Invalid && rightGun != EntityUid.Invalid;
+        return gun1 != EntityUid.Invalid && gun2 != EntityUid.Invalid;
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -26,7 +26,7 @@
     tags:
     - Sidearm
   - type: CanDualWield # 🌟Starlight🌟
-    dualWieldInaccuracyPenalty: 15
+    dualWieldInaccuracyPenalty: 30
   - type: Clothing
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -49,7 +49,7 @@
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
   - type: CanDualWield # 🌟Starlight🌟
-    dualWieldInaccuracyPenalty: 25
+    dualWieldInaccuracyPenalty: 27
   - type: StaticPrice
     price: 500
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -23,6 +23,7 @@
     - suitStorage
   - type: AmmoCounter
   - type: CanDualWield # 🌟Starlight🌟
+    dualWieldInaccuracyPenalty: 68
   - type: Gun
     minAngle: 2
     maxAngle: 16


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Uh if you ask me. i forgot to add it to SMGs and it needed a nerf on where it DID exist (the dual weild penalty)

## Why we need to add this
balance. its OP as shit right now. and massively unbalanced,
especially for crew. they can dualweild WT550s and laserbeam anything.
## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl:  Scarlet Lightweaver.
- tweak: Changed the spread penalty for dualweild guns.
- fix: Fixed dualweilding mechanic and improper shooting.
