### PR TITLE
(HOTFIX) Invalid devices on Boxcars and Cork fixed

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Boxcars.yml
+++ b/Resources/Maps/_Starlight/Stations/Boxcars.yml
@@ -8614,8 +8614,6 @@ entities:
       pos: -4.5,-98.5
       parent: 3
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: DeviceLinkSink
       invokeCounter: 1
     - type: DeviceLinkSource
@@ -8710,8 +8708,6 @@ entities:
       pos: -4.5,-95.5
       parent: 3
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: DeviceLinkSink
       invokeCounter: 1
     - type: DeviceLinkSource

--- a/Resources/Maps/_Starlight/Stations/Cork.yml
+++ b/Resources/Maps/_Starlight/Stations/Cork.yml
@@ -7597,8 +7597,6 @@ entities:
       pos: 33.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: AccessReader
       accessListsOriginal:
       - - Atmospherics
@@ -8793,8 +8791,6 @@ entities:
       pos: -48.5,19.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 53
       - 4324
@@ -9076,8 +9072,6 @@ entities:
       pos: 18.5,-9.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 23
   - uid: 221
@@ -9214,8 +9208,6 @@ entities:
       pos: 20.5,11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 40
       - 4310
@@ -36552,8 +36544,6 @@ entities:
       pos: 20.5,-11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 24
       - 23
@@ -36724,8 +36714,6 @@ entities:
       pos: -46.5,20.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 53
       - 4324
@@ -36735,8 +36723,6 @@ entities:
       pos: -50.5,18.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 53
       - 4324
@@ -36746,8 +36732,6 @@ entities:
       pos: -50.5,20.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 53
       - 4324
@@ -36757,8 +36741,6 @@ entities:
       pos: -48.5,17.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 53
       - 4324
@@ -36784,8 +36766,6 @@ entities:
       pos: -21.5,21.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
   - uid: 4483
     components:
     - type: Transform
@@ -36793,8 +36773,6 @@ entities:
       pos: -16.5,26.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
   - uid: 4484
     components:
     - type: Transform
@@ -36896,8 +36874,6 @@ entities:
       pos: -4.5,17.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 4307
       - 37
@@ -36908,8 +36884,6 @@ entities:
       pos: -2.5,17.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 4307
       - 37
@@ -45667,8 +45641,6 @@ entities:
       pos: -8.5,18.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 44
     - type: AtmosPipeColor
@@ -45690,8 +45662,6 @@ entities:
       pos: 4.5,-7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 13
     - type: AtmosPipeColor
@@ -46493,8 +46463,6 @@ entities:
       pos: 18.5,-11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 23
     - type: AtmosPipeColor
@@ -46761,8 +46729,6 @@ entities:
       pos: 5.5,-7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 13
     - type: AtmosPipeColor
@@ -46839,8 +46805,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 27
   - uid: 5690
@@ -72018,8 +71982,6 @@ entities:
       pos: -12.5,21.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8636
       - 8637


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Cork and Boxcars have invalid device lists. This causes them to fail to load on release.

This wasn't caught due to tests being broken right now.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Map will fail to load without this fix.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- fix: (Boxcars) Fixed invalid devices that caused the map to fail to load.
- fix: (Cork) Fixed invalid vehicles that caused the map to fail to load.