### PR TITLE
All at Once Upkeep

### DIFF
--- a/Resources/Locale/en-US/_Starlight/gamerules.ftl
+++ b/Resources/Locale/en-US/_Starlight/gamerules.ftl
@@ -13,5 +13,5 @@ vampire-gamemode-description = Blood-drinkers in space! Don't let it get out of 
 vamptraitorling-title = Vamptraitorlings
 vamptraitorling-description = What a horrible night to have a curse
 
-all-at-once-except-zombies-title = Almost All at Once
-all-at-once-except-zombies-title = It's almost just not your day...
+all-at-once-except-zombieteors-title = Almost All at Once
+all-at-once-except-zombieteors-title = It's almost just not your day...

--- a/Resources/Locale/en-US/_Starlight/gamerules.ftl
+++ b/Resources/Locale/en-US/_Starlight/gamerules.ftl
@@ -12,3 +12,6 @@ vampire-gamemode-description = Blood-drinkers in space! Don't let it get out of 
 
 vamptraitorling-title = Vamptraitorlings
 vamptraitorling-description = What a horrible night to have a curse
+
+all-at-once-except-zombies-title = Almost All at Once
+all-at-once-except-zombies-title = It's almost just not your day...

--- a/Resources/Prototypes/_StarLight/game_presets.yml
+++ b/Resources/Prototypes/_StarLight/game_presets.yml
@@ -27,9 +27,9 @@
   - almostall
   - allnt
   - allexceptroundenders
-  name: all-at-once-except-zombies-title
+  name: all-at-once-except-zombieteors-title
   minPlayers: 15 # Starlight, for Delta
-  description: all-at-once-except-zombies-title
+  description: all-at-once-except-zombieteors-title
   showInVote: false
   rules:
     - Nukeops

--- a/Resources/Prototypes/_StarLight/game_presets.yml
+++ b/Resources/Prototypes/_StarLight/game_presets.yml
@@ -1,0 +1,51 @@
+
+- type: gamePreset
+  id: Vamptraitorling
+  alias:
+    - lingtraitorvamp
+    - traitorlingvamp
+    - vamptraitorling
+    - vamplingtraitor
+    - lingvamptraitor
+    - traitorvampling
+  name: vamptraitorling-title
+  description: vamptraitorling-description
+  showInVote: true
+  minPlayers: 50
+  rules:
+    - SLChangelingLess
+    - TraitorLess
+    - VampireLess
+    - SubGamemodesRuleVampTraitorLing
+    - BasicStationEventScheduler
+    - BasicRoundstartVariation
+
+
+- type: gamePreset
+  id: AlmostAllAtOnce
+  alias:
+  - almostall
+  - allnt
+  name: all-at-once-except-zombies-title
+  minPlayers: 15 # Starlight, for Delta
+  description: all-at-once-except-zombies-title
+  showInVote: false
+  rules:
+    - Nukeops
+    - Traitor
+    - Revolutionary
+    - Wizard
+    - Xenoborgs
+    - KesslerSyndromeScheduler
+    - RampingStationEventScheduler
+    - SLChangeling #Starlight
+    - SpaceTrafficControlEventScheduler
+    - BasicRoundstartVariation
+    - BasicRoundstartVariation # Starlight, ShitStation
+    - DerelictGenericCyborgSpawn # Starlight, ShitStation
+    - IonStorm # Starlight, ShitStation
+    - Vampire #Starlight
+    - SiliconLiberation #Starlight
+    - Brighteye #Starlight
+    - ThiefGamerule # Starlight, Event Light
+

--- a/Resources/Prototypes/_StarLight/game_presets.yml
+++ b/Resources/Prototypes/_StarLight/game_presets.yml
@@ -26,6 +26,7 @@
   alias:
   - almostall
   - allnt
+  - allexceptroundenders
   name: all-at-once-except-zombies-title
   minPlayers: 15 # Starlight, for Delta
   description: all-at-once-except-zombies-title
@@ -36,7 +37,6 @@
     - Revolutionary
     - Wizard
     - Xenoborgs
-    - KesslerSyndromeScheduler
     - RampingStationEventScheduler
     - SLChangeling #Starlight
     - SpaceTrafficControlEventScheduler

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -34,7 +34,7 @@
   alias:
   - all
   name: all-at-once-title
-  minPlayers: 40
+  minPlayers: 15 # Starlight, for Delta
   description: all-at-once-description
   showInVote: false
   rules:
@@ -49,8 +49,13 @@
     - SLChangeling #Starlight
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
+    - BasicRoundstartVariation # Starlight, ShitStation
+    - DerelictGenericCyborgSpawn # Starlight, ShitStation
+    - IonStorm # Starlight, ShitStation
     - Vampire #Starlight
-#    - SiliconLiberation #Starlight
+    - SiliconLiberation #Starlight
+    - Brighteye #Starlight
+    - ThiefGamerule # Starlight, Event Light
 
 - type: gamePreset
   id: AllerAtOnce
@@ -62,7 +67,7 @@
   name: aller-at-once-title
   description: aller-at-once-description
   showInVote: false #Please god dont do this
-  minPlayers: 40
+  minPlayers: 15 # Starlight, for Delta
   rules:
     - Nukeops
     - Traitor
@@ -71,6 +76,7 @@
     - Wizard
     - Xenoborgs
     - BasicStationEventScheduler
+    - BasicStationEventScheduler # Starlight, ShitStation
     - KesslerSyndromeScheduler
     - MeteorSwarmMildScheduler
     - MeteorSwarmScheduler
@@ -78,8 +84,23 @@
     - SpaceTrafficControlEventScheduler
     - SpaceTrafficControlFriendlyEventScheduler
     - BasicRoundstartVariation
+    - BasicRoundstartVariation # Starlight, ShitStation
+    - BasicRoundstartVariation # Starlight, ShitStation
+    - BasicRoundstartVariation # Starlight, ShitStation
+    - BasicRoundstartVariation # Starlight, ShitStation
+    - DerelictGenericCyborgSpawn # Starlight, ShitStation
+    - DerelictGenericCyborgSpawn # Starlight, ShitStation
+    - IonStorm # Starlight, ShitStation
+    - IonStorm # Starlight, ShitStation
+    - CockroachMigration # Starlight, ShitStation
+    - MouseMigration # Starlight, ShitStation
     - SLChangeling # Starlight
-#    - SiliconLiberation #Starlight
+    - SiliconLiberation #Starlight
+    - Brighteye #Starlight
+    - ThiefGamerule # Starlight, Event Light
+    - RailroadingTerminator # Starlight
+    - RailroadingMinor # Starlight
+    - NanoChatSpam # Starlight 
 
 - type: gamePreset
   id: Extended
@@ -339,29 +360,6 @@
     - SubGamemodesRuleNoChangelings #Starlight
     - BasicStationEventScheduler
     - BasicRoundstartVariation
-
-#Starlight start
-- type: gamePreset
-  id: Vamptraitorling
-  alias:
-    - lingtraitorvamp
-    - traitorlingvamp
-    - vamptraitorling
-    - vamplingtraitor
-    - lingvamptraitor
-    - traitorvampling
-  name: vamptraitorling-title
-  description: vamptraitorling-description
-  showInVote: true #Starlight
-  minPlayers: 50 #Starlight
-  rules:
-    - SLChangelingLess # Starlight
-    - TraitorLess #Starlight
-    - VampireLess # Starlight
-    - SubGamemodesRuleVampTraitorLing #Starlight
-    - BasicStationEventScheduler
-    - BasicRoundstartVariation
-#Starlight end
 
 #Starlight EventLight Gamemode for Event Usage 
 - type: gamePreset

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -100,7 +100,6 @@
     - ThiefGamerule # Starlight, Event Light
     - RailroadingTerminator # Starlight
     - RailroadingMinor # Starlight
-    - NanoChatSpam # Starlight 
 
 - type: gamePreset
   id: Extended


### PR DESCRIPTION
## Short description
Updates All at Once and Aller at Once to actually include everything relevant to their gamemodes.

## Why we need to add this
Brighteyes, SELF, Terminators, Thieves, and ShitStation were not present in All/AllerAtOnce. Also moves Vamptraitorling to a game_presets.yml file in _Starlight.

Adds a new game preset, AlmostAllAtOnce. It's All at Once without Zombies and Kessler. Might actually have a round that lasts more than 20 minutes with this...

Lowers All/Aller/AlmostAll's minpops to 15, so they can be run on Delta.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: Adds Brighteye, SELF, Thieves, and ShitStation(toned down) to AllAtOnce.
- add: Adds Brighteye, SELF, Thieves, ShitStation, RailroadingTerminator, and RailroadingMinor to AllerAtOnce.
- add: Adds a new game preset, AlmostAllAtOnce. It's AllAtOnce without Zombies and Kessler.
- tweak: Moves Vamptraitorling to _Starlight/game_presets.yml.
- tweak: Lowers minimum pop requirement for AllAtOnce, AllerAtOnce, and AlmostAllAtOnce to 15, for Delta.
