### PR TITLE
Add target slots to DamageOnEquipComponent

### DIFF
--- a/Content.Server/_Starlight/Clothing/Systems/DamageOnEquipSystem.cs
+++ b/Content.Server/_Starlight/Clothing/Systems/DamageOnEquipSystem.cs
@@ -29,10 +29,12 @@ public sealed class DamageOnEquipSystem : EntitySystem
         switch (ev)
         {
             case GotEquippedEvent equipped when comp.EquipDamage is not null:
+                if (equipped.SlotFlags != comp.TargetSlots) return;
                 target = equipped.Equipee;
                 damage = comp.EquipDamage;
                 break;
             case GotUnequippedEvent unequipped when comp.UnequipDamage is not null:
+                if (unequipped.SlotFlags != comp.TargetSlots) return;
                 target = unequipped.Equipee;
                 damage = comp.UnequipDamage;
                 break;

--- a/Content.Shared/_Starlight/Clothing/Components/DamageOnEquipComponent.cs
+++ b/Content.Shared/_Starlight/Clothing/Components/DamageOnEquipComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Damage;
+using Content.Shared.Inventory;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._Starlight.Clothing.Components;
@@ -8,6 +9,7 @@ public sealed partial class DamageOnEquipComponent : Component
 {
     [DataField] public DamageSpecifier? EquipDamage;
     [DataField] public DamageSpecifier? UnequipDamage;
+    [DataField] public SlotFlags TargetSlots;
     [DataField] public bool IgnoreResistances;
     [DataField] public bool InterruptDoAfters;
     [DataField] public bool IgnoreGlobalModifiers;

--- a/Resources/Prototypes/_Starlight/Admeme/neomoth/hatthatkillsyou.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/neomoth/hatthatkillsyou.yml
@@ -9,6 +9,7 @@
       unequipDamage:
         types:
           Slash: 2000
+      targetSlots: HEAD
       ignoreResistances: true
       delay: 4
       popupDelay: 2
@@ -24,6 +25,7 @@
       unequipDamage:
         types:
           Blunt: 2000
+      targetSlots: HEAD
       delay: 5
       popupDelay: 2.5
       popupLocId: hat-killsyou-gib
@@ -38,6 +40,7 @@
       unequipDamage:
         types:
           Heat: 99999999
+      targetSlots: HEAD
       delay: 7
       popupDelay: 3.5
       popupLocId: hat-killsyou-ash


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Forgot to make the hat that kills you only target a specific slot. It would kill you if you put it in your pocket and took it out.
This is no longer the case and it now targets your head slot specifically.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes unintended behavior
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: The Hat That Kills You If You Take It Off no longer kills you if you equip and unequip it to a slot other than your head.