### PR TITLE
Minor Corporate Law Tweak

### DIFF
--- a/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
@@ -78,6 +78,8 @@ guide-entry-sl-security-sop-parole = Parole
 guide-entry-sl-security-sop-permitacquisition = Permit Acquisiton
 guide-entry-sl-security-sop-specialsituations = Special Situations
 
+guide-entry-rules-changeling-clause = Changeling Clause
+
 guide-entry-sl-legal-sop-intro = Legal
 
 guide-entry-sl-engineering-sop-intro = Engineering

--- a/Resources/Prototypes/Guidebook/security.yml
+++ b/Resources/Prototypes/Guidebook/security.yml
@@ -29,8 +29,16 @@
   text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml"
   children:
   - SpaceLawCrimeList
+  - ChangelingClause #Starlight
 
+# Starlight Start
 - type: guideEntry
   id: SpaceLawCrimeList
   name: guide-entry-rules-sl-crime-list
   text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml"
+
+- type: guideEntry
+  id: ChangelingClause
+  name: guide-entry-rules-changeling-clause
+  text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/ChangelingClause.xml"
+#Starlight End

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/ChangelingClause.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/ChangelingClause.xml
@@ -1,0 +1,13 @@
+﻿<Document>
+  
+  [bold]This section is only avalable to characters with Secure Knowledge. Navigating the Guidebook is not an IC action and does not reveal Metashielded information.[/bold]
+  
+  ## Changelings
+
+  Codename: Parasite. Confirmed Changelings are not legally protected by Corporate Law. An individual suspected of being a Changeling may, on Code Blue or higher, be detained and forced to undergo a blood test to determine their nature. Any confirmed Changeling is to be executed and incinerated immediately. Authorization for these executions is not required, so long as blood tests have been properly performed.
+
+  Blood tests are required as legal proof that an individual is a Changeling, first hand testimony is not enough to authorize an execution. Failure to procure a valid blood test is Unlawful Execution regardless of who authorized it.
+  
+
+  [textlink="Return to Corporate Law" link="SpaceLaw"]
+</Document>

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -165,11 +165,8 @@
   - Silicon laws may only be altered to ensure the safety of the crew. A Silicon with non-standard laws is allowed to keep these laws so long as they do not pose a threat to the crew. Unbound Silicons who break Corporate Law may have their laws altered as part of their sentence.
   - Hostile Silicons of non-NanoTrasen origins are considered non-crew entities. They are afforded none of the protections under Corporate Law that other Silicons are and should be treated according to their hostility and the danger they pose.
   
-  ## Changelings
-
-  Confirmed Changelings are not legally protected by Corporate Law. An individual suspected of being a Changeling may, on Code Blue or higher, be detained and forced to undergo a blood test to determine their nature. Any confirmed Changeling is to be executed and incinerated immediately. Authorization for these executions is not required, so long as blood tests have been properly performed.
-
-  Blood tests are required as legal proof that an individual is a Changeling, first hand testimony is not enough to authorize an execution. Failure to procure a valid blood test is Unlawful Execution regardless of who authorized it.
+  ## Codename: Parasite
+  [textlink="Security Debrief. Authorized Personnel Only." link="ChangelingClause"]
   
   ## Clowns
   Clowns are permitted exemption from certain Minor crimes by the Carnival Treaties so long as the offenses are not repeated. These are; Trespass, Disturbance, Impersonation and Fraud. Per stipulations mandated by the Honkdignitaries, “You get one for free.” Back to back offenses are not protected, however repeat offenses committed over a longer period of time may be permitted depending on the policy of the station you are on.
@@ -178,6 +175,6 @@
 
   Addendum 2525 - In the event of a Cult Incursion or confirmed involvement with Giggles-at-Crimes, all Clowns on station are to undergo Tracking Implantation, and all Mimes Mind Shielding. Mind Shielded Mimes may be granted elevated security authorization to perform their duties in combating the threat of Cult of the Honkmother extremists, per the Carnival Treaties. This must be authorized by the Captain or Central Command, and Central Command must be notified.
   
-  ## Crime Listing
+  # Crime Listing
   - [textlink="Crime Listing" link="SpaceLawCrimeList"]
 </Document>


### PR DESCRIPTION
## Short description
Moved the Changeling section of the Civil Code into a new guidebook page with a disclaimer that it is only known to those with Secure Knowledge.

## Why we need to add this
There's been some concern about the Corporate Law book, which opens the guidebook page, containing Metashielded information. While we've always worked on a 'Guidebooks are non canon' policy, especially after _certain events_, this change works as a temporary fix for that. Now, you have to click off the Corporate Law page, with a big OOC disclaimer that the section you just opened isn't visible to everyone.

This does not require wiki changes as it is only for the benefit of the guidebook ingame specifically due to how it works, with a book that opens the page.

_PS: Due to early Starlight stuff just being in the upstream files a lot, this kind of needed to also be because its nested under the Security Tab and the Space Law Tab._

## Media (Video/Screenshots)
<img width="922" height="718" alt="image" src="https://github.com/user-attachments/assets/581a7bc6-8324-4890-93c4-cfcd8419e63b" />

<img width="916" height="710" alt="image" src="https://github.com/user-attachments/assets/79804928-78f0-4bfb-9d52-04c21fff9f3e" />

Ignore the missing locale file, I fixed that I just don't feel like spending 5 minutes booting up the server and client again to screenshot it again.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Moved the Changeling section of the Corporate Law guidebook page into a new page, accessed by clicking a link where the old section used to be. The link/page it sends you to both state that only characters with Secure Knowledge know the information. This is so the main page, opened by a book in game, can be 99% IC/Canon and not break metashield.

