### PR TITLE
BSO Tweaks w/ X-01 Changes

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -45,7 +45,7 @@
     NTRepBriefcaseSecureStealObjective: 0.75 # Same as most NT Rep stuff.
     BSOHardsuitStealObjective: 0.75 # Same as the above...
     BSOMagbootsStealObjective: 0.75 # Easier to hide, at least.
-    BSOWeaponStealObjective: 0.75 # Blue shield weapons. It's easier to steal the SP8T since they don't always carry it around, and guaranteed to exist.
+    BSOWeaponStealObjective: 0.5 # Steal the Blueshield's X-01. Always exists in their locker.
     CorporateSecretsStealObjective: 0.75 #Starlight Unique Target
     CriminalReportsStealObjective: 0.75 #Starlight Unique Target
     SecureKnowledgeStealObjective:  0.75 #Starlight Unique Target

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -45,7 +45,7 @@
     NTRepBriefcaseSecureStealObjective: 0.75 # Same as most NT Rep stuff.
     BSOHardsuitStealObjective: 0.75 # Same as the above...
     BSOMagbootsStealObjective: 0.75 # Easier to hide, at least.
-    BSOWeaponStealObjective: 0.5 # Steal the Blueshield's X-01. Always exists in their locker.
+    BSOWeaponStealObjective: 0.75 # Blue Shield weapons. Includes the X-01 and SP8T.
     CorporateSecretsStealObjective: 0.75 #Starlight Unique Target
     CriminalReportsStealObjective: 0.75 #Starlight Unique Target
     SecureKnowledgeStealObjective:  0.75 #Starlight Unique Target

--- a/Resources/Prototypes/_Starlight/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Fills/Items/belt.yml
@@ -68,11 +68,13 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - id: Handcuffs
-        - id: Handcuffs
         - id: Stunbaton
+        - id: Handcuffs
+        - id: Handcuffs
         - id: GrenadeFlashBang
         - id: TearGasGrenade
+        - id: MagazinePistol40SP
+          amount: 2
         - id: MedkitCombatFilled
 
 - type: entity
@@ -84,11 +86,13 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - id: Handcuffs
-        - id: Handcuffs
         - id: Stunbaton
+        - id: Handcuffs
+        - id: Handcuffs
         - id: GrenadeFlashBang
         - id: TearGasGrenade
+        - id: MagazinePistol40SP
+          amount: 2
         - id: MedkitCombatFilled
 
 

--- a/Resources/Prototypes/_Starlight/Catalog/Fills/Lockers/representatives.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Fills/Lockers/representatives.yml
@@ -100,7 +100,7 @@
           tableId: CriminalDocumentTable
 
 - type: entity
-  id: LockerBSOFilled
+  id: LockerBlueshieldFilled
   categories: [ ShouldMapStation ]
   suffix: Filled
   parent: LockerBlueshield
@@ -111,13 +111,11 @@
         children:
         - id: FlashlightSeclite
         - id: ClothingHandsGlovesCombat
-        - id: ClothingShoesBootsCombat
+        - id: ClothingShoesBootsJack
         - id: TrackingImplanter
           amount: 3
         - id: MedkitAdvancedFilled
-        - id: WeaponPistolSP8T
-        - id: MagazinePistol40SP
-          amount: 2
+        - id: WeaponMultiphaseGun
         - id: ClothingEyesGlassesBlueShield
         - id: ClothingEyesHudBlueShield
         - id: ClothingHeadHatBeretBlueShield
@@ -135,9 +133,9 @@
         - id: RubberStampBSO
 
 - type: entity
-  id: LockerBSOFilledBluespaced
+  id: LockerBlueshieldFilledBluespaced
   suffix: Filled, Bluespaced
-  parent: LockerBSOFilled
+  parent: LockerBlueshieldFilled
   categories: [ Spawner ]
   components:
   - type: TriggerOnSpawn

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Belt/belts.yml
@@ -123,7 +123,7 @@
   - type: Clothing
     sprite: _Starlight/Clothing/Belt/blueshieldwebbing.rsi
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.1
 
 - type: entity
   parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseBlueShieldContraband]
@@ -140,7 +140,7 @@
   - type: Clothing
     sprite: _Starlight/Clothing/Belt/blueshieldmedicalbelt.rsi
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.1
 
 - type: entity
   parent: [ClothingBeltBrigmedic]

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -271,7 +271,7 @@
       fireCost: 75
       magState: kill
       visualState: kill-unshaded
-    - proto: DestroyBeam
+    - proto: DestructionBeam
       fireCost: 100
       magState: destroy
       visualState: destroy-unshaded

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -272,7 +272,7 @@
       magState: kill
       visualState: kill-unshaded
     - proto: DestroyBeam
-      fireCost: 750
+      fireCost: 100
       magState: destroy
       visualState: destroy-unshaded
   - type: Battery

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -180,7 +180,7 @@
         - ""
         - dust
     - type: StealTarget
-      stealGroup: OfficerHandgun
+      stealGroup: BSOWeapon
       
 - type: entity
   name: sp-8ar

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -180,8 +180,8 @@
         - ""
         - dust
     - type: StealTarget
-      stealGroup: BSOWeapon
-
+      stealGroup: OfficerHandgun
+      
 - type: entity
   name: sp-8ar
   parent: [WeaponPistolDP, BaseSecurityContraband]

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -1294,13 +1294,13 @@
 - type: entity
   id: DestroyBeam
   name: destroying beam
-  parent: EnergyTrace
+  parent: BasicHitscanNoBeam
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
     damage:
       types:
-        Structural: 100
+        Heat: 60
   - type: HitscanBasicVisuals
     muzzleFlash:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
@@ -1693,4 +1693,29 @@
       sprite:
         sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
         state: fmj
+
+- type: entity
+  id: DestructionBeam
+  name: destruction beam
+  parent: EnergyTrace
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: HitscanBasicDamage
+      damage:
+        types:
+          Structural: 100
+    - type: HitscanBasicVisuals
+      muzzleFlash:
+        sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+        state: muzzle_blue
+      travelFlash:
+        sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+        state: beam_blue
+      impactFlash:
+        sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+        state: impact_blue
+
+
 # Starlight
+
+

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -1294,13 +1294,13 @@
 - type: entity
   id: DestroyBeam
   name: destroying beam
-  parent: BasicHitscanNoBeam
+  parent: EnergyTrace
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
     damage:
       types:
-        Heat: 60
+        Structural: 100
   - type: HitscanBasicVisuals
     muzzleFlash:
       sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi

--- a/Resources/Prototypes/_Starlight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/loadout_groups.yml
@@ -503,6 +503,7 @@
   minLimit: 0
   defaultSelected: 1
   loadouts:
+  - JackBoots
   - CombatBoots
   - HighHeelBootsFilled
 

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representives/blueshield.yml
@@ -61,8 +61,8 @@
     # id: BlueShieldPDA
     ears: ClothingHeadsetAltBSO # Starlight
     # belt: ClothingBeltBlueShieldWebbingFilled
-    pocket1: WeaponMultiphaseGun
-    pocket2: HandheldBSOCrewMonitor
+    pocket1: HandheldBSOCrewMonitor
+    pocket2: WeaponPistolSP8T
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representives/blueshield.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representives/blueshield.yml
@@ -61,8 +61,8 @@
     # id: BlueShieldPDA
     ears: ClothingHeadsetAltBSO # Starlight
     # belt: ClothingBeltBlueShieldWebbingFilled
-    pocket1: HandheldBSOCrewMonitor
-    pocket2: WeaponPistolSP8T
+    pocket1: WeaponPistolSP8T
+    pocket2: HandheldBSOCrewMonitor
   storage:
     back:
     - Flash

--- a/Resources/_Starlight/migration.yml
+++ b/Resources/_Starlight/migration.yml
@@ -56,3 +56,6 @@ CrateStarterXenobiology: null
 
 #2026-02-15
 ClothingOuterArmorSovietFlak: ClothingOuterArmorSovietPlate
+
+#2026-03-06
+LockerBSOFilled: LockerBlueshieldFilled


### PR DESCRIPTION
## Short description
Adjusted a few things for Blueshields equipment:

- Belt now looks cleaner with the stunbaton at the front.
- Belt now holds the two pistol mags for the sp-8t on spawn.
- BSOs now come with the sp-8t in their pocket rather than their X-01.
- X-01 now spawns in the BSO locker for thieving targets and other shenanigans. - [1]
- X-01 DestroyBeam now does 100 structual instead of 60 heat. - [2]
- X01 DestroyBeam has 15 shots - [2]
- BSOs now can spawn with Jackboots. - [3]
- BSO lockers now comes with jackboots rather than combat boots.
- Thieves now need to steal the X-01 instead of the sp-8t when doing BSOWeaponStealObjective
- Thieves can now steal the SP-8t as an alternative for stealing an officers gun for OfficerHandgunsStealCollectionObjective

## Why we need to add this

[1] - It was odd that all other characters must get their powerful weapon yet BSO always spawned with theirs, with a possible thieving target. It also meant that two BSOs spawning means the BSO can duel wield a super powerful weapon. wew boy

[2] - The BSO is usually supposed to be a bodyguard. It isn't super enjoyable to have a beam that can completely two shot anyone in a second (0.5 seconds per shot) with 120 heat. I thought it would be more fitting for the BSO to have an escape tool to move their protection targets into areas such as through walls into maints from other departments etc. 

The gun now has 15 shots that deal 100 each, which can take out a wall in 7 shots, a reinforced wall in a mag + 2 recharges (including the fact the gun keeps recharging as you shoot), an airlock in 5 shots, and hits glass windows rather than going through them.

Might make the shot do 5 heat damage cause it might be funny, not sure.

[3] - A lot of maps would give a dresser or Jackboots to BSOs while others didn't. This made it so you practically just had to go grab one from security. You are a station protector, as the slowdown was mostly given to station protectors to combat major threats. Aka why nukies usually don't have them (vanilla style, for wizden). Felt it was right to finally give them the option but didn't remove them from the loadout so people can still be absolutely stylish.

## Media (Video/Screenshots)
<img width="865" height="799" alt="Screenshot_20260306_223522" src="https://github.com/user-attachments/assets/c920c8ff-5f8f-4ce5-9a41-9bea870a4cea" />
<img width="380" height="570" alt="Screenshot_20260306_223620-2" src="https://github.com/user-attachments/assets/26fba5b7-22d0-46a3-84c3-4792f1d5ac8b" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Coolsurf6
- tweak: BSO Belts have been cleaned up.
- tweak: BSOs now spawn with their SP-8T instead of their X-01.
- tweak: Two pistol mags of .40 now spawn in BSO belts rather than their locker.
- tweak: X-01 now spawns in the BSO lockers.
- tweak: X-01 Destroy Beam now does 100 structural with 15 shots to take down walls and airlocks.
- tweak: BSO Lockers now spawn with jackboots instead of combat boots.
- add: BSOs can now spawn with Jackboots.
- tweak: Stealing the BSO weapon now only allows for the X-01 as the target.
- tweak: Stealing officer weapons now accepts the sp-8t as a valid target.