### PR TITLE
Added Nitric Acid blood for Cyclorites

### DIFF
--- a/Resources/Locale/en-US/_Starlight/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_Starlight/reagents/meta/biological.ftl
@@ -9,3 +9,6 @@ reagent-desc-resomi-blood = Smells like piss.
 
 reagent-name-dark-blood = dark blood
 reagent-desc-dark-blood = The blood from a creature of The Dark.
+
+reagent-name-cyclorite-blood = diluted nitric acid blood
+reagent-desc-cyclorite-blood = Feels slightly acidic.

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -180,7 +180,7 @@
       - !type:ModifyBloodLevel
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Arachnid ]
+          type: [ Arachnid, Cyclorite ]
           inverted: true
         amount: 0.4
   

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -232,6 +232,9 @@
         damage:
           types:
             Cold: 0.5 # liquid nitrogen is cold
+        conditions:
+          - !type:MetabolizerTypeCondition
+            type: [ Cyclorite ]
     Gas:
       effects:
       - !type:Oxygenate
@@ -253,6 +256,13 @@
         ratios:
           NitrousOxide: 1.0
           Nitrogen: -1.0
+    Medicine:
+      effects:
+        - !type:ModifyBloodLevel
+          conditions:
+            - !type:MetabolizerTypeCondition
+              type: [ Cyclorite ]
+          amount: 0.4
 
 - type: reagent
   id: NitrousOxide

--- a/Resources/Prototypes/Recipes/Reactions/biological.yml
+++ b/Resources/Prototypes/Recipes/Reactions/biological.yml
@@ -94,3 +94,18 @@
     Mold: 2
     Protein: 1
     Toxin: 1
+
+- type: reaction
+  id: CycloriteBloodBreakdown
+  source: true
+  requiredMixerCategories:
+    - Centrifuge
+  reactants:
+    SulfurBlood:
+      amount: 20
+  products:
+    Nitrogen: 3
+    Hydrogen: 3
+    Oxygen: 9
+    CarbonDioxide: 1
+    Protein: 4

--- a/Resources/Prototypes/Recipes/Reactions/biological.yml
+++ b/Resources/Prototypes/Recipes/Reactions/biological.yml
@@ -101,7 +101,7 @@
   requiredMixerCategories:
     - Centrifuge
   reactants:
-    SulfurBlood:
+    CycloriteBlood:
       amount: 20
   products:
     Nitrogen: 3

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -245,7 +245,8 @@
     - Sap # Starlight-start
     - AvaliBlood
     - DarkBlood
-    - ResomiBlood # Starlight-end
+    - ResomiBlood 
+    - CycloriteBlood # Starlight-end
 
 - type: xenoArchTrigger
   id: TriggerThrow

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/cyclorites.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/cyclorites.yml
@@ -71,7 +71,7 @@
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:
-      - ReagentId: NitricAcidBlood
+      - ReagentId: CycloriteBlood
         Quantity: 300
   - type: MovementSpeedModifierScale
     movementSpeedScale: 0.5

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/cyclorites.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/cyclorites.yml
@@ -55,7 +55,7 @@
     damageOverlayGroups:
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
-        color: "#7a8bf2"
+        color: "#9457eb"
   - type: MeleeWeapon
     soundHit:
       collection: AlienClaw
@@ -71,7 +71,7 @@
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:
-      - ReagentId: CopperBlood
+      - ReagentId: NitricAcidBlood
         Quantity: 300
   - type: MovementSpeedModifierScale
     movementSpeedScale: 0.5

--- a/Resources/Prototypes/_Starlight/Reagents/biological.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/biological.yml
@@ -52,3 +52,14 @@
         effectProto: StatusEffectTheDark
         type: Add
         time: 5
+
+- type: reagent
+  parent: Blood
+  id: CycloriteBlood
+  name: reagent-name-cyclorite-blood
+  group: Biological
+  desc: reagent-desc-cyclorite-blood
+  flavor: acidic
+  color: "#9457eb"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-strong-smelling

--- a/Resources/Prototypes/_Starlight/Reagents/biological.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/biological.yml
@@ -78,7 +78,7 @@
           ignoreResistances: false
           damage:
             types:
-              Caustic: 1
+              Caustic: 0.1
         - !type:Emote
           emote: Scream
           probability: 0.1
@@ -88,7 +88,7 @@
           inverted: true
   metabolisms:
     Poison:
-      metabolismRate: 1.00 # slightly faster metabolism
+      metabolismRate: 1.00 # slightly faster metabolism for an acid
       effects:
         - !type:HealthChange
           damage:

--- a/Resources/Prototypes/_Starlight/Reagents/biological.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/biological.yml
@@ -59,7 +59,7 @@
   name: reagent-name-cyclorite-blood
   group: Biological
   desc: reagent-desc-cyclorite-blood
-  flavor: acidic
+  flavor: acid
   color: "#9457eb"
   recognizable: true
   physicalDesc: reagent-physical-desc-strong-smelling
@@ -79,13 +79,17 @@
           damage:
             types:
               Caustic: 0.1
+          conditions:
+          - !type:MetabolizerTypeCondition
+            type: [ Cyclorite ]
+            inverted: true
         - !type:Emote
           emote: Scream
           probability: 0.1
-      conditions:
-        - !type:MetabolizerTypeCondition
-          type: [ Cyclorite ]
-          inverted: true
+          conditions:
+          - !type:MetabolizerTypeCondition
+            type: [ Cyclorite ]
+            inverted: true
   metabolisms:
     Poison:
       metabolismRate: 1.00 # slightly faster metabolism for an acid

--- a/Resources/Prototypes/_Starlight/Reagents/biological.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/biological.yml
@@ -63,3 +63,54 @@
   color: "#9457eb"
   recognizable: true
   physicalDesc: reagent-physical-desc-strong-smelling
+  plantMetabolism:
+    - !type:PlantAdjustToxins
+      amount: 5
+    - !type:PlantAdjustWeeds
+      amount: -1
+    - !type:PlantAdjustHealth
+      amount: -2
+  reactiveEffects:
+    Acidic:
+      methods: [ Touch ]
+      effects:
+        - !type:HealthChange
+          ignoreResistances: false
+          damage:
+            types:
+              Caustic: 1
+        - !type:Emote
+          emote: Scream
+          probability: 0.1
+      conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Cyclorite ]
+          inverted: true
+  metabolisms:
+    Poison:
+      metabolismRate: 1.00 # slightly faster metabolism
+      effects:
+        - !type:HealthChange
+          damage:
+            types:
+              Caustic: 1
+          conditions:
+            - !type:MetabolizerTypeCondition
+              type: [ Cyclorite ]
+              inverted: true
+        - !type:PopupMessage
+          type: Local
+          visualType: Large
+          messages: [ "generic-reagent-effect-burning-insides" ]
+          probability: 0.2
+          conditions:
+            - !type:MetabolizerTypeCondition
+              type: [ Cyclorite ]
+              inverted: true
+        - !type:Emote
+          emote: Scream
+          probability: 0.2
+          conditions:
+            - !type:MetabolizerTypeCondition
+              type: [ Cyclorite ]
+              inverted: true

--- a/Resources/Prototypes/_Starlight/Reagents/biological.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/biological.yml
@@ -96,7 +96,7 @@
               Caustic: 1
           conditions:
             - !type:MetabolizerTypeCondition
-              type: [ Cyclorite ]
+              type: [ Cyclorite, Bloodsucker ]
               inverted: true
         - !type:PopupMessage
           type: Local
@@ -105,12 +105,22 @@
           probability: 0.2
           conditions:
             - !type:MetabolizerTypeCondition
-              type: [ Cyclorite ]
+              type: [ Cyclorite, Bloodsucker ]
               inverted: true
         - !type:Emote
           emote: Scream
           probability: 0.2
           conditions:
             - !type:MetabolizerTypeCondition
-              type: [ Cyclorite ]
+              type: [ Cyclorite, Bloodsucker ]
               inverted: true
+    Medicine:
+      effects:
+        - !type:HealthChange
+          conditions:
+            - !type:MetabolizerTypeCondition
+              type: [ Bloodsucker ]
+          damage:
+            groups:
+              Brute: -3
+              Burn: -1.25


### PR DESCRIPTION
## Short description
Added a new blood type for Cyclorites, nitric acid!

This type of blood is also slightly damaging, but only to those who aren't cyclorites (duh). It isn't an extreme amount as it technically would be a replenishing source of caustic damage, so it's diluted instead. Does mean slipping on it slightly burns though!

## Why we need to add this
More species are getting unique blood types, more fancy colours for all wakes of life. 

## Media (Video/Screenshots)
<img width="384" height="479" alt="image" src="https://github.com/user-attachments/assets/d0e4ecaf-c75a-4e97-bbf2-bfa6869a630d" />
<img width="537" height="297" alt="image" src="https://github.com/user-attachments/assets/74977b9b-8be2-4bfa-bea6-1e1411086bb1" />
<img width="534" height="269" alt="image" src="https://github.com/user-attachments/assets/f3e8c183-6ccb-4068-95d9-a3fc493239de" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Coolsurf6
- add: Cyclorites now come with diluted nitric acid blood.
- tweak: Cyclorites now need nitrogen instead of iron to regenerate blood and don't take cold damage from it.
