### PR TITLE
Adds soviet EVA to commie rift

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Objects/Specific/soviet_armaments_crate.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Specific/soviet_armaments_crate.yml
@@ -35,6 +35,8 @@
         - id: EmagCommie
           weight: 1
         - id: ClothingOuterArmorSovietPlate
+          weight: 5
+        - id: ClothingBackpackDuffelSovietEVABundle
           weight: 3
         - id: WeaponShotgunToz106Extended
           weight: 6


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds EVA suits to the rev rift

## Why we need to add this
its never used. its meant for revs. no reason not to. it dosnt have much armor. and revs die easily from spacing

## Media (Video/Screenshots)
NA
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: Scarlet Lightweaver
- add: Added the soviet EVA softsuit to the rev rift!.
- remove: Removed herobrine.
