### PR TITLE
REnames the railgun due to lore conflicts.

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/charon_ammo.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/charon_ammo.yml
@@ -1,11 +1,11 @@
-# Starlight - M321-CHARON 'Thanatos' 280mm Railgun Ammunition
+# Starlight - M321-CHARYBDIS 'Thanatos' 280mm Railgun Ammunition
 
-# Base Charon 280mm cartridge (abstract)
+# Base Charybdis 280mm cartridge (abstract)
 - type: entity
   abstract: true
   parent: [BaseItem, BaseMajorContraband]
   id: BaseCharon280mmCartridge
-  name: base 280mm Charon cartridge
+  name: base 280mm Charybdis cartridge
   components:
   - type: Tag
     tags:
@@ -13,14 +13,14 @@
   - type: Item
     size: Huge
 
-# M381 CHARON 280mm 26.5kg Slug
+# M381 CHARYBDIS 280mm 26.5kg Slug
 # A massive kinetic penetrator. Pierces through targets and structures before detonating.
 - type: entity
   parent: BaseCharon280mmCartridge
   id: CartridgeCharon280mmSlug
-  name: M381 CHARON 280mm 26.5kg slug
+  name: M381 CHARYBDIS 280mm 26.5kg slug
   description: >-
-    A 26.5 kilogram depleted-tungsten penetrator round for the M321-CHARON 'Thanatos' railgun system.
+    A 26.5 kilogram depleted-tungsten penetrator round for the M321-CHARYBDIS 'Thanatos' railgun system.
     The slug punches through multiple targets and structural layers before its delayed fuse detonates.
     Handle with extreme care. Requires manual chamber loading.
   suffix: Slug
@@ -40,14 +40,14 @@
   - type: StaticPrice
     price: 2000
 
-# M381 CHARON 280mm 40KG Subnuclear Slug
+# M381 CHARYBDIS 280mm 40KG Subnuclear Slug
 # A subnuclear warhead. Detonates on impact with a catastrophic area-of-effect blast.
 - type: entity
   parent: BaseCharon280mmCartridge
   id: CartridgeCharon280mmSubnuclear
-  name: M381 CHARON 280mm 40kg subnuclear slug
+  name: M381 CHARYBDIS 280mm 40kg subnuclear slug
   description: >-
-    A 40 kilogram subnuclear warhead packaged as a railgun slug for the M321-CHARON 'Thanatos' system.
+    A 40 kilogram subnuclear warhead packaged as a railgun slug for the M321-CHARYBDIS 'Thanatos' system.
     Detonates on first contact, producing a massive subnuclear detonation with significant residual radiation.
     RESTRICTED to authorized combat operations only. Requires manual chamber loading.
   suffix: Subnuclear

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/charon_projectiles.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/charon_projectiles.yml
@@ -1,10 +1,10 @@
-# Starlight - M321-CHARON 'Thanatos' 280mm Railgun Projectiles
+# Starlight - M321-CHARYBDIS 'Thanatos' 280mm Railgun Projectiles
 
-# M381 CHARON 280mm 26.5kg Slug
+# M381 CHARYBDIS 280mm 26.5kg Slug
 # Pierces through soft targets while dealing massive kinetic damage, then detonates.
 - type: entity
   id: BulletCharon280mmSlug
-  name: M381 CHARON 280mm slug
+  name: M381 CHARYBDIS 280mm slug
   parent: BaseBulletTrigger
   categories: [ HideSpawnMenu ]
   components:
@@ -36,11 +36,11 @@
     scale: 1.2
     requireInSpace: true
 
-# M381 CHARON 280mm 40KG Subnuclear Slug
+# M381 CHARYBDIS 280mm 40KG Subnuclear Slug
 # Does not pierce - detonates on first impact with a devastating subnuclear explosion.
 - type: entity
   id: BulletCharon280mmSubnuclear
-  name: M381 CHARON 280mm subnuclear slug
+  name: M381 CHARYBDIS 280mm subnuclear slug
   parent: BaseBulletTrigger
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Shuttles/shuttle_cannons.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Shuttles/shuttle_cannons.yml
@@ -204,12 +204,12 @@
   - type: StaticPrice
     price: 6000
 
-# M321-CHARON 'Thanatos' 280mm Railgun - Single-shot, manually loaded, extreme damage
+# M321-CHARYBDIS 'Thanatos' 280mm Railgun - Single-shot, manually loaded, extreme damage
 - type: entity
   id: ShuttleGunCharon
   parent: ShuttleGunBase
-  name: M321-CHARON 'Thanatos' 280mm Railgun
-  description: A single-shot electromagnetic railgun of unparalleled destructive capability. Accelerates a 280mm slug to devastating velocities. Requires manual loading of each round into the open chamber before firing. Named for the ferryman of the dead - because that is what you become upon encountering one.
+  name: M321-CHARYBDIS 'Thanatos' 280mm Railgun
+  description: A single-shot electromagnetic railgun of unparalleled destructive capability. Accelerates a 280mm slug to devastating velocities. Requires manual loading of each round into the open chamber before firing. Named for the devouring whirlpool of legend - because that is what awaits those who face one.
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Shuttleguns/Charon.rsi


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Renames the shuttle railgun due to lore conflicts.
did not change IDs due to shuttles that are ingame having it. and it would mess it up BADLY
## Why we need to add this
Request of @Grapegifter  head of staff
## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: Scarlet Lightweaver
- tweak: Changed the ship railguns name.