### PR TITLE
Rename Binary to EAL

### DIFF
--- a/Resources/Prototypes/_Starlight/datasets.yml
+++ b/Resources/Prototypes/_Starlight/datasets.yml
@@ -1214,7 +1214,7 @@
   values:
   - Galactic Common
   - Sol Common
-  - Encrypted Audio Language
+  - Encoded Audio Language
   - Canilunzt
   - Bubblish
   - Chittin

--- a/Resources/Prototypes/_Starlight/datasets.yml
+++ b/Resources/Prototypes/_Starlight/datasets.yml
@@ -1214,7 +1214,7 @@
   values:
   - Galactic Common
   - Sol Common
-  - Binary
+  - Encrypted Audio Language
   - Canilunzt
   - Bubblish
   - Chittin


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
The language silicons use is called EAL not binary. Binary is the channel/hivemind they talk on.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Pedantic correct is the best kind of correct


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: SiTW
- fix: Binary is now correctly called EAL in thaven moods.

