### PR TITLE
Fix Vox dying very quickly to max pressure oxygen

### DIFF
--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -222,6 +222,7 @@ public sealed class MetabolizerSystem : SharedMetabolizerSystem
                 {
                     if (scale < effect.MinScale)
                         continue;
+                    scale = Math.Min(scale, effect.MaxScale ?? scale); // Starlight
 
                     if (effect.Probability < 1.0f && !_random.Prob(effect.Probability))
                         continue;

--- a/Content.Shared/EntityEffects/EntityEffect.cs
+++ b/Content.Shared/EntityEffects/EntityEffect.cs
@@ -22,6 +22,12 @@ public abstract partial class EntityEffect
     public virtual float MinScale { get; private set; }
 
     /// <summary>
+    /// STARLIGHT: If our scale is greater than this value, the effect is clamped.
+    /// </summary>
+    [DataField]
+    public virtual float? MaxScale { get; private set; }
+
+    /// <summary>
     /// If true, then it allows the scale multiplier to go above 1.
     /// </summary>
     [DataField]

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -62,6 +62,7 @@
         - !type:MetabolizerTypeCondition
           type: [ Vox ]
         ignoreResistances: true
+        maxScale: 16 # Starlight: Cap damage per breath, no more instant death
         damage:
           types:
             Poison: 0.7


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

- Adds MaxScale on reagent HealthModifiers to better control absurd inhalation amounts (think: Healium)
- Set sensible MaxScale on Vox-breathing-oxygen damage.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

- If you set an oxygen tank or similar to max output pressure you'll deal a very high amount of damage per breath, much higher than you normally might get.

- By adding this to the engine some other peeps have an easier time making making Healium more reasonable (not me working on that PR but they want the MaxScale as well).

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Coming

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ ] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Added hard cap on how much damage Voxes take per oxygen breath.

