### PR TITLE
(Lobster) Removes voidpack spawn from Medical Maints

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Lobster.yml
+++ b/Resources/Maps/_Starlight/Stations/Lobster.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 02/22/2026 12:49:17
+  time: 03/06/2026 21:18:01
   entityCount: 24898
 maps:
 - 1
@@ -6282,9 +6282,11 @@ entities:
             1: 32818
             0: 8
           -1,-8:
-            0: 56784
+            0: 52688
+            2: 4096
           -1,-7:
-            0: 32713
+            2: 1
+            0: 32712
           -1,-6:
             0: 65295
           -1,-9:
@@ -6558,7 +6560,8 @@ entities:
           -11,-5:
             0: 59596
           -10,-4:
-            0: 36863
+            0: 36607
+            2: 256
           -10,-3:
             0: 63624
             1: 34
@@ -7191,31 +7194,31 @@ entities:
             0: 4497
             1: 17472
           10,4:
-            2: 5
+            3: 5
             1: 3840
           10,5:
             0: 36863
           10,6:
             0: 48051
           10,3:
-            2: 20480
+            3: 20480
             0: 255
           11,4:
-            2: 3
+            3: 3
             1: 3840
-            3: 8
+            4: 8
           11,5:
             0: 65535
           11,6:
             0: 65531
           11,3:
-            2: 12288
-            3: 32768
+            3: 12288
+            4: 32768
             0: 255
           12,4:
-            3: 1
+            4: 1
             1: 3840
-            2: 12
+            3: 12
           12,6:
             0: 65535
           12,7:
@@ -7254,8 +7257,8 @@ entities:
             0: 65535
           12,3:
             0: 255
-            3: 4096
-            2: 49152
+            4: 4096
+            3: 49152
           12,5:
             0: 3822
           13,5:
@@ -7265,15 +7268,15 @@ entities:
           13,7:
             0: 56719
           13,4:
-            2: 238
+            3: 238
             1: 57344
           13,8:
             0: 221
           13,3:
-            2: 57344
+            3: 57344
             0: 255
           14,4:
-            2: 3
+            3: 3
             0: 60928
             1: 8
           14,5:
@@ -7320,22 +7323,22 @@ entities:
           13,0:
             0: 3822
           13,1:
-            4: 1632
+            5: 1632
           13,-1:
             0: 57344
-            5: 238
+            6: 238
           14,0:
             0: 57906
             1: 3276
           14,1:
-            6: 816
+            7: 816
             1: 34944
           14,2:
             0: 65527
             1: 8
           14,-1:
             0: 60620
-            5: 19
+            6: 19
           15,0:
             0: 56797
           15,2:
@@ -7549,7 +7552,7 @@ entities:
             0: 39935
             1: 25600
           13,-2:
-            5: 65256
+            6: 65256
           13,-5:
             0: 65535
           14,-4:
@@ -7559,7 +7562,7 @@ entities:
             0: 52479
             1: 13056
           14,-2:
-            5: 4368
+            6: 4368
             0: 52428
           14,-5:
             0: 65535
@@ -8190,7 +8193,8 @@ entities:
             0: 60544
             1: 18
           0,-14:
-            0: 65535
+            0: 57343
+            2: 8192
           -1,-14:
             0: 52991
           0,-13:
@@ -8291,6 +8295,11 @@ entities:
           moles:
             Oxygen: 21.824879
             Nitrogen: 82.10312
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+            Oxygen: 20.078888
+            Nitrogen: 75.53487
         - volume: 2500
           temperature: 293.15
           moles: {}
@@ -9400,7 +9409,7 @@ entities:
       pos: -1.5,5.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -26234.38
+      secondsUntilStateChange: -26623.586
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9633,7 +9642,7 @@ entities:
       pos: 67.5,48.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -63054.715
+      secondsUntilStateChange: -63443.918
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10095,7 +10104,7 @@ entities:
       pos: 87.5,-23.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -114194.91
+      secondsUntilStateChange: -114584.11
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -65758,7 +65767,7 @@ entities:
       parent: 2
     - type: ItemPlacer
       placedEntities:
-      - 17405
+      - 17404
     - type: PlaceableSurface
       isPlaceable: False
 - proto: ChemMaster
@@ -68262,10 +68271,10 @@ entities:
       pos: -59.5,40.5
       parent: 2
     - type: AnalysisConsole
-      analyzerEntity: 17533
+      analyzerEntity: 17531
     - type: DeviceLinkSource
       linkedPorts:
-        17533:
+        17531:
         - - ArtifactAnalyzerSender
           - ArtifactAnalyzerReceiver
   - uid: 11268
@@ -68274,10 +68283,10 @@ entities:
       pos: -54.5,37.5
       parent: 2
     - type: AnalysisConsole
-      analyzerEntity: 17534
+      analyzerEntity: 17532
     - type: DeviceLinkSource
       linkedPorts:
-        17534:
+        17532:
         - - ArtifactAnalyzerSender
           - ArtifactAnalyzerReceiver
 - proto: ComputerAtmosMonitoring
@@ -68301,10 +68310,10 @@ entities:
       pos: -46.5,-10.5
       parent: 2
     - type: BodyScanner
-      tableEntity: 17650
+      tableEntity: 17648
     - type: DeviceLinkSource
       linkedPorts:
-        17650:
+        17648:
         - - BodyScannerSender
           - BodyScannerReceiver
   - uid: 11272
@@ -68314,10 +68323,10 @@ entities:
       pos: -46.5,-8.5
       parent: 2
     - type: BodyScanner
-      tableEntity: 17649
+      tableEntity: 17647
     - type: DeviceLinkSource
       linkedPorts:
-        17649:
+        17647:
         - - BodyScannerSender
           - BodyScannerReceiver
 - proto: ComputerBroken
@@ -108679,75 +108688,75 @@ entities:
       parent: 2
 - proto: KitchenOven
   entities:
-  - uid: 17380
+  - uid: 17379
     components:
     - type: Transform
       pos: 48.5,-1.5
       parent: 2
-  - uid: 17381
+  - uid: 17380
     components:
     - type: Transform
       pos: -61.5,12.5
       parent: 2
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 17382
+  - uid: 17381
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 2
-  - uid: 17383
+  - uid: 17382
     components:
     - type: Transform
       pos: -38.5,8.5
       parent: 2
-  - uid: 17384
+  - uid: 17383
     components:
     - type: Transform
       pos: 47.5,-2.5
       parent: 2
-  - uid: 17385
+  - uid: 17384
     components:
     - type: Transform
       pos: 57.5,3.5
       parent: 2
-  - uid: 17386
+  - uid: 17385
     components:
     - type: Transform
       pos: -66.5,12.5
       parent: 2
-  - uid: 17387
+  - uid: 17386
     components:
     - type: Transform
       pos: -67.5,40.5
       parent: 2
 - proto: KitchenSpike
   entities:
-  - uid: 17388
+  - uid: 17387
     components:
     - type: Transform
       pos: 53.5,-2.5
       parent: 2
-  - uid: 17389
+  - uid: 17388
     components:
     - type: Transform
       pos: 56.5,-2.5
       parent: 2
 - proto: KitchenStove
   entities:
-  - uid: 17390
+  - uid: 17389
     components:
     - type: Transform
       pos: 48.5,-1.5
       parent: 2
-  - uid: 17391
+  - uid: 17390
     components:
     - type: Transform
       pos: -61.5,12.5
       parent: 2
 - proto: KnifePlastic
   entities:
-  - uid: 17392
+  - uid: 17391
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -108755,80 +108764,80 @@ entities:
       parent: 2
 - proto: Lamp
   entities:
-  - uid: 17393
+  - uid: 17392
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.385906,19.82909
       parent: 2
-  - uid: 17394
+  - uid: 17393
     components:
     - type: Transform
       pos: 0.51982474,2.9410257
       parent: 2
-  - uid: 17395
+  - uid: 17394
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.61242,5.190862
       parent: 2
-  - uid: 17396
+  - uid: 17395
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.487935,19.949064
       parent: 2
-  - uid: 17397
+  - uid: 17396
     components:
     - type: Transform
       pos: -77.50159,-1.3621345
       parent: 2
 - proto: LampBanana
   entities:
-  - uid: 17398
+  - uid: 17397
     components:
     - type: Transform
       pos: 25.51952,3.838722
       parent: 2
 - proto: LampGold
   entities:
-  - uid: 17399
+  - uid: 17398
     components:
     - type: Transform
       pos: -39.966583,32.73777
       parent: 2
-  - uid: 17400
+  - uid: 17399
     components:
     - type: Transform
       pos: -1.5652523,45.724556
       parent: 2
 - proto: LampInterrogator
   entities:
-  - uid: 17401
+  - uid: 17400
     components:
     - type: Transform
       pos: -7.5295353,-4.264649
       parent: 2
 - proto: Lantern
   entities:
-  - uid: 17402
+  - uid: 17401
     components:
     - type: Transform
       pos: 8.309326,40.7715
       parent: 2
-  - uid: 17403
+  - uid: 17402
     components:
     - type: Transform
       pos: -42.762222,-16.396807
       parent: 2
-  - uid: 17404
+  - uid: 17403
     components:
     - type: Transform
       pos: -55.696243,-15.089373
       parent: 2
 - proto: LargeBeaker
   entities:
-  - uid: 17405
+  - uid: 17404
     components:
     - type: Transform
       pos: -67.51895,42.943844
@@ -108837,21 +108846,21 @@ entities:
       enabled: False
 - proto: LauncherCreamPie
   entities:
-  - uid: 17406
+  - uid: 17405
     components:
     - type: Transform
       pos: 24.51754,5.4970446
       parent: 2
 - proto: LeftArmBorg
   entities:
-  - uid: 17407
+  - uid: 17406
     components:
     - type: Transform
       pos: 24.273123,-8.450962
       parent: 2
 - proto: LibrarianPDA
   entities:
-  - uid: 17408
+  - uid: 17407
     components:
     - type: Transform
       pos: 6.2664676,-15.416402
@@ -108860,124 +108869,124 @@ entities:
       processingListings: {}
 - proto: LightBulb
   entities:
+  - uid: 17409
+    components:
+    - type: Transform
+      parent: 17408
+    - type: Physics
+      canCollide: False
   - uid: 17410
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17411
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17412
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17413
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17414
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17415
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17416
     components:
     - type: Transform
-      parent: 17409
-    - type: Physics
-      canCollide: False
-  - uid: 17417
-    components:
-    - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
 - proto: LightReplacer
   entities:
-  - uid: 17426
+  - uid: 17425
     components:
     - type: Transform
       pos: 14.508276,-16.28527
       parent: 2
-  - uid: 17427
+  - uid: 17426
     components:
     - type: Transform
       pos: 80.40431,-47.350624
       parent: 2
-  - uid: 17428
+  - uid: 17427
     components:
     - type: Transform
       pos: 80.66438,-47.346245
       parent: 2
 - proto: LightTube
   entities:
+  - uid: 17417
+    components:
+    - type: Transform
+      parent: 17408
+    - type: Physics
+      canCollide: False
   - uid: 17418
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17419
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17420
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17421
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17422
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17423
     components:
     - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
   - uid: 17424
     components:
     - type: Transform
-      parent: 17409
-    - type: Physics
-      canCollide: False
-  - uid: 17425
-    components:
-    - type: Transform
-      parent: 17409
+      parent: 17408
     - type: Physics
       canCollide: False
 - proto: LockableButtonBrig
   entities:
-  - uid: 17429
+  - uid: 17428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -108999,7 +109008,7 @@ entities:
           - Open
     - type: Fixtures
       fixtures: {}
-  - uid: 17430
+  - uid: 17429
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -109017,60 +109026,60 @@ entities:
       fixtures: {}
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
-  - uid: 17431
+  - uid: 17430
     components:
     - type: Transform
       pos: 36.5,6.5
       parent: 2
-  - uid: 17432
+  - uid: 17431
     components:
     - type: Transform
       pos: 37.5,6.5
       parent: 2
 - proto: LockerBoozeFilled
   entities:
-  - uid: 17433
+  - uid: 17432
     components:
     - type: Transform
       pos: 31.5,5.5
       parent: 2
-  - uid: 17434
+  - uid: 17433
     components:
     - type: Transform
       pos: 32.5,5.5
       parent: 2
-  - uid: 17435
+  - uid: 17434
     components:
     - type: Transform
       pos: 68.5,-29.5
       parent: 2
 - proto: LockerBotanistFilled
   entities:
-  - uid: 17436
+  - uid: 17435
     components:
     - type: Transform
       pos: 53.5,2.5
       parent: 2
-  - uid: 17437
+  - uid: 17436
     components:
     - type: Transform
       pos: 55.5,2.5
       parent: 2
-  - uid: 17438
+  - uid: 17437
     components:
     - type: Transform
       pos: 54.5,2.5
       parent: 2
 - proto: LockerBrigmedicFilled
   entities:
-  - uid: 17439
+  - uid: 17438
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 2
 - proto: LockerBSOFilled
   entities:
-  - uid: 17440
+  - uid: 17439
     components:
     - type: Transform
       pos: -26.5,47.5
@@ -109085,7 +109094,7 @@ entities:
           Nitrogen: 6.568249
 - proto: LockerCaptain
   entities:
-  - uid: 17441
+  - uid: 17440
     components:
     - type: MetaData
       desc: We know this gets stolen a lot
@@ -109103,91 +109112,91 @@ entities:
           Nitrogen: 6.568249
 - proto: LockerCaptainFilledNoLaser
   entities:
-  - uid: 17442
+  - uid: 17441
     components:
     - type: Transform
       pos: 6.5,45.5
       parent: 2
 - proto: LockerChemistryFilled
   entities:
-  - uid: 17444
+  - uid: 17442
     components:
     - type: Transform
       pos: -35.5,5.5
       parent: 2
-  - uid: 17445
+  - uid: 17443
     components:
     - type: Transform
       pos: -34.5,3.5
       parent: 2
 - proto: LockerChiefEngineerFilled
   entities:
-  - uid: 17446
+  - uid: 17444
     components:
     - type: Transform
       pos: 34.5,30.5
       parent: 2
 - proto: LockerChiefMedicalOfficerFilledHardsuit
   entities:
-  - uid: 17447
+  - uid: 17445
     components:
     - type: Transform
       pos: -50.5,-2.5
       parent: 2
 - proto: LockerClown
   entities:
-  - uid: 17448
+  - uid: 17446
     components:
     - type: Transform
       pos: 25.5,2.5
       parent: 2
 - proto: LockerDetectiveFilled
   entities:
-  - uid: 17449
+  - uid: 17447
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 2
 - proto: LockerEngineerFilledHardsuit
   entities:
-  - uid: 17450
+  - uid: 17448
     components:
     - type: Transform
       pos: 38.5,27.5
       parent: 2
-  - uid: 17451
+  - uid: 17449
     components:
     - type: Transform
       pos: 39.5,27.5
       parent: 2
-  - uid: 17452
+  - uid: 17450
     components:
     - type: Transform
       pos: 37.5,27.5
       parent: 2
-  - uid: 17453
+  - uid: 17451
     components:
     - type: Transform
       pos: 36.5,26.5
       parent: 2
-  - uid: 17454
+  - uid: 17452
     components:
     - type: Transform
       pos: 41.5,26.5
       parent: 2
 - proto: LockerEvidence
   entities:
-  - uid: 17455
+  - uid: 17453
     components:
     - type: Transform
       pos: -7.5,1.5
       parent: 2
-  - uid: 17456
+  - uid: 17454
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 2
-  - uid: 17457
+  - uid: 17455
     components:
     - type: Transform
       pos: 2.5,9.5
@@ -109201,25 +109210,25 @@ entities:
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 17458
-  - uid: 17459
+          ent: 17456
+  - uid: 17457
     components:
     - type: Transform
       pos: 76.5,-22.5
       parent: 2
 - proto: LockerFreezer
   entities:
-  - uid: 17460
+  - uid: 17458
     components:
     - type: Transform
       pos: 56.5,-5.5
       parent: 2
-  - uid: 17461
+  - uid: 17459
     components:
     - type: Transform
       pos: 56.5,-4.5
       parent: 2
-  - uid: 17462
+  - uid: 17460
     components:
     - type: Transform
       pos: 45.5,0.5
@@ -109255,19 +109264,19 @@ entities:
           showEnts: False
           occludes: True
           ent: null
-  - uid: 17463
+  - uid: 17461
     components:
     - type: Transform
       pos: -62.5,12.5
       parent: 2
     - type: Lock
       locked: False
-  - uid: 17464
+  - uid: 17462
     components:
     - type: Transform
       pos: 85.5,-42.5
       parent: 2
-  - uid: 17465
+  - uid: 17463
     components:
     - type: Transform
       pos: 7.5,-5.5
@@ -109276,7 +109285,7 @@ entities:
       locked: False
 - proto: LockerFreezerVaultFilled
   entities:
-  - uid: 17466
+  - uid: 17464
     components:
     - type: Transform
       pos: -24.5,32.5
@@ -109343,51 +109352,51 @@ entities:
           ent: null
 - proto: LockerIAAFilled
   entities:
-  - uid: 17467
+  - uid: 17465
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 2
-  - uid: 17468
+  - uid: 17466
     components:
     - type: Transform
       pos: -17.5,7.5
       parent: 2
 - proto: LockerMagistrateFilled
   entities:
-  - uid: 17469
+  - uid: 17467
     components:
     - type: Transform
       pos: -22.5,5.5
       parent: 2
 - proto: LockerMedicalFilled
   entities:
-  - uid: 17470
+  - uid: 17468
     components:
     - type: Transform
       pos: -57.5,1.5
       parent: 2
-  - uid: 17471
+  - uid: 17469
     components:
     - type: Transform
       pos: -57.5,0.5
       parent: 2
-  - uid: 17472
+  - uid: 17470
     components:
     - type: Transform
       pos: -57.5,-0.5
       parent: 2
-  - uid: 17473
+  - uid: 17471
     components:
     - type: Transform
       pos: -53.5,1.5
       parent: 2
-  - uid: 17474
+  - uid: 17472
     components:
     - type: Transform
       pos: -53.5,0.5
       parent: 2
-  - uid: 17475
+  - uid: 17473
     components:
     - type: Transform
       pos: -53.5,-0.5
@@ -109424,243 +109433,267 @@ entities:
           ent: null
 - proto: LockerMedicineFilled
   entities:
-  - uid: 17476
+  - uid: 17474
     components:
     - type: Transform
       pos: -38.5,1.5
       parent: 2
-  - uid: 17477
+  - uid: 17475
     components:
     - type: Transform
       pos: -38.5,-3.5
       parent: 2
-  - uid: 17478
+  - uid: 17476
     components:
     - type: Transform
       pos: -43.5,-5.5
       parent: 2
 - proto: LockerMime
   entities:
-  - uid: 17479
+  - uid: 17477
     components:
     - type: Transform
       pos: 25.5,-5.5
       parent: 2
 - proto: LockerMiningSpecialistLargeFilledHardsuit
   entities:
-  - uid: 17480
+  - uid: 17478
     components:
     - type: Transform
       pos: 28.5,36.5
       parent: 2
-  - uid: 17481
+  - uid: 17479
     components:
     - type: Transform
       pos: 29.5,36.5
       parent: 2
 - proto: LockerParamedicFilled
   entities:
-  - uid: 17482
+  - uid: 17480
     components:
     - type: Transform
       pos: -26.5,4.5
       parent: 2
-  - uid: 17483
+  - uid: 17481
     components:
     - type: Transform
       pos: -26.5,3.5
       parent: 2
 - proto: LockerPrisoner
   entities:
-  - uid: 17484
+  - uid: 17482
     components:
     - type: Transform
       pos: 14.5,-2.5
       parent: 2
 - proto: LockerPrisoner2
   entities:
-  - uid: 17485
+  - uid: 17483
     components:
     - type: Transform
       pos: 13.5,-2.5
       parent: 2
 - proto: LockerPrisoner3
   entities:
-  - uid: 17486
+  - uid: 17484
     components:
     - type: Transform
       pos: 12.5,-2.5
       parent: 2
 - proto: LockerPrisoner4
   entities:
-  - uid: 17487
+  - uid: 17485
     components:
     - type: Transform
       pos: 11.5,-2.5
       parent: 2
 - proto: LockerPrisoner5
   entities:
-  - uid: 17488
+  - uid: 17486
     components:
     - type: Transform
       pos: 11.5,-4.5
       parent: 2
 - proto: LockerPrisoner6
   entities:
-  - uid: 17489
+  - uid: 17487
     components:
     - type: Transform
       pos: 12.5,-4.5
       parent: 2
 - proto: LockerQuarterMasterFilled
   entities:
-  - uid: 17490
+  - uid: 17488
     components:
     - type: Transform
       pos: 29.5,22.5
       parent: 2
 - proto: LockerRepresentativeFilled
   entities:
-  - uid: 17491
+  - uid: 17489
     components:
     - type: Transform
       pos: -11.5,35.5
       parent: 2
 - proto: LockerResearchDirectorFilled
   entities:
-  - uid: 17492
+  - uid: 17490
     components:
     - type: Transform
       pos: -38.5,32.5
       parent: 2
 - proto: LockerSalvageLeadFilledHardsuit
   entities:
-  - uid: 17493
+  - uid: 17491
     components:
     - type: Transform
       pos: 28.5,28.5
       parent: 2
 - proto: LockerSalvageSpecialist
   entities:
-  - uid: 17494
+  - uid: 17492
     components:
     - type: Transform
       pos: -3.5,-27.5
       parent: 2
-  - uid: 17495
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+  - uid: 17493
     components:
     - type: Transform
       pos: -3.5,-28.5
       parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: LockerSalvageSpecialistLargeFilledHardsuit
   entities:
-  - uid: 17496
+  - uid: 17494
     components:
     - type: Transform
       pos: 31.5,36.5
       parent: 2
-  - uid: 17497
+  - uid: 17495
     components:
     - type: Transform
       pos: 32.5,36.5
       parent: 2
 - proto: LockerScienceFilled
   entities:
-  - uid: 17498
+  - uid: 17496
     components:
     - type: Transform
       pos: -43.5,37.5
       parent: 2
-  - uid: 17499
+  - uid: 17497
     components:
     - type: Transform
       pos: -43.5,36.5
       parent: 2
-  - uid: 17500
+  - uid: 17498
     components:
     - type: Transform
       pos: -45.5,39.5
       parent: 2
-  - uid: 17501
+  - uid: 17499
     components:
     - type: Transform
       pos: -46.5,39.5
       parent: 2
-  - uid: 17502
+  - uid: 17500
     components:
     - type: Transform
       pos: -43.5,35.5
       parent: 2
 - proto: LockerSecurityLargeFilled
   entities:
-  - uid: 17503
+  - uid: 17501
     components:
     - type: Transform
       pos: 9.5,10.5
       parent: 2
-  - uid: 17504
+  - uid: 17502
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 2
-  - uid: 17505
+  - uid: 17503
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 2
-  - uid: 17506
+  - uid: 17504
     components:
     - type: Transform
       pos: 9.5,8.5
       parent: 2
-  - uid: 17507
+  - uid: 17505
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 2
-  - uid: 17508
+  - uid: 17506
     components:
     - type: Transform
       pos: 9.5,9.5
       parent: 2
 - proto: LockerSteelLarge
   entities:
-  - uid: 17509
+  - uid: 17507
     components:
     - type: Transform
       pos: 1.5,-36.5
       parent: 2
-  - uid: 17510
+  - uid: 17508
     components:
     - type: Transform
       pos: -24.5,36.5
       parent: 2
-  - uid: 17511
+  - uid: 17509
     components:
     - type: Transform
       pos: -25.5,36.5
       parent: 2
-  - uid: 17512
+  - uid: 17510
     components:
     - type: Transform
       pos: 68.5,-25.5
       parent: 2
-  - uid: 17513
+  - uid: 17511
     components:
     - type: Transform
       pos: 1.5,-52.5
       parent: 2
-  - uid: 17514
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+  - uid: 17512
     components:
     - type: Transform
       pos: 11.5,-54.5
       parent: 2
-  - uid: 17515
+  - uid: 17513
     components:
     - type: Transform
       pos: 10.5,-54.5
       parent: 2
-  - uid: 17516
+  - uid: 17514
     components:
     - type: Transform
       pos: 9.5,-54.5
@@ -109775,7 +109808,7 @@ entities:
           showEnts: False
           occludes: True
           ent: null
-  - uid: 17517
+  - uid: 17515
     components:
     - type: Transform
       pos: 68.5,-45.5
@@ -109794,14 +109827,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 17518
+          - 17516
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: LockerWardenFilled
   entities:
-  - uid: 17519
+  - uid: 17517
     components:
     - type: Transform
       pos: 4.5,2.5
@@ -109811,44 +109844,44 @@ entities:
       - - Armory
 - proto: LootSpawnerMedicalClassy
   entities:
-  - uid: 17520
+  - uid: 17518
     components:
     - type: Transform
       pos: -36.5,-5.5
       parent: 2
-  - uid: 17521
+  - uid: 17519
     components:
     - type: Transform
       pos: -33.5,-5.5
       parent: 2
-  - uid: 17522
+  - uid: 17520
     components:
     - type: Transform
       pos: -30.5,-5.5
       parent: 2
-  - uid: 17523
+  - uid: 17521
     components:
     - type: Transform
       pos: -27.5,-5.5
       parent: 2
 - proto: LuxuryPen
   entities:
-  - uid: 17524
+  - uid: 17522
     components:
     - type: Transform
       pos: 4.512158,-4.352394
       parent: 2
-  - uid: 17525
+  - uid: 17523
     components:
     - type: Transform
       pos: -66.41989,14.650101
       parent: 2
-  - uid: 17526
+  - uid: 17524
     components:
     - type: Transform
       pos: -20.426176,-9.529484
       parent: 2
-  - uid: 17527
+  - uid: 17525
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -109856,20 +109889,20 @@ entities:
       parent: 2
 - proto: MachineAnomalyGenerator
   entities:
-  - uid: 17528
+  - uid: 17526
     components:
     - type: Transform
       pos: -53.5,31.5
       parent: 2
 - proto: MachineAnomalyVessel
   entities:
-  - uid: 17529
+  - uid: 17527
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,26.5
       parent: 2
-  - uid: 17530
+  - uid: 17528
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -109877,13 +109910,13 @@ entities:
       parent: 2
 - proto: MachineAPE
   entities:
-  - uid: 17531
+  - uid: 17529
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,26.5
       parent: 2
-  - uid: 17532
+  - uid: 17530
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -109891,53 +109924,53 @@ entities:
       parent: 2
 - proto: MachineArtifactAnalyzer
   entities:
-  - uid: 17533
+  - uid: 17531
     components:
     - type: Transform
       pos: -60.5,44.5
       parent: 2
-  - uid: 17534
+  - uid: 17532
     components:
     - type: Transform
       pos: -53.5,40.5
       parent: 2
-  - uid: 17535
+  - uid: 17533
     components:
     - type: Transform
       pos: -73.5,-6.5
       parent: 2
 - proto: MachineCentrifuge
   entities:
-  - uid: 17536
+  - uid: 17534
     components:
     - type: Transform
       pos: -33.5,4.5
       parent: 2
-  - uid: 17537
+  - uid: 17535
     components:
     - type: Transform
       pos: -67.5,41.5
       parent: 2
 - proto: MachineElectrolysisUnit
   entities:
-  - uid: 17538
+  - uid: 17536
     components:
     - type: Transform
       pos: -33.5,3.5
       parent: 2
 - proto: MachineFrame
   entities:
-  - uid: 17539
+  - uid: 17537
     components:
     - type: Transform
       pos: -46.5,28.5
       parent: 2
-  - uid: 17540
+  - uid: 17538
     components:
     - type: Transform
       pos: -22.5,-15.5
       parent: 2
-  - uid: 17541
+  - uid: 17539
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -109945,26 +109978,26 @@ entities:
       parent: 2
 - proto: MachineFrameDestroyed
   entities:
-  - uid: 17542
+  - uid: 17540
     components:
     - type: Transform
       pos: -22.5,-13.5
       parent: 2
-  - uid: 17543
+  - uid: 17541
     components:
     - type: Transform
       pos: -45.5,9.5
       parent: 2
 - proto: MachineMaterialSilo
   entities:
-  - uid: 17544
+  - uid: 17542
     components:
     - type: Transform
       pos: -43.5,29.5
       parent: 2
 - proto: MailingUnit
   entities:
-  - uid: 17545
+  - uid: 17543
     components:
     - type: Transform
       pos: 59.5,3.5
@@ -109974,7 +110007,7 @@ entities:
     - type: Configuration
       config:
         tag: Botany
-  - uid: 17546
+  - uid: 17544
     components:
     - type: Transform
       pos: -34.5,5.5
@@ -109986,6 +110019,18 @@ entities:
         tag: Chemistry
 - proto: MaintenanceFluffSpawner
   entities:
+  - uid: 17545
+    components:
+    - type: Transform
+      pos: 67.5,-36.5
+      parent: 2
+  - uid: 17546
+    components:
+    - type: Transform
+      pos: 67.5,-36.5
+      parent: 2
+- proto: MaintenanceToolSpawner
+  entities:
   - uid: 17547
     components:
     - type: Transform
@@ -109996,24 +110041,12 @@ entities:
     - type: Transform
       pos: 67.5,-36.5
       parent: 2
-- proto: MaintenanceToolSpawner
-  entities:
   - uid: 17549
-    components:
-    - type: Transform
-      pos: 67.5,-36.5
-      parent: 2
-  - uid: 17550
-    components:
-    - type: Transform
-      pos: 67.5,-36.5
-      parent: 2
-  - uid: 17551
     components:
     - type: Transform
       pos: -30.5,27.5
       parent: 2
-  - uid: 17552
+  - uid: 17550
     components:
     - type: Transform
       pos: -36.5,30.5
@@ -110300,7 +110333,7 @@ entities:
           showEnts: False
           occludes: False
           ent: null
-  - uid: 17553
+  - uid: 17551
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -110308,25 +110341,25 @@ entities:
       parent: 2
 - proto: Matchbox
   entities:
-  - uid: 17554
+  - uid: 17552
     components:
     - type: Transform
       pos: -41.571552,29.80782
       parent: 2
-  - uid: 17555
+  - uid: 17553
     components:
     - type: Transform
       pos: 10.623393,45.747627
       parent: 2
 - proto: MatchstickSpent
   entities:
-  - uid: 17556
+  - uid: 17554
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.727559,44.71283
       parent: 2
-  - uid: 17557
+  - uid: 17555
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -110334,121 +110367,121 @@ entities:
       parent: 2
 - proto: MaterialCloth
   entities:
-  - uid: 17558
+  - uid: 17556
     components:
     - type: Transform
       pos: -3.4796867,29.543125
       parent: 2
 - proto: MaterialDurathread
   entities:
-  - uid: 17559
+  - uid: 17557
     components:
     - type: Transform
       pos: -3.5,29.5
       parent: 2
 - proto: Mattress
   entities:
-  - uid: 17560
+  - uid: 17558
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 2
-  - uid: 17561
+  - uid: 17559
     components:
     - type: Transform
       pos: -18.5,-22.5
       parent: 2
-  - uid: 17562
+  - uid: 17560
     components:
     - type: Transform
       pos: -27.5,-22.5
       parent: 2
 - proto: MechEquipmentGrabber
   entities:
-  - uid: 17563
+  - uid: 17561
     components:
     - type: Transform
       pos: 19.539124,19.613354
       parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 17564
+  - uid: 17562
     components:
     - type: Transform
       pos: -27.5,-6.5
       parent: 2
-  - uid: 17565
+  - uid: 17563
     components:
     - type: Transform
       pos: -30.5,-6.5
       parent: 2
-  - uid: 17566
+  - uid: 17564
     components:
     - type: Transform
       pos: -33.5,-6.5
       parent: 2
-  - uid: 17567
+  - uid: 17565
     components:
     - type: Transform
       pos: -36.5,-6.5
       parent: 2
-  - uid: 17568
+  - uid: 17566
     components:
     - type: Transform
       pos: -32.5,-1.5
       parent: 2
-  - uid: 17569
+  - uid: 17567
     components:
     - type: Transform
       pos: -34.5,-1.5
       parent: 2
-  - uid: 17570
+  - uid: 17568
     components:
     - type: Transform
       pos: -32.5,-0.5
       parent: 2
-  - uid: 17571
+  - uid: 17569
     components:
     - type: Transform
       pos: -34.5,-0.5
       parent: 2
-  - uid: 17572
+  - uid: 17570
     components:
     - type: Transform
       pos: -23.5,-1.5
       parent: 2
-  - uid: 17573
+  - uid: 17571
     components:
     - type: Transform
       pos: 14.5,5.5
       parent: 2
-  - uid: 17574
+  - uid: 17572
     components:
     - type: Transform
       pos: 14.5,6.5
       parent: 2
-  - uid: 17575
+  - uid: 17573
     components:
     - type: Transform
       pos: 14.5,4.5
       parent: 2
 - proto: MedicalRecordsComputerCircuitboard
   entities:
-  - uid: 17576
+  - uid: 17574
     components:
     - type: Transform
       pos: 6.5039306,20.325598
       parent: 2
 - proto: MedicalTechFab
   entities:
-  - uid: 17577
+  - uid: 17575
     components:
     - type: Transform
       pos: -55.5,-1.5
       parent: 2
 - proto: MedicalTechFabCircuitboard
   entities:
-  - uid: 17578
+  - uid: 17576
     components:
     - type: Transform
       pos: 6.5664306,20.013098
@@ -110478,100 +110511,100 @@ entities:
           - 15736
 - proto: MedkitAdvancedFilled
   entities:
-  - uid: 17579
+  - uid: 17577
     components:
     - type: Transform
       pos: -11.5,54.5
       parent: 2
-  - uid: 17580
+  - uid: 17578
     components:
     - type: Transform
       pos: -28.500378,2.5908375
       parent: 2
-  - uid: 17581
+  - uid: 17579
     components:
     - type: Transform
       pos: -25.482405,-2.512302
       parent: 2
-  - uid: 17582
+  - uid: 17580
     components:
     - type: Transform
       pos: 32.454735,32.744175
       parent: 2
 - proto: MedkitBruteFilled
   entities:
-  - uid: 17583
+  - uid: 17581
     components:
     - type: Transform
       pos: -36.47575,-0.8705157
       parent: 2
 - proto: MedkitBurnFilled
   entities:
-  - uid: 17584
+  - uid: 17582
     components:
     - type: Transform
       pos: -36.507,-1.3861407
       parent: 2
 - proto: MedkitFilled
   entities:
-  - uid: 17585
+  - uid: 17583
     components:
     - type: Transform
       pos: 2.566029,-33.04042
       parent: 2
 - proto: MedkitOxygenFilled
   entities:
-  - uid: 17586
+  - uid: 17584
     components:
     - type: Transform
       pos: -36.4445,-0.3861407
       parent: 2
 - proto: MedkitRadiationFilled
   entities:
-  - uid: 17587
+  - uid: 17585
     components:
     - type: Transform
       pos: -33.49831,-1.4798908
       parent: 2
 - proto: MedkitToxinFilled
   entities:
-  - uid: 17588
+  - uid: 17586
     components:
     - type: Transform
       pos: -33.420185,-0.6361407
       parent: 2
-  - uid: 17589
+  - uid: 17587
     components:
     - type: Transform
       pos: -21.490675,-19.454489
       parent: 2
 - proto: MetalDoor
   entities:
-  - uid: 17590
+  - uid: 17588
     components:
     - type: Transform
       pos: 32.5,23.5
       parent: 2
-  - uid: 17591
+  - uid: 17589
     components:
     - type: Transform
       pos: -72.5,-0.5
       parent: 2
-  - uid: 17592
+  - uid: 17590
     components:
     - type: Transform
       pos: -68.5,-3.5
       parent: 2
 - proto: MinaPlush
   entities:
-  - uid: 17593
+  - uid: 17591
     components:
     - type: Transform
       pos: -10.448357,41.547855
       parent: 2
 - proto: MinimoogInstrument
   entities:
-  - uid: 17594
+  - uid: 17592
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -110579,7 +110612,7 @@ entities:
       parent: 2
 - proto: Mirror
   entities:
-  - uid: 17595
+  - uid: 17593
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -110587,7 +110620,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17596
+  - uid: 17594
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -110595,7 +110628,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17597
+  - uid: 17595
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -110603,7 +110636,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17598
+  - uid: 17596
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -110613,29 +110646,29 @@ entities:
       fixtures: {}
 - proto: MonkeyCubeBox
   entities:
-  - uid: 17599
+  - uid: 17597
     components:
     - type: Transform
       pos: -70.45932,41.692825
       parent: 2
-  - uid: 17600
+  - uid: 17598
     components:
     - type: Transform
       pos: -70.44767,40.657166
       parent: 2
 - proto: MopBucketFull
   entities:
-  - uid: 17601
+  - uid: 17599
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 2
-  - uid: 17602
+  - uid: 17600
     components:
     - type: Transform
       pos: -0.5,-41.5
       parent: 2
-  - uid: 17603
+  - uid: 17601
     components:
     - type: Transform
       pos: 14.5,-17.5
@@ -110656,22 +110689,22 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 17604
+  - uid: 17602
     components:
     - type: Transform
       pos: 0.46070862,-13.396371
       parent: 2
-  - uid: 17605
+  - uid: 17603
     components:
     - type: Transform
       pos: -0.7057785,-41.481754
       parent: 2
-  - uid: 17606
+  - uid: 17604
     components:
     - type: Transform
       pos: 82.42738,-11.484835
       parent: 2
-  - uid: 17607
+  - uid: 17605
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -110679,7 +110712,7 @@ entities:
       parent: 2
 - proto: Morgue
   entities:
-  - uid: 17608
+  - uid: 17606
     components:
     - type: Transform
       pos: -50.5,10.5
@@ -110692,75 +110725,75 @@ entities:
         moles:
           Oxygen: 1.7459903
           Nitrogen: 6.568249
-  - uid: 17609
+  - uid: 17607
     components:
     - type: Transform
       pos: -49.5,10.5
       parent: 2
-  - uid: 17610
+  - uid: 17608
     components:
     - type: Transform
       pos: -47.5,10.5
       parent: 2
-  - uid: 17611
+  - uid: 17609
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,7.5
       parent: 2
-  - uid: 17612
+  - uid: 17610
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -49.5,7.5
       parent: 2
-  - uid: 17613
+  - uid: 17611
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,7.5
       parent: 2
-  - uid: 17614
+  - uid: 17612
     components:
     - type: Transform
       pos: -51.5,10.5
       parent: 2
-  - uid: 17615
+  - uid: 17613
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -51.5,7.5
       parent: 2
-  - uid: 17616
+  - uid: 17614
     components:
     - type: Transform
       pos: -46.5,10.5
       parent: 2
-  - uid: 17617
+  - uid: 17615
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,21.5
       parent: 2
-  - uid: 17618
+  - uid: 17616
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,22.5
       parent: 2
-  - uid: 17619
+  - uid: 17617
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -68.5,22.5
       parent: 2
-  - uid: 17620
+  - uid: 17618
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -68.5,21.5
       parent: 2
-  - uid: 17621
+  - uid: 17619
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -110774,85 +110807,85 @@ entities:
       parent: 11050
     - type: Physics
       canCollide: False
-  - uid: 17622
+  - uid: 17620
     components:
     - type: Transform
       pos: -5.047331,23.61741
       parent: 2
-  - uid: 17623
+  - uid: 17621
     components:
     - type: Transform
       pos: -5.172331,23.664286
       parent: 2
-  - uid: 17624
+  - uid: 17622
     components:
     - type: Transform
       pos: -19.638948,54.52805
       parent: 2
-  - uid: 17625
+  - uid: 17623
     components:
     - type: Transform
       pos: -19.467073,54.6218
       parent: 2
-  - uid: 17626
+  - uid: 17624
     components:
     - type: Transform
       pos: -46.338432,30.592684
       parent: 2
 - proto: nctterminal
   entities:
-  - uid: 17627
+  - uid: 17625
     components:
     - type: Transform
       pos: -24.5,17.5
       parent: 2
 - proto: NitrogenCanister
   entities:
-  - uid: 17628
+  - uid: 17626
     components:
     - type: Transform
       pos: -55.5,34.5
       parent: 2
-  - uid: 17629
+  - uid: 17627
     components:
     - type: Transform
       pos: 7.5,31.5
       parent: 2
-  - uid: 17630
+  - uid: 17628
     components:
     - type: Transform
       pos: -33.5,-10.5
       parent: 2
-  - uid: 17631
+  - uid: 17629
     components:
     - type: Transform
       pos: -36.5,32.5
       parent: 2
-  - uid: 17632
+  - uid: 17630
     components:
     - type: Transform
       pos: 72.5,-20.5
       parent: 2
-  - uid: 17633
+  - uid: 17631
     components:
     - type: Transform
       pos: 57.5,5.5
       parent: 2
-  - uid: 17634
+  - uid: 17632
     components:
     - type: Transform
       pos: 59.5,13.5
       parent: 2
 - proto: NitrogenTankFilled
   entities:
-  - uid: 17635
+  - uid: 17633
     components:
     - type: Transform
       pos: 24.650553,-35.597385
       parent: 2
 - proto: NitrousOxideCanister
   entities:
-  - uid: 17636
+  - uid: 17634
     components:
     - type: Transform
       pos: 49.5,6.5
@@ -110862,7 +110895,7 @@ entities:
       - - Atmospherics
       - - Engineering
       - - Research
-  - uid: 17637
+  - uid: 17635
     components:
     - type: Transform
       pos: 44.5,16.5
@@ -110879,40 +110912,40 @@ entities:
       locked: False
 - proto: NitrousOxideTankFilled
   entities:
-  - uid: 17638
+  - uid: 17636
     components:
     - type: Transform
       pos: -65.71317,26.504837
       parent: 2
-  - uid: 17639
+  - uid: 17637
     components:
     - type: Transform
       pos: -65.58817,26.489212
       parent: 2
 - proto: NTFlag
   entities:
-  - uid: 17640
+  - uid: 17638
     components:
     - type: Transform
       pos: -7.5,38.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17641
+  - uid: 17639
     components:
     - type: Transform
       pos: -15.5,38.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17642
+  - uid: 17640
     components:
     - type: Transform
       pos: 43.5,-13.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17643
+  - uid: 17641
     components:
     - type: Transform
       pos: 49.5,-13.5
@@ -110921,96 +110954,96 @@ entities:
       fixtures: {}
 - proto: NuclearBomb
   entities:
-  - uid: 17644
+  - uid: 17642
     components:
     - type: Transform
       pos: -26.5,30.5
       parent: 2
 - proto: NuclearBombKeg
   entities:
-  - uid: 17645
+  - uid: 17643
     components:
     - type: Transform
       pos: -15.5,35.5
       parent: 2
-  - uid: 17646
+  - uid: 17644
     components:
     - type: Transform
       pos: 8.5,32.5
       parent: 2
 - proto: Omnitool
   entities:
-  - uid: 17647
+  - uid: 17645
     components:
     - type: Transform
       pos: -28.333275,32.45733
       parent: 2
 - proto: OperatingTable
   entities:
-  - uid: 17648
+  - uid: 17646
     components:
     - type: Transform
       pos: -47.5,7.5
       parent: 2
-  - uid: 17649
+  - uid: 17647
     components:
     - type: Transform
       pos: -46.5,-7.5
       parent: 2
     - type: OperatingTable
       scanner: 11272
-  - uid: 17650
+  - uid: 17648
     components:
     - type: Transform
       pos: -46.5,-11.5
       parent: 2
     - type: OperatingTable
       scanner: 11271
-  - uid: 17651
+  - uid: 17649
     components:
     - type: Transform
       pos: -66.5,26.5
       parent: 2
-  - uid: 17652
+  - uid: 17650
     components:
     - type: Transform
       pos: -53.5,-16.5
       parent: 2
 - proto: OreProcessor
   entities:
-  - uid: 17653
+  - uid: 17651
     components:
     - type: Transform
       pos: 27.5,34.5
       parent: 2
 - proto: OxygenCanister
   entities:
-  - uid: 17654
+  - uid: 17652
     components:
     - type: Transform
       pos: -54.5,34.5
       parent: 2
-  - uid: 17655
+  - uid: 17653
     components:
     - type: Transform
       pos: 6.5,31.5
       parent: 2
-  - uid: 17656
+  - uid: 17654
     components:
     - type: Transform
       pos: -1.5,-26.5
       parent: 2
-  - uid: 17657
+  - uid: 17655
     components:
     - type: Transform
       pos: -36.5,31.5
       parent: 2
-  - uid: 17658
+  - uid: 17656
     components:
     - type: Transform
       pos: 72.5,-21.5
       parent: 2
-  - uid: 17659
+  - uid: 17657
     components:
     - type: Transform
       pos: 48.5,6.5
@@ -111020,12 +111053,12 @@ entities:
       - - Atmospherics
       - - Engineering
       - - Research
-  - uid: 17660
+  - uid: 17658
     components:
     - type: Transform
       pos: 54.5,5.5
       parent: 2
-  - uid: 17661
+  - uid: 17659
     components:
     - type: Transform
       pos: 58.5,13.5
@@ -111060,14 +111093,14 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 17662
+  - uid: 17660
     components:
     - type: Transform
       pos: 24.400553,-35.534885
       parent: 2
 - proto: PaintingMonkey
   entities:
-  - uid: 17663
+  - uid: 17661
     components:
     - type: Transform
       pos: -0.5,-17.5
@@ -111076,7 +111109,7 @@ entities:
       fixtures: {}
 - proto: PaintingOldGuitarist
   entities:
-  - uid: 17664
+  - uid: 17662
     components:
     - type: Transform
       pos: 43.5,4.5
@@ -111085,7 +111118,7 @@ entities:
       fixtures: {}
 - proto: PaintingSaturn
   entities:
-  - uid: 17665
+  - uid: 17663
     components:
     - type: Transform
       pos: -14.5,8.5
@@ -111094,7 +111127,7 @@ entities:
       fixtures: {}
 - proto: PaintingSkeletonBoof
   entities:
-  - uid: 17666
+  - uid: 17664
     components:
     - type: Transform
       pos: -6.5,-12.5
@@ -111103,7 +111136,7 @@ entities:
       fixtures: {}
 - proto: PaintingSkeletonCigarette
   entities:
-  - uid: 17667
+  - uid: 17665
     components:
     - type: Transform
       pos: -11.5,-12.5
@@ -111112,108 +111145,108 @@ entities:
       fixtures: {}
 - proto: Paper
   entities:
-  - uid: 17668
+  - uid: 17666
     components:
     - type: Transform
       pos: -21.73234,2.5539255
       parent: 2
-  - uid: 17669
+  - uid: 17667
     components:
     - type: Transform
       pos: -21.654215,2.4601755
       parent: 2
-  - uid: 17670
+  - uid: 17668
     components:
     - type: Transform
       pos: -21.497965,2.6476755
       parent: 2
-  - uid: 17671
+  - uid: 17669
     components:
     - type: Transform
       pos: -21.404215,2.5070505
       parent: 2
-  - uid: 17672
+  - uid: 17670
     components:
     - type: Transform
       pos: -21.26359,2.6320505
       parent: 2
-  - uid: 17673
+  - uid: 17671
     components:
     - type: Transform
       pos: 11.034941,26.731014
       parent: 2
-  - uid: 17674
+  - uid: 17672
     components:
     - type: Transform
       pos: 11.034941,26.71539
       parent: 2
-  - uid: 17675
+  - uid: 17673
     components:
     - type: Transform
       pos: 11.066191,26.59039
       parent: 2
-  - uid: 17676
+  - uid: 17674
     components:
     - type: Transform
       pos: 11.097441,26.543514
       parent: 2
-  - uid: 17677
+  - uid: 17675
     components:
     - type: Transform
       pos: 11.081816,26.43414
       parent: 2
-  - uid: 17678
+  - uid: 17676
     components:
     - type: Transform
       pos: 11.159941,26.418514
       parent: 2
-  - uid: 17679
+  - uid: 17677
     components:
     - type: Transform
       pos: 11.144316,26.387264
       parent: 2
-  - uid: 17680
+  - uid: 17678
     components:
     - type: Transform
       pos: 11.238066,26.43414
       parent: 2
-  - uid: 17681
+  - uid: 17679
     components:
     - type: Transform
       pos: 11.425566,26.77789
       parent: 2
-  - uid: 17682
+  - uid: 17680
     components:
     - type: Transform
       pos: 11.378691,26.34039
       parent: 2
-  - uid: 17683
+  - uid: 17681
     components:
     - type: Transform
       pos: 11.409941,26.543514
       parent: 2
-  - uid: 17684
+  - uid: 17682
     components:
     - type: Transform
       pos: 11.284941,26.77789
       parent: 2
 - proto: PaperArtifactAnalyzer
   entities:
-  - uid: 17685
+  - uid: 17683
     components:
     - type: Transform
       pos: -77.582405,-3.5621881
       parent: 2
     - type: Paper
       content: dude its fucking glowing
-  - uid: 17686
+  - uid: 17684
     components:
     - type: Transform
       pos: -77.41053,-3.3121884
       parent: 2
     - type: Paper
       content: man its smelly as shit
-  - uid: 17687
+  - uid: 17685
     components:
     - type: Transform
       pos: -77.69178,-3.1871884
@@ -111222,204 +111255,204 @@ entities:
       content: 'fucking shit arti '
 - proto: PaperBin10
   entities:
-  - uid: 17688
+  - uid: 17686
     components:
     - type: Transform
       pos: -24.5,19.5
       parent: 2
-  - uid: 17689
+  - uid: 17687
     components:
     - type: Transform
       pos: -1.5,43.5
       parent: 2
-  - uid: 17690
+  - uid: 17688
     components:
     - type: Transform
       pos: 10.5,-19.5
       parent: 2
-  - uid: 17691
+  - uid: 17689
     components:
     - type: Transform
       pos: -40.5,-3.5
       parent: 2
 - proto: PaperBin20
   entities:
-  - uid: 17692
+  - uid: 17690
     components:
     - type: Transform
       pos: -17.5,9.5
       parent: 2
-  - uid: 17693
+  - uid: 17691
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 2
-  - uid: 17694
+  - uid: 17692
     components:
     - type: Transform
       pos: -10.5,35.5
       parent: 2
-  - uid: 17695
+  - uid: 17693
     components:
     - type: Transform
       pos: -29.5,47.5
       parent: 2
-  - uid: 17696
+  - uid: 17694
     components:
     - type: Transform
       pos: -6.5,30.5
       parent: 2
-  - uid: 17697
+  - uid: 17695
     components:
     - type: Transform
       pos: -4.5,24.5
       parent: 2
-  - uid: 17698
+  - uid: 17696
     components:
     - type: Transform
       pos: -16.5,47.5
       parent: 2
-  - uid: 17699
+  - uid: 17697
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 2
-  - uid: 17700
+  - uid: 17698
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 2
 - proto: PaperBin5
   entities:
-  - uid: 17701
+  - uid: 17699
     components:
     - type: Transform
       pos: -5.5,35.5
       parent: 2
 - proto: PaperCNCSheet
   entities:
-  - uid: 17702
+  - uid: 17700
     components:
     - type: Transform
       pos: 4.449658,-4.258644
       parent: 2
-  - uid: 17703
+  - uid: 17701
     components:
     - type: Transform
       pos: 4.355908,-4.133644
       parent: 2
-  - uid: 17704
+  - uid: 17702
     components:
     - type: Transform
       pos: 4.512158,-4.243019
       parent: 2
-  - uid: 17705
+  - uid: 17703
     components:
     - type: Transform
       pos: 4.668408,-4.180519
       parent: 2
-  - uid: 17706
+  - uid: 17704
     components:
     - type: Transform
       pos: 4.418408,-4.321144
       parent: 2
 - proto: PaperDoor
   entities:
-  - uid: 17707
+  - uid: 17705
     components:
     - type: Transform
       pos: -27.5,37.5
       parent: 2
 - proto: PaperOffice
   entities:
-  - uid: 17458
+  - uid: 17456
     components:
     - type: Transform
-      parent: 17457
+      parent: 17455
     - type: Paper
       content: general contraband, lost & found
     - type: Physics
       canCollide: False
-  - uid: 17708
+  - uid: 17706
     components:
     - type: Transform
       pos: 15.351492,-9.323252
       parent: 2
-  - uid: 17709
+  - uid: 17707
     components:
     - type: Transform
       pos: 7.6173334,1.5030736
       parent: 2
-  - uid: 17710
+  - uid: 17708
     components:
     - type: Transform
       pos: 15.663992,-9.292002
       parent: 2
-  - uid: 17711
+  - uid: 17709
     components:
     - type: Transform
       pos: 15.476492,-9.557627
       parent: 2
-  - uid: 17712
+  - uid: 17710
     components:
     - type: Transform
       pos: 15.726492,-9.510752
       parent: 2
-  - uid: 17713
+  - uid: 17711
     components:
     - type: Transform
       pos: -5.540404,36.404533
       parent: 2
-  - uid: 17714
+  - uid: 17712
     components:
     - type: Transform
       pos: -5.748619,36.32525
       parent: 2
-  - uid: 17715
+  - uid: 17713
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.60474,-3.3619068
       parent: 2
-  - uid: 17716
+  - uid: 17714
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.54224,-3.486907
       parent: 2
-  - uid: 17717
+  - uid: 17715
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.993492,7.5848107
       parent: 2
-  - uid: 17718
+  - uid: 17716
     components:
     - type: Transform
       pos: -42.055992,7.0066857
       parent: 2
-  - uid: 17719
+  - uid: 17717
     components:
     - type: Transform
       pos: -41.899742,6.7254357
       parent: 2
-  - uid: 17720
+  - uid: 17718
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -42.274742,7.6316857
       parent: 2
-  - uid: 17721
+  - uid: 17719
     components:
     - type: Transform
       pos: -5.2826133,36.72168
       parent: 2
-  - uid: 17722
+  - uid: 17720
     components:
     - type: Transform
       pos: 8.370422,19.704836
       parent: 2
-  - uid: 17723
+  - uid: 17721
     components:
     - type: MetaData
       name: Note - Some assembly required
@@ -111458,43 +111491,43 @@ entities:
 
         - B
     - type: ActiveUserInterface
-  - uid: 17724
+  - uid: 17722
     components:
     - type: Transform
       pos: 7.6017084,1.8155736
       parent: 2
-  - uid: 17725
+  - uid: 17723
     components:
     - type: Transform
       pos: 7.4298334,1.6593236
       parent: 2
-  - uid: 17726
+  - uid: 17724
     components:
     - type: Transform
       pos: 7.1329584,1.6749486
       parent: 2
-  - uid: 17727
+  - uid: 17725
     components:
     - type: Transform
       pos: 7.2423334,1.5811986
       parent: 2
 - proto: ParticleAcceleratorComputerCircuitboard
   entities:
-  - uid: 17728
+  - uid: 17726
     components:
     - type: Transform
       pos: 3.2020822,20.385052
       parent: 2
 - proto: ParticleAcceleratorControlBoxUnfinished
   entities:
-  - uid: 17729
+  - uid: 17727
     components:
     - type: Transform
       pos: 74.5,17.5
       parent: 2
 - proto: ParticleAcceleratorEmitterForeUnfinished
   entities:
-  - uid: 17730
+  - uid: 17728
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -111502,7 +111535,7 @@ entities:
       parent: 2
 - proto: ParticleAcceleratorEmitterPortUnfinished
   entities:
-  - uid: 17731
+  - uid: 17729
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -111510,7 +111543,7 @@ entities:
       parent: 2
 - proto: ParticleAcceleratorEmitterStarboardUnfinished
   entities:
-  - uid: 17732
+  - uid: 17730
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -111518,7 +111551,7 @@ entities:
       parent: 2
 - proto: ParticleAcceleratorEndCapUnfinished
   entities:
-  - uid: 17733
+  - uid: 17731
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -111526,7 +111559,7 @@ entities:
       parent: 2
 - proto: ParticleAcceleratorFuelChamberUnfinished
   entities:
-  - uid: 17734
+  - uid: 17732
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -111534,7 +111567,7 @@ entities:
       parent: 2
 - proto: ParticleAcceleratorPowerBoxUnfinished
   entities:
-  - uid: 17735
+  - uid: 17733
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -111542,109 +111575,109 @@ entities:
       parent: 2
 - proto: PartRodMetal
   entities:
-  - uid: 17736
+  - uid: 17734
     components:
     - type: Transform
       pos: 41.57545,24.364496
       parent: 2
-  - uid: 17737
+  - uid: 17735
     components:
     - type: Transform
       pos: 43.5257,26.53842
       parent: 2
-  - uid: 17738
+  - uid: 17736
     components:
     - type: Transform
       pos: 59.33826,9.527999
       parent: 2
-  - uid: 17739
+  - uid: 17737
     components:
     - type: Transform
       pos: 59.710793,9.458179
       parent: 2
 - proto: Pen
   entities:
-  - uid: 17740
+  - uid: 17738
     components:
     - type: Transform
       pos: 8.53402,19.511576
       parent: 2
 - proto: PenCap
   entities:
-  - uid: 17741
+  - uid: 17739
     components:
     - type: Transform
       pos: -1.361409,45.226833
       parent: 2
 - proto: PewEndLeft
   entities:
-  - uid: 17742
+  - uid: 17740
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,16.5
       parent: 2
-  - uid: 17743
+  - uid: 17741
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,16.5
       parent: 2
-  - uid: 17744
+  - uid: 17742
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -55.5,16.5
       parent: 2
-  - uid: 17745
+  - uid: 17743
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -54.5,16.5
       parent: 2
-  - uid: 17746
+  - uid: 17744
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -53.5,16.5
       parent: 2
-  - uid: 17747
+  - uid: 17745
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,21.5
       parent: 2
-  - uid: 17748
+  - uid: 17746
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -53.5,21.5
       parent: 2
-  - uid: 17749
+  - uid: 17747
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,21.5
       parent: 2
-  - uid: 17750
+  - uid: 17748
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,16.5
       parent: 2
-  - uid: 17751
+  - uid: 17749
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,21.5
       parent: 2
-  - uid: 17752
+  - uid: 17750
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -55.5,21.5
       parent: 2
-  - uid: 17753
+  - uid: 17751
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -111652,73 +111685,73 @@ entities:
       parent: 2
 - proto: PewEndRight
   entities:
-  - uid: 17754
+  - uid: 17752
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,20.5
       parent: 2
-  - uid: 17755
+  - uid: 17753
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,20.5
       parent: 2
-  - uid: 17756
+  - uid: 17754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,15.5
       parent: 2
-  - uid: 17757
+  - uid: 17755
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,20.5
       parent: 2
-  - uid: 17758
+  - uid: 17756
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -54.5,20.5
       parent: 2
-  - uid: 17759
+  - uid: 17757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,15.5
       parent: 2
-  - uid: 17760
+  - uid: 17758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -53.5,20.5
       parent: 2
-  - uid: 17761
+  - uid: 17759
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -55.5,15.5
       parent: 2
-  - uid: 17762
+  - uid: 17760
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,15.5
       parent: 2
-  - uid: 17763
+  - uid: 17761
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -54.5,15.5
       parent: 2
-  - uid: 17764
+  - uid: 17762
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -53.5,15.5
       parent: 2
-  - uid: 17765
+  - uid: 17763
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -111726,7 +111759,7 @@ entities:
       parent: 2
 - proto: PianoInstrument
   entities:
-  - uid: 17766
+  - uid: 17764
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -111734,34 +111767,34 @@ entities:
       parent: 2
 - proto: Pickaxe
   entities:
-  - uid: 17767
+  - uid: 17765
     components:
     - type: Transform
       pos: 32.361603,31.647158
       parent: 2
-  - uid: 17768
+  - uid: 17766
     components:
     - type: Transform
       pos: 32.549103,31.647158
       parent: 2
-  - uid: 17769
+  - uid: 17767
     components:
     - type: Transform
       pos: 32.642853,31.569033
       parent: 2
-  - uid: 17770
+  - uid: 17768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.502228,31.647158
       parent: 2
-  - uid: 17771
+  - uid: 17769
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.408478,31.600283
       parent: 2
-  - uid: 17772
+  - uid: 17770
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -111769,48 +111802,48 @@ entities:
       parent: 2
 - proto: PigPlushie
   entities:
-  - uid: 17773
+  - uid: 17771
     components:
     - type: Transform
       pos: 2.4869084,-18.538908
       parent: 2
 - proto: PillCanister
   entities:
-  - uid: 17774
+  - uid: 17772
     components:
     - type: Transform
       pos: -32.276703,21.616102
       parent: 2
     - type: Storage
       storedItems:
-        17784:
+        17782:
           position: 4,1
           _rotation: South
-        17775:
+        17773:
           position: 3,1
           _rotation: South
-        17776:
+        17774:
           position: 2,1
           _rotation: South
-        17777:
+        17775:
           position: 1,1
           _rotation: South
-        17778:
+        17776:
           position: 0,1
           _rotation: South
-        17779:
+        17777:
           position: 4,0
           _rotation: South
-        17780:
+        17778:
           position: 3,0
           _rotation: South
-        17781:
+        17779:
           position: 2,0
           _rotation: South
-        17782:
+        17780:
           position: 1,0
           _rotation: South
-        17783:
+        17781:
           position: 0,0
           _rotation: South
     - type: ContainerContainer
@@ -111819,8 +111852,6 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 17783
-          - 17782
           - 17781
           - 17780
           - 17779
@@ -111828,96 +111859,98 @@ entities:
           - 17777
           - 17776
           - 17775
-          - 17784
+          - 17774
+          - 17773
+          - 17782
 - proto: PillCanisterRandom
   entities:
-  - uid: 17785
+  - uid: 17783
     components:
     - type: Transform
       pos: -23.851377,-3.1032302
       parent: 2
 - proto: PillSpaceDrugs
   entities:
+  - uid: 17773
+    components:
+    - type: Transform
+      parent: 17772
+    - type: Physics
+      canCollide: False
+  - uid: 17774
+    components:
+    - type: Transform
+      parent: 17772
+    - type: Physics
+      canCollide: False
   - uid: 17775
     components:
     - type: Transform
-      parent: 17774
+      parent: 17772
     - type: Physics
       canCollide: False
   - uid: 17776
     components:
     - type: Transform
-      parent: 17774
+      parent: 17772
     - type: Physics
       canCollide: False
   - uid: 17777
     components:
     - type: Transform
-      parent: 17774
+      parent: 17772
     - type: Physics
       canCollide: False
   - uid: 17778
     components:
     - type: Transform
-      parent: 17774
+      parent: 17772
     - type: Physics
       canCollide: False
   - uid: 17779
     components:
     - type: Transform
-      parent: 17774
+      parent: 17772
     - type: Physics
       canCollide: False
   - uid: 17780
     components:
     - type: Transform
-      parent: 17774
+      parent: 17772
     - type: Physics
       canCollide: False
   - uid: 17781
     components:
     - type: Transform
-      parent: 17774
+      parent: 17772
     - type: Physics
       canCollide: False
   - uid: 17782
     components:
     - type: Transform
-      parent: 17774
-    - type: Physics
-      canCollide: False
-  - uid: 17783
-    components:
-    - type: Transform
-      parent: 17774
-    - type: Physics
-      canCollide: False
-  - uid: 17784
-    components:
-    - type: Transform
-      parent: 17774
+      parent: 17772
     - type: Physics
       canCollide: False
 - proto: PinpointerNuclear
   entities:
-  - uid: 17786
+  - uid: 17784
     components:
     - type: Transform
       pos: -2.2245262,48.55539
       parent: 2
-  - uid: 17787
+  - uid: 17785
     components:
     - type: Transform
       pos: -27.94265,32.566704
       parent: 2
 - proto: PlasmaCanister
   entities:
-  - uid: 17788
+  - uid: 17786
     components:
     - type: Transform
       pos: -52.5,34.5
       parent: 2
-  - uid: 17789
+  - uid: 17787
     components:
     - type: Transform
       pos: 47.5,16.5
@@ -111927,185 +111960,185 @@ entities:
       releasePressure: 100
     - type: Lock
       locked: False
-  - uid: 17790
+  - uid: 17788
     components:
     - type: Transform
       pos: 44.5,6.5
       parent: 2
-  - uid: 17791
+  - uid: 17789
     components:
     - type: Transform
       pos: 45.5,6.5
       parent: 2
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 17792
+  - uid: 17790
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -72.5,40.5
       parent: 2
-  - uid: 17793
+  - uid: 17791
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -67.5,45.5
       parent: 2
-  - uid: 17794
+  - uid: 17792
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -69.5,36.5
       parent: 2
-  - uid: 17795
+  - uid: 17793
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -67.5,36.5
       parent: 2
-  - uid: 17796
+  - uid: 17794
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -71.5,40.5
       parent: 2
-  - uid: 17797
+  - uid: 17795
     components:
     - type: Transform
       pos: -69.5,45.5
       parent: 2
-  - uid: 17798
+  - uid: 17796
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,38.5
       parent: 2
-  - uid: 17799
+  - uid: 17797
     components:
     - type: Transform
       pos: -1.5,36.5
       parent: 2
-  - uid: 17800
+  - uid: 17798
     components:
     - type: Transform
       pos: -4.5,38.5
+      parent: 2
+  - uid: 17799
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,38.5
+      parent: 2
+  - uid: 17800
+    components:
+    - type: Transform
+      pos: -3.5,38.5
       parent: 2
   - uid: 17801
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,38.5
-      parent: 2
-  - uid: 17802
-    components:
-    - type: Transform
-      pos: -3.5,38.5
-      parent: 2
-  - uid: 17803
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
       pos: -4.5,38.5
       parent: 2
-  - uid: 17804
+  - uid: 17802
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,38.5
       parent: 2
-  - uid: 17805
+  - uid: 17803
     components:
     - type: Transform
       pos: 0.5,36.5
       parent: 2
-  - uid: 17806
+  - uid: 17804
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,38.5
       parent: 2
-  - uid: 17807
+  - uid: 17805
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,38.5
       parent: 2
-  - uid: 17808
+  - uid: 17806
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -56.5,27.5
       parent: 2
-  - uid: 17809
+  - uid: 17807
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,27.5
       parent: 2
-  - uid: 17810
+  - uid: 17808
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 81.5,-39.5
       parent: 2
-  - uid: 17811
+  - uid: 17809
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 82.5,-39.5
       parent: 2
+  - uid: 17810
+    components:
+    - type: Transform
+      pos: 81.5,-39.5
+      parent: 2
+  - uid: 17811
+    components:
+    - type: Transform
+      pos: 82.5,-39.5
+      parent: 2
   - uid: 17812
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 81.5,-39.5
       parent: 2
   - uid: 17813
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 82.5,-39.5
       parent: 2
   - uid: 17814
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 81.5,-39.5
+      pos: -67.5,35.5
       parent: 2
   - uid: 17815
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 82.5,-39.5
-      parent: 2
-  - uid: 17816
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -67.5,35.5
-      parent: 2
-  - uid: 17817
-    components:
-    - type: Transform
       pos: -67.5,45.5
       parent: 2
-  - uid: 17818
+  - uid: 17816
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,40.5
       parent: 2
-  - uid: 17819
+  - uid: 17817
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,41.5
       parent: 2
-  - uid: 17820
+  - uid: 17818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -67.5,46.5
       parent: 2
-  - uid: 17821
+  - uid: 17819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -112113,13 +112146,13 @@ entities:
       parent: 2
 - proto: PlasmaWindoorSecureArmoryLocked
   entities:
-  - uid: 17822
+  - uid: 17820
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-11.5
       parent: 2
-  - uid: 17823
+  - uid: 17821
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -112127,7 +112160,7 @@ entities:
       parent: 2
 - proto: PlasmaWindoorSecureAtmosphericsLocked
   entities:
-  - uid: 17824
+  - uid: 17822
     components:
     - type: Transform
       pos: 57.5,14.5
@@ -112136,10 +112169,10 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        17825:
+        17823:
         - - DoorStatus
           - DoorBolt
-  - uid: 17825
+  - uid: 17823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -112149,82 +112182,82 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        17824:
+        17822:
         - - DoorStatus
           - DoorBolt
 - proto: PlasmaWindoorSecureCommandLocked
   entities:
-  - uid: 17826
+  - uid: 17824
     components:
     - type: Transform
       pos: -0.5,36.5
       parent: 2
-  - uid: 17827
+  - uid: 17825
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,38.5
       parent: 2
-  - uid: 17828
+  - uid: 17826
     components:
     - type: Transform
       pos: 65.5,46.5
       parent: 2
 - proto: PlasmaWindoorSecureScienceLocked
   entities:
-  - uid: 17829
+  - uid: 17827
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -55.5,27.5
       parent: 2
-  - uid: 17830
+  - uid: 17828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -51.5,27.5
       parent: 2
-  - uid: 17831
+  - uid: 17829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -51.5,26.5
       parent: 2
-  - uid: 17832
+  - uid: 17830
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -55.5,26.5
       parent: 2
-  - uid: 17833
+  - uid: 17831
     components:
     - type: Transform
       pos: -66.5,45.5
       parent: 2
-  - uid: 17834
+  - uid: 17832
     components:
     - type: Transform
       pos: -68.5,45.5
       parent: 2
-  - uid: 17835
+  - uid: 17833
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,42.5
       parent: 2
-  - uid: 17836
+  - uid: 17834
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,39.5
       parent: 2
-  - uid: 17837
+  - uid: 17835
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -68.5,36.5
       parent: 2
-  - uid: 17838
+  - uid: 17836
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -112232,239 +112265,239 @@ entities:
       parent: 2
 - proto: PlasticFlapsAirtightClear
   entities:
-  - uid: 17839
+  - uid: 17837
     components:
     - type: Transform
       pos: 23.5,40.5
       parent: 2
-  - uid: 17840
+  - uid: 17838
     components:
     - type: Transform
       pos: 19.5,40.5
       parent: 2
-  - uid: 17841
+  - uid: 17839
     components:
     - type: Transform
       pos: 19.5,37.5
       parent: 2
-  - uid: 17842
+  - uid: 17840
     components:
     - type: Transform
       pos: 23.5,37.5
       parent: 2
 - proto: PlasticFlapsAirtightOpaque
   entities:
-  - uid: 17843
+  - uid: 17841
     components:
     - type: Transform
       pos: -4.5,-31.5
       parent: 2
-  - uid: 17844
+  - uid: 17842
     components:
     - type: Transform
       pos: -5.5,-29.5
       parent: 2
 - proto: PlasticFlapsClear
   entities:
-  - uid: 17845
+  - uid: 17843
     components:
     - type: Transform
       pos: -70.5,9.5
       parent: 2
-  - uid: 17846
+  - uid: 17844
     components:
     - type: Transform
       pos: 14.5,19.5
       parent: 2
 - proto: PlayerStationAi
   entities:
-  - uid: 17847
+  - uid: 17845
     components:
     - type: Transform
       pos: 65.5,47.5
       parent: 2
     - type: StationAiCore
-      lawConsole: 20738
+      lawConsole: 20736
     - type: DeviceLinkSource
       linkedPorts:
-        20738:
+        20736:
         - - AiLawConsoleSender
           - AiLawConsoleReceiver
 - proto: Plunger
   entities:
-  - uid: 17848
+  - uid: 17846
     components:
     - type: Transform
       pos: -25.805666,-10.038255
       parent: 2
 - proto: PlushieAtmosian
   entities:
-  - uid: 17849
+  - uid: 17847
     components:
     - type: Transform
       pos: 53.513134,17.393738
       parent: 2
 - proto: PlushieCarp
   entities:
-  - uid: 17850
+  - uid: 17848
     components:
     - type: Transform
       pos: -0.56684494,47.47947
       parent: 2
 - proto: PlushieHolocarp
   entities:
-  - uid: 17851
+  - uid: 17849
     components:
     - type: Transform
       pos: -1.5660138,47.65436
       parent: 2
-  - uid: 17852
+  - uid: 17850
     components:
     - type: Transform
       pos: -2.0633914,47.466694
       parent: 2
-  - uid: 17853
+  - uid: 17851
     components:
     - type: Transform
       pos: -3.3873065,47.59079
       parent: 2
 - proto: PlushieLizard
   entities:
-  - uid: 17854
+  - uid: 17852
     components:
     - type: Transform
       pos: -5.3222733,36.067566
       parent: 2
-  - uid: 17855
+  - uid: 17853
     components:
     - type: Transform
       pos: -50.469025,23.98906
       parent: 2
-  - uid: 17856
+  - uid: 17854
     components:
     - type: Transform
       pos: -50.67215,23.910934
       parent: 2
-  - uid: 17857
+  - uid: 17855
     components:
     - type: Transform
       pos: -50.3909,23.42656
       parent: 2
-  - uid: 17858
+  - uid: 17856
     components:
     - type: Transform
       pos: -50.6409,23.442184
       parent: 2
-  - uid: 17859
+  - uid: 17857
     components:
     - type: Transform
       pos: -50.656525,23.410934
       parent: 2
-  - uid: 17860
+  - uid: 17858
     components:
     - type: Transform
       pos: -50.531525,23.598434
       parent: 2
-  - uid: 17861
+  - uid: 17859
     components:
     - type: Transform
       pos: -50.312775,23.89531
       parent: 2
-  - uid: 17862
+  - uid: 17860
     components:
     - type: Transform
       pos: -50.281525,24.08281
       parent: 2
-  - uid: 17863
+  - uid: 17861
     components:
     - type: Transform
       pos: -50.469025,24.45781
       parent: 2
-  - uid: 17864
+  - uid: 17862
     components:
     - type: Transform
       pos: -50.67215,24.535934
       parent: 2
-  - uid: 17865
+  - uid: 17863
     components:
     - type: Transform
       pos: -50.437775,24.723434
       parent: 2
-  - uid: 17866
+  - uid: 17864
     components:
     - type: Transform
       pos: -50.3284,24.55156
       parent: 2
-  - uid: 17867
+  - uid: 17865
     components:
     - type: Transform
       pos: -50.23465,24.504684
       parent: 2
-  - uid: 17868
+  - uid: 17866
     components:
     - type: Transform
       pos: -50.48465,24.379684
       parent: 2
-  - uid: 17869
+  - uid: 17867
     components:
     - type: Transform
       pos: -50.469025,23.98906
       parent: 2
-  - uid: 17870
+  - uid: 17868
     components:
     - type: Transform
       pos: -50.3909,23.567184
       parent: 2
-  - uid: 17871
+  - uid: 17869
     components:
     - type: Transform
       pos: -50.437775,23.254684
       parent: 2
-  - uid: 17872
+  - uid: 17870
     components:
     - type: Transform
       pos: -50.2659,23.317184
       parent: 2
-  - uid: 17873
+  - uid: 17871
     components:
     - type: Transform
       pos: 42.594593,-32.238495
       parent: 2
-  - uid: 17874
+  - uid: 17872
     components:
     - type: Transform
       pos: 69.59751,-34.339916
       parent: 2
 - proto: PlushieLizardMirrored
   entities:
-  - uid: 17875
+  - uid: 17873
     components:
     - type: Transform
       pos: -5.788279,35.899086
       parent: 2
 - proto: PlushieMimeLizard
   entities:
-  - uid: 17876
+  - uid: 17874
     components:
     - type: Transform
       pos: 23.648123,-8.388462
       parent: 2
 - proto: PlushieNuke
   entities:
-  - uid: 17878
+  - uid: 17876
     components:
     - type: Transform
-      parent: 17877
+      parent: 17875
     - type: Physics
       canCollide: False
 - proto: PlushieRainbowCarp
   entities:
-  - uid: 17879
+  - uid: 17877
     components:
     - type: Transform
       pos: -1.153023,47.46697
       parent: 2
-  - uid: 17880
+  - uid: 17878
     components:
     - type: Transform
       pos: -2.8482745,47.475197
@@ -112480,48 +112513,48 @@ entities:
     - type: InsideEntityStorage
 - proto: PlushieSharkBlue
   entities:
-  - uid: 17881
+  - uid: 17879
     components:
     - type: Transform
       pos: 64.26178,-17.845455
       parent: 2
-  - uid: 17882
+  - uid: 17880
     components:
     - type: Transform
       pos: 65.44884,-19.849495
       parent: 2
-  - uid: 17883
+  - uid: 17881
     components:
     - type: Transform
       pos: 67.63634,-19.849495
       parent: 2
 - proto: PlushieSharkGrey
   entities:
-  - uid: 17884
+  - uid: 17882
     components:
     - type: Transform
       pos: 64.04259,-18.89637
       parent: 2
-  - uid: 17885
+  - uid: 17883
     components:
     - type: Transform
       pos: 62.04259,-17.36512
       parent: 2
 - proto: PlushieSharkPink
   entities:
-  - uid: 17886
+  - uid: 17884
     components:
     - type: Transform
       pos: 65.59268,-18.64233
       parent: 2
-  - uid: 17887
+  - uid: 17885
     components:
     - type: Transform
       pos: 68.02696,-20.974495
       parent: 2
 - proto: PlushieVox
   entities:
-  - uid: 17888
+  - uid: 17886
     components:
     - type: MetaData
       desc: The tag misspelt "Dragon". Strange.
@@ -112529,63 +112562,63 @@ entities:
     - type: Transform
       pos: -15.350812,37.632603
       parent: 2
-  - uid: 17889
+  - uid: 17887
     components:
     - type: Transform
       pos: -22.515736,41.59473
       parent: 2
 - proto: PortableFlasher
   entities:
-  - uid: 17890
+  - uid: 17888
     components:
     - type: Transform
       pos: -8.5,-13.5
       parent: 2
 - proto: PortableGeneratorJrPacman
   entities:
-  - uid: 17891
+  - uid: 17889
     components:
     - type: Transform
       pos: 70.5,-21.5
       parent: 2
-  - uid: 17892
+  - uid: 17890
     components:
     - type: Transform
       pos: 12.5,33.5
       parent: 2
-  - uid: 17893
+  - uid: 17891
     components:
     - type: Transform
       pos: -20.5,7.5
       parent: 2
-  - uid: 17894
+  - uid: 17892
     components:
     - type: Transform
       pos: -31.5,-10.5
       parent: 2
-  - uid: 17895
+  - uid: 17893
     components:
     - type: Transform
       pos: 13.5,-11.5
       parent: 2
-  - uid: 17896
+  - uid: 17894
     components:
     - type: Transform
       pos: -33.5,29.5
       parent: 2
-  - uid: 17897
+  - uid: 17895
     components:
     - type: Transform
       pos: -54.5,13.5
       parent: 2
 - proto: PortableGeneratorPacman
   entities:
-  - uid: 17898
+  - uid: 17896
     components:
     - type: Transform
       pos: -1.5,41.5
       parent: 2
-  - uid: 17899
+  - uid: 17897
     components:
     - type: Transform
       pos: -76.5,-0.5
@@ -112596,38 +112629,38 @@ entities:
       activeIndex: 1
 - proto: PortableGeneratorPacmanMachineCircuitboard
   entities:
-  - uid: 17900
+  - uid: 17898
     components:
     - type: Transform
       pos: 3.1083322,20.650677
       parent: 2
 - proto: PortableGeneratorSuperPacman
   entities:
-  - uid: 17901
+  - uid: 17899
     components:
     - type: Transform
       pos: -16.5,-11.5
       parent: 2
 - proto: PortableScrubber
   entities:
-  - uid: 17902
+  - uid: 17900
     components:
     - type: Transform
       pos: 41.5,6.5
       parent: 2
-  - uid: 17903
+  - uid: 17901
     components:
     - type: Transform
       pos: 42.5,6.5
       parent: 2
-  - uid: 17904
+  - uid: 17902
     components:
     - type: Transform
       pos: 43.5,6.5
       parent: 2
 - proto: PosterContrabandAmbrosiaVulgaris
   entities:
-  - uid: 17905
+  - uid: 17903
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -112637,7 +112670,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandBeachStarYamamoto
   entities:
-  - uid: 17906
+  - uid: 17904
     components:
     - type: Transform
       pos: 25.5,5.5
@@ -112646,7 +112679,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandClown
   entities:
-  - uid: 17907
+  - uid: 17905
     components:
     - type: Transform
       pos: 22.5,1.5
@@ -112655,7 +112688,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandCommunistState
   entities:
-  - uid: 17908
+  - uid: 17906
     components:
     - type: Transform
       pos: 25.5,1.5
@@ -112664,7 +112697,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandHackingGuide
   entities:
-  - uid: 17909
+  - uid: 17907
     components:
     - type: Transform
       pos: 22.5,-4.5
@@ -112673,7 +112706,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandLamarr
   entities:
-  - uid: 17910
+  - uid: 17908
     components:
     - type: Transform
       pos: -78.5,-2.5
@@ -112682,7 +112715,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandMissingGloves
   entities:
-  - uid: 17911
+  - uid: 17909
     components:
     - type: Transform
       pos: 25.5,-4.5
@@ -112691,7 +112724,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandPunchShit
   entities:
-  - uid: 17912
+  - uid: 17910
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -112701,7 +112734,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandTools
   entities:
-  - uid: 17913
+  - uid: 17911
     components:
     - type: Transform
       pos: 21.5,-4.5
@@ -112710,7 +112743,7 @@ entities:
       fixtures: {}
 - proto: PosterContrabandWehWatches
   entities:
-  - uid: 17914
+  - uid: 17912
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -112718,7 +112751,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17915
+  - uid: 17913
     components:
     - type: Transform
       pos: 24.5,1.5
@@ -112727,14 +112760,14 @@ entities:
       fixtures: {}
 - proto: PosterLegitAnatomyPoster
   entities:
-  - uid: 17916
+  - uid: 17914
     components:
     - type: Transform
       pos: 21.5,5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17917
+  - uid: 17915
     components:
     - type: Transform
       pos: -25.5,7.5
@@ -112743,7 +112776,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitCarpMount
   entities:
-  - uid: 17918
+  - uid: 17916
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -112753,7 +112786,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitCleanHands
   entities:
-  - uid: 17919
+  - uid: 17917
     components:
     - type: Transform
       pos: -44.5,-13.5
@@ -112762,7 +112795,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitCleanliness
   entities:
-  - uid: 17920
+  - uid: 17918
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -112770,14 +112803,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17921
+  - uid: 17919
     components:
     - type: Transform
       pos: -65.5,40.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17922
+  - uid: 17920
     components:
     - type: Transform
       pos: -43.5,-13.5
@@ -112786,7 +112819,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitDoNotCauseCancer
   entities:
-  - uid: 17923
+  - uid: 17921
     components:
     - type: Transform
       pos: -25.5,6.5
@@ -112795,7 +112828,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitDoNotQuestion
   entities:
-  - uid: 17924
+  - uid: 17922
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -112805,7 +112838,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitEnlist
   entities:
-  - uid: 17925
+  - uid: 17923
     components:
     - type: Transform
       pos: -27.5,21.5
@@ -112814,7 +112847,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitEyeChart
   entities:
-  - uid: 17926
+  - uid: 17924
     components:
     - type: Transform
       pos: -25.5,10.5
@@ -112823,7 +112856,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitMime
   entities:
-  - uid: 17927
+  - uid: 17925
     components:
     - type: Transform
       pos: 24.5,-4.5
@@ -112832,21 +112865,21 @@ entities:
       fixtures: {}
 - proto: PosterLegitNanotrasenLogo
   entities:
-  - uid: 17928
+  - uid: 17926
     components:
     - type: Transform
       pos: -16.5,38.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17929
+  - uid: 17927
     components:
     - type: Transform
       pos: -19.5,3.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 17930
+  - uid: 17928
     components:
     - type: Transform
       pos: -22.5,17.5
@@ -112855,7 +112888,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitNTTGC
   entities:
-  - uid: 17931
+  - uid: 17929
     components:
     - type: Transform
       pos: -14.5,38.5
@@ -112864,7 +112897,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitPeriodicTable
   entities:
-  - uid: 17932
+  - uid: 17930
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -112874,7 +112907,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitScience
   entities:
-  - uid: 17933
+  - uid: 17931
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -112884,7 +112917,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitSecWatch
   entities:
-  - uid: 17934
+  - uid: 17932
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -112894,7 +112927,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitStateLaws
   entities:
-  - uid: 17935
+  - uid: 17933
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -112904,7 +112937,7 @@ entities:
       fixtures: {}
 - proto: PosterLegitVacation
   entities:
-  - uid: 17936
+  - uid: 17934
     components:
     - type: Transform
       pos: -26.5,21.5
@@ -112913,271 +112946,271 @@ entities:
       fixtures: {}
 - proto: PottedPlant1
   entities:
-  - uid: 17937
+  - uid: 17935
     components:
     - type: Transform
       pos: 28.405626,-41.753475
       parent: 2
 - proto: PottedPlant11
   entities:
-  - uid: 17938
+  - uid: 17936
     components:
     - type: Transform
       pos: -45.56503,5.5618353
       parent: 2
 - proto: PottedPlant12
   entities:
-  - uid: 17939
+  - uid: 17937
     components:
     - type: Transform
       pos: -26.5,10.5
       parent: 2
 - proto: PottedPlant22
   entities:
-  - uid: 17940
+  - uid: 17938
     components:
     - type: Transform
       pos: 16.5,-25.5
       parent: 2
 - proto: PottedPlant23
   entities:
-  - uid: 17941
+  - uid: 17939
     components:
     - type: Transform
       pos: -36.681267,34.282253
       parent: 2
 - proto: PottedPlant7
   entities:
-  - uid: 17942
+  - uid: 17940
     components:
     - type: Transform
       pos: -51.5,5.5
       parent: 2
 - proto: PottedPlantBioluminscent
   entities:
-  - uid: 17943
+  - uid: 17941
     components:
     - type: Transform
       pos: -4.5,50.5
       parent: 2
-  - uid: 17944
+  - uid: 17942
     components:
     - type: Transform
       pos: -67.5,24.5
       parent: 2
 - proto: PottedPlantRandom
   entities:
-  - uid: 17945
+  - uid: 17943
     components:
     - type: Transform
       pos: -48.5,5.5
       parent: 2
-  - uid: 17946
+  - uid: 17944
     components:
     - type: Transform
       pos: -26.5,39.5
       parent: 2
-  - uid: 17947
+  - uid: 17945
     components:
     - type: Transform
       pos: -8.5,41.5
       parent: 2
-  - uid: 17948
+  - uid: 17946
     components:
     - type: Transform
       pos: 15.5,18.5
       parent: 2
-  - uid: 17949
+  - uid: 17947
     components:
     - type: Transform
       pos: 16.5,-37.5
       parent: 2
-  - uid: 17950
+  - uid: 17948
     components:
     - type: Transform
       pos: 17.5,-32.5
       parent: 2
-  - uid: 17951
+  - uid: 17949
     components:
     - type: Transform
       pos: 12.5,-34.5
       parent: 2
-  - uid: 17952
+  - uid: 17950
     components:
     - type: Transform
       pos: 9.5,-27.5
       parent: 2
-  - uid: 17953
+  - uid: 17951
     components:
     - type: Transform
       pos: 7.5,-32.5
       parent: 2
-  - uid: 17954
+  - uid: 17952
     components:
     - type: Transform
       pos: 3.5,-37.5
       parent: 2
-  - uid: 17955
+  - uid: 17953
     components:
     - type: Transform
       pos: -34.5,38.5
       parent: 2
-  - uid: 17956
+  - uid: 17954
     components:
     - type: Transform
       pos: 20.5,-35.5
       parent: 2
-  - uid: 17957
+  - uid: 17955
     components:
     - type: Transform
       pos: 18.5,-35.5
       parent: 2
-  - uid: 17958
+  - uid: 17956
     components:
     - type: Transform
       pos: 17.5,36.5
       parent: 2
 - proto: PottedPlantRandomPlastic
   entities:
-  - uid: 17959
+  - uid: 17957
     components:
     - type: Transform
       pos: 62.5,-36.5
       parent: 2
-  - uid: 17960
+  - uid: 17958
     components:
     - type: Transform
       pos: 56.5,-36.5
       parent: 2
-  - uid: 17961
+  - uid: 17959
     components:
     - type: Transform
       pos: 56.5,-40.5
       parent: 2
-  - uid: 17962
+  - uid: 17960
     components:
     - type: Transform
       pos: 62.5,-40.5
       parent: 2
 - proto: PowerCellHigh
   entities:
-  - uid: 17963
+  - uid: 17961
     components:
     - type: Transform
       pos: -27.4114,32.45733
       parent: 2
 - proto: PowerCellRecharger
   entities:
-  - uid: 17964
+  - uid: 17962
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,6.5
       parent: 2
-  - uid: 17965
+  - uid: 17963
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,55.5
       parent: 2
-  - uid: 17966
+  - uid: 17964
     components:
     - type: Transform
       pos: -10.5,1.5
       parent: 2
-  - uid: 17967
+  - uid: 17965
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-28.5
       parent: 2
-  - uid: 17968
+  - uid: 17966
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-33.5
       parent: 2
-  - uid: 17969
+  - uid: 17967
     components:
     - type: Transform
       pos: 41.5,25.5
       parent: 2
-  - uid: 17970
+  - uid: 17968
     components:
     - type: Transform
       pos: 31.5,12.5
       parent: 2
-  - uid: 17971
+  - uid: 17969
     components:
     - type: Transform
       pos: 38.5,6.5
       parent: 2
-  - uid: 17972
+  - uid: 17970
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 43.5,27.5
       parent: 2
-  - uid: 17973
+  - uid: 17971
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-22.5
       parent: 2
-  - uid: 17974
+  - uid: 17972
     components:
     - type: Transform
       pos: -71.5,-2.5
       parent: 2
-  - uid: 17975
+  - uid: 17973
     components:
     - type: Transform
       pos: 30.5,-35.5
       parent: 2
-  - uid: 17976
+  - uid: 17974
     components:
     - type: Transform
       pos: 65.5,-37.5
       parent: 2
-  - uid: 17977
+  - uid: 17975
     components:
     - type: Transform
       pos: 26.5,36.5
       parent: 2
-  - uid: 17978
+  - uid: 17976
     components:
     - type: Transform
       pos: -44.5,26.5
       parent: 2
-  - uid: 17979
+  - uid: 17977
     components:
     - type: Transform
       pos: -46.5,37.5
       parent: 2
-  - uid: 17980
+  - uid: 17978
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 2
-  - uid: 17981
+  - uid: 17979
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,35.5
       parent: 2
-  - uid: 17982
+  - uid: 17980
     components:
     - type: Transform
       pos: -37.5,8.5
       parent: 2
-  - uid: 17983
+  - uid: 17981
     components:
     - type: Transform
       pos: -57.5,5.5
       parent: 2
 - proto: PowerComputerCircuitboard
   entities:
-  - uid: 17984
+  - uid: 17982
     components:
     - type: Transform
       pos: 6.5351806,19.247473
@@ -113192,468 +113225,468 @@ entities:
       canCollide: False
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 17985
+  - uid: 17983
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-18.5
       parent: 2
-  - uid: 17986
+  - uid: 17984
     components:
     - type: Transform
       pos: 65.5,50.5
       parent: 2
-  - uid: 17987
+  - uid: 17985
     components:
     - type: Transform
       pos: 77.5,13.5
       parent: 2
-  - uid: 17988
+  - uid: 17986
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 77.5,23.5
       parent: 2
-  - uid: 17989
+  - uid: 17987
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,18.5
       parent: 2
-  - uid: 17990
+  - uid: 17988
     components:
     - type: Transform
       pos: -2.5,21.5
       parent: 2
-  - uid: 17991
+  - uid: 17989
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 2
-  - uid: 17992
+  - uid: 17990
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-14.5
       parent: 2
-  - uid: 17993
+  - uid: 17991
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-19.5
       parent: 2
-  - uid: 17994
+  - uid: 17992
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-23.5
       parent: 2
-  - uid: 17995
+  - uid: 17993
     components:
     - type: Transform
       pos: 11.5,-21.5
       parent: 2
-  - uid: 17996
+  - uid: 17994
     components:
     - type: Transform
       pos: -24.5,-12.5
       parent: 2
-  - uid: 17997
+  - uid: 17995
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,-21.5
       parent: 2
-  - uid: 17998
+  - uid: 17996
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,-21.5
       parent: 2
-  - uid: 17999
+  - uid: 17997
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-16.5
       parent: 2
-  - uid: 18000
+  - uid: 17998
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,7.5
       parent: 2
-  - uid: 18001
+  - uid: 17999
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-7.5
       parent: 2
-  - uid: 18002
+  - uid: 18000
     components:
     - type: Transform
       pos: -22.5,-1.5
       parent: 2
-  - uid: 18003
+  - uid: 18001
     components:
     - type: Transform
       pos: -23.5,0.5
       parent: 2
-  - uid: 18004
+  - uid: 18002
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,9.5
       parent: 2
-  - uid: 18005
+  - uid: 18003
     components:
     - type: Transform
       pos: -16.5,-7.5
       parent: 2
-  - uid: 18006
+  - uid: 18004
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-14.5
       parent: 2
-  - uid: 18007
+  - uid: 18005
     components:
     - type: Transform
       pos: -14.5,-20.5
       parent: 2
-  - uid: 18008
+  - uid: 18006
     components:
     - type: Transform
       pos: -11.5,-31.5
       parent: 2
-  - uid: 18009
+  - uid: 18007
     components:
     - type: Transform
       pos: 4.5,-21.5
       parent: 2
-  - uid: 18010
+  - uid: 18008
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-27.5
       parent: 2
-  - uid: 18011
+  - uid: 18009
     components:
     - type: Transform
       pos: 21.5,-5.5
       parent: 2
-  - uid: 18012
+  - uid: 18010
     components:
     - type: Transform
       pos: 25.5,-5.5
       parent: 2
-  - uid: 18013
+  - uid: 18011
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,2.5
       parent: 2
-  - uid: 18014
+  - uid: 18012
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,2.5
       parent: 2
-  - uid: 18015
+  - uid: 18013
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,6.5
       parent: 2
-  - uid: 18016
+  - uid: 18014
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,6.5
       parent: 2
-  - uid: 18017
+  - uid: 18015
     components:
     - type: Transform
       pos: -26.5,-8.5
       parent: 2
-  - uid: 18018
+  - uid: 18016
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,-10.5
       parent: 2
-  - uid: 18019
+  - uid: 18017
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -47.5,-16.5
       parent: 2
-  - uid: 18020
+  - uid: 18018
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -51.5,-12.5
       parent: 2
-  - uid: 18021
+  - uid: 18019
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -52.5,-14.5
       parent: 2
-  - uid: 18022
+  - uid: 18020
     components:
     - type: Transform
       pos: -56.5,-11.5
       parent: 2
-  - uid: 18023
+  - uid: 18021
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,-6.5
       parent: 2
-  - uid: 18024
+  - uid: 18022
     components:
     - type: Transform
       pos: -40.5,-14.5
       parent: 2
-  - uid: 18025
+  - uid: 18023
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,34.5
       parent: 2
-  - uid: 18026
+  - uid: 18024
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,36.5
       parent: 2
-  - uid: 18027
+  - uid: 18025
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,34.5
       parent: 2
-  - uid: 18028
+  - uid: 18026
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,34.5
       parent: 2
-  - uid: 18029
+  - uid: 18027
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,30.5
       parent: 2
-  - uid: 18030
+  - uid: 18028
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,26.5
       parent: 2
-  - uid: 18031
+  - uid: 18029
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,34.5
       parent: 2
-  - uid: 18032
+  - uid: 18030
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,22.5
       parent: 2
-  - uid: 18033
+  - uid: 18031
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,23.5
       parent: 2
-  - uid: 18034
+  - uid: 18032
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,28.5
       parent: 2
-  - uid: 18035
+  - uid: 18033
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,31.5
       parent: 2
-  - uid: 18036
+  - uid: 18034
     components:
     - type: Transform
       pos: 6.5,37.5
       parent: 2
-  - uid: 18037
+  - uid: 18035
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,44.5
       parent: 2
-  - uid: 18038
+  - uid: 18036
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,36.5
       parent: 2
-  - uid: 18039
+  - uid: 18037
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,29.5
       parent: 2
-  - uid: 18040
+  - uid: 18038
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -53.5,-3.5
       parent: 2
-  - uid: 18041
+  - uid: 18039
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -74.5,10.5
       parent: 2
-  - uid: 18042
+  - uid: 18040
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -74.5,12.5
       parent: 2
-  - uid: 18043
+  - uid: 18041
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -71.5,13.5
       parent: 2
-  - uid: 18044
+  - uid: 18042
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -73.5,9.5
       parent: 2
-  - uid: 18045
+  - uid: 18043
     components:
     - type: Transform
       pos: -73.5,-0.5
       parent: 2
-  - uid: 18046
+  - uid: 18044
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 71.5,-43.5
       parent: 2
-  - uid: 18047
+  - uid: 18045
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,-44.5
       parent: 2
-  - uid: 18048
+  - uid: 18046
     components:
     - type: Transform
       pos: 71.5,-39.5
       parent: 2
-  - uid: 18049
+  - uid: 18047
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-24.5
       parent: 2
-  - uid: 18050
+  - uid: 18048
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 71.5,-29.5
       parent: 2
-  - uid: 18051
+  - uid: 18049
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 71.5,-34.5
       parent: 2
-  - uid: 18052
+  - uid: 18050
     components:
     - type: Transform
       pos: -76.5,11.5
       parent: 2
-  - uid: 18053
+  - uid: 18051
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,59.5
       parent: 2
-  - uid: 18054
+  - uid: 18052
     components:
     - type: Transform
       pos: 34.5,55.5
       parent: 2
-  - uid: 18055
+  - uid: 18053
     components:
     - type: Transform
       pos: 37.5,55.5
       parent: 2
-  - uid: 18056
+  - uid: 18054
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,41.5
       parent: 2
-  - uid: 18057
+  - uid: 18055
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,41.5
       parent: 2
-  - uid: 18058
+  - uid: 18056
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,59.5
       parent: 2
-  - uid: 18059
+  - uid: 18057
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,51.5
       parent: 2
-  - uid: 18060
+  - uid: 18058
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,49.5
       parent: 2
-  - uid: 18061
+  - uid: 18059
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,47.5
       parent: 2
-  - uid: 18062
+  - uid: 18060
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,45.5
       parent: 2
-  - uid: 18063
+  - uid: 18061
     components:
     - type: Transform
       pos: 37.5,65.5
       parent: 2
-  - uid: 18064
+  - uid: 18062
     components:
     - type: Transform
       pos: 34.5,65.5
       parent: 2
-  - uid: 18065
+  - uid: 18063
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,70.5
       parent: 2
-  - uid: 18066
+  - uid: 18064
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -113661,1507 +113694,1507 @@ entities:
       parent: 2
 - proto: PoweredLEDSmallLight
   entities:
-  - uid: 18067
+  - uid: 18065
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,22.5
       parent: 2
-  - uid: 18068
+  - uid: 18066
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 53.5,-3.5
       parent: 2
-  - uid: 18069
+  - uid: 18067
     components:
     - type: Transform
       pos: 50.5,3.5
       parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 18070
+  - uid: 18068
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-9.5
       parent: 2
-  - uid: 18071
+  - uid: 18069
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,9.5
       parent: 2
-  - uid: 18072
+  - uid: 18070
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-0.5
       parent: 2
-  - uid: 18073
+  - uid: 18071
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-11.5
       parent: 2
-  - uid: 18074
+  - uid: 18072
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-4.5
       parent: 2
-  - uid: 18075
+  - uid: 18073
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-5.5
       parent: 2
-  - uid: 18076
+  - uid: 18074
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 2
-  - uid: 18077
+  - uid: 18075
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-8.5
       parent: 2
-  - uid: 18078
+  - uid: 18076
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-10.5
       parent: 2
-  - uid: 18079
+  - uid: 18077
     components:
     - type: Transform
       pos: 59.5,13.5
       parent: 2
-  - uid: 18080
+  - uid: 18078
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,41.5
       parent: 2
-  - uid: 18081
+  - uid: 18079
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,54.5
       parent: 2
-  - uid: 18082
+  - uid: 18080
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,50.5
       parent: 2
-  - uid: 18083
+  - uid: 18081
     components:
     - type: Transform
       pos: 1.5,46.5
       parent: 2
-  - uid: 18084
+  - uid: 18082
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,45.5
       parent: 2
-  - uid: 18085
+  - uid: 18083
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,44.5
       parent: 2
-  - uid: 18086
+  - uid: 18084
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,36.5
       parent: 2
-  - uid: 18087
+  - uid: 18085
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,36.5
       parent: 2
-  - uid: 18088
+  - uid: 18086
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,51.5
       parent: 2
-  - uid: 18089
+  - uid: 18087
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,46.5
       parent: 2
-  - uid: 18090
+  - uid: 18088
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,54.5
       parent: 2
-  - uid: 18091
+  - uid: 18089
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,44.5
       parent: 2
-  - uid: 18092
+  - uid: 18090
     components:
     - type: Transform
       pos: -24.5,50.5
       parent: 2
-  - uid: 18093
+  - uid: 18091
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,37.5
       parent: 2
-  - uid: 18094
+  - uid: 18092
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,47.5
       parent: 2
-  - uid: 18095
+  - uid: 18093
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,27.5
       parent: 2
-  - uid: 18096
+  - uid: 18094
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,27.5
       parent: 2
-  - uid: 18097
+  - uid: 18095
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,47.5
       parent: 2
-  - uid: 18098
+  - uid: 18096
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,47.5
       parent: 2
-  - uid: 18099
+  - uid: 18097
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,36.5
       parent: 2
-  - uid: 18100
+  - uid: 18098
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,47.5
       parent: 2
-  - uid: 18101
+  - uid: 18099
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,47.5
       parent: 2
-  - uid: 18102
+  - uid: 18100
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,39.5
       parent: 2
-  - uid: 18103
+  - uid: 18101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,36.5
       parent: 2
-  - uid: 18104
+  - uid: 18102
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,37.5
       parent: 2
-  - uid: 18105
+  - uid: 18103
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,39.5
       parent: 2
-  - uid: 18106
+  - uid: 18104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,39.5
       parent: 2
-  - uid: 18107
+  - uid: 18105
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,39.5
       parent: 2
-  - uid: 18108
+  - uid: 18106
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,25.5
       parent: 2
-  - uid: 18109
+  - uid: 18107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,25.5
       parent: 2
-  - uid: 18110
+  - uid: 18108
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,32.5
       parent: 2
-  - uid: 18111
+  - uid: 18109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,28.5
       parent: 2
-  - uid: 18112
+  - uid: 18110
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,44.5
       parent: 2
-  - uid: 18113
+  - uid: 18111
     components:
     - type: Transform
       pos: -24.5,37.5
       parent: 2
-  - uid: 18114
+  - uid: 18112
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,29.5
       parent: 2
-  - uid: 18115
+  - uid: 18113
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,31.5
       parent: 2
-  - uid: 18116
+  - uid: 18114
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 2
-  - uid: 18117
+  - uid: 18115
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 2
-  - uid: 18118
+  - uid: 18116
     components:
     - type: Transform
       pos: -0.5,-18.5
       parent: 2
-  - uid: 18119
+  - uid: 18117
     components:
     - type: Transform
       pos: -6.5,-13.5
       parent: 2
-  - uid: 18120
+  - uid: 18118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-6.5
       parent: 2
-  - uid: 18121
+  - uid: 18119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-13.5
       parent: 2
-  - uid: 18122
+  - uid: 18120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-9.5
       parent: 2
-  - uid: 18123
+  - uid: 18121
     components:
     - type: Transform
       pos: -11.5,-13.5
       parent: 2
-  - uid: 18124
+  - uid: 18122
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,8.5
       parent: 2
-  - uid: 18125
+  - uid: 18123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,9.5
       parent: 2
-  - uid: 18126
+  - uid: 18124
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,3.5
       parent: 2
-  - uid: 18127
+  - uid: 18125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,3.5
       parent: 2
-  - uid: 18128
+  - uid: 18126
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,9.5
       parent: 2
-  - uid: 18129
+  - uid: 18127
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,6.5
       parent: 2
-  - uid: 18130
+  - uid: 18128
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,6.5
       parent: 2
-  - uid: 18131
+  - uid: 18129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,9.5
       parent: 2
-  - uid: 18132
+  - uid: 18130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,3.5
       parent: 2
-  - uid: 18133
+  - uid: 18131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 2
-  - uid: 18134
+  - uid: 18132
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,3.5
       parent: 2
-  - uid: 18135
+  - uid: 18133
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,3.5
       parent: 2
-  - uid: 18136
+  - uid: 18134
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,6.5
       parent: 2
-  - uid: 18137
+  - uid: 18135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,4.5
       parent: 2
-  - uid: 18138
+  - uid: 18136
     components:
     - type: Transform
       pos: -21.5,5.5
       parent: 2
-  - uid: 18139
+  - uid: 18137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,9.5
       parent: 2
-  - uid: 18140
+  - uid: 18138
     components:
     - type: Transform
       pos: -9.5,16.5
       parent: 2
-  - uid: 18141
+  - uid: 18139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 2
-  - uid: 18142
+  - uid: 18140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-0.5
       parent: 2
-  - uid: 18143
+  - uid: 18141
     components:
     - type: Transform
       pos: -17.5,1.5
       parent: 2
-  - uid: 18144
+  - uid: 18142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-0.5
       parent: 2
-  - uid: 18145
+  - uid: 18143
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 2
-  - uid: 18146
+  - uid: 18144
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-3.5
       parent: 2
-  - uid: 18147
+  - uid: 18145
     components:
     - type: Transform
       pos: -16.5,-2.5
       parent: 2
-  - uid: 18148
+  - uid: 18146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,-5.5
       parent: 2
-  - uid: 18149
+  - uid: 18147
     components:
     - type: Transform
       pos: -53.5,1.5
       parent: 2
-  - uid: 18150
+  - uid: 18148
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,6.5
       parent: 2
-  - uid: 18151
+  - uid: 18149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,6.5
       parent: 2
-  - uid: 18152
+  - uid: 18150
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,4.5
       parent: 2
-  - uid: 18153
+  - uid: 18151
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,9.5
       parent: 2
-  - uid: 18154
+  - uid: 18152
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,5.5
       parent: 2
-  - uid: 18155
+  - uid: 18153
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,-6.5
       parent: 2
-  - uid: 18156
+  - uid: 18154
     components:
     - type: Transform
       pos: -45.5,-7.5
       parent: 2
-  - uid: 18157
+  - uid: 18155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,-3.5
       parent: 2
-  - uid: 18158
+  - uid: 18156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,-3.5
       parent: 2
-  - uid: 18159
+  - uid: 18157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,-3.5
       parent: 2
-  - uid: 18160
+  - uid: 18158
     components:
     - type: Transform
       pos: -44.5,1.5
       parent: 2
-  - uid: 18161
+  - uid: 18159
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -51.5,-1.5
       parent: 2
-  - uid: 18162
+  - uid: 18160
     components:
     - type: Transform
       pos: -48.5,1.5
       parent: 2
-  - uid: 18163
+  - uid: 18161
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,-11.5
       parent: 2
-  - uid: 18164
+  - uid: 18162
     components:
     - type: Transform
       pos: -57.5,1.5
       parent: 2
-  - uid: 18165
+  - uid: 18163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -53.5,3.5
       parent: 2
-  - uid: 18166
+  - uid: 18164
     components:
     - type: Transform
       pos: -57.5,5.5
       parent: 2
-  - uid: 18167
+  - uid: 18165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,-11.5
       parent: 2
-  - uid: 18168
+  - uid: 18166
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -47.5,3.5
       parent: 2
-  - uid: 18169
+  - uid: 18167
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,6.5
       parent: 2
-  - uid: 18170
+  - uid: 18168
     components:
     - type: Transform
       pos: -52.5,21.5
       parent: 2
-  - uid: 18171
+  - uid: 18169
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -52.5,15.5
       parent: 2
-  - uid: 18172
+  - uid: 18170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,14.5
       parent: 2
-  - uid: 18173
+  - uid: 18171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,22.5
       parent: 2
-  - uid: 18174
+  - uid: 18172
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -62.5,14.5
       parent: 2
-  - uid: 18175
+  - uid: 18173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -62.5,22.5
       parent: 2
-  - uid: 18176
+  - uid: 18174
     components:
     - type: Transform
       pos: -65.5,24.5
       parent: 2
-  - uid: 18177
+  - uid: 18175
     components:
     - type: Transform
       pos: -65.5,18.5
       parent: 2
-  - uid: 18178
+  - uid: 18176
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -65.5,20.5
       parent: 2
-  - uid: 18179
+  - uid: 18177
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -68.5,26.5
       parent: 2
-  - uid: 18180
+  - uid: 18178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -51.5,26.5
       parent: 2
-  - uid: 18181
+  - uid: 18179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -55.5,26.5
       parent: 2
-  - uid: 18182
+  - uid: 18180
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -65.5,26.5
       parent: 2
-  - uid: 18183
+  - uid: 18181
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,31.5
       parent: 2
-  - uid: 18184
+  - uid: 18182
     components:
     - type: Transform
       pos: -65.5,33.5
       parent: 2
-  - uid: 18185
+  - uid: 18183
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -61.5,45.5
       parent: 2
-  - uid: 18186
+  - uid: 18184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,37.5
       parent: 2
-  - uid: 18187
+  - uid: 18185
     components:
     - type: Transform
       pos: -45.5,39.5
       parent: 2
-  - uid: 18188
+  - uid: 18186
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -49.5,34.5
       parent: 2
-  - uid: 18189
+  - uid: 18187
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,34.5
       parent: 2
-  - uid: 18190
+  - uid: 18188
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -64.5,39.5
       parent: 2
-  - uid: 18191
+  - uid: 18189
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -57.5,35.5
       parent: 2
-  - uid: 18192
+  - uid: 18190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -47.5,42.5
       parent: 2
-  - uid: 18193
+  - uid: 18191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,32.5
       parent: 2
-  - uid: 18194
+  - uid: 18192
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -48.5,26.5
       parent: 2
-  - uid: 18195
+  - uid: 18193
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -48.5,31.5
       parent: 2
-  - uid: 18196
+  - uid: 18194
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,25.5
       parent: 2
-  - uid: 18197
+  - uid: 18195
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,27.5
       parent: 2
-  - uid: 18198
+  - uid: 18196
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,32.5
       parent: 2
-  - uid: 18199
+  - uid: 18197
     components:
     - type: Transform
       pos: 9.5,22.5
       parent: 2
-  - uid: 18200
+  - uid: 18198
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,24.5
       parent: 2
-  - uid: 18201
+  - uid: 18199
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,18.5
       parent: 2
-  - uid: 18202
+  - uid: 18200
     components:
     - type: Transform
       pos: 13.5,31.5
       parent: 2
-  - uid: 18203
+  - uid: 18201
     components:
     - type: Transform
       pos: 21.5,39.5
       parent: 2
-  - uid: 18204
+  - uid: 18202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,20.5
       parent: 2
-  - uid: 18205
+  - uid: 18203
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,17.5
       parent: 2
-  - uid: 18206
+  - uid: 18204
     components:
     - type: Transform
       pos: 22.5,22.5
       parent: 2
-  - uid: 18207
+  - uid: 18205
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,26.5
       parent: 2
-  - uid: 18208
+  - uid: 18206
     components:
     - type: Transform
       pos: 24.5,26.5
       parent: 2
-  - uid: 18209
+  - uid: 18207
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,35.5
       parent: 2
-  - uid: 18210
+  - uid: 18208
     components:
     - type: Transform
       pos: 18.5,36.5
       parent: 2
-  - uid: 18211
+  - uid: 18209
     components:
     - type: Transform
       pos: 24.5,36.5
       parent: 2
-  - uid: 18212
+  - uid: 18210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,28.5
       parent: 2
-  - uid: 18213
+  - uid: 18211
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,33.5
       parent: 2
-  - uid: 18214
+  - uid: 18212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,31.5
       parent: 2
-  - uid: 18215
+  - uid: 18213
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,28.5
       parent: 2
-  - uid: 18216
+  - uid: 18214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,36.5
       parent: 2
-  - uid: 18217
+  - uid: 18215
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-32.5
       parent: 2
-  - uid: 18218
+  - uid: 18216
     components:
     - type: Transform
       pos: 9.5,-25.5
       parent: 2
-  - uid: 18219
+  - uid: 18217
     components:
     - type: Transform
       pos: 15.5,-25.5
       parent: 2
-  - uid: 18220
+  - uid: 18218
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,37.5
       parent: 2
-  - uid: 18221
+  - uid: 18219
     components:
     - type: Transform
       pos: 3.5,-39.5
       parent: 2
-  - uid: 18222
+  - uid: 18220
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-40.5
       parent: 2
-  - uid: 18223
+  - uid: 18221
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-40.5
       parent: 2
-  - uid: 18224
+  - uid: 18222
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-40.5
       parent: 2
-  - uid: 18225
+  - uid: 18223
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-37.5
       parent: 2
-  - uid: 18226
+  - uid: 18224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-32.5
       parent: 2
-  - uid: 18227
+  - uid: 18225
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-28.5
       parent: 2
-  - uid: 18228
+  - uid: 18226
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-32.5
       parent: 2
-  - uid: 18229
+  - uid: 18227
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-3.5
       parent: 2
-  - uid: 18230
+  - uid: 18228
     components:
     - type: Transform
       pos: 21.5,0.5
       parent: 2
-  - uid: 18231
+  - uid: 18229
     components:
     - type: Transform
       pos: 25.5,0.5
       parent: 2
-  - uid: 18232
+  - uid: 18230
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,-3.5
       parent: 2
-  - uid: 18233
+  - uid: 18231
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,5.5
       parent: 2
-  - uid: 18234
+  - uid: 18232
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,5.5
       parent: 2
-  - uid: 18235
+  - uid: 18233
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-33.5
       parent: 2
-  - uid: 18236
+  - uid: 18234
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-24.5
       parent: 2
-  - uid: 18237
+  - uid: 18235
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-14.5
       parent: 2
-  - uid: 18238
+  - uid: 18236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-14.5
       parent: 2
-  - uid: 18239
+  - uid: 18237
     components:
     - type: Transform
       pos: 33.5,5.5
       parent: 2
-  - uid: 18240
+  - uid: 18238
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,4.5
       parent: 2
-  - uid: 18241
+  - uid: 18239
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,-26.5
       parent: 2
-  - uid: 18242
+  - uid: 18240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,-23.5
       parent: 2
-  - uid: 18243
+  - uid: 18241
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-19.5
       parent: 2
-  - uid: 18244
+  - uid: 18242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-30.5
       parent: 2
-  - uid: 18245
+  - uid: 18243
     components:
     - type: Transform
       pos: 41.5,-24.5
       parent: 2
-  - uid: 18246
+  - uid: 18244
     components:
     - type: Transform
       pos: -33.5,1.5
       parent: 2
-  - uid: 18247
+  - uid: 18245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 47.5,3.5
       parent: 2
-  - uid: 18248
+  - uid: 18246
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,-1.5
       parent: 2
-  - uid: 18249
+  - uid: 18247
     components:
     - type: Transform
       pos: 49.5,-8.5
       parent: 2
-  - uid: 18250
+  - uid: 18248
     components:
     - type: Transform
       pos: 41.5,-8.5
       parent: 2
-  - uid: 18251
+  - uid: 18249
     components:
     - type: Transform
       pos: 51.5,-16.5
       parent: 2
-  - uid: 18252
+  - uid: 18250
     components:
     - type: Transform
       pos: 49.5,-14.5
       parent: 2
-  - uid: 18253
+  - uid: 18251
     components:
     - type: Transform
       pos: 43.5,-14.5
       parent: 2
-  - uid: 18254
+  - uid: 18252
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-21.5
       parent: 2
-  - uid: 18255
+  - uid: 18253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 54.5,-21.5
       parent: 2
-  - uid: 18256
+  - uid: 18254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 49.5,-30.5
       parent: 2
-  - uid: 18257
+  - uid: 18255
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 52.5,-30.5
       parent: 2
-  - uid: 18258
+  - uid: 18256
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 57.5,3.5
       parent: 2
-  - uid: 18259
+  - uid: 18257
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 65.5,-4.5
       parent: 2
-  - uid: 18260
+  - uid: 18258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-6.5
       parent: 2
-  - uid: 18261
+  - uid: 18259
     components:
     - type: Transform
       pos: 54.5,2.5
       parent: 2
-  - uid: 18262
+  - uid: 18260
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 58.5,-1.5
       parent: 2
-  - uid: 18263
+  - uid: 18261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-22.5
       parent: 2
-  - uid: 18264
+  - uid: 18262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-18.5
       parent: 2
-  - uid: 18265
+  - uid: 18263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-26.5
       parent: 2
-  - uid: 18266
+  - uid: 18264
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-14.5
       parent: 2
-  - uid: 18267
+  - uid: 18265
     components:
     - type: Transform
       pos: 74.5,-22.5
       parent: 2
-  - uid: 18268
+  - uid: 18266
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 76.5,-28.5
       parent: 2
-  - uid: 18269
+  - uid: 18267
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 80.5,-8.5
       parent: 2
-  - uid: 18270
+  - uid: 18268
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 80.5,-10.5
       parent: 2
-  - uid: 18271
+  - uid: 18269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 77.5,-23.5
       parent: 2
-  - uid: 18272
+  - uid: 18270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,27.5
       parent: 2
-  - uid: 18273
+  - uid: 18271
     components:
     - type: Transform
       pos: 41.5,13.5
       parent: 2
-  - uid: 18274
+  - uid: 18272
     components:
     - type: Transform
       pos: 52.5,13.5
       parent: 2
-  - uid: 18275
+  - uid: 18273
     components:
     - type: Transform
       pos: 46.5,13.5
       parent: 2
-  - uid: 18276
+  - uid: 18274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 41.5,6.5
       parent: 2
-  - uid: 18277
+  - uid: 18275
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 50.5,5.5
       parent: 2
-  - uid: 18278
+  - uid: 18276
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,19.5
       parent: 2
-  - uid: 18279
+  - uid: 18277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,18.5
       parent: 2
-  - uid: 18280
+  - uid: 18278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,13.5
       parent: 2
-  - uid: 18281
+  - uid: 18279
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,14.5
       parent: 2
-  - uid: 18282
+  - uid: 18280
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,19.5
       parent: 2
-  - uid: 18283
+  - uid: 18281
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,26.5
       parent: 2
-  - uid: 18284
+  - uid: 18282
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,27.5
       parent: 2
-  - uid: 18285
+  - uid: 18283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 39.5,20.5
       parent: 2
-  - uid: 18286
+  - uid: 18284
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 44.5,20.5
       parent: 2
-  - uid: 18287
+  - uid: 18285
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 48.5,24.5
       parent: 2
-  - uid: 18288
+  - uid: 18286
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 57.5,23.5
       parent: 2
-  - uid: 18289
+  - uid: 18287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 54.5,21.5
       parent: 2
-  - uid: 18290
+  - uid: 18288
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 50.5,20.5
       parent: 2
-  - uid: 18291
+  - uid: 18289
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 53.5,26.5
       parent: 2
-  - uid: 18292
+  - uid: 18290
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,26.5
       parent: 2
-  - uid: 18293
+  - uid: 18291
     components:
     - type: Transform
       pos: 49.5,33.5
       parent: 2
-  - uid: 18294
+  - uid: 18292
     components:
     - type: Transform
       pos: 35.5,32.5
       parent: 2
-  - uid: 18295
+  - uid: 18293
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 74.5,13.5
       parent: 2
-  - uid: 18296
+  - uid: 18294
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 74.5,23.5
       parent: 2
-  - uid: 18297
+  - uid: 18295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,51.5
       parent: 2
-  - uid: 18298
+  - uid: 18296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,17.5
       parent: 2
-  - uid: 18299
+  - uid: 18297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,7.5
       parent: 2
-  - uid: 18300
+  - uid: 18298
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,6.5
       parent: 2
-  - uid: 18301
+  - uid: 18299
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,43.5
       parent: 2
-  - uid: 18302
+  - uid: 18300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,43.5
       parent: 2
-  - uid: 18303
+  - uid: 18301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,51.5
       parent: 2
-  - uid: 18304
+  - uid: 18302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-37.5
       parent: 2
-  - uid: 18305
+  - uid: 18303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-37.5
       parent: 2
-  - uid: 18306
+  - uid: 18304
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,2.5
       parent: 2
-  - uid: 18307
+  - uid: 18305
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 66.5,-41.5
       parent: 2
-  - uid: 18308
+  - uid: 18306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 52.5,-50.5
       parent: 2
-  - uid: 18309
+  - uid: 18307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,-50.5
       parent: 2
-  - uid: 18310
+  - uid: 18308
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 66.5,-50.5
       parent: 2
-  - uid: 18311
+  - uid: 18309
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,-50.5
       parent: 2
-  - uid: 18312
+  - uid: 18310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 49.5,-41.5
       parent: 2
-  - uid: 18313
+  - uid: 18311
     components:
     - type: Transform
       pos: 41.5,-36.5
       parent: 2
-  - uid: 18314
+  - uid: 18312
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 51.5,-41.5
       parent: 2
-  - uid: 18315
+  - uid: 18313
     components:
     - type: Transform
       pos: 57.5,-36.5
       parent: 2
-  - uid: 18316
+  - uid: 18314
     components:
     - type: Transform
       pos: 61.5,-36.5
       parent: 2
-  - uid: 18317
+  - uid: 18315
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,-3.5
       parent: 2
-  - uid: 18318
+  - uid: 18316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,31.5
       parent: 2
-  - uid: 18319
+  - uid: 18317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,8.5
       parent: 2
-  - uid: 18320
+  - uid: 18318
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-2.5
       parent: 2
-  - uid: 18321
+  - uid: 18319
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 2
-  - uid: 18322
+  - uid: 18320
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,3.5
       parent: 2
-  - uid: 18323
+  - uid: 18321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-11.5
       parent: 2
-  - uid: 18324
+  - uid: 18322
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,6.5
       parent: 2
-  - uid: 18325
+  - uid: 18323
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 2
-  - uid: 18326
+  - uid: 18324
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -115169,13 +115202,13 @@ entities:
       parent: 2
 - proto: PoweredlightBlue
   entities:
-  - uid: 18327
+  - uid: 18325
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 64.5,39.5
       parent: 2
-  - uid: 18328
+  - uid: 18326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -115183,67 +115216,67 @@ entities:
       parent: 2
 - proto: PoweredlightExterior
   entities:
-  - uid: 18329
+  - uid: 18327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 79.5,14.5
       parent: 2
-  - uid: 18330
+  - uid: 18328
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 79.5,21.5
       parent: 2
-  - uid: 18331
+  - uid: 18329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 92.5,21.5
       parent: 2
-  - uid: 18332
+  - uid: 18330
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 92.5,14.5
       parent: 2
-  - uid: 18333
+  - uid: 18331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,0.5
       parent: 2
-  - uid: 18334
+  - uid: 18332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -67.5,-3.5
       parent: 2
-  - uid: 18335
+  - uid: 18333
     components:
     - type: Transform
       pos: -39.5,-24.5
       parent: 2
-  - uid: 18336
+  - uid: 18334
     components:
     - type: Transform
       pos: -35.5,-24.5
       parent: 2
 - proto: PoweredlightLED
   entities:
-  - uid: 18337
+  - uid: 18335
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,19.5
       parent: 2
-  - uid: 18338
+  - uid: 18336
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -69.5,44.5
       parent: 2
-  - uid: 18339
+  - uid: 18337
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -115251,7 +115284,7 @@ entities:
       parent: 2
 - proto: PoweredlightPink
   entities:
-  - uid: 18340
+  - uid: 18338
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -115259,59 +115292,59 @@ entities:
       parent: 2
 - proto: PoweredLightPostSmall
   entities:
-  - uid: 18341
+  - uid: 18339
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,12.5
       parent: 2
-  - uid: 18342
+  - uid: 18340
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,12.5
       parent: 2
-  - uid: 18343
+  - uid: 18341
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -47.5,12.5
       parent: 2
-  - uid: 18344
+  - uid: 18342
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,22.5
       parent: 2
-  - uid: 18345
+  - uid: 18343
     components:
     - type: Transform
       pos: -13.5,19.5
       parent: 2
-  - uid: 18346
+  - uid: 18344
     components:
     - type: Transform
       pos: 71.5,-10.5
       parent: 2
 - proto: PoweredlightRed
   entities:
-  - uid: 18347
+  - uid: 18345
     components:
     - type: Transform
       pos: 68.5,47.5
       parent: 2
-  - uid: 18348
+  - uid: 18346
     components:
     - type: Transform
       pos: 62.5,47.5
       parent: 2
-  - uid: 18349
+  - uid: 18347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 61.5,43.5
       parent: 2
-  - uid: 18350
+  - uid: 18348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -115319,30 +115352,30 @@ entities:
       parent: 2
 - proto: PoweredlightSodium
   entities:
-  - uid: 18351
+  - uid: 18349
     components:
     - type: Transform
       pos: 43.5,-2.5
       parent: 2
-  - uid: 18352
+  - uid: 18350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-1.5
       parent: 2
-  - uid: 18353
+  - uid: 18351
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,-34.5
       parent: 2
-  - uid: 18354
+  - uid: 18352
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 68.5,-29.5
       parent: 2
-  - uid: 18355
+  - uid: 18353
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -115350,960 +115383,960 @@ entities:
       parent: 2
 - proto: PoweredSmallLight
   entities:
-  - uid: 18356
+  - uid: 18354
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-  - uid: 18357
+  - uid: 18355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-5.5
       parent: 2
-  - uid: 18358
+  - uid: 18356
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,10.5
       parent: 2
-  - uid: 18359
+  - uid: 18357
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,12.5
       parent: 2
-  - uid: 18360
+  - uid: 18358
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 18361
+  - uid: 18359
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,12.5
       parent: 2
-  - uid: 18362
+  - uid: 18360
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-5.5
       parent: 2
-  - uid: 18363
+  - uid: 18361
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-5.5
       parent: 2
-  - uid: 18364
+  - uid: 18362
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,-5.5
       parent: 2
-  - uid: 18365
+  - uid: 18363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,-5.5
       parent: 2
-  - uid: 18366
+  - uid: 18364
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,37.5
       parent: 2
-  - uid: 18367
+  - uid: 18365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-41.5
       parent: 2
-  - uid: 18368
+  - uid: 18366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-39.5
       parent: 2
-  - uid: 18369
+  - uid: 18367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-37.5
       parent: 2
-  - uid: 18370
+  - uid: 18368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-35.5
       parent: 2
-  - uid: 18371
+  - uid: 18369
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-36.5
       parent: 2
-  - uid: 18372
+  - uid: 18370
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-40.5
       parent: 2
-  - uid: 18373
+  - uid: 18371
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,-19.5
       parent: 2
-  - uid: 18374
+  - uid: 18372
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,-30.5
       parent: 2
-  - uid: 18375
+  - uid: 18373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 83.5,-7.5
       parent: 2
-  - uid: 18376
+  - uid: 18374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 83.5,-11.5
       parent: 2
-  - uid: 18377
+  - uid: 18375
     components:
     - type: Transform
       pos: 15.5,-16.5
       parent: 2
-  - uid: 18378
+  - uid: 18376
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-19.5
       parent: 2
-  - uid: 18379
+  - uid: 18377
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,20.5
       parent: 2
-  - uid: 18380
+  - uid: 18378
     components:
     - type: Transform
       pos: 5.5,23.5
       parent: 2
-  - uid: 18381
+  - uid: 18379
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,-6.5
       parent: 2
-  - uid: 18382
+  - uid: 18380
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-11.5
       parent: 2
-  - uid: 18383
+  - uid: 18381
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,-35.5
       parent: 2
-  - uid: 18384
+  - uid: 18382
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,-35.5
       parent: 2
-  - uid: 18385
+  - uid: 18383
     components:
     - type: Transform
       pos: 27.5,-36.5
       parent: 2
-  - uid: 18386
+  - uid: 18384
     components:
     - type: Transform
       pos: 18.5,-35.5
       parent: 2
-  - uid: 18387
+  - uid: 18385
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-36.5
       parent: 2
-  - uid: 18388
+  - uid: 18386
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-9.5
       parent: 2
-  - uid: 18389
+  - uid: 18387
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 2
-  - uid: 18390
+  - uid: 18388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-16.5
       parent: 2
-  - uid: 18391
+  - uid: 18389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-16.5
       parent: 2
-  - uid: 18392
+  - uid: 18390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,15.5
       parent: 2
-  - uid: 18393
+  - uid: 18391
     components:
     - type: Transform
       pos: 75.5,21.5
       parent: 2
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 18394
+  - uid: 18392
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 53.5,5.5
       parent: 2
-  - uid: 18395
+  - uid: 18393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,5.5
       parent: 2
-  - uid: 18396
+  - uid: 18394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,48.5
       parent: 2
-  - uid: 18397
+  - uid: 18395
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,40.5
       parent: 2
-  - uid: 18398
+  - uid: 18396
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,47.5
       parent: 2
-  - uid: 18399
+  - uid: 18397
     components:
     - type: Transform
       pos: -50.5,10.5
       parent: 2
-  - uid: 18400
+  - uid: 18398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,12.5
       parent: 2
-  - uid: 18401
+  - uid: 18399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,12.5
       parent: 2
-  - uid: 18402
+  - uid: 18400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,7.5
       parent: 2
-  - uid: 18403
+  - uid: 18401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,7.5
       parent: 2
-  - uid: 18404
+  - uid: 18402
     components:
     - type: Transform
       pos: -45.5,10.5
       parent: 2
-  - uid: 18405
+  - uid: 18403
     components:
     - type: Transform
       pos: -55.5,32.5
       parent: 2
-  - uid: 18406
+  - uid: 18404
     components:
     - type: Transform
       pos: -51.5,32.5
       parent: 2
-  - uid: 18407
+  - uid: 18405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,26.5
       parent: 2
-  - uid: 18408
+  - uid: 18406
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -63.5,26.5
       parent: 2
-  - uid: 18409
+  - uid: 18407
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -54.5,40.5
       parent: 2
-  - uid: 18410
+  - uid: 18408
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -52.5,40.5
       parent: 2
-  - uid: 18411
+  - uid: 18409
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,36.5
       parent: 2
-  - uid: 18412
+  - uid: 18410
     components:
     - type: Transform
       pos: 33.5,-8.5
       parent: 2
-  - uid: 18413
+  - uid: 18411
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-0.5
       parent: 2
-  - uid: 18414
+  - uid: 18412
     components:
     - type: Transform
       pos: 78.5,-13.5
       parent: 2
-  - uid: 18415
+  - uid: 18413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,17.5
       parent: 2
-  - uid: 18416
+  - uid: 18414
     components:
     - type: Transform
       pos: 21.5,-9.5
       parent: 2
-  - uid: 18417
+  - uid: 18415
     components:
     - type: Transform
       pos: 25.5,-9.5
       parent: 2
-  - uid: 18418
+  - uid: 18416
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,-14.5
       parent: 2
-  - uid: 18419
+  - uid: 18417
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-6.5
       parent: 2
-  - uid: 18420
+  - uid: 18418
     components:
     - type: Transform
       pos: 33.5,-2.5
       parent: 2
-  - uid: 18421
+  - uid: 18419
     components:
     - type: Transform
       pos: 37.5,4.5
       parent: 2
-  - uid: 18422
+  - uid: 18420
     components:
     - type: Transform
       pos: 41.5,4.5
       parent: 2
-  - uid: 18423
+  - uid: 18421
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,2.5
       parent: 2
-  - uid: 18424
+  - uid: 18422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,2.5
       parent: 2
-  - uid: 18425
+  - uid: 18423
     components:
     - type: Transform
       pos: 39.5,-16.5
       parent: 2
-  - uid: 18426
+  - uid: 18424
     components:
     - type: Transform
       pos: 40.5,-20.5
       parent: 2
-  - uid: 18427
+  - uid: 18425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 40.5,-29.5
       parent: 2
-  - uid: 18428
+  - uid: 18426
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 39.5,-33.5
       parent: 2
-  - uid: 18429
+  - uid: 18427
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-7.5
       parent: 2
-  - uid: 18430
+  - uid: 18428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-9.5
       parent: 2
-  - uid: 18431
+  - uid: 18429
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-11.5
       parent: 2
-  - uid: 18432
+  - uid: 18430
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,28.5
       parent: 2
-  - uid: 18433
+  - uid: 18431
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,18.5
       parent: 2
-  - uid: 18434
+  - uid: 18432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 67.5,17.5
       parent: 2
-  - uid: 18435
+  - uid: 18433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 63.5,17.5
       parent: 2
-  - uid: 18436
+  - uid: 18434
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,22.5
       parent: 2
-  - uid: 18437
+  - uid: 18435
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,22.5
       parent: 2
-  - uid: 18438
+  - uid: 18436
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,28.5
       parent: 2
-  - uid: 18439
+  - uid: 18437
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,34.5
       parent: 2
-  - uid: 18440
+  - uid: 18438
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,34.5
       parent: 2
-  - uid: 18441
+  - uid: 18439
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 53.5,16.5
       parent: 2
-  - uid: 18442
+  - uid: 18440
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 54.5,32.5
       parent: 2
-  - uid: 18443
+  - uid: 18441
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 56.5,32.5
       parent: 2
-  - uid: 18444
+  - uid: 18442
     components:
     - type: Transform
       pos: 21.5,15.5
       parent: 2
-  - uid: 18445
+  - uid: 18443
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,13.5
       parent: 2
-  - uid: 18446
+  - uid: 18444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,8.5
       parent: 2
-  - uid: 18447
+  - uid: 18445
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-13.5
       parent: 2
-  - uid: 18448
+  - uid: 18446
     components:
     - type: Transform
       pos: 66.5,-8.5
       parent: 2
-  - uid: 18449
+  - uid: 18447
     components:
     - type: Transform
       pos: 57.5,-8.5
       parent: 2
-  - uid: 18450
+  - uid: 18448
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-14.5
       parent: 2
-  - uid: 18451
+  - uid: 18449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 73.5,-17.5
       parent: 2
-  - uid: 18452
+  - uid: 18450
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,-16.5
       parent: 2
-  - uid: 18453
+  - uid: 18451
     components:
     - type: Transform
       pos: 83.5,-13.5
       parent: 2
-  - uid: 18454
+  - uid: 18452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 79.5,-25.5
       parent: 2
-  - uid: 18455
+  - uid: 18453
     components:
     - type: Transform
       pos: -40.5,25.5
       parent: 2
-  - uid: 18456
+  - uid: 18454
     components:
     - type: Transform
       pos: -36.5,25.5
       parent: 2
-  - uid: 18457
+  - uid: 18455
     components:
     - type: Transform
       pos: 49.5,18.5
       parent: 2
-  - uid: 18458
+  - uid: 18456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 27.5,25.5
       parent: 2
-  - uid: 18459
+  - uid: 18457
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,25.5
       parent: 2
-  - uid: 18460
+  - uid: 18458
     components:
     - type: Transform
       pos: 41.5,18.5
       parent: 2
-  - uid: 18461
+  - uid: 18459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 38.5,16.5
       parent: 2
-  - uid: 18462
+  - uid: 18460
     components:
     - type: Transform
       pos: 14.5,15.5
       parent: 2
-  - uid: 18463
+  - uid: 18461
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,20.5
       parent: 2
-  - uid: 18464
+  - uid: 18462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-16.5
       parent: 2
-  - uid: 18465
+  - uid: 18463
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-20.5
       parent: 2
-  - uid: 18466
+  - uid: 18464
     components:
     - type: Transform
       pos: 5.5,-43.5
       parent: 2
-  - uid: 18467
+  - uid: 18465
     components:
     - type: Transform
       pos: 13.5,-43.5
       parent: 2
-  - uid: 18468
+  - uid: 18466
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,-17.5
       parent: 2
-  - uid: 18469
+  - uid: 18467
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,36.5
       parent: 2
-  - uid: 18470
+  - uid: 18468
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,-16.5
       parent: 2
-  - uid: 18471
+  - uid: 18469
     components:
     - type: Transform
       pos: -31.5,-12.5
       parent: 2
-  - uid: 18472
+  - uid: 18470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,39.5
       parent: 2
-  - uid: 18473
+  - uid: 18471
     components:
     - type: Transform
       pos: -6.5,41.5
       parent: 2
-  - uid: 18474
+  - uid: 18472
     components:
     - type: Transform
       pos: -9.5,-20.5
       parent: 2
-  - uid: 18475
+  - uid: 18473
     components:
     - type: Transform
       pos: -6.5,-25.5
       parent: 2
-  - uid: 18476
+  - uid: 18474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-29.5
       parent: 2
-  - uid: 18477
+  - uid: 18475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-29.5
       parent: 2
-  - uid: 18478
+  - uid: 18476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-12.5
       parent: 2
-  - uid: 18479
+  - uid: 18477
     components:
     - type: Transform
       pos: -41.5,38.5
       parent: 2
-  - uid: 18480
+  - uid: 18478
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -52.5,-7.5
       parent: 2
-  - uid: 18481
+  - uid: 18479
     components:
     - type: Transform
       pos: -69.5,11.5
       parent: 2
-  - uid: 18482
+  - uid: 18480
     components:
     - type: Transform
       pos: -67.5,8.5
       parent: 2
-  - uid: 18483
+  - uid: 18481
     components:
     - type: Transform
       pos: -60.5,8.5
       parent: 2
-  - uid: 18484
+  - uid: 18482
     components:
     - type: Transform
       pos: -56.5,11.5
       parent: 2
-  - uid: 18485
+  - uid: 18483
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -56.5,7.5
       parent: 2
-  - uid: 18486
+  - uid: 18484
     components:
     - type: Transform
       pos: -65.5,12.5
       parent: 2
-  - uid: 18487
+  - uid: 18485
     components:
     - type: Transform
       pos: -62.5,12.5
       parent: 2
-  - uid: 18488
+  - uid: 18486
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,19.5
       parent: 2
-  - uid: 18489
+  - uid: 18487
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -76.5,-3.5
       parent: 2
-  - uid: 18490
+  - uid: 18488
     components:
     - type: Transform
       pos: -69.5,-3.5
       parent: 2
-  - uid: 18491
+  - uid: 18489
     components:
     - type: Transform
       pos: 27.5,-43.5
       parent: 2
-  - uid: 18492
+  - uid: 18490
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-40.5
       parent: 2
-  - uid: 18493
+  - uid: 18491
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,-41.5
       parent: 2
-  - uid: 18494
+  - uid: 18492
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 68.5,-41.5
       parent: 2
-  - uid: 18495
+  - uid: 18493
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-49.5
       parent: 2
-  - uid: 18496
+  - uid: 18494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-49.5
       parent: 2
-  - uid: 18497
+  - uid: 18495
     components:
     - type: Transform
       pos: 78.5,-40.5
       parent: 2
-  - uid: 18498
+  - uid: 18496
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 82.5,-41.5
       parent: 2
-  - uid: 18499
+  - uid: 18497
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 79.5,-48.5
       parent: 2
-  - uid: 18500
+  - uid: 18498
     components:
     - type: Transform
       pos: 80.5,-43.5
       parent: 2
-  - uid: 18501
+  - uid: 18499
     components:
     - type: Transform
       pos: 82.5,-38.5
       parent: 2
-  - uid: 18502
+  - uid: 18500
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 85.5,-41.5
       parent: 2
-  - uid: 18503
+  - uid: 18501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 82.5,-47.5
       parent: 2
-  - uid: 18504
+  - uid: 18502
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 70.5,-21.5
       parent: 2
-  - uid: 18505
+  - uid: 18503
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 68.5,-38.5
       parent: 2
-  - uid: 18506
+  - uid: 18504
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-21.5
       parent: 2
-  - uid: 18507
+  - uid: 18505
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-16.5
       parent: 2
-  - uid: 18508
+  - uid: 18506
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-8.5
       parent: 2
-  - uid: 18509
+  - uid: 18507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,18.5
       parent: 2
-  - uid: 18510
+  - uid: 18508
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,-19.5
       parent: 2
-  - uid: 18511
+  - uid: 18509
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,-20.5
       parent: 2
-  - uid: 18512
+  - uid: 18510
     components:
     - type: Transform
       pos: 40.5,16.5
       parent: 2
-  - uid: 18513
+  - uid: 18511
     components:
     - type: Transform
       pos: 42.5,16.5
       parent: 2
-  - uid: 18514
+  - uid: 18512
     components:
     - type: Transform
       pos: 45.5,16.5
       parent: 2
-  - uid: 18515
+  - uid: 18513
     components:
     - type: Transform
       pos: 48.5,16.5
       parent: 2
-  - uid: 18516
+  - uid: 18514
     components:
     - type: Transform
       pos: 51.5,16.5
       parent: 2
-  - uid: 18517
+  - uid: 18515
     components:
     - type: Transform
       pos: 57.5,16.5
       parent: 2
-  - uid: 18518
+  - uid: 18516
     components:
     - type: Transform
       pos: 32.5,1.5
       parent: 2
-  - uid: 18519
+  - uid: 18517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,27.5
       parent: 2
-  - uid: 18520
+  - uid: 18518
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,17.5
       parent: 2
-  - uid: 18521
+  - uid: 18519
     components:
     - type: Transform
       pos: -18.5,33.5
       parent: 2
-  - uid: 18522
+  - uid: 18520
     components:
     - type: Transform
       pos: -9.5,33.5
       parent: 2
-  - uid: 18523
+  - uid: 18521
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,24.5
       parent: 2
-  - uid: 18524
+  - uid: 18522
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -116311,7 +116344,7 @@ entities:
       parent: 2
 - proto: PrinterDoc
   entities:
-  - uid: 18525
+  - uid: 18523
     components:
     - type: Transform
       pos: -24.5,18.5
@@ -116323,7 +116356,7 @@ entities:
       - Experimental
       - CivilianServices
       - Biochemical
-  - uid: 18526
+  - uid: 18524
     components:
     - type: Transform
       pos: 9.5,-19.5
@@ -116335,74 +116368,74 @@ entities:
       - Experimental
       - CivilianServices
       - Biochemical
-  - uid: 18527
+  - uid: 18525
     components:
     - type: Transform
       pos: -5.5,33.5
       parent: 2
-  - uid: 18528
+  - uid: 18526
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,35.5
       parent: 2
-  - uid: 18529
+  - uid: 18527
     components:
     - type: Transform
       pos: -23.5,51.5
       parent: 2
-  - uid: 18530
+  - uid: 18528
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,7.5
       parent: 2
-  - uid: 18531
+  - uid: 18529
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 2
-  - uid: 18532
+  - uid: 18530
     components:
     - type: Transform
       pos: -11.5,4.5
       parent: 2
-  - uid: 18533
+  - uid: 18531
     components:
     - type: Transform
       pos: -20.5,5.5
       parent: 2
-  - uid: 18534
+  - uid: 18532
     components:
     - type: Transform
       pos: 41.5,30.5
       parent: 2
-  - uid: 18535
+  - uid: 18533
     components:
     - type: Transform
       pos: 10.5,24.5
       parent: 2
-  - uid: 18536
+  - uid: 18534
     components:
     - type: Transform
       pos: 15.5,24.5
       parent: 2
-  - uid: 18537
+  - uid: 18535
     components:
     - type: Transform
       pos: 14.5,36.5
       parent: 2
-  - uid: 18538
+  - uid: 18536
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 2
-  - uid: 18539
+  - uid: 18537
     components:
     - type: Transform
       pos: -48.5,0.5
       parent: 2
-  - uid: 18540
+  - uid: 18538
     components:
     - type: Transform
       pos: -41.5,-3.5
@@ -116414,7 +116447,7 @@ entities:
       - Experimental
       - CivilianServices
       - Biochemical
-  - uid: 18541
+  - uid: 18539
     components:
     - type: Transform
       pos: 9.5,6.5
@@ -116428,2375 +116461,2375 @@ entities:
       - Biochemical
 - proto: Protolathe
   entities:
-  - uid: 18542
+  - uid: 18540
     components:
     - type: Transform
       pos: -46.5,29.5
       parent: 2
 - proto: Rack
   entities:
-  - uid: 18543
+  - uid: 18541
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 2
-  - uid: 18544
+  - uid: 18542
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,41.5
       parent: 2
-  - uid: 18545
+  - uid: 18543
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,37.5
       parent: 2
-  - uid: 18546
+  - uid: 18544
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,29.5
       parent: 2
-  - uid: 18547
+  - uid: 18545
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,28.5
       parent: 2
-  - uid: 18548
+  - uid: 18546
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,30.5
       parent: 2
-  - uid: 18549
+  - uid: 18547
     components:
     - type: Transform
       pos: -25.5,32.5
       parent: 2
-  - uid: 18550
+  - uid: 18548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,41.5
       parent: 2
-  - uid: 18551
+  - uid: 18549
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 2
-  - uid: 18552
+  - uid: 18550
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 2
-  - uid: 18553
+  - uid: 18551
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 2
-  - uid: 18554
+  - uid: 18552
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 2
-  - uid: 18555
+  - uid: 18553
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 2
-  - uid: 18556
+  - uid: 18554
     components:
     - type: Transform
       pos: -7.5,-16.5
       parent: 2
-  - uid: 18557
+  - uid: 18555
     components:
     - type: Transform
       pos: -11.5,-13.5
       parent: 2
-  - uid: 18558
+  - uid: 18556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,4.5
       parent: 2
-  - uid: 18559
+  - uid: 18557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-2.5
       parent: 2
-  - uid: 18560
+  - uid: 18558
     components:
     - type: Transform
       pos: -27.5,-5.5
       parent: 2
-  - uid: 18561
+  - uid: 18559
     components:
     - type: Transform
       pos: -33.5,-5.5
       parent: 2
-  - uid: 18562
+  - uid: 18560
     components:
     - type: Transform
       pos: -36.5,-5.5
       parent: 2
-  - uid: 18563
+  - uid: 18561
     components:
     - type: Transform
       pos: -30.5,-5.5
       parent: 2
-  - uid: 18564
+  - uid: 18562
     components:
     - type: Transform
       pos: -44.5,0.5
       parent: 2
-  - uid: 18565
+  - uid: 18563
     components:
     - type: Transform
       pos: -56.5,-1.5
       parent: 2
-  - uid: 18566
+  - uid: 18564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,10.5
       parent: 2
-  - uid: 18567
+  - uid: 18565
     components:
     - type: Transform
       pos: -65.5,26.5
       parent: 2
-  - uid: 18568
+  - uid: 18566
     components:
     - type: Transform
       pos: -43.5,25.5
       parent: 2
-  - uid: 18569
+  - uid: 18567
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -61.5,40.5
       parent: 2
-  - uid: 18570
+  - uid: 18568
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 46.5,28.5
       parent: 2
-  - uid: 18571
+  - uid: 18569
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,26.5
       parent: 2
-  - uid: 18572
+  - uid: 18570
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,26.5
       parent: 2
-  - uid: 18573
+  - uid: 18571
     components:
     - type: Transform
       pos: 19.5,19.5
       parent: 2
-  - uid: 18574
+  - uid: 18572
     components:
     - type: Transform
       pos: 0.5,-41.5
       parent: 2
-  - uid: 18575
+  - uid: 18573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-33.5
       parent: 2
-  - uid: 18576
+  - uid: 18574
     components:
     - type: Transform
       pos: 55.5,-20.5
       parent: 2
-  - uid: 18577
+  - uid: 18575
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 48.5,-34.5
       parent: 2
-  - uid: 18578
+  - uid: 18576
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-34.5
       parent: 2
-  - uid: 18579
+  - uid: 18577
     components:
     - type: Transform
       pos: 54.5,-0.5
       parent: 2
-  - uid: 18580
+  - uid: 18578
     components:
     - type: Transform
       pos: 82.5,-11.5
       parent: 2
-  - uid: 18581
+  - uid: 18579
     components:
     - type: Transform
       pos: 77.5,-25.5
       parent: 2
-  - uid: 18582
+  - uid: 18580
     components:
     - type: Transform
       pos: 41.5,24.5
       parent: 2
-  - uid: 18583
+  - uid: 18581
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 43.5,26.5
       parent: 2
-  - uid: 18584
+  - uid: 18582
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,-16.5
       parent: 2
-  - uid: 18585
+  - uid: 18583
     components:
     - type: Transform
       pos: -10.5,21.5
       parent: 2
-  - uid: 18586
+  - uid: 18584
     components:
     - type: Transform
       pos: -9.5,21.5
       parent: 2
-  - uid: 18587
+  - uid: 18585
     components:
     - type: Transform
       pos: -7.5,21.5
       parent: 2
-  - uid: 18588
+  - uid: 18586
     components:
     - type: Transform
       pos: -6.5,21.5
       parent: 2
-  - uid: 18589
+  - uid: 18587
     components:
     - type: Transform
       pos: -1.5,25.5
       parent: 2
-  - uid: 18590
+  - uid: 18588
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,23.5
       parent: 2
-  - uid: 18591
+  - uid: 18589
     components:
     - type: Transform
       pos: -27.5,-12.5
       parent: 2
-  - uid: 18592
+  - uid: 18590
     components:
     - type: Transform
       pos: -26.5,-12.5
       parent: 2
-  - uid: 18593
+  - uid: 18591
     components:
     - type: Transform
       pos: -25.5,-12.5
       parent: 2
-  - uid: 18594
+  - uid: 18592
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-23.5
       parent: 2
-  - uid: 18595
+  - uid: 18593
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-13.5
       parent: 2
-  - uid: 18596
+  - uid: 18594
     components:
     - type: Transform
       pos: -42.5,-16.5
       parent: 2
-  - uid: 18597
+  - uid: 18595
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,-10.5
       parent: 2
-  - uid: 18598
+  - uid: 18596
     components:
     - type: Transform
       pos: -30.5,27.5
       parent: 2
-  - uid: 18599
+  - uid: 18597
     components:
     - type: Transform
       pos: -36.5,30.5
       parent: 2
-  - uid: 18600
+  - uid: 18598
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-35.5
       parent: 2
-  - uid: 18601
+  - uid: 18599
     components:
     - type: Transform
       pos: 3.5,-53.5
       parent: 2
-  - uid: 18602
+  - uid: 18600
     components:
     - type: Transform
       pos: 67.5,-36.5
       parent: 2
-  - uid: 18603
+  - uid: 18601
     components:
     - type: Transform
       pos: 73.5,-28.5
       parent: 2
-  - uid: 18604
+  - uid: 18602
     components:
     - type: Transform
       pos: 16.5,36.5
       parent: 2
-  - uid: 18605
+  - uid: 18603
     components:
     - type: Transform
       pos: 59.5,9.5
       parent: 2
-  - uid: 18606
+  - uid: 18604
     components:
     - type: Transform
       pos: -70.5,41.5
       parent: 2
-  - uid: 18607
+  - uid: 18605
     components:
     - type: Transform
       pos: -70.5,40.5
       parent: 2
 - proto: RadarConsoleCircuitboard
   entities:
-  - uid: 18608
+  - uid: 18606
     components:
     - type: Transform
       pos: 6.5351806,18.825598
       parent: 2
 - proto: RadiationCollectorFullTank
   entities:
-  - uid: 18609
+  - uid: 18607
     components:
     - type: Transform
       pos: 80.5,19.5
       parent: 2
-  - uid: 18610
+  - uid: 18608
     components:
     - type: Transform
       pos: 80.5,20.5
       parent: 2
-  - uid: 18611
+  - uid: 18609
     components:
     - type: Transform
       pos: 80.5,16.5
       parent: 2
-  - uid: 18612
+  - uid: 18610
     components:
     - type: Transform
       pos: 80.5,17.5
       parent: 2
-  - uid: 18613
+  - uid: 18611
     components:
     - type: Transform
       pos: 90.5,16.5
       parent: 2
-  - uid: 18614
+  - uid: 18612
     components:
     - type: Transform
       pos: 90.5,17.5
       parent: 2
-  - uid: 18615
+  - uid: 18613
     components:
     - type: Transform
       pos: 90.5,19.5
       parent: 2
-  - uid: 18616
+  - uid: 18614
     components:
     - type: Transform
       pos: 90.5,20.5
       parent: 2
 - proto: Railing
   entities:
-  - uid: 18617
+  - uid: 18615
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-5.5
       parent: 2
-  - uid: 18618
+  - uid: 18616
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,38.5
       parent: 2
-  - uid: 18619
+  - uid: 18617
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,52.5
       parent: 2
-  - uid: 18620
+  - uid: 18618
     components:
     - type: Transform
       pos: -31.5,45.5
       parent: 2
-  - uid: 18621
+  - uid: 18619
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,50.5
       parent: 2
-  - uid: 18622
+  - uid: 18620
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,47.5
       parent: 2
-  - uid: 18623
+  - uid: 18621
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,48.5
       parent: 2
-  - uid: 18624
+  - uid: 18622
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,49.5
       parent: 2
-  - uid: 18625
+  - uid: 18623
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,49.5
       parent: 2
-  - uid: 18626
+  - uid: 18624
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,41.5
       parent: 2
-  - uid: 18627
+  - uid: 18625
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,49.5
       parent: 2
-  - uid: 18628
+  - uid: 18626
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,50.5
       parent: 2
-  - uid: 18629
+  - uid: 18627
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,49.5
       parent: 2
-  - uid: 18630
+  - uid: 18628
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,47.5
       parent: 2
-  - uid: 18631
+  - uid: 18629
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,48.5
       parent: 2
-  - uid: 18632
+  - uid: 18630
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,26.5
       parent: 2
-  - uid: 18633
+  - uid: 18631
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,26.5
       parent: 2
-  - uid: 18634
+  - uid: 18632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
+      pos: -9.5,31.5
+      parent: 2
+  - uid: 18633
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,30.5
+      parent: 2
+  - uid: 18634
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -9.5,31.5
       parent: 2
   - uid: 18635
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: -9.5,30.5
       parent: 2
   - uid: 18636
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,31.5
-      parent: 2
-  - uid: 18637
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,30.5
-      parent: 2
-  - uid: 18638
-    components:
-    - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,4.5
       parent: 2
-  - uid: 18639
+  - uid: 18637
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,8.5
       parent: 2
-  - uid: 18640
+  - uid: 18638
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,8.5
       parent: 2
-  - uid: 18641
+  - uid: 18639
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,8.5
       parent: 2
-  - uid: 18642
+  - uid: 18640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,8.5
       parent: 2
-  - uid: 18643
+  - uid: 18641
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,8.5
       parent: 2
-  - uid: 18644
+  - uid: 18642
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,8.5
       parent: 2
-  - uid: 18645
+  - uid: 18643
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-43.5
       parent: 2
-  - uid: 18646
+  - uid: 18644
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,9.5
       parent: 2
-  - uid: 18647
+  - uid: 18645
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,10.5
       parent: 2
-  - uid: 18648
+  - uid: 18646
     components:
     - type: Transform
       pos: -15.5,24.5
       parent: 2
-  - uid: 18649
+  - uid: 18647
     components:
     - type: Transform
       pos: -18.5,24.5
       parent: 2
-  - uid: 18650
+  - uid: 18648
     components:
     - type: Transform
       pos: -19.5,24.5
       parent: 2
-  - uid: 18651
+  - uid: 18649
     components:
     - type: Transform
       pos: -16.5,24.5
       parent: 2
-  - uid: 18652
+  - uid: 18650
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,25.5
       parent: 2
-  - uid: 18653
+  - uid: 18651
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,26.5
       parent: 2
-  - uid: 18654
+  - uid: 18652
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,28.5
       parent: 2
-  - uid: 18655
+  - uid: 18653
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,29.5
       parent: 2
-  - uid: 18656
+  - uid: 18654
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,30.5
       parent: 2
-  - uid: 18657
+  - uid: 18655
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,30.5
       parent: 2
-  - uid: 18658
+  - uid: 18656
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,30.5
       parent: 2
-  - uid: 18659
+  - uid: 18657
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,30.5
       parent: 2
-  - uid: 18660
+  - uid: 18658
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,29.5
       parent: 2
-  - uid: 18661
+  - uid: 18659
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,28.5
       parent: 2
-  - uid: 18662
+  - uid: 18660
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,26.5
       parent: 2
-  - uid: 18663
+  - uid: 18661
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,25.5
       parent: 2
-  - uid: 18664
+  - uid: 18662
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -41.5,20.5
       parent: 2
-  - uid: 18665
+  - uid: 18663
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -42.5,20.5
       parent: 2
-  - uid: 18666
+  - uid: 18664
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,19.5
       parent: 2
-  - uid: 18667
+  - uid: 18665
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,17.5
       parent: 2
-  - uid: 18668
+  - uid: 18666
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,16.5
       parent: 2
-  - uid: 18669
+  - uid: 18667
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,16.5
       parent: 2
-  - uid: 18670
+  - uid: 18668
     components:
     - type: Transform
       pos: -41.5,15.5
       parent: 2
-  - uid: 18671
+  - uid: 18669
     components:
     - type: Transform
       pos: -42.5,15.5
       parent: 2
-  - uid: 18672
+  - uid: 18670
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,19.5
       parent: 2
-  - uid: 18673
+  - uid: 18671
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,18.5
       parent: 2
-  - uid: 18674
+  - uid: 18672
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,17.5
       parent: 2
-  - uid: 18675
+  - uid: 18673
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,18.5
       parent: 2
-  - uid: 18676
+  - uid: 18674
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,16.5
       parent: 2
-  - uid: 18677
+  - uid: 18675
     components:
     - type: Transform
       pos: -50.5,20.5
       parent: 2
-  - uid: 18678
+  - uid: 18676
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -51.5,21.5
       parent: 2
-  - uid: 18679
+  - uid: 18677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -51.5,15.5
       parent: 2
-  - uid: 18680
+  - uid: 18678
     components:
     - type: Transform
       pos: -61.5,16.5
       parent: 2
-  - uid: 18681
+  - uid: 18679
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,19.5
       parent: 2
-  - uid: 18682
+  - uid: 18680
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -61.5,20.5
       parent: 2
-  - uid: 18683
+  - uid: 18681
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,17.5
       parent: 2
-  - uid: 18684
+  - uid: 18682
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,26.5
       parent: 2
-  - uid: 18685
+  - uid: 18683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,27.5
       parent: 2
-  - uid: 18686
+  - uid: 18684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,28.5
       parent: 2
-  - uid: 18687
+  - uid: 18685
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,29.5
       parent: 2
-  - uid: 18688
+  - uid: 18686
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -55.5,32.5
       parent: 2
-  - uid: 18689
+  - uid: 18687
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -55.5,31.5
       parent: 2
-  - uid: 18690
+  - uid: 18688
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -51.5,32.5
       parent: 2
-  - uid: 18691
+  - uid: 18689
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -51.5,31.5
       parent: 2
-  - uid: 18692
+  - uid: 18690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,30.5
       parent: 2
-  - uid: 18693
+  - uid: 18691
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,31.5
       parent: 2
-  - uid: 18694
+  - uid: 18692
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,18.5
       parent: 2
-  - uid: 18695
+  - uid: 18693
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,18.5
       parent: 2
-  - uid: 18696
+  - uid: 18694
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,19.5
       parent: 2
-  - uid: 18697
+  - uid: 18695
     components:
     - type: Transform
       pos: 32.5,30.5
       parent: 2
-  - uid: 18698
+  - uid: 18696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-25.5
       parent: 2
-  - uid: 18699
+  - uid: 18697
     components:
     - type: Transform
       pos: 3.5,-44.5
       parent: 2
-  - uid: 18700
+  - uid: 18698
     components:
     - type: Transform
       pos: 5.5,-44.5
       parent: 2
-  - uid: 18701
+  - uid: 18699
     components:
     - type: Transform
       pos: 6.5,-44.5
       parent: 2
-  - uid: 18702
+  - uid: 18700
     components:
     - type: Transform
       pos: 7.5,-44.5
       parent: 2
-  - uid: 18703
+  - uid: 18701
     components:
     - type: Transform
       pos: 8.5,-44.5
       parent: 2
-  - uid: 18704
+  - uid: 18702
     components:
     - type: Transform
       pos: 4.5,-44.5
       parent: 2
-  - uid: 18705
+  - uid: 18703
     components:
     - type: Transform
       pos: 9.5,-44.5
       parent: 2
-  - uid: 18706
+  - uid: 18704
     components:
     - type: Transform
       pos: 10.5,-44.5
       parent: 2
-  - uid: 18707
+  - uid: 18705
     components:
     - type: Transform
       pos: 11.5,-44.5
       parent: 2
-  - uid: 18708
+  - uid: 18706
     components:
     - type: Transform
       pos: 12.5,-44.5
       parent: 2
-  - uid: 18709
+  - uid: 18707
     components:
     - type: Transform
       pos: 13.5,-44.5
       parent: 2
-  - uid: 18710
+  - uid: 18708
     components:
     - type: Transform
       pos: 14.5,-44.5
       parent: 2
-  - uid: 18711
+  - uid: 18709
     components:
     - type: Transform
       pos: 15.5,-44.5
       parent: 2
-  - uid: 18712
+  - uid: 18710
     components:
     - type: Transform
       pos: 16.5,-44.5
       parent: 2
-  - uid: 18713
+  - uid: 18711
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-32.5
       parent: 2
-  - uid: 18714
+  - uid: 18712
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,11.5
       parent: 2
-  - uid: 18715
+  - uid: 18713
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,10.5
       parent: 2
-  - uid: 18716
+  - uid: 18714
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,11.5
       parent: 2
-  - uid: 18717
+  - uid: 18715
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,9.5
       parent: 2
-  - uid: 18718
+  - uid: 18716
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,10.5
       parent: 2
-  - uid: 18719
+  - uid: 18717
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,9.5
       parent: 2
-  - uid: 18720
+  - uid: 18718
     components:
     - type: Transform
       pos: 22.5,12.5
       parent: 2
-  - uid: 18721
+  - uid: 18719
     components:
     - type: Transform
       pos: 23.5,12.5
       parent: 2
-  - uid: 18722
+  - uid: 18720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,20.5
       parent: 2
-  - uid: 18723
+  - uid: 18721
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,19.5
       parent: 2
-  - uid: 18724
+  - uid: 18722
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,18.5
       parent: 2
-  - uid: 18725
+  - uid: 18723
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,17.5
       parent: 2
-  - uid: 18726
+  - uid: 18724
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,16.5
       parent: 2
-  - uid: 18727
+  - uid: 18725
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,16.5
       parent: 2
-  - uid: 18728
+  - uid: 18726
     components:
     - type: Transform
       pos: -16.5,21.5
       parent: 2
-  - uid: 18729
+  - uid: 18727
     components:
     - type: Transform
       pos: -15.5,21.5
       parent: 2
-  - uid: 18730
+  - uid: 18728
     components:
     - type: Transform
       pos: -14.5,21.5
       parent: 2
-  - uid: 18731
+  - uid: 18729
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,17.5
       parent: 2
-  - uid: 18732
+  - uid: 18730
     components:
     - type: Transform
       pos: -13.5,21.5
       parent: 2
-  - uid: 18733
+  - uid: 18731
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,50.5
       parent: 2
-  - uid: 18734
+  - uid: 18732
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,-35.5
       parent: 2
-  - uid: 18735
+  - uid: 18733
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-35.5
       parent: 2
-  - uid: 18736
+  - uid: 18734
     components:
     - type: Transform
       pos: 37.5,1.5
       parent: 2
-  - uid: 18737
+  - uid: 18735
     components:
     - type: Transform
       pos: 38.5,1.5
       parent: 2
-  - uid: 18738
+  - uid: 18736
     components:
     - type: Transform
       pos: 40.5,1.5
       parent: 2
-  - uid: 18739
+  - uid: 18737
     components:
     - type: Transform
       pos: 39.5,1.5
       parent: 2
-  - uid: 18740
+  - uid: 18738
     components:
     - type: Transform
       pos: 43.5,-30.5
       parent: 2
-  - uid: 18741
+  - uid: 18739
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 44.5,-23.5
       parent: 2
-  - uid: 18742
+  - uid: 18740
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 43.5,-34.5
       parent: 2
-  - uid: 18743
+  - uid: 18741
     components:
     - type: Transform
       pos: 44.5,-26.5
       parent: 2
-  - uid: 18744
+  - uid: 18742
     components:
     - type: Transform
       pos: 42.5,-15.5
       parent: 2
-  - uid: 18745
+  - uid: 18743
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 44.5,-30.5
       parent: 2
-  - uid: 18746
+  - uid: 18744
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-22.5
       parent: 2
-  - uid: 18747
+  - uid: 18745
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-27.5
       parent: 2
-  - uid: 18748
+  - uid: 18746
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 42.5,-34.5
       parent: 2
-  - uid: 18749
+  - uid: 18747
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-16.5
       parent: 2
-  - uid: 18750
+  - uid: 18748
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-18.5
       parent: 2
-  - uid: 18751
+  - uid: 18749
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-17.5
       parent: 2
+  - uid: 18750
+    components:
+    - type: Transform
+      pos: 43.5,-15.5
+      parent: 2
+  - uid: 18751
+    components:
+    - type: Transform
+      pos: 43.5,-15.5
+      parent: 2
   - uid: 18752
-    components:
-    - type: Transform
-      pos: 43.5,-15.5
-      parent: 2
-  - uid: 18753
-    components:
-    - type: Transform
-      pos: 43.5,-15.5
-      parent: 2
-  - uid: 18754
     components:
     - type: Transform
       pos: 44.5,-19.5
       parent: 2
-  - uid: 18755
+  - uid: 18753
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-33.5
       parent: 2
-  - uid: 18756
+  - uid: 18754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-32.5
       parent: 2
-  - uid: 18757
+  - uid: 18755
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-31.5
       parent: 2
-  - uid: 18758
+  - uid: 18756
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-29.5
       parent: 2
-  - uid: 18759
+  - uid: 18757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-28.5
       parent: 2
-  - uid: 18760
+  - uid: 18758
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 43.5,-30.5
       parent: 2
-  - uid: 18761
+  - uid: 18759
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-21.5
       parent: 2
-  - uid: 18762
+  - uid: 18760
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-20.5
       parent: 2
-  - uid: 18763
+  - uid: 18761
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 43.5,-19.5
       parent: 2
-  - uid: 18764
+  - uid: 18762
     components:
     - type: Transform
       pos: 43.5,-19.5
       parent: 2
-  - uid: 18765
+  - uid: 18763
     components:
     - type: Transform
       pos: 50.5,1.5
       parent: 2
-  - uid: 18766
+  - uid: 18764
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 58.5,13.5
       parent: 2
-  - uid: 18767
+  - uid: 18765
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-43.5
       parent: 2
-  - uid: 18768
+  - uid: 18766
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-31.5
       parent: 2
-  - uid: 18769
+  - uid: 18767
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-32.5
       parent: 2
-  - uid: 18770
+  - uid: 18768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,-31.5
       parent: 2
-  - uid: 18771
+  - uid: 18769
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,-32.5
       parent: 2
-  - uid: 18772
+  - uid: 18770
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-34.5
       parent: 2
-  - uid: 18773
+  - uid: 18771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,-34.5
       parent: 2
-  - uid: 18774
+  - uid: 18772
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,0.5
       parent: 2
-  - uid: 18775
+  - uid: 18773
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,1.5
       parent: 2
-  - uid: 18776
+  - uid: 18774
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,2.5
       parent: 2
-  - uid: 18777
+  - uid: 18775
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 66.5,4.5
       parent: 2
-  - uid: 18778
+  - uid: 18776
     components:
     - type: Transform
       pos: 63.5,5.5
       parent: 2
-  - uid: 18779
+  - uid: 18777
     components:
     - type: Transform
       pos: 64.5,5.5
       parent: 2
-  - uid: 18780
+  - uid: 18778
     components:
     - type: Transform
       pos: 65.5,5.5
       parent: 2
-  - uid: 18781
+  - uid: 18779
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 62.5,-0.5
       parent: 2
-  - uid: 18782
+  - uid: 18780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 65.5,-0.5
       parent: 2
-  - uid: 18783
+  - uid: 18781
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-29.5
       parent: 2
-  - uid: 18784
+  - uid: 18782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,-8.5
       parent: 2
-  - uid: 18785
+  - uid: 18783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,-10.5
       parent: 2
-  - uid: 18786
+  - uid: 18784
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,-10.5
       parent: 2
-  - uid: 18787
+  - uid: 18785
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 73.5,-13.5
       parent: 2
-  - uid: 18788
+  - uid: 18786
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,-13.5
       parent: 2
-  - uid: 18789
+  - uid: 18787
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,-13.5
       parent: 2
-  - uid: 18790
+  - uid: 18788
     components:
     - type: Transform
       pos: 67.5,-7.5
       parent: 2
-  - uid: 18791
+  - uid: 18789
     components:
     - type: Transform
       pos: 68.5,-7.5
       parent: 2
-  - uid: 18792
+  - uid: 18790
     components:
     - type: Transform
       pos: 69.5,-7.5
       parent: 2
-  - uid: 18793
+  - uid: 18791
     components:
     - type: Transform
       pos: 71.5,-7.5
       parent: 2
-  - uid: 18794
+  - uid: 18792
     components:
     - type: Transform
       pos: 72.5,-7.5
       parent: 2
-  - uid: 18795
+  - uid: 18793
     components:
     - type: Transform
       pos: 73.5,-7.5
       parent: 2
-  - uid: 18796
+  - uid: 18794
     components:
     - type: Transform
       pos: 74.5,-7.5
       parent: 2
-  - uid: 18797
+  - uid: 18795
     components:
     - type: Transform
       pos: 75.5,-7.5
       parent: 2
-  - uid: 18798
+  - uid: 18796
     components:
     - type: Transform
       pos: 70.5,-7.5
       parent: 2
-  - uid: 18799
+  - uid: 18797
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 79.5,-26.5
       parent: 2
-  - uid: 18800
+  - uid: 18798
     components:
     - type: Transform
       pos: 79.5,-22.5
       parent: 2
-  - uid: 18801
+  - uid: 18799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 80.5,-30.5
       parent: 2
-  - uid: 18802
+  - uid: 18800
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 85.5,-30.5
       parent: 2
-  - uid: 18803
+  - uid: 18801
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-11.5
       parent: 2
-  - uid: 18804
+  - uid: 18802
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-12.5
       parent: 2
-  - uid: 18805
+  - uid: 18803
     components:
     - type: Transform
       pos: 85.5,-10.5
       parent: 2
-  - uid: 18806
+  - uid: 18804
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 79.5,-30.5
       parent: 2
-  - uid: 18807
+  - uid: 18805
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-28.5
       parent: 2
-  - uid: 18808
+  - uid: 18806
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,22.5
       parent: 2
-  - uid: 18809
+  - uid: 18807
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,23.5
       parent: 2
-  - uid: 18810
+  - uid: 18808
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,24.5
       parent: 2
-  - uid: 18811
+  - uid: 18809
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,26.5
       parent: 2
-  - uid: 18812
+  - uid: 18810
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,27.5
       parent: 2
-  - uid: 18813
+  - uid: 18811
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,28.5
       parent: 2
-  - uid: 18814
+  - uid: 18812
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,29.5
       parent: 2
-  - uid: 18815
+  - uid: 18813
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,30.5
       parent: 2
-  - uid: 18816
+  - uid: 18814
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,31.5
       parent: 2
-  - uid: 18817
+  - uid: 18815
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,32.5
       parent: 2
-  - uid: 18818
+  - uid: 18816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,33.5
       parent: 2
-  - uid: 18819
+  - uid: 18817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,25.5
       parent: 2
-  - uid: 18820
+  - uid: 18818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,34.5
       parent: 2
-  - uid: 18821
+  - uid: 18819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,36.5
       parent: 2
-  - uid: 18822
+  - uid: 18820
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,35.5
       parent: 2
-  - uid: 18823
+  - uid: 18821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,35.5
       parent: 2
-  - uid: 18824
+  - uid: 18822
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,33.5
       parent: 2
-  - uid: 18825
+  - uid: 18823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,34.5
       parent: 2
-  - uid: 18826
+  - uid: 18824
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,36.5
       parent: 2
-  - uid: 18827
+  - uid: 18825
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,32.5
       parent: 2
-  - uid: 18828
+  - uid: 18826
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,31.5
       parent: 2
-  - uid: 18829
+  - uid: 18827
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,30.5
       parent: 2
-  - uid: 18830
+  - uid: 18828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,28.5
       parent: 2
-  - uid: 18831
+  - uid: 18829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,27.5
       parent: 2
-  - uid: 18832
+  - uid: 18830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,29.5
       parent: 2
-  - uid: 18833
+  - uid: 18831
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,25.5
       parent: 2
-  - uid: 18834
+  - uid: 18832
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,26.5
       parent: 2
-  - uid: 18835
+  - uid: 18833
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,22.5
       parent: 2
-  - uid: 18836
+  - uid: 18834
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,23.5
       parent: 2
-  - uid: 18837
+  - uid: 18835
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,24.5
       parent: 2
-  - uid: 18838
+  - uid: 18836
     components:
     - type: Transform
       pos: 65.5,72.5
       parent: 2
-  - uid: 18839
+  - uid: 18837
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 65.5,70.5
       parent: 2
-  - uid: 18840
+  - uid: 18838
     components:
     - type: Transform
       pos: 65.5,64.5
       parent: 2
-  - uid: 18841
+  - uid: 18839
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 65.5,62.5
       parent: 2
-  - uid: 18842
+  - uid: 18840
     components:
     - type: Transform
       pos: 65.5,58.5
+      parent: 2
+  - uid: 18841
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 60.5,21.5
+      parent: 2
+  - uid: 18842
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 61.5,21.5
       parent: 2
   - uid: 18843
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 60.5,21.5
+      pos: 62.5,21.5
       parent: 2
   - uid: 18844
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 61.5,21.5
+      pos: 68.5,21.5
       parent: 2
   - uid: 18845
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 62.5,21.5
+      pos: 60.5,21.5
       parent: 2
   - uid: 18846
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 68.5,21.5
+      pos: 61.5,21.5
       parent: 2
   - uid: 18847
     components:
     - type: Transform
-      pos: 60.5,21.5
+      pos: 62.5,21.5
       parent: 2
   - uid: 18848
     components:
     - type: Transform
-      pos: 61.5,21.5
+      pos: 68.5,21.5
       parent: 2
   - uid: 18849
     components:
     - type: Transform
-      pos: 62.5,21.5
+      pos: 61.5,16.5
       parent: 2
   - uid: 18850
     components:
     - type: Transform
-      pos: 68.5,21.5
+      pos: 62.5,16.5
       parent: 2
   - uid: 18851
     components:
     - type: Transform
-      pos: 61.5,16.5
+      pos: 66.5,16.5
       parent: 2
   - uid: 18852
     components:
     - type: Transform
-      pos: 62.5,16.5
+      pos: 65.5,16.5
       parent: 2
   - uid: 18853
     components:
     - type: Transform
-      pos: 66.5,16.5
+      pos: 68.5,16.5
       parent: 2
   - uid: 18854
     components:
     - type: Transform
-      pos: 65.5,16.5
-      parent: 2
-  - uid: 18855
-    components:
-    - type: Transform
-      pos: 68.5,16.5
-      parent: 2
-  - uid: 18856
-    components:
-    - type: Transform
       pos: 64.5,16.5
       parent: 2
-  - uid: 18857
+  - uid: 18855
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,4.5
       parent: 2
-  - uid: 18858
+  - uid: 18856
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,4.5
       parent: 2
-  - uid: 18859
+  - uid: 18857
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,4.5
       parent: 2
-  - uid: 18860
+  - uid: 18858
     components:
     - type: Transform
       pos: 10.5,46.5
       parent: 2
-  - uid: 18861
+  - uid: 18859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,28.5
       parent: 2
-  - uid: 18862
+  - uid: 18860
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,29.5
       parent: 2
-  - uid: 18863
+  - uid: 18861
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,18.5
       parent: 2
-  - uid: 18864
+  - uid: 18862
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,19.5
       parent: 2
-  - uid: 18865
+  - uid: 18863
     components:
     - type: Transform
       pos: 51.5,1.5
       parent: 2
-  - uid: 18866
+  - uid: 18864
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-10.5
       parent: 2
-  - uid: 18867
+  - uid: 18865
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,-14.5
       parent: 2
-  - uid: 18868
+  - uid: 18866
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-11.5
       parent: 2
-  - uid: 18869
+  - uid: 18867
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-12.5
       parent: 2
-  - uid: 18870
+  - uid: 18868
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,-15.5
       parent: 2
-  - uid: 18871
+  - uid: 18869
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,-33.5
       parent: 2
-  - uid: 18872
+  - uid: 18870
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,-43.5
       parent: 2
-  - uid: 18873
+  - uid: 18871
     components:
     - type: Transform
       pos: 36.5,-31.5
       parent: 2
-  - uid: 18874
+  - uid: 18872
     components:
     - type: Transform
       pos: 37.5,-27.5
       parent: 2
-  - uid: 18875
+  - uid: 18873
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,-29.5
       parent: 2
-  - uid: 18876
+  - uid: 18874
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,-22.5
       parent: 2
-  - uid: 18877
+  - uid: 18875
     components:
     - type: Transform
       pos: 37.5,-20.5
       parent: 2
-  - uid: 18878
+  - uid: 18876
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,-43.5
       parent: 2
-  - uid: 18879
+  - uid: 18877
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,-43.5
       parent: 2
-  - uid: 18880
+  - uid: 18878
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-43.5
       parent: 2
-  - uid: 18881
+  - uid: 18879
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,-43.5
       parent: 2
-  - uid: 18882
+  - uid: 18880
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-43.5
       parent: 2
-  - uid: 18883
+  - uid: 18881
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,-43.5
       parent: 2
-  - uid: 18884
+  - uid: 18882
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-43.5
       parent: 2
-  - uid: 18885
+  - uid: 18883
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-43.5
       parent: 2
-  - uid: 18886
+  - uid: 18884
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-43.5
       parent: 2
-  - uid: 18887
+  - uid: 18885
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-50.5
       parent: 2
-  - uid: 18888
+  - uid: 18886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-47.5
       parent: 2
-  - uid: 18889
+  - uid: 18887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-46.5
       parent: 2
-  - uid: 18890
+  - uid: 18888
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-45.5
       parent: 2
-  - uid: 18891
+  - uid: 18889
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-44.5
       parent: 2
-  - uid: 18892
+  - uid: 18890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-43.5
       parent: 2
-  - uid: 18893
+  - uid: 18891
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-42.5
       parent: 2
-  - uid: 18894
+  - uid: 18892
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-41.5
       parent: 2
-  - uid: 18895
+  - uid: 18893
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-48.5
       parent: 2
-  - uid: 18896
+  - uid: 18894
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-50.5
       parent: 2
-  - uid: 18897
+  - uid: 18895
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-48.5
       parent: 2
-  - uid: 18898
+  - uid: 18896
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-46.5
       parent: 2
-  - uid: 18899
+  - uid: 18897
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-45.5
       parent: 2
-  - uid: 18900
+  - uid: 18898
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-44.5
       parent: 2
-  - uid: 18901
+  - uid: 18899
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-43.5
       parent: 2
-  - uid: 18902
+  - uid: 18900
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-42.5
       parent: 2
-  - uid: 18903
+  - uid: 18901
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-47.5
       parent: 2
-  - uid: 18904
+  - uid: 18902
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-41.5
       parent: 2
-  - uid: 18905
+  - uid: 18903
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-50.5
       parent: 2
-  - uid: 18906
+  - uid: 18904
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-49.5
       parent: 2
-  - uid: 18907
+  - uid: 18905
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-47.5
       parent: 2
-  - uid: 18908
+  - uid: 18906
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-46.5
       parent: 2
-  - uid: 18909
+  - uid: 18907
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-45.5
       parent: 2
-  - uid: 18910
+  - uid: 18908
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-48.5
       parent: 2
-  - uid: 18911
+  - uid: 18909
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-41.5
       parent: 2
-  - uid: 18912
+  - uid: 18910
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-44.5
       parent: 2
-  - uid: 18913
+  - uid: 18911
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-43.5
       parent: 2
-  - uid: 18914
+  - uid: 18912
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-42.5
       parent: 2
-  - uid: 18915
+  - uid: 18913
     components:
     - type: Transform
       pos: 50.5,-40.5
       parent: 2
-  - uid: 18916
+  - uid: 18914
     components:
     - type: Transform
       pos: 86.5,-18.5
       parent: 2
-  - uid: 18917
+  - uid: 18915
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 86.5,-22.5
       parent: 2
-  - uid: 18918
+  - uid: 18916
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 84.5,-20.5
       parent: 2
-  - uid: 18919
+  - uid: 18917
     components:
     - type: Transform
       pos: 74.5,-39.5
       parent: 2
-  - uid: 18920
+  - uid: 18918
     components:
     - type: Transform
       pos: 75.5,-39.5
       parent: 2
-  - uid: 18921
+  - uid: 18919
     components:
     - type: Transform
       pos: 76.5,-39.5
       parent: 2
-  - uid: 18922
+  - uid: 18920
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,-42.5
       parent: 2
-  - uid: 18923
+  - uid: 18921
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,-42.5
       parent: 2
-  - uid: 18924
+  - uid: 18922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-55.5
       parent: 2
-  - uid: 18925
+  - uid: 18923
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-54.5
       parent: 2
-  - uid: 18926
+  - uid: 18924
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-53.5
       parent: 2
-  - uid: 18927
+  - uid: 18925
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-52.5
       parent: 2
-  - uid: 18928
+  - uid: 18926
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-56.5
       parent: 2
-  - uid: 18929
+  - uid: 18927
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-58.5
       parent: 2
-  - uid: 18930
+  - uid: 18928
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-58.5
       parent: 2
-  - uid: 18931
+  - uid: 18929
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-59.5
       parent: 2
-  - uid: 18932
+  - uid: 18930
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-59.5
       parent: 2
-  - uid: 18933
+  - uid: 18931
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-60.5
       parent: 2
-  - uid: 18934
+  - uid: 18932
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-60.5
       parent: 2
-  - uid: 18935
+  - uid: 18933
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-60.5
       parent: 2
-  - uid: 18936
+  - uid: 18934
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-60.5
       parent: 2
-  - uid: 18937
+  - uid: 18935
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-58.5
       parent: 2
-  - uid: 18938
+  - uid: 18936
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-56.5
       parent: 2
-  - uid: 18939
+  - uid: 18937
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-55.5
       parent: 2
+  - uid: 18938
+    components:
+    - type: Transform
+      pos: 13.5,-54.5
+      parent: 2
+  - uid: 18939
+    components:
+    - type: Transform
+      pos: 13.5,-54.5
+      parent: 2
   - uid: 18940
-    components:
-    - type: Transform
-      pos: 13.5,-54.5
-      parent: 2
-  - uid: 18941
-    components:
-    - type: Transform
-      pos: 13.5,-54.5
-      parent: 2
-  - uid: 18942
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-43.5
       parent: 2
-  - uid: 18943
+  - uid: 18941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 49.5,-41.5
       parent: 2
-  - uid: 18944
+  - uid: 18942
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 57.5,-36.5
       parent: 2
-  - uid: 18945
+  - uid: 18943
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 61.5,-36.5
       parent: 2
-  - uid: 18946
+  - uid: 18944
     components:
     - type: Transform
       pos: 58.5,-40.5
       parent: 2
-  - uid: 18947
+  - uid: 18945
     components:
     - type: Transform
       pos: 59.5,-40.5
       parent: 2
-  - uid: 18948
+  - uid: 18946
     components:
     - type: Transform
       pos: 60.5,-40.5
       parent: 2
-  - uid: 18949
+  - uid: 18947
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,34.5
       parent: 2
-  - uid: 18950
+  - uid: 18948
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,36.5
       parent: 2
-  - uid: 18951
+  - uid: 18949
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,35.5
       parent: 2
-  - uid: 18952
+  - uid: 18950
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,12.5
       parent: 2
-  - uid: 18953
+  - uid: 18951
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,12.5
       parent: 2
-  - uid: 18954
+  - uid: 18952
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,46.5
       parent: 2
-  - uid: 18955
+  - uid: 18953
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,50.5
       parent: 2
-  - uid: 18956
+  - uid: 18954
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,50.5
       parent: 2
-  - uid: 18957
+  - uid: 18955
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,46.5
       parent: 2
-  - uid: 18958
+  - uid: 18956
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -118804,1091 +118837,1091 @@ entities:
       parent: 2
 - proto: RailingCorner
   entities:
-  - uid: 18959
+  - uid: 18957
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,49.5
       parent: 2
-  - uid: 18960
+  - uid: 18958
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,46.5
       parent: 2
-  - uid: 18961
+  - uid: 18959
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,51.5
       parent: 2
-  - uid: 18962
+  - uid: 18960
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,45.5
       parent: 2
-  - uid: 18963
+  - uid: 18961
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,52.5
       parent: 2
-  - uid: 18964
+  - uid: 18962
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,50.5
       parent: 2
-  - uid: 18965
+  - uid: 18963
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,8.5
       parent: 2
-  - uid: 18966
+  - uid: 18964
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,24.5
       parent: 2
-  - uid: 18967
+  - uid: 18965
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,30.5
       parent: 2
-  - uid: 18968
+  - uid: 18966
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,30.5
       parent: 2
-  - uid: 18969
+  - uid: 18967
     components:
     - type: Transform
       pos: -14.5,24.5
       parent: 2
-  - uid: 18970
+  - uid: 18968
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,20.5
       parent: 2
-  - uid: 18971
+  - uid: 18969
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,20.5
       parent: 2
-  - uid: 18972
+  - uid: 18970
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,15.5
       parent: 2
-  - uid: 18973
+  - uid: 18971
     components:
     - type: Transform
       pos: -38.5,15.5
       parent: 2
-  - uid: 18974
+  - uid: 18972
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,20.5
       parent: 2
-  - uid: 18975
+  - uid: 18973
     components:
     - type: Transform
       pos: -60.5,16.5
       parent: 2
-  - uid: 18976
+  - uid: 18974
     components:
     - type: Transform
       pos: 31.5,29.5
       parent: 2
-  - uid: 18977
+  - uid: 18975
     components:
     - type: Transform
       pos: 17.5,-44.5
       parent: 2
-  - uid: 18978
+  - uid: 18976
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-26.5
       parent: 2
-  - uid: 18979
+  - uid: 18977
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-31.5
       parent: 2
-  - uid: 18980
+  - uid: 18978
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,17.5
       parent: 2
-  - uid: 18981
+  - uid: 18979
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,1.5
       parent: 2
-  - uid: 18982
+  - uid: 18980
     components:
     - type: Transform
       pos: 41.5,1.5
       parent: 2
-  - uid: 18983
+  - uid: 18981
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 66.5,3.5
       parent: 2
-  - uid: 18984
+  - uid: 18982
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 86.5,-27.5
       parent: 2
-  - uid: 18985
+  - uid: 18983
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-13.5
       parent: 2
-  - uid: 18986
+  - uid: 18984
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 72.5,-12.5
       parent: 2
-  - uid: 18987
+  - uid: 18985
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 71.5,-11.5
       parent: 2
-  - uid: 18988
+  - uid: 18986
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 70.5,-10.5
       parent: 2
-  - uid: 18989
+  - uid: 18987
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,-9.5
       parent: 2
-  - uid: 18990
+  - uid: 18988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 81.5,-29.5
       parent: 2
-  - uid: 18991
+  - uid: 18989
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 84.5,-29.5
       parent: 2
-  - uid: 18992
+  - uid: 18990
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 64.5,72.5
       parent: 2
-  - uid: 18993
+  - uid: 18991
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 64.5,58.5
       parent: 2
-  - uid: 18994
+  - uid: 18992
     components:
     - type: Transform
       pos: 66.5,58.5
       parent: 2
-  - uid: 18995
+  - uid: 18993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,62.5
       parent: 2
-  - uid: 18996
+  - uid: 18994
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,62.5
       parent: 2
-  - uid: 18997
+  - uid: 18995
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 64.5,64.5
       parent: 2
-  - uid: 18998
+  - uid: 18996
     components:
     - type: Transform
       pos: 66.5,64.5
       parent: 2
-  - uid: 18999
+  - uid: 18997
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,70.5
       parent: 2
-  - uid: 19000
+  - uid: 18998
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,70.5
       parent: 2
-  - uid: 19001
+  - uid: 18999
     components:
     - type: Transform
       pos: 66.5,72.5
       parent: 2
-  - uid: 19002
+  - uid: 19000
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 60.5,16.5
       parent: 2
-  - uid: 19003
+  - uid: 19001
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-7.5
       parent: 2
-  - uid: 19004
+  - uid: 19002
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-6.5
       parent: 2
-  - uid: 19005
+  - uid: 19003
     components:
     - type: Transform
       pos: -22.5,-7.5
       parent: 2
-  - uid: 19006
+  - uid: 19004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-6.5
       parent: 2
-  - uid: 19007
+  - uid: 19005
     components:
     - type: Transform
       pos: -19.5,-7.5
       parent: 2
-  - uid: 19008
+  - uid: 19006
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-13.5
       parent: 2
-  - uid: 19009
+  - uid: 19007
     components:
     - type: Transform
       pos: 56.5,-51.5
       parent: 2
-  - uid: 19010
+  - uid: 19008
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-51.5
       parent: 2
-  - uid: 19011
+  - uid: 19009
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 85.5,-21.5
       parent: 2
-  - uid: 19012
+  - uid: 19010
     components:
     - type: Transform
       pos: 85.5,-19.5
       parent: 2
-  - uid: 19013
+  - uid: 19011
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-51.5
       parent: 2
-  - uid: 19014
+  - uid: 19012
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-57.5
       parent: 2
-  - uid: 19015
+  - uid: 19013
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-58.5
       parent: 2
-  - uid: 19016
+  - uid: 19014
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-59.5
       parent: 2
-  - uid: 19017
+  - uid: 19015
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-59.5
       parent: 2
-  - uid: 19018
+  - uid: 19016
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-58.5
       parent: 2
-  - uid: 19019
+  - uid: 19017
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,-57.5
       parent: 2
-  - uid: 19020
+  - uid: 19018
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-52.5
       parent: 2
-  - uid: 19021
+  - uid: 19019
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-54.5
       parent: 2
-  - uid: 19022
+  - uid: 19020
     components:
     - type: Transform
       pos: 3.5,-52.5
       parent: 2
 - proto: RailingCornerSmall
   entities:
-  - uid: 19023
+  - uid: 19021
     components:
     - type: Transform
       pos: 18.5,-5.5
       parent: 2
-  - uid: 19024
+  - uid: 19022
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-1.5
       parent: 2
-  - uid: 19025
+  - uid: 19023
     components:
     - type: Transform
       pos: 18.5,-3.5
       parent: 2
-  - uid: 19026
+  - uid: 19024
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-3.5
       parent: 2
-  - uid: 19027
+  - uid: 19025
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,40.5
       parent: 2
-  - uid: 19028
+  - uid: 19026
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,38.5
       parent: 2
-  - uid: 19029
+  - uid: 19027
     components:
     - type: Transform
       pos: -32.5,51.5
       parent: 2
-  - uid: 19030
+  - uid: 19028
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,46.5
       parent: 2
-  - uid: 19031
+  - uid: 19029
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,51.5
       parent: 2
-  - uid: 19032
+  - uid: 19030
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,46.5
       parent: 2
-  - uid: 19033
+  - uid: 19031
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,51.5
       parent: 2
-  - uid: 19034
+  - uid: 19032
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,46.5
       parent: 2
-  - uid: 19035
+  - uid: 19033
     components:
     - type: Transform
       pos: 1.5,-43.5
       parent: 2
-  - uid: 19036
+  - uid: 19034
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,49.5
       parent: 2
-  - uid: 19037
+  - uid: 19035
     components:
     - type: Transform
       pos: -47.5,10.5
       parent: 2
-  - uid: 19038
+  - uid: 19036
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,10.5
       parent: 2
-  - uid: 19039
+  - uid: 19037
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,15.5
       parent: 2
-  - uid: 19040
+  - uid: 19038
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -43.5,15.5
       parent: 2
-  - uid: 19041
+  - uid: 19039
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,20.5
       parent: 2
-  - uid: 19042
+  - uid: 19040
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,20.5
       parent: 2
-  - uid: 19043
+  - uid: 19041
     components:
     - type: Transform
       pos: -44.5,20.5
       parent: 2
-  - uid: 19044
+  - uid: 19042
     components:
     - type: Transform
       pos: -40.5,20.5
       parent: 2
-  - uid: 19045
+  - uid: 19043
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,15.5
       parent: 2
-  - uid: 19046
+  - uid: 19044
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,15.5
       parent: 2
-  - uid: 19047
+  - uid: 19045
     components:
     - type: Transform
       pos: -59.5,17.5
       parent: 2
-  - uid: 19048
+  - uid: 19046
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,19.5
       parent: 2
-  - uid: 19049
+  - uid: 19047
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,24.5
       parent: 2
-  - uid: 19050
+  - uid: 19048
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -64.5,30.5
       parent: 2
-  - uid: 19051
+  - uid: 19049
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -55.5,30.5
       parent: 2
-  - uid: 19052
+  - uid: 19050
     components:
     - type: Transform
       pos: -54.5,30.5
       parent: 2
-  - uid: 19053
+  - uid: 19051
     components:
     - type: Transform
       pos: -51.5,30.5
       parent: 2
-  - uid: 19054
+  - uid: 19052
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -52.5,30.5
       parent: 2
-  - uid: 19055
+  - uid: 19053
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -43.5,32.5
       parent: 2
-  - uid: 19056
+  - uid: 19054
     components:
     - type: Transform
       pos: -43.5,29.5
       parent: 2
-  - uid: 19057
+  - uid: 19055
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,29.5
       parent: 2
-  - uid: 19058
+  - uid: 19056
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,32.5
       parent: 2
-  - uid: 19059
+  - uid: 19057
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,18.5
       parent: 2
-  - uid: 19060
+  - uid: 19058
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,30.5
       parent: 2
-  - uid: 19061
+  - uid: 19059
     components:
     - type: Transform
       pos: -14.5,16.5
       parent: 2
-  - uid: 19062
+  - uid: 19060
     components:
     - type: Transform
       pos: 9.5,-43.5
       parent: 2
-  - uid: 19063
+  - uid: 19061
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-43.5
       parent: 2
-  - uid: 19064
+  - uid: 19062
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-43.5
       parent: 2
-  - uid: 19065
+  - uid: 19063
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-43.5
       parent: 2
-  - uid: 19066
+  - uid: 19064
     components:
     - type: Transform
       pos: 13.5,-43.5
       parent: 2
-  - uid: 19067
+  - uid: 19065
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-43.5
       parent: 2
-  - uid: 19068
+  - uid: 19066
     components:
     - type: Transform
       pos: 17.5,-43.5
       parent: 2
-  - uid: 19069
+  - uid: 19067
     components:
     - type: Transform
       pos: -17.5,30.5
       parent: 2
-  - uid: 19070
+  - uid: 19068
     components:
     - type: Transform
       pos: 18.5,-33.5
       parent: 2
-  - uid: 19071
+  - uid: 19069
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-24.5
       parent: 2
-  - uid: 19072
+  - uid: 19070
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,12.5
       parent: 2
-  - uid: 19073
+  - uid: 19071
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,12.5
       parent: 2
-  - uid: 19074
+  - uid: 19072
     components:
     - type: Transform
       pos: 24.5,9.5
       parent: 2
-  - uid: 19075
+  - uid: 19073
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,9.5
       parent: 2
-  - uid: 19076
+  - uid: 19074
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,24.5
       parent: 2
-  - uid: 19077
+  - uid: 19075
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,27.5
       parent: 2
-  - uid: 19078
+  - uid: 19076
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,27.5
       parent: 2
-  - uid: 19079
+  - uid: 19077
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,30.5
       parent: 2
-  - uid: 19080
+  - uid: 19078
     components:
     - type: Transform
       pos: -20.5,27.5
       parent: 2
-  - uid: 19081
+  - uid: 19079
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,27.5
       parent: 2
-  - uid: 19082
+  - uid: 19080
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,16.5
       parent: 2
-  - uid: 19083
+  - uid: 19081
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,21.5
       parent: 2
-  - uid: 19084
+  - uid: 19082
     components:
     - type: Transform
       pos: -12.5,17.5
       parent: 2
-  - uid: 19085
+  - uid: 19083
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,2.5
       parent: 2
-  - uid: 19086
+  - uid: 19084
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 41.5,2.5
       parent: 2
-  - uid: 19087
+  - uid: 19085
     components:
     - type: Transform
       pos: 44.5,-19.5
       parent: 2
-  - uid: 19088
+  - uid: 19086
     components:
     - type: Transform
       pos: 45.5,-23.5
       parent: 2
-  - uid: 19089
+  - uid: 19087
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-19.5
       parent: 2
-  - uid: 19090
+  - uid: 19088
     components:
     - type: Transform
       pos: 45.5,-30.5
       parent: 2
-  - uid: 19091
+  - uid: 19089
     components:
     - type: Transform
       pos: 44.5,-34.5
       parent: 2
-  - uid: 19092
+  - uid: 19090
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,-15.5
       parent: 2
-  - uid: 19093
+  - uid: 19091
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-26.5
       parent: 2
-  - uid: 19094
+  - uid: 19092
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,-30.5
       parent: 2
-  - uid: 19095
+  - uid: 19093
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-43.5
       parent: 2
-  - uid: 19096
+  - uid: 19094
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 48.5,-30.5
       parent: 2
-  - uid: 19097
+  - uid: 19095
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 53.5,-30.5
       parent: 2
-  - uid: 19098
+  - uid: 19096
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,3.5
       parent: 2
-  - uid: 19099
+  - uid: 19097
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,5.5
       parent: 2
-  - uid: 19100
+  - uid: 19098
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 70.5,-11.5
       parent: 2
-  - uid: 19101
+  - uid: 19099
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 66.5,-9.5
       parent: 2
-  - uid: 19102
+  - uid: 19100
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,-10.5
       parent: 2
-  - uid: 19103
+  - uid: 19101
     components:
     - type: Transform
       pos: 76.5,-13.5
       parent: 2
-  - uid: 19104
+  - uid: 19102
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 72.5,-13.5
       parent: 2
-  - uid: 19105
+  - uid: 19103
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 71.5,-12.5
       parent: 2
-  - uid: 19106
+  - uid: 19104
     components:
     - type: Transform
       pos: 81.5,-30.5
       parent: 2
-  - uid: 19107
+  - uid: 19105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 84.5,-30.5
       parent: 2
-  - uid: 19108
+  - uid: 19106
     components:
     - type: Transform
       pos: 82.5,-29.5
       parent: 2
-  - uid: 19109
+  - uid: 19107
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 87.5,-13.5
       parent: 2
-  - uid: 19110
+  - uid: 19108
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 83.5,-29.5
       parent: 2
-  - uid: 19111
+  - uid: 19109
     components:
     - type: Transform
       pos: 86.5,-30.5
       parent: 2
-  - uid: 19112
+  - uid: 19110
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 86.5,-10.5
       parent: 2
-  - uid: 19113
+  - uid: 19111
     components:
     - type: Transform
       pos: 87.5,-27.5
       parent: 2
-  - uid: 19114
+  - uid: 19112
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 78.5,-30.5
       parent: 2
-  - uid: 19115
+  - uid: 19113
     components:
     - type: Transform
       pos: 63.5,21.5
       parent: 2
-  - uid: 19116
+  - uid: 19114
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,21.5
       parent: 2
-  - uid: 19117
+  - uid: 19115
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 67.5,21.5
       parent: 2
-  - uid: 19118
+  - uid: 19116
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,21.5
       parent: 2
-  - uid: 19119
+  - uid: 19117
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 60.5,17.5
       parent: 2
-  - uid: 19120
+  - uid: 19118
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,20.5
       parent: 2
-  - uid: 19121
+  - uid: 19119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -57.5,-13.5
       parent: 2
-  - uid: 19122
+  - uid: 19120
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,8.5
       parent: 2
-  - uid: 19123
+  - uid: 19121
     components:
     - type: Transform
       pos: 27.5,-43.5
       parent: 2
-  - uid: 19124
+  - uid: 19122
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 51.5,-40.5
       parent: 2
-  - uid: 19125
+  - uid: 19123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 85.5,-22.5
       parent: 2
-  - uid: 19126
+  - uid: 19124
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 84.5,-21.5
       parent: 2
-  - uid: 19127
+  - uid: 19125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 84.5,-19.5
       parent: 2
-  - uid: 19128
+  - uid: 19126
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 85.5,-18.5
       parent: 2
-  - uid: 19129
+  - uid: 19127
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-51.5
       parent: 2
-  - uid: 19130
+  - uid: 19128
     components:
     - type: Transform
       pos: 14.5,-57.5
       parent: 2
-  - uid: 19131
+  - uid: 19129
     components:
     - type: Transform
       pos: 13.5,-58.5
       parent: 2
-  - uid: 19132
+  - uid: 19130
     components:
     - type: Transform
       pos: 11.5,-59.5
       parent: 2
-  - uid: 19133
+  - uid: 19131
     components:
     - type: Transform
       pos: 10.5,-60.5
       parent: 2
-  - uid: 19134
+  - uid: 19132
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-60.5
       parent: 2
-  - uid: 19135
+  - uid: 19133
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-59.5
       parent: 2
-  - uid: 19136
+  - uid: 19134
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-58.5
       parent: 2
-  - uid: 19137
+  - uid: 19135
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-57.5
       parent: 2
-  - uid: 19138
+  - uid: 19136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-54.5
       parent: 2
-  - uid: 19139
+  - uid: 19137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-44.5
       parent: 2
-  - uid: 19140
+  - uid: 19138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 49.5,-40.5
       parent: 2
-  - uid: 19141
+  - uid: 19139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,-40.5
       parent: 2
-  - uid: 19142
+  - uid: 19140
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 62.5,-40.5
       parent: 2
-  - uid: 19143
+  - uid: 19141
     components:
     - type: Transform
       pos: 61.5,-37.5
       parent: 2
-  - uid: 19144
+  - uid: 19142
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 57.5,-37.5
       parent: 2
-  - uid: 19145
+  - uid: 19143
     components:
     - type: Transform
       pos: 17.5,33.5
       parent: 2
-  - uid: 19146
+  - uid: 19144
     components:
     - type: Transform
       pos: 58.5,12.5
       parent: 2
-  - uid: 19147
+  - uid: 19145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,29.5
       parent: 2
-  - uid: 19148
+  - uid: 19146
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -119896,1083 +119929,1083 @@ entities:
       parent: 2
 - proto: RailingRound
   entities:
-  - uid: 19149
+  - uid: 19147
     components:
     - type: Transform
       pos: -9.5,29.5
       parent: 2
-  - uid: 19150
+  - uid: 19148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,32.5
       parent: 2
-  - uid: 19151
+  - uid: 19149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,70.5
       parent: 2
-  - uid: 19152
+  - uid: 19150
     components:
     - type: Transform
       pos: 34.5,65.5
       parent: 2
-  - uid: 19153
+  - uid: 19151
     components:
     - type: Transform
       pos: 37.5,65.5
       parent: 2
-  - uid: 19154
+  - uid: 19152
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,59.5
       parent: 2
-  - uid: 19155
+  - uid: 19153
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,59.5
       parent: 2
-  - uid: 19156
+  - uid: 19154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,41.5
       parent: 2
-  - uid: 19157
+  - uid: 19155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,41.5
       parent: 2
-  - uid: 19158
+  - uid: 19156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,70.5
       parent: 2
-  - uid: 19159
+  - uid: 19157
     components:
     - type: Transform
       pos: 34.5,55.5
       parent: 2
-  - uid: 19160
+  - uid: 19158
     components:
     - type: Transform
       pos: 37.5,55.5
       parent: 2
 - proto: RandomArtifactSpawner
   entities:
-  - uid: 19161
+  - uid: 19159
     components:
     - type: Transform
       pos: -73.5,-6.5
       parent: 2
-  - uid: 19162
+  - uid: 19160
     components:
     - type: Transform
       pos: -53.5,40.5
       parent: 2
 - proto: RandomArtifactSpawner20
   entities:
-  - uid: 19163
+  - uid: 19161
     components:
     - type: Transform
       pos: -60.5,44.5
       parent: 2
 - proto: RandomDrinkBottle
   entities:
-  - uid: 19164
+  - uid: 19162
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 2
-  - uid: 19165
+  - uid: 19163
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 2
 - proto: RandomInstruments
   entities:
-  - uid: 19166
+  - uid: 19164
     components:
     - type: Transform
       pos: 44.5,2.5
       parent: 2
-  - uid: 19167
+  - uid: 19165
     components:
     - type: Transform
       pos: 44.5,2.5
       parent: 2
 - proto: RandomPosterLegit
   entities:
-  - uid: 19168
+  - uid: 19166
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 2
-  - uid: 19169
+  - uid: 19167
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 2
-  - uid: 19170
+  - uid: 19168
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-  - uid: 19171
+  - uid: 19169
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 19172
+  - uid: 19170
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 2
-  - uid: 19173
+  - uid: 19171
     components:
     - type: Transform
       pos: -5.5,-15.5
       parent: 2
-  - uid: 19174
+  - uid: 19172
     components:
     - type: Transform
       pos: -23.5,24.5
       parent: 2
-  - uid: 19175
+  - uid: 19173
     components:
     - type: Transform
       pos: 0.5,-29.5
       parent: 2
-  - uid: 19176
+  - uid: 19174
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-36.5
       parent: 2
-  - uid: 19177
+  - uid: 19175
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 2
-  - uid: 19178
+  - uid: 19176
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 2
-  - uid: 19179
+  - uid: 19177
     components:
     - type: Transform
       pos: 17.5,-1.5
       parent: 2
-  - uid: 19180
+  - uid: 19178
     components:
     - type: Transform
       pos: -19.5,-2.5
       parent: 2
-  - uid: 19181
+  - uid: 19179
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 2
-  - uid: 19182
+  - uid: 19180
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 2
-  - uid: 19183
+  - uid: 19181
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 2
-  - uid: 19184
+  - uid: 19182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-39.5
       parent: 2
-  - uid: 19185
+  - uid: 19183
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-40.5
       parent: 2
-  - uid: 19186
+  - uid: 19184
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-38.5
       parent: 2
-  - uid: 19187
+  - uid: 19185
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 2
-  - uid: 19188
+  - uid: 19186
     components:
     - type: Transform
       pos: -12.5,-14.5
       parent: 2
-  - uid: 19189
+  - uid: 19187
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 2
-  - uid: 19190
+  - uid: 19188
     components:
     - type: Transform
       pos: -11.5,-4.5
       parent: 2
-  - uid: 19191
+  - uid: 19189
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 2
-  - uid: 19192
+  - uid: 19190
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 2
-  - uid: 19193
+  - uid: 19191
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 2
-  - uid: 19194
+  - uid: 19192
     components:
     - type: Transform
       pos: -14.5,11.5
       parent: 2
-  - uid: 19195
+  - uid: 19193
     components:
     - type: Transform
       pos: -20.5,11.5
       parent: 2
-  - uid: 19196
+  - uid: 19194
     components:
     - type: Transform
       pos: -32.5,4.5
       parent: 2
-  - uid: 19197
+  - uid: 19195
     components:
     - type: Transform
       pos: -26.5,-4.5
       parent: 2
-  - uid: 19198
+  - uid: 19196
     components:
     - type: Transform
       pos: -24.5,-2.5
       parent: 2
-  - uid: 19199
+  - uid: 19197
     components:
     - type: Transform
       pos: -32.5,-4.5
       parent: 2
-  - uid: 19200
+  - uid: 19198
     components:
     - type: Transform
       pos: -44.5,2.5
       parent: 2
-  - uid: 19201
+  - uid: 19199
     components:
     - type: Transform
       pos: -47.5,2.5
       parent: 2
-  - uid: 19202
+  - uid: 19200
     components:
     - type: Transform
       pos: -47.5,-2.5
       parent: 2
-  - uid: 19203
+  - uid: 19201
     components:
     - type: Transform
       pos: -53.5,-1.5
       parent: 2
-  - uid: 19204
+  - uid: 19202
     components:
     - type: Transform
       pos: -57.5,-1.5
       parent: 2
-  - uid: 19205
+  - uid: 19203
     components:
     - type: Transform
       pos: -56.5,6.5
       parent: 2
-  - uid: 19206
+  - uid: 19204
     components:
     - type: Transform
       pos: -54.5,6.5
       parent: 2
-  - uid: 19207
+  - uid: 19205
     components:
     - type: Transform
       pos: -44.5,11.5
       parent: 2
-  - uid: 19208
+  - uid: 19206
     components:
     - type: Transform
       pos: -50.5,6.5
       parent: 2
-  - uid: 19209
+  - uid: 19207
     components:
     - type: Transform
       pos: -44.5,6.5
       parent: 2
-  - uid: 19210
+  - uid: 19208
     components:
     - type: Transform
       pos: -47.5,6.5
       parent: 2
-  - uid: 19211
+  - uid: 19209
     components:
     - type: Transform
       pos: -49.5,12.5
       parent: 2
-  - uid: 19212
+  - uid: 19210
     components:
     - type: Transform
       pos: -49.5,23.5
       parent: 2
-  - uid: 19213
+  - uid: 19211
     components:
     - type: Transform
       pos: -55.5,22.5
       parent: 2
-  - uid: 19214
+  - uid: 19212
     components:
     - type: Transform
       pos: -55.5,14.5
       parent: 2
-  - uid: 19215
+  - uid: 19213
     components:
     - type: Transform
       pos: -51.5,14.5
       parent: 2
-  - uid: 19216
+  - uid: 19214
     components:
     - type: Transform
       pos: -51.5,22.5
       parent: 2
-  - uid: 19217
+  - uid: 19215
     components:
     - type: Transform
       pos: -63.5,16.5
       parent: 2
-  - uid: 19218
+  - uid: 19216
     components:
     - type: Transform
       pos: -63.5,21.5
       parent: 2
-  - uid: 19219
+  - uid: 19217
     components:
     - type: Transform
       pos: -58.5,25.5
       parent: 2
-  - uid: 19220
+  - uid: 19218
     components:
     - type: Transform
       pos: -61.5,25.5
       parent: 2
-  - uid: 19221
+  - uid: 19219
     components:
     - type: Transform
       pos: -64.5,25.5
       parent: 2
-  - uid: 19222
+  - uid: 19220
     components:
     - type: Transform
       pos: -70.5,44.5
       parent: 2
-  - uid: 19223
+  - uid: 19221
     components:
     - type: Transform
       pos: -70.5,37.5
       parent: 2
-  - uid: 19224
+  - uid: 19222
     components:
     - type: Transform
       pos: -42.5,38.5
       parent: 2
-  - uid: 19225
+  - uid: 19223
     components:
     - type: Transform
       pos: -42.5,35.5
       parent: 2
-  - uid: 19226
+  - uid: 19224
     components:
     - type: Transform
       pos: -46.5,40.5
       parent: 2
-  - uid: 19227
+  - uid: 19225
     components:
     - type: Transform
       pos: -42.5,26.5
       parent: 2
-  - uid: 19228
+  - uid: 19226
     components:
     - type: Transform
       pos: -49.5,25.5
       parent: 2
-  - uid: 19229
+  - uid: 19227
     components:
     - type: Transform
       pos: -34.5,25.5
       parent: 2
-  - uid: 19230
+  - uid: 19228
     components:
     - type: Transform
       pos: -39.5,33.5
       parent: 2
-  - uid: 19231
+  - uid: 19229
     components:
     - type: Transform
       pos: -23.5,38.5
       parent: 2
-  - uid: 19232
+  - uid: 19230
     components:
     - type: Transform
       pos: -20.5,46.5
       parent: 2
-  - uid: 19233
+  - uid: 19231
     components:
     - type: Transform
       pos: -10.5,46.5
       parent: 2
-  - uid: 19234
+  - uid: 19232
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,44.5
       parent: 2
-  - uid: 19235
+  - uid: 19233
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,40.5
       parent: 2
-  - uid: 19236
+  - uid: 19234
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,35.5
       parent: 2
-  - uid: 19237
+  - uid: 19235
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,31.5
       parent: 2
-  - uid: 19238
+  - uid: 19236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,29.5
       parent: 2
-  - uid: 19239
+  - uid: 19237
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,24.5
       parent: 2
-  - uid: 19240
+  - uid: 19238
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,24.5
       parent: 2
-  - uid: 19241
+  - uid: 19239
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,19.5
       parent: 2
-  - uid: 19242
+  - uid: 19240
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,33.5
       parent: 2
-  - uid: 19243
+  - uid: 19241
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,27.5
       parent: 2
-  - uid: 19244
+  - uid: 19242
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,35.5
       parent: 2
-  - uid: 19245
+  - uid: 19243
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,33.5
       parent: 2
-  - uid: 19246
+  - uid: 19244
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,31.5
       parent: 2
-  - uid: 19247
+  - uid: 19245
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,19.5
       parent: 2
-  - uid: 19248
+  - uid: 19246
     components:
     - type: Transform
       pos: 21.5,-23.5
       parent: 2
-  - uid: 19249
+  - uid: 19247
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,35.5
       parent: 2
-  - uid: 19250
+  - uid: 19248
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,31.5
       parent: 2
-  - uid: 19251
+  - uid: 19249
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,29.5
       parent: 2
-  - uid: 19252
+  - uid: 19250
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,23.5
       parent: 2
-  - uid: 19253
+  - uid: 19251
     components:
     - type: Transform
       pos: 7.5,26.5
       parent: 2
-  - uid: 19254
+  - uid: 19252
     components:
     - type: Transform
       pos: 23.5,23.5
       parent: 2
-  - uid: 19255
+  - uid: 19253
     components:
     - type: Transform
       pos: 25.5,27.5
       parent: 2
-  - uid: 19256
+  - uid: 19254
     components:
     - type: Transform
       pos: 25.5,23.5
       parent: 2
-  - uid: 19257
+  - uid: 19255
     components:
     - type: Transform
       pos: 21.5,27.5
       parent: 2
-  - uid: 19258
+  - uid: 19256
     components:
     - type: Transform
       pos: 14.5,27.5
       parent: 2
-  - uid: 19259
+  - uid: 19257
     components:
     - type: Transform
       pos: 31.5,21.5
       parent: 2
-  - uid: 19260
+  - uid: 19258
     components:
     - type: Transform
       pos: 42.5,32.5
       parent: 2
-  - uid: 19261
+  - uid: 19259
     components:
     - type: Transform
       pos: 56.5,25.5
       parent: 2
-  - uid: 19262
+  - uid: 19260
     components:
     - type: Transform
       pos: 35.5,23.5
       parent: 2
-  - uid: 19263
+  - uid: 19261
     components:
     - type: Transform
       pos: 37.5,19.5
       parent: 2
-  - uid: 19264
+  - uid: 19262
     components:
     - type: Transform
       pos: 35.5,6.5
       parent: 2
-  - uid: 19265
+  - uid: 19263
     components:
     - type: Transform
       pos: 39.5,6.5
       parent: 2
-  - uid: 19266
+  - uid: 19264
     components:
     - type: Transform
       pos: 71.5,23.5
       parent: 2
-  - uid: 19267
+  - uid: 19265
     components:
     - type: Transform
       pos: 71.5,13.5
       parent: 2
-  - uid: 19268
+  - uid: 19266
     components:
     - type: Transform
       pos: 63.5,39.5
       parent: 2
-  - uid: 19269
+  - uid: 19267
     components:
     - type: Transform
       pos: 67.5,39.5
       parent: 2
-  - uid: 19270
+  - uid: 19268
     components:
     - type: Transform
       pos: 52.5,-0.5
       parent: 2
-  - uid: 19271
+  - uid: 19269
     components:
     - type: Transform
       pos: 46.5,1.5
       parent: 2
-  - uid: 19272
+  - uid: 19270
     components:
     - type: Transform
       pos: 43.5,-1.5
       parent: 2
-  - uid: 19273
+  - uid: 19271
     components:
     - type: Transform
       pos: 52.5,-5.5
       parent: 2
-  - uid: 19274
+  - uid: 19272
     components:
     - type: Transform
       pos: 57.5,-5.5
       parent: 2
-  - uid: 19275
+  - uid: 19273
     components:
     - type: Transform
       pos: 57.5,-1.5
       parent: 2
-  - uid: 19276
+  - uid: 19274
     components:
     - type: Transform
       pos: 53.5,3.5
       parent: 2
-  - uid: 19277
+  - uid: 19275
     components:
     - type: Transform
       pos: 55.5,3.5
       parent: 2
-  - uid: 19278
+  - uid: 19276
     components:
     - type: Transform
       pos: 66.5,-5.5
       parent: 2
-  - uid: 19279
+  - uid: 19277
     components:
     - type: Transform
       pos: 66.5,-1.5
       parent: 2
-  - uid: 19280
+  - uid: 19278
     components:
     - type: Transform
       pos: 77.5,-10.5
       parent: 2
-  - uid: 19281
+  - uid: 19279
     components:
     - type: Transform
       pos: 77.5,-8.5
       parent: 2
-  - uid: 19282
+  - uid: 19280
     components:
     - type: Transform
       pos: 77.5,-6.5
       parent: 2
-  - uid: 19283
+  - uid: 19281
     components:
     - type: Transform
       pos: 84.5,-9.5
       parent: 2
-  - uid: 19284
+  - uid: 19282
     components:
     - type: Transform
       pos: 82.5,-12.5
       parent: 2
-  - uid: 19285
+  - uid: 19283
     components:
     - type: Transform
       pos: 69.5,-23.5
       parent: 2
-  - uid: 19286
+  - uid: 19284
     components:
     - type: Transform
       pos: 72.5,-17.5
       parent: 2
-  - uid: 19287
+  - uid: 19285
     components:
     - type: Transform
       pos: 69.5,-19.5
       parent: 2
-  - uid: 19288
+  - uid: 19286
     components:
     - type: Transform
       pos: 69.5,-30.5
       parent: 2
-  - uid: 19289
+  - uid: 19287
     components:
     - type: Transform
       pos: 63.5,-35.5
       parent: 2
-  - uid: 19290
+  - uid: 19288
     components:
     - type: Transform
       pos: 66.5,-35.5
       parent: 2
-  - uid: 19291
+  - uid: 19289
     components:
     - type: Transform
       pos: 57.5,-35.5
       parent: 2
-  - uid: 19292
+  - uid: 19290
     components:
     - type: Transform
       pos: 52.5,-35.5
       parent: 2
-  - uid: 19293
+  - uid: 19291
     components:
     - type: Transform
       pos: 49.5,-35.5
       parent: 2
-  - uid: 19294
+  - uid: 19292
     components:
     - type: Transform
       pos: 46.5,-35.5
       parent: 2
-  - uid: 19295
+  - uid: 19293
     components:
     - type: Transform
       pos: 39.5,-30.5
       parent: 2
-  - uid: 19296
+  - uid: 19294
     components:
     - type: Transform
       pos: 40.5,-26.5
       parent: 2
-  - uid: 19297
+  - uid: 19295
     components:
     - type: Transform
       pos: 40.5,-23.5
       parent: 2
-  - uid: 19298
+  - uid: 19296
     components:
     - type: Transform
       pos: 39.5,-19.5
       parent: 2
-  - uid: 19299
+  - uid: 19297
     components:
     - type: Transform
       pos: 33.5,-28.5
       parent: 2
-  - uid: 19300
+  - uid: 19298
     components:
     - type: Transform
       pos: 14.5,-24.5
       parent: 2
-  - uid: 19301
+  - uid: 19299
     components:
     - type: Transform
       pos: 10.5,-24.5
       parent: 2
-  - uid: 19302
+  - uid: 19300
     components:
     - type: Transform
       pos: 7.5,-33.5
       parent: 2
-  - uid: 19303
+  - uid: 19301
     components:
     - type: Transform
       pos: 9.5,-39.5
       parent: 2
-  - uid: 19304
+  - uid: 19302
     components:
     - type: Transform
       pos: 13.5,-39.5
       parent: 2
-  - uid: 19305
+  - uid: 19303
     components:
     - type: Transform
       pos: 0.5,-31.5
       parent: 2
-  - uid: 19306
+  - uid: 19304
     components:
     - type: Transform
       pos: 14.5,-15.5
       parent: 2
-  - uid: 19307
+  - uid: 19305
     components:
     - type: Transform
       pos: 16.5,-5.5
       parent: 2
-  - uid: 19308
+  - uid: 19306
     components:
     - type: Transform
       pos: -47.5,-7.5
       parent: 2
-  - uid: 19309
+  - uid: 19307
     components:
     - type: Transform
       pos: -47.5,-11.5
       parent: 2
-  - uid: 19310
+  - uid: 19308
     components:
     - type: Transform
       pos: -39.5,-9.5
       parent: 2
-  - uid: 19311
+  - uid: 19309
     components:
     - type: Transform
       pos: -60.5,23.5
       parent: 2
-  - uid: 19312
+  - uid: 19310
     components:
     - type: Transform
       pos: -60.5,13.5
       parent: 2
-  - uid: 19313
+  - uid: 19311
     components:
     - type: Transform
       pos: -7.5,36.5
       parent: 2
 - proto: RandomSoap
   entities:
-  - uid: 19314
+  - uid: 19312
     components:
     - type: Transform
       pos: 12.5,-17.5
       parent: 2
 - proto: RandomSpawner100
   entities:
-  - uid: 19315
+  - uid: 19313
     components:
     - type: Transform
       pos: 62.5,-34.5
       parent: 2
-  - uid: 19316
+  - uid: 19314
     components:
     - type: Transform
       pos: 65.5,-33.5
       parent: 2
-  - uid: 19317
+  - uid: 19315
     components:
     - type: Transform
       pos: 63.5,-31.5
       parent: 2
-  - uid: 19318
+  - uid: 19316
     components:
     - type: Transform
       pos: 66.5,-30.5
       parent: 2
-  - uid: 19319
+  - uid: 19317
     components:
     - type: Transform
       pos: 64.5,-30.5
       parent: 2
-  - uid: 19320
+  - uid: 19318
     components:
     - type: Transform
       pos: 64.5,-33.5
       parent: 2
-  - uid: 19321
+  - uid: 19319
     components:
     - type: Transform
       pos: 57.5,-32.5
       parent: 2
-  - uid: 19322
+  - uid: 19320
     components:
     - type: Transform
       pos: 58.5,-33.5
       parent: 2
-  - uid: 19323
+  - uid: 19321
     components:
     - type: Transform
       pos: 59.5,-29.5
       parent: 2
-  - uid: 19324
+  - uid: 19322
     components:
     - type: Transform
       pos: 60.5,-28.5
       parent: 2
-  - uid: 19325
+  - uid: 19323
     components:
     - type: Transform
       pos: 61.5,-27.5
       parent: 2
-  - uid: 19326
+  - uid: 19324
     components:
     - type: Transform
       pos: 63.5,-26.5
       parent: 2
-  - uid: 19327
+  - uid: 19325
     components:
     - type: Transform
       pos: 65.5,-27.5
       parent: 2
-  - uid: 19328
+  - uid: 19326
     components:
     - type: Transform
       pos: 66.5,-25.5
       parent: 2
-  - uid: 19329
+  - uid: 19327
     components:
     - type: Transform
       pos: 67.5,-27.5
       parent: 2
 - proto: RandomVendingDrinks
   entities:
-  - uid: 19330
+  - uid: 19328
     components:
     - type: Transform
       pos: 15.5,10.5
       parent: 2
-  - uid: 19331
+  - uid: 19329
     components:
     - type: Transform
       pos: 15.5,-34.5
       parent: 2
-  - uid: 19332
+  - uid: 19330
     components:
     - type: Transform
       pos: 16.5,-20.5
       parent: 2
-  - uid: 19333
+  - uid: 19331
     components:
     - type: Transform
       pos: 43.5,-0.5
       parent: 2
-  - uid: 19334
+  - uid: 19332
     components:
     - type: Transform
       pos: 55.5,-36.5
       parent: 2
-  - uid: 19335
+  - uid: 19333
     components:
     - type: Transform
       pos: 66.5,-42.5
       parent: 2
-  - uid: 19336
+  - uid: 19334
     components:
     - type: Transform
       pos: -22.5,19.5
       parent: 2
 - proto: RandomVendingSnacks
   entities:
-  - uid: 19337
+  - uid: 19335
     components:
     - type: Transform
       pos: -18.5,-0.5
       parent: 2
-  - uid: 19338
+  - uid: 19336
     components:
     - type: Transform
       pos: -42.5,10.5
       parent: 2
-  - uid: 19339
+  - uid: 19337
     components:
     - type: Transform
       pos: 15.5,9.5
       parent: 2
-  - uid: 19340
+  - uid: 19338
     components:
     - type: Transform
       pos: 16.5,-34.5
       parent: 2
-  - uid: 19341
+  - uid: 19339
     components:
     - type: Transform
       pos: 15.5,-20.5
       parent: 2
-  - uid: 19342
+  - uid: 19340
     components:
     - type: Transform
       pos: 43.5,0.5
       parent: 2
-  - uid: 19343
+  - uid: 19341
     components:
     - type: Transform
       pos: 54.5,-36.5
       parent: 2
-  - uid: 19344
+  - uid: 19342
     components:
     - type: Transform
       pos: 66.5,-41.5
       parent: 2
-  - uid: 19345
+  - uid: 19343
     components:
     - type: Transform
       pos: -22.5,18.5
       parent: 2
 - proto: RandomWoodenSupport
   entities:
-  - uid: 19346
+  - uid: 19344
     components:
     - type: Transform
       pos: -49.5,-18.5
       parent: 2
-  - uid: 19347
+  - uid: 19345
     components:
     - type: Transform
       pos: -57.5,-11.5
       parent: 2
-  - uid: 19348
+  - uid: 19346
     components:
     - type: Transform
       pos: -55.5,-8.5
       parent: 2
 - proto: RCD
   entities:
-  - uid: 19349
+  - uid: 19347
     components:
     - type: Transform
       pos: 36.40911,29.864853
       parent: 2
 - proto: RCDAmmo
   entities:
-  - uid: 19350
+  - uid: 19348
     components:
     - type: Transform
       pos: 36.424736,29.458603
       parent: 2
-  - uid: 19351
+  - uid: 19349
     components:
     - type: Transform
       pos: 36.549736,29.411728
       parent: 2
 - proto: Recycler
   entities:
-  - uid: 19352
+  - uid: 19350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,28.5
       parent: 2
-  - uid: 19353
+  - uid: 19351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -120984,693 +121017,693 @@ entities:
       enabled: True
 - proto: ReinforcedGirder
   entities:
-  - uid: 19354
+  - uid: 19352
     components:
     - type: Transform
       pos: -77.5,32.5
       parent: 2
-  - uid: 19355
+  - uid: 19353
     components:
     - type: Transform
       pos: -75.5,38.5
       parent: 2
-  - uid: 19356
+  - uid: 19354
     components:
     - type: Transform
       pos: -75.5,34.5
       parent: 2
-  - uid: 19357
+  - uid: 19355
     components:
     - type: Transform
       pos: -70.5,51.5
       parent: 2
-  - uid: 19358
+  - uid: 19356
     components:
     - type: Transform
       pos: -63.5,51.5
       parent: 2
-  - uid: 19359
+  - uid: 19357
     components:
     - type: Transform
       pos: -57.5,43.5
       parent: 2
-  - uid: 19360
+  - uid: 19358
     components:
     - type: Transform
       pos: -57.5,48.5
       parent: 2
-  - uid: 19361
+  - uid: 19359
     components:
     - type: Transform
       pos: -63.5,48.5
       parent: 2
-  - uid: 19362
+  - uid: 19360
     components:
     - type: Transform
       pos: -63.5,43.5
       parent: 2
-  - uid: 19363
+  - uid: 19361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,-44.5
       parent: 2
-  - uid: 19364
+  - uid: 19362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-24.5
       parent: 2
-  - uid: 19365
+  - uid: 19363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-42.5
       parent: 2
-  - uid: 19366
+  - uid: 19364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-33.5
       parent: 2
-  - uid: 19367
+  - uid: 19365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,-42.5
       parent: 2
-  - uid: 19368
+  - uid: 19366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,-44.5
       parent: 2
-  - uid: 19369
+  - uid: 19367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,-42.5
       parent: 2
-  - uid: 19370
+  - uid: 19368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-42.5
       parent: 2
-  - uid: 19371
+  - uid: 19369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-33.5
       parent: 2
-  - uid: 19372
+  - uid: 19370
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-24.5
       parent: 2
-  - uid: 19373
+  - uid: 19371
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,-24.5
       parent: 2
-  - uid: 19374
+  - uid: 19372
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,-24.5
       parent: 2
-  - uid: 19375
+  - uid: 19373
     components:
     - type: Transform
       pos: -4.5,58.5
       parent: 2
-  - uid: 19376
+  - uid: 19374
     components:
     - type: Transform
       pos: -15.5,60.5
       parent: 2
-  - uid: 19377
+  - uid: 19375
     components:
     - type: Transform
       pos: -22.5,60.5
       parent: 2
-  - uid: 19378
+  - uid: 19376
     components:
     - type: Transform
       pos: -8.5,60.5
       parent: 2
-  - uid: 19379
+  - uid: 19377
     components:
     - type: Transform
       pos: -26.5,58.5
       parent: 2
-  - uid: 19380
+  - uid: 19378
     components:
     - type: Transform
       pos: -27.5,57.5
       parent: 2
-  - uid: 19381
+  - uid: 19379
     components:
     - type: Transform
       pos: -24.5,59.5
       parent: 2
-  - uid: 19382
+  - uid: 19380
     components:
     - type: Transform
       pos: -10.5,58.5
       parent: 2
-  - uid: 19383
+  - uid: 19381
     components:
     - type: Transform
       pos: -24.5,56.5
       parent: 2
-  - uid: 19384
+  - uid: 19382
     components:
     - type: Transform
       pos: -6.5,56.5
       parent: 2
-  - uid: 19385
+  - uid: 19383
     components:
     - type: Transform
       pos: -20.5,58.5
       parent: 2
-  - uid: 19386
+  - uid: 19384
     components:
     - type: Transform
       pos: -15.5,58.5
       parent: 2
-  - uid: 19387
+  - uid: 19385
     components:
     - type: Transform
       pos: -6.5,59.5
       parent: 2
-  - uid: 19388
+  - uid: 19386
     components:
     - type: Transform
       pos: -3.5,57.5
       parent: 2
-  - uid: 19389
+  - uid: 19387
     components:
     - type: Transform
       pos: -63.5,54.5
       parent: 2
-  - uid: 19390
+  - uid: 19388
     components:
     - type: Transform
       pos: -70.5,54.5
       parent: 2
-  - uid: 19391
+  - uid: 19389
     components:
     - type: Transform
       pos: -74.5,51.5
       parent: 2
-  - uid: 19392
+  - uid: 19390
     components:
     - type: Transform
       pos: -75.5,48.5
       parent: 2
-  - uid: 19393
+  - uid: 19391
     components:
     - type: Transform
       pos: -57.5,54.5
       parent: 2
-  - uid: 19394
+  - uid: 19392
     components:
     - type: Transform
       pos: -51.5,54.5
       parent: 2
-  - uid: 19395
+  - uid: 19393
     components:
     - type: Transform
       pos: -45.5,54.5
       parent: 2
-  - uid: 19396
+  - uid: 19394
     components:
     - type: Transform
       pos: -42.5,51.5
       parent: 2
-  - uid: 19397
+  - uid: 19395
     components:
     - type: Transform
       pos: -40.5,46.5
       parent: 2
-  - uid: 19398
+  - uid: 19396
     components:
     - type: Transform
       pos: -73.5,34.5
       parent: 2
-  - uid: 19399
+  - uid: 19397
     components:
     - type: Transform
       pos: -73.5,25.5
       parent: 2
-  - uid: 19400
+  - uid: 19398
     components:
     - type: Transform
       pos: -67.5,48.5
       parent: 2
-  - uid: 19401
+  - uid: 19399
     components:
     - type: Transform
       pos: -71.5,25.5
       parent: 2
-  - uid: 19402
+  - uid: 19400
     components:
     - type: Transform
       pos: -71.5,34.5
       parent: 2
-  - uid: 19403
+  - uid: 19401
     components:
     - type: Transform
       pos: -73.5,16.5
       parent: 2
-  - uid: 19404
+  - uid: 19402
     components:
     - type: Transform
       pos: -71.5,16.5
       parent: 2
-  - uid: 19405
+  - uid: 19403
     components:
     - type: Transform
       pos: 5.5,52.5
       parent: 2
-  - uid: 19406
+  - uid: 19404
     components:
     - type: Transform
       pos: -38.5,56.5
       parent: 2
-  - uid: 19407
+  - uid: 19405
     components:
     - type: Transform
       pos: -40.5,54.5
       parent: 2
-  - uid: 19408
+  - uid: 19406
     components:
     - type: Transform
       pos: 9.5,51.5
       parent: 2
-  - uid: 19409
+  - uid: 19407
     components:
     - type: Transform
       pos: 11.5,53.5
       parent: 2
-  - uid: 19410
+  - uid: 19408
     components:
     - type: Transform
       pos: 11.5,46.5
       parent: 2
-  - uid: 19411
+  - uid: 19409
     components:
     - type: Transform
       pos: 7.5,53.5
       parent: 2
-  - uid: 19412
+  - uid: 19410
     components:
     - type: Transform
       pos: 3.5,54.5
       parent: 2
-  - uid: 19413
+  - uid: 19411
     components:
     - type: Transform
       pos: -70.5,48.5
       parent: 2
-  - uid: 19414
+  - uid: 19412
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,56.5
       parent: 2
-  - uid: 19415
+  - uid: 19413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,58.5
       parent: 2
-  - uid: 19416
+  - uid: 19414
     components:
     - type: Transform
       pos: 37.5,69.5
       parent: 2
-  - uid: 19417
+  - uid: 19415
     components:
     - type: Transform
       pos: 37.5,66.5
       parent: 2
-  - uid: 19418
+  - uid: 19416
     components:
     - type: Transform
       pos: 34.5,66.5
       parent: 2
-  - uid: 19419
+  - uid: 19417
     components:
     - type: Transform
       pos: 34.5,69.5
       parent: 2
-  - uid: 19420
+  - uid: 19418
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,58.5
       parent: 2
-  - uid: 19421
+  - uid: 19419
     components:
     - type: Transform
       pos: 34.5,51.5
       parent: 2
-  - uid: 19422
+  - uid: 19420
     components:
     - type: Transform
       pos: 34.5,49.5
       parent: 2
-  - uid: 19423
+  - uid: 19421
     components:
     - type: Transform
       pos: 34.5,47.5
       parent: 2
-  - uid: 19424
+  - uid: 19422
     components:
     - type: Transform
       pos: 34.5,45.5
       parent: 2
-  - uid: 19425
+  - uid: 19423
     components:
     - type: Transform
       pos: 37.5,47.5
       parent: 2
-  - uid: 19426
+  - uid: 19424
     components:
     - type: Transform
       pos: 37.5,45.5
       parent: 2
-  - uid: 19427
+  - uid: 19425
     components:
     - type: Transform
       pos: 37.5,51.5
       parent: 2
-  - uid: 19428
+  - uid: 19426
     components:
     - type: Transform
       pos: 37.5,49.5
       parent: 2
-  - uid: 19429
+  - uid: 19427
     components:
     - type: Transform
       pos: 36.5,71.5
       parent: 2
-  - uid: 19430
+  - uid: 19428
     components:
     - type: Transform
       pos: 35.5,71.5
       parent: 2
-  - uid: 19431
+  - uid: 19429
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,56.5
       parent: 2
-  - uid: 19432
+  - uid: 19430
     components:
     - type: Transform
       pos: -77.5,42.5
       parent: 2
-  - uid: 19433
+  - uid: 19431
     components:
     - type: Transform
       pos: -77.5,38.5
       parent: 2
-  - uid: 19434
+  - uid: 19432
     components:
     - type: Transform
       pos: -77.5,34.5
       parent: 2
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 19435
+  - uid: 19433
     components:
     - type: Transform
       pos: 53.5,7.5
       parent: 2
-  - uid: 19436
+  - uid: 19434
     components:
     - type: Transform
       pos: 40.5,14.5
       parent: 2
-  - uid: 19437
+  - uid: 19435
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 2
-  - uid: 19438
+  - uid: 19436
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 2
-  - uid: 19439
+  - uid: 19437
     components:
     - type: Transform
       pos: -8.5,-12.5
       parent: 2
-  - uid: 19440
+  - uid: 19438
     components:
     - type: Transform
       pos: -9.5,-12.5
       parent: 2
-  - uid: 19441
+  - uid: 19439
     components:
     - type: Transform
       pos: -49.5,40.5
       parent: 2
-  - uid: 19442
+  - uid: 19440
     components:
     - type: Transform
       pos: -47.5,40.5
       parent: 2
-  - uid: 19443
+  - uid: 19441
     components:
     - type: Transform
       pos: -61.5,43.5
       parent: 2
-  - uid: 19444
+  - uid: 19442
     components:
     - type: Transform
       pos: -59.5,43.5
       parent: 2
-  - uid: 19445
+  - uid: 19443
     components:
     - type: Transform
       pos: -53.5,25.5
       parent: 2
-  - uid: 19446
+  - uid: 19444
     components:
     - type: Transform
       pos: -52.5,25.5
       parent: 2
-  - uid: 19447
+  - uid: 19445
     components:
     - type: Transform
       pos: -54.5,25.5
       parent: 2
-  - uid: 19448
+  - uid: 19446
     components:
     - type: Transform
       pos: -52.5,38.5
       parent: 2
-  - uid: 19449
+  - uid: 19447
     components:
     - type: Transform
       pos: -55.5,39.5
       parent: 2
-  - uid: 19450
+  - uid: 19448
     components:
     - type: Transform
       pos: -51.5,39.5
       parent: 2
-  - uid: 19451
+  - uid: 19449
     components:
     - type: Transform
       pos: -54.5,38.5
       parent: 2
-  - uid: 19452
+  - uid: 19450
     components:
     - type: Transform
       pos: 50.5,14.5
       parent: 2
-  - uid: 19453
+  - uid: 19451
     components:
     - type: Transform
       pos: 51.5,14.5
       parent: 2
-  - uid: 19454
+  - uid: 19452
     components:
     - type: Transform
       pos: 47.5,14.5
       parent: 2
-  - uid: 19455
+  - uid: 19453
     components:
     - type: Transform
       pos: 44.5,14.5
       parent: 2
-  - uid: 19456
+  - uid: 19454
     components:
     - type: Transform
       pos: 42.5,14.5
       parent: 2
-  - uid: 19457
+  - uid: 19455
     components:
     - type: Transform
       pos: 48.5,14.5
       parent: 2
-  - uid: 19458
+  - uid: 19456
     components:
     - type: Transform
       pos: 45.5,14.5
       parent: 2
-  - uid: 19459
+  - uid: 19457
     components:
     - type: Transform
       pos: 55.5,14.5
       parent: 2
-  - uid: 19460
+  - uid: 19458
     components:
     - type: Transform
       pos: 54.5,14.5
       parent: 2
-  - uid: 19461
+  - uid: 19459
     components:
     - type: Transform
       pos: 53.5,14.5
       parent: 2
-  - uid: 19462
+  - uid: 19460
     components:
     - type: Transform
       pos: 56.5,24.5
       parent: 2
-  - uid: 19463
+  - uid: 19461
     components:
     - type: Transform
       pos: 52.5,24.5
       parent: 2
-  - uid: 19464
+  - uid: 19462
     components:
     - type: Transform
       pos: 64.5,43.5
       parent: 2
-  - uid: 19465
+  - uid: 19463
     components:
     - type: Transform
       pos: 63.5,42.5
       parent: 2
-  - uid: 19466
+  - uid: 19464
     components:
     - type: Transform
       pos: 66.5,46.5
       parent: 2
-  - uid: 19467
+  - uid: 19465
     components:
     - type: Transform
       pos: 66.5,47.5
       parent: 2
-  - uid: 19468
+  - uid: 19466
     components:
     - type: Transform
       pos: 64.5,46.5
       parent: 2
-  - uid: 19469
+  - uid: 19467
     components:
     - type: Transform
       pos: 64.5,47.5
       parent: 2
-  - uid: 19470
+  - uid: 19468
     components:
     - type: Transform
       pos: 63.5,46.5
       parent: 2
-  - uid: 19471
+  - uid: 19469
     components:
     - type: Transform
       pos: 63.5,45.5
       parent: 2
-  - uid: 19472
+  - uid: 19470
     components:
     - type: Transform
       pos: 63.5,44.5
       parent: 2
-  - uid: 19473
+  - uid: 19471
     components:
     - type: Transform
       pos: 63.5,43.5
       parent: 2
-  - uid: 19474
+  - uid: 19472
     components:
     - type: Transform
       pos: 67.5,46.5
       parent: 2
-  - uid: 19475
+  - uid: 19473
     components:
     - type: Transform
       pos: 67.5,45.5
       parent: 2
-  - uid: 19476
+  - uid: 19474
     components:
     - type: Transform
       pos: 67.5,44.5
       parent: 2
-  - uid: 19477
+  - uid: 19475
     components:
     - type: Transform
       pos: 67.5,43.5
       parent: 2
-  - uid: 19478
+  - uid: 19476
     components:
     - type: Transform
       pos: 66.5,43.5
       parent: 2
-  - uid: 19479
+  - uid: 19477
     components:
     - type: Transform
       pos: 67.5,42.5
       parent: 2
-  - uid: 19480
+  - uid: 19478
     components:
     - type: Transform
       pos: 54.5,25.5
       parent: 2
-  - uid: 19481
+  - uid: 19479
     components:
     - type: Transform
       pos: 57.5,7.5
       parent: 2
-  - uid: 19482
+  - uid: 19480
     components:
     - type: Transform
       pos: 56.5,7.5
       parent: 2
-  - uid: 19483
+  - uid: 19481
     components:
     - type: Transform
       pos: 54.5,7.5
       parent: 2
-  - uid: 19484
+  - uid: 19482
     components:
     - type: Transform
       pos: -67.5,34.5
       parent: 2
-  - uid: 19485
+  - uid: 19483
     components:
     - type: Transform
       pos: -66.5,34.5
       parent: 2
 - proto: ReinforcedPlasmaWindowDiagonal
   entities:
-  - uid: 19486
+  - uid: 19484
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -55.5,38.5
       parent: 2
-  - uid: 19487
+  - uid: 19485
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -121678,2074 +121711,2074 @@ entities:
       parent: 2
 - proto: ReinforcedWindow
   entities:
-  - uid: 19488
+  - uid: 19486
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 2
-  - uid: 19489
+  - uid: 19487
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 2
-  - uid: 19490
+  - uid: 19488
     components:
     - type: Transform
       pos: 17.5,-7.5
       parent: 2
-  - uid: 19491
+  - uid: 19489
     components:
     - type: Transform
       pos: -26.5,17.5
       parent: 2
-  - uid: 19492
+  - uid: 19490
     components:
     - type: Transform
       pos: -27.5,17.5
       parent: 2
-  - uid: 19493
+  - uid: 19491
     components:
     - type: Transform
       pos: 13.5,8.5
       parent: 2
-  - uid: 19494
+  - uid: 19492
     components:
     - type: Transform
       pos: 11.5,8.5
       parent: 2
-  - uid: 19495
+  - uid: 19493
     components:
     - type: Transform
       pos: 11.5,2.5
       parent: 2
-  - uid: 19496
+  - uid: 19494
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 2
-  - uid: 19497
+  - uid: 19495
     components:
     - type: Transform
       pos: 17.5,-6.5
       parent: 2
-  - uid: 19498
+  - uid: 19496
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 2
-  - uid: 19499
+  - uid: 19497
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 2
-  - uid: 19500
+  - uid: 19498
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 2
-  - uid: 19501
+  - uid: 19499
     components:
     - type: Transform
       pos: 17.5,-8.5
       parent: 2
-  - uid: 19502
+  - uid: 19500
     components:
     - type: Transform
       pos: 17.5,-9.5
       parent: 2
-  - uid: 19503
+  - uid: 19501
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 2
-  - uid: 19504
+  - uid: 19502
     components:
     - type: Transform
       pos: 17.5,-3.5
       parent: 2
-  - uid: 19505
+  - uid: 19503
     components:
     - type: Transform
       pos: 14.5,-5.5
       parent: 2
-  - uid: 19506
+  - uid: 19504
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 2
-  - uid: 19507
+  - uid: 19505
     components:
     - type: Transform
       pos: -65.5,42.5
       parent: 2
-  - uid: 19508
+  - uid: 19506
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 2
-  - uid: 19509
+  - uid: 19507
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-  - uid: 19510
+  - uid: 19508
     components:
     - type: Transform
       pos: 17.5,1.5
       parent: 2
-  - uid: 19511
+  - uid: 19509
     components:
     - type: Transform
       pos: 13.5,11.5
       parent: 2
-  - uid: 19512
+  - uid: 19510
     components:
     - type: Transform
       pos: 11.5,11.5
       parent: 2
-  - uid: 19513
+  - uid: 19511
     components:
     - type: Transform
       pos: 5.5,46.5
       parent: 2
-  - uid: 19514
+  - uid: 19512
     components:
     - type: Transform
       pos: 6.5,46.5
       parent: 2
-  - uid: 19515
+  - uid: 19513
     components:
     - type: Transform
       pos: 19.5,-38.5
       parent: 2
-  - uid: 19516
+  - uid: 19514
     components:
     - type: Transform
       pos: 26.5,-38.5
       parent: 2
-  - uid: 19517
+  - uid: 19515
     components:
     - type: Transform
       pos: 23.5,-38.5
       parent: 2
-  - uid: 19518
+  - uid: 19516
     components:
     - type: Transform
       pos: -3.5,51.5
       parent: 2
-  - uid: 19519
+  - uid: 19517
     components:
     - type: Transform
       pos: -9.5,-30.5
       parent: 2
-  - uid: 19520
+  - uid: 19518
     components:
     - type: Transform
       pos: -31.5,47.5
       parent: 2
-  - uid: 19521
+  - uid: 19519
     components:
     - type: Transform
       pos: -21.5,42.5
       parent: 2
-  - uid: 19522
+  - uid: 19520
     components:
     - type: Transform
       pos: -11.5,50.5
       parent: 2
-  - uid: 19523
+  - uid: 19521
     components:
     - type: Transform
       pos: -5.5,51.5
       parent: 2
-  - uid: 19524
+  - uid: 19522
     components:
     - type: Transform
       pos: -2.5,51.5
       parent: 2
-  - uid: 19525
+  - uid: 19523
     components:
     - type: Transform
       pos: -6.5,49.5
       parent: 2
-  - uid: 19526
+  - uid: 19524
     components:
     - type: Transform
       pos: -6.5,47.5
       parent: 2
-  - uid: 19527
+  - uid: 19525
     components:
     - type: Transform
       pos: -20.5,38.5
       parent: 2
-  - uid: 19528
+  - uid: 19526
     components:
     - type: Transform
       pos: -16.5,42.5
       parent: 2
-  - uid: 19529
+  - uid: 19527
     components:
     - type: Transform
       pos: -19.5,42.5
       parent: 2
-  - uid: 19530
+  - uid: 19528
     components:
     - type: Transform
       pos: -19.5,49.5
       parent: 2
-  - uid: 19531
+  - uid: 19529
     components:
     - type: Transform
       pos: -10.5,49.5
       parent: 2
-  - uid: 19532
+  - uid: 19530
     components:
     - type: Transform
       pos: -11.5,42.5
       parent: 2
-  - uid: 19533
+  - uid: 19531
     components:
     - type: Transform
       pos: -19.5,50.5
       parent: 2
-  - uid: 19534
+  - uid: 19532
     components:
     - type: Transform
       pos: -18.5,50.5
       parent: 2
-  - uid: 19535
+  - uid: 19533
     components:
     - type: Transform
       pos: -11.5,49.5
       parent: 2
-  - uid: 19536
+  - uid: 19534
     components:
     - type: Transform
       pos: -4.5,51.5
       parent: 2
-  - uid: 19537
+  - uid: 19535
     components:
     - type: Transform
       pos: -0.5,51.5
       parent: 2
-  - uid: 19538
+  - uid: 19536
     components:
     - type: Transform
       pos: -24.5,43.5
       parent: 2
-  - uid: 19539
+  - uid: 19537
     components:
     - type: Transform
       pos: -20.5,49.5
       parent: 2
-  - uid: 19540
+  - uid: 19538
     components:
     - type: Transform
       pos: -10.5,48.5
       parent: 2
-  - uid: 19541
+  - uid: 19539
     components:
     - type: Transform
       pos: -22.5,42.5
       parent: 2
-  - uid: 19542
+  - uid: 19540
     components:
     - type: Transform
       pos: -30.5,50.5
       parent: 2
-  - uid: 19543
+  - uid: 19541
     components:
     - type: Transform
       pos: -30.5,47.5
       parent: 2
-  - uid: 19544
+  - uid: 19542
     components:
     - type: Transform
       pos: -31.5,50.5
       parent: 2
-  - uid: 19545
+  - uid: 19543
     components:
     - type: Transform
       pos: -24.5,45.5
       parent: 2
-  - uid: 19546
+  - uid: 19544
     components:
     - type: Transform
       pos: -12.5,42.5
       parent: 2
-  - uid: 19547
+  - uid: 19545
     components:
     - type: Transform
       pos: -18.5,42.5
       parent: 2
-  - uid: 19548
+  - uid: 19546
     components:
     - type: Transform
       pos: -14.5,42.5
       parent: 2
-  - uid: 19549
+  - uid: 19547
     components:
     - type: Transform
       pos: -20.5,35.5
       parent: 2
-  - uid: 19550
+  - uid: 19548
     components:
     - type: Transform
       pos: -9.5,42.5
       parent: 2
-  - uid: 19551
+  - uid: 19549
     components:
     - type: Transform
       pos: -8.5,42.5
       parent: 2
-  - uid: 19552
+  - uid: 19550
     components:
     - type: Transform
       pos: -6.5,48.5
       parent: 2
-  - uid: 19553
+  - uid: 19551
     components:
     - type: Transform
       pos: -20.5,48.5
       parent: 2
-  - uid: 19554
+  - uid: 19552
     components:
     - type: Transform
       pos: -1.5,51.5
       parent: 2
-  - uid: 19555
+  - uid: 19553
     components:
     - type: Transform
       pos: -6.5,46.5
       parent: 2
-  - uid: 19556
+  - uid: 19554
     components:
     - type: Transform
       pos: -7.5,33.5
       parent: 2
-  - uid: 19557
+  - uid: 19555
     components:
     - type: Transform
       pos: -12.5,50.5
       parent: 2
-  - uid: 19558
+  - uid: 19556
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 2
-  - uid: 19559
+  - uid: 19557
     components:
     - type: Transform
       pos: -7.5,28.5
       parent: 2
-  - uid: 19560
+  - uid: 19558
     components:
     - type: Transform
       pos: -7.5,29.5
       parent: 2
-  - uid: 19561
+  - uid: 19559
     components:
     - type: Transform
       pos: -7.5,30.5
       parent: 2
-  - uid: 19562
+  - uid: 19560
     components:
     - type: Transform
       pos: -7.5,31.5
       parent: 2
-  - uid: 19563
+  - uid: 19561
     components:
     - type: Transform
       pos: -9.5,54.5
       parent: 2
-  - uid: 19564
+  - uid: 19562
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
-  - uid: 19565
+  - uid: 19563
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 2
-  - uid: 19566
+  - uid: 19564
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 2
-  - uid: 19567
+  - uid: 19565
     components:
     - type: Transform
       pos: -14.5,-1.5
       parent: 2
-  - uid: 19568
+  - uid: 19566
     components:
     - type: Transform
       pos: -15.5,-1.5
       parent: 2
-  - uid: 19569
+  - uid: 19567
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-  - uid: 19570
+  - uid: 19568
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
-  - uid: 19571
+  - uid: 19569
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 2
-  - uid: 19572
+  - uid: 19570
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 2
-  - uid: 19573
+  - uid: 19571
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 2
-  - uid: 19574
+  - uid: 19572
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 2
-  - uid: 19575
+  - uid: 19573
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 2
-  - uid: 19576
+  - uid: 19574
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 2
-  - uid: 19577
+  - uid: 19575
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 2
-  - uid: 19578
+  - uid: 19576
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
-  - uid: 19579
+  - uid: 19577
     components:
     - type: Transform
       pos: -8.5,54.5
       parent: 2
-  - uid: 19580
+  - uid: 19578
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 2
-  - uid: 19581
+  - uid: 19579
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
-  - uid: 19582
+  - uid: 19580
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
-  - uid: 19583
+  - uid: 19581
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 2
-  - uid: 19584
+  - uid: 19582
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 2
-  - uid: 19585
+  - uid: 19583
     components:
     - type: Transform
       pos: -8.5,53.5
       parent: 2
-  - uid: 19586
+  - uid: 19584
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 2
-  - uid: 19587
+  - uid: 19585
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 2
-  - uid: 19588
+  - uid: 19586
     components:
     - type: Transform
       pos: -1.5,-12.5
       parent: 2
-  - uid: 19589
+  - uid: 19587
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 2
-  - uid: 19590
+  - uid: 19588
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 2
-  - uid: 19591
+  - uid: 19589
     components:
     - type: Transform
       pos: -12.5,56.5
       parent: 2
-  - uid: 19592
+  - uid: 19590
     components:
     - type: Transform
       pos: -33.5,6.5
       parent: 2
-  - uid: 19593
+  - uid: 19591
     components:
     - type: Transform
       pos: -33.5,10.5
       parent: 2
-  - uid: 19594
+  - uid: 19592
     components:
     - type: Transform
       pos: -18.5,55.5
       parent: 2
-  - uid: 19595
+  - uid: 19593
     components:
     - type: Transform
       pos: -29.5,4.5
       parent: 2
-  - uid: 19596
+  - uid: 19594
     components:
     - type: Transform
       pos: -28.5,5.5
       parent: 2
-  - uid: 19597
+  - uid: 19595
     components:
     - type: Transform
       pos: -29.5,5.5
       parent: 2
-  - uid: 19598
+  - uid: 19596
     components:
     - type: Transform
       pos: -29.5,3.5
       parent: 2
-  - uid: 19599
+  - uid: 19597
     components:
     - type: Transform
       pos: -29.5,2.5
       parent: 2
-  - uid: 19600
+  - uid: 19598
     components:
     - type: Transform
       pos: -29.5,1.5
       parent: 2
-  - uid: 19601
+  - uid: 19599
     components:
     - type: Transform
       pos: -28.5,1.5
       parent: 2
-  - uid: 19602
+  - uid: 19600
     components:
     - type: Transform
       pos: -37.5,11.5
       parent: 2
-  - uid: 19603
+  - uid: 19601
     components:
     - type: Transform
       pos: -39.5,10.5
       parent: 2
-  - uid: 19604
+  - uid: 19602
     components:
     - type: Transform
       pos: -39.5,4.5
       parent: 2
-  - uid: 19605
+  - uid: 19603
     components:
     - type: Transform
       pos: -39.5,9.5
       parent: 2
-  - uid: 19606
+  - uid: 19604
     components:
     - type: Transform
       pos: -39.5,3.5
       parent: 2
-  - uid: 19607
+  - uid: 19605
     components:
     - type: Transform
       pos: -37.5,2.5
       parent: 2
-  - uid: 19608
+  - uid: 19606
     components:
     - type: Transform
       pos: -36.5,11.5
       parent: 2
-  - uid: 19609
+  - uid: 19607
     components:
     - type: Transform
       pos: -35.5,11.5
       parent: 2
-  - uid: 19610
+  - uid: 19608
     components:
     - type: Transform
       pos: -21.5,54.5
       parent: 2
-  - uid: 19611
+  - uid: 19609
     components:
     - type: Transform
       pos: -58.5,4.5
       parent: 2
-  - uid: 19612
+  - uid: 19610
     components:
     - type: Transform
       pos: 69.5,16.5
       parent: 2
-  - uid: 19613
+  - uid: 19611
     components:
     - type: Transform
       pos: -39.5,-2.5
       parent: 2
-  - uid: 19614
+  - uid: 19612
     components:
     - type: Transform
       pos: -39.5,0.5
       parent: 2
-  - uid: 19615
+  - uid: 19613
     components:
     - type: Transform
       pos: -42.5,2.5
       parent: 2
-  - uid: 19616
+  - uid: 19614
     components:
     - type: Transform
       pos: -40.5,2.5
       parent: 2
-  - uid: 19617
+  - uid: 19615
     components:
     - type: Transform
       pos: -50.5,2.5
       parent: 2
-  - uid: 19618
+  - uid: 19616
     components:
     - type: Transform
       pos: -49.5,2.5
       parent: 2
-  - uid: 19619
+  - uid: 19617
     components:
     - type: Transform
       pos: -56.5,2.5
       parent: 2
-  - uid: 19620
+  - uid: 19618
     components:
     - type: Transform
       pos: -52.5,-0.5
       parent: 2
-  - uid: 19621
+  - uid: 19619
     components:
     - type: Transform
       pos: -58.5,3.5
       parent: 2
-  - uid: 19622
+  - uid: 19620
     components:
     - type: Transform
       pos: -52.5,1.5
       parent: 2
-  - uid: 19623
+  - uid: 19621
     components:
     - type: Transform
       pos: -52.5,0.5
       parent: 2
-  - uid: 19624
+  - uid: 19622
     components:
     - type: Transform
       pos: -58.5,5.5
       parent: 2
-  - uid: 19625
+  - uid: 19623
     components:
     - type: Transform
       pos: -58.5,-0.5
       parent: 2
-  - uid: 19626
+  - uid: 19624
     components:
     - type: Transform
       pos: -58.5,0.5
       parent: 2
-  - uid: 19627
+  - uid: 19625
     components:
     - type: Transform
       pos: -58.5,1.5
       parent: 2
-  - uid: 19628
+  - uid: 19626
     components:
     - type: Transform
       pos: -52.5,3.5
       parent: 2
-  - uid: 19629
+  - uid: 19627
     components:
     - type: Transform
       pos: -52.5,5.5
       parent: 2
-  - uid: 19630
+  - uid: 19628
     components:
     - type: Transform
       pos: -54.5,2.5
       parent: 2
-  - uid: 19631
+  - uid: 19629
     components:
     - type: Transform
       pos: -47.5,0.5
       parent: 2
-  - uid: 19632
+  - uid: 19630
     components:
     - type: Transform
       pos: -47.5,-0.5
       parent: 2
-  - uid: 19633
+  - uid: 19631
     components:
     - type: Transform
       pos: 34.5,40.5
       parent: 2
-  - uid: 19634
+  - uid: 19632
     components:
     - type: Transform
       pos: -39.5,-10.5
       parent: 2
-  - uid: 19635
+  - uid: 19633
     components:
     - type: Transform
       pos: -39.5,-11.5
       parent: 2
-  - uid: 19636
+  - uid: 19634
     components:
     - type: Transform
       pos: 69.5,18.5
       parent: 2
-  - uid: 19637
+  - uid: 19635
     components:
     - type: Transform
       pos: -19.5,55.5
       parent: 2
-  - uid: 19638
+  - uid: 19636
     components:
     - type: Transform
       pos: -15.5,56.5
       parent: 2
-  - uid: 19639
+  - uid: 19637
     components:
     - type: Transform
       pos: -25.5,47.5
       parent: 2
-  - uid: 19640
+  - uid: 19638
     components:
     - type: Transform
       pos: 37.5,40.5
       parent: 2
-  - uid: 19641
+  - uid: 19639
     components:
     - type: Transform
       pos: 34.5,39.5
       parent: 2
-  - uid: 19642
+  - uid: 19640
     components:
     - type: Transform
       pos: 34.5,38.5
       parent: 2
-  - uid: 19643
+  - uid: 19641
     components:
     - type: Transform
       pos: -69.5,27.5
       parent: 2
-  - uid: 19644
+  - uid: 19642
     components:
     - type: Transform
       pos: -69.5,28.5
       parent: 2
-  - uid: 19645
+  - uid: 19643
     components:
     - type: Transform
       pos: -69.5,29.5
       parent: 2
-  - uid: 19646
+  - uid: 19644
     components:
     - type: Transform
       pos: -69.5,30.5
       parent: 2
-  - uid: 19647
+  - uid: 19645
     components:
     - type: Transform
       pos: -69.5,31.5
       parent: 2
-  - uid: 19648
+  - uid: 19646
     components:
     - type: Transform
       pos: -58.5,34.5
       parent: 2
-  - uid: 19649
+  - uid: 19647
     components:
     - type: Transform
       pos: -61.5,34.5
       parent: 2
-  - uid: 19650
+  - uid: 19648
     components:
     - type: Transform
       pos: -64.5,34.5
       parent: 2
-  - uid: 19651
+  - uid: 19649
     components:
     - type: Transform
       pos: -44.5,33.5
       parent: 2
-  - uid: 19652
+  - uid: 19650
     components:
     - type: Transform
       pos: -45.5,33.5
       parent: 2
-  - uid: 19653
+  - uid: 19651
     components:
     - type: Transform
       pos: -42.5,30.5
       parent: 2
-  - uid: 19654
+  - uid: 19652
     components:
     - type: Transform
       pos: -42.5,31.5
       parent: 2
-  - uid: 19655
+  - uid: 19653
     components:
     - type: Transform
       pos: -48.5,44.5
       parent: 2
-  - uid: 19656
+  - uid: 19654
     components:
     - type: Transform
       pos: -48.5,46.5
       parent: 2
-  - uid: 19657
+  - uid: 19655
     components:
     - type: Transform
       pos: -57.5,40.5
       parent: 2
-  - uid: 19658
+  - uid: 19656
     components:
     - type: Transform
       pos: -58.5,40.5
       parent: 2
-  - uid: 19659
+  - uid: 19657
     components:
     - type: Transform
       pos: -58.5,41.5
       parent: 2
-  - uid: 19660
+  - uid: 19658
     components:
     - type: Transform
       pos: -59.5,41.5
       parent: 2
-  - uid: 19661
+  - uid: 19659
     components:
     - type: Transform
       pos: -61.5,41.5
       parent: 2
-  - uid: 19662
+  - uid: 19660
     components:
     - type: Transform
       pos: -62.5,41.5
       parent: 2
-  - uid: 19663
+  - uid: 19661
     components:
     - type: Transform
       pos: -62.5,40.5
       parent: 2
-  - uid: 19664
+  - uid: 19662
     components:
     - type: Transform
       pos: -63.5,40.5
       parent: 2
-  - uid: 19665
+  - uid: 19663
     components:
     - type: Transform
       pos: 69.5,20.5
       parent: 2
-  - uid: 19666
+  - uid: 19664
     components:
     - type: Transform
       pos: 10.5,23.5
       parent: 2
-  - uid: 19667
+  - uid: 19665
     components:
     - type: Transform
       pos: 13.5,23.5
       parent: 2
-  - uid: 19668
+  - uid: 19666
     components:
     - type: Transform
       pos: 14.5,22.5
       parent: 2
-  - uid: 19669
+  - uid: 19667
     components:
     - type: Transform
       pos: 14.5,20.5
       parent: 2
-  - uid: 19670
+  - uid: 19668
     components:
     - type: Transform
       pos: 16.5,16.5
       parent: 2
-  - uid: 19671
+  - uid: 19669
     components:
     - type: Transform
       pos: 17.5,16.5
       parent: 2
-  - uid: 19672
+  - uid: 19670
     components:
     - type: Transform
       pos: 18.5,16.5
       parent: 2
-  - uid: 19673
+  - uid: 19671
     components:
     - type: Transform
       pos: 19.5,16.5
       parent: 2
-  - uid: 19674
+  - uid: 19672
     components:
     - type: Transform
       pos: 21.5,17.5
       parent: 2
-  - uid: 19675
+  - uid: 19673
     components:
     - type: Transform
       pos: 21.5,18.5
       parent: 2
-  - uid: 19676
+  - uid: 19674
     components:
     - type: Transform
       pos: 21.5,19.5
       parent: 2
-  - uid: 19677
+  - uid: 19675
     components:
     - type: Transform
       pos: 18.5,39.5
       parent: 2
-  - uid: 19678
+  - uid: 19676
     components:
     - type: Transform
       pos: 18.5,38.5
       parent: 2
-  - uid: 19679
+  - uid: 19677
     components:
     - type: Transform
       pos: 24.5,39.5
       parent: 2
-  - uid: 19680
+  - uid: 19678
     components:
     - type: Transform
       pos: 24.5,38.5
       parent: 2
-  - uid: 19681
+  - uid: 19679
     components:
     - type: Transform
       pos: 21.5,37.5
       parent: 2
-  - uid: 19682
+  - uid: 19680
     components:
     - type: Transform
       pos: 14.5,37.5
       parent: 2
-  - uid: 19683
+  - uid: 19681
     components:
     - type: Transform
       pos: 15.5,37.5
       parent: 2
-  - uid: 19684
+  - uid: 19682
     components:
     - type: Transform
       pos: 16.5,37.5
       parent: 2
-  - uid: 19685
+  - uid: 19683
     components:
     - type: Transform
       pos: 17.5,37.5
       parent: 2
-  - uid: 19686
+  - uid: 19684
     components:
     - type: Transform
       pos: 24.5,16.5
       parent: 2
-  - uid: 19687
+  - uid: 19685
     components:
     - type: Transform
       pos: 25.5,16.5
       parent: 2
-  - uid: 19688
+  - uid: 19686
     components:
     - type: Transform
       pos: 23.5,16.5
       parent: 2
-  - uid: 19689
+  - uid: 19687
     components:
     - type: Transform
       pos: 27.5,32.5
       parent: 2
-  - uid: 19690
+  - uid: 19688
     components:
     - type: Transform
       pos: 27.5,36.5
       parent: 2
-  - uid: 19691
+  - uid: 19689
     components:
     - type: Transform
       pos: 32.5,-15.5
       parent: 2
-  - uid: 19692
+  - uid: 19690
     components:
     - type: Transform
       pos: 33.5,35.5
       parent: 2
-  - uid: 19693
+  - uid: 19691
     components:
     - type: Transform
       pos: 22.5,-15.5
       parent: 2
-  - uid: 19694
+  - uid: 19692
     components:
     - type: Transform
       pos: 31.5,-15.5
       parent: 2
-  - uid: 19695
+  - uid: 19693
     components:
     - type: Transform
       pos: 25.5,-15.5
       parent: 2
-  - uid: 19696
+  - uid: 19694
     components:
     - type: Transform
       pos: 30.5,-15.5
       parent: 2
-  - uid: 19697
+  - uid: 19695
     components:
     - type: Transform
       pos: 24.5,-15.5
       parent: 2
-  - uid: 19698
+  - uid: 19696
     components:
     - type: Transform
       pos: 29.5,-15.5
       parent: 2
-  - uid: 19699
+  - uid: 19697
     components:
     - type: Transform
       pos: 23.5,-15.5
       parent: 2
-  - uid: 19700
+  - uid: 19698
     components:
     - type: Transform
       pos: 23.5,-34.5
       parent: 2
-  - uid: 19701
+  - uid: 19699
     components:
     - type: Transform
       pos: -14.5,56.5
       parent: 2
-  - uid: 19702
+  - uid: 19700
     components:
     - type: Transform
       pos: 22.5,-34.5
       parent: 2
-  - uid: 19703
+  - uid: 19701
     components:
     - type: Transform
       pos: 24.5,-34.5
       parent: 2
-  - uid: 19704
+  - uid: 19702
     components:
     - type: Transform
       pos: 33.5,-32.5
       parent: 2
-  - uid: 19705
+  - uid: 19703
     components:
     - type: Transform
       pos: 33.5,-33.5
       parent: 2
-  - uid: 19706
+  - uid: 19704
     components:
     - type: Transform
       pos: 33.5,-31.5
       parent: 2
-  - uid: 19707
+  - uid: 19705
     components:
     - type: Transform
       pos: 25.5,-34.5
       parent: 2
-  - uid: 19708
+  - uid: 19706
     components:
     - type: Transform
       pos: 30.5,-34.5
       parent: 2
-  - uid: 19709
+  - uid: 19707
     components:
     - type: Transform
       pos: 31.5,-34.5
       parent: 2
-  - uid: 19710
+  - uid: 19708
     components:
     - type: Transform
       pos: 32.5,-34.5
       parent: 2
-  - uid: 19711
+  - uid: 19709
     components:
     - type: Transform
       pos: 29.5,-34.5
       parent: 2
-  - uid: 19712
+  - uid: 19710
     components:
     - type: Transform
       pos: 21.5,-33.5
       parent: 2
-  - uid: 19713
+  - uid: 19711
     components:
     - type: Transform
       pos: 21.5,-32.5
       parent: 2
-  - uid: 19714
+  - uid: 19712
     components:
     - type: Transform
       pos: 21.5,-31.5
       parent: 2
-  - uid: 19715
+  - uid: 19713
     components:
     - type: Transform
       pos: 21.5,-27.5
       parent: 2
-  - uid: 19716
+  - uid: 19714
     components:
     - type: Transform
       pos: 21.5,-26.5
       parent: 2
-  - uid: 19717
+  - uid: 19715
     components:
     - type: Transform
       pos: 21.5,-25.5
       parent: 2
-  - uid: 19718
+  - uid: 19716
     components:
     - type: Transform
       pos: 21.5,-24.5
       parent: 2
-  - uid: 19719
+  - uid: 19717
     components:
     - type: Transform
       pos: 21.5,-20.5
       parent: 2
-  - uid: 19720
+  - uid: 19718
     components:
     - type: Transform
       pos: 21.5,-19.5
       parent: 2
-  - uid: 19721
+  - uid: 19719
     components:
     - type: Transform
       pos: 21.5,-17.5
       parent: 2
-  - uid: 19722
+  - uid: 19720
     components:
     - type: Transform
       pos: 21.5,-16.5
       parent: 2
-  - uid: 19723
+  - uid: 19721
     components:
     - type: Transform
       pos: 33.5,-16.5
       parent: 2
-  - uid: 19724
+  - uid: 19722
     components:
     - type: Transform
       pos: 33.5,-17.5
       parent: 2
-  - uid: 19725
+  - uid: 19723
     components:
     - type: Transform
       pos: 33.5,-19.5
       parent: 2
-  - uid: 19726
+  - uid: 19724
     components:
     - type: Transform
       pos: 33.5,-20.5
       parent: 2
-  - uid: 19727
+  - uid: 19725
     components:
     - type: Transform
       pos: 33.5,-24.5
       parent: 2
-  - uid: 19728
+  - uid: 19726
     components:
     - type: Transform
       pos: 33.5,-25.5
       parent: 2
-  - uid: 19729
+  - uid: 19727
     components:
     - type: Transform
       pos: 33.5,-26.5
       parent: 2
-  - uid: 19730
+  - uid: 19728
     components:
     - type: Transform
       pos: 33.5,-27.5
       parent: 2
-  - uid: 19731
+  - uid: 19729
     components:
     - type: Transform
       pos: 51.5,-13.5
       parent: 2
-  - uid: 19732
+  - uid: 19730
     components:
     - type: Transform
       pos: 49.5,-12.5
       parent: 2
-  - uid: 19733
+  - uid: 19731
     components:
     - type: Transform
       pos: 43.5,-12.5
       parent: 2
-  - uid: 19734
+  - uid: 19732
     components:
     - type: Transform
       pos: 44.5,-12.5
       parent: 2
-  - uid: 19735
+  - uid: 19733
     components:
     - type: Transform
       pos: 48.5,-12.5
       parent: 2
-  - uid: 19736
+  - uid: 19734
     components:
     - type: Transform
       pos: 51.5,-14.5
       parent: 2
-  - uid: 19737
+  - uid: 19735
     components:
     - type: Transform
       pos: 41.5,-14.5
       parent: 2
-  - uid: 19738
+  - uid: 19736
     components:
     - type: Transform
       pos: 42.5,-13.5
       parent: 2
-  - uid: 19739
+  - uid: 19737
     components:
     - type: Transform
       pos: 41.5,-13.5
       parent: 2
-  - uid: 19740
+  - uid: 19738
     components:
     - type: Transform
       pos: 50.5,-13.5
       parent: 2
-  - uid: 19741
+  - uid: 19739
     components:
     - type: Transform
       pos: -14.5,34.5
       parent: 2
-  - uid: 19742
+  - uid: 19740
     components:
     - type: Transform
       pos: -13.5,34.5
       parent: 2
-  - uid: 19743
+  - uid: 19741
     components:
     - type: Transform
       pos: -16.5,34.5
       parent: 2
-  - uid: 19744
+  - uid: 19742
     components:
     - type: Transform
       pos: -16.5,56.5
       parent: 2
-  - uid: 19745
+  - uid: 19743
     components:
     - type: Transform
       pos: -18.5,56.5
       parent: 2
-  - uid: 19746
+  - uid: 19744
     components:
     - type: Transform
       pos: -17.5,56.5
       parent: 2
-  - uid: 19747
+  - uid: 19745
     components:
     - type: Transform
       pos: -15.5,34.5
       parent: 2
-  - uid: 19748
+  - uid: 19746
     components:
     - type: Transform
       pos: -17.5,34.5
       parent: 2
-  - uid: 19749
+  - uid: 19747
     components:
     - type: Transform
       pos: -25.5,48.5
       parent: 2
-  - uid: 19750
+  - uid: 19748
     components:
     - type: Transform
       pos: -25.5,50.5
       parent: 2
-  - uid: 19751
+  - uid: 19749
     components:
     - type: Transform
       pos: -7.5,53.5
       parent: 2
-  - uid: 19752
+  - uid: 19750
     components:
     - type: Transform
       pos: -7.5,52.5
       parent: 2
-  - uid: 19753
+  - uid: 19751
     components:
     - type: Transform
       pos: -22.5,53.5
       parent: 2
-  - uid: 19754
+  - uid: 19752
     components:
     - type: Transform
       pos: -23.5,53.5
       parent: 2
-  - uid: 19755
+  - uid: 19753
     components:
     - type: Transform
       pos: -23.5,52.5
       parent: 2
-  - uid: 19756
+  - uid: 19754
     components:
     - type: Transform
       pos: 64.5,-15.5
       parent: 2
-  - uid: 19757
+  - uid: 19755
     components:
     - type: Transform
       pos: 65.5,-15.5
       parent: 2
-  - uid: 19758
+  - uid: 19756
     components:
     - type: Transform
       pos: 62.5,-15.5
       parent: 2
-  - uid: 19759
+  - uid: 19757
     components:
     - type: Transform
       pos: 59.5,-15.5
       parent: 2
-  - uid: 19760
+  - uid: 19758
     components:
     - type: Transform
       pos: 57.5,-15.5
       parent: 2
-  - uid: 19761
+  - uid: 19759
     components:
     - type: Transform
       pos: 52.5,-15.5
       parent: 2
-  - uid: 19762
+  - uid: 19760
     components:
     - type: Transform
       pos: 60.5,-15.5
       parent: 2
-  - uid: 19763
+  - uid: 19761
     components:
     - type: Transform
       pos: 63.5,-15.5
       parent: 2
-  - uid: 19764
+  - uid: 19762
     components:
     - type: Transform
       pos: 58.5,-15.5
       parent: 2
-  - uid: 19765
+  - uid: 19763
     components:
     - type: Transform
       pos: 53.5,-15.5
       parent: 2
-  - uid: 19766
+  - uid: 19764
     components:
     - type: Transform
       pos: 55.5,-15.5
       parent: 2
-  - uid: 19767
+  - uid: 19765
     components:
     - type: Transform
       pos: 54.5,-15.5
       parent: 2
-  - uid: 19768
+  - uid: 19766
     components:
     - type: Transform
       pos: -24.5,52.5
       parent: 2
-  - uid: 19769
+  - uid: 19767
     components:
     - type: Transform
       pos: -22.5,54.5
       parent: 2
-  - uid: 19770
+  - uid: 19768
     components:
     - type: Transform
       pos: -13.5,56.5
       parent: 2
-  - uid: 19771
+  - uid: 19769
     components:
     - type: Transform
       pos: -11.5,55.5
       parent: 2
-  - uid: 19772
+  - uid: 19770
     components:
     - type: Transform
       pos: -12.5,55.5
       parent: 2
-  - uid: 19773
+  - uid: 19771
     components:
     - type: Transform
       pos: 61.5,3.5
       parent: 2
-  - uid: 19774
+  - uid: 19772
     components:
     - type: Transform
       pos: 61.5,1.5
       parent: 2
-  - uid: 19775
+  - uid: 19773
     components:
     - type: Transform
       pos: 61.5,2.5
       parent: 2
-  - uid: 19776
+  - uid: 19774
     components:
     - type: Transform
       pos: 61.5,-0.5
       parent: 2
-  - uid: 19777
+  - uid: 19775
     components:
     - type: Transform
       pos: 61.5,0.5
       parent: 2
-  - uid: 19778
+  - uid: 19776
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
-  - uid: 19779
+  - uid: 19777
     components:
     - type: Transform
       pos: 40.5,33.5
       parent: 2
-  - uid: 19780
+  - uid: 19778
     components:
     - type: Transform
       pos: 87.5,-16.5
       parent: 2
-  - uid: 19781
+  - uid: 19779
     components:
     - type: Transform
       pos: 87.5,-24.5
       parent: 2
-  - uid: 19782
+  - uid: 19780
     components:
     - type: Transform
       pos: 78.5,-27.5
       parent: 2
-  - uid: 19783
+  - uid: 19781
     components:
     - type: Transform
       pos: 78.5,-22.5
       parent: 2
-  - uid: 19784
+  - uid: 19782
     components:
     - type: Transform
       pos: 77.5,-29.5
       parent: 2
-  - uid: 19785
+  - uid: 19783
     components:
     - type: Transform
       pos: 78.5,-28.5
       parent: 2
-  - uid: 19786
+  - uid: 19784
     components:
     - type: Transform
       pos: 78.5,-29.5
       parent: 2
-  - uid: 19787
+  - uid: 19785
     components:
     - type: Transform
       pos: 78.5,-21.5
       parent: 2
-  - uid: 19788
+  - uid: 19786
     components:
     - type: Transform
       pos: 77.5,-21.5
       parent: 2
-  - uid: 19789
+  - uid: 19787
     components:
     - type: Transform
       pos: 78.5,-26.5
       parent: 2
-  - uid: 19790
+  - uid: 19788
     components:
     - type: Transform
       pos: 39.5,10.5
       parent: 2
-  - uid: 19791
+  - uid: 19789
     components:
     - type: Transform
       pos: 43.5,24.5
       parent: 2
-  - uid: 19792
+  - uid: 19790
     components:
     - type: Transform
       pos: 51.5,23.5
       parent: 2
-  - uid: 19793
+  - uid: 19791
     components:
     - type: Transform
       pos: 39.5,7.5
       parent: 2
-  - uid: 19794
+  - uid: 19792
     components:
     - type: Transform
       pos: 35.5,7.5
       parent: 2
-  - uid: 19795
+  - uid: 19793
     components:
     - type: Transform
       pos: 35.5,10.5
       parent: 2
-  - uid: 19796
+  - uid: 19794
     components:
     - type: Transform
       pos: 35.5,16.5
       parent: 2
-  - uid: 19797
+  - uid: 19795
     components:
     - type: Transform
       pos: 37.5,21.5
       parent: 2
-  - uid: 19798
+  - uid: 19796
     components:
     - type: Transform
       pos: 33.5,12.5
       parent: 2
-  - uid: 19799
+  - uid: 19797
     components:
     - type: Transform
       pos: 30.5,12.5
       parent: 2
-  - uid: 19800
+  - uid: 19798
     components:
     - type: Transform
       pos: 42.5,26.5
       parent: 2
-  - uid: 19801
+  - uid: 19799
     components:
     - type: Transform
       pos: 42.5,25.5
       parent: 2
-  - uid: 19802
+  - uid: 19800
     components:
     - type: Transform
       pos: 38.5,23.5
       parent: 2
-  - uid: 19803
+  - uid: 19801
     components:
     - type: Transform
       pos: 40.5,23.5
       parent: 2
-  - uid: 19804
+  - uid: 19802
     components:
     - type: Transform
       pos: 37.5,28.5
       parent: 2
-  - uid: 19805
+  - uid: 19803
     components:
     - type: Transform
       pos: 38.5,28.5
       parent: 2
-  - uid: 19806
+  - uid: 19804
     components:
     - type: Transform
       pos: 48.5,20.5
       parent: 2
-  - uid: 19807
+  - uid: 19805
     components:
     - type: Transform
       pos: 48.5,22.5
       parent: 2
-  - uid: 19808
+  - uid: 19806
     components:
     - type: Transform
       pos: 48.5,21.5
       parent: 2
-  - uid: 19809
+  - uid: 19807
     components:
     - type: Transform
       pos: 49.5,23.5
       parent: 2
-  - uid: 19810
+  - uid: 19808
     components:
     - type: Transform
       pos: 50.5,23.5
       parent: 2
-  - uid: 19811
+  - uid: 19809
     components:
     - type: Transform
       pos: 43.5,29.5
       parent: 2
-  - uid: 19812
+  - uid: 19810
     components:
     - type: Transform
       pos: 44.5,29.5
       parent: 2
-  - uid: 19813
+  - uid: 19811
     components:
     - type: Transform
       pos: 45.5,29.5
       parent: 2
-  - uid: 19814
+  - uid: 19812
     components:
     - type: Transform
       pos: 47.5,29.5
       parent: 2
-  - uid: 19815
+  - uid: 19813
     components:
     - type: Transform
       pos: 48.5,29.5
       parent: 2
-  - uid: 19816
+  - uid: 19814
     components:
     - type: Transform
       pos: 46.5,29.5
       parent: 2
-  - uid: 19817
+  - uid: 19815
     components:
     - type: Transform
       pos: 49.5,29.5
       parent: 2
-  - uid: 19818
+  - uid: 19816
     components:
     - type: Transform
       pos: 54.5,29.5
       parent: 2
-  - uid: 19819
+  - uid: 19817
     components:
     - type: Transform
       pos: 56.5,29.5
       parent: 2
-  - uid: 19820
+  - uid: 19818
     components:
     - type: Transform
       pos: 46.5,24.5
       parent: 2
-  - uid: 19821
+  - uid: 19819
     components:
     - type: Transform
       pos: 78.5,18.5
       parent: 2
-  - uid: 19822
+  - uid: 19820
     components:
     - type: Transform
       pos: 78.5,17.5
       parent: 2
-  - uid: 19823
+  - uid: 19821
     components:
     - type: Transform
       pos: 78.5,20.5
       parent: 2
-  - uid: 19824
+  - uid: 19822
     components:
     - type: Transform
       pos: 78.5,19.5
       parent: 2
-  - uid: 19825
+  - uid: 19823
     components:
     - type: Transform
       pos: 78.5,16.5
       parent: 2
-  - uid: 19826
+  - uid: 19824
     components:
     - type: Transform
       pos: -13.5,-25.5
       parent: 2
-  - uid: 19827
+  - uid: 19825
     components:
     - type: Transform
       pos: -9.5,17.5
       parent: 2
-  - uid: 19828
+  - uid: 19826
     components:
     - type: Transform
       pos: -8.5,17.5
       parent: 2
-  - uid: 19829
+  - uid: 19827
     components:
     - type: Transform
       pos: -7.5,17.5
       parent: 2
-  - uid: 19830
+  - uid: 19828
     components:
     - type: Transform
       pos: -6.5,17.5
       parent: 2
-  - uid: 19831
+  - uid: 19829
     components:
     - type: Transform
       pos: -12.5,-28.5
       parent: 2
-  - uid: 19832
+  - uid: 19830
     components:
     - type: Transform
       pos: -13.5,-28.5
       parent: 2
-  - uid: 19833
+  - uid: 19831
     components:
     - type: Transform
       pos: -13.5,-27.5
       parent: 2
-  - uid: 19834
+  - uid: 19832
     components:
     - type: Transform
       pos: -13.5,-26.5
       parent: 2
-  - uid: 19835
+  - uid: 19833
     components:
     - type: Transform
       pos: -11.5,-28.5
       parent: 2
-  - uid: 19836
+  - uid: 19834
     components:
     - type: Transform
       pos: 68.5,-32.5
       parent: 2
-  - uid: 19837
+  - uid: 19835
     components:
     - type: Transform
       pos: -11.5,-27.5
       parent: 2
-  - uid: 19838
+  - uid: 19836
     components:
     - type: Transform
       pos: -27.5,-23.5
       parent: 2
-  - uid: 19839
+  - uid: 19837
     components:
     - type: Transform
       pos: -26.5,-23.5
       parent: 2
-  - uid: 19840
+  - uid: 19838
     components:
     - type: Transform
       pos: -25.5,-23.5
       parent: 2
-  - uid: 19841
+  - uid: 19839
     components:
     - type: Transform
       pos: -25.5,-22.5
       parent: 2
-  - uid: 19842
+  - uid: 19840
     components:
     - type: Transform
       pos: -25.5,-21.5
       parent: 2
-  - uid: 19843
+  - uid: 19841
     components:
     - type: Transform
       pos: -18.5,-23.5
       parent: 2
-  - uid: 19844
+  - uid: 19842
     components:
     - type: Transform
       pos: -19.5,-23.5
       parent: 2
-  - uid: 19845
+  - uid: 19843
     components:
     - type: Transform
       pos: -20.5,-23.5
       parent: 2
-  - uid: 19846
+  - uid: 19844
     components:
     - type: Transform
       pos: -20.5,-22.5
       parent: 2
-  - uid: 19847
+  - uid: 19845
     components:
     - type: Transform
       pos: -20.5,-21.5
       parent: 2
-  - uid: 19848
+  - uid: 19846
     components:
     - type: Transform
       pos: -21.5,-20.5
       parent: 2
-  - uid: 19849
+  - uid: 19847
     components:
     - type: Transform
       pos: -22.5,-20.5
       parent: 2
-  - uid: 19850
+  - uid: 19848
     components:
     - type: Transform
       pos: -23.5,-20.5
       parent: 2
-  - uid: 19851
+  - uid: 19849
     components:
     - type: Transform
       pos: -24.5,-20.5
       parent: 2
-  - uid: 19852
+  - uid: 19850
     components:
     - type: Transform
       pos: -19.5,-20.5
       parent: 2
-  - uid: 19853
+  - uid: 19851
     components:
     - type: Transform
       pos: 67.5,-32.5
       parent: 2
-  - uid: 19854
+  - uid: 19852
     components:
     - type: Transform
       pos: -11.5,-33.5
       parent: 2
-  - uid: 19855
+  - uid: 19853
     components:
     - type: Transform
       pos: -10.5,-33.5
       parent: 2
-  - uid: 19856
+  - uid: 19854
     components:
     - type: Transform
       pos: -41.5,-17.5
       parent: 2
-  - uid: 19857
+  - uid: 19855
     components:
     - type: Transform
       pos: -39.5,-17.5
       parent: 2
-  - uid: 19858
+  - uid: 19856
     components:
     - type: Transform
       pos: -38.5,-17.5
       parent: 2
-  - uid: 19859
+  - uid: 19857
     components:
     - type: Transform
       pos: -36.5,-17.5
       parent: 2
-  - uid: 19860
+  - uid: 19858
     components:
     - type: Transform
       pos: -38.5,-23.5
       parent: 2
-  - uid: 19861
+  - uid: 19859
     components:
     - type: Transform
       pos: -36.5,-23.5
       parent: 2
-  - uid: 19862
+  - uid: 19860
     components:
     - type: Transform
       pos: -5.5,-27.5
       parent: 2
-  - uid: 19863
+  - uid: 19861
     components:
     - type: Transform
       pos: -38.5,39.5
       parent: 2
-  - uid: 19864
+  - uid: 19862
     components:
     - type: Transform
       pos: -40.5,39.5
       parent: 2
-  - uid: 19865
+  - uid: 19863
     components:
     - type: Transform
       pos: -39.5,39.5
       parent: 2
-  - uid: 19866
+  - uid: 19864
     components:
     - type: Transform
       pos: -37.5,39.5
       parent: 2
-  - uid: 19867
+  - uid: 19865
     components:
     - type: Transform
       pos: -36.5,39.5
       parent: 2
-  - uid: 19868
+  - uid: 19866
     components:
     - type: Transform
       pos: -34.5,39.5
       parent: 2
-  - uid: 19869
+  - uid: 19867
     components:
     - type: Transform
       pos: 25.5,-38.5
       parent: 2
-  - uid: 19870
+  - uid: 19868
     components:
     - type: Transform
       pos: 18.5,-38.5
       parent: 2
-  - uid: 19871
+  - uid: 19869
     components:
     - type: Transform
       pos: 28.5,-42.5
       parent: 2
-  - uid: 19872
+  - uid: 19870
     components:
     - type: Transform
       pos: 27.5,-41.5
       parent: 2
-  - uid: 19873
+  - uid: 19871
     components:
     - type: Transform
       pos: 27.5,-40.5
       parent: 2
-  - uid: 19874
+  - uid: 19872
     components:
     - type: Transform
       pos: 29.5,-42.5
       parent: 2
-  - uid: 19875
+  - uid: 19873
     components:
     - type: Transform
       pos: 30.5,-42.5
       parent: 2
-  - uid: 19876
+  - uid: 19874
     components:
     - type: Transform
       pos: 22.5,-38.5
       parent: 2
-  - uid: 19877
+  - uid: 19875
     components:
     - type: Transform
       pos: 21.5,-38.5
       parent: 2
-  - uid: 19878
+  - uid: 19876
     components:
     - type: Transform
       pos: 27.5,-39.5
       parent: 2
-  - uid: 19879
+  - uid: 19877
     components:
     - type: Transform
       pos: 36.5,-39.5
       parent: 2
-  - uid: 19880
+  - uid: 19878
     components:
     - type: Transform
       pos: 67.5,-33.5
       parent: 2
-  - uid: 19881
+  - uid: 19879
     components:
     - type: Transform
       pos: 67.5,-34.5
       parent: 2
-  - uid: 19882
+  - uid: 19880
     components:
     - type: Transform
       pos: -6.5,52.5
       parent: 2
-  - uid: 19883
+  - uid: 19881
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 2
-  - uid: 19884
+  - uid: 19882
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 2
-  - uid: 19885
+  - uid: 19883
     components:
     - type: Transform
       pos: 39.5,33.5
       parent: 2
-  - uid: 19886
+  - uid: 19884
     components:
     - type: Transform
       pos: 38.5,35.5
       parent: 2
-  - uid: 19887
+  - uid: 19885
     components:
     - type: Transform
       pos: 38.5,36.5
       parent: 2
-  - uid: 19888
+  - uid: 19886
     components:
     - type: Transform
       pos: 38.5,37.5
       parent: 2
-  - uid: 19889
+  - uid: 19887
     components:
     - type: Transform
       pos: 38.5,40.5
       parent: 2
-  - uid: 19890
+  - uid: 19888
     components:
     - type: Transform
       pos: 6.5,11.5
       parent: 2
-  - uid: 19891
+  - uid: 19889
     components:
     - type: Transform
       pos: 10.5,6.5
       parent: 2
-  - uid: 19892
+  - uid: 19890
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 2
-  - uid: 19893
+  - uid: 19891
     components:
     - type: Transform
       pos: 7.5,11.5
       parent: 2
-  - uid: 19894
+  - uid: 19892
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 2
-  - uid: 19895
+  - uid: 19893
     components:
     - type: Transform
       pos: 16.5,-1.5
       parent: 2
-  - uid: 19896
+  - uid: 19894
     components:
     - type: Transform
       pos: 15.5,-1.5
       parent: 2
-  - uid: 19897
+  - uid: 19895
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 2
-  - uid: 19898
+  - uid: 19896
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 2
-  - uid: 19899
+  - uid: 19897
     components:
     - type: Transform
       pos: -65.5,43.5
       parent: 2
-  - uid: 19900
+  - uid: 19898
     components:
     - type: Transform
       pos: -65.5,41.5
       parent: 2
 - proto: RemoteSignaller
   entities:
-  - uid: 19901
+  - uid: 19899
     components:
     - type: MetaData
       name: bedroom blast doors
@@ -123763,55 +123796,55 @@ entities:
         950:
         - - Pressed
           - Toggle
-  - uid: 19902
+  - uid: 19900
     components:
     - type: Transform
       pos: -34.65559,27.559319
       parent: 2
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 19903
+  - uid: 19901
     components:
     - type: Transform
       pos: -49.5,43.5
       parent: 2
 - proto: ResearchComputerCircuitboard
   entities:
-  - uid: 19904
+  - uid: 19902
     components:
     - type: Transform
       pos: 3.7333322,20.619427
       parent: 2
 - proto: Retractor
   entities:
-  - uid: 19905
+  - uid: 19903
     components:
     - type: Transform
       pos: -45.494118,8.488342
       parent: 2
 - proto: RevolverCapGun
   entities:
-  - uid: 19906
+  - uid: 19904
     components:
     - type: Transform
       pos: -6.5018587,39.566113
       parent: 2
-  - uid: 19907
+  - uid: 19905
     components:
     - type: Transform
       pos: 21.545708,-6.2727547
       parent: 2
-  - uid: 19908
+  - uid: 19906
     components:
     - type: Transform
       pos: 8.529913,-39.59766
       parent: 2
-  - uid: 19909
+  - uid: 19907
     components:
     - type: Transform
       pos: -3.7343574,19.683527
       parent: 2
-  - uid: 19910
+  - uid: 19908
     components:
     - type: Transform
       pos: 4.6066175,-18.183628
@@ -123827,282 +123860,282 @@ entities:
       inSlotFlag: BACK
     - type: Physics
       canCollide: False
-  - uid: 19911
+  - uid: 19909
     components:
     - type: Transform
       pos: -25.489525,32.42608
       parent: 2
-  - uid: 19912
+  - uid: 19910
     components:
     - type: Transform
       pos: 23.54879,5.4814196
       parent: 2
-  - uid: 19913
+  - uid: 19911
     components:
     - type: Transform
       pos: 39.25823,4.5107894
       parent: 2
-  - uid: 19914
+  - uid: 19912
     components:
     - type: Transform
       pos: 7.4569874,35.450542
       parent: 2
 - proto: RubberStampApproved
   entities:
-  - uid: 19915
+  - uid: 19913
     components:
     - type: Transform
       pos: -21.320812,41.516605
       parent: 2
 - proto: RubberStampDenied
   entities:
-  - uid: 19916
+  - uid: 19914
     components:
     - type: Transform
       pos: -21.503101,41.75098
       parent: 2
 - proto: SalvageMagnet
   entities:
-  - uid: 19917
+  - uid: 19915
     components:
     - type: Transform
       pos: 37.5,39.5
       parent: 2
 - proto: SaxophoneInstrument
   entities:
-  - uid: 19918
+  - uid: 19916
     components:
     - type: Transform
       pos: -77.48821,-2.7215095
       parent: 2
 - proto: Scalpel
   entities:
-  - uid: 19919
+  - uid: 19917
     components:
     - type: Transform
       pos: -45.509743,8.707092
       parent: 2
-  - uid: 19920
+  - uid: 19918
     components:
     - type: Transform
       pos: -55.421375,-16.550985
       parent: 2
 - proto: ScalpelShiv
   entities:
-  - uid: 19921
+  - uid: 19919
     components:
     - type: Transform
       pos: 3.514542,-12.504271
       parent: 2
-  - uid: 19922
+  - uid: 19920
     components:
     - type: Transform
       pos: -55.427135,-16.25411
       parent: 2
 - proto: ScrapMedkit
   entities:
-  - uid: 19923
+  - uid: 19921
     components:
     - type: Transform
       pos: -20.567188,-19.376364
       parent: 2
-  - uid: 19924
+  - uid: 19922
     components:
     - type: Transform
       pos: -54.50527,-15.06661
       parent: 2
 - proto: Screen
   entities:
-  - uid: 19925
+  - uid: 19923
     components:
     - type: Transform
       pos: 87.5,-14.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19926
+  - uid: 19924
     components:
     - type: Transform
       pos: 27.5,-15.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19927
+  - uid: 19925
     components:
     - type: Transform
       pos: 21.5,-8.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19928
+  - uid: 19926
     components:
     - type: Transform
       pos: 51.5,-15.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19929
+  - uid: 19927
     components:
     - type: Transform
       pos: 61.5,-15.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19930
+  - uid: 19928
     components:
     - type: Transform
       pos: 57.5,-7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19931
+  - uid: 19929
     components:
     - type: Transform
       pos: 70.5,-17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19932
+  - uid: 19930
     components:
     - type: Transform
       pos: 87.5,-26.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19933
+  - uid: 19931
     components:
     - type: Transform
       pos: 87.5,-18.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19934
+  - uid: 19932
     components:
     - type: Transform
       pos: 87.5,-22.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19935
+  - uid: 19933
     components:
     - type: Transform
       pos: -26.5,5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19936
+  - uid: 19934
     components:
     - type: Transform
       pos: 78.5,-12.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19937
+  - uid: 19935
     components:
     - type: Transform
       pos: 29.5,2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19938
+  - uid: 19936
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19939
+  - uid: 19937
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19940
+  - uid: 19938
     components:
     - type: Transform
       pos: -12.5,18.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19941
+  - uid: 19939
     components:
     - type: Transform
       pos: -11.5,27.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19942
+  - uid: 19940
     components:
     - type: Transform
       pos: -23.5,28.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19943
+  - uid: 19941
     components:
     - type: Transform
       pos: -18.5,27.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19944
+  - uid: 19942
     components:
     - type: Transform
       pos: -34.5,22.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19945
+  - uid: 19943
     components:
     - type: Transform
       pos: -43.5,24.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19946
+  - uid: 19944
     components:
     - type: Transform
       pos: -46.5,11.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19947
+  - uid: 19945
     components:
     - type: Transform
       pos: -35.5,-4.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19948
+  - uid: 19946
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19949
+  - uid: 19947
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19950
+  - uid: 19948
     components:
     - type: Transform
       pos: 27.5,16.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19951
+  - uid: 19949
     components:
     - type: Transform
       pos: 48.5,23.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19952
+  - uid: 19950
     components:
     - type: Transform
       pos: -45.5,40.5
@@ -124111,19 +124144,19 @@ entities:
       fixtures: {}
 - proto: Screwdriver
   entities:
-  - uid: 19953
+  - uid: 19951
     components:
     - type: Transform
       pos: -46.791557,30.780184
       parent: 2
-  - uid: 19954
+  - uid: 19952
     components:
     - type: Transform
       pos: -46.697807,30.592684
       parent: 2
 - proto: SecurityTechFab
   entities:
-  - uid: 19955
+  - uid: 19953
     components:
     - type: Transform
       pos: -10.5,-7.5
@@ -124137,116 +124170,116 @@ entities:
       - Biochemical
 - proto: SecurityTechFabCircuitboard
   entities:
-  - uid: 19956
+  - uid: 19954
     components:
     - type: Transform
       pos: 6.5508056,18.497473
       parent: 2
 - proto: SeedExtractor
   entities:
-  - uid: 19957
+  - uid: 19955
     components:
     - type: Transform
       pos: 9.5,-5.5
       parent: 2
-  - uid: 19958
+  - uid: 19956
     components:
     - type: Transform
       pos: 60.5,0.5
       parent: 2
 - proto: ShardGlass
   entities:
-  - uid: 19959
+  - uid: 19957
     components:
     - type: Transform
       pos: 63.97458,-28.461584
       parent: 2
-  - uid: 19960
+  - uid: 19958
     components:
     - type: Transform
       pos: 62.458954,-29.961584
       parent: 2
-  - uid: 19961
+  - uid: 19959
     components:
     - type: Transform
       pos: 62.583954,-30.274084
       parent: 2
-  - uid: 19962
+  - uid: 19960
     components:
     - type: Transform
       pos: 60.583954,-33.75846
       parent: 2
-  - uid: 19963
+  - uid: 19961
     components:
     - type: Transform
       pos: 59.84958,-31.977211
       parent: 2
-  - uid: 19964
+  - uid: 19962
     components:
     - type: Transform
       pos: 58.84958,-33.992836
       parent: 2
-  - uid: 19965
+  - uid: 19963
     components:
     - type: Transform
       pos: 60.802704,-29.13346
       parent: 2
-  - uid: 19966
+  - uid: 19964
     components:
     - type: Transform
       pos: 66.56833,-26.78971
       parent: 2
-  - uid: 19967
+  - uid: 19965
     components:
     - type: Transform
       pos: 65.69333,-27.35221
       parent: 2
 - proto: SheetGlass
   entities:
-  - uid: 19968
+  - uid: 19966
     components:
     - type: Transform
       pos: -60.526897,31.574072
       parent: 2
+  - uid: 19967
+    components:
+    - type: Transform
+      pos: -43.462337,25.554003
+      parent: 2
+  - uid: 19968
+    components:
+    - type: Transform
+      pos: -43.462337,25.554003
+      parent: 2
   - uid: 19969
-    components:
-    - type: Transform
-      pos: -43.462337,25.554003
-      parent: 2
-  - uid: 19970
-    components:
-    - type: Transform
-      pos: -43.462337,25.554003
-      parent: 2
-  - uid: 19971
     components:
     - type: Transform
       pos: 20.295801,17.59948
       parent: 2
-  - uid: 19972
+  - uid: 19970
     components:
     - type: Transform
       pos: 3.5,-33.5
       parent: 2
-  - uid: 19973
+  - uid: 19971
     components:
     - type: Transform
       pos: 41.591076,24.442621
       parent: 2
-  - uid: 19974
+  - uid: 19972
     components:
     - type: Transform
       pos: 43.5,26.5
       parent: 2
 - proto: SheetPlasma
   entities:
-  - uid: 19975
+  - uid: 19973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5195332,41.467716
       parent: 2
-  - uid: 19976
+  - uid: 19974
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -124263,113 +124296,113 @@ entities:
     - type: InsideEntityStorage
 - proto: SheetPlasteel
   entities:
-  - uid: 19977
+  - uid: 19975
     components:
     - type: Transform
       pos: 20.733301,17.63073
       parent: 2
 - proto: SheetPlastic
   entities:
-  - uid: 19978
+  - uid: 19976
     components:
     - type: Transform
       pos: -11.354582,-7.4687614
       parent: 2
-  - uid: 19979
+  - uid: 19977
     components:
     - type: Transform
       pos: -60.401897,31.714697
       parent: 2
+  - uid: 19978
+    components:
+    - type: Transform
+      pos: -43.446712,25.554003
+      parent: 2
+  - uid: 19979
+    components:
+    - type: Transform
+      pos: -43.446712,25.554003
+      parent: 2
   - uid: 19980
-    components:
-    - type: Transform
-      pos: -43.446712,25.554003
-      parent: 2
-  - uid: 19981
-    components:
-    - type: Transform
-      pos: -43.446712,25.554003
-      parent: 2
-  - uid: 19982
     components:
     - type: Transform
       pos: 19.952051,17.63073
       parent: 2
-  - uid: 19983
+  - uid: 19981
     components:
     - type: Transform
       pos: 41.591076,24.380121
       parent: 2
 - proto: SheetSteel
   entities:
-  - uid: 19984
+  - uid: 19982
     components:
     - type: Transform
       pos: 0.50299597,9.497643
       parent: 2
-  - uid: 19985
+  - uid: 19983
     components:
     - type: Transform
       pos: -11.588957,-7.4062614
       parent: 2
-  - uid: 19986
+  - uid: 19984
     components:
     - type: Transform
       pos: -56.481823,-1.511231
       parent: 2
-  - uid: 19987
+  - uid: 19985
     components:
     - type: Transform
       pos: 19.467676,17.583855
       parent: 2
-  - uid: 19988
+  - uid: 19986
     components:
     - type: Transform
       pos: -60.596622,31.714697
       parent: 2
+  - uid: 19987
+    components:
+    - type: Transform
+      pos: -43.462337,25.554003
+      parent: 2
+  - uid: 19988
+    components:
+    - type: Transform
+      pos: -43.462337,25.554003
+      parent: 2
   - uid: 19989
-    components:
-    - type: Transform
-      pos: -43.462337,25.554003
-      parent: 2
-  - uid: 19990
-    components:
-    - type: Transform
-      pos: -43.462337,25.554003
-      parent: 2
-  - uid: 19991
     components:
     - type: Transform
       pos: 3.5,-33.5
       parent: 2
-  - uid: 19992
+  - uid: 19990
     components:
     - type: Transform
       pos: 30.5,15.5
       parent: 2
-  - uid: 19993
+  - uid: 19991
     components:
     - type: Transform
       pos: 41.528576,24.505121
       parent: 2
-  - uid: 19994
+  - uid: 19992
     components:
     - type: Transform
       pos: 46.53861,28.539917
       parent: 2
-  - uid: 19995
+  - uid: 19993
     components:
     - type: Transform
       pos: 59.374004,9.711176
       parent: 2
-  - uid: 19996
+  - uid: 19994
     components:
     - type: Transform
       pos: 59.69997,9.711176
       parent: 2
 - proto: SheetUranium
   entities:
-  - uid: 19997
+  - uid: 19995
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -124377,7 +124410,7 @@ entities:
       parent: 2
 - proto: ShelfBar
   entities:
-  - uid: 19998
+  - uid: 19996
     components:
     - type: Transform
       pos: 33.5,-1.5
@@ -124386,34 +124419,34 @@ entities:
       fixtures: {}
 - proto: Shovel
   entities:
-  - uid: 19999
+  - uid: 19997
     components:
     - type: Transform
       pos: -1.5345926,25.534763
       parent: 2
 - proto: ShowcaseRobot
   entities:
-  - uid: 20000
+  - uid: 19998
     components:
     - type: Transform
       pos: -14.5,35.5
       parent: 2
 - proto: ShowcaseRobotAntique
   entities:
-  - uid: 20001
+  - uid: 19999
     components:
     - type: Transform
       pos: -16.5,35.5
       parent: 2
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 20002
+  - uid: 20000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,11.5
       parent: 2
-  - uid: 20003
+  - uid: 20001
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124421,7 +124454,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20004
+  - uid: 20002
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124429,7 +124462,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20005
+  - uid: 20003
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124437,7 +124470,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20006
+  - uid: 20004
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124445,263 +124478,263 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20007
+  - uid: 20005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,11.5
       parent: 2
-  - uid: 20008
+  - uid: 20006
     components:
     - type: Transform
       pos: -30.5,47.5
       parent: 2
-  - uid: 20009
+  - uid: 20007
     components:
     - type: Transform
       pos: -31.5,47.5
       parent: 2
-  - uid: 20010
+  - uid: 20008
     components:
     - type: Transform
       pos: -31.5,50.5
       parent: 2
-  - uid: 20011
+  - uid: 20009
     components:
     - type: Transform
       pos: -30.5,50.5
       parent: 2
-  - uid: 20012
+  - uid: 20010
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,49.5
       parent: 2
-  - uid: 20013
+  - uid: 20011
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,48.5
       parent: 2
-  - uid: 20014
+  - uid: 20012
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,47.5
       parent: 2
-  - uid: 20015
+  - uid: 20013
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,50.5
       parent: 2
-  - uid: 20016
+  - uid: 20014
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,3.5
       parent: 2
-  - uid: 20017
+  - uid: 20015
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-  - uid: 20018
+  - uid: 20016
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 2
-  - uid: 20019
+  - uid: 20017
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
-  - uid: 20020
+  - uid: 20018
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 2
-  - uid: 20021
+  - uid: 20019
     components:
     - type: Transform
       pos: -15.5,-1.5
       parent: 2
-  - uid: 20022
+  - uid: 20020
     components:
     - type: Transform
       pos: -14.5,-1.5
       parent: 2
-  - uid: 20023
+  - uid: 20021
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 2
-  - uid: 20024
+  - uid: 20022
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
-  - uid: 20025
+  - uid: 20023
     components:
     - type: Transform
       pos: -37.5,11.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20026
+  - uid: 20024
     components:
     - type: Transform
       pos: -36.5,11.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20027
+  - uid: 20025
     components:
     - type: Transform
       pos: -35.5,11.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20028
+  - uid: 20026
     components:
     - type: Transform
       pos: 6.5,-42.5
       parent: 2
-  - uid: 20029
+  - uid: 20027
     components:
     - type: Transform
       pos: 7.5,-42.5
       parent: 2
-  - uid: 20030
+  - uid: 20028
     components:
     - type: Transform
       pos: 8.5,-42.5
       parent: 2
-  - uid: 20031
+  - uid: 20029
     components:
     - type: Transform
       pos: 11.5,-42.5
       parent: 2
-  - uid: 20032
+  - uid: 20030
     components:
     - type: Transform
       pos: 12.5,-42.5
       parent: 2
-  - uid: 20033
+  - uid: 20031
     components:
     - type: Transform
       pos: 10.5,-42.5
       parent: 2
-  - uid: 20034
+  - uid: 20032
     components:
     - type: Transform
       pos: 14.5,-42.5
       parent: 2
-  - uid: 20035
+  - uid: 20033
     components:
     - type: Transform
       pos: 15.5,-42.5
       parent: 2
-  - uid: 20036
+  - uid: 20034
     components:
     - type: Transform
       pos: 16.5,-42.5
       parent: 2
-  - uid: 20037
+  - uid: 20035
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-29.5
       parent: 2
-  - uid: 20038
+  - uid: 20036
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-28.5
       parent: 2
-  - uid: 20039
+  - uid: 20037
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-27.5
       parent: 2
-  - uid: 20040
+  - uid: 20038
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-22.5
       parent: 2
-  - uid: 20041
+  - uid: 20039
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-21.5
       parent: 2
-  - uid: 20042
+  - uid: 20040
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-20.5
       parent: 2
-  - uid: 20043
+  - uid: 20041
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-18.5
       parent: 2
-  - uid: 20044
+  - uid: 20042
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-17.5
       parent: 2
-  - uid: 20045
+  - uid: 20043
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-16.5
       parent: 2
-  - uid: 20046
+  - uid: 20044
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-31.5
       parent: 2
-  - uid: 20047
+  - uid: 20045
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-32.5
       parent: 2
-  - uid: 20048
+  - uid: 20046
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-33.5
       parent: 2
-  - uid: 20049
+  - uid: 20047
     components:
     - type: Transform
       pos: -30.5,17.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20050
+  - uid: 20048
     components:
     - type: Transform
       pos: -31.5,17.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20051
+  - uid: 20049
     components:
     - type: Transform
       pos: -29.5,17.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20052
+  - uid: 20050
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124709,7 +124742,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20053
+  - uid: 20051
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124717,7 +124750,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20054
+  - uid: 20052
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124725,49 +124758,49 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20055
+  - uid: 20053
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,11.5
       parent: 2
-  - uid: 20056
+  - uid: 20054
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,11.5
       parent: 2
-  - uid: 20057
+  - uid: 20055
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,11.5
       parent: 2
-  - uid: 20058
+  - uid: 20056
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,11.5
       parent: 2
-  - uid: 20059
+  - uid: 20057
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,11.5
       parent: 2
-  - uid: 20060
+  - uid: 20058
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,11.5
       parent: 2
-  - uid: 20061
+  - uid: 20059
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,11.5
       parent: 2
-  - uid: 20062
+  - uid: 20060
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -124775,31 +124808,31 @@ entities:
       parent: 2
 - proto: ShuttersRadiationOpen
   entities:
-  - uid: 20063
+  - uid: 20061
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 78.5,16.5
       parent: 2
-  - uid: 20064
+  - uid: 20062
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 78.5,17.5
       parent: 2
-  - uid: 20065
+  - uid: 20063
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 78.5,18.5
       parent: 2
-  - uid: 20066
+  - uid: 20064
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 78.5,19.5
       parent: 2
-  - uid: 20067
+  - uid: 20065
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124807,73 +124840,73 @@ entities:
       parent: 2
 - proto: ShuttersWindow
   entities:
-  - uid: 20068
+  - uid: 20066
     components:
     - type: Transform
       pos: -61.5,42.5
       parent: 2
-  - uid: 20069
+  - uid: 20067
     components:
     - type: Transform
       pos: -59.5,42.5
       parent: 2
 - proto: ShuttersWindowOpen
   entities:
-  - uid: 20070
+  - uid: 20068
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 2
-  - uid: 20071
+  - uid: 20069
     components:
     - type: Transform
       pos: 43.5,-7.5
       parent: 2
-  - uid: 20072
+  - uid: 20070
     components:
     - type: Transform
       pos: 44.5,-7.5
       parent: 2
-  - uid: 20073
+  - uid: 20071
     components:
     - type: Transform
       pos: 45.5,-7.5
       parent: 2
-  - uid: 20074
+  - uid: 20072
     components:
     - type: Transform
       pos: 46.5,-7.5
       parent: 2
-  - uid: 20075
+  - uid: 20073
     components:
     - type: Transform
       pos: 47.5,-7.5
       parent: 2
-  - uid: 20076
+  - uid: 20074
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-6.5
       parent: 2
-  - uid: 20077
+  - uid: 20075
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-5.5
       parent: 2
-  - uid: 20078
+  - uid: 20076
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-4.5
       parent: 2
-  - uid: 20079
+  - uid: 20077
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-3.5
       parent: 2
-  - uid: 20080
+  - uid: 20078
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124881,7 +124914,7 @@ entities:
       parent: 2
 - proto: SignAiUpload
   entities:
-  - uid: 20081
+  - uid: 20079
     components:
     - type: Transform
       pos: -7.5,41.5
@@ -124890,7 +124923,7 @@ entities:
       fixtures: {}
 - proto: SignalButton
   entities:
-  - uid: 20082
+  - uid: 20080
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124898,14 +124931,14 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20070:
+        20068:
         - - Pressed
           - Toggle
     - type: Fixtures
       fixtures: {}
 - proto: SignalButtonDirectional
   entities:
-  - uid: 20083
+  - uid: 20081
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124918,20 +124951,14 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20084
+  - uid: 20082
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20016:
-        - - Pressed
-          - Toggle
-        20020:
-        - - Pressed
-          - Toggle
-        20019:
+        20014:
         - - Pressed
           - Toggle
         20018:
@@ -124940,9 +124967,15 @@ entities:
         20017:
         - - Pressed
           - Toggle
+        20016:
+        - - Pressed
+          - Toggle
+        20015:
+        - - Pressed
+          - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20085
+  - uid: 20083
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124950,21 +124983,21 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20021:
+        20019:
+        - - Pressed
+          - Toggle
+        20020:
         - - Pressed
           - Toggle
         20022:
         - - Pressed
           - Toggle
-        20024:
-        - - Pressed
-          - Toggle
-        20023:
+        20021:
         - - Pressed
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20086
+  - uid: 20084
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -124977,7 +125010,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20087
+  - uid: 20085
     components:
     - type: Transform
       pos: 78.5,-10.5
@@ -124989,7 +125022,7 @@ entities:
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20088
+  - uid: 20086
     components:
     - type: Transform
       pos: 78.5,-8.5
@@ -125001,7 +125034,7 @@ entities:
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20089
+  - uid: 20087
     components:
     - type: Transform
       pos: 78.5,-6.5
@@ -125013,7 +125046,7 @@ entities:
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20090
+  - uid: 20088
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125026,7 +125059,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20091
+  - uid: 20089
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125039,7 +125072,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20092
+  - uid: 20090
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125052,7 +125085,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20093
+  - uid: 20091
     components:
     - type: MetaData
       desc: Opens and closes the radiation shutters.
@@ -125063,6 +125096,12 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
+        20061:
+        - - Pressed
+          - Toggle
+        20062:
+        - - Pressed
+          - Toggle
         20063:
         - - Pressed
           - Toggle
@@ -125072,15 +125111,9 @@ entities:
         20065:
         - - Pressed
           - Toggle
-        20066:
-        - - Pressed
-          - Toggle
-        20067:
-        - - Pressed
-          - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20094
+  - uid: 20092
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125095,7 +125128,7 @@ entities:
       fixtures: {}
 - proto: SignalSwitch
   entities:
-  - uid: 20095
+  - uid: 20093
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125103,7 +125136,12 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20008:
+        20006:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20007:
         - - Off
           - Open
         - - On
@@ -125113,12 +125151,7 @@ entities:
           - Open
         - - On
           - Close
-        20011:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20010:
+        20008:
         - - Off
           - Open
         - - On
@@ -125133,22 +125166,22 @@ entities:
           - Open
         - - On
           - Close
-        20014:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20013:
-        - - On
-          - Close
-        - - Off
-          - Open
         20012:
         - - Off
           - Open
         - - On
           - Close
-        20015:
+        20011:
+        - - On
+          - Close
+        - - Off
+          - Open
+        20010:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20013:
         - - Off
           - Open
         - - On
@@ -125157,7 +125190,7 @@ entities:
       fixtures: {}
 - proto: SignalSwitchDirectional
   entities:
-  - uid: 20096
+  - uid: 20094
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125165,7 +125198,12 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20005:
+        20003:
+        - - On
+          - Open
+        - - Off
+          - Close
+        20002:
         - - On
           - Open
         - - Off
@@ -125175,19 +125213,14 @@ entities:
           - Open
         - - Off
           - Close
-        20006:
-        - - On
-          - Open
-        - - Off
-          - Close
-        20003:
+        20001:
         - - On
           - Open
         - - Off
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20097
+  - uid: 20095
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -125195,17 +125228,36 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20002:
+        20000:
         - - On
           - Open
         - - Off
           - Close
-        20007:
+        20005:
         - - On
           - Open
         - - Off
           - Close
-        20058:
+        20056:
+        - - On
+          - Open
+        - - Off
+          - Close
+        20057:
+        - - On
+          - Open
+        - - Off
+          - Close
+    - type: Fixtures
+      fixtures: {}
+  - uid: 20096
+    components:
+    - type: Transform
+      pos: 13.5,8.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        20060:
         - - On
           - Open
         - - Off
@@ -125215,33 +125267,14 @@ entities:
           - Open
         - - Off
           - Close
-    - type: Fixtures
-      fixtures: {}
-  - uid: 20098
-    components:
-    - type: Transform
-      pos: 13.5,8.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        20062:
-        - - On
-          - Open
-        - - Off
-          - Close
-        20061:
-        - - On
-          - Open
-        - - Off
-          - Close
-        20060:
+        20058:
         - - On
           - Open
         - - Off
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20099
+  - uid: 20097
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125266,7 +125299,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20100
+  - uid: 20098
     components:
     - type: Transform
       pos: 4.5,46.5
@@ -125290,7 +125323,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20101
+  - uid: 20099
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125310,7 +125343,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20102
+  - uid: 20100
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125318,17 +125351,17 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20057:
-        - - On
-          - Open
-        - - Off
-          - Close
-        20056:
-        - - On
-          - Open
-        - - Off
-          - Close
         20055:
+        - - On
+          - Open
+        - - Off
+          - Close
+        20054:
+        - - On
+          - Open
+        - - Off
+          - Close
+        20053:
         - - On
           - Open
         - - Off
@@ -125350,7 +125383,7 @@ entities:
           - Open
     - type: Fixtures
       fixtures: {}
-  - uid: 20103
+  - uid: 20101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125358,37 +125391,37 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
+        20023:
+        - - Status
+          - Toggle
+        20024:
+        - - Status
+          - Toggle
         20025:
-        - - Status
-          - Toggle
-        20026:
-        - - Status
-          - Toggle
-        20027:
         - - Status
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20104
+  - uid: 20102
     components:
     - type: Transform
       pos: -62.5,40.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20068:
+        20066:
         - - On
           - Close
         - - Off
           - Open
-        20069:
+        20067:
         - - Off
           - Open
         - - On
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20105
+  - uid: 20103
     components:
     - type: Transform
       pos: -58.5,40.5
@@ -125412,7 +125445,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20106
+  - uid: 20104
     components:
     - type: Transform
       pos: -52.5,38.5
@@ -125436,7 +125469,7 @@ entities:
           - Open
     - type: Fixtures
       fixtures: {}
-  - uid: 20107
+  - uid: 20105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -125444,22 +125477,27 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20052:
-        - - On
-          - Close
-        - - Off
-          - Open
-        20053:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20054:
-        - - Off
-          - Open
-        - - On
-          - Close
         20050:
+        - - On
+          - Close
+        - - Off
+          - Open
+        20051:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20052:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20048:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20047:
         - - Off
           - Open
         - - On
@@ -125468,15 +125506,10 @@ entities:
         - - Off
           - Open
         - - On
-          - Close
-        20051:
-        - - Off
-          - Open
-        - - On
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20108
+  - uid: 20106
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125484,17 +125517,17 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20030:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20029:
-        - - Off
-          - Open
-        - - On
-          - Close
         20028:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20027:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20026:
         - - Off
           - Open
         - - On
@@ -125511,7 +125544,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20109
+  - uid: 20107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125519,17 +125552,17 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20032:
+        20030:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20029:
         - - Off
           - Open
         - - On
           - Close
         20031:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20033:
         - - Off
           - Open
         - - On
@@ -125546,7 +125579,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20110
+  - uid: 20108
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125554,17 +125587,17 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20036:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20035:
-        - - Off
-          - Open
-        - - On
-          - Close
         20034:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20033:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20032:
         - - Off
           - Open
         - - On
@@ -125581,7 +125614,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20111
+  - uid: 20109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125589,7 +125622,7 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20048:
+        20046:
         - - Off
           - Open
         - - On
@@ -125599,12 +125632,12 @@ entities:
           - DoorBolt
         - - Off
           - DoorBolt
-        20047:
+        20045:
         - - Off
           - Open
         - - On
           - Close
-        20046:
+        20044:
         - - Off
           - Open
         - - On
@@ -125616,7 +125649,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20112
+  - uid: 20110
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125629,7 +125662,7 @@ entities:
           - DoorBolt
         - - On
           - DoorBolt
-        20037:
+        20035:
         - - Off
           - Open
         - - On
@@ -125639,19 +125672,19 @@ entities:
           - DoorBolt
         - - Off
           - DoorBolt
-        20038:
+        20036:
         - - Off
           - Open
         - - On
           - Close
-        20039:
+        20037:
         - - Off
           - Open
         - - On
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20113
+  - uid: 20111
     components:
     - type: Transform
       pos: 41.5,-19.5
@@ -125663,7 +125696,7 @@ entities:
           - DoorBolt
         - - Off
           - DoorBolt
-        20042:
+        20040:
         - - Off
           - Open
         - - On
@@ -125673,36 +125706,36 @@ entities:
           - DoorBolt
         - - On
           - DoorBolt
-        20041:
+        20039:
         - - Off
           - Open
         - - On
           - Close
-        20040:
+        20038:
         - - Off
           - Open
         - - On
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20114
+  - uid: 20112
     components:
     - type: Transform
       pos: 40.5,-15.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20045:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20044:
-        - - Off
-          - Open
-        - - On
-          - Close
         20043:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20042:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20041:
         - - Off
           - Open
         - - On
@@ -125719,14 +125752,14 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20115
+  - uid: 20113
     components:
     - type: Transform
       pos: 42.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20116
+  - uid: 20114
     components:
     - type: Transform
       pos: 21.2172,40.498383
@@ -125745,7 +125778,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20117
+  - uid: 20115
     components:
     - type: Transform
       pos: 21.749607,40.498383
@@ -125764,7 +125797,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20118
+  - uid: 20116
     components:
     - type: Transform
       pos: 54.5,14.5
@@ -125790,7 +125823,7 @@ entities:
       fixtures: {}
 - proto: SignAnomaly
   entities:
-  - uid: 20119
+  - uid: 20117
     components:
     - type: Transform
       pos: -49.5,33.5
@@ -125799,7 +125832,7 @@ entities:
       fixtures: {}
 - proto: SignAnomaly2
   entities:
-  - uid: 20120
+  - uid: 20118
     components:
     - type: Transform
       pos: -49.5,31.5
@@ -125808,7 +125841,7 @@ entities:
       fixtures: {}
 - proto: SignArmory
   entities:
-  - uid: 20121
+  - uid: 20119
     components:
     - type: Transform
       pos: -5.5,-9.5
@@ -125817,28 +125850,28 @@ entities:
       fixtures: {}
 - proto: SignArrivals
   entities:
-  - uid: 20122
+  - uid: 20120
     components:
     - type: Transform
       pos: 32.5,-30.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20123
+  - uid: 20121
     components:
     - type: Transform
       pos: 32.5,-23.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20124
+  - uid: 20122
     components:
     - type: Transform
       pos: 22.5,-21.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20125
+  - uid: 20123
     components:
     - type: Transform
       pos: 22.5,-28.5
@@ -125847,7 +125880,7 @@ entities:
       fixtures: {}
 - proto: SignBar
   entities:
-  - uid: 20126
+  - uid: 20124
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -125855,7 +125888,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20127
+  - uid: 20125
     components:
     - type: Transform
       pos: 35.5,-1.5
@@ -125864,7 +125897,7 @@ entities:
       fixtures: {}
 - proto: SignBath
   entities:
-  - uid: 20128
+  - uid: 20126
     components:
     - type: Transform
       pos: 3.5,-38.5
@@ -125873,7 +125906,7 @@ entities:
       fixtures: {}
 - proto: SignBridge
   entities:
-  - uid: 20129
+  - uid: 20127
     components:
     - type: Transform
       pos: -16.5,27.5
@@ -125882,7 +125915,7 @@ entities:
       fixtures: {}
 - proto: SignBrigmed
   entities:
-  - uid: 20130
+  - uid: 20128
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125892,14 +125925,14 @@ entities:
       fixtures: {}
 - proto: SignCargo
   entities:
-  - uid: 20131
+  - uid: 20129
     components:
     - type: Transform
       pos: 14.5,18.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20132
+  - uid: 20130
     components:
     - type: Transform
       pos: 18.5,23.5
@@ -125908,7 +125941,7 @@ entities:
       fixtures: {}
 - proto: SignCargoDock
   entities:
-  - uid: 20133
+  - uid: 20131
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125918,7 +125951,7 @@ entities:
       fixtures: {}
 - proto: SignChapel
   entities:
-  - uid: 20134
+  - uid: 20132
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125926,7 +125959,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20135
+  - uid: 20133
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125936,7 +125969,7 @@ entities:
       fixtures: {}
 - proto: SignChem
   entities:
-  - uid: 20136
+  - uid: 20134
     components:
     - type: Transform
       pos: -39.5,6.5
@@ -125945,7 +125978,7 @@ entities:
       fixtures: {}
 - proto: SignDangerMed
   entities:
-  - uid: 20137
+  - uid: 20135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -125953,7 +125986,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20138
+  - uid: 20136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125961,7 +125994,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20139
+  - uid: 20137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125971,7 +126004,7 @@ entities:
       fixtures: {}
 - proto: SignDetective
   entities:
-  - uid: 20140
+  - uid: 20138
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -125981,14 +126014,14 @@ entities:
       fixtures: {}
 - proto: SignDirectionalEscapePod
   entities:
-  - uid: 20141
+  - uid: 20139
     components:
     - type: Transform
       pos: 18.5,-34.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20142
+  - uid: 20140
     components:
     - type: Transform
       pos: 36.5,-34.5
@@ -125997,7 +126030,7 @@ entities:
       fixtures: {}
 - proto: SignDisposalProper
   entities:
-  - uid: 20143
+  - uid: 20141
     components:
     - type: Transform
       pos: -6.5,-26.5
@@ -126006,7 +126039,7 @@ entities:
       fixtures: {}
 - proto: SignElectricalMed
   entities:
-  - uid: 20144
+  - uid: 20142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126016,7 +126049,7 @@ entities:
       fixtures: {}
 - proto: SignEngine
   entities:
-  - uid: 20145
+  - uid: 20143
     components:
     - type: Transform
       pos: 50.5,29.5
@@ -126025,7 +126058,7 @@ entities:
       fixtures: {}
 - proto: SignEscapePods
   entities:
-  - uid: 20146
+  - uid: 20144
     components:
     - type: Transform
       pos: 27.5,-38.5
@@ -126034,7 +126067,7 @@ entities:
       fixtures: {}
 - proto: SignEVA
   entities:
-  - uid: 20147
+  - uid: 20145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126044,28 +126077,28 @@ entities:
       fixtures: {}
 - proto: SignHead
   entities:
-  - uid: 20148
+  - uid: 20146
     components:
     - type: Transform
       pos: -6.5,45.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20149
+  - uid: 20147
     components:
     - type: Transform
       pos: -42.5,29.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20150
+  - uid: 20148
     components:
     - type: Transform
       pos: 21.5,20.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20151
+  - uid: 20149
     components:
     - type: Transform
       pos: 39.5,28.5
@@ -126074,7 +126107,7 @@ entities:
       fixtures: {}
 - proto: SignHydro1
   entities:
-  - uid: 20152
+  - uid: 20150
     components:
     - type: Transform
       pos: 61.5,-7.5
@@ -126083,7 +126116,7 @@ entities:
       fixtures: {}
 - proto: SignInterrogation
   entities:
-  - uid: 20153
+  - uid: 20151
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126093,7 +126126,7 @@ entities:
       fixtures: {}
 - proto: SignJanitor
   entities:
-  - uid: 20154
+  - uid: 20152
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126103,7 +126136,7 @@ entities:
       fixtures: {}
 - proto: SignKiddiePlaque
   entities:
-  - uid: 20155
+  - uid: 20153
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126113,14 +126146,14 @@ entities:
       fixtures: {}
 - proto: SignKitchen
   entities:
-  - uid: 20156
+  - uid: 20154
     components:
     - type: Transform
       pos: 41.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20157
+  - uid: 20155
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126130,7 +126163,7 @@ entities:
       fixtures: {}
 - proto: SignLawyer
   entities:
-  - uid: 20158
+  - uid: 20156
     components:
     - type: Transform
       pos: -16.5,11.5
@@ -126139,7 +126172,7 @@ entities:
       fixtures: {}
 - proto: SignMagneticsMed
   entities:
-  - uid: 20159
+  - uid: 20157
     components:
     - type: Transform
       pos: 38.5,39.5
@@ -126148,7 +126181,7 @@ entities:
       fixtures: {}
 - proto: SignMaterials
   entities:
-  - uid: 20160
+  - uid: 20158
     components:
     - type: Transform
       pos: 2.5,17.5
@@ -126157,14 +126190,14 @@ entities:
       fixtures: {}
 - proto: SignMedical
   entities:
-  - uid: 20161
+  - uid: 20159
     components:
     - type: Transform
       pos: -25.5,11.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20162
+  - uid: 20160
     components:
     - type: Transform
       pos: -33.5,11.5
@@ -126173,7 +126206,7 @@ entities:
       fixtures: {}
 - proto: SignMining
   entities:
-  - uid: 20163
+  - uid: 20161
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126183,7 +126216,7 @@ entities:
       fixtures: {}
 - proto: SignMorgue
   entities:
-  - uid: 20164
+  - uid: 20162
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126193,7 +126226,7 @@ entities:
       fixtures: {}
 - proto: SignPlaque
   entities:
-  - uid: 20165
+  - uid: 20163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126203,7 +126236,7 @@ entities:
       fixtures: {}
 - proto: SignPsychology
   entities:
-  - uid: 20166
+  - uid: 20164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126213,14 +126246,14 @@ entities:
       fixtures: {}
 - proto: SignRobo
   entities:
-  - uid: 20167
+  - uid: 20165
     components:
     - type: Transform
       pos: -65.5,34.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20168
+  - uid: 20166
     components:
     - type: Transform
       pos: -57.5,31.5
@@ -126229,7 +126262,7 @@ entities:
       fixtures: {}
 - proto: SignSalvage
   entities:
-  - uid: 20169
+  - uid: 20167
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126239,119 +126272,119 @@ entities:
       fixtures: {}
 - proto: SignShock
   entities:
-  - uid: 20170
+  - uid: 20168
     components:
     - type: Transform
       pos: 55.5,48.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20171
+  - uid: 20169
     components:
     - type: Transform
       pos: 61.5,56.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20172
+  - uid: 20170
     components:
     - type: Transform
       pos: 56.5,53.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20173
+  - uid: 20171
     components:
     - type: Transform
       pos: 69.5,56.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20174
+  - uid: 20172
     components:
     - type: Transform
       pos: 74.5,53.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20175
+  - uid: 20173
     components:
     - type: Transform
       pos: 75.5,48.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20176
+  - uid: 20174
     components:
     - type: Transform
       pos: 59.5,34.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20177
+  - uid: 20175
     components:
     - type: Transform
       pos: 61.5,22.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20178
+  - uid: 20176
     components:
     - type: Transform
       pos: 69.5,22.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20179
+  - uid: 20177
     components:
     - type: Transform
       pos: 71.5,34.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20180
+  - uid: 20178
     components:
     - type: Transform
       pos: 59.5,29.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20181
+  - uid: 20179
     components:
     - type: Transform
       pos: 59.5,39.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20182
+  - uid: 20180
     components:
     - type: Transform
       pos: 71.5,39.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20183
+  - uid: 20181
     components:
     - type: Transform
       pos: 71.5,26.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20184
+  - uid: 20182
     components:
     - type: Transform
       pos: 62.5,14.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20185
+  - uid: 20183
     components:
     - type: Transform
       pos: 61.5,9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20186
+  - uid: 20184
     components:
     - type: Transform
       pos: 70.5,14.5
@@ -126360,7 +126393,7 @@ entities:
       fixtures: {}
 - proto: SignSurgery
   entities:
-  - uid: 20187
+  - uid: 20185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126370,7 +126403,7 @@ entities:
       fixtures: {}
 - proto: SignVault
   entities:
-  - uid: 20188
+  - uid: 20186
     components:
     - type: Transform
       pos: -23.5,32.5
@@ -126379,7 +126412,7 @@ entities:
       fixtures: {}
 - proto: SignXenobio
   entities:
-  - uid: 20189
+  - uid: 20187
     components:
     - type: Transform
       pos: -65.5,37.5
@@ -126388,32 +126421,32 @@ entities:
       fixtures: {}
 - proto: SingularityGenerator
   entities:
-  - uid: 20190
+  - uid: 20188
     components:
     - type: Transform
       pos: 74.5,22.5
       parent: 2
 - proto: Sink
   entities:
-  - uid: 20191
+  - uid: 20189
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-1.5
       parent: 2
-  - uid: 20192
+  - uid: 20190
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 54.5,-6.5
       parent: 2
-  - uid: 20193
+  - uid: 20191
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 49.5,-6.5
       parent: 2
-  - uid: 20194
+  - uid: 20192
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126421,65 +126454,65 @@ entities:
       parent: 2
 - proto: SinkStemless
   entities:
-  - uid: 20195
+  - uid: 20193
     components:
     - type: Transform
       pos: -3.5,-41.5
       parent: 2
-  - uid: 20196
+  - uid: 20194
     components:
     - type: Transform
       pos: -3.5,-39.5
       parent: 2
-  - uid: 20197
+  - uid: 20195
     components:
     - type: Transform
       pos: -3.5,-37.5
       parent: 2
-  - uid: 20198
+  - uid: 20196
     components:
     - type: Transform
       pos: -3.5,-35.5
       parent: 2
 - proto: SinkStemlessWater
   entities:
-  - uid: 20199
+  - uid: 20197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-41.5
       parent: 2
-  - uid: 20200
+  - uid: 20198
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-39.5
       parent: 2
-  - uid: 20201
+  - uid: 20199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 68.5,-30.5
       parent: 2
-  - uid: 20202
+  - uid: 20200
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 78.5,-9.5
       parent: 2
-  - uid: 20203
+  - uid: 20201
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 78.5,-11.5
       parent: 2
-  - uid: 20204
+  - uid: 20202
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 78.5,-7.5
       parent: 2
-  - uid: 20205
+  - uid: 20203
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126487,83 +126520,83 @@ entities:
       parent: 2
 - proto: SinkWide
   entities:
-  - uid: 20206
+  - uid: 20204
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-13.5
       parent: 2
-  - uid: 20207
+  - uid: 20205
     components:
     - type: Transform
       pos: 35.5,-2.5
       parent: 2
-  - uid: 20208
+  - uid: 20206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,40.5
       parent: 2
-  - uid: 20209
+  - uid: 20207
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,5.5
       parent: 2
-  - uid: 20210
+  - uid: 20208
     components:
     - type: Transform
       pos: -36.5,10.5
       parent: 2
-  - uid: 20211
+  - uid: 20209
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -43.5,-12.5
       parent: 2
-  - uid: 20212
+  - uid: 20210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,-12.5
       parent: 2
-  - uid: 20213
+  - uid: 20211
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,26.5
       parent: 2
-  - uid: 20214
+  - uid: 20212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -67.5,26.5
       parent: 2
-  - uid: 20215
+  - uid: 20213
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-38.5
       parent: 2
-  - uid: 20216
+  - uid: 20214
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 58.5,-5.5
       parent: 2
-  - uid: 20217
+  - uid: 20215
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 83.5,-10.5
       parent: 2
-  - uid: 20218
+  - uid: 20216
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-17.5
       parent: 2
-  - uid: 20219
+  - uid: 20217
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126571,7 +126604,7 @@ entities:
       parent: 2
 - proto: SLVendingMachineEngi
   entities:
-  - uid: 20220
+  - uid: 20218
     components:
     - type: Transform
       pos: 43.5,25.5
@@ -126580,7 +126613,7 @@ entities:
       processingListings: {}
 - proto: SLVendingMachineFashion
   entities:
-  - uid: 20221
+  - uid: 20219
     components:
     - type: Transform
       pos: 7.5,-34.5
@@ -126589,14 +126622,14 @@ entities:
       processingListings: {}
 - proto: SLVendingMachineHugDispenser
   entities:
-  - uid: 20222
+  - uid: 20220
     components:
     - type: Transform
       pos: 42.5,-12.5
       parent: 2
 - proto: SLVendingMachineMedical
   entities:
-  - uid: 20223
+  - uid: 20221
     components:
     - type: Transform
       pos: -46.5,-9.5
@@ -126605,145 +126638,145 @@ entities:
       processingListings: {}
 - proto: SLVendingMachineMining
   entities:
-  - uid: 20224
+  - uid: 20222
     components:
     - type: Transform
       pos: 28.5,31.5
       parent: 2
 - proto: SLVendingMachineSalvage
   entities:
-  - uid: 20225
+  - uid: 20223
     components:
     - type: Transform
       pos: 28.5,33.5
       parent: 2
 - proto: SLVendingMachineSecurity
   entities:
-  - uid: 20226
+  - uid: 20224
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 2
 - proto: SmartFridge
   entities:
-  - uid: 20227
+  - uid: 20225
     components:
     - type: Transform
       pos: -34.5,2.5
       parent: 2
-  - uid: 20228
+  - uid: 20226
     components:
     - type: Transform
       pos: -44.5,-5.5
       parent: 2
-  - uid: 20229
+  - uid: 20227
     components:
     - type: Transform
       pos: 48.5,-4.5
       parent: 2
 - proto: SMESAdvanced
   entities:
-  - uid: 20230
+  - uid: 20228
     components:
     - type: Transform
       pos: 46.5,21.5
       parent: 2
-  - uid: 20231
+  - uid: 20229
     components:
     - type: Transform
       pos: 46.5,22.5
       parent: 2
-  - uid: 20232
+  - uid: 20230
     components:
     - type: Transform
       pos: 46.5,20.5
       parent: 2
-  - uid: 20233
+  - uid: 20231
     components:
     - type: Transform
       pos: 46.5,23.5
       parent: 2
-  - uid: 20234
+  - uid: 20232
     components:
     - type: Transform
       pos: 64.5,50.5
       parent: 2
-  - uid: 20235
+  - uid: 20233
     components:
     - type: Transform
       pos: 77.5,15.5
       parent: 2
 - proto: SMESBasic
   entities:
-  - uid: 20236
+  - uid: 20234
     components:
     - type: Transform
       pos: -4.5,41.5
       parent: 2
-  - uid: 20237
+  - uid: 20235
     components:
     - type: Transform
       pos: -16.5,-10.5
       parent: 2
-  - uid: 20238
+  - uid: 20236
     components:
     - type: Transform
       pos: -37.5,-19.5
       parent: 2
 - proto: SnowBattlemap
   entities:
-  - uid: 20239
+  - uid: 20237
     components:
     - type: Transform
       pos: 69.54626,-42.478077
       parent: 2
 - proto: SodaDispenser
   entities:
-  - uid: 20240
+  - uid: 20238
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 2
-  - uid: 20241
+  - uid: 20239
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 2
-  - uid: 20242
+  - uid: 20240
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,-3.5
       parent: 2
-  - uid: 20243
+  - uid: 20241
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 66.5,-32.5
       parent: 2
-  - uid: 20244
+  - uid: 20242
     components:
     - type: Transform
       pos: -38.5,38.5
       parent: 2
 - proto: SofaCorner
   entities:
-  - uid: 20245
+  - uid: 20243
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 2
 - proto: SofaEndLeft
   entities:
-  - uid: 20246
+  - uid: 20244
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 2
 - proto: SofaEndLeftBrown
   entities:
-  - uid: 20247
+  - uid: 20245
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126751,7 +126784,7 @@ entities:
       parent: 2
 - proto: SofaEndRight
   entities:
-  - uid: 20248
+  - uid: 20246
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126759,7 +126792,7 @@ entities:
       parent: 2
 - proto: SofaEndRightBrown
   entities:
-  - uid: 20249
+  - uid: 20247
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126767,7 +126800,7 @@ entities:
       parent: 2
 - proto: SofaFancyEndLeft
   entities:
-  - uid: 20250
+  - uid: 20248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126775,7 +126808,7 @@ entities:
       parent: 2
 - proto: SofaFancyEndRight
   entities:
-  - uid: 20251
+  - uid: 20249
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126783,2579 +126816,2579 @@ entities:
       parent: 2
 - proto: SofaMiddle
   entities:
-  - uid: 20252
+  - uid: 20250
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 2
 - proto: SolarPanel
   entities:
-  - uid: 20253
+  - uid: 20251
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,73.5
       parent: 2
-  - uid: 20254
+  - uid: 20252
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,58.5
       parent: 2
-  - uid: 20255
+  - uid: 20253
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,73.5
       parent: 2
-  - uid: 20256
+  - uid: 20254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,72.5
       parent: 2
-  - uid: 20257
+  - uid: 20255
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,72.5
       parent: 2
-  - uid: 20258
+  - uid: 20256
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,70.5
       parent: 2
-  - uid: 20259
+  - uid: 20257
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,70.5
       parent: 2
-  - uid: 20260
+  - uid: 20258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,70.5
       parent: 2
-  - uid: 20261
+  - uid: 20259
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,68.5
       parent: 2
-  - uid: 20262
+  - uid: 20260
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,68.5
       parent: 2
-  - uid: 20263
+  - uid: 20261
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,68.5
       parent: 2
-  - uid: 20264
+  - uid: 20262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,68.5
       parent: 2
-  - uid: 20265
+  - uid: 20263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,66.5
       parent: 2
-  - uid: 20266
+  - uid: 20264
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,66.5
       parent: 2
-  - uid: 20267
+  - uid: 20265
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,66.5
       parent: 2
-  - uid: 20268
+  - uid: 20266
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,66.5
       parent: 2
-  - uid: 20269
+  - uid: 20267
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,64.5
       parent: 2
-  - uid: 20270
+  - uid: 20268
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,64.5
       parent: 2
-  - uid: 20271
+  - uid: 20269
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,64.5
       parent: 2
-  - uid: 20272
+  - uid: 20270
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,64.5
       parent: 2
-  - uid: 20273
+  - uid: 20271
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,64.5
       parent: 2
-  - uid: 20274
+  - uid: 20272
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,62.5
       parent: 2
-  - uid: 20275
+  - uid: 20273
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,62.5
       parent: 2
-  - uid: 20276
+  - uid: 20274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,62.5
       parent: 2
-  - uid: 20277
+  - uid: 20275
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,62.5
       parent: 2
-  - uid: 20278
+  - uid: 20276
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,62.5
       parent: 2
-  - uid: 20279
+  - uid: 20277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,62.5
       parent: 2
-  - uid: 20280
+  - uid: 20278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,60.5
       parent: 2
-  - uid: 20281
+  - uid: 20279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,60.5
       parent: 2
-  - uid: 20282
+  - uid: 20280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,60.5
       parent: 2
-  - uid: 20283
+  - uid: 20281
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,60.5
       parent: 2
-  - uid: 20284
+  - uid: 20282
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,60.5
       parent: 2
-  - uid: 20285
+  - uid: 20283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,60.5
       parent: 2
-  - uid: 20286
+  - uid: 20284
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,60.5
       parent: 2
-  - uid: 20287
+  - uid: 20285
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,58.5
       parent: 2
-  - uid: 20288
+  - uid: 20286
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,58.5
       parent: 2
-  - uid: 20289
+  - uid: 20287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,58.5
       parent: 2
-  - uid: 20290
+  - uid: 20288
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,58.5
       parent: 2
-  - uid: 20291
+  - uid: 20289
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,58.5
       parent: 2
-  - uid: 20292
+  - uid: 20290
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,58.5
       parent: 2
-  - uid: 20293
+  - uid: 20291
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,58.5
       parent: 2
-  - uid: 20294
+  - uid: 20292
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,57.5
       parent: 2
-  - uid: 20295
+  - uid: 20293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,57.5
       parent: 2
-  - uid: 20296
+  - uid: 20294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,56.5
       parent: 2
-  - uid: 20297
+  - uid: 20295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,58.5
       parent: 2
-  - uid: 20298
+  - uid: 20296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,58.5
       parent: 2
-  - uid: 20299
+  - uid: 20297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,58.5
       parent: 2
-  - uid: 20300
+  - uid: 20298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 72.5,58.5
       parent: 2
-  - uid: 20301
+  - uid: 20299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 73.5,58.5
       parent: 2
-  - uid: 20302
+  - uid: 20300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,58.5
       parent: 2
-  - uid: 20303
+  - uid: 20301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,57.5
       parent: 2
-  - uid: 20304
+  - uid: 20302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,57.5
       parent: 2
-  - uid: 20305
+  - uid: 20303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,56.5
       parent: 2
-  - uid: 20306
+  - uid: 20304
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,60.5
       parent: 2
-  - uid: 20307
+  - uid: 20305
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,60.5
       parent: 2
-  - uid: 20308
+  - uid: 20306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,60.5
       parent: 2
-  - uid: 20309
+  - uid: 20307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 72.5,60.5
       parent: 2
-  - uid: 20310
+  - uid: 20308
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 73.5,60.5
       parent: 2
-  - uid: 20311
+  - uid: 20309
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,60.5
       parent: 2
-  - uid: 20312
+  - uid: 20310
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,60.5
       parent: 2
-  - uid: 20313
+  - uid: 20311
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,62.5
       parent: 2
-  - uid: 20314
+  - uid: 20312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,62.5
       parent: 2
-  - uid: 20315
+  - uid: 20313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,62.5
       parent: 2
-  - uid: 20316
+  - uid: 20314
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,62.5
       parent: 2
-  - uid: 20317
+  - uid: 20315
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 72.5,62.5
       parent: 2
-  - uid: 20318
+  - uid: 20316
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 73.5,62.5
       parent: 2
-  - uid: 20319
+  - uid: 20317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,64.5
       parent: 2
-  - uid: 20320
+  - uid: 20318
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,64.5
       parent: 2
-  - uid: 20321
+  - uid: 20319
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,64.5
       parent: 2
-  - uid: 20322
+  - uid: 20320
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 72.5,64.5
       parent: 2
-  - uid: 20323
+  - uid: 20321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,64.5
       parent: 2
-  - uid: 20324
+  - uid: 20322
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,66.5
       parent: 2
-  - uid: 20325
+  - uid: 20323
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,66.5
       parent: 2
-  - uid: 20326
+  - uid: 20324
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,66.5
       parent: 2
-  - uid: 20327
+  - uid: 20325
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,66.5
       parent: 2
-  - uid: 20328
+  - uid: 20326
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,68.5
       parent: 2
-  - uid: 20329
+  - uid: 20327
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,68.5
       parent: 2
-  - uid: 20330
+  - uid: 20328
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,68.5
       parent: 2
-  - uid: 20331
+  - uid: 20329
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,68.5
       parent: 2
-  - uid: 20332
+  - uid: 20330
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,70.5
       parent: 2
-  - uid: 20333
+  - uid: 20331
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,70.5
       parent: 2
-  - uid: 20334
+  - uid: 20332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,70.5
       parent: 2
-  - uid: 20335
+  - uid: 20333
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,72.5
       parent: 2
-  - uid: 20336
+  - uid: 20334
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,72.5
       parent: 2
-  - uid: 20337
+  - uid: 20335
     components:
     - type: Transform
       pos: -44.5,-40.5
       parent: 2
-  - uid: 20338
+  - uid: 20336
     components:
     - type: Transform
       pos: -42.5,-34.5
       parent: 2
-  - uid: 20339
+  - uid: 20337
     components:
     - type: Transform
       pos: -41.5,-38.5
       parent: 2
-  - uid: 20340
+  - uid: 20338
     components:
     - type: Transform
       pos: -46.5,-40.5
       parent: 2
-  - uid: 20341
+  - uid: 20339
     components:
     - type: Transform
       pos: -42.5,-38.5
       parent: 2
-  - uid: 20342
+  - uid: 20340
     components:
     - type: Transform
       pos: -43.5,-38.5
       parent: 2
-  - uid: 20343
+  - uid: 20341
     components:
     - type: Transform
       pos: -45.5,-40.5
       parent: 2
-  - uid: 20344
+  - uid: 20342
     components:
     - type: Transform
       pos: -42.5,-40.5
       parent: 2
-  - uid: 20345
+  - uid: 20343
     components:
     - type: Transform
       pos: -45.5,-38.5
       parent: 2
-  - uid: 20346
+  - uid: 20344
     components:
     - type: Transform
       pos: -46.5,-38.5
       parent: 2
-  - uid: 20347
+  - uid: 20345
     components:
     - type: Transform
       pos: -39.5,-40.5
       parent: 2
-  - uid: 20348
+  - uid: 20346
     components:
     - type: Transform
       pos: -40.5,-40.5
       parent: 2
-  - uid: 20349
+  - uid: 20347
     components:
     - type: Transform
       pos: -41.5,-40.5
       parent: 2
-  - uid: 20350
+  - uid: 20348
     components:
     - type: Transform
       pos: -43.5,-40.5
       parent: 2
-  - uid: 20351
+  - uid: 20349
     components:
     - type: Transform
       pos: -40.5,-38.5
       parent: 2
-  - uid: 20352
+  - uid: 20350
     components:
     - type: Transform
       pos: -41.5,-34.5
       parent: 2
-  - uid: 20353
+  - uid: 20351
     components:
     - type: Transform
       pos: -43.5,-36.5
       parent: 2
-  - uid: 20354
+  - uid: 20352
     components:
     - type: Transform
       pos: -35.5,-36.5
       parent: 2
-  - uid: 20355
+  - uid: 20353
     components:
     - type: Transform
       pos: -44.5,-38.5
       parent: 2
-  - uid: 20356
+  - uid: 20354
     components:
     - type: Transform
       pos: -39.5,-38.5
       parent: 2
-  - uid: 20357
+  - uid: 20355
     components:
     - type: Transform
       pos: -42.5,-36.5
       parent: 2
-  - uid: 20358
+  - uid: 20356
     components:
     - type: Transform
       pos: -41.5,-36.5
       parent: 2
-  - uid: 20359
+  - uid: 20357
     components:
     - type: Transform
       pos: -40.5,-36.5
       parent: 2
-  - uid: 20360
+  - uid: 20358
     components:
     - type: Transform
       pos: -39.5,-36.5
       parent: 2
-  - uid: 20361
+  - uid: 20359
     components:
     - type: Transform
       pos: -43.5,-34.5
       parent: 2
-  - uid: 20362
+  - uid: 20360
     components:
     - type: Transform
       pos: -44.5,-34.5
       parent: 2
-  - uid: 20363
+  - uid: 20361
     components:
     - type: Transform
       pos: -45.5,-36.5
       parent: 2
-  - uid: 20364
+  - uid: 20362
     components:
     - type: Transform
       pos: -46.5,-34.5
       parent: 2
-  - uid: 20365
+  - uid: 20363
     components:
     - type: Transform
       pos: -44.5,-36.5
       parent: 2
-  - uid: 20366
+  - uid: 20364
     components:
     - type: Transform
       pos: -46.5,-36.5
       parent: 2
-  - uid: 20367
+  - uid: 20365
     components:
     - type: Transform
       pos: -45.5,-34.5
       parent: 2
-  - uid: 20368
+  - uid: 20366
     components:
     - type: Transform
       pos: -40.5,-34.5
       parent: 2
-  - uid: 20369
+  - uid: 20367
     components:
     - type: Transform
       pos: -39.5,-34.5
       parent: 2
-  - uid: 20370
+  - uid: 20368
     components:
     - type: Transform
       pos: -39.5,-32.5
       parent: 2
-  - uid: 20371
+  - uid: 20369
     components:
     - type: Transform
       pos: -40.5,-32.5
       parent: 2
-  - uid: 20372
+  - uid: 20370
     components:
     - type: Transform
       pos: -41.5,-32.5
       parent: 2
-  - uid: 20373
+  - uid: 20371
     components:
     - type: Transform
       pos: -42.5,-32.5
       parent: 2
-  - uid: 20374
+  - uid: 20372
     components:
     - type: Transform
       pos: -43.5,-32.5
       parent: 2
-  - uid: 20375
+  - uid: 20373
     components:
     - type: Transform
       pos: -45.5,-32.5
       parent: 2
-  - uid: 20376
+  - uid: 20374
     components:
     - type: Transform
       pos: -46.5,-32.5
       parent: 2
-  - uid: 20377
+  - uid: 20375
     components:
     - type: Transform
       pos: -44.5,-32.5
       parent: 2
-  - uid: 20378
+  - uid: 20376
     components:
     - type: Transform
       pos: -46.5,-30.5
       parent: 2
-  - uid: 20379
+  - uid: 20377
     components:
     - type: Transform
       pos: -45.5,-30.5
       parent: 2
-  - uid: 20380
+  - uid: 20378
     components:
     - type: Transform
       pos: -43.5,-30.5
       parent: 2
-  - uid: 20381
+  - uid: 20379
     components:
     - type: Transform
       pos: -42.5,-30.5
       parent: 2
-  - uid: 20382
+  - uid: 20380
     components:
     - type: Transform
       pos: -41.5,-30.5
       parent: 2
-  - uid: 20383
+  - uid: 20381
     components:
     - type: Transform
       pos: -40.5,-30.5
       parent: 2
-  - uid: 20384
+  - uid: 20382
     components:
     - type: Transform
       pos: -39.5,-30.5
       parent: 2
-  - uid: 20385
+  - uid: 20383
     components:
     - type: Transform
       pos: -44.5,-30.5
       parent: 2
-  - uid: 20386
+  - uid: 20384
     components:
     - type: Transform
       pos: -39.5,-28.5
       parent: 2
-  - uid: 20387
+  - uid: 20385
     components:
     - type: Transform
       pos: -40.5,-28.5
       parent: 2
-  - uid: 20388
+  - uid: 20386
     components:
     - type: Transform
       pos: -41.5,-28.5
       parent: 2
-  - uid: 20389
+  - uid: 20387
     components:
     - type: Transform
       pos: -42.5,-28.5
       parent: 2
-  - uid: 20390
+  - uid: 20388
     components:
     - type: Transform
       pos: -44.5,-28.5
       parent: 2
-  - uid: 20391
+  - uid: 20389
     components:
     - type: Transform
       pos: -45.5,-28.5
       parent: 2
-  - uid: 20392
+  - uid: 20390
     components:
     - type: Transform
       pos: -46.5,-28.5
       parent: 2
-  - uid: 20393
+  - uid: 20391
     components:
     - type: Transform
       pos: -43.5,-28.5
       parent: 2
-  - uid: 20394
+  - uid: 20392
     components:
     - type: Transform
       pos: -46.5,-26.5
       parent: 2
-  - uid: 20395
+  - uid: 20393
     components:
     - type: Transform
       pos: -45.5,-26.5
       parent: 2
-  - uid: 20396
+  - uid: 20394
     components:
     - type: Transform
       pos: -44.5,-26.5
       parent: 2
-  - uid: 20397
+  - uid: 20395
     components:
     - type: Transform
       pos: -43.5,-26.5
       parent: 2
-  - uid: 20398
+  - uid: 20396
     components:
     - type: Transform
       pos: -42.5,-26.5
       parent: 2
-  - uid: 20399
+  - uid: 20397
     components:
     - type: Transform
       pos: -41.5,-26.5
       parent: 2
-  - uid: 20400
+  - uid: 20398
     components:
     - type: Transform
       pos: -40.5,-26.5
       parent: 2
-  - uid: 20401
+  - uid: 20399
     components:
     - type: Transform
       pos: -39.5,-26.5
       parent: 2
-  - uid: 20402
+  - uid: 20400
     components:
     - type: Transform
       pos: -34.5,-26.5
       parent: 2
-  - uid: 20403
+  - uid: 20401
     components:
     - type: Transform
       pos: -33.5,-26.5
       parent: 2
-  - uid: 20404
+  - uid: 20402
     components:
     - type: Transform
       pos: -32.5,-26.5
       parent: 2
-  - uid: 20405
+  - uid: 20403
     components:
     - type: Transform
       pos: -30.5,-26.5
       parent: 2
-  - uid: 20406
+  - uid: 20404
     components:
     - type: Transform
       pos: -29.5,-26.5
       parent: 2
-  - uid: 20407
+  - uid: 20405
     components:
     - type: Transform
       pos: -28.5,-26.5
       parent: 2
-  - uid: 20408
+  - uid: 20406
     components:
     - type: Transform
       pos: -31.5,-26.5
       parent: 2
-  - uid: 20409
+  - uid: 20407
     components:
     - type: Transform
       pos: -35.5,-26.5
       parent: 2
-  - uid: 20410
+  - uid: 20408
     components:
     - type: Transform
       pos: -35.5,-28.5
       parent: 2
-  - uid: 20411
+  - uid: 20409
     components:
     - type: Transform
       pos: -34.5,-28.5
       parent: 2
-  - uid: 20412
+  - uid: 20410
     components:
     - type: Transform
       pos: -33.5,-28.5
       parent: 2
-  - uid: 20413
+  - uid: 20411
     components:
     - type: Transform
       pos: -31.5,-28.5
       parent: 2
-  - uid: 20414
+  - uid: 20412
     components:
     - type: Transform
       pos: -30.5,-28.5
       parent: 2
-  - uid: 20415
+  - uid: 20413
     components:
     - type: Transform
       pos: -29.5,-28.5
       parent: 2
-  - uid: 20416
+  - uid: 20414
     components:
     - type: Transform
       pos: -28.5,-28.5
       parent: 2
-  - uid: 20417
+  - uid: 20415
     components:
     - type: Transform
       pos: -32.5,-28.5
       parent: 2
-  - uid: 20418
+  - uid: 20416
     components:
     - type: Transform
       pos: -28.5,-30.5
       parent: 2
-  - uid: 20419
+  - uid: 20417
     components:
     - type: Transform
       pos: -29.5,-30.5
       parent: 2
-  - uid: 20420
+  - uid: 20418
     components:
     - type: Transform
       pos: -30.5,-30.5
       parent: 2
-  - uid: 20421
+  - uid: 20419
     components:
     - type: Transform
       pos: -32.5,-30.5
       parent: 2
-  - uid: 20422
+  - uid: 20420
     components:
     - type: Transform
       pos: -33.5,-30.5
       parent: 2
-  - uid: 20423
+  - uid: 20421
     components:
     - type: Transform
       pos: -34.5,-30.5
       parent: 2
-  - uid: 20424
+  - uid: 20422
     components:
     - type: Transform
       pos: -35.5,-30.5
       parent: 2
-  - uid: 20425
+  - uid: 20423
     components:
     - type: Transform
       pos: -31.5,-30.5
       parent: 2
-  - uid: 20426
+  - uid: 20424
     components:
     - type: Transform
       pos: -35.5,-32.5
       parent: 2
-  - uid: 20427
+  - uid: 20425
     components:
     - type: Transform
       pos: -34.5,-32.5
       parent: 2
-  - uid: 20428
+  - uid: 20426
     components:
     - type: Transform
       pos: -33.5,-32.5
       parent: 2
-  - uid: 20429
+  - uid: 20427
     components:
     - type: Transform
       pos: -32.5,-32.5
       parent: 2
-  - uid: 20430
+  - uid: 20428
     components:
     - type: Transform
       pos: -30.5,-32.5
       parent: 2
-  - uid: 20431
+  - uid: 20429
     components:
     - type: Transform
       pos: -29.5,-32.5
       parent: 2
-  - uid: 20432
+  - uid: 20430
     components:
     - type: Transform
       pos: -28.5,-32.5
       parent: 2
-  - uid: 20433
+  - uid: 20431
     components:
     - type: Transform
       pos: -31.5,-32.5
       parent: 2
-  - uid: 20434
+  - uid: 20432
     components:
     - type: Transform
       pos: -28.5,-34.5
       parent: 2
-  - uid: 20435
+  - uid: 20433
     components:
     - type: Transform
       pos: -29.5,-34.5
       parent: 2
-  - uid: 20436
+  - uid: 20434
     components:
     - type: Transform
       pos: -30.5,-34.5
       parent: 2
-  - uid: 20437
+  - uid: 20435
     components:
     - type: Transform
       pos: -33.5,-34.5
       parent: 2
-  - uid: 20438
+  - uid: 20436
     components:
     - type: Transform
       pos: -32.5,-34.5
       parent: 2
-  - uid: 20439
+  - uid: 20437
     components:
     - type: Transform
       pos: -34.5,-34.5
       parent: 2
-  - uid: 20440
+  - uid: 20438
     components:
     - type: Transform
       pos: -35.5,-34.5
       parent: 2
-  - uid: 20441
+  - uid: 20439
     components:
     - type: Transform
       pos: -31.5,-34.5
       parent: 2
-  - uid: 20442
+  - uid: 20440
     components:
     - type: Transform
       pos: -34.5,-36.5
       parent: 2
-  - uid: 20443
+  - uid: 20441
     components:
     - type: Transform
       pos: -33.5,-36.5
       parent: 2
-  - uid: 20444
+  - uid: 20442
     components:
     - type: Transform
       pos: -31.5,-36.5
       parent: 2
-  - uid: 20445
+  - uid: 20443
     components:
     - type: Transform
       pos: -30.5,-36.5
       parent: 2
-  - uid: 20446
+  - uid: 20444
     components:
     - type: Transform
       pos: -29.5,-36.5
       parent: 2
-  - uid: 20447
+  - uid: 20445
     components:
     - type: Transform
       pos: -28.5,-36.5
       parent: 2
-  - uid: 20448
+  - uid: 20446
     components:
     - type: Transform
       pos: -32.5,-36.5
       parent: 2
-  - uid: 20449
+  - uid: 20447
     components:
     - type: Transform
       pos: -28.5,-38.5
       parent: 2
-  - uid: 20450
+  - uid: 20448
     components:
     - type: Transform
       pos: -30.5,-38.5
       parent: 2
-  - uid: 20451
+  - uid: 20449
     components:
     - type: Transform
       pos: -31.5,-38.5
       parent: 2
-  - uid: 20452
+  - uid: 20450
     components:
     - type: Transform
       pos: -32.5,-38.5
       parent: 2
-  - uid: 20453
+  - uid: 20451
     components:
     - type: Transform
       pos: -33.5,-38.5
       parent: 2
-  - uid: 20454
+  - uid: 20452
     components:
     - type: Transform
       pos: -34.5,-38.5
       parent: 2
-  - uid: 20455
+  - uid: 20453
     components:
     - type: Transform
       pos: -35.5,-38.5
       parent: 2
-  - uid: 20456
+  - uid: 20454
     components:
     - type: Transform
       pos: -29.5,-38.5
       parent: 2
-  - uid: 20457
+  - uid: 20455
     components:
     - type: Transform
       pos: -35.5,-40.5
       parent: 2
-  - uid: 20458
+  - uid: 20456
     components:
     - type: Transform
       pos: -33.5,-40.5
       parent: 2
-  - uid: 20459
+  - uid: 20457
     components:
     - type: Transform
       pos: -32.5,-40.5
       parent: 2
-  - uid: 20460
+  - uid: 20458
     components:
     - type: Transform
       pos: -34.5,-40.5
       parent: 2
-  - uid: 20461
+  - uid: 20459
     components:
     - type: Transform
       pos: -30.5,-40.5
       parent: 2
-  - uid: 20462
+  - uid: 20460
     components:
     - type: Transform
       pos: -29.5,-40.5
       parent: 2
-  - uid: 20463
+  - uid: 20461
     components:
     - type: Transform
       pos: -31.5,-40.5
       parent: 2
-  - uid: 20464
+  - uid: 20462
     components:
     - type: Transform
       pos: -28.5,-40.5
       parent: 2
 - proto: SolarTracker
   entities:
-  - uid: 20465
+  - uid: 20463
     components:
     - type: Transform
       pos: 63.5,75.5
       parent: 2
-  - uid: 20466
+  - uid: 20464
     components:
     - type: Transform
       pos: 67.5,75.5
       parent: 2
-  - uid: 20467
+  - uid: 20465
     components:
     - type: Transform
       pos: -37.5,-42.5
       parent: 2
 - proto: SolidSecretDoor
   entities:
-  - uid: 20468
+  - uid: 20466
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-18.5
       parent: 2
-  - uid: 20469
+  - uid: 20467
     components:
     - type: Transform
       pos: 11.5,29.5
       parent: 2
 - proto: SpaceCash
   entities:
-  - uid: 20470
+  - uid: 20468
     components:
     - type: Transform
       pos: -25.535286,28.743128
       parent: 2
-  - uid: 20471
+  - uid: 20469
     components:
     - type: Transform
       pos: -25.472786,28.618128
       parent: 2
-  - uid: 20472
+  - uid: 20470
     components:
     - type: Transform
       pos: -25.39466,28.430628
       parent: 2
 - proto: SpawnMechPaddyFilled
   entities:
-  - uid: 20473
+  - uid: 20471
     components:
     - type: Transform
       pos: -11.5,-15.5
       parent: 2
 - proto: SpawnMechRipley
   entities:
-  - uid: 20474
+  - uid: 20472
     components:
     - type: Transform
       pos: 20.5,19.5
       parent: 2
 - proto: SpawnMobCarp
   entities:
-  - uid: 20475
+  - uid: 20473
     components:
     - type: Transform
       pos: -75.5,-2.5
       parent: 2
-  - uid: 20476
+  - uid: 20474
     components:
     - type: Transform
       pos: -70.5,-5.5
       parent: 2
 - proto: SpawnMobCarpHolo
   entities:
-  - uid: 20477
+  - uid: 20475
     components:
     - type: Transform
       pos: 82.5,-47.5
       parent: 2
 - proto: SpawnMobCat
   entities:
-  - uid: 20478
+  - uid: 20476
     components:
     - type: Transform
       pos: -48.5,1.5
       parent: 2
 - proto: SpawnMobCatKitten
   entities:
-  - uid: 20479
+  - uid: 20477
     components:
     - type: Transform
       pos: 4.5,-55.5
       parent: 2
 - proto: SpawnMobCorgi
   entities:
-  - uid: 20480
+  - uid: 20478
     components:
     - type: Transform
       pos: -6.5,23.5
       parent: 2
 - proto: SpawnMobCow
   entities:
-  - uid: 20481
+  - uid: 20479
     components:
     - type: Transform
       pos: 50.5,2.5
       parent: 2
-  - uid: 20482
+  - uid: 20480
     components:
     - type: Transform
       pos: 66.5,1.5
       parent: 2
 - proto: SpawnMobFoxRenault
   entities:
-  - uid: 20483
+  - uid: 20481
     components:
     - type: Transform
       pos: 1.5,46.5
       parent: 2
 - proto: SpawnMobFrog
   entities:
-  - uid: 20484
+  - uid: 20482
     components:
     - type: Transform
       pos: -38.5,-10.5
       parent: 2
-  - uid: 20485
+  - uid: 20483
     components:
     - type: Transform
       pos: -38.5,-11.5
       parent: 2
 - proto: SpawnMobGoat
   entities:
-  - uid: 20486
+  - uid: 20484
     components:
     - type: Transform
       pos: 62.5,3.5
       parent: 2
 - proto: SpawnMobHonkBot
   entities:
-  - uid: 20487
+  - uid: 20485
     components:
     - type: Transform
       pos: 23.5,3.5
       parent: 2
 - proto: SpawnMobKangarooWillow
   entities:
-  - uid: 20488
+  - uid: 20486
     components:
     - type: Transform
       pos: 50.5,-32.5
       parent: 2
 - proto: SpawnMobLizard
   entities:
-  - uid: 20489
+  - uid: 20487
     components:
     - type: Transform
       pos: 79.5,-44.5
       parent: 2
 - proto: SpawnMobMcGriff
   entities:
-  - uid: 20490
+  - uid: 20488
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 2
 - proto: SpawnMobParrot
   entities:
-  - uid: 20491
+  - uid: 20489
     components:
     - type: Transform
       pos: 23.5,-6.5
       parent: 2
-  - uid: 20492
+  - uid: 20490
     components:
     - type: Transform
       pos: 36.5,31.5
       parent: 2
 - proto: SpawnMobPenguin
   entities:
-  - uid: 20493
+  - uid: 20491
     components:
     - type: Transform
       pos: 70.5,-9.5
       parent: 2
-  - uid: 20494
+  - uid: 20492
     components:
     - type: Transform
       pos: 74.5,-9.5
       parent: 2
-  - uid: 20495
+  - uid: 20493
     components:
     - type: Transform
       pos: 74.5,-11.5
       parent: 2
-  - uid: 20496
+  - uid: 20494
     components:
     - type: Transform
       pos: 72.5,-8.5
       parent: 2
-  - uid: 20497
+  - uid: 20495
     components:
     - type: Transform
       pos: 28.5,25.5
       parent: 2
-  - uid: 20498
+  - uid: 20496
     components:
     - type: Transform
       pos: 30.5,25.5
       parent: 2
-  - uid: 20499
+  - uid: 20497
     components:
     - type: Transform
       pos: 32.5,26.5
       parent: 2
-  - uid: 20500
+  - uid: 20498
     components:
     - type: Transform
       pos: 33.5,24.5
       parent: 2
-  - uid: 20501
+  - uid: 20499
     components:
     - type: Transform
       pos: 27.5,26.5
       parent: 2
-  - uid: 20502
+  - uid: 20500
     components:
     - type: Transform
       pos: 34.5,25.5
       parent: 2
 - proto: SpawnMobRaccoonMorticia
   entities:
-  - uid: 20503
+  - uid: 20501
     components:
     - type: Transform
       pos: 25.5,22.5
       parent: 2
 - proto: SpawnMobShiva
   entities:
-  - uid: 20504
+  - uid: 20502
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 2
 - proto: SpawnMobWalter
   entities:
-  - uid: 20505
+  - uid: 20503
     components:
     - type: Transform
       pos: -38.5,6.5
       parent: 2
 - proto: SpawnPointAssistant
   entities:
-  - uid: 20506
+  - uid: 20504
     components:
     - type: Transform
       pos: 49.5,-20.5
       parent: 2
-  - uid: 20507
+  - uid: 20505
     components:
     - type: Transform
       pos: 49.5,-19.5
       parent: 2
-  - uid: 20508
+  - uid: 20506
     components:
     - type: Transform
       pos: 55.5,-33.5
       parent: 2
-  - uid: 20509
+  - uid: 20507
     components:
     - type: Transform
       pos: 50.5,-25.5
       parent: 2
-  - uid: 20510
+  - uid: 20508
     components:
     - type: Transform
       pos: 60.5,-22.5
       parent: 2
-  - uid: 20511
+  - uid: 20509
     components:
     - type: Transform
       pos: 53.5,-16.5
       parent: 2
-  - uid: 20512
+  - uid: 20510
     components:
     - type: Transform
       pos: 5.5,-36.5
       parent: 2
-  - uid: 20513
+  - uid: 20511
     components:
     - type: Transform
       pos: 6.5,-36.5
       parent: 2
-  - uid: 20514
+  - uid: 20512
     components:
     - type: Transform
       pos: 7.5,-36.5
       parent: 2
-  - uid: 20515
+  - uid: 20513
     components:
     - type: Transform
       pos: 8.5,-36.5
       parent: 2
-  - uid: 20516
+  - uid: 20514
     components:
     - type: Transform
       pos: 9.5,-36.5
       parent: 2
-  - uid: 20517
+  - uid: 20515
     components:
     - type: Transform
       pos: 10.5,-36.5
       parent: 2
-  - uid: 20518
+  - uid: 20516
     components:
     - type: Transform
       pos: 11.5,-36.5
       parent: 2
-  - uid: 20519
+  - uid: 20517
     components:
     - type: Transform
       pos: 12.5,-36.5
       parent: 2
-  - uid: 20520
+  - uid: 20518
     components:
     - type: Transform
       pos: 13.5,-36.5
       parent: 2
-  - uid: 20521
+  - uid: 20519
     components:
     - type: Transform
       pos: 14.5,-36.5
       parent: 2
-  - uid: 20522
+  - uid: 20520
     components:
     - type: Transform
       pos: 3.5,-31.5
       parent: 2
-  - uid: 20523
+  - uid: 20521
     components:
     - type: Transform
       pos: 3.5,-30.5
       parent: 2
-  - uid: 20524
+  - uid: 20522
     components:
     - type: Transform
       pos: 3.5,-29.5
       parent: 2
-  - uid: 20525
+  - uid: 20523
     components:
     - type: Transform
       pos: -0.5,-39.5
       parent: 2
-  - uid: 20526
+  - uid: 20524
     components:
     - type: Transform
       pos: -0.5,-38.5
       parent: 2
-  - uid: 20527
+  - uid: 20525
     components:
     - type: Transform
       pos: -0.5,-37.5
       parent: 2
-  - uid: 20528
+  - uid: 20526
     components:
     - type: Transform
       pos: 3.5,-40.5
       parent: 2
-  - uid: 20529
+  - uid: 20527
     components:
     - type: Transform
       pos: 7.5,-40.5
       parent: 2
-  - uid: 20530
+  - uid: 20528
     components:
     - type: Transform
       pos: 11.5,-40.5
       parent: 2
-  - uid: 20531
+  - uid: 20529
     components:
     - type: Transform
       pos: 15.5,-40.5
       parent: 2
-  - uid: 20532
+  - uid: 20530
     components:
     - type: Transform
       pos: 40.5,-28.5
       parent: 2
-  - uid: 20533
+  - uid: 20531
     components:
     - type: Transform
       pos: 40.5,-21.5
       parent: 2
-  - uid: 20534
+  - uid: 20532
     components:
     - type: Transform
       pos: 39.5,-17.5
       parent: 2
-  - uid: 20535
+  - uid: 20533
     components:
     - type: Transform
       pos: 39.5,-32.5
       parent: 2
-  - uid: 20536
+  - uid: 20534
     components:
     - type: Transform
       pos: 38.5,-6.5
       parent: 2
-  - uid: 20537
+  - uid: 20535
     components:
     - type: Transform
       pos: 38.5,-5.5
       parent: 2
-  - uid: 20538
+  - uid: 20536
     components:
     - type: Transform
       pos: 38.5,-4.5
       parent: 2
-  - uid: 20539
+  - uid: 20537
     components:
     - type: Transform
       pos: 38.5,-3.5
       parent: 2
-  - uid: 20540
+  - uid: 20538
     components:
     - type: Transform
       pos: 38.5,-2.5
       parent: 2
-  - uid: 20541
+  - uid: 20539
     components:
     - type: Transform
       pos: 30.5,-2.5
       parent: 2
-  - uid: 20542
+  - uid: 20540
     components:
     - type: Transform
       pos: 30.5,-3.5
       parent: 2
-  - uid: 20543
+  - uid: 20541
     components:
     - type: Transform
       pos: 30.5,-4.5
       parent: 2
-  - uid: 20544
+  - uid: 20542
     components:
     - type: Transform
       pos: 30.5,-5.5
       parent: 2
-  - uid: 20545
+  - uid: 20543
     components:
     - type: Transform
       pos: 30.5,-6.5
       parent: 2
-  - uid: 20546
+  - uid: 20544
     components:
     - type: Transform
       pos: 32.5,9.5
       parent: 2
-  - uid: 20547
+  - uid: 20545
     components:
     - type: Transform
       pos: 11.5,20.5
       parent: 2
-  - uid: 20548
+  - uid: 20546
     components:
     - type: Transform
       pos: -29.5,8.5
       parent: 2
-  - uid: 20549
+  - uid: 20547
     components:
     - type: Transform
       pos: -57.5,18.5
       parent: 2
-  - uid: 20550
+  - uid: 20548
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 2
 - proto: SpawnPointAtmos
   entities:
-  - uid: 20551
+  - uid: 20549
     components:
     - type: Transform
       pos: 36.5,7.5
       parent: 2
-  - uid: 20552
+  - uid: 20550
     components:
     - type: Transform
       pos: 37.5,7.5
       parent: 2
 - proto: SpawnPointBartender
   entities:
-  - uid: 20553
+  - uid: 20551
     components:
     - type: Transform
       pos: 34.5,3.5
       parent: 2
-  - uid: 20554
+  - uid: 20552
     components:
     - type: Transform
       pos: 34.5,5.5
       parent: 2
 - proto: SpawnPointBlueShield
   entities:
-  - uid: 20555
+  - uid: 20553
     components:
     - type: Transform
       pos: -27.5,49.5
       parent: 2
 - proto: SpawnPointBorg
   entities:
-  - uid: 20556
+  - uid: 20554
     components:
     - type: Transform
       pos: -66.5,32.5
       parent: 2
-  - uid: 20557
+  - uid: 20555
     components:
     - type: Transform
       pos: -67.5,32.5
       parent: 2
-  - uid: 20558
+  - uid: 20556
     components:
     - type: Transform
       pos: -68.5,32.5
       parent: 2
 - proto: SpawnPointBotanist
   entities:
-  - uid: 20559
+  - uid: 20557
     components:
     - type: Transform
       pos: 55.5,1.5
       parent: 2
-  - uid: 20560
+  - uid: 20558
     components:
     - type: Transform
       pos: 54.5,1.5
       parent: 2
-  - uid: 20561
+  - uid: 20559
     components:
     - type: Transform
       pos: 53.5,1.5
       parent: 2
 - proto: SpawnPointBoxer
   entities:
-  - uid: 20562
+  - uid: 20560
     components:
     - type: Transform
       pos: 49.5,-34.5
       parent: 2
-  - uid: 20563
+  - uid: 20561
     components:
     - type: Transform
       pos: 52.5,-31.5
       parent: 2
 - proto: SpawnPointBrigmedic
   entities:
-  - uid: 20564
+  - uid: 20562
     components:
     - type: Transform
       pos: 13.5,5.5
       parent: 2
 - proto: SpawnPointCaptain
   entities:
-  - uid: 20565
+  - uid: 20563
     components:
     - type: Transform
       pos: 4.5,44.5
       parent: 2
 - proto: SpawnPointCargoTechnician
   entities:
-  - uid: 20566
+  - uid: 20564
     components:
     - type: Transform
       pos: 16.5,18.5
       parent: 2
-  - uid: 20567
+  - uid: 20565
     components:
     - type: Transform
       pos: 16.5,19.5
       parent: 2
-  - uid: 20568
+  - uid: 20566
     components:
     - type: Transform
       pos: 16.5,20.5
       parent: 2
-  - uid: 20569
+  - uid: 20567
     components:
     - type: Transform
       pos: 16.5,21.5
       parent: 2
-  - uid: 20570
+  - uid: 20568
     components:
     - type: Transform
       pos: 22.5,25.5
       parent: 2
-  - uid: 20571
+  - uid: 20569
     components:
     - type: Transform
       pos: 23.5,25.5
       parent: 2
-  - uid: 20572
+  - uid: 20570
     components:
     - type: Transform
       pos: 24.5,25.5
       parent: 2
 - proto: SpawnPointChaplain
   entities:
-  - uid: 20573
+  - uid: 20571
     components:
     - type: Transform
       pos: -64.5,17.5
       parent: 2
 - proto: SpawnPointChef
   entities:
-  - uid: 20574
+  - uid: 20572
     components:
     - type: Transform
       pos: 47.5,-6.5
       parent: 2
-  - uid: 20575
+  - uid: 20573
     components:
     - type: Transform
       pos: 48.5,-5.5
       parent: 2
 - proto: SpawnPointChemist
   entities:
-  - uid: 20576
+  - uid: 20574
     components:
     - type: Transform
       pos: -37.5,4.5
       parent: 2
-  - uid: 20577
+  - uid: 20575
     components:
     - type: Transform
       pos: -37.5,9.5
       parent: 2
-  - uid: 20578
+  - uid: 20576
     components:
     - type: Transform
       pos: -34.5,7.5
       parent: 2
 - proto: SpawnPointChiefEngineer
   entities:
-  - uid: 20579
+  - uid: 20577
     components:
     - type: Transform
       pos: -15.5,44.5
       parent: 2
 - proto: SpawnPointChiefMedicalOfficer
   entities:
-  - uid: 20580
+  - uid: 20578
     components:
     - type: Transform
       pos: -17.5,44.5
       parent: 2
 - proto: SpawnPointClown
   entities:
-  - uid: 20581
+  - uid: 20579
     components:
     - type: Transform
       pos: 23.5,4.5
       parent: 2
 - proto: SpawnPointDetective
   entities:
-  - uid: 20582
+  - uid: 20580
     components:
     - type: Transform
       pos: -13.5,-3.5
       parent: 2
 - proto: SpawnPointDutyOfficer
   entities:
-  - uid: 20583
+  - uid: 20581
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 2
-  - uid: 20584
+  - uid: 20582
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 2
-  - uid: 20585
+  - uid: 20583
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 2
 - proto: SpawnPointHeadOfPersonnel
   entities:
-  - uid: 20586
+  - uid: 20584
     components:
     - type: Transform
       pos: -14.5,44.5
       parent: 2
 - proto: SpawnPointHeadOfSecurity
   entities:
-  - uid: 20587
+  - uid: 20585
     components:
     - type: Transform
       pos: -18.5,44.5
       parent: 2
 - proto: SpawnPointHeadOfSecurityWeapon
   entities:
-  - uid: 20588
+  - uid: 20586
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 2
 - proto: SpawnPointIAA
   entities:
-  - uid: 20589
+  - uid: 20587
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
-  - uid: 20590
+  - uid: 20588
     components:
     - type: Transform
       pos: -17.5,8.5
       parent: 2
 - proto: SpawnPointJanitor
   entities:
-  - uid: 20591
+  - uid: 20589
     components:
     - type: Transform
       pos: 13.5,-17.5
       parent: 2
-  - uid: 20592
+  - uid: 20590
     components:
     - type: Transform
       pos: 15.5,-17.5
       parent: 2
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 20593
+  - uid: 20591
     components:
     - type: Transform
       pos: 35.5,-29.5
       parent: 2
-  - uid: 20594
+  - uid: 20592
     components:
     - type: Transform
       pos: 19.5,-29.5
       parent: 2
 - proto: SpawnPointMagistrate
   entities:
-  - uid: 20595
+  - uid: 20593
     components:
     - type: Transform
       pos: -21.5,4.5
       parent: 2
 - proto: SpawnPointmailtech
   entities:
-  - uid: 20596
+  - uid: 20594
     components:
     - type: Transform
       pos: 12.5,24.5
       parent: 2
-  - uid: 20597
+  - uid: 20595
     components:
     - type: Transform
       pos: 11.5,24.5
       parent: 2
 - proto: SpawnPointMedicalDoctor
   entities:
-  - uid: 20598
+  - uid: 20596
     components:
     - type: Transform
       pos: -37.5,-6.5
       parent: 2
-  - uid: 20599
+  - uid: 20597
     components:
     - type: Transform
       pos: -34.5,-6.5
       parent: 2
-  - uid: 20600
+  - uid: 20598
     components:
     - type: Transform
       pos: -31.5,-6.5
       parent: 2
-  - uid: 20601
+  - uid: 20599
     components:
     - type: Transform
       pos: -28.5,-6.5
       parent: 2
-  - uid: 20602
+  - uid: 20600
     components:
     - type: Transform
       pos: -32.5,-3.5
       parent: 2
 - proto: SpawnPointMedicalIntern
   entities:
-  - uid: 20603
+  - uid: 20601
     components:
     - type: Transform
       pos: -54.5,1.5
       parent: 2
-  - uid: 20604
+  - uid: 20602
     components:
     - type: Transform
       pos: -54.5,0.5
       parent: 2
-  - uid: 20605
+  - uid: 20603
     components:
     - type: Transform
       pos: -54.5,-0.5
       parent: 2
-  - uid: 20606
+  - uid: 20604
     components:
     - type: Transform
       pos: -56.5,1.5
       parent: 2
-  - uid: 20607
+  - uid: 20605
     components:
     - type: Transform
       pos: -56.5,0.5
       parent: 2
-  - uid: 20608
+  - uid: 20606
     components:
     - type: Transform
       pos: -56.5,-0.5
       parent: 2
 - proto: SpawnPointMime
   entities:
-  - uid: 20609
+  - uid: 20607
     components:
     - type: Transform
       pos: 23.5,-7.5
       parent: 2
 - proto: SpawnPointminingspecialist
   entities:
-  - uid: 20610
+  - uid: 20608
     components:
     - type: Transform
       pos: 28.5,35.5
       parent: 2
-  - uid: 20611
+  - uid: 20609
     components:
     - type: Transform
       pos: 29.5,35.5
       parent: 2
-  - uid: 20612
+  - uid: 20610
     components:
     - type: Transform
       pos: 29.5,34.5
       parent: 2
-  - uid: 20613
+  - uid: 20611
     components:
     - type: Transform
       pos: 28.5,34.5
       parent: 2
 - proto: SpawnPointMusician
   entities:
-  - uid: 20614
+  - uid: 20612
     components:
     - type: Transform
       pos: 47.5,2.5
       parent: 2
-  - uid: 20615
+  - uid: 20613
     components:
     - type: Transform
       pos: 47.5,4.5
       parent: 2
 - proto: SpawnPointNCT
   entities:
-  - uid: 20616
+  - uid: 20614
     components:
     - type: Transform
       pos: -27.5,20.5
       parent: 2
-  - uid: 20617
+  - uid: 20615
     components:
     - type: Transform
       pos: -26.5,20.5
       parent: 2
 - proto: SpawnPointNtrep
   entities:
-  - uid: 20618
+  - uid: 20616
     components:
     - type: Transform
       pos: -12.5,44.5
       parent: 2
 - proto: SpawnPointObserver
   entities:
-  - uid: 20619
+  - uid: 20617
     components:
     - type: Transform
       pos: -17.5,27.5
       parent: 2
 - proto: SpawnPointParamedic
   entities:
-  - uid: 20620
+  - uid: 20618
     components:
     - type: Transform
       pos: -27.5,3.5
       parent: 2
-  - uid: 20621
+  - uid: 20619
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
 - proto: SpawnPointPsychologist
   entities:
-  - uid: 20622
+  - uid: 20620
     components:
     - type: Transform
       pos: -32.5,20.5
       parent: 2
 - proto: SpawnPointQuartermaster
   entities:
-  - uid: 20623
+  - uid: 20621
     components:
     - type: Transform
       pos: -13.5,44.5
       parent: 2
 - proto: SpawnPointResearchAssistant
   entities:
-  - uid: 20624
+  - uid: 20622
     components:
     - type: Transform
       pos: -46.5,38.5
       parent: 2
-  - uid: 20625
+  - uid: 20623
     components:
     - type: Transform
       pos: -45.5,38.5
       parent: 2
-  - uid: 20626
+  - uid: 20624
     components:
     - type: Transform
       pos: -44.5,38.5
       parent: 2
 - proto: SpawnPointResearchDirector
   entities:
-  - uid: 20627
+  - uid: 20625
     components:
     - type: Transform
       pos: -16.5,44.5
       parent: 2
 - proto: SpawnPointRoboticist
   entities:
-  - uid: 20628
+  - uid: 20626
     components:
     - type: Transform
       pos: -62.5,30.5
       parent: 2
-  - uid: 20629
+  - uid: 20627
     components:
     - type: Transform
       pos: -61.5,30.5
       parent: 2
 - proto: SpawnPointSalvageLead
   entities:
-  - uid: 20630
+  - uid: 20628
     components:
     - type: Transform
       pos: 28.5,29.5
       parent: 2
 - proto: SpawnPointSalvageSpecialist
   entities:
-  - uid: 20631
+  - uid: 20629
     components:
     - type: Transform
       pos: 31.5,34.5
       parent: 2
-  - uid: 20632
+  - uid: 20630
     components:
     - type: Transform
       pos: 32.5,34.5
       parent: 2
-  - uid: 20633
+  - uid: 20631
     components:
     - type: Transform
       pos: 32.5,35.5
       parent: 2
-  - uid: 20634
+  - uid: 20632
     components:
     - type: Transform
       pos: 31.5,35.5
       parent: 2
 - proto: SpawnPointScientist
   entities:
-  - uid: 20635
+  - uid: 20633
     components:
     - type: Transform
       pos: -44.5,37.5
       parent: 2
-  - uid: 20636
+  - uid: 20634
     components:
     - type: Transform
       pos: -44.5,36.5
       parent: 2
-  - uid: 20637
+  - uid: 20635
     components:
     - type: Transform
       pos: -44.5,35.5
       parent: 2
-  - uid: 20638
+  - uid: 20636
     components:
     - type: Transform
       pos: -44.5,34.5
       parent: 2
 - proto: SpawnPointSecurityCadet
   entities:
-  - uid: 20639
+  - uid: 20637
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 2
-  - uid: 20640
+  - uid: 20638
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 2
-  - uid: 20641
+  - uid: 20639
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 2
-  - uid: 20642
+  - uid: 20640
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 2
-  - uid: 20643
+  - uid: 20641
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 2
-  - uid: 20644
+  - uid: 20642
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 2
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 20645
+  - uid: 20643
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 2
-  - uid: 20646
+  - uid: 20644
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 2
-  - uid: 20647
+  - uid: 20645
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 2
-  - uid: 20648
+  - uid: 20646
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 2
-  - uid: 20649
+  - uid: 20647
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 2
-  - uid: 20650
+  - uid: 20648
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 2
-  - uid: 20651
+  - uid: 20649
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 2
-  - uid: 20652
+  - uid: 20650
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 2
 - proto: SpawnPointServiceWorker
   entities:
-  - uid: 20653
+  - uid: 20651
     components:
     - type: Transform
       pos: -4.5,-41.5
       parent: 2
-  - uid: 20654
+  - uid: 20652
     components:
     - type: Transform
       pos: -4.5,-39.5
       parent: 2
-  - uid: 20655
+  - uid: 20653
     components:
     - type: Transform
       pos: -4.5,-37.5
       parent: 2
-  - uid: 20656
+  - uid: 20654
     components:
     - type: Transform
       pos: -4.5,-35.5
       parent: 2
 - proto: SpawnPointStationEngineer
   entities:
-  - uid: 20657
+  - uid: 20655
     components:
     - type: Transform
       pos: 37.5,26.5
       parent: 2
-  - uid: 20658
+  - uid: 20656
     components:
     - type: Transform
       pos: 38.5,26.5
       parent: 2
-  - uid: 20659
+  - uid: 20657
     components:
     - type: Transform
       pos: 39.5,26.5
       parent: 2
-  - uid: 20660
+  - uid: 20658
     components:
     - type: Transform
       pos: 37.5,25.5
       parent: 2
-  - uid: 20661
+  - uid: 20659
     components:
     - type: Transform
       pos: 38.5,25.5
       parent: 2
-  - uid: 20662
+  - uid: 20660
     components:
     - type: Transform
       pos: 39.5,25.5
       parent: 2
 - proto: SpawnPointSurgeon
   entities:
-  - uid: 20663
+  - uid: 20661
     components:
     - type: Transform
       pos: -43.5,-8.5
       parent: 2
-  - uid: 20664
+  - uid: 20662
     components:
     - type: Transform
       pos: -43.5,-10.5
       parent: 2
 - proto: SpawnPointTechnicalAssistant
   entities:
-  - uid: 20665
+  - uid: 20663
     components:
     - type: Transform
       pos: 40.5,26.5
       parent: 2
-  - uid: 20666
+  - uid: 20664
     components:
     - type: Transform
       pos: 40.5,25.5
       parent: 2
-  - uid: 20667
+  - uid: 20665
     components:
     - type: Transform
       pos: 40.5,24.5
       parent: 2
 - proto: SpawnPointWarden
   entities:
-  - uid: 20668
+  - uid: 20666
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 2
 - proto: SpeedLoaderLightRifle
   entities:
-  - uid: 20669
+  - uid: 20667
     components:
     - type: Transform
       pos: -28.344889,30.29947
       parent: 2
 - proto: SpeedLoaderMagnumFMJ
   entities:
-  - uid: 20670
+  - uid: 20668
     components:
     - type: Transform
       pos: 0.6824219,-19.683615
       parent: 2
 - proto: SprayBottleSpaceCleaner
   entities:
-  - uid: 20671
+  - uid: 20669
     components:
     - type: Transform
       pos: 13.242651,-16.50402
       parent: 2
-  - uid: 20672
+  - uid: 20670
     components:
     - type: Transform
       pos: 13.117651,-16.457146
       parent: 2
 - proto: SprayBottleWater
   entities:
+  - uid: 20671
+    components:
+    - type: Transform
+      pos: 84.4078,-49.27303
+      parent: 2
+  - uid: 20672
+    components:
+    - type: Transform
+      pos: 84.4078,-49.27303
+      parent: 2
   - uid: 20673
-    components:
-    - type: Transform
-      pos: 84.4078,-49.27303
-      parent: 2
-  - uid: 20674
-    components:
-    - type: Transform
-      pos: 84.4078,-49.27303
-      parent: 2
-  - uid: 20675
     components:
     - type: Transform
       pos: 84.73592,-49.507404
       parent: 2
-  - uid: 20676
+  - uid: 20674
     components:
     - type: Transform
       pos: 84.73592,-49.507404
       parent: 2
 - proto: SS13Memorial
   entities:
-  - uid: 20677
+  - uid: 20675
     components:
     - type: Transform
       pos: -53.5,24.5
       parent: 2
 - proto: StairDark
   entities:
-  - uid: 20678
+  - uid: 20676
     components:
     - type: Transform
       pos: -16.5,50.5
       parent: 2
-  - uid: 20679
+  - uid: 20677
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,43.5
       parent: 2
-  - uid: 20680
+  - uid: 20678
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,44.5
       parent: 2
-  - uid: 20681
+  - uid: 20679
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,44.5
       parent: 2
-  - uid: 20682
+  - uid: 20680
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,45.5
       parent: 2
-  - uid: 20683
+  - uid: 20681
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,43.5
       parent: 2
-  - uid: 20684
+  - uid: 20682
     components:
     - type: Transform
       pos: -15.5,50.5
       parent: 2
-  - uid: 20685
+  - uid: 20683
     components:
     - type: Transform
       pos: -14.5,50.5
       parent: 2
-  - uid: 20686
+  - uid: 20684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,45.5
       parent: 2
-  - uid: 20687
+  - uid: 20685
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,7.5
       parent: 2
-  - uid: 20688
+  - uid: 20686
     components:
     - type: Transform
       pos: -68.5,29.5
       parent: 2
-  - uid: 20689
+  - uid: 20687
     components:
     - type: Transform
       pos: -67.5,29.5
       parent: 2
-  - uid: 20690
+  - uid: 20688
     components:
     - type: Transform
       pos: -66.5,29.5
       parent: 2
-  - uid: 20691
+  - uid: 20689
     components:
     - type: Transform
       pos: -65.5,29.5
       parent: 2
-  - uid: 20692
+  - uid: 20690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-23.5
       parent: 2
-  - uid: 20693
+  - uid: 20691
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-22.5
       parent: 2
-  - uid: 20694
+  - uid: 20692
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-21.5
       parent: 2
-  - uid: 20695
+  - uid: 20693
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-27.5
       parent: 2
-  - uid: 20696
+  - uid: 20694
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-29.5
       parent: 2
-  - uid: 20697
+  - uid: 20695
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-28.5
       parent: 2
-  - uid: 20698
+  - uid: 20696
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-30.5
       parent: 2
-  - uid: 20699
+  - uid: 20697
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,-35.5
       parent: 2
-  - uid: 20700
+  - uid: 20698
     components:
     - type: Transform
       pos: 18.5,-18.5
       parent: 2
-  - uid: 20701
+  - uid: 20699
     components:
     - type: Transform
       pos: 19.5,-18.5
       parent: 2
-  - uid: 20702
+  - uid: 20700
     components:
     - type: Transform
       pos: 20.5,-18.5
       parent: 2
-  - uid: 20703
+  - uid: 20701
     components:
     - type: Transform
       pos: 34.5,-18.5
       parent: 2
-  - uid: 20704
+  - uid: 20702
     components:
     - type: Transform
       pos: 35.5,-18.5
       parent: 2
-  - uid: 20705
+  - uid: 20703
     components:
     - type: Transform
       pos: 36.5,-18.5
       parent: 2
-  - uid: 20706
+  - uid: 20704
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 52.5,21.5
       parent: 2
-  - uid: 20707
+  - uid: 20705
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 52.5,22.5
       parent: 2
-  - uid: 20708
+  - uid: 20706
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,21.5
       parent: 2
-  - uid: 20709
+  - uid: 20707
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,22.5
       parent: 2
-  - uid: 20710
+  - uid: 20708
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-32.5
       parent: 2
-  - uid: 20711
+  - uid: 20709
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-35.5
       parent: 2
-  - uid: 20712
+  - uid: 20710
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,-28.5
       parent: 2
-  - uid: 20713
+  - uid: 20711
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129363,48 +129396,48 @@ entities:
       parent: 2
 - proto: Stairs
   entities:
-  - uid: 20714
+  - uid: 20712
     components:
     - type: Transform
       pos: 16.5,-43.5
       parent: 2
-  - uid: 20715
+  - uid: 20713
     components:
     - type: Transform
       pos: 12.5,-43.5
       parent: 2
-  - uid: 20716
+  - uid: 20714
     components:
     - type: Transform
       pos: 8.5,-43.5
       parent: 2
 - proto: StairStageDark
   entities:
-  - uid: 20717
+  - uid: 20715
     components:
     - type: Transform
       pos: -48.5,10.5
       parent: 2
 - proto: StairStageWood
   entities:
-  - uid: 20718
+  - uid: 20716
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,5.5
       parent: 2
-  - uid: 20719
+  - uid: 20717
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,5.5
       parent: 2
-  - uid: 20720
+  - uid: 20718
     components:
     - type: Transform
       pos: -9.5,7.5
       parent: 2
-  - uid: 20721
+  - uid: 20719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -129412,93 +129445,93 @@ entities:
       parent: 2
 - proto: StairWhite
   entities:
-  - uid: 20722
+  - uid: 20720
     components:
     - type: Transform
       pos: 82.5,-8.5
       parent: 2
-  - uid: 20723
+  - uid: 20721
     components:
     - type: Transform
       pos: 83.5,-8.5
       parent: 2
 - proto: StairWood
   entities:
-  - uid: 20724
+  - uid: 20722
     components:
     - type: Transform
       pos: -5.5,47.5
       parent: 2
-  - uid: 20725
+  - uid: 20723
     components:
     - type: Transform
       pos: -25.5,42.5
       parent: 2
-  - uid: 20726
+  - uid: 20724
     components:
     - type: Transform
       pos: -26.5,42.5
       parent: 2
-  - uid: 20727
+  - uid: 20725
     components:
     - type: Transform
       pos: -4.5,47.5
       parent: 2
-  - uid: 20728
+  - uid: 20726
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,15.5
       parent: 2
-  - uid: 20729
+  - uid: 20727
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,21.5
       parent: 2
-  - uid: 20730
+  - uid: 20728
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,14.5
       parent: 2
-  - uid: 20731
+  - uid: 20729
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,22.5
       parent: 2
-  - uid: 20732
+  - uid: 20730
     components:
     - type: Transform
       pos: 42.5,1.5
       parent: 2
 - proto: StasisBed
   entities:
-  - uid: 20733
+  - uid: 20731
     components:
     - type: Transform
       pos: -25.5,-1.5
       parent: 2
-  - uid: 20734
+  - uid: 20732
     components:
     - type: Transform
       pos: -25.5,-3.5
       parent: 2
-  - uid: 20735
+  - uid: 20733
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 2
 - proto: StationAiFixerComputer
   entities:
-  - uid: 20736
+  - uid: 20734
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,30.5
       parent: 2
-  - uid: 20737
+  - uid: 20735
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129506,14 +129539,14 @@ entities:
       parent: 2
 - proto: StationAiUploadComputer
   entities:
-  - uid: 20738
+  - uid: 20736
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,35.5
       parent: 2
     - type: SiliconLawUpdater
-      core: 17847
+      core: 17845
     - type: Pullable
       prevFixedRotation: True
     - type: AccessReader
@@ -129521,21 +129554,21 @@ entities:
       - - ResearchDirector
 - proto: StationAnchor
   entities:
-  - uid: 20739
+  - uid: 20737
     components:
     - type: Transform
       pos: 50.5,21.5
       parent: 2
 - proto: StationMap
   entities:
-  - uid: 20740
+  - uid: 20738
     components:
     - type: Transform
       pos: -46.5,24.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20741
+  - uid: 20739
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -129543,7 +129576,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20742
+  - uid: 20740
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -129551,21 +129584,21 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20743
+  - uid: 20741
     components:
     - type: Transform
       pos: -4.5,17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20744
+  - uid: 20742
     components:
     - type: Transform
       pos: 14.5,16.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20745
+  - uid: 20743
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129573,7 +129606,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20746
+  - uid: 20744
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129581,14 +129614,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20747
+  - uid: 20745
     components:
     - type: Transform
       pos: 16.5,-24.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20748
+  - uid: 20746
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129596,7 +129629,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20749
+  - uid: 20747
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129604,21 +129637,21 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20750
+  - uid: 20748
     components:
     - type: Transform
       pos: 53.5,-7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20751
+  - uid: 20749
     components:
     - type: Transform
       pos: 66.5,-7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20752
+  - uid: 20750
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -129626,7 +129659,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20753
+  - uid: 20751
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -129634,14 +129667,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20754
+  - uid: 20752
     components:
     - type: Transform
       pos: 25.5,-8.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20755
+  - uid: 20753
     components:
     - type: Transform
       pos: -23.5,17.5
@@ -129650,7 +129683,7 @@ entities:
       fixtures: {}
 - proto: StatueBananiumClown
   entities:
-  - uid: 20756
+  - uid: 20754
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -129658,55 +129691,55 @@ entities:
       parent: 2
 - proto: SteelBench
   entities:
-  - uid: 20757
+  - uid: 20755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 75.5,-26.5
       parent: 2
-  - uid: 20758
+  - uid: 20756
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 75.5,-27.5
       parent: 2
-  - uid: 20759
+  - uid: 20757
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 75.5,-28.5
       parent: 2
-  - uid: 20760
+  - uid: 20758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 77.5,-26.5
       parent: 2
-  - uid: 20761
+  - uid: 20759
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 77.5,-27.5
       parent: 2
-  - uid: 20762
+  - uid: 20760
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 77.5,-28.5
       parent: 2
-  - uid: 20763
+  - uid: 20761
     components:
     - type: Transform
       pos: 37.5,24.5
       parent: 2
-  - uid: 20764
+  - uid: 20762
     components:
     - type: Transform
       pos: 38.5,24.5
       parent: 2
 - proto: StinkyPlush
   entities:
-  - uid: 20765
+  - uid: 20763
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129714,382 +129747,382 @@ entities:
       parent: 2
 - proto: Stool
   entities:
-  - uid: 20766
+  - uid: 20764
     components:
     - type: Transform
       pos: 35.504627,-4.315342
       parent: 2
-  - uid: 20767
+  - uid: 20765
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.345122,23.711897
       parent: 2
-  - uid: 20768
+  - uid: 20766
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,2.5
       parent: 2
-  - uid: 20769
+  - uid: 20767
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.594593,-32.37912
       parent: 2
-  - uid: 20770
+  - uid: 20768
     components:
     - type: Transform
       pos: -12.5100155,-26.414732
       parent: 2
 - proto: StoolBar
   entities:
-  - uid: 20771
+  - uid: 20769
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,9.5
       parent: 2
-  - uid: 20772
+  - uid: 20770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,9.5
       parent: 2
-  - uid: 20773
+  - uid: 20771
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,48.5
       parent: 2
-  - uid: 20774
+  - uid: 20772
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,47.5
       parent: 2
-  - uid: 20775
+  - uid: 20773
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,48.5
       parent: 2
-  - uid: 20776
+  - uid: 20774
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,47.5
       parent: 2
-  - uid: 20777
+  - uid: 20775
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,4.5
       parent: 2
-  - uid: 20778
+  - uid: 20776
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,3.5
       parent: 2
-  - uid: 20779
+  - uid: 20777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-8.5
       parent: 2
-  - uid: 20780
+  - uid: 20778
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,-8.5
       parent: 2
-  - uid: 20781
+  - uid: 20779
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-7.5
       parent: 2
-  - uid: 20782
+  - uid: 20780
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-6.5
       parent: 2
-  - uid: 20783
+  - uid: 20781
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-5.5
       parent: 2
-  - uid: 20784
+  - uid: 20782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-4.5
       parent: 2
-  - uid: 20785
+  - uid: 20783
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-3.5
       parent: 2
-  - uid: 20786
+  - uid: 20784
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-2.5
       parent: 2
-  - uid: 20787
+  - uid: 20785
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-1.5
       parent: 2
-  - uid: 20788
+  - uid: 20786
     components:
     - type: Transform
       pos: 31.5,-0.5
       parent: 2
-  - uid: 20789
+  - uid: 20787
     components:
     - type: Transform
       pos: 32.5,-0.5
       parent: 2
-  - uid: 20790
+  - uid: 20788
     components:
     - type: Transform
       pos: 36.5,-0.5
       parent: 2
-  - uid: 20791
+  - uid: 20789
     components:
     - type: Transform
       pos: 37.5,-0.5
       parent: 2
-  - uid: 20792
+  - uid: 20790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-1.5
       parent: 2
-  - uid: 20793
+  - uid: 20791
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-2.5
       parent: 2
-  - uid: 20794
+  - uid: 20792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-4.5
       parent: 2
-  - uid: 20795
+  - uid: 20793
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-5.5
       parent: 2
-  - uid: 20796
+  - uid: 20794
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-6.5
       parent: 2
-  - uid: 20797
+  - uid: 20795
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-7.5
       parent: 2
-  - uid: 20798
+  - uid: 20796
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-3.5
       parent: 2
-  - uid: 20799
+  - uid: 20797
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,-8.5
       parent: 2
-  - uid: 20800
+  - uid: 20798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,-8.5
       parent: 2
-  - uid: 20801
+  - uid: 20799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 44.5,-8.5
       parent: 2
-  - uid: 20802
+  - uid: 20800
     components:
     - type: Transform
       pos: 62.5,-27.5
       parent: 2
-  - uid: 20803
+  - uid: 20801
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 61.5,-28.5
       parent: 2
-  - uid: 20804
+  - uid: 20802
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 61.5,-29.5
       parent: 2
-  - uid: 20805
+  - uid: 20803
     components:
     - type: Transform
       pos: 64.5,-27.5
       parent: 2
-  - uid: 20806
+  - uid: 20804
     components:
     - type: Transform
       pos: 65.5,-27.5
       parent: 2
-  - uid: 20807
+  - uid: 20805
     components:
     - type: Transform
       pos: 63.5,-27.5
       parent: 2
-  - uid: 20808
+  - uid: 20806
     components:
     - type: Transform
       pos: 66.5,-27.5
       parent: 2
-  - uid: 20809
+  - uid: 20807
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 60.5,-30.5
       parent: 2
-  - uid: 20810
+  - uid: 20808
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 60.5,-31.5
       parent: 2
-  - uid: 20811
+  - uid: 20809
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 59.5,-32.5
       parent: 2
-  - uid: 20812
+  - uid: 20810
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 59.5,-33.5
       parent: 2
-  - uid: 20813
+  - uid: 20811
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-3.5
       parent: 2
-  - uid: 20814
+  - uid: 20812
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-6.5
       parent: 2
-  - uid: 20815
+  - uid: 20813
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-5.5
       parent: 2
-  - uid: 20816
+  - uid: 20814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 43.5,-8.5
       parent: 2
-  - uid: 20817
+  - uid: 20815
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 47.5,-8.5
       parent: 2
-  - uid: 20818
+  - uid: 20816
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 46.5,-8.5
       parent: 2
-  - uid: 20819
+  - uid: 20817
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 45.5,-8.5
       parent: 2
-  - uid: 20820
+  - uid: 20818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,-8.5
       parent: 2
-  - uid: 20821
+  - uid: 20819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,-8.5
       parent: 2
-  - uid: 20822
+  - uid: 20820
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,-8.5
       parent: 2
-  - uid: 20823
+  - uid: 20821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-2.5
       parent: 2
-  - uid: 20824
+  - uid: 20822
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-4.5
       parent: 2
-  - uid: 20825
+  - uid: 20823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -41.5,35.5
       parent: 2
-  - uid: 20826
+  - uid: 20824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,35.5
       parent: 2
-  - uid: 20827
+  - uid: 20825
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,35.5
       parent: 2
-  - uid: 20828
+  - uid: 20826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,35.5
       parent: 2
-  - uid: 20829
+  - uid: 20827
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,35.5
       parent: 2
-  - uid: 20830
+  - uid: 20828
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130097,17 +130130,17 @@ entities:
       parent: 2
 - proto: StorageCanister
   entities:
-  - uid: 20831
+  - uid: 20829
     components:
     - type: Transform
       pos: -51.5,34.5
       parent: 2
-  - uid: 20832
+  - uid: 20830
     components:
     - type: Transform
       pos: -50.5,34.5
       parent: 2
-  - uid: 20833
+  - uid: 20831
     components:
     - type: Transform
       pos: 50.5,16.5
@@ -130120,91 +130153,91 @@ entities:
     - type: GasCanister
       releaseValve: True
       releasePressure: 100
-  - uid: 20834
+  - uid: 20832
     components:
     - type: Transform
       pos: 46.5,6.5
       parent: 2
-  - uid: 20835
+  - uid: 20833
     components:
     - type: Transform
       pos: 47.5,6.5
       parent: 2
 - proto: SubstationBasic
   entities:
-  - uid: 20836
+  - uid: 20834
     components:
     - type: Transform
       pos: -2.5,41.5
       parent: 2
-  - uid: 20837
+  - uid: 20835
     components:
     - type: Transform
       pos: 66.5,50.5
       parent: 2
-  - uid: 20838
+  - uid: 20836
     components:
     - type: Transform
       pos: 77.5,21.5
       parent: 2
-  - uid: 20839
+  - uid: 20837
     components:
     - type: Transform
       pos: 43.5,23.5
       parent: 2
-  - uid: 20840
+  - uid: 20838
     components:
     - type: Transform
       pos: 6.5,22.5
       parent: 2
-  - uid: 20841
+  - uid: 20839
     components:
     - type: MetaData
       name: substation (Medical)
     - type: Transform
       pos: -25.5,-5.5
       parent: 2
-  - uid: 20842
+  - uid: 20840
     components:
     - type: MetaData
       name: substation (Security)
     - type: Transform
       pos: -16.5,-12.5
       parent: 2
-  - uid: 20843
+  - uid: 20841
     components:
     - type: Transform
       pos: -39.5,-19.5
       parent: 2
-  - uid: 20844
+  - uid: 20842
     components:
     - type: MetaData
       name: substation (Command)
     - type: Transform
       pos: -24.5,26.5
       parent: 2
-  - uid: 20845
+  - uid: 20843
     components:
     - type: MetaData
       name: substation (Arrivals)
     - type: Transform
       pos: 1.5,-23.5
       parent: 2
-  - uid: 20846
+  - uid: 20844
     components:
     - type: MetaData
       name: substation (Science)
     - type: Transform
       pos: -29.5,23.5
       parent: 2
-  - uid: 20847
+  - uid: 20845
     components:
     - type: MetaData
       name: substation (Service)
     - type: Transform
       pos: 16.5,3.5
       parent: 2
-  - uid: 20848
+  - uid: 20846
     components:
     - type: MetaData
       name: substation (Evac)
@@ -130213,7 +130246,7 @@ entities:
       parent: 2
 - proto: SubstationWallBasic
   entities:
-  - uid: 20849
+  - uid: 20847
     components:
     - type: Transform
       pos: 79.5,-42.5
@@ -130318,7 +130351,7 @@ entities:
           - 11165
 - proto: SuitStorageBlueShield
   entities:
-  - uid: 20850
+  - uid: 20848
     components:
     - type: Transform
       pos: -27.5,47.5
@@ -130333,40 +130366,40 @@ entities:
           Nitrogen: 6.568249
 - proto: SuitStorageCE
   entities:
-  - uid: 20851
+  - uid: 20849
     components:
     - type: Transform
       pos: 41.5,29.5
       parent: 2
 - proto: SuitStorageEngi
   entities:
-  - uid: 20852
+  - uid: 20850
     components:
     - type: Transform
       pos: -38.5,-22.5
       parent: 2
-  - uid: 20853
+  - uid: 20851
     components:
     - type: Transform
       pos: -38.5,-21.5
       parent: 2
-- proto: SuitStorageHOS
+- proto: SuitStorageEVAEmergency
   entities:
-  - uid: 20854
-    components:
-    - type: Transform
-      pos: -1.5,-13.5
-      parent: 2
-- proto: SuitStorageNTSRA
-  entities:
-  - uid: 20855
+  - uid: 20853
     components:
     - type: Transform
       pos: -39.5,-13.5
       parent: 2
+- proto: SuitStorageHOS
+  entities:
+  - uid: 20852
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
 - proto: SuitStorageRD
   entities:
-  - uid: 20856
+  - uid: 20854
     components:
     - type: Transform
       pos: -41.5,32.5
@@ -130435,21 +130468,21 @@ entities:
           - 17357
 - proto: SuitStorageWarden
   entities:
-  - uid: 20857
+  - uid: 20855
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
 - proto: SuperSynthesizerInstrument
   entities:
-  - uid: 20858
+  - uid: 20856
     components:
     - type: Transform
       pos: -3.526002,-32.99698
       parent: 2
 - proto: SurveillanceCameraCommand
   entities:
-  - uid: 20859
+  - uid: 20857
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130460,7 +130493,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Sauna
-  - uid: 20860
+  - uid: 20858
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130471,7 +130504,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Bridge West
-  - uid: 20861
+  - uid: 20859
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130482,7 +130515,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Bridge East
-  - uid: 20862
+  - uid: 20860
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130493,7 +130526,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Captain's Room
-  - uid: 20863
+  - uid: 20861
     components:
     - type: Transform
       pos: -24.5,36.5
@@ -130503,7 +130536,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Sauna Changing Room
-  - uid: 20864
+  - uid: 20862
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130514,7 +130547,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Showroom
-  - uid: 20865
+  - uid: 20863
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130525,7 +130558,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: NTR's Area
-  - uid: 20866
+  - uid: 20864
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130536,7 +130569,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Captain's Balcony
-  - uid: 20867
+  - uid: 20865
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130547,7 +130580,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: BSO's Room
-  - uid: 20868
+  - uid: 20866
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130558,7 +130591,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Conference Area
-  - uid: 20869
+  - uid: 20867
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130569,7 +130602,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Bridge Main
-  - uid: 20870
+  - uid: 20868
     components:
     - type: Transform
       pos: -2.5,39.5
@@ -130579,7 +130612,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: AI Upload
-  - uid: 20871
+  - uid: 20869
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130590,7 +130623,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Entry Airlock
-  - uid: 20872
+  - uid: 20870
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130601,7 +130634,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: HoP's Office
-  - uid: 20873
+  - uid: 20871
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130612,7 +130645,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: HoP's Bedroom
-  - uid: 20874
+  - uid: 20872
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130623,7 +130656,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: EVA
-  - uid: 20875
+  - uid: 20873
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130634,7 +130667,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Vault
-  - uid: 20876
+  - uid: 20874
     components:
     - type: Transform
       pos: 5.5,43.5
@@ -130644,7 +130677,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Captain's Bedroom
-  - uid: 20877
+  - uid: 20875
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130657,7 +130690,7 @@ entities:
       id: NCT Office
 - proto: SurveillanceCameraEngineering
   entities:
-  - uid: 20878
+  - uid: 20876
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130668,7 +130701,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmospherics South
-  - uid: 20879
+  - uid: 20877
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130679,7 +130712,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmospherics Front Desk
-  - uid: 20880
+  - uid: 20878
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130690,7 +130723,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Front Desk
-  - uid: 20881
+  - uid: 20879
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130701,7 +130734,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AI Core Bridge West
-  - uid: 20882
+  - uid: 20880
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130712,7 +130745,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmospherics West
-  - uid: 20883
+  - uid: 20881
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130723,7 +130756,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmospherics North
-  - uid: 20884
+  - uid: 20882
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130734,7 +130767,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Hall
-  - uid: 20885
+  - uid: 20883
     components:
     - type: Transform
       pos: 37.5,24.5
@@ -130744,7 +130777,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Locker Room
-  - uid: 20886
+  - uid: 20884
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130755,7 +130788,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: CE's Bedroom
-  - uid: 20887
+  - uid: 20885
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130766,7 +130799,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: CE's Office
-  - uid: 20888
+  - uid: 20886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130777,7 +130810,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Main
-  - uid: 20889
+  - uid: 20887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130788,7 +130821,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Exit Hallway
-  - uid: 20890
+  - uid: 20888
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130799,7 +130832,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Telecomms
-  - uid: 20891
+  - uid: 20889
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130810,7 +130843,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AME
-  - uid: 20892
+  - uid: 20890
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130821,7 +130854,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Outdoor Area
-  - uid: 20893
+  - uid: 20891
     components:
     - type: Transform
       pos: 67.5,17.5
@@ -130831,7 +130864,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engine Entry
-  - uid: 20894
+  - uid: 20892
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130842,7 +130875,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: PA North
-  - uid: 20895
+  - uid: 20893
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130853,7 +130886,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: PA South
-  - uid: 20896
+  - uid: 20894
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130864,7 +130897,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Singularity Engine North
-  - uid: 20897
+  - uid: 20895
     components:
     - type: Transform
       pos: 85.5,11.5
@@ -130874,7 +130907,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Singularity Engine South
-  - uid: 20898
+  - uid: 20896
     components:
     - type: Transform
       pos: 72.5,26.5
@@ -130884,7 +130917,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AI Core Bridge East
-  - uid: 20899
+  - uid: 20897
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130895,7 +130928,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AI Core Bridge North
-  - uid: 20900
+  - uid: 20898
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130906,7 +130939,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AI Core West
-  - uid: 20901
+  - uid: 20899
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130917,7 +130950,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AI Core East
-  - uid: 20902
+  - uid: 20900
     components:
     - type: Transform
       pos: 4.5,18.5
@@ -130929,7 +130962,7 @@ entities:
       id: Tech Vault
 - proto: SurveillanceCameraGeneral
   entities:
-  - uid: 20903
+  - uid: 20901
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130939,7 +130972,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20904
+  - uid: 20902
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130949,7 +130982,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20905
+  - uid: 20903
     components:
     - type: Transform
       pos: 55.5,-34.5
@@ -130958,7 +130991,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20906
+  - uid: 20904
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130968,7 +131001,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20907
+  - uid: 20905
     components:
     - type: Transform
       pos: 68.5,-27.5
@@ -130977,7 +131010,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20908
+  - uid: 20906
     components:
     - type: Transform
       pos: 66.5,-14.5
@@ -130986,7 +131019,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20909
+  - uid: 20907
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130996,7 +131029,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20910
+  - uid: 20908
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131006,7 +131039,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20911
+  - uid: 20909
     components:
     - type: Transform
       pos: 27.5,-14.5
@@ -131015,7 +131048,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20912
+  - uid: 20910
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131025,7 +131058,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20913
+  - uid: 20911
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131035,7 +131068,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20914
+  - uid: 20912
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131045,7 +131078,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20915
+  - uid: 20913
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131055,7 +131088,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20916
+  - uid: 20914
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131065,7 +131098,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20917
+  - uid: 20915
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131075,7 +131108,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20918
+  - uid: 20916
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131085,7 +131118,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20919
+  - uid: 20917
     components:
     - type: Transform
       pos: 21.5,6.5
@@ -131094,7 +131127,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20920
+  - uid: 20918
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131104,7 +131137,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20921
+  - uid: 20919
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131114,7 +131147,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20922
+  - uid: 20920
     components:
     - type: Transform
       pos: -14.5,12.5
@@ -131123,7 +131156,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20923
+  - uid: 20921
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131133,7 +131166,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20924
+  - uid: 20922
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131143,7 +131176,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20925
+  - uid: 20923
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131153,7 +131186,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20926
+  - uid: 20924
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131163,7 +131196,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20927
+  - uid: 20925
     components:
     - type: Transform
       pos: -44.5,12.5
@@ -131172,7 +131205,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20928
+  - uid: 20926
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131182,7 +131215,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20929
+  - uid: 20927
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131192,7 +131225,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20930
+  - uid: 20928
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131202,7 +131235,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20931
+  - uid: 20929
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131212,7 +131245,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20932
+  - uid: 20930
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131222,7 +131255,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20933
+  - uid: 20931
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131232,7 +131265,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20934
+  - uid: 20932
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131242,7 +131275,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20935
+  - uid: 20933
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131252,7 +131285,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20936
+  - uid: 20934
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131260,7 +131293,7 @@ entities:
       parent: 2
 - proto: SurveillanceCameraMedical
   entities:
-  - uid: 20937
+  - uid: 20935
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131271,7 +131304,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Medical Lobby
-  - uid: 20938
+  - uid: 20936
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131282,7 +131315,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Triage Main
-  - uid: 20939
+  - uid: 20937
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131293,7 +131326,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Triage West
-  - uid: 20940
+  - uid: 20938
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131304,7 +131337,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Chemistry
-  - uid: 20941
+  - uid: 20939
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131315,7 +131348,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Triage East
-  - uid: 20942
+  - uid: 20940
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131326,7 +131359,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Surgery
-  - uid: 20943
+  - uid: 20941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131337,7 +131370,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: CMO's Room
-  - uid: 20944
+  - uid: 20942
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131348,7 +131381,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Medical Locker Room
-  - uid: 20945
+  - uid: 20943
     components:
     - type: Transform
       pos: -44.5,3.5
@@ -131358,7 +131391,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Medical Main Hallway
-  - uid: 20946
+  - uid: 20944
     components:
     - type: Transform
       pos: -46.5,7.5
@@ -131368,7 +131401,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Morgue
-  - uid: 20947
+  - uid: 20945
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131379,7 +131412,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Medical Breakroom
-  - uid: 20948
+  - uid: 20946
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131392,79 +131425,79 @@ entities:
       id: Psychologist's Office
 - proto: SurveillanceCameraMonitorCircuitboard
   entities:
-  - uid: 17518
+  - uid: 17516
     components:
     - type: Transform
-      parent: 17517
+      parent: 17515
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: SurveillanceCameraRouterCommand
   entities:
-  - uid: 20949
+  - uid: 20947
     components:
     - type: Transform
       pos: 61.5,45.5
       parent: 2
 - proto: SurveillanceCameraRouterConstructed
   entities:
-  - uid: 20950
+  - uid: 20948
     components:
     - type: Transform
       pos: -28.5,29.5
       parent: 2
 - proto: SurveillanceCameraRouterEngineering
   entities:
-  - uid: 20951
+  - uid: 20949
     components:
     - type: Transform
       pos: 61.5,44.5
       parent: 2
 - proto: SurveillanceCameraRouterGeneral
   entities:
-  - uid: 20952
+  - uid: 20950
     components:
     - type: Transform
       pos: 61.5,42.5
       parent: 2
 - proto: SurveillanceCameraRouterMedical
   entities:
-  - uid: 20953
+  - uid: 20951
     components:
     - type: Transform
       pos: 61.5,41.5
       parent: 2
 - proto: SurveillanceCameraRouterScience
   entities:
-  - uid: 20954
+  - uid: 20952
     components:
     - type: Transform
       pos: 69.5,45.5
       parent: 2
 - proto: SurveillanceCameraRouterSecurity
   entities:
-  - uid: 20955
+  - uid: 20953
     components:
     - type: Transform
       pos: 69.5,44.5
       parent: 2
 - proto: SurveillanceCameraRouterService
   entities:
-  - uid: 20956
+  - uid: 20954
     components:
     - type: Transform
       pos: 69.5,43.5
       parent: 2
 - proto: SurveillanceCameraRouterSupply
   entities:
-  - uid: 20957
+  - uid: 20955
     components:
     - type: Transform
       pos: 69.5,42.5
       parent: 2
 - proto: SurveillanceCameraScience
   entities:
-  - uid: 20958
+  - uid: 20956
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131475,7 +131508,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Server Room
-  - uid: 20959
+  - uid: 20957
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131486,7 +131519,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Science Front Desk
-  - uid: 20960
+  - uid: 20958
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131497,7 +131530,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Anomaly Generator Room
-  - uid: 20961
+  - uid: 20959
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131508,7 +131541,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Robotics East
-  - uid: 20962
+  - uid: 20960
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131519,7 +131552,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Robotics West
-  - uid: 20963
+  - uid: 20961
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131530,7 +131563,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Science Breakroom
-  - uid: 20964
+  - uid: 20962
     components:
     - type: Transform
       pos: -53.5,34.5
@@ -131540,7 +131573,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Artifact East
-  - uid: 20965
+  - uid: 20963
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131551,7 +131584,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: RD's Room
-  - uid: 20966
+  - uid: 20964
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131564,7 +131597,7 @@ entities:
       id: Xenobio
 - proto: SurveillanceCameraSecurity
   entities:
-  - uid: 20967
+  - uid: 20965
     components:
     - type: Transform
       pos: 0.5,6.5
@@ -131574,7 +131607,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Warden's Office
-  - uid: 20968
+  - uid: 20966
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131585,7 +131618,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: HoS's Office
-  - uid: 20969
+  - uid: 20967
     components:
     - type: Transform
       pos: -9.5,-16.5
@@ -131595,7 +131628,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Higher Armory
-  - uid: 20970
+  - uid: 20968
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131606,7 +131639,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Lower Armory
-  - uid: 20971
+  - uid: 20969
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131617,7 +131650,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Interrogation
-  - uid: 20972
+  - uid: 20970
     components:
     - type: Transform
       pos: -11.5,-0.5
@@ -131627,7 +131660,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Detective's Room
-  - uid: 20973
+  - uid: 20971
     components:
     - type: Transform
       pos: -17.5,3.5
@@ -131637,7 +131670,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Law Storage Room
-  - uid: 20974
+  - uid: 20972
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131648,7 +131681,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Magistrate's Office
-  - uid: 20975
+  - uid: 20973
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131659,7 +131692,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Law Office
-  - uid: 20976
+  - uid: 20974
     components:
     - type: Transform
       pos: -10.5,3.5
@@ -131669,7 +131702,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Court
-  - uid: 20977
+  - uid: 20975
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131680,7 +131713,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: HoS's Bedroom
-  - uid: 20978
+  - uid: 20976
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131691,7 +131724,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Security Evac Checkpoint
-  - uid: 20979
+  - uid: 20977
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131699,7 +131732,7 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Locker Room
-  - uid: 20980
+  - uid: 20978
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131707,14 +131740,14 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Brigmed
-  - uid: 20981
+  - uid: 20979
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 2
     - type: SurveillanceCamera
       id: East Hallway
-  - uid: 20982
+  - uid: 20980
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131722,14 +131755,14 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Lounge
-  - uid: 20983
+  - uid: 20981
     components:
     - type: Transform
       pos: 14.5,-9.5
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Visitation
-  - uid: 20984
+  - uid: 20982
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131737,7 +131770,7 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Enterance
-  - uid: 20985
+  - uid: 20983
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131745,7 +131778,7 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Kitchen
-  - uid: 20986
+  - uid: 20984
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131753,7 +131786,7 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Closet
-  - uid: 20987
+  - uid: 20985
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131761,7 +131794,7 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Dorm 1
-  - uid: 20988
+  - uid: 20986
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131769,14 +131802,14 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Dorm 2
-  - uid: 20989
+  - uid: 20987
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 2
     - type: SurveillanceCamera
       id: Security
-  - uid: 20990
+  - uid: 20988
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131786,7 +131819,7 @@ entities:
       id: Warden's Bedroom
 - proto: SurveillanceCameraService
   entities:
-  - uid: 20991
+  - uid: 20989
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131797,7 +131830,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Bartender's Room
-  - uid: 20992
+  - uid: 20990
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131808,7 +131841,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Stage
-  - uid: 20993
+  - uid: 20991
     components:
     - type: Transform
       pos: 35.5,-6.5
@@ -131818,7 +131851,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Bar
-  - uid: 20994
+  - uid: 20992
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131829,7 +131862,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Freezer
-  - uid: 20995
+  - uid: 20993
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131840,7 +131873,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Kitchen
-  - uid: 20996
+  - uid: 20994
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131851,7 +131884,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Music Room
-  - uid: 20997
+  - uid: 20995
     components:
     - type: Transform
       pos: 62.5,-6.5
@@ -131861,7 +131894,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Botany
-  - uid: 20998
+  - uid: 20996
     components:
     - type: Transform
       pos: 66.5,-0.5
@@ -131871,7 +131904,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Botany Outdoor
-  - uid: 20999
+  - uid: 20997
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131882,7 +131915,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Janitor's Closet
-  - uid: 21000
+  - uid: 20998
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131893,7 +131926,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Crematorium
-  - uid: 21001
+  - uid: 20999
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131904,7 +131937,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Chapel
-  - uid: 21002
+  - uid: 21000
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131915,13 +131948,13 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Disposals
-  - uid: 21003
+  - uid: 21001
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -52.5,16.5
       parent: 2
-  - uid: 21004
+  - uid: 21002
     components:
     - type: Transform
       pos: -52.5,15.5
@@ -131933,7 +131966,7 @@ entities:
       id: Chapel Entry
 - proto: SurveillanceCameraSupply
   entities:
-  - uid: 21005
+  - uid: 21003
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131944,7 +131977,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Cargo Front Desk
-  - uid: 21006
+  - uid: 21004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131955,13 +131988,13 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Cargo Bay
-  - uid: 21007
+  - uid: 21005
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,31.5
       parent: 2
-  - uid: 21008
+  - uid: 21006
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131972,7 +132005,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Salvage Dock
-  - uid: 21009
+  - uid: 21007
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131983,7 +132016,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Salvage Locker Room
-  - uid: 21010
+  - uid: 21008
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131994,7 +132027,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Mail Room
-  - uid: 21011
+  - uid: 21009
     components:
     - type: Transform
       pos: 18.5,24.5
@@ -132004,7 +132037,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Cargo Connector
-  - uid: 21012
+  - uid: 21010
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -132015,7 +132048,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: QM's Office
-  - uid: 21013
+  - uid: 21011
     components:
     - type: Transform
       pos: 28.5,19.5
@@ -132027,38 +132060,38 @@ entities:
       id: QM's Bedroom
 - proto: SurveillanceCameraWirelessRouterConstructed
   entities:
-  - uid: 21014
+  - uid: 21012
     components:
     - type: Transform
       pos: 69.5,41.5
       parent: 2
 - proto: SurveillanceCameraWirelessRouterEntertainment
   entities:
-  - uid: 21015
+  - uid: 21013
     components:
     - type: Transform
       pos: 61.5,43.5
       parent: 2
 - proto: SusPlushie
   entities:
-  - uid: 21016
+  - uid: 21014
     components:
     - type: Transform
       pos: -30.748,41.053074
       parent: 2
-  - uid: 21017
+  - uid: 21015
     components:
     - type: Transform
       pos: 4.4347425,-19.480503
       parent: 2
-  - uid: 21018
+  - uid: 21016
     components:
     - type: Transform
       pos: -49.749134,-8.31368
       parent: 2
 - proto: SyndicateMicrowave
   entities:
-  - uid: 21019
+  - uid: 21017
     components:
     - type: Transform
       pos: 85.5,-39.5
@@ -132071,798 +132104,798 @@ entities:
       parent: 15734
     - type: Physics
       canCollide: False
-  - uid: 21020
+  - uid: 21018
     components:
     - type: Transform
       pos: -27.500624,-12.448242
       parent: 2
-  - uid: 21021
+  - uid: 21019
     components:
     - type: Transform
       pos: -66.49377,42.6762
       parent: 2
 - proto: Table
   entities:
-  - uid: 21022
+  - uid: 21020
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-2.5
       parent: 2
-  - uid: 21023
+  - uid: 21021
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 2
-  - uid: 21024
+  - uid: 21022
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-2.5
       parent: 2
-  - uid: 21025
+  - uid: 21023
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 2
-  - uid: 21026
+  - uid: 21024
     components:
     - type: Transform
       pos: -45.5,5.5
       parent: 2
-  - uid: 21027
+  - uid: 21025
     components:
     - type: Transform
       pos: -25.5,45.5
       parent: 2
-  - uid: 21028
+  - uid: 21026
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
-  - uid: 21029
+  - uid: 21027
     components:
     - type: Transform
       pos: -26.5,45.5
       parent: 2
-  - uid: 21030
+  - uid: 21028
     components:
     - type: Transform
       pos: 51.5,-6.5
       parent: 2
-  - uid: 21031
+  - uid: 21029
     components:
     - type: Transform
       pos: 0.5,41.5
       parent: 2
-  - uid: 21032
+  - uid: 21030
     components:
     - type: Transform
       pos: 51.5,-5.5
       parent: 2
-  - uid: 21033
+  - uid: 21031
     components:
     - type: Transform
       pos: -10.5,1.5
       parent: 2
-  - uid: 21034
+  - uid: 21032
     components:
     - type: Transform
       pos: -9.5,1.5
       parent: 2
-  - uid: 21035
+  - uid: 21033
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 2
-  - uid: 21036
+  - uid: 21034
     components:
     - type: Transform
       pos: -9.5,-5.5
       parent: 2
-  - uid: 21037
+  - uid: 21035
     components:
     - type: Transform
       pos: -9.5,-4.5
       parent: 2
-  - uid: 21038
+  - uid: 21036
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 2
-  - uid: 21039
+  - uid: 21037
     components:
     - type: Transform
       pos: 51.5,0.5
       parent: 2
-  - uid: 21040
+  - uid: 21038
     components:
     - type: Transform
       pos: -33.5,8.5
       parent: 2
-  - uid: 21041
+  - uid: 21039
     components:
     - type: Transform
       pos: -28.5,2.5
       parent: 2
-  - uid: 21042
+  - uid: 21040
     components:
     - type: Transform
       pos: -33.5,3.5
       parent: 2
-  - uid: 21043
+  - uid: 21041
     components:
     - type: Transform
       pos: -33.5,4.5
       parent: 2
-  - uid: 21044
+  - uid: 21042
     components:
     - type: Transform
       pos: -33.5,7.5
       parent: 2
-  - uid: 21045
+  - uid: 21043
     components:
     - type: Transform
       pos: -54.5,-1.5
       parent: 2
-  - uid: 21046
+  - uid: 21044
     components:
     - type: Transform
       pos: -39.5,-5.5
       parent: 2
-  - uid: 21047
+  - uid: 21045
     components:
     - type: Transform
       pos: -51.5,5.5
       parent: 2
-  - uid: 21048
+  - uid: 21046
     components:
     - type: Transform
       pos: -68.5,20.5
       parent: 2
-  - uid: 21049
+  - uid: 21047
     components:
     - type: Transform
       pos: -64.5,20.5
       parent: 2
-  - uid: 21050
+  - uid: 21048
     components:
     - type: Transform
       pos: -68.5,24.5
       parent: 2
-  - uid: 21051
+  - uid: 21049
     components:
     - type: Transform
       pos: -67.5,24.5
       parent: 2
-  - uid: 21052
+  - uid: 21050
     components:
     - type: Transform
       pos: -66.5,24.5
       parent: 2
-  - uid: 21053
+  - uid: 21051
     components:
     - type: Transform
       pos: -68.5,27.5
       parent: 2
-  - uid: 21054
+  - uid: 21052
     components:
     - type: Transform
       pos: -68.5,28.5
       parent: 2
-  - uid: 21055
+  - uid: 21053
     components:
     - type: Transform
       pos: -62.5,31.5
       parent: 2
-  - uid: 21056
+  - uid: 21054
     components:
     - type: Transform
       pos: -60.5,31.5
       parent: 2
-  - uid: 21057
+  - uid: 21055
     components:
     - type: Transform
       pos: -60.5,30.5
       parent: 2
-  - uid: 21058
+  - uid: 21056
     components:
     - type: Transform
       pos: -62.5,27.5
       parent: 2
-  - uid: 21059
+  - uid: 21057
     components:
     - type: Transform
       pos: -61.5,27.5
       parent: 2
-  - uid: 21060
+  - uid: 21058
     components:
     - type: Transform
       pos: -44.5,39.5
       parent: 2
-  - uid: 21061
+  - uid: 21059
     components:
     - type: Transform
       pos: -43.5,39.5
       parent: 2
-  - uid: 21062
+  - uid: 21060
     components:
     - type: Transform
       pos: -43.5,26.5
       parent: 2
-  - uid: 21063
+  - uid: 21061
     components:
     - type: Transform
       pos: -44.5,26.5
       parent: 2
-  - uid: 21064
+  - uid: 21062
     components:
     - type: Transform
       pos: 44.5,28.5
       parent: 2
-  - uid: 21065
+  - uid: 21063
     components:
     - type: Transform
       pos: 45.5,28.5
       parent: 2
-  - uid: 21066
+  - uid: 21064
     components:
     - type: Transform
       pos: -43.5,38.5
       parent: 2
-  - uid: 21067
+  - uid: 21065
     components:
     - type: Transform
       pos: 43.5,28.5
       parent: 2
-  - uid: 21068
+  - uid: 21066
     components:
     - type: Transform
       pos: 12.5,26.5
       parent: 2
-  - uid: 21069
+  - uid: 21067
     components:
     - type: Transform
       pos: 11.5,26.5
       parent: 2
-  - uid: 21070
+  - uid: 21068
     components:
     - type: Transform
       pos: 10.5,26.5
       parent: 2
-  - uid: 21071
+  - uid: 21069
     components:
     - type: Transform
       pos: 20.5,17.5
       parent: 2
-  - uid: 21072
+  - uid: 21070
     components:
     - type: Transform
       pos: 16.5,22.5
       parent: 2
-  - uid: 21073
+  - uid: 21071
     components:
     - type: Transform
       pos: 19.5,17.5
       parent: 2
-  - uid: 21074
+  - uid: 21072
     components:
     - type: Transform
       pos: 25.5,25.5
       parent: 2
-  - uid: 21075
+  - uid: 21073
     components:
     - type: Transform
       pos: 25.5,24.5
       parent: 2
-  - uid: 21076
+  - uid: 21074
     components:
     - type: Transform
       pos: 25.5,26.5
       parent: 2
-  - uid: 21077
+  - uid: 21075
     components:
     - type: Transform
       pos: 2.5,-33.5
       parent: 2
-  - uid: 21078
+  - uid: 21076
     components:
     - type: Transform
       pos: 1.5,-32.5
       parent: 2
-  - uid: 21079
+  - uid: 21077
     components:
     - type: Transform
       pos: 2.5,-32.5
       parent: 2
-  - uid: 21080
+  - uid: 21078
     components:
     - type: Transform
       pos: 1.5,-29.5
       parent: 2
-  - uid: 21081
+  - uid: 21079
     components:
     - type: Transform
       pos: 1.5,-28.5
       parent: 2
-  - uid: 21082
+  - uid: 21080
     components:
     - type: Transform
       pos: 2.5,-28.5
       parent: 2
-  - uid: 21083
+  - uid: 21081
     components:
     - type: Transform
       pos: 5.5,-28.5
       parent: 2
-  - uid: 21084
+  - uid: 21082
     components:
     - type: Transform
       pos: 47.5,-4.5
       parent: 2
-  - uid: 21085
+  - uid: 21083
     components:
     - type: Transform
       pos: 49.5,-3.5
       parent: 2
-  - uid: 21086
+  - uid: 21084
     components:
     - type: Transform
       pos: 47.5,-3.5
       parent: 2
-  - uid: 21087
+  - uid: 21085
     components:
     - type: Transform
       pos: 47.5,-2.5
       parent: 2
-  - uid: 21088
+  - uid: 21086
     components:
     - type: Transform
       pos: 49.5,-1.5
       parent: 2
-  - uid: 21089
+  - uid: 21087
     components:
     - type: Transform
       pos: 47.5,-1.5
       parent: 2
-  - uid: 21090
+  - uid: 21088
     components:
     - type: Transform
       pos: 48.5,-3.5
       parent: 2
-  - uid: 21091
+  - uid: 21089
     components:
     - type: Transform
       pos: 48.5,-2.5
       parent: 2
-  - uid: 21092
+  - uid: 21090
     components:
     - type: Transform
       pos: 49.5,-2.5
       parent: 2
-  - uid: 21093
+  - uid: 21091
     components:
     - type: Transform
       pos: 49.5,-4.5
       parent: 2
-  - uid: 21094
+  - uid: 21092
     components:
     - type: Transform
       pos: 69.5,-42.5
       parent: 2
-  - uid: 21095
+  - uid: 21093
     components:
     - type: Transform
       pos: 69.5,-43.5
       parent: 2
-  - uid: 21096
+  - uid: 21094
     components:
     - type: Transform
       pos: 70.5,-42.5
       parent: 2
-  - uid: 21097
+  - uid: 21095
     components:
     - type: Transform
       pos: 60.5,3.5
       parent: 2
-  - uid: 21098
+  - uid: 21096
     components:
     - type: Transform
       pos: 58.5,3.5
       parent: 2
-  - uid: 21099
+  - uid: 21097
     components:
     - type: Transform
       pos: 57.5,3.5
       parent: 2
-  - uid: 21100
+  - uid: 21098
     components:
     - type: Transform
       pos: 57.5,2.5
       parent: 2
-  - uid: 21101
+  - uid: 21099
     components:
     - type: Transform
       pos: 60.5,-0.5
       parent: 2
-  - uid: 21102
+  - uid: 21100
     components:
     - type: Transform
       pos: 74.5,-22.5
       parent: 2
-  - uid: 21103
+  - uid: 21101
     components:
     - type: Transform
       pos: 38.5,6.5
       parent: 2
-  - uid: 21104
+  - uid: 21102
     components:
     - type: Transform
       pos: 49.5,25.5
       parent: 2
-  - uid: 21105
+  - uid: 21103
     components:
     - type: Transform
       pos: 50.5,25.5
       parent: 2
-  - uid: 21106
+  - uid: 21104
     components:
     - type: Transform
       pos: 64.5,42.5
       parent: 2
-  - uid: 21107
+  - uid: 21105
     components:
     - type: Transform
       pos: 66.5,42.5
       parent: 2
-  - uid: 21108
+  - uid: 21106
     components:
     - type: Transform
       pos: 43.5,27.5
       parent: 2
-  - uid: 21109
+  - uid: 21107
     components:
     - type: Transform
       pos: 13.5,-16.5
       parent: 2
-  - uid: 21110
+  - uid: 21108
     components:
     - type: Transform
       pos: 12.5,-16.5
       parent: 2
-  - uid: 21111
+  - uid: 21109
     components:
     - type: Transform
       pos: 14.5,-16.5
       parent: 2
-  - uid: 21112
+  - uid: 21110
     components:
     - type: Transform
       pos: -29.5,-15.5
       parent: 2
-  - uid: 21113
+  - uid: 21111
     components:
     - type: Transform
       pos: -30.5,-15.5
       parent: 2
-  - uid: 21115
+  - uid: 21112
     components:
     - type: Transform
       pos: 51.5,-0.5
       parent: 2
-  - uid: 21116
+  - uid: 21113
     components:
     - type: Transform
       pos: -26.5,-22.5
       parent: 2
-  - uid: 21117
+  - uid: 21114
     components:
     - type: Transform
       pos: -19.5,-22.5
       parent: 2
-  - uid: 21118
+  - uid: 21115
     components:
     - type: Transform
       pos: -8.5,-22.5
       parent: 2
-  - uid: 21119
+  - uid: 21116
     components:
     - type: Transform
       pos: -19.5,-11.5
       parent: 2
-  - uid: 21120
+  - uid: 21117
     components:
     - type: Transform
       pos: -38.5,-13.5
       parent: 2
-  - uid: 21121
+  - uid: 21118
     components:
     - type: Transform
       pos: -37.5,-13.5
       parent: 2
-  - uid: 21122
+  - uid: 21119
     components:
     - type: Transform
       pos: -34.5,27.5
       parent: 2
-  - uid: 21123
+  - uid: 21120
     components:
     - type: Transform
       pos: -77.5,-3.5
       parent: 2
-  - uid: 21124
+  - uid: 21121
     components:
     - type: Transform
       pos: -77.5,-2.5
       parent: 2
-  - uid: 21125
+  - uid: 21122
     components:
     - type: Transform
       pos: -77.5,-1.5
       parent: 2
-  - uid: 21126
+  - uid: 21123
     components:
     - type: Transform
       pos: 30.5,-35.5
       parent: 2
-  - uid: 21127
+  - uid: 21124
     components:
     - type: Transform
       pos: 78.5,-46.5
       parent: 2
-  - uid: 21128
+  - uid: 21125
     components:
     - type: Transform
       pos: 80.5,-47.5
       parent: 2
-  - uid: 21129
+  - uid: 21126
     components:
     - type: Transform
       pos: 80.5,-48.5
       parent: 2
-  - uid: 21130
+  - uid: 21127
     components:
     - type: Transform
       pos: 65.5,-36.5
       parent: 2
-  - uid: 21131
+  - uid: 21128
     components:
     - type: Transform
       pos: 65.5,-37.5
       parent: 2
-  - uid: 21132
+  - uid: 21129
     components:
     - type: Transform
       pos: 26.5,36.5
       parent: 2
-  - uid: 21133
+  - uid: 21130
     components:
     - type: Transform
       pos: 16.5,24.5
       parent: 2
-  - uid: 21134
+  - uid: 21131
     components:
     - type: Transform
       pos: 17.5,24.5
       parent: 2
-  - uid: 21135
+  - uid: 21132
     components:
     - type: Transform
       pos: 37.5,35.5
       parent: 2
-  - uid: 21136
+  - uid: 21133
     components:
     - type: Transform
       pos: 37.5,37.5
       parent: 2
 - proto: TableCarpet
   entities:
-  - uid: 21137
+  - uid: 21134
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,18.5
       parent: 2
-  - uid: 21138
+  - uid: 21135
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,19.5
       parent: 2
-  - uid: 21139
+  - uid: 21136
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,17.5
       parent: 2
-  - uid: 21140
+  - uid: 21137
     components:
     - type: Transform
       pos: 22.5,19.5
       parent: 2
-  - uid: 21141
+  - uid: 21138
     components:
     - type: Transform
       pos: 22.5,18.5
       parent: 2
-  - uid: 21142
+  - uid: 21139
     components:
     - type: Transform
       pos: 22.5,17.5
       parent: 2
-  - uid: 21143
+  - uid: 21140
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,34.5
       parent: 2
-  - uid: 21144
+  - uid: 21141
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,34.5
       parent: 2
-  - uid: 21145
+  - uid: 21142
     components:
     - type: Transform
       pos: 32.5,32.5
       parent: 2
-  - uid: 21146
+  - uid: 21143
     components:
     - type: Transform
       pos: 32.5,31.5
       parent: 2
-  - uid: 21147
+  - uid: 21144
     components:
     - type: Transform
       pos: 32.5,33.5
       parent: 2
-  - uid: 21148
+  - uid: 21145
     components:
     - type: Transform
       pos: 8.5,-15.5
       parent: 2
-  - uid: 21149
+  - uid: 21146
     components:
     - type: Transform
       pos: -14.5,-21.5
       parent: 2
-  - uid: 21150
+  - uid: 21147
     components:
     - type: Transform
       pos: -14.5,-21.5
       parent: 2
-  - uid: 21151
+  - uid: 21148
     components:
     - type: Transform
       pos: 8.5,19.5
       parent: 2
 - proto: TableCounterWood
   entities:
-  - uid: 21152
+  - uid: 21149
     components:
     - type: Transform
       pos: 32.5,-7.5
       parent: 2
-  - uid: 21153
+  - uid: 21150
     components:
     - type: Transform
       pos: 31.5,-2.5
       parent: 2
-  - uid: 21154
+  - uid: 21151
     components:
     - type: Transform
       pos: 31.5,-5.5
       parent: 2
-  - uid: 21155
+  - uid: 21152
     components:
     - type: Transform
       pos: 37.5,-4.5
       parent: 2
-  - uid: 21156
+  - uid: 21153
     components:
     - type: Transform
       pos: 31.5,-3.5
       parent: 2
-  - uid: 21157
+  - uid: 21154
     components:
     - type: Transform
       pos: 37.5,-3.5
       parent: 2
-  - uid: 21158
+  - uid: 21155
     components:
     - type: Transform
       pos: 37.5,-2.5
       parent: 2
-  - uid: 21159
+  - uid: 21156
     components:
     - type: Transform
       pos: 37.5,-6.5
       parent: 2
-  - uid: 21160
+  - uid: 21157
     components:
     - type: Transform
       pos: 37.5,-5.5
       parent: 2
-  - uid: 21161
+  - uid: 21158
     components:
     - type: Transform
       pos: 37.5,-7.5
       parent: 2
-  - uid: 21162
+  - uid: 21159
     components:
     - type: Transform
       pos: 36.5,-1.5
       parent: 2
-  - uid: 21163
+  - uid: 21160
     components:
     - type: Transform
       pos: 37.5,-1.5
       parent: 2
-  - uid: 21164
+  - uid: 21161
     components:
     - type: Transform
       pos: 36.5,-7.5
       parent: 2
-  - uid: 21165
+  - uid: 21162
     components:
     - type: Transform
       pos: 31.5,-7.5
       parent: 2
-  - uid: 21166
+  - uid: 21163
     components:
     - type: Transform
       pos: 31.5,-6.5
       parent: 2
-  - uid: 21167
+  - uid: 21164
     components:
     - type: Transform
       pos: 31.5,-4.5
       parent: 2
-  - uid: 21168
+  - uid: 21165
     components:
     - type: Transform
       pos: 31.5,-1.5
       parent: 2
-  - uid: 21169
+  - uid: 21166
     components:
     - type: Transform
       pos: 32.5,-1.5
       parent: 2
-  - uid: 21170
+  - uid: 21167
     components:
     - type: Transform
       pos: -41.5,36.5
       parent: 2
-  - uid: 21171
+  - uid: 21168
     components:
     - type: Transform
       pos: -40.5,36.5
       parent: 2
-  - uid: 21172
+  - uid: 21169
     components:
     - type: Transform
       pos: -39.5,36.5
       parent: 2
-  - uid: 21173
+  - uid: 21170
     components:
     - type: Transform
       pos: -38.5,36.5
       parent: 2
-  - uid: 21174
+  - uid: 21171
     components:
     - type: Transform
       pos: -37.5,36.5
       parent: 2
 - proto: TableFancyBlue
   entities:
-  - uid: 21175
+  - uid: 21172
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,4.5
       parent: 2
-  - uid: 21176
+  - uid: 21173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -132870,7 +132903,7 @@ entities:
       parent: 2
 - proto: TableFancyPurple
   entities:
-  - uid: 21177
+  - uid: 21174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -132878,37 +132911,37 @@ entities:
       parent: 2
 - proto: TableFancyRed
   entities:
-  - uid: 21178
+  - uid: 21175
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,22.5
       parent: 2
-  - uid: 21179
+  - uid: 21176
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,14.5
       parent: 2
-  - uid: 21180
+  - uid: 21177
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -57.5,14.5
       parent: 2
-  - uid: 21181
+  - uid: 21178
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,14.5
       parent: 2
-  - uid: 21182
+  - uid: 21179
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,22.5
       parent: 2
-  - uid: 21183
+  - uid: 21180
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -132916,123 +132949,123 @@ entities:
       parent: 2
 - proto: TableGlass
   entities:
-  - uid: 21184
+  - uid: 21181
     components:
     - type: Transform
       pos: -24.5,19.5
       parent: 2
-  - uid: 21185
+  - uid: 21182
     components:
     - type: Transform
       pos: -24.5,20.5
       parent: 2
-  - uid: 21186
+  - uid: 21183
     components:
     - type: Transform
       pos: -46.5,37.5
       parent: 2
-  - uid: 21187
+  - uid: 21184
     components:
     - type: Transform
       pos: -46.5,36.5
       parent: 2
-  - uid: 21188
+  - uid: 21185
     components:
     - type: Transform
       pos: -21.5,41.5
       parent: 2
-  - uid: 21189
+  - uid: 21186
     components:
     - type: Transform
       pos: -22.5,41.5
       parent: 2
-  - uid: 21190
+  - uid: 21187
     components:
     - type: Transform
       pos: -10.5,41.5
       parent: 2
-  - uid: 21191
+  - uid: 21188
     components:
     - type: Transform
       pos: -11.5,41.5
       parent: 2
-  - uid: 21192
+  - uid: 21189
     components:
     - type: Transform
       pos: -56.5,5.5
       parent: 2
-  - uid: 21193
+  - uid: 21190
     components:
     - type: Transform
       pos: -57.5,5.5
       parent: 2
-  - uid: 21194
+  - uid: 21191
     components:
     - type: Transform
       pos: -57.5,3.5
       parent: 2
-  - uid: 21195
+  - uid: 21192
     components:
     - type: Transform
       pos: -53.5,5.5
       parent: 2
-  - uid: 21196
+  - uid: 21193
     components:
     - type: Transform
       pos: -42.5,-12.5
       parent: 2
-  - uid: 21197
+  - uid: 21194
     components:
     - type: Transform
       pos: -41.5,-12.5
       parent: 2
-  - uid: 21198
+  - uid: 21195
     components:
     - type: Transform
       pos: -22.5,-1.5
       parent: 2
-  - uid: 21199
+  - uid: 21196
     components:
     - type: Transform
       pos: -55.5,-16.5
       parent: 2
-  - uid: 21200
+  - uid: 21197
     components:
     - type: Transform
       pos: -55.5,-15.5
       parent: 2
-  - uid: 21201
+  - uid: 21198
     components:
     - type: Transform
       pos: -54.5,-15.5
       parent: 2
-  - uid: 21202
+  - uid: 21199
     components:
     - type: Transform
       pos: -54.5,-14.5
       parent: 2
-  - uid: 21203
+  - uid: 21200
     components:
     - type: Transform
       pos: 85.5,-40.5
       parent: 2
-  - uid: 21204
+  - uid: 21201
     components:
     - type: Transform
       pos: 85.5,-39.5
       parent: 2
-  - uid: 21205
+  - uid: 21202
     components:
     - type: Transform
       pos: -40.5,-3.5
       parent: 2
-  - uid: 21206
+  - uid: 21203
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -67.5,42.5
       parent: 2
-  - uid: 21207
+  - uid: 21204
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -133040,1705 +133073,1705 @@ entities:
       parent: 2
 - proto: TablePlasmaGlass
   entities:
-  - uid: 21208
+  - uid: 21205
     components:
     - type: Transform
       pos: -50.5,32.5
       parent: 2
-  - uid: 21209
+  - uid: 21206
     components:
     - type: Transform
       pos: -50.5,31.5
       parent: 2
-  - uid: 21210
+  - uid: 21207
     components:
     - type: Transform
       pos: -56.5,32.5
       parent: 2
-  - uid: 21211
+  - uid: 21208
     components:
     - type: Transform
       pos: -56.5,31.5
       parent: 2
-  - uid: 21212
+  - uid: 21209
     components:
     - type: Transform
       pos: -50.5,30.5
       parent: 2
-  - uid: 21213
+  - uid: 21210
     components:
     - type: Transform
       pos: -56.5,30.5
       parent: 2
-  - uid: 21214
+  - uid: 21211
     components:
     - type: Transform
       pos: -25.5,-19.5
       parent: 2
-  - uid: 21215
+  - uid: 21212
     components:
     - type: Transform
       pos: -24.5,-19.5
       parent: 2
-  - uid: 21216
+  - uid: 21213
     components:
     - type: Transform
       pos: -21.5,-19.5
       parent: 2
-  - uid: 21217
+  - uid: 21214
     components:
     - type: Transform
       pos: -20.5,-19.5
       parent: 2
-  - uid: 21218
+  - uid: 21215
     components:
     - type: Transform
       pos: -72.5,-2.5
       parent: 2
-  - uid: 21219
+  - uid: 21216
     components:
     - type: Transform
       pos: -71.5,-2.5
       parent: 2
 - proto: TableReinforced
   entities:
-  - uid: 17443
+  - uid: 21217
     components:
     - type: Transform
       pos: 11.5,9.5
       parent: 2
-  - uid: 21220
+  - uid: 21218
     components:
     - type: Transform
       pos: 12.5,11.5
       parent: 2
-  - uid: 21221
+  - uid: 21219
     components:
     - type: Transform
       pos: 11.5,10.5
       parent: 2
-  - uid: 21222
+  - uid: 21220
     components:
     - type: Transform
       pos: -5.5,37.5
       parent: 2
-  - uid: 21223
+  - uid: 21221
     components:
     - type: Transform
       pos: -5.5,35.5
       parent: 2
-  - uid: 21224
+  - uid: 21222
     components:
     - type: Transform
       pos: -5.5,36.5
       parent: 2
-  - uid: 21225
+  - uid: 21223
     components:
     - type: Transform
       pos: -14.5,55.5
       parent: 2
-  - uid: 21226
+  - uid: 21224
     components:
     - type: Transform
       pos: -16.5,55.5
       parent: 2
-  - uid: 21227
+  - uid: 21225
     components:
     - type: Transform
       pos: -11.5,54.5
       parent: 2
-  - uid: 21228
+  - uid: 21226
     components:
     - type: Transform
       pos: -19.5,54.5
       parent: 2
-  - uid: 21229
+  - uid: 21227
     components:
     - type: Transform
       pos: -6.5,41.5
       parent: 2
-  - uid: 21230
+  - uid: 21228
     components:
     - type: Transform
       pos: -6.5,39.5
       parent: 2
-  - uid: 21231
+  - uid: 21229
     components:
     - type: Transform
       pos: -7.5,32.5
       parent: 2
-  - uid: 21232
+  - uid: 21230
     components:
     - type: Transform
       pos: -7.5,50.5
       parent: 2
-  - uid: 21233
+  - uid: 21231
     components:
     - type: Transform
       pos: -7.5,51.5
       parent: 2
-  - uid: 21234
+  - uid: 21232
     components:
     - type: Transform
       pos: -26.5,32.5
       parent: 2
-  - uid: 21235
+  - uid: 21233
     components:
     - type: Transform
       pos: -26.5,28.5
       parent: 2
-  - uid: 21236
+  - uid: 21234
     components:
     - type: Transform
       pos: -27.5,28.5
       parent: 2
-  - uid: 21237
+  - uid: 21235
     components:
     - type: Transform
       pos: -28.5,28.5
       parent: 2
-  - uid: 21238
+  - uid: 21236
     components:
     - type: Transform
       pos: -27.5,32.5
       parent: 2
-  - uid: 21239
+  - uid: 21237
     components:
     - type: Transform
       pos: -28.5,32.5
       parent: 2
-  - uid: 21240
+  - uid: 21238
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
-  - uid: 21241
+  - uid: 21239
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 2
-  - uid: 21242
+  - uid: 21240
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 2
-  - uid: 21243
+  - uid: 21241
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 2
-  - uid: 21244
+  - uid: 21242
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 2
-  - uid: 21245
+  - uid: 21243
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 21246
+  - uid: 21244
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 2
-  - uid: 21247
+  - uid: 21245
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 2
-  - uid: 21248
+  - uid: 21246
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 2
-  - uid: 21249
+  - uid: 21247
     components:
     - type: Transform
       pos: -29.5,7.5
       parent: 2
-  - uid: 21250
+  - uid: 21248
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 2
-  - uid: 21251
+  - uid: 21249
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 2
-  - uid: 21252
+  - uid: 21250
     components:
     - type: Transform
       pos: -28.5,7.5
       parent: 2
-  - uid: 21253
+  - uid: 21251
     components:
     - type: Transform
       pos: -35.5,2.5
       parent: 2
-  - uid: 21254
+  - uid: 21252
     components:
     - type: Transform
       pos: -36.5,2.5
       parent: 2
-  - uid: 21255
+  - uid: 21253
     components:
     - type: Transform
       pos: -36.5,-1.5
       parent: 2
-  - uid: 21256
+  - uid: 21254
     components:
     - type: Transform
       pos: -36.5,-0.5
       parent: 2
-  - uid: 21257
+  - uid: 21255
     components:
     - type: Transform
       pos: -33.5,-0.5
       parent: 2
-  - uid: 21258
+  - uid: 21256
     components:
     - type: Transform
       pos: -33.5,-1.5
       parent: 2
-  - uid: 21259
+  - uid: 21257
     components:
     - type: Transform
       pos: -45.5,-9.5
       parent: 2
-  - uid: 21260
+  - uid: 21258
     components:
     - type: Transform
       pos: -44.5,-9.5
       parent: 2
-  - uid: 21261
+  - uid: 21259
     components:
     - type: Transform
       pos: -44.5,-8.5
       parent: 2
-  - uid: 21262
+  - uid: 21260
     components:
     - type: Transform
       pos: -44.5,-10.5
       parent: 2
-  - uid: 21263
+  - uid: 21261
     components:
     - type: Transform
       pos: -45.5,24.5
       parent: 2
-  - uid: 21264
+  - uid: 21262
     components:
     - type: Transform
       pos: -44.5,24.5
       parent: 2
-  - uid: 21265
+  - uid: 21263
     components:
     - type: Transform
       pos: 12.5,23.5
       parent: 2
-  - uid: 21266
+  - uid: 21264
     components:
     - type: Transform
       pos: 11.5,23.5
       parent: 2
-  - uid: 21267
+  - uid: 21265
     components:
     - type: Transform
       pos: 14.5,21.5
       parent: 2
-  - uid: 21268
+  - uid: 21266
     components:
     - type: Transform
       pos: 21.5,-7.5
       parent: 2
-  - uid: 21269
+  - uid: 21267
     components:
     - type: Transform
       pos: 21.5,-6.5
       parent: 2
-  - uid: 21270
+  - uid: 21268
     components:
     - type: Transform
       pos: 22.5,-8.5
       parent: 2
-  - uid: 21271
+  - uid: 21269
     components:
     - type: Transform
       pos: 23.5,-8.5
       parent: 2
-  - uid: 21272
+  - uid: 21270
     components:
     - type: Transform
       pos: 24.5,-8.5
       parent: 2
-  - uid: 21273
+  - uid: 21271
     components:
     - type: Transform
       pos: 25.5,-7.5
       parent: 2
-  - uid: 21274
+  - uid: 21272
     components:
     - type: Transform
       pos: 25.5,-6.5
       parent: 2
-  - uid: 21275
+  - uid: 21273
     components:
     - type: Transform
       pos: 21.5,4.5
       parent: 2
-  - uid: 21276
+  - uid: 21274
     components:
     - type: Transform
       pos: 22.5,5.5
       parent: 2
-  - uid: 21277
+  - uid: 21275
     components:
     - type: Transform
       pos: 23.5,5.5
       parent: 2
-  - uid: 21278
+  - uid: 21276
     components:
     - type: Transform
       pos: 24.5,5.5
       parent: 2
-  - uid: 21279
+  - uid: 21277
     components:
     - type: Transform
       pos: 25.5,4.5
       parent: 2
-  - uid: 21280
+  - uid: 21278
     components:
     - type: Transform
       pos: 25.5,3.5
       parent: 2
-  - uid: 21281
+  - uid: 21279
     components:
     - type: Transform
       pos: 43.5,-2.5
       parent: 2
-  - uid: 21282
+  - uid: 21280
     components:
     - type: Transform
       pos: 43.5,-7.5
       parent: 2
-  - uid: 21283
+  - uid: 21281
     components:
     - type: Transform
       pos: 45.5,-7.5
       parent: 2
-  - uid: 21284
+  - uid: 21282
     components:
     - type: Transform
       pos: 46.5,-7.5
       parent: 2
-  - uid: 21285
+  - uid: 21283
     components:
     - type: Transform
       pos: 47.5,-7.5
       parent: 2
-  - uid: 21286
+  - uid: 21284
     components:
     - type: Transform
       pos: 44.5,-7.5
       parent: 2
-  - uid: 21287
+  - uid: 21285
     components:
     - type: Transform
       pos: 41.5,-6.5
       parent: 2
-  - uid: 21288
+  - uid: 21286
     components:
     - type: Transform
       pos: 44.5,-2.5
       parent: 2
-  - uid: 21289
+  - uid: 21287
     components:
     - type: Transform
       pos: 41.5,-5.5
       parent: 2
-  - uid: 21290
+  - uid: 21288
     components:
     - type: Transform
       pos: 41.5,-4.5
       parent: 2
-  - uid: 21291
+  - uid: 21289
     components:
     - type: Transform
       pos: 41.5,-3.5
       parent: 2
-  - uid: 21292
+  - uid: 21290
     components:
     - type: Transform
       pos: 41.5,-2.5
       parent: 2
-  - uid: 21293
+  - uid: 21291
     components:
     - type: Transform
       pos: 44.5,-3.5
       parent: 2
-  - uid: 21294
+  - uid: 21292
     components:
     - type: Transform
       pos: 59.5,-7.5
       parent: 2
-  - uid: 21295
+  - uid: 21293
     components:
     - type: Transform
       pos: 58.5,-7.5
       parent: 2
-  - uid: 21296
+  - uid: 21294
     components:
     - type: Transform
       pos: 60.5,-7.5
       parent: 2
-  - uid: 21297
+  - uid: 21295
     components:
     - type: Transform
       pos: 35.5,9.5
       parent: 2
-  - uid: 21298
+  - uid: 21296
     components:
     - type: Transform
       pos: 35.5,8.5
       parent: 2
-  - uid: 21299
+  - uid: 21297
     components:
     - type: Transform
       pos: 31.5,12.5
       parent: 2
-  - uid: 21300
+  - uid: 21298
     components:
     - type: Transform
       pos: 32.5,12.5
       parent: 2
-  - uid: 21301
+  - uid: 21299
     components:
     - type: Transform
       pos: 30.5,15.5
       parent: 2
-  - uid: 21302
+  - uid: 21300
     components:
     - type: Transform
       pos: 6.5,18.5
       parent: 2
-  - uid: 21303
+  - uid: 21301
     components:
     - type: Transform
       pos: 6.5,19.5
       parent: 2
-  - uid: 21304
+  - uid: 21302
     components:
     - type: Transform
       pos: 6.5,20.5
       parent: 2
-  - uid: 21305
+  - uid: 21303
     components:
     - type: Transform
       pos: 5.5,20.5
       parent: 2
-  - uid: 21306
+  - uid: 21304
     components:
     - type: Transform
       pos: 4.5,20.5
       parent: 2
-  - uid: 21307
+  - uid: 21305
     components:
     - type: Transform
       pos: 3.5,20.5
       parent: 2
-  - uid: 21308
+  - uid: 21306
     components:
     - type: Transform
       pos: 2.5,20.5
       parent: 2
-  - uid: 21309
+  - uid: 21307
     components:
     - type: Transform
       pos: 41.5,25.5
       parent: 2
-  - uid: 21310
+  - uid: 21308
     components:
     - type: Transform
       pos: 36.5,27.5
       parent: 2
-  - uid: 21311
+  - uid: 21309
     components:
     - type: Transform
       pos: 44.5,-4.5
       parent: 2
-  - uid: 21312
+  - uid: 21310
     components:
     - type: Transform
       pos: -3.5,-30.5
       parent: 2
-  - uid: 21313
+  - uid: 21311
     components:
     - type: Transform
       pos: -65.5,9.5
       parent: 2
-  - uid: 21314
+  - uid: 21312
     components:
     - type: Transform
       pos: -64.5,9.5
       parent: 2
-  - uid: 21315
+  - uid: 21313
     components:
     - type: Transform
       pos: -63.5,9.5
       parent: 2
-  - uid: 21316
+  - uid: 21314
     components:
     - type: Transform
       pos: -61.5,9.5
       parent: 2
-  - uid: 21317
+  - uid: 21315
     components:
     - type: Transform
       pos: -62.5,9.5
       parent: 2
-  - uid: 21318
+  - uid: 21316
     components:
     - type: Transform
       pos: -60.5,10.5
       parent: 2
-  - uid: 21319
+  - uid: 21317
     components:
     - type: Transform
       pos: -60.5,11.5
       parent: 2
-  - uid: 21320
+  - uid: 21318
     components:
     - type: Transform
       pos: -63.5,12.5
       parent: 2
-  - uid: 21321
+  - uid: 21319
     components:
     - type: Transform
       pos: -64.5,12.5
       parent: 2
-  - uid: 21322
+  - uid: 21320
     components:
     - type: Transform
       pos: -65.5,12.5
       parent: 2
-  - uid: 21323
+  - uid: 21321
     components:
     - type: Transform
       pos: -66.5,12.5
       parent: 2
-  - uid: 21324
+  - uid: 21322
     components:
     - type: Transform
       pos: -68.5,9.5
       parent: 2
-  - uid: 21325
+  - uid: 21323
     components:
     - type: Transform
       pos: -69.5,9.5
       parent: 2
-  - uid: 21326
+  - uid: 21324
     components:
     - type: Transform
       pos: 84.5,-48.5
       parent: 2
-  - uid: 21327
+  - uid: 21325
     components:
     - type: Transform
       pos: 84.5,-49.5
       parent: 2
-  - uid: 21328
+  - uid: 21326
     components:
     - type: Transform
       pos: 84.5,-47.5
       parent: 2
-  - uid: 21329
+  - uid: 21327
     components:
     - type: Transform
       pos: 83.5,-49.5
       parent: 2
 - proto: TableReinforcedGlass
   entities:
-  - uid: 21330
+  - uid: 21328
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,6.5
       parent: 2
-  - uid: 21331
+  - uid: 21329
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,7.5
       parent: 2
-  - uid: 21332
+  - uid: 21330
     components:
     - type: Transform
       pos: 5.5,48.5
       parent: 2
-  - uid: 21333
+  - uid: 21331
     components:
     - type: Transform
       pos: 5.5,47.5
       parent: 2
-  - uid: 21334
+  - uid: 21332
     components:
     - type: Transform
       pos: -6.5,30.5
       parent: 2
-  - uid: 21335
+  - uid: 21333
     components:
     - type: Transform
       pos: -6.5,29.5
       parent: 2
-  - uid: 21336
+  - uid: 21334
     components:
     - type: Transform
       pos: -3.5,33.5
       parent: 2
-  - uid: 21337
+  - uid: 21335
     components:
     - type: Transform
       pos: -7.5,25.5
       parent: 2
-  - uid: 21338
+  - uid: 21336
     components:
     - type: Transform
       pos: -38.5,9.5
       parent: 2
-  - uid: 21339
+  - uid: 21337
     components:
     - type: Transform
       pos: -35.5,7.5
       parent: 2
-  - uid: 21340
+  - uid: 21338
     components:
     - type: Transform
       pos: -37.5,3.5
       parent: 2
-  - uid: 21341
+  - uid: 21339
     components:
     - type: Transform
       pos: -38.5,8.5
       parent: 2
-  - uid: 21342
+  - uid: 21340
     components:
     - type: Transform
       pos: -45.5,8.5
       parent: 2
-  - uid: 21343
+  - uid: 21341
     components:
     - type: Transform
       pos: -47.5,30.5
       parent: 2
-  - uid: 21344
+  - uid: 21342
     components:
     - type: Transform
       pos: -46.5,30.5
       parent: 2
-  - uid: 21345
+  - uid: 21343
     components:
     - type: Transform
       pos: 6.5,-43.5
       parent: 2
-  - uid: 21346
+  - uid: 21344
     components:
     - type: Transform
       pos: 10.5,-43.5
       parent: 2
-  - uid: 21347
+  - uid: 21345
     components:
     - type: Transform
       pos: 14.5,-43.5
       parent: 2
-  - uid: 21348
+  - uid: 21346
     components:
     - type: Transform
       pos: -37.5,8.5
       parent: 2
-  - uid: 21349
+  - uid: 21347
     components:
     - type: Transform
       pos: -67.5,41.5
       parent: 2
-  - uid: 21350
+  - uid: 21348
     components:
     - type: Transform
       pos: -66.5,41.5
       parent: 2
-  - uid: 21351
+  - uid: 21349
     components:
     - type: Transform
       pos: -67.5,40.5
       parent: 2
 - proto: TableStone
   entities:
-  - uid: 21352
+  - uid: 21350
     components:
     - type: Transform
       pos: -29.5,36.5
       parent: 2
-  - uid: 21353
+  - uid: 21351
     components:
     - type: Transform
       pos: -28.5,36.5
       parent: 2
-  - uid: 21354
+  - uid: 21352
     components:
     - type: Transform
       pos: -31.5,41.5
       parent: 2
-  - uid: 21355
+  - uid: 21353
     components:
     - type: Transform
       pos: 13.5,-55.5
       parent: 2
-  - uid: 21356
+  - uid: 21354
     components:
     - type: Transform
       pos: 9.5,-59.5
       parent: 2
-  - uid: 21357
+  - uid: 21355
     components:
     - type: Transform
       pos: 8.5,-59.5
       parent: 2
-  - uid: 21358
+  - uid: 21356
     components:
     - type: Transform
       pos: 3.5,-58.5
       parent: 2
-  - uid: 21359
+  - uid: 21357
     components:
     - type: Transform
       pos: 7.5,-59.5
       parent: 2
-  - uid: 21360
+  - uid: 21358
     components:
     - type: Transform
       pos: 12.5,-55.5
       parent: 2
-  - uid: 21361
+  - uid: 21359
     components:
     - type: Transform
       pos: 13.5,-56.5
       parent: 2
-  - uid: 21362
+  - uid: 21360
     components:
     - type: Transform
       pos: 4.5,-58.5
       parent: 2
-  - uid: 21363
+  - uid: 21361
     components:
     - type: Transform
       pos: -0.5,-56.5
       parent: 2
-  - uid: 21364
+  - uid: 21362
     components:
     - type: Transform
       pos: 0.5,-57.5
       parent: 2
-  - uid: 21365
+  - uid: 21363
     components:
     - type: Transform
       pos: -0.5,-55.5
       parent: 2
 - proto: TableWood
   entities:
-  - uid: 21366
+  - uid: 21364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 2
-  - uid: 21367
+  - uid: 21365
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 2
-  - uid: 21368
+  - uid: 21366
     components:
     - type: Transform
       pos: 15.5,-9.5
       parent: 2
-  - uid: 21369
+  - uid: 21367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-4.5
       parent: 2
-  - uid: 21370
+  - uid: 21368
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-  - uid: 21371
+  - uid: 21369
     components:
     - type: Transform
       pos: -26.5,19.5
       parent: 2
-  - uid: 21372
+  - uid: 21370
     components:
     - type: Transform
       pos: -27.5,19.5
       parent: 2
-  - uid: 21373
+  - uid: 21371
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 2
-  - uid: 21374
+  - uid: 21372
     components:
     - type: Transform
       pos: 16.5,-9.5
       parent: 2
-  - uid: 21375
+  - uid: 21373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 2
-  - uid: 21376
+  - uid: 21374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 2
-  - uid: 21377
+  - uid: 21375
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 2
-  - uid: 21378
+  - uid: 21376
     components:
     - type: Transform
       pos: 16.5,-6.5
       parent: 2
-  - uid: 21379
+  - uid: 21377
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 2
-  - uid: 21380
+  - uid: 21378
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 2
-  - uid: 21381
+  - uid: 21379
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 2
-  - uid: 21382
+  - uid: 21380
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 2
-  - uid: 21383
+  - uid: 21381
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 2
-  - uid: 21384
+  - uid: 21382
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 2
-  - uid: 21385
+  - uid: 21383
     components:
     - type: Transform
       pos: 10.5,-19.5
       parent: 2
-  - uid: 21386
+  - uid: 21384
     components:
     - type: Transform
       pos: -0.5,45.5
       parent: 2
-  - uid: 21387
+  - uid: 21385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,36.5
       parent: 2
-  - uid: 21388
+  - uid: 21386
     components:
     - type: Transform
       pos: -28.5,47.5
       parent: 2
-  - uid: 21389
+  - uid: 21387
     components:
     - type: Transform
       pos: -28.5,50.5
       parent: 2
-  - uid: 21390
+  - uid: 21388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,48.5
       parent: 2
-  - uid: 21391
+  - uid: 21389
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,48.5
       parent: 2
-  - uid: 21392
+  - uid: 21390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,50.5
       parent: 2
-  - uid: 21393
+  - uid: 21391
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,50.5
       parent: 2
-  - uid: 21394
+  - uid: 21392
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,37.5
       parent: 2
-  - uid: 21395
+  - uid: 21393
     components:
     - type: Transform
       pos: -16.5,45.5
       parent: 2
-  - uid: 21396
+  - uid: 21394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,37.5
       parent: 2
-  - uid: 21397
+  - uid: 21395
     components:
     - type: Transform
       pos: -1.5,44.5
       parent: 2
-  - uid: 21398
+  - uid: 21396
     components:
     - type: Transform
       pos: -17.5,45.5
       parent: 2
-  - uid: 21399
+  - uid: 21397
     components:
     - type: Transform
       pos: -14.5,45.5
       parent: 2
-  - uid: 21400
+  - uid: 21398
     components:
     - type: Transform
       pos: -14.5,47.5
       parent: 2
-  - uid: 21401
+  - uid: 21399
     components:
     - type: Transform
       pos: -15.5,45.5
       parent: 2
-  - uid: 21402
+  - uid: 21400
     components:
     - type: Transform
       pos: -15.5,47.5
       parent: 2
-  - uid: 21403
+  - uid: 21401
     components:
     - type: Transform
       pos: -13.5,45.5
       parent: 2
-  - uid: 21404
+  - uid: 21402
     components:
     - type: Transform
       pos: -4.5,50.5
       parent: 2
-  - uid: 21405
+  - uid: 21403
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,37.5
       parent: 2
-  - uid: 21406
+  - uid: 21404
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,37.5
       parent: 2
-  - uid: 21407
+  - uid: 21405
     components:
     - type: Transform
       pos: -1.5,43.5
       parent: 2
-  - uid: 21408
+  - uid: 21406
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,38.5
       parent: 2
-  - uid: 21409
+  - uid: 21407
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,38.5
       parent: 2
-  - uid: 21410
+  - uid: 21408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,38.5
       parent: 2
-  - uid: 21411
+  - uid: 21409
     components:
     - type: Transform
       pos: -10.5,35.5
       parent: 2
-  - uid: 21412
+  - uid: 21410
     components:
     - type: Transform
       pos: -29.5,50.5
       parent: 2
-  - uid: 21413
+  - uid: 21411
     components:
     - type: Transform
       pos: -29.5,47.5
       parent: 2
-  - uid: 21414
+  - uid: 21412
     components:
     - type: Transform
       pos: -16.5,47.5
       parent: 2
-  - uid: 21415
+  - uid: 21413
     components:
     - type: Transform
       pos: -1.5,45.5
       parent: 2
-  - uid: 21416
+  - uid: 21414
     components:
     - type: Transform
       pos: -12.5,45.5
       parent: 2
-  - uid: 21417
+  - uid: 21415
     components:
     - type: Transform
       pos: -5.5,23.5
       parent: 2
-  - uid: 21418
+  - uid: 21416
     components:
     - type: Transform
       pos: -4.5,23.5
       parent: 2
-  - uid: 21419
+  - uid: 21417
     components:
     - type: Transform
       pos: -4.5,24.5
       parent: 2
-  - uid: 21420
+  - uid: 21418
     components:
     - type: Transform
       pos: -18.5,45.5
       parent: 2
-  - uid: 21421
+  - uid: 21419
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,4.5
       parent: 2
-  - uid: 21422
+  - uid: 21420
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 2
-  - uid: 21423
+  - uid: 21421
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 2
-  - uid: 21424
+  - uid: 21422
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 2
-  - uid: 21425
+  - uid: 21423
     components:
     - type: Transform
       pos: -11.5,6.5
       parent: 2
-  - uid: 21426
+  - uid: 21424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,4.5
       parent: 2
-  - uid: 21427
+  - uid: 21425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,4.5
       parent: 2
-  - uid: 21428
+  - uid: 21426
     components:
     - type: Transform
       pos: -18.5,10.5
       parent: 2
-  - uid: 21429
+  - uid: 21427
     components:
     - type: Transform
       pos: -17.5,10.5
       parent: 2
-  - uid: 21430
+  - uid: 21428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,9.5
       parent: 2
-  - uid: 21431
+  - uid: 21429
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 2
-  - uid: 21432
+  - uid: 21430
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 2
-  - uid: 21433
+  - uid: 21431
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,7.5
       parent: 2
-  - uid: 21434
+  - uid: 21432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,7.5
       parent: 2
-  - uid: 21435
+  - uid: 21433
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 2
-  - uid: 21436
+  - uid: 21434
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 2
-  - uid: 21437
+  - uid: 21435
     components:
     - type: Transform
       pos: -17.5,-4.5
       parent: 2
-  - uid: 21438
+  - uid: 21436
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
-  - uid: 21439
+  - uid: 21437
     components:
     - type: Transform
       pos: -16.5,-4.5
       parent: 2
-  - uid: 21440
+  - uid: 21438
     components:
     - type: Transform
       pos: -18.5,-5.5
       parent: 2
-  - uid: 21441
+  - uid: 21439
     components:
     - type: Transform
       pos: -21.5,2.5
       parent: 2
-  - uid: 21442
+  - uid: 21440
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 2
-  - uid: 21443
+  - uid: 21441
     components:
     - type: Transform
       pos: -21.5,5.5
       parent: 2
-  - uid: 21444
+  - uid: 21442
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 2
-  - uid: 21445
+  - uid: 21443
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 2
-  - uid: 21446
+  - uid: 21444
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-15.5
       parent: 2
-  - uid: 21447
+  - uid: 21445
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-15.5
       parent: 2
-  - uid: 21448
+  - uid: 21446
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 2
-  - uid: 21449
+  - uid: 21447
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 2
-  - uid: 21450
+  - uid: 21448
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 2
-  - uid: 21451
+  - uid: 21449
     components:
     - type: Transform
       pos: -2.5,-20.5
       parent: 2
-  - uid: 21452
+  - uid: 21450
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 2
-  - uid: 21453
+  - uid: 21451
     components:
     - type: Transform
       pos: -51.5,-2.5
       parent: 2
-  - uid: 21454
+  - uid: 21452
     components:
     - type: Transform
       pos: -50.5,1.5
       parent: 2
-  - uid: 21455
+  - uid: 21453
     components:
     - type: Transform
       pos: -50.5,0.5
       parent: 2
-  - uid: 21456
+  - uid: 21454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,17.5
       parent: 2
-  - uid: 21457
+  - uid: 21455
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,16.5
       parent: 2
-  - uid: 21458
+  - uid: 21456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,20.5
       parent: 2
-  - uid: 21459
+  - uid: 21457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,19.5
       parent: 2
-  - uid: 21460
+  - uid: 21458
     components:
     - type: Transform
       pos: -61.5,20.5
       parent: 2
-  - uid: 21461
+  - uid: 21459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -66.5,14.5
       parent: 2
-  - uid: 21462
+  - uid: 21460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -67.5,14.5
       parent: 2
-  - uid: 21463
+  - uid: 21461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -68.5,14.5
       parent: 2
-  - uid: 21464
+  - uid: 21462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -68.5,15.5
       parent: 2
-  - uid: 21465
+  - uid: 21463
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -68.5,16.5
       parent: 2
-  - uid: 21466
+  - uid: 21464
     components:
     - type: Transform
       pos: -61.5,16.5
       parent: 2
-  - uid: 21467
+  - uid: 21465
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -39.5,32.5
       parent: 2
-  - uid: 21468
+  - uid: 21466
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,32.5
       parent: 2
-  - uid: 21469
+  - uid: 21467
     components:
     - type: Transform
       pos: -38.5,28.5
       parent: 2
-  - uid: 21470
+  - uid: 21468
     components:
     - type: Transform
       pos: -38.5,27.5
       parent: 2
-  - uid: 21471
+  - uid: 21469
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-14.5
       parent: 2
-  - uid: 21472
+  - uid: 21470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-14.5
       parent: 2
-  - uid: 21473
+  - uid: 21471
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-14.5
       parent: 2
-  - uid: 21474
+  - uid: 21472
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-14.5
       parent: 2
-  - uid: 21475
+  - uid: 21473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,-3.5
       parent: 2
-  - uid: 21476
+  - uid: 21474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,-5.5
       parent: 2
-  - uid: 21477
+  - uid: 21475
     components:
     - type: Transform
       pos: 32.5,3.5
       parent: 2
-  - uid: 21478
+  - uid: 21476
     components:
     - type: Transform
       pos: 37.5,4.5
       parent: 2
-  - uid: 21479
+  - uid: 21477
     components:
     - type: Transform
       pos: 38.5,4.5
       parent: 2
-  - uid: 21480
+  - uid: 21478
     components:
     - type: Transform
       pos: 40.5,4.5
       parent: 2
-  - uid: 21481
+  - uid: 21479
     components:
     - type: Transform
       pos: 42.5,4.5
       parent: 2
-  - uid: 21482
+  - uid: 21480
     components:
     - type: Transform
       pos: 41.5,4.5
       parent: 2
-  - uid: 21483
+  - uid: 21481
     components:
     - type: Transform
       pos: 39.5,4.5
       parent: 2
-  - uid: 21484
+  - uid: 21482
     components:
     - type: Transform
       pos: 30.5,1.5
       parent: 2
-  - uid: 21485
+  - uid: 21483
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,-28.5
       parent: 2
-  - uid: 21486
+  - uid: 21484
     components:
     - type: Transform
       pos: 65.5,-28.5
       parent: 2
-  - uid: 21487
+  - uid: 21485
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,-28.5
       parent: 2
-  - uid: 21488
+  - uid: 21486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,-32.5
       parent: 2
-  - uid: 21489
+  - uid: 21487
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-32.5
       parent: 2
-  - uid: 21490
+  - uid: 21488
     components:
     - type: Transform
       pos: 66.5,-28.5
       parent: 2
-  - uid: 21491
+  - uid: 21489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 63.5,-28.5
       parent: 2
-  - uid: 21492
+  - uid: 21490
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-31.5
       parent: 2
-  - uid: 21493
+  - uid: 21491
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,-29.5
       parent: 2
-  - uid: 21494
+  - uid: 21492
     components:
     - type: Transform
       pos: 60.5,-34.5
       parent: 2
-  - uid: 21495
+  - uid: 21493
     components:
     - type: Transform
       pos: 60.5,-33.5
       parent: 2
-  - uid: 21496
+  - uid: 21494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-30.5
       parent: 2
-  - uid: 21497
+  - uid: 21495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,-30.5
       parent: 2
-  - uid: 21498
+  - uid: 21496
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,-33.5
       parent: 2
-  - uid: 21499
+  - uid: 21497
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,-32.5
       parent: 2
-  - uid: 21500
+  - uid: 21498
     components:
     - type: Transform
       pos: 41.5,31.5
       parent: 2
-  - uid: 21501
+  - uid: 21499
     components:
     - type: Transform
       pos: 40.5,31.5
       parent: 2
-  - uid: 21502
+  - uid: 21500
     components:
     - type: Transform
       pos: 39.5,31.5
       parent: 2
-  - uid: 21503
+  - uid: 21501
     components:
     - type: Transform
       pos: 36.5,29.5
       parent: 2
-  - uid: 21504
+  - uid: 21502
     components:
     - type: Transform
       pos: 36.5,30.5
       parent: 2
-  - uid: 21505
+  - uid: 21503
     components:
     - type: Transform
       pos: -31.5,21.5
       parent: 2
-  - uid: 21506
+  - uid: 21504
     components:
     - type: Transform
       pos: -32.5,21.5
       parent: 2
-  - uid: 21507
+  - uid: 21505
     components:
     - type: Transform
       pos: -3.5,19.5
       parent: 2
-  - uid: 21508
+  - uid: 21506
     components:
     - type: Transform
       pos: -4.5,19.5
       parent: 2
-  - uid: 21509
+  - uid: 21507
     components:
     - type: Transform
       pos: -2.5,19.5
       parent: 2
-  - uid: 21510
+  - uid: 21508
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 2
-  - uid: 21511
+  - uid: 21509
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 2
-  - uid: 21512
+  - uid: 21510
     components:
     - type: Transform
       pos: 6.5,-15.5
       parent: 2
-  - uid: 21513
+  - uid: 21511
     components:
     - type: Transform
       pos: 6.5,-14.5
       parent: 2
-  - uid: 21514
+  - uid: 21512
     components:
     - type: Transform
       pos: -20.5,-9.5
       parent: 2
-  - uid: 21515
+  - uid: 21513
     components:
     - type: Transform
       pos: -20.5,-10.5
       parent: 2
-  - uid: 21516
+  - uid: 21514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,-5.5
       parent: 2
-  - uid: 21517
+  - uid: 21515
     components:
     - type: Transform
       pos: -37.5,38.5
       parent: 2
-  - uid: 21518
+  - uid: 21516
     components:
     - type: Transform
       pos: -41.5,38.5
       parent: 2
-  - uid: 21519
+  - uid: 21517
     components:
     - type: Transform
       pos: -40.5,38.5
       parent: 2
-  - uid: 21520
+  - uid: 21518
     components:
     - type: Transform
       pos: -33.5,38.5
       parent: 2
-  - uid: 21521
+  - uid: 21519
     components:
     - type: Transform
       pos: -33.5,35.5
       parent: 2
-  - uid: 21522
+  - uid: 21520
     components:
     - type: Transform
       pos: -38.5,38.5
       parent: 2
-  - uid: 21523
+  - uid: 21521
     components:
     - type: Transform
       pos: -51.5,-6.5
       parent: 2
-  - uid: 21524
+  - uid: 21522
     components:
     - type: Transform
       pos: -52.5,-6.5
       parent: 2
-  - uid: 21525
+  - uid: 21523
     components:
     - type: Transform
       pos: -57.5,7.5
       parent: 2
-  - uid: 21526
+  - uid: 21524
     components:
     - type: Transform
       pos: -54.5,7.5
       parent: 2
-  - uid: 21527
+  - uid: 21525
     components:
     - type: Transform
       pos: -54.5,8.5
       parent: 2
-  - uid: 21528
+  - uid: 21526
     components:
     - type: Transform
       pos: -57.5,8.5
       parent: 2
-  - uid: 21529
+  - uid: 21527
     components:
     - type: Transform
       pos: 69.5,-34.5
       parent: 2
-  - uid: 21530
+  - uid: 21528
     components:
     - type: Transform
       pos: 69.5,-33.5
       parent: 2
-  - uid: 21531
+  - uid: 21529
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 2
 - proto: TargetDarts
   entities:
-  - uid: 21532
+  - uid: 21530
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 2
 - proto: TargetStrange
   entities:
-  - uid: 21533
+  - uid: 21531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -134746,7 +134779,7 @@ entities:
       parent: 2
 - proto: TargetSyndicate
   entities:
-  - uid: 21534
+  - uid: 21532
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -134754,14 +134787,14 @@ entities:
       parent: 2
 - proto: TegCenter
   entities:
-  - uid: 21535
+  - uid: 21533
     components:
     - type: Transform
       pos: 60.5,11.5
       parent: 2
 - proto: TegCirculator
   entities:
-  - uid: 21536
+  - uid: 21534
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -134769,7 +134802,7 @@ entities:
       parent: 2
     - type: PointLight
       color: '#FF3300FF'
-  - uid: 21537
+  - uid: 21535
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -134779,132 +134812,132 @@ entities:
       color: '#FF3300FF'
 - proto: TelecomServerFilledCargo
   entities:
-  - uid: 21538
+  - uid: 21536
     components:
     - type: Transform
       pos: 54.5,33.5
       parent: 2
 - proto: TelecomServerFilledCommand
   entities:
-  - uid: 21539
+  - uid: 21537
     components:
     - type: Transform
       pos: -28.5,31.5
       parent: 2
 - proto: TelecomServerFilledCommon
   entities:
-  - uid: 21540
+  - uid: 21538
     components:
     - type: Transform
       pos: 54.5,32.5
       parent: 2
 - proto: TelecomServerFilledEngineering
   entities:
-  - uid: 21541
+  - uid: 21539
     components:
     - type: Transform
       pos: 56.5,32.5
       parent: 2
 - proto: TelecomServerFilledLaw
   entities:
-  - uid: 21542
+  - uid: 21540
     components:
     - type: Transform
       pos: 54.5,31.5
       parent: 2
 - proto: TelecomServerFilledMedical
   entities:
-  - uid: 21543
+  - uid: 21541
     components:
     - type: Transform
       pos: 56.5,31.5
       parent: 2
 - proto: TelecomServerFilledScience
   entities:
-  - uid: 21544
+  - uid: 21542
     components:
     - type: Transform
       pos: 54.5,30.5
       parent: 2
 - proto: TelecomServerFilledSecurity
   entities:
-  - uid: 21545
+  - uid: 21543
     components:
     - type: Transform
       pos: 56.5,30.5
       parent: 2
 - proto: TelecomServerFilledService
   entities:
-  - uid: 21546
+  - uid: 21544
     components:
     - type: Transform
       pos: 56.5,33.5
       parent: 2
 - proto: TeslaCoil
   entities:
-  - uid: 21547
+  - uid: 21545
     components:
     - type: Transform
       pos: 85.5,23.5
       parent: 2
-  - uid: 21548
+  - uid: 21546
     components:
     - type: Transform
       pos: 80.5,14.5
       parent: 2
-  - uid: 21549
+  - uid: 21547
     components:
     - type: Transform
       pos: 80.5,22.5
       parent: 2
-  - uid: 21550
+  - uid: 21548
     components:
     - type: Transform
       pos: 90.5,18.5
       parent: 2
-  - uid: 21551
+  - uid: 21549
     components:
     - type: Transform
       pos: 90.5,22.5
       parent: 2
-  - uid: 21552
+  - uid: 21550
     components:
     - type: Transform
       pos: 90.5,21.5
       parent: 2
-  - uid: 21553
+  - uid: 21551
     components:
     - type: Transform
       pos: 90.5,15.5
       parent: 2
-  - uid: 21554
+  - uid: 21552
     components:
     - type: Transform
       pos: 80.5,15.5
       parent: 2
-  - uid: 21555
+  - uid: 21553
     components:
     - type: Transform
       pos: 90.5,14.5
       parent: 2
-  - uid: 21556
+  - uid: 21554
     components:
     - type: Transform
       pos: 85.5,13.5
       parent: 2
-  - uid: 21557
+  - uid: 21555
     components:
     - type: Transform
       pos: 80.5,21.5
       parent: 2
-  - uid: 21558
+  - uid: 21556
     components:
     - type: Transform
       pos: 80.5,18.5
       parent: 2
 - proto: TeslaGenerator
   entities:
-  - uid: 21559
+  - uid: 21557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -134912,174 +134945,174 @@ entities:
       parent: 2
 - proto: TeslaGroundingRod
   entities:
-  - uid: 21560
+  - uid: 21558
     components:
     - type: Transform
       pos: 87.5,13.5
       parent: 2
-  - uid: 21561
+  - uid: 21559
     components:
     - type: Transform
       pos: 83.5,13.5
       parent: 2
-  - uid: 21562
+  - uid: 21560
     components:
     - type: Transform
       pos: 83.5,23.5
       parent: 2
-  - uid: 21563
+  - uid: 21561
     components:
     - type: Transform
       pos: 87.5,23.5
       parent: 2
 - proto: TintedWindow
   entities:
-  - uid: 21564
+  - uid: 21562
     components:
     - type: Transform
       pos: -15.5,6.5
       parent: 2
-  - uid: 21565
+  - uid: 21563
     components:
     - type: Transform
       pos: 11.5,-9.5
       parent: 2
-  - uid: 21566
+  - uid: 21564
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 2
-  - uid: 21567
+  - uid: 21565
     components:
     - type: Transform
       pos: -16.5,6.5
       parent: 2
-  - uid: 21568
+  - uid: 21566
     components:
     - type: Transform
       pos: 9.5,-9.5
       parent: 2
-  - uid: 21569
+  - uid: 21567
     components:
     - type: Transform
       pos: -17.5,6.5
       parent: 2
-  - uid: 21570
+  - uid: 21568
     components:
     - type: Transform
       pos: -18.5,6.5
       parent: 2
-  - uid: 21571
+  - uid: 21569
     components:
     - type: Transform
       pos: -36.5,-4.5
       parent: 2
-  - uid: 21572
+  - uid: 21570
     components:
     - type: Transform
       pos: -33.5,-4.5
       parent: 2
-  - uid: 21573
+  - uid: 21571
     components:
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
-  - uid: 21574
+  - uid: 21572
     components:
     - type: Transform
       pos: -27.5,-4.5
       parent: 2
-  - uid: 21575
+  - uid: 21573
     components:
     - type: Transform
       pos: -44.5,-4.5
       parent: 2
-  - uid: 21576
+  - uid: 21574
     components:
     - type: Transform
       pos: -41.5,-4.5
       parent: 2
-  - uid: 21577
+  - uid: 21575
     components:
     - type: Transform
       pos: -43.5,8.5
       parent: 2
-  - uid: 21578
+  - uid: 21576
     components:
     - type: Transform
       pos: -43.5,10.5
       parent: 2
-  - uid: 21579
+  - uid: 21577
     components:
     - type: Transform
       pos: 11.5,-24.5
       parent: 2
-  - uid: 21580
+  - uid: 21578
     components:
     - type: Transform
       pos: 13.5,-24.5
       parent: 2
-  - uid: 21581
+  - uid: 21579
     components:
     - type: Transform
       pos: 12.5,-24.5
       parent: 2
-  - uid: 21582
+  - uid: 21580
     components:
     - type: Transform
       pos: 2.5,-35.5
       parent: 2
-  - uid: 21583
+  - uid: 21581
     components:
     - type: Transform
       pos: 2.5,-36.5
       parent: 2
-  - uid: 21584
+  - uid: 21582
     components:
     - type: Transform
       pos: 2.5,-37.5
       parent: 2
-  - uid: 21585
+  - uid: 21583
     components:
     - type: Transform
       pos: 81.5,-8.5
       parent: 2
-  - uid: 21586
+  - uid: 21584
     components:
     - type: Transform
       pos: 81.5,-9.5
       parent: 2
-  - uid: 21587
+  - uid: 21585
     components:
     - type: Transform
       pos: 81.5,-10.5
       parent: 2
-  - uid: 21588
+  - uid: 21586
     components:
     - type: Transform
       pos: 81.5,-11.5
       parent: 2
-  - uid: 21589
+  - uid: 21587
     components:
     - type: Transform
       pos: 67.5,-43.5
       parent: 2
-  - uid: 21590
+  - uid: 21588
     components:
     - type: Transform
       pos: 67.5,-45.5
       parent: 2
-  - uid: 21591
+  - uid: 21589
     components:
     - type: Transform
       pos: 67.5,-44.5
       parent: 2
-  - uid: 21592
+  - uid: 21590
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 2
-  - uid: 21593
+  - uid: 21591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -135087,7 +135120,7 @@ entities:
       parent: 2
 - proto: ToiletDirtyWater
   entities:
-  - uid: 21594
+  - uid: 21592
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -135095,55 +135128,55 @@ entities:
       parent: 2
 - proto: ToiletDirtyWaterFilled
   entities:
-  - uid: 21595
+  - uid: 21593
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-35.5
       parent: 2
-  - uid: 21596
+  - uid: 21594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-41.5
       parent: 2
-  - uid: 21597
+  - uid: 21595
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-37.5
       parent: 2
-  - uid: 21598
+  - uid: 21596
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-39.5
       parent: 2
-  - uid: 21599
+  - uid: 21597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-11.5
       parent: 2
-  - uid: 21600
+  - uid: 21598
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-9.5
       parent: 2
-  - uid: 21601
+  - uid: 21599
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-7.5
       parent: 2
-  - uid: 21602
+  - uid: 21600
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-21.5
       parent: 2
-  - uid: 21603
+  - uid: 21601
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -135151,7 +135184,7 @@ entities:
       parent: 2
 - proto: ToiletEmpty
   entities:
-  - uid: 17877
+  - uid: 17875
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -135162,7 +135195,7 @@ entities:
         stash: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 17878
+          ent: 17876
         disposals: !type:Container
           showEnts: False
           occludes: True
@@ -135171,7 +135204,7 @@ entities:
       isOpen: True
 - proto: ToiletGoldenDirtyWater
   entities:
-  - uid: 21604
+  - uid: 21602
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -135179,127 +135212,127 @@ entities:
       parent: 2
 - proto: ToolboxElectricalFilled
   entities:
-  - uid: 21605
+  - uid: 21603
     components:
     - type: Transform
       pos: -7.616148,51.316463
       parent: 2
-  - uid: 21606
+  - uid: 21604
     components:
     - type: Transform
       pos: 1.5252552,-29.005726
       parent: 2
 - proto: ToolboxEmergencyFilled
   entities:
-  - uid: 21607
+  - uid: 21605
     components:
     - type: Transform
       pos: -7.485688,51.806026
       parent: 2
-  - uid: 21608
+  - uid: 21606
     components:
     - type: Transform
       pos: -9.633643,1.7259798
       parent: 2
-  - uid: 21609
+  - uid: 21607
     components:
     - type: Transform
       pos: 1.5408802,-29.286976
       parent: 2
-  - uid: 21610
+  - uid: 21608
     components:
     - type: Transform
       pos: -22.666674,-10.771671
       parent: 2
-  - uid: 21611
+  - uid: 21609
     components:
     - type: Transform
       pos: -51.47452,-6.207698
       parent: 2
 - proto: ToolboxGoldFilled
   entities:
-  - uid: 21612
+  - uid: 21610
     components:
     - type: Transform
       pos: -26.64328,28.591188
       parent: 2
 - proto: ToolboxMechanicalFilled
   entities:
-  - uid: 21613
+  - uid: 21611
     components:
     - type: Transform
       pos: -7.412305,51.536766
       parent: 2
-  - uid: 21614
+  - uid: 21612
     components:
     - type: Transform
       pos: -9.493018,1.5228548
       parent: 2
-  - uid: 21615
+  - uid: 21613
     components:
     - type: Transform
       pos: 1.5565052,-29.5526
       parent: 2
-  - uid: 21616
+  - uid: 21614
     components:
     - type: Transform
       pos: -77.45696,-2.0808845
       parent: 2
 - proto: ToolboxSyndicate
   entities:
-  - uid: 17409
+  - uid: 17408
     components:
     - type: Transform
       pos: 84.50539,-48.37823
       parent: 2
     - type: Storage
       storedItems:
-        17418:
+        17417:
           position: 0,0
           _rotation: South
-        17419:
+        17418:
           position: 1,0
           _rotation: South
-        17420:
+        17419:
           position: 2,0
           _rotation: South
-        17421:
+        17420:
           position: 3,0
           _rotation: South
-        17422:
+        17421:
           position: 4,0
           _rotation: South
-        17423:
+        17422:
           position: 5,0
           _rotation: South
-        17424:
+        17423:
           position: 6,0
           _rotation: South
-        17425:
+        17424:
           position: 7,0
           _rotation: South
-        17410:
+        17409:
           position: 0,2
           _rotation: South
-        17411:
+        17410:
           position: 1,2
           _rotation: South
-        17412:
+        17411:
           position: 2,2
           _rotation: South
-        17413:
+        17412:
           position: 3,2
           _rotation: South
-        17414:
+        17413:
           position: 4,2
           _rotation: South
-        17415:
+        17414:
           position: 5,2
           _rotation: South
-        17416:
+        17415:
           position: 6,2
           _rotation: South
-        17417:
+        17416:
           position: 7,2
           _rotation: South
     - type: ContainerContainer
@@ -135308,6 +135341,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
+          - 17417
           - 17418
           - 17419
           - 17420
@@ -135315,7 +135349,7 @@ entities:
           - 17422
           - 17423
           - 17424
-          - 17425
+          - 17409
           - 17410
           - 17411
           - 17412
@@ -135323,161 +135357,160 @@ entities:
           - 17414
           - 17415
           - 17416
-          - 17417
 - proto: ToolboxSyndicateFilled
   entities:
-  - uid: 21617
+  - uid: 21615
     components:
     - type: Transform
       pos: -49.48351,-8.673055
       parent: 2
 - proto: TowelColorBlue
   entities:
-  - uid: 21618
+  - uid: 21616
     components:
     - type: Transform
       pos: 82.29385,-10.896404
       parent: 2
 - proto: TowelColorGold
   entities:
-  - uid: 21619
+  - uid: 21617
     components:
     - type: Transform
       pos: -28.63916,28.76595
       parent: 2
 - proto: TowelColorNT
   entities:
-  - uid: 21620
+  - uid: 21618
     components:
     - type: Transform
       pos: 5.514326,41.568054
       parent: 2
 - proto: TowelColorWhite
   entities:
-  - uid: 21621
+  - uid: 21619
     components:
     - type: Transform
       pos: -23.644468,37.682213
       parent: 2
-  - uid: 21622
+  - uid: 21620
     components:
     - type: Transform
       pos: -23.628843,37.463463
       parent: 2
-  - uid: 21623
+  - uid: 21621
     components:
     - type: Transform
       pos: -23.331968,37.479088
       parent: 2
-  - uid: 21624
+  - uid: 21622
     components:
     - type: Transform
       pos: -23.378843,37.713463
       parent: 2
-  - uid: 21625
+  - uid: 21623
     components:
     - type: Transform
       pos: 0.42520165,-41.263172
       parent: 2
-  - uid: 21626
+  - uid: 21624
     components:
     - type: Transform
       pos: 0.70645165,-41.614735
       parent: 2
-  - uid: 21627
+  - uid: 21625
     components:
     - type: Transform
       pos: 12.486158,-55.397842
       parent: 2
-  - uid: 21628
+  - uid: 21626
     components:
     - type: Transform
       pos: 12.658033,-55.507217
       parent: 2
-  - uid: 21629
+  - uid: 21627
     components:
     - type: Transform
       pos: 9.541169,-59.4435
       parent: 2
-  - uid: 21630
+  - uid: 21628
     components:
     - type: Transform
       pos: 9.447419,-59.28725
       parent: 2
-  - uid: 21631
+  - uid: 21629
     components:
     - type: Transform
       pos: 0.33032274,-57.271626
       parent: 2
-  - uid: 21632
+  - uid: 21630
     components:
     - type: Transform
       pos: 0.58032274,-57.427876
       parent: 2
 - proto: ToyAi
   entities:
-  - uid: 21633
+  - uid: 21631
     components:
     - type: Transform
       pos: -5.560234,37.663208
       parent: 2
-  - uid: 21634
+  - uid: 21632
     components:
     - type: Transform
       pos: -6.4991302,41.675488
       parent: 2
 - proto: ToyFigurineCaptain
   entities:
-  - uid: 21635
+  - uid: 21633
     components:
     - type: Transform
       pos: -0.96034086,45.638508
       parent: 2
 - proto: ToyFigurineFootsoldier
   entities:
-  - uid: 21636
+  - uid: 21634
     components:
     - type: Transform
       pos: 70.26308,-42.103077
       parent: 2
 - proto: ToyFigurineSecurity
   entities:
-  - uid: 21637
+  - uid: 21635
     components:
     - type: Transform
       pos: 69.67714,-43.181202
       parent: 2
 - proto: ToyFigurineThief
   entities:
-  - uid: 21638
+  - uid: 21636
     components:
     - type: Transform
       pos: 5.4945135,-15.209955
       parent: 2
 - proto: ToyHammer
   entities:
-  - uid: 21639
+  - uid: 21637
     components:
     - type: Transform
       pos: -5.470999,36.81088
       parent: 2
 - proto: ToySword
   entities:
-  - uid: 21640
+  - uid: 21638
     components:
     - type: Transform
       pos: -2.422716,48.696014
       parent: 2
 - proto: TP14KitchenDeepFryer
   entities:
-  - uid: 21114
+  - uid: 21639
     components:
     - type: Transform
       pos: 50.5,0.5
       parent: 2
 - proto: TP14KitchenDeepFryerTabletop
   entities:
-  - uid: 17379
+  - uid: 21640
     components:
     - type: Transform
       pos: -64.5,12.5
@@ -135655,7 +135688,7 @@ entities:
           - Reverse
         - - Middle
           - Off
-        19352:
+        19350:
         - - Left
           - Forward
         - - Right
@@ -135700,7 +135733,7 @@ entities:
           - Reverse
         - - Middle
           - Off
-        19353:
+        19351:
         - - Left
           - Forward
         - - Right
@@ -135812,6 +135845,20 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
+        20061:
+        - - Left
+          - Open
+        - - Right
+          - Open
+        - - Middle
+          - Close
+        20062:
+        - - Left
+          - Open
+        - - Right
+          - Open
+        - - Middle
+          - Close
         20063:
         - - Left
           - Open
@@ -135827,20 +135874,6 @@ entities:
         - - Middle
           - Close
         20065:
-        - - Left
-          - Open
-        - - Right
-          - Open
-        - - Middle
-          - Close
-        20066:
-        - - Left
-          - Open
-        - - Right
-          - Open
-        - - Middle
-          - Close
-        20067:
         - - Left
           - Open
         - - Right
@@ -150971,7 +151004,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -2746.7566
+      secondsUntilStateChange: -3135.9617
       state: Opening
     - type: Airlock
       autoClose: False


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Medical maints on Lobster had a `SuitStorageNTSRA` mapped which straight up spawns with a void jetpack.

<img width="183" height="206" alt="image" src="https://github.com/user-attachments/assets/5304597d-95ac-46cb-af1c-7a919d078f2b" />

This PR replaces that suit storage with a suit storage that just has a regular EVA emergency suit.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- The voidpack is silly good and should not be that easy to get.
- It leads to a lot of powergaming as people rush for it.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1003" height="791" alt="image" src="https://github.com/user-attachments/assets/38a75838-8086-4be2-97a1-05043674af65" />

fig. 1 - Replaced suit storage.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CawsForConcern
- tweak: (Lobster) Swapped out suit storage locker that spawned with a void jetpack in Medical maints for a suit storage locker with an emergency EVA suit.