### PR TITLE
Enforcers & Due Process now count as officer handguns for thieving objectives

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -128,6 +128,8 @@
         - tan
         - grey
         - greengrip
+    - type: StealTarget
+      stealGroup: OfficerHandgun
 
 - type: entity
   name: Due Process
@@ -164,6 +166,8 @@
           whitelist:
             tags:
               - CartridgePistolDP
+    - type: StealTarget
+      stealGroup: OfficerHandgun
 
 - type: entity
   name: sp-8t


### PR DESCRIPTION
## Short description
Enforcer and Due Process handguns now count as valid thieving targets for officer handgun objectives.

## Why we need to add this
Stealing an officers gun for it to be an enforcer and not count was kinda wacky. I've also added it to the Due Process as well.

## Media (Video/Screenshots)
<img width="1197" height="1013" alt="image" src="https://github.com/user-attachments/assets/39a8c0bc-5a20-4de1-942f-1f00e1cf83ed" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Coolsurf6
- fix: Thieves can now steal Enforcers and Due Process as officer handguns.

