### PR TITLE
Reverts #3469

### DIFF
--- a/Content.Server/_Starlight/Shadekin/ShadekinSystem.cs
+++ b/Content.Server/_Starlight/Shadekin/ShadekinSystem.cs
@@ -378,7 +378,7 @@ public sealed partial class ShadekinSystem : EntitySystem
             _speed.RefreshMovementSpeedModifiers(uid);
 
             if (component.CurrentState == ShadekinState.Extreme)
-                ApplyLightDamage(uid, 5);
+                ApplyLightDamage(uid, 1);
 
             if (TryComp<BrighteyeComponent>(uid, out var brighteye))
                 UpdateEnergy(uid, component, brighteye);


### PR DESCRIPTION

## Short description
Reverts #3469 since it was mentioned in #3469 that it should be reverted in a separate PR.

## Why we need to add this
Reverts #3469 since it was mentioned in #3469 that it should be reverted in a separate PR.

## Media (Video/Screenshots)
n/A

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl:
- tweak: Reverts Shadekin Light Damage back to original value.
