### PR TITLE
Update deep fried snacks: larger corndogs, fix item size, and fix tags

### DIFF
--- a/Resources/Prototypes/_TP/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/_TP/Entities/Objects/Consumable/Food/snacks.yml
@@ -25,6 +25,7 @@
   - type: Tag
     tags:
     - ClothMade
+    - FoodSnack #Starlight
 
 - type: entity
   id: TP14FoodCheeseSticks
@@ -46,6 +47,12 @@
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
+  #Starlight start
+  - type: Tag
+    tags:
+    - Cooked
+    - FoodSnack
+  #Starlight end
 
 - type: entity
   parent: FoodSnackBase
@@ -62,11 +69,27 @@
     solutions:
       food:
         reagents:
-        - ReagentId: Nutriment
-          Quantity: 10
+          #Starlight start
+          - ReagentId: Nutriment
+            Quantity: 9
+          - ReagentId: Protein
+            Quantity: 9
+          #Starlight end
   - type: Sprite
     sprite: _TP/Objects/Consumable/fried-food.rsi
     state: Corndog
+  #Starlight start
+  - type: Item
+    size: Small
+    shape:
+    - 0,0,1,0
+  - type: Tag
+    tags:
+    - Cooked
+    - Meat
+    - Sausage
+    - FoodSnack
+  #Starlight end
 
 - type: entity
   parent: FoodSnackBase
@@ -88,6 +111,12 @@
   - type: Sprite
     sprite: _TP/Objects/Consumable/fried-food.rsi
     state: Fried_Icecream
+  #Starlight start
+  - type: Tag
+    tags:
+    - Cooked
+    - FoodSnack
+  #Starlight end
 
 - type: entity
   parent: FoodSnackBase
@@ -109,3 +138,13 @@
   - type: Sprite
     sprite: _TP/Objects/Consumable/fried-food.rsi
     state: Funnel_Cake
+  #Starlight start
+  - type: Item
+    size: Small
+    shape:
+    - 0,0,1,0
+  - type: Tag
+    tags:
+    - Cooked
+    - FoodSnack
+  #Starlight end


### PR DESCRIPTION
## Short description
Small update to deep fried food recipes, mostly increasing hunger restored from corndogs, and classifying them as meat to allow carnivores to eat them.

## Why we need to add this
Corndog values were based on the nutritional value of the Trieste sausages, which are much smaller than the ones used on Starlight. This meant that a corndog would essentially lose 50% of hunger restoration, highly inefficient as a food item.
This has been changed to match that of cooked sausages, with one extra unit of nutrition.

#### Original source item values
https://github.com/ss14Starlight/space-station-14/blob/d7719b3e0f6a473db19aba9b0b3a953e3db35def/Resources/Prototypes/_TP/Entities/Objects/Consumable/Food/meat.yml#L42-L46

#### Starlight source item values:
https://github.com/ss14Starlight/space-station-14/blob/d7719b3e0f6a473db19aba9b0b3a953e3db35def/Resources/Prototypes/_Starlight/Entities/Objects/Consumable/Food/organmeats.yml#L118-L122

In addition, they were not correctly tagged as a meat item, meaning meat-only crew could not eat them.

As a trade-off, the item size has been increased to not make it too compact of a food item. Funnel cake item size was also increased as its rather compact already, though its nutritional value is unchanged.

## Media (Video/Screenshots)
<img width="120" alt="image" src="https://github.com/user-attachments/assets/2cd3b859-4c66-4686-bc0d-e8ed36428140" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- tweak: Corndogs are now twice as large, with roughly double the nutritional value.
- tweak: Funnel cakes are now twice as large.
- fix: Corndogs are now classified as a meat food.
