### PR TITLE
[BUGFIX] Abductor gizmo now saves a valid EntityCoordinates.

### DIFF
--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Gizmo.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Gizmo.cs
@@ -14,6 +14,7 @@ using Content.Shared.Tag;
 using Content.Shared.Popups;
 using System;
 using Content.Shared.ActionBlocker;
+using Robust.Shared.Map.Components;
 
 namespace Content.Server.Starlight.Antags.Abductor;
 
@@ -89,6 +90,10 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         EnsureComp<AbductorVictimComponent>(args.Target.Value, out var victimComponent);
         victimComponent.LastActivation = _time.CurTime + TimeSpan.FromMinutes(5);
 
-        victimComponent.Position ??= EnsureComp<TransformComponent>(args.Target.Value).Coordinates;
+        var transform = EnsureComp<TransformComponent>(args.Target.Value);
+        while (!TryComp<MapGridComponent>(transform.ParentUid, out _) && !TryComp<MapComponent>(transform.ParentUid, out _))
+            transform = EnsureComp<TransformComponent>(transform.ParentUid);
+
+        victimComponent.Position ??= transform.Coordinates;
     }
 }

--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Gizmo.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Gizmo.cs
@@ -14,7 +14,6 @@ using Content.Shared.Tag;
 using Content.Shared.Popups;
 using System;
 using Content.Shared.ActionBlocker;
-using Robust.Shared.Map.Components;
 
 namespace Content.Server.Starlight.Antags.Abductor;
 
@@ -90,10 +89,11 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         EnsureComp<AbductorVictimComponent>(args.Target.Value, out var victimComponent);
         victimComponent.LastActivation = _time.CurTime + TimeSpan.FromMinutes(5);
 
-        var transform = EnsureComp<TransformComponent>(args.Target.Value);
-        while (!TryComp<MapGridComponent>(transform.ParentUid, out _) && !TryComp<MapComponent>(transform.ParentUid, out _))
-            transform = EnsureComp<TransformComponent>(transform.ParentUid);
+        // Turns out this just works?? Thought it would just convert to the same entitycoords but fuckin apparently not
+        var coords =
+            _xformSys.ToCoordinates(
+                _xformSys.ToMapCoordinates(EnsureComp<TransformComponent>(args.Target.Value).Coordinates));
 
-        victimComponent.Position ??= transform.Coordinates;
+        victimComponent.Position ??= coords;
     }
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
A bug was discovered regarding the abductor gizmo.
If you were strapped into something, in a crate, or otherwise parented to another entity, using the gizmo on you would save your CURRENT `EntityCoordinates`, which includes the fact that it is parented to another entity. When being sent back then, you would be set to those coordinates, still parented to the entity but not in whatever state prevented you from moving. This allowed for jank such as: moving the parent entity to move you, pulling it yourself for superspeed, ability to walk in zero gravity, etc.
This PR fixes the bug by climbing up the parent tree until finding a grid or a map, then using the child's coordinates. In practice, if a chair is on a grid, it will climb up and find the grid, then set you to the chair's coords instead of your coords, that way you teleport to the chair, parented to the grid instead of the chair.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Fixed a bug where using an abductor gizmo on someone who was parented to another entity (such as being buckled) would result in erroneous behavior upon teleporting them back from the abductor shuttle.