### PR TITLE
round restart firing pin - hot fix p0

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -123,7 +123,6 @@
     #HOSWeaponStealObjective: 1                # HoS Gun variants, Traitor target, not thief
     FiringPinStealObjective: 1
     FiringPinAdvancedLaserStealObjective: 1
-    FiringPinSmartLMGStealObjective: 1
     LogProbeCartridgeStealObjective: 1 # Detective
     MedTekCartridgeStealObjective: 1 # CMO, yet again
     SecurityTechFabCircuitboardStealObjective: 1 # sec

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pins/pins.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pins/pins.yml
@@ -59,8 +59,6 @@
   - type: FiringPin
     pinType: SmartLMG
   - type: FiringPinShotCounter
-  - type: StealTarget
-    stealGroup: FiringPinSmartLMG
 
 - type: entity
   parent: FiringPin

--- a/Resources/Prototypes/_Starlight/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/_Starlight/Objectives/stealTargetGroups.yml
@@ -221,13 +221,6 @@
     state: adv-laser
 
 - type: stealTargetGroup
-  id: FiringPinSmartLMG
-  name: steal-target-groups-firing-pin-smart-lmg
-  sprite:
-    sprite: _Starlight/Objects/Weapons/Guns/Pins/firing_pins.rsi
-    state: lmg
-
-- type: stealTargetGroup
   id: LogProbeCartridge
   name: steal-target-groups-log-probe-cartridge
   sprite:

--- a/Resources/Prototypes/_Starlight/Objectives/thief.yml
+++ b/Resources/Prototypes/_Starlight/Objectives/thief.yml
@@ -78,15 +78,6 @@
     difficulty: 1
 
 - type: entity
-  parent: BaseThiefStealObjective
-  id: FiringPinSmartLMGStealObjective
-  components:
-    - type: StealCondition
-      stealGroup: FiringPinSmartLMG
-    - type: Objective
-      difficulty: 1
-
-- type: entity
   parent: [BaseThiefStealObjective, BaseThiefSecurityStealObjective]
   id: LogProbeCartridgeStealObjective
   components:


### PR DESCRIPTION
## Short description
[PR to remove smart lmg firing pin objective](https://github.com/ss14Starlight/space-station-14/pull/3606) removed only 1 of the 6 things it needed to, resulting it the round restarting every time thief rolled.

## Why we need to add this
P0 hotfix stop round restart loop

## Media (Video/Screenshots)
no

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: un-fucks the theif gamemode so it doesnt crash the round every time thief rolls.

