### PR TITLE
(Lobster) Cryogenic sleep unit in GenPop + Performers

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Lobster.yml
+++ b/Resources/Maps/_Starlight/Stations/Lobster.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/06/2026 21:18:01
-  entityCount: 24898
+  time: 03/10/2026 03:58:38
+  entityCount: 24905
 maps:
 - 1
 grids:
@@ -9409,7 +9409,7 @@ entities:
       pos: -1.5,5.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -26623.586
+      secondsUntilStateChange: -26964.393
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9642,7 +9642,7 @@ entities:
       pos: 67.5,48.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -63443.918
+      secondsUntilStateChange: -63784.723
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10104,7 +10104,7 @@ entities:
       pos: 87.5,-23.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -114584.11
+      secondsUntilStateChange: -114924.914
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -69718,6 +69718,13 @@ entities:
     - type: Transform
       pos: -56.43009,32.4647
       parent: 2
+- proto: CryogenicSleepUnit
+  entities:
+  - uid: 24900
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 2
 - proto: CryogenicSleepUnitSpawner
   entities:
   - uid: 11484
@@ -109036,6 +109043,21 @@ entities:
     - type: Transform
       pos: 37.5,6.5
       parent: 2
+- proto: LockerBlueshieldFilled
+  entities:
+  - uid: 17439
+    components:
+    - type: Transform
+      pos: -26.5,47.5
+      parent: 2
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: LockerBoozeFilled
   entities:
   - uid: 17432
@@ -109077,21 +109099,6 @@ entities:
     - type: Transform
       pos: 11.5,4.5
       parent: 2
-- proto: LockerBSOFilled
-  entities:
-  - uid: 17439
-    components:
-    - type: Transform
-      pos: -26.5,47.5
-      parent: 2
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-          Oxygen: 1.7459903
-          Nitrogen: 6.568249
 - proto: LockerCaptain
   entities:
   - uid: 17440
@@ -128869,6 +128876,38 @@ entities:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
+- proto: SpawnPointPerformer
+  entities:
+  - uid: 24899
+    components:
+    - type: Transform
+      pos: 10.5,45.5
+      parent: 2
+  - uid: 24901
+    components:
+    - type: Transform
+      pos: 23.5,-2.5
+      parent: 2
+  - uid: 24902
+    components:
+    - type: Transform
+      pos: 39.5,2.5
+      parent: 2
+  - uid: 24903
+    components:
+    - type: Transform
+      pos: 47.5,-31.5
+      parent: 2
+  - uid: 24904
+    components:
+    - type: Transform
+      pos: 22.5,-1.5
+      parent: 2
+  - uid: 24905
+    components:
+    - type: Transform
+      pos: 24.5,-1.5
+      parent: 2
 - proto: SpawnPointPsychologist
   entities:
   - uid: 20620
@@ -130385,14 +130424,14 @@ entities:
       parent: 2
 - proto: SuitStorageEVAEmergency
   entities:
-  - uid: 20853
+  - uid: 20852
     components:
     - type: Transform
       pos: -39.5,-13.5
       parent: 2
 - proto: SuitStorageHOS
   entities:
-  - uid: 20852
+  - uid: 20853
     components:
     - type: Transform
       pos: -1.5,-13.5
@@ -151004,7 +151043,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -3135.9617
+      secondsUntilStateChange: -3476.7678
       state: Opening
     - type: Airlock
       autoClose: False

--- a/Resources/Maps/_Starlight/Stations/Lobster.yml
+++ b/Resources/Maps/_Starlight/Stations/Lobster.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/10/2026 03:58:38
-  entityCount: 24905
+  time: 03/10/2026 04:05:33
+  entityCount: 24906
 maps:
 - 1
 grids:
@@ -9409,7 +9409,7 @@ entities:
       pos: -1.5,5.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -26964.393
+      secondsUntilStateChange: -27378.443
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9642,7 +9642,7 @@ entities:
       pos: 67.5,48.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -63784.723
+      secondsUntilStateChange: -64198.773
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10104,7 +10104,7 @@ entities:
       pos: 87.5,-23.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -114924.914
+      secondsUntilStateChange: -115338.97
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -69488,6 +69488,11 @@ entities:
     - type: Transform
       pos: -52.5,-18.5
       parent: 2
+  - uid: 20225
+    components:
+    - type: Transform
+      pos: -44.5,-5.5
+      parent: 2
 - proto: CrateNPCDuck
   entities:
   - uid: 11459
@@ -69720,7 +69725,7 @@ entities:
       parent: 2
 - proto: CryogenicSleepUnit
   entities:
-  - uid: 24900
+  - uid: 24899
     components:
     - type: Transform
       pos: 3.5,-5.5
@@ -109445,15 +109450,15 @@ entities:
     - type: Transform
       pos: -38.5,1.5
       parent: 2
-  - uid: 17475
-    components:
-    - type: Transform
-      pos: -38.5,-3.5
-      parent: 2
   - uid: 17476
     components:
     - type: Transform
       pos: -43.5,-5.5
+      parent: 2
+  - uid: 24905
+    components:
+    - type: Transform
+      pos: -38.5,-2.5
       parent: 2
 - proto: LockerMime
   entities:
@@ -112324,10 +112329,10 @@ entities:
       pos: 65.5,47.5
       parent: 2
     - type: StationAiCore
-      lawConsole: 20736
+      lawConsole: 20735
     - type: DeviceLinkSource
       linkedPorts:
-        20736:
+        20735:
         - - AiLawConsoleSender
           - AiLawConsoleReceiver
 - proto: Plunger
@@ -114232,976 +114237,970 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -38.5,-3.5
+      pos: -29.5,-3.5
       parent: 2
   - uid: 18156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -29.5,-3.5
+      pos: -35.5,-3.5
       parent: 2
   - uid: 18157
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,-3.5
-      parent: 2
-  - uid: 18158
-    components:
-    - type: Transform
       pos: -44.5,1.5
       parent: 2
-  - uid: 18159
+  - uid: 18158
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -51.5,-1.5
       parent: 2
-  - uid: 18160
+  - uid: 18159
     components:
     - type: Transform
       pos: -48.5,1.5
       parent: 2
-  - uid: 18161
+  - uid: 18160
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,-11.5
       parent: 2
-  - uid: 18162
+  - uid: 18161
     components:
     - type: Transform
       pos: -57.5,1.5
       parent: 2
-  - uid: 18163
+  - uid: 18162
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -53.5,3.5
       parent: 2
-  - uid: 18164
+  - uid: 18163
     components:
     - type: Transform
       pos: -57.5,5.5
       parent: 2
-  - uid: 18165
+  - uid: 18164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,-11.5
       parent: 2
-  - uid: 18166
+  - uid: 18165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -47.5,3.5
       parent: 2
-  - uid: 18167
+  - uid: 18166
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,6.5
       parent: 2
-  - uid: 18168
+  - uid: 18167
     components:
     - type: Transform
       pos: -52.5,21.5
       parent: 2
-  - uid: 18169
+  - uid: 18168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -52.5,15.5
       parent: 2
-  - uid: 18170
+  - uid: 18169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,14.5
       parent: 2
-  - uid: 18171
+  - uid: 18170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,22.5
       parent: 2
-  - uid: 18172
+  - uid: 18171
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -62.5,14.5
       parent: 2
-  - uid: 18173
+  - uid: 18172
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -62.5,22.5
       parent: 2
-  - uid: 18174
+  - uid: 18173
     components:
     - type: Transform
       pos: -65.5,24.5
       parent: 2
-  - uid: 18175
+  - uid: 18174
     components:
     - type: Transform
       pos: -65.5,18.5
       parent: 2
-  - uid: 18176
+  - uid: 18175
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -65.5,20.5
       parent: 2
-  - uid: 18177
+  - uid: 18176
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -68.5,26.5
       parent: 2
-  - uid: 18178
+  - uid: 18177
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -51.5,26.5
       parent: 2
-  - uid: 18179
+  - uid: 18178
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -55.5,26.5
       parent: 2
-  - uid: 18180
+  - uid: 18179
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -65.5,26.5
       parent: 2
-  - uid: 18181
+  - uid: 18180
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,31.5
       parent: 2
-  - uid: 18182
+  - uid: 18181
     components:
     - type: Transform
       pos: -65.5,33.5
       parent: 2
-  - uid: 18183
+  - uid: 18182
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -61.5,45.5
       parent: 2
-  - uid: 18184
+  - uid: 18183
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,37.5
       parent: 2
-  - uid: 18185
+  - uid: 18184
     components:
     - type: Transform
       pos: -45.5,39.5
       parent: 2
-  - uid: 18186
+  - uid: 18185
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -49.5,34.5
       parent: 2
-  - uid: 18187
+  - uid: 18186
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,34.5
       parent: 2
-  - uid: 18188
+  - uid: 18187
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -64.5,39.5
       parent: 2
-  - uid: 18189
+  - uid: 18188
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -57.5,35.5
       parent: 2
-  - uid: 18190
+  - uid: 18189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -47.5,42.5
       parent: 2
-  - uid: 18191
+  - uid: 18190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,32.5
       parent: 2
-  - uid: 18192
+  - uid: 18191
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -48.5,26.5
       parent: 2
-  - uid: 18193
+  - uid: 18192
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -48.5,31.5
       parent: 2
-  - uid: 18194
+  - uid: 18193
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,25.5
       parent: 2
-  - uid: 18195
+  - uid: 18194
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,27.5
       parent: 2
-  - uid: 18196
+  - uid: 18195
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,32.5
       parent: 2
-  - uid: 18197
+  - uid: 18196
     components:
     - type: Transform
       pos: 9.5,22.5
       parent: 2
-  - uid: 18198
+  - uid: 18197
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,24.5
       parent: 2
-  - uid: 18199
+  - uid: 18198
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,18.5
       parent: 2
-  - uid: 18200
+  - uid: 18199
     components:
     - type: Transform
       pos: 13.5,31.5
       parent: 2
-  - uid: 18201
+  - uid: 18200
     components:
     - type: Transform
       pos: 21.5,39.5
       parent: 2
-  - uid: 18202
+  - uid: 18201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,20.5
       parent: 2
-  - uid: 18203
+  - uid: 18202
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,17.5
       parent: 2
-  - uid: 18204
+  - uid: 18203
     components:
     - type: Transform
       pos: 22.5,22.5
       parent: 2
-  - uid: 18205
+  - uid: 18204
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,26.5
       parent: 2
-  - uid: 18206
+  - uid: 18205
     components:
     - type: Transform
       pos: 24.5,26.5
       parent: 2
-  - uid: 18207
+  - uid: 18206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,35.5
       parent: 2
-  - uid: 18208
+  - uid: 18207
     components:
     - type: Transform
       pos: 18.5,36.5
       parent: 2
-  - uid: 18209
+  - uid: 18208
     components:
     - type: Transform
       pos: 24.5,36.5
       parent: 2
-  - uid: 18210
+  - uid: 18209
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,28.5
       parent: 2
-  - uid: 18211
+  - uid: 18210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,33.5
       parent: 2
-  - uid: 18212
+  - uid: 18211
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,31.5
       parent: 2
-  - uid: 18213
+  - uid: 18212
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,28.5
       parent: 2
-  - uid: 18214
+  - uid: 18213
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,36.5
       parent: 2
-  - uid: 18215
+  - uid: 18214
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-32.5
       parent: 2
-  - uid: 18216
+  - uid: 18215
     components:
     - type: Transform
       pos: 9.5,-25.5
       parent: 2
-  - uid: 18217
+  - uid: 18216
     components:
     - type: Transform
       pos: 15.5,-25.5
       parent: 2
-  - uid: 18218
+  - uid: 18217
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,37.5
       parent: 2
-  - uid: 18219
+  - uid: 18218
     components:
     - type: Transform
       pos: 3.5,-39.5
       parent: 2
-  - uid: 18220
+  - uid: 18219
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-40.5
       parent: 2
-  - uid: 18221
+  - uid: 18220
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-40.5
       parent: 2
-  - uid: 18222
+  - uid: 18221
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-40.5
       parent: 2
-  - uid: 18223
+  - uid: 18222
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-37.5
       parent: 2
-  - uid: 18224
+  - uid: 18223
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-32.5
       parent: 2
-  - uid: 18225
+  - uid: 18224
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-28.5
       parent: 2
-  - uid: 18226
+  - uid: 18225
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-32.5
       parent: 2
-  - uid: 18227
+  - uid: 18226
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-3.5
       parent: 2
-  - uid: 18228
+  - uid: 18227
     components:
     - type: Transform
       pos: 21.5,0.5
       parent: 2
-  - uid: 18229
+  - uid: 18228
     components:
     - type: Transform
       pos: 25.5,0.5
       parent: 2
-  - uid: 18230
+  - uid: 18229
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,-3.5
       parent: 2
-  - uid: 18231
+  - uid: 18230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,5.5
       parent: 2
-  - uid: 18232
+  - uid: 18231
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,5.5
       parent: 2
-  - uid: 18233
+  - uid: 18232
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-33.5
       parent: 2
-  - uid: 18234
+  - uid: 18233
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-24.5
       parent: 2
-  - uid: 18235
+  - uid: 18234
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-14.5
       parent: 2
-  - uid: 18236
+  - uid: 18235
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-14.5
       parent: 2
-  - uid: 18237
+  - uid: 18236
     components:
     - type: Transform
       pos: 33.5,5.5
       parent: 2
-  - uid: 18238
+  - uid: 18237
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,4.5
       parent: 2
-  - uid: 18239
+  - uid: 18238
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,-26.5
       parent: 2
-  - uid: 18240
+  - uid: 18239
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,-23.5
       parent: 2
-  - uid: 18241
+  - uid: 18240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-19.5
       parent: 2
-  - uid: 18242
+  - uid: 18241
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-30.5
       parent: 2
-  - uid: 18243
+  - uid: 18242
     components:
     - type: Transform
       pos: 41.5,-24.5
       parent: 2
-  - uid: 18244
+  - uid: 18243
     components:
     - type: Transform
       pos: -33.5,1.5
       parent: 2
-  - uid: 18245
+  - uid: 18244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 47.5,3.5
       parent: 2
-  - uid: 18246
+  - uid: 18245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,-1.5
       parent: 2
-  - uid: 18247
+  - uid: 18246
     components:
     - type: Transform
       pos: 49.5,-8.5
       parent: 2
-  - uid: 18248
+  - uid: 18247
     components:
     - type: Transform
       pos: 41.5,-8.5
       parent: 2
-  - uid: 18249
+  - uid: 18248
     components:
     - type: Transform
       pos: 51.5,-16.5
       parent: 2
-  - uid: 18250
+  - uid: 18249
     components:
     - type: Transform
       pos: 49.5,-14.5
       parent: 2
-  - uid: 18251
+  - uid: 18250
     components:
     - type: Transform
       pos: 43.5,-14.5
       parent: 2
-  - uid: 18252
+  - uid: 18251
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-21.5
       parent: 2
-  - uid: 18253
+  - uid: 18252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 54.5,-21.5
       parent: 2
-  - uid: 18254
+  - uid: 18253
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 49.5,-30.5
       parent: 2
-  - uid: 18255
+  - uid: 18254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 52.5,-30.5
       parent: 2
-  - uid: 18256
+  - uid: 18255
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 57.5,3.5
       parent: 2
-  - uid: 18257
+  - uid: 18256
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 65.5,-4.5
       parent: 2
-  - uid: 18258
+  - uid: 18257
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-6.5
       parent: 2
-  - uid: 18259
+  - uid: 18258
     components:
     - type: Transform
       pos: 54.5,2.5
       parent: 2
-  - uid: 18260
+  - uid: 18259
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 58.5,-1.5
       parent: 2
-  - uid: 18261
+  - uid: 18260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-22.5
       parent: 2
-  - uid: 18262
+  - uid: 18261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-18.5
       parent: 2
-  - uid: 18263
+  - uid: 18262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-26.5
       parent: 2
-  - uid: 18264
+  - uid: 18263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-14.5
       parent: 2
-  - uid: 18265
+  - uid: 18264
     components:
     - type: Transform
       pos: 74.5,-22.5
       parent: 2
-  - uid: 18266
+  - uid: 18265
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 76.5,-28.5
       parent: 2
-  - uid: 18267
+  - uid: 18266
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 80.5,-8.5
       parent: 2
-  - uid: 18268
+  - uid: 18267
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 80.5,-10.5
       parent: 2
-  - uid: 18269
+  - uid: 18268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 77.5,-23.5
       parent: 2
-  - uid: 18270
+  - uid: 18269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,27.5
       parent: 2
-  - uid: 18271
+  - uid: 18270
     components:
     - type: Transform
       pos: 41.5,13.5
       parent: 2
-  - uid: 18272
+  - uid: 18271
     components:
     - type: Transform
       pos: 52.5,13.5
       parent: 2
-  - uid: 18273
+  - uid: 18272
     components:
     - type: Transform
       pos: 46.5,13.5
       parent: 2
-  - uid: 18274
+  - uid: 18273
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 41.5,6.5
       parent: 2
-  - uid: 18275
+  - uid: 18274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 50.5,5.5
       parent: 2
-  - uid: 18276
+  - uid: 18275
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,19.5
       parent: 2
-  - uid: 18277
+  - uid: 18276
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,18.5
       parent: 2
-  - uid: 18278
+  - uid: 18277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,13.5
       parent: 2
-  - uid: 18279
+  - uid: 18278
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,14.5
       parent: 2
-  - uid: 18280
+  - uid: 18279
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,19.5
       parent: 2
-  - uid: 18281
+  - uid: 18280
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,26.5
       parent: 2
-  - uid: 18282
+  - uid: 18281
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,27.5
       parent: 2
-  - uid: 18283
+  - uid: 18282
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 39.5,20.5
       parent: 2
-  - uid: 18284
+  - uid: 18283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 44.5,20.5
       parent: 2
-  - uid: 18285
+  - uid: 18284
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 48.5,24.5
       parent: 2
-  - uid: 18286
+  - uid: 18285
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 57.5,23.5
       parent: 2
-  - uid: 18287
+  - uid: 18286
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 54.5,21.5
       parent: 2
-  - uid: 18288
+  - uid: 18287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 50.5,20.5
       parent: 2
-  - uid: 18289
+  - uid: 18288
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 53.5,26.5
       parent: 2
-  - uid: 18290
+  - uid: 18289
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,26.5
       parent: 2
-  - uid: 18291
+  - uid: 18290
     components:
     - type: Transform
       pos: 49.5,33.5
       parent: 2
-  - uid: 18292
+  - uid: 18291
     components:
     - type: Transform
       pos: 35.5,32.5
       parent: 2
-  - uid: 18293
+  - uid: 18292
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 74.5,13.5
       parent: 2
-  - uid: 18294
+  - uid: 18293
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 74.5,23.5
       parent: 2
-  - uid: 18295
+  - uid: 18294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,51.5
       parent: 2
-  - uid: 18296
+  - uid: 18295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,17.5
       parent: 2
-  - uid: 18297
+  - uid: 18296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,7.5
       parent: 2
-  - uid: 18298
+  - uid: 18297
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,6.5
       parent: 2
-  - uid: 18299
+  - uid: 18298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,43.5
       parent: 2
-  - uid: 18300
+  - uid: 18299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,43.5
       parent: 2
-  - uid: 18301
+  - uid: 18300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,51.5
       parent: 2
-  - uid: 18302
+  - uid: 18301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-37.5
       parent: 2
-  - uid: 18303
+  - uid: 18302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-37.5
       parent: 2
-  - uid: 18304
+  - uid: 18303
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,2.5
       parent: 2
-  - uid: 18305
+  - uid: 18304
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 66.5,-41.5
       parent: 2
-  - uid: 18306
+  - uid: 18305
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 52.5,-50.5
       parent: 2
-  - uid: 18307
+  - uid: 18306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,-50.5
       parent: 2
-  - uid: 18308
+  - uid: 18307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 66.5,-50.5
       parent: 2
-  - uid: 18309
+  - uid: 18308
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,-50.5
       parent: 2
-  - uid: 18310
+  - uid: 18309
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 49.5,-41.5
       parent: 2
-  - uid: 18311
+  - uid: 18310
     components:
     - type: Transform
       pos: 41.5,-36.5
       parent: 2
-  - uid: 18312
+  - uid: 18311
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 51.5,-41.5
       parent: 2
-  - uid: 18313
+  - uid: 18312
     components:
     - type: Transform
       pos: 57.5,-36.5
       parent: 2
-  - uid: 18314
+  - uid: 18313
     components:
     - type: Transform
       pos: 61.5,-36.5
       parent: 2
-  - uid: 18315
+  - uid: 18314
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,-3.5
       parent: 2
-  - uid: 18316
+  - uid: 18315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,31.5
       parent: 2
-  - uid: 18317
+  - uid: 18316
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,8.5
       parent: 2
-  - uid: 18318
+  - uid: 18317
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-2.5
       parent: 2
-  - uid: 18319
+  - uid: 18318
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 2
-  - uid: 18320
+  - uid: 18319
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,3.5
       parent: 2
-  - uid: 18321
+  - uid: 18320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-11.5
       parent: 2
-  - uid: 18322
+  - uid: 18321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,6.5
       parent: 2
-  - uid: 18323
+  - uid: 18322
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 2
-  - uid: 18324
+  - uid: 18323
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -115209,13 +115208,13 @@ entities:
       parent: 2
 - proto: PoweredlightBlue
   entities:
-  - uid: 18325
+  - uid: 18324
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 64.5,39.5
       parent: 2
-  - uid: 18326
+  - uid: 18325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -115223,67 +115222,67 @@ entities:
       parent: 2
 - proto: PoweredlightExterior
   entities:
-  - uid: 18327
+  - uid: 18326
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 79.5,14.5
       parent: 2
-  - uid: 18328
+  - uid: 18327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 79.5,21.5
       parent: 2
-  - uid: 18329
+  - uid: 18328
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 92.5,21.5
       parent: 2
-  - uid: 18330
+  - uid: 18329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 92.5,14.5
       parent: 2
-  - uid: 18331
+  - uid: 18330
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,0.5
       parent: 2
-  - uid: 18332
+  - uid: 18331
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -67.5,-3.5
       parent: 2
-  - uid: 18333
+  - uid: 18332
     components:
     - type: Transform
       pos: -39.5,-24.5
       parent: 2
-  - uid: 18334
+  - uid: 18333
     components:
     - type: Transform
       pos: -35.5,-24.5
       parent: 2
 - proto: PoweredlightLED
   entities:
-  - uid: 18335
+  - uid: 18334
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,19.5
       parent: 2
-  - uid: 18336
+  - uid: 18335
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -69.5,44.5
       parent: 2
-  - uid: 18337
+  - uid: 18336
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -115291,7 +115290,7 @@ entities:
       parent: 2
 - proto: PoweredlightPink
   entities:
-  - uid: 18338
+  - uid: 18337
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -115299,59 +115298,59 @@ entities:
       parent: 2
 - proto: PoweredLightPostSmall
   entities:
-  - uid: 18339
+  - uid: 18338
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,12.5
       parent: 2
-  - uid: 18340
+  - uid: 18339
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,12.5
       parent: 2
-  - uid: 18341
+  - uid: 18340
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -47.5,12.5
       parent: 2
-  - uid: 18342
+  - uid: 18341
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,22.5
       parent: 2
-  - uid: 18343
+  - uid: 18342
     components:
     - type: Transform
       pos: -13.5,19.5
       parent: 2
-  - uid: 18344
+  - uid: 18343
     components:
     - type: Transform
       pos: 71.5,-10.5
       parent: 2
 - proto: PoweredlightRed
   entities:
-  - uid: 18345
+  - uid: 18344
     components:
     - type: Transform
       pos: 68.5,47.5
       parent: 2
-  - uid: 18346
+  - uid: 18345
     components:
     - type: Transform
       pos: 62.5,47.5
       parent: 2
-  - uid: 18347
+  - uid: 18346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 61.5,43.5
       parent: 2
-  - uid: 18348
+  - uid: 18347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -115359,30 +115358,30 @@ entities:
       parent: 2
 - proto: PoweredlightSodium
   entities:
-  - uid: 18349
+  - uid: 18348
     components:
     - type: Transform
       pos: 43.5,-2.5
       parent: 2
-  - uid: 18350
+  - uid: 18349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-1.5
       parent: 2
-  - uid: 18351
+  - uid: 18350
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,-34.5
       parent: 2
-  - uid: 18352
+  - uid: 18351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 68.5,-29.5
       parent: 2
-  - uid: 18353
+  - uid: 18352
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -115390,960 +115389,960 @@ entities:
       parent: 2
 - proto: PoweredSmallLight
   entities:
-  - uid: 18354
+  - uid: 18353
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-  - uid: 18355
+  - uid: 18354
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-5.5
       parent: 2
-  - uid: 18356
+  - uid: 18355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,10.5
       parent: 2
-  - uid: 18357
+  - uid: 18356
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,12.5
       parent: 2
-  - uid: 18358
+  - uid: 18357
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 18359
+  - uid: 18358
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,12.5
       parent: 2
-  - uid: 18360
+  - uid: 18359
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,-5.5
       parent: 2
-  - uid: 18361
+  - uid: 18360
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-5.5
       parent: 2
-  - uid: 18362
+  - uid: 18361
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,-5.5
       parent: 2
-  - uid: 18363
+  - uid: 18362
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,-5.5
       parent: 2
-  - uid: 18364
+  - uid: 18363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,37.5
       parent: 2
-  - uid: 18365
+  - uid: 18364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-41.5
       parent: 2
-  - uid: 18366
+  - uid: 18365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-39.5
       parent: 2
-  - uid: 18367
+  - uid: 18366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-37.5
       parent: 2
-  - uid: 18368
+  - uid: 18367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-35.5
       parent: 2
-  - uid: 18369
+  - uid: 18368
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-36.5
       parent: 2
-  - uid: 18370
+  - uid: 18369
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-40.5
       parent: 2
-  - uid: 18371
+  - uid: 18370
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,-19.5
       parent: 2
-  - uid: 18372
+  - uid: 18371
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 43.5,-30.5
       parent: 2
-  - uid: 18373
+  - uid: 18372
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 83.5,-7.5
       parent: 2
-  - uid: 18374
+  - uid: 18373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 83.5,-11.5
       parent: 2
-  - uid: 18375
+  - uid: 18374
     components:
     - type: Transform
       pos: 15.5,-16.5
       parent: 2
-  - uid: 18376
+  - uid: 18375
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-19.5
       parent: 2
-  - uid: 18377
+  - uid: 18376
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,20.5
       parent: 2
-  - uid: 18378
+  - uid: 18377
     components:
     - type: Transform
       pos: 5.5,23.5
       parent: 2
-  - uid: 18379
+  - uid: 18378
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,-6.5
       parent: 2
-  - uid: 18380
+  - uid: 18379
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-11.5
       parent: 2
-  - uid: 18381
+  - uid: 18380
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,-35.5
       parent: 2
-  - uid: 18382
+  - uid: 18381
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,-35.5
       parent: 2
-  - uid: 18383
+  - uid: 18382
     components:
     - type: Transform
       pos: 27.5,-36.5
       parent: 2
-  - uid: 18384
+  - uid: 18383
     components:
     - type: Transform
       pos: 18.5,-35.5
       parent: 2
-  - uid: 18385
+  - uid: 18384
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-36.5
       parent: 2
-  - uid: 18386
+  - uid: 18385
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-9.5
       parent: 2
-  - uid: 18387
+  - uid: 18386
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 2
-  - uid: 18388
+  - uid: 18387
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-16.5
       parent: 2
-  - uid: 18389
+  - uid: 18388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,-16.5
       parent: 2
-  - uid: 18390
+  - uid: 18389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,15.5
       parent: 2
-  - uid: 18391
+  - uid: 18390
     components:
     - type: Transform
       pos: 75.5,21.5
       parent: 2
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 18392
+  - uid: 18391
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 53.5,5.5
       parent: 2
-  - uid: 18393
+  - uid: 18392
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,5.5
       parent: 2
-  - uid: 18394
+  - uid: 18393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,48.5
       parent: 2
-  - uid: 18395
+  - uid: 18394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,40.5
       parent: 2
-  - uid: 18396
+  - uid: 18395
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,47.5
       parent: 2
-  - uid: 18397
+  - uid: 18396
     components:
     - type: Transform
       pos: -50.5,10.5
       parent: 2
-  - uid: 18398
+  - uid: 18397
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,12.5
       parent: 2
-  - uid: 18399
+  - uid: 18398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,12.5
       parent: 2
-  - uid: 18400
+  - uid: 18399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,7.5
       parent: 2
-  - uid: 18401
+  - uid: 18400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,7.5
       parent: 2
-  - uid: 18402
+  - uid: 18401
     components:
     - type: Transform
       pos: -45.5,10.5
       parent: 2
-  - uid: 18403
+  - uid: 18402
     components:
     - type: Transform
       pos: -55.5,32.5
       parent: 2
-  - uid: 18404
+  - uid: 18403
     components:
     - type: Transform
       pos: -51.5,32.5
       parent: 2
-  - uid: 18405
+  - uid: 18404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,26.5
       parent: 2
-  - uid: 18406
+  - uid: 18405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -63.5,26.5
       parent: 2
-  - uid: 18407
+  - uid: 18406
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -54.5,40.5
       parent: 2
-  - uid: 18408
+  - uid: 18407
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -52.5,40.5
       parent: 2
-  - uid: 18409
+  - uid: 18408
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -19.5,36.5
       parent: 2
-  - uid: 18410
+  - uid: 18409
     components:
     - type: Transform
       pos: 33.5,-8.5
       parent: 2
-  - uid: 18411
+  - uid: 18410
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-0.5
       parent: 2
-  - uid: 18412
+  - uid: 18411
     components:
     - type: Transform
       pos: 78.5,-13.5
       parent: 2
-  - uid: 18413
+  - uid: 18412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,17.5
       parent: 2
-  - uid: 18414
+  - uid: 18413
     components:
     - type: Transform
       pos: 21.5,-9.5
       parent: 2
-  - uid: 18415
+  - uid: 18414
     components:
     - type: Transform
       pos: 25.5,-9.5
       parent: 2
-  - uid: 18416
+  - uid: 18415
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,-14.5
       parent: 2
-  - uid: 18417
+  - uid: 18416
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-6.5
       parent: 2
-  - uid: 18418
+  - uid: 18417
     components:
     - type: Transform
       pos: 33.5,-2.5
       parent: 2
-  - uid: 18419
+  - uid: 18418
     components:
     - type: Transform
       pos: 37.5,4.5
       parent: 2
-  - uid: 18420
+  - uid: 18419
     components:
     - type: Transform
       pos: 41.5,4.5
       parent: 2
-  - uid: 18421
+  - uid: 18420
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,2.5
       parent: 2
-  - uid: 18422
+  - uid: 18421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,2.5
       parent: 2
-  - uid: 18423
+  - uid: 18422
     components:
     - type: Transform
       pos: 39.5,-16.5
       parent: 2
-  - uid: 18424
+  - uid: 18423
     components:
     - type: Transform
       pos: 40.5,-20.5
       parent: 2
-  - uid: 18425
+  - uid: 18424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 40.5,-29.5
       parent: 2
-  - uid: 18426
+  - uid: 18425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 39.5,-33.5
       parent: 2
-  - uid: 18427
+  - uid: 18426
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-7.5
       parent: 2
-  - uid: 18428
+  - uid: 18427
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-9.5
       parent: 2
-  - uid: 18429
+  - uid: 18428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-11.5
       parent: 2
-  - uid: 18430
+  - uid: 18429
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,28.5
       parent: 2
-  - uid: 18431
+  - uid: 18430
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,18.5
       parent: 2
-  - uid: 18432
+  - uid: 18431
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 67.5,17.5
       parent: 2
-  - uid: 18433
+  - uid: 18432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 63.5,17.5
       parent: 2
-  - uid: 18434
+  - uid: 18433
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,22.5
       parent: 2
-  - uid: 18435
+  - uid: 18434
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,22.5
       parent: 2
-  - uid: 18436
+  - uid: 18435
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,28.5
       parent: 2
-  - uid: 18437
+  - uid: 18436
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,34.5
       parent: 2
-  - uid: 18438
+  - uid: 18437
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,34.5
       parent: 2
-  - uid: 18439
+  - uid: 18438
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 53.5,16.5
       parent: 2
-  - uid: 18440
+  - uid: 18439
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 54.5,32.5
       parent: 2
-  - uid: 18441
+  - uid: 18440
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 56.5,32.5
       parent: 2
-  - uid: 18442
+  - uid: 18441
     components:
     - type: Transform
       pos: 21.5,15.5
       parent: 2
-  - uid: 18443
+  - uid: 18442
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,13.5
       parent: 2
-  - uid: 18444
+  - uid: 18443
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,8.5
       parent: 2
-  - uid: 18445
+  - uid: 18444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-13.5
       parent: 2
-  - uid: 18446
+  - uid: 18445
     components:
     - type: Transform
       pos: 66.5,-8.5
       parent: 2
-  - uid: 18447
+  - uid: 18446
     components:
     - type: Transform
       pos: 57.5,-8.5
       parent: 2
-  - uid: 18448
+  - uid: 18447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-14.5
       parent: 2
-  - uid: 18449
+  - uid: 18448
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 73.5,-17.5
       parent: 2
-  - uid: 18450
+  - uid: 18449
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,-16.5
       parent: 2
-  - uid: 18451
+  - uid: 18450
     components:
     - type: Transform
       pos: 83.5,-13.5
       parent: 2
-  - uid: 18452
+  - uid: 18451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 79.5,-25.5
       parent: 2
-  - uid: 18453
+  - uid: 18452
     components:
     - type: Transform
       pos: -40.5,25.5
       parent: 2
-  - uid: 18454
+  - uid: 18453
     components:
     - type: Transform
       pos: -36.5,25.5
       parent: 2
-  - uid: 18455
+  - uid: 18454
     components:
     - type: Transform
       pos: 49.5,18.5
       parent: 2
-  - uid: 18456
+  - uid: 18455
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 27.5,25.5
       parent: 2
-  - uid: 18457
+  - uid: 18456
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,25.5
       parent: 2
-  - uid: 18458
+  - uid: 18457
     components:
     - type: Transform
       pos: 41.5,18.5
       parent: 2
-  - uid: 18459
+  - uid: 18458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 38.5,16.5
       parent: 2
-  - uid: 18460
+  - uid: 18459
     components:
     - type: Transform
       pos: 14.5,15.5
       parent: 2
-  - uid: 18461
+  - uid: 18460
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,20.5
       parent: 2
-  - uid: 18462
+  - uid: 18461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-16.5
       parent: 2
-  - uid: 18463
+  - uid: 18462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-20.5
       parent: 2
-  - uid: 18464
+  - uid: 18463
     components:
     - type: Transform
       pos: 5.5,-43.5
       parent: 2
-  - uid: 18465
+  - uid: 18464
     components:
     - type: Transform
       pos: 13.5,-43.5
       parent: 2
-  - uid: 18466
+  - uid: 18465
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,-17.5
       parent: 2
-  - uid: 18467
+  - uid: 18466
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,36.5
       parent: 2
-  - uid: 18468
+  - uid: 18467
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -21.5,-16.5
       parent: 2
-  - uid: 18469
+  - uid: 18468
     components:
     - type: Transform
       pos: -31.5,-12.5
       parent: 2
-  - uid: 18470
+  - uid: 18469
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,39.5
       parent: 2
-  - uid: 18471
+  - uid: 18470
     components:
     - type: Transform
       pos: -6.5,41.5
       parent: 2
-  - uid: 18472
+  - uid: 18471
     components:
     - type: Transform
       pos: -9.5,-20.5
       parent: 2
-  - uid: 18473
+  - uid: 18472
     components:
     - type: Transform
       pos: -6.5,-25.5
       parent: 2
-  - uid: 18474
+  - uid: 18473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-29.5
       parent: 2
-  - uid: 18475
+  - uid: 18474
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-29.5
       parent: 2
-  - uid: 18476
+  - uid: 18475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-12.5
       parent: 2
-  - uid: 18477
+  - uid: 18476
     components:
     - type: Transform
       pos: -41.5,38.5
       parent: 2
-  - uid: 18478
+  - uid: 18477
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -52.5,-7.5
       parent: 2
-  - uid: 18479
+  - uid: 18478
     components:
     - type: Transform
       pos: -69.5,11.5
       parent: 2
-  - uid: 18480
+  - uid: 18479
     components:
     - type: Transform
       pos: -67.5,8.5
       parent: 2
-  - uid: 18481
+  - uid: 18480
     components:
     - type: Transform
       pos: -60.5,8.5
       parent: 2
-  - uid: 18482
+  - uid: 18481
     components:
     - type: Transform
       pos: -56.5,11.5
       parent: 2
-  - uid: 18483
+  - uid: 18482
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -56.5,7.5
       parent: 2
-  - uid: 18484
+  - uid: 18483
     components:
     - type: Transform
       pos: -65.5,12.5
       parent: 2
-  - uid: 18485
+  - uid: 18484
     components:
     - type: Transform
       pos: -62.5,12.5
       parent: 2
-  - uid: 18486
+  - uid: 18485
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,19.5
       parent: 2
-  - uid: 18487
+  - uid: 18486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -76.5,-3.5
       parent: 2
-  - uid: 18488
+  - uid: 18487
     components:
     - type: Transform
       pos: -69.5,-3.5
       parent: 2
-  - uid: 18489
+  - uid: 18488
     components:
     - type: Transform
       pos: 27.5,-43.5
       parent: 2
-  - uid: 18490
+  - uid: 18489
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-40.5
       parent: 2
-  - uid: 18491
+  - uid: 18490
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,-41.5
       parent: 2
-  - uid: 18492
+  - uid: 18491
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 68.5,-41.5
       parent: 2
-  - uid: 18493
+  - uid: 18492
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-49.5
       parent: 2
-  - uid: 18494
+  - uid: 18493
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-49.5
       parent: 2
-  - uid: 18495
+  - uid: 18494
     components:
     - type: Transform
       pos: 78.5,-40.5
       parent: 2
-  - uid: 18496
+  - uid: 18495
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 82.5,-41.5
       parent: 2
-  - uid: 18497
+  - uid: 18496
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 79.5,-48.5
       parent: 2
-  - uid: 18498
+  - uid: 18497
     components:
     - type: Transform
       pos: 80.5,-43.5
       parent: 2
-  - uid: 18499
+  - uid: 18498
     components:
     - type: Transform
       pos: 82.5,-38.5
       parent: 2
-  - uid: 18500
+  - uid: 18499
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 85.5,-41.5
       parent: 2
-  - uid: 18501
+  - uid: 18500
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 82.5,-47.5
       parent: 2
-  - uid: 18502
+  - uid: 18501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 70.5,-21.5
       parent: 2
-  - uid: 18503
+  - uid: 18502
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 68.5,-38.5
       parent: 2
-  - uid: 18504
+  - uid: 18503
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-21.5
       parent: 2
-  - uid: 18505
+  - uid: 18504
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-16.5
       parent: 2
-  - uid: 18506
+  - uid: 18505
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-8.5
       parent: 2
-  - uid: 18507
+  - uid: 18506
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,18.5
       parent: 2
-  - uid: 18508
+  - uid: 18507
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,-19.5
       parent: 2
-  - uid: 18509
+  - uid: 18508
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,-20.5
       parent: 2
-  - uid: 18510
+  - uid: 18509
     components:
     - type: Transform
       pos: 40.5,16.5
       parent: 2
-  - uid: 18511
+  - uid: 18510
     components:
     - type: Transform
       pos: 42.5,16.5
       parent: 2
-  - uid: 18512
+  - uid: 18511
     components:
     - type: Transform
       pos: 45.5,16.5
       parent: 2
-  - uid: 18513
+  - uid: 18512
     components:
     - type: Transform
       pos: 48.5,16.5
       parent: 2
-  - uid: 18514
+  - uid: 18513
     components:
     - type: Transform
       pos: 51.5,16.5
       parent: 2
-  - uid: 18515
+  - uid: 18514
     components:
     - type: Transform
       pos: 57.5,16.5
       parent: 2
-  - uid: 18516
+  - uid: 18515
     components:
     - type: Transform
       pos: 32.5,1.5
       parent: 2
-  - uid: 18517
+  - uid: 18516
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,27.5
       parent: 2
-  - uid: 18518
+  - uid: 18517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,17.5
       parent: 2
-  - uid: 18519
+  - uid: 18518
     components:
     - type: Transform
       pos: -18.5,33.5
       parent: 2
-  - uid: 18520
+  - uid: 18519
     components:
     - type: Transform
       pos: -9.5,33.5
       parent: 2
-  - uid: 18521
+  - uid: 18520
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,24.5
       parent: 2
-  - uid: 18522
+  - uid: 18521
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -116351,7 +116350,7 @@ entities:
       parent: 2
 - proto: PrinterDoc
   entities:
-  - uid: 18523
+  - uid: 18522
     components:
     - type: Transform
       pos: -24.5,18.5
@@ -116363,7 +116362,7 @@ entities:
       - Experimental
       - CivilianServices
       - Biochemical
-  - uid: 18524
+  - uid: 18523
     components:
     - type: Transform
       pos: 9.5,-19.5
@@ -116375,74 +116374,74 @@ entities:
       - Experimental
       - CivilianServices
       - Biochemical
-  - uid: 18525
+  - uid: 18524
     components:
     - type: Transform
       pos: -5.5,33.5
       parent: 2
-  - uid: 18526
+  - uid: 18525
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,35.5
       parent: 2
-  - uid: 18527
+  - uid: 18526
     components:
     - type: Transform
       pos: -23.5,51.5
       parent: 2
-  - uid: 18528
+  - uid: 18527
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -18.5,7.5
       parent: 2
-  - uid: 18529
+  - uid: 18528
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 2
-  - uid: 18530
+  - uid: 18529
     components:
     - type: Transform
       pos: -11.5,4.5
       parent: 2
-  - uid: 18531
+  - uid: 18530
     components:
     - type: Transform
       pos: -20.5,5.5
       parent: 2
-  - uid: 18532
+  - uid: 18531
     components:
     - type: Transform
       pos: 41.5,30.5
       parent: 2
-  - uid: 18533
+  - uid: 18532
     components:
     - type: Transform
       pos: 10.5,24.5
       parent: 2
-  - uid: 18534
+  - uid: 18533
     components:
     - type: Transform
       pos: 15.5,24.5
       parent: 2
-  - uid: 18535
+  - uid: 18534
     components:
     - type: Transform
       pos: 14.5,36.5
       parent: 2
-  - uid: 18536
+  - uid: 18535
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 2
-  - uid: 18537
+  - uid: 18536
     components:
     - type: Transform
       pos: -48.5,0.5
       parent: 2
-  - uid: 18538
+  - uid: 18537
     components:
     - type: Transform
       pos: -41.5,-3.5
@@ -116454,7 +116453,7 @@ entities:
       - Experimental
       - CivilianServices
       - Biochemical
-  - uid: 18539
+  - uid: 18538
     components:
     - type: Transform
       pos: 9.5,6.5
@@ -116468,1184 +116467,1189 @@ entities:
       - Biochemical
 - proto: Protolathe
   entities:
-  - uid: 18540
+  - uid: 18539
     components:
     - type: Transform
       pos: -46.5,29.5
       parent: 2
 - proto: Rack
   entities:
-  - uid: 18541
+  - uid: 18540
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 2
-  - uid: 18542
+  - uid: 18541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,41.5
       parent: 2
-  - uid: 18543
+  - uid: 18542
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,37.5
       parent: 2
-  - uid: 18544
+  - uid: 18543
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,29.5
       parent: 2
-  - uid: 18545
+  - uid: 18544
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,28.5
       parent: 2
-  - uid: 18546
+  - uid: 18545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,30.5
       parent: 2
-  - uid: 18547
+  - uid: 18546
     components:
     - type: Transform
       pos: -25.5,32.5
       parent: 2
-  - uid: 18548
+  - uid: 18547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,41.5
       parent: 2
-  - uid: 18549
+  - uid: 18548
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 2
-  - uid: 18550
+  - uid: 18549
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 2
-  - uid: 18551
+  - uid: 18550
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 2
-  - uid: 18552
+  - uid: 18551
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 2
-  - uid: 18553
+  - uid: 18552
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 2
-  - uid: 18554
+  - uid: 18553
     components:
     - type: Transform
       pos: -7.5,-16.5
       parent: 2
-  - uid: 18555
+  - uid: 18554
     components:
     - type: Transform
       pos: -11.5,-13.5
       parent: 2
-  - uid: 18556
+  - uid: 18555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,4.5
       parent: 2
-  - uid: 18557
+  - uid: 18556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,-2.5
       parent: 2
-  - uid: 18558
+  - uid: 18557
     components:
     - type: Transform
       pos: -27.5,-5.5
       parent: 2
-  - uid: 18559
+  - uid: 18558
     components:
     - type: Transform
       pos: -33.5,-5.5
       parent: 2
-  - uid: 18560
+  - uid: 18559
     components:
     - type: Transform
       pos: -36.5,-5.5
       parent: 2
-  - uid: 18561
+  - uid: 18560
     components:
     - type: Transform
       pos: -30.5,-5.5
       parent: 2
-  - uid: 18562
+  - uid: 18561
     components:
     - type: Transform
       pos: -44.5,0.5
       parent: 2
-  - uid: 18563
+  - uid: 18562
     components:
     - type: Transform
       pos: -56.5,-1.5
       parent: 2
-  - uid: 18564
+  - uid: 18563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,10.5
       parent: 2
-  - uid: 18565
+  - uid: 18564
     components:
     - type: Transform
       pos: -65.5,26.5
       parent: 2
-  - uid: 18566
+  - uid: 18565
     components:
     - type: Transform
       pos: -43.5,25.5
       parent: 2
-  - uid: 18567
+  - uid: 18566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -61.5,40.5
       parent: 2
-  - uid: 18568
+  - uid: 18567
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 46.5,28.5
       parent: 2
-  - uid: 18569
+  - uid: 18568
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,26.5
       parent: 2
-  - uid: 18570
+  - uid: 18569
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,26.5
       parent: 2
-  - uid: 18571
+  - uid: 18570
     components:
     - type: Transform
       pos: 19.5,19.5
       parent: 2
-  - uid: 18572
+  - uid: 18571
     components:
     - type: Transform
       pos: 0.5,-41.5
       parent: 2
-  - uid: 18573
+  - uid: 18572
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-33.5
       parent: 2
-  - uid: 18574
+  - uid: 18573
     components:
     - type: Transform
       pos: 55.5,-20.5
       parent: 2
-  - uid: 18575
+  - uid: 18574
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 48.5,-34.5
       parent: 2
-  - uid: 18576
+  - uid: 18575
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-34.5
       parent: 2
-  - uid: 18577
+  - uid: 18576
     components:
     - type: Transform
       pos: 54.5,-0.5
       parent: 2
-  - uid: 18578
+  - uid: 18577
     components:
     - type: Transform
       pos: 82.5,-11.5
       parent: 2
-  - uid: 18579
+  - uid: 18578
     components:
     - type: Transform
       pos: 77.5,-25.5
       parent: 2
-  - uid: 18580
+  - uid: 18579
     components:
     - type: Transform
       pos: 41.5,24.5
       parent: 2
-  - uid: 18581
+  - uid: 18580
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 43.5,26.5
       parent: 2
-  - uid: 18582
+  - uid: 18581
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,-16.5
       parent: 2
-  - uid: 18583
+  - uid: 18582
     components:
     - type: Transform
       pos: -10.5,21.5
       parent: 2
-  - uid: 18584
+  - uid: 18583
     components:
     - type: Transform
       pos: -9.5,21.5
       parent: 2
-  - uid: 18585
+  - uid: 18584
     components:
     - type: Transform
       pos: -7.5,21.5
       parent: 2
-  - uid: 18586
+  - uid: 18585
     components:
     - type: Transform
       pos: -6.5,21.5
       parent: 2
-  - uid: 18587
+  - uid: 18586
     components:
     - type: Transform
       pos: -1.5,25.5
       parent: 2
-  - uid: 18588
+  - uid: 18587
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,23.5
       parent: 2
-  - uid: 18589
+  - uid: 18588
     components:
     - type: Transform
       pos: -27.5,-12.5
       parent: 2
-  - uid: 18590
+  - uid: 18589
     components:
     - type: Transform
       pos: -26.5,-12.5
       parent: 2
-  - uid: 18591
+  - uid: 18590
     components:
     - type: Transform
       pos: -25.5,-12.5
       parent: 2
-  - uid: 18592
+  - uid: 18591
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-23.5
       parent: 2
-  - uid: 18593
+  - uid: 18592
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-13.5
       parent: 2
-  - uid: 18594
+  - uid: 18593
     components:
     - type: Transform
       pos: -42.5,-16.5
       parent: 2
-  - uid: 18595
+  - uid: 18594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,-10.5
       parent: 2
-  - uid: 18596
+  - uid: 18595
     components:
     - type: Transform
       pos: -30.5,27.5
       parent: 2
-  - uid: 18597
+  - uid: 18596
     components:
     - type: Transform
       pos: -36.5,30.5
       parent: 2
-  - uid: 18598
+  - uid: 18597
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-35.5
       parent: 2
-  - uid: 18599
+  - uid: 18598
     components:
     - type: Transform
       pos: 3.5,-53.5
       parent: 2
-  - uid: 18600
+  - uid: 18599
     components:
     - type: Transform
       pos: 67.5,-36.5
       parent: 2
-  - uid: 18601
+  - uid: 18600
     components:
     - type: Transform
       pos: 73.5,-28.5
       parent: 2
-  - uid: 18602
+  - uid: 18601
     components:
     - type: Transform
       pos: 16.5,36.5
       parent: 2
-  - uid: 18603
+  - uid: 18602
     components:
     - type: Transform
       pos: 59.5,9.5
       parent: 2
-  - uid: 18604
+  - uid: 18603
     components:
     - type: Transform
       pos: -70.5,41.5
       parent: 2
-  - uid: 18605
+  - uid: 18604
     components:
     - type: Transform
       pos: -70.5,40.5
       parent: 2
 - proto: RadarConsoleCircuitboard
   entities:
-  - uid: 18606
+  - uid: 18605
     components:
     - type: Transform
       pos: 6.5351806,18.825598
       parent: 2
 - proto: RadiationCollectorFullTank
   entities:
-  - uid: 18607
+  - uid: 18606
     components:
     - type: Transform
       pos: 80.5,19.5
       parent: 2
-  - uid: 18608
+  - uid: 18607
     components:
     - type: Transform
       pos: 80.5,20.5
       parent: 2
-  - uid: 18609
+  - uid: 18608
     components:
     - type: Transform
       pos: 80.5,16.5
       parent: 2
-  - uid: 18610
+  - uid: 18609
     components:
     - type: Transform
       pos: 80.5,17.5
       parent: 2
-  - uid: 18611
+  - uid: 18610
     components:
     - type: Transform
       pos: 90.5,16.5
       parent: 2
-  - uid: 18612
+  - uid: 18611
     components:
     - type: Transform
       pos: 90.5,17.5
       parent: 2
-  - uid: 18613
+  - uid: 18612
     components:
     - type: Transform
       pos: 90.5,19.5
       parent: 2
-  - uid: 18614
+  - uid: 18613
     components:
     - type: Transform
       pos: 90.5,20.5
       parent: 2
 - proto: Railing
   entities:
-  - uid: 18615
+  - uid: 18614
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-5.5
       parent: 2
-  - uid: 18616
+  - uid: 18615
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,38.5
       parent: 2
-  - uid: 18617
+  - uid: 18616
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,52.5
       parent: 2
-  - uid: 18618
+  - uid: 18617
     components:
     - type: Transform
       pos: -31.5,45.5
       parent: 2
-  - uid: 18619
+  - uid: 18618
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,50.5
       parent: 2
-  - uid: 18620
+  - uid: 18619
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,47.5
       parent: 2
-  - uid: 18621
+  - uid: 18620
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,48.5
       parent: 2
-  - uid: 18622
+  - uid: 18621
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,49.5
       parent: 2
-  - uid: 18623
+  - uid: 18622
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,49.5
       parent: 2
-  - uid: 18624
+  - uid: 18623
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,41.5
       parent: 2
-  - uid: 18625
+  - uid: 18624
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,49.5
       parent: 2
-  - uid: 18626
+  - uid: 18625
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,50.5
       parent: 2
-  - uid: 18627
+  - uid: 18626
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,49.5
       parent: 2
-  - uid: 18628
+  - uid: 18627
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,47.5
       parent: 2
-  - uid: 18629
+  - uid: 18628
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,48.5
       parent: 2
-  - uid: 18630
+  - uid: 18629
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,26.5
       parent: 2
-  - uid: 18631
+  - uid: 18630
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,26.5
       parent: 2
-  - uid: 18632
+  - uid: 18631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,31.5
       parent: 2
-  - uid: 18633
+  - uid: 18632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,30.5
+      parent: 2
+  - uid: 18633
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,31.5
       parent: 2
   - uid: 18634
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -9.5,31.5
-      parent: 2
-  - uid: 18635
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,30.5
       parent: 2
-  - uid: 18636
+  - uid: 18635
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,4.5
       parent: 2
-  - uid: 18637
+  - uid: 18636
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,8.5
       parent: 2
-  - uid: 18638
+  - uid: 18637
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,8.5
       parent: 2
-  - uid: 18639
+  - uid: 18638
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,8.5
       parent: 2
-  - uid: 18640
+  - uid: 18639
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,8.5
       parent: 2
-  - uid: 18641
+  - uid: 18640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,8.5
       parent: 2
-  - uid: 18642
+  - uid: 18641
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,8.5
       parent: 2
-  - uid: 18643
+  - uid: 18642
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-43.5
       parent: 2
-  - uid: 18644
+  - uid: 18643
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,9.5
       parent: 2
-  - uid: 18645
+  - uid: 18644
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,10.5
       parent: 2
-  - uid: 18646
+  - uid: 18645
     components:
     - type: Transform
       pos: -15.5,24.5
       parent: 2
-  - uid: 18647
+  - uid: 18646
     components:
     - type: Transform
       pos: -18.5,24.5
       parent: 2
-  - uid: 18648
+  - uid: 18647
     components:
     - type: Transform
       pos: -19.5,24.5
       parent: 2
-  - uid: 18649
+  - uid: 18648
     components:
     - type: Transform
       pos: -16.5,24.5
       parent: 2
-  - uid: 18650
+  - uid: 18649
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,25.5
       parent: 2
-  - uid: 18651
+  - uid: 18650
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,26.5
       parent: 2
-  - uid: 18652
+  - uid: 18651
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,28.5
       parent: 2
-  - uid: 18653
+  - uid: 18652
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,29.5
       parent: 2
-  - uid: 18654
+  - uid: 18653
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,30.5
       parent: 2
-  - uid: 18655
+  - uid: 18654
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,30.5
       parent: 2
-  - uid: 18656
+  - uid: 18655
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,30.5
       parent: 2
-  - uid: 18657
+  - uid: 18656
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,30.5
       parent: 2
-  - uid: 18658
+  - uid: 18657
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,29.5
       parent: 2
-  - uid: 18659
+  - uid: 18658
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,28.5
       parent: 2
-  - uid: 18660
+  - uid: 18659
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,26.5
       parent: 2
-  - uid: 18661
+  - uid: 18660
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,25.5
       parent: 2
-  - uid: 18662
+  - uid: 18661
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -41.5,20.5
       parent: 2
-  - uid: 18663
+  - uid: 18662
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -42.5,20.5
       parent: 2
-  - uid: 18664
+  - uid: 18663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,19.5
       parent: 2
-  - uid: 18665
+  - uid: 18664
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,17.5
       parent: 2
-  - uid: 18666
+  - uid: 18665
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,16.5
       parent: 2
-  - uid: 18667
+  - uid: 18666
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,16.5
       parent: 2
-  - uid: 18668
+  - uid: 18667
     components:
     - type: Transform
       pos: -41.5,15.5
       parent: 2
-  - uid: 18669
+  - uid: 18668
     components:
     - type: Transform
       pos: -42.5,15.5
       parent: 2
-  - uid: 18670
+  - uid: 18669
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,19.5
       parent: 2
-  - uid: 18671
+  - uid: 18670
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,18.5
       parent: 2
-  - uid: 18672
+  - uid: 18671
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,17.5
       parent: 2
-  - uid: 18673
+  - uid: 18672
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,18.5
       parent: 2
-  - uid: 18674
+  - uid: 18673
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,16.5
       parent: 2
-  - uid: 18675
+  - uid: 18674
     components:
     - type: Transform
       pos: -50.5,20.5
       parent: 2
-  - uid: 18676
+  - uid: 18675
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -51.5,21.5
       parent: 2
-  - uid: 18677
+  - uid: 18676
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -51.5,15.5
       parent: 2
-  - uid: 18678
+  - uid: 18677
     components:
     - type: Transform
       pos: -61.5,16.5
       parent: 2
-  - uid: 18679
+  - uid: 18678
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,19.5
       parent: 2
-  - uid: 18680
+  - uid: 18679
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -61.5,20.5
       parent: 2
-  - uid: 18681
+  - uid: 18680
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,17.5
       parent: 2
-  - uid: 18682
+  - uid: 18681
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,26.5
       parent: 2
-  - uid: 18683
+  - uid: 18682
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,27.5
       parent: 2
-  - uid: 18684
+  - uid: 18683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,28.5
       parent: 2
-  - uid: 18685
+  - uid: 18684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -64.5,29.5
       parent: 2
-  - uid: 18686
+  - uid: 18685
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -55.5,32.5
       parent: 2
-  - uid: 18687
+  - uid: 18686
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -55.5,31.5
       parent: 2
-  - uid: 18688
+  - uid: 18687
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -51.5,32.5
       parent: 2
-  - uid: 18689
+  - uid: 18688
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -51.5,31.5
       parent: 2
-  - uid: 18690
+  - uid: 18689
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,30.5
       parent: 2
-  - uid: 18691
+  - uid: 18690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,31.5
       parent: 2
-  - uid: 18692
+  - uid: 18691
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,18.5
       parent: 2
-  - uid: 18693
+  - uid: 18692
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,18.5
       parent: 2
-  - uid: 18694
+  - uid: 18693
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,19.5
       parent: 2
-  - uid: 18695
+  - uid: 18694
     components:
     - type: Transform
       pos: 32.5,30.5
       parent: 2
-  - uid: 18696
+  - uid: 18695
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-25.5
       parent: 2
-  - uid: 18697
+  - uid: 18696
     components:
     - type: Transform
       pos: 3.5,-44.5
       parent: 2
-  - uid: 18698
+  - uid: 18697
     components:
     - type: Transform
       pos: 5.5,-44.5
       parent: 2
-  - uid: 18699
+  - uid: 18698
     components:
     - type: Transform
       pos: 6.5,-44.5
       parent: 2
-  - uid: 18700
+  - uid: 18699
     components:
     - type: Transform
       pos: 7.5,-44.5
       parent: 2
-  - uid: 18701
+  - uid: 18700
     components:
     - type: Transform
       pos: 8.5,-44.5
       parent: 2
-  - uid: 18702
+  - uid: 18701
     components:
     - type: Transform
       pos: 4.5,-44.5
       parent: 2
-  - uid: 18703
+  - uid: 18702
     components:
     - type: Transform
       pos: 9.5,-44.5
       parent: 2
-  - uid: 18704
+  - uid: 18703
     components:
     - type: Transform
       pos: 10.5,-44.5
       parent: 2
-  - uid: 18705
+  - uid: 18704
     components:
     - type: Transform
       pos: 11.5,-44.5
       parent: 2
-  - uid: 18706
+  - uid: 18705
     components:
     - type: Transform
       pos: 12.5,-44.5
       parent: 2
-  - uid: 18707
+  - uid: 18706
     components:
     - type: Transform
       pos: 13.5,-44.5
       parent: 2
-  - uid: 18708
+  - uid: 18707
     components:
     - type: Transform
       pos: 14.5,-44.5
       parent: 2
-  - uid: 18709
+  - uid: 18708
     components:
     - type: Transform
       pos: 15.5,-44.5
       parent: 2
-  - uid: 18710
+  - uid: 18709
     components:
     - type: Transform
       pos: 16.5,-44.5
       parent: 2
-  - uid: 18711
+  - uid: 18710
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-32.5
       parent: 2
-  - uid: 18712
+  - uid: 18711
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,11.5
       parent: 2
-  - uid: 18713
+  - uid: 18712
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,10.5
       parent: 2
-  - uid: 18714
+  - uid: 18713
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,11.5
       parent: 2
-  - uid: 18715
+  - uid: 18714
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,9.5
       parent: 2
-  - uid: 18716
+  - uid: 18715
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,10.5
       parent: 2
-  - uid: 18717
+  - uid: 18716
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,9.5
       parent: 2
-  - uid: 18718
+  - uid: 18717
     components:
     - type: Transform
       pos: 22.5,12.5
       parent: 2
-  - uid: 18719
+  - uid: 18718
     components:
     - type: Transform
       pos: 23.5,12.5
       parent: 2
-  - uid: 18720
+  - uid: 18719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,20.5
       parent: 2
-  - uid: 18721
+  - uid: 18720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,19.5
       parent: 2
-  - uid: 18722
+  - uid: 18721
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,18.5
       parent: 2
-  - uid: 18723
+  - uid: 18722
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,17.5
       parent: 2
-  - uid: 18724
+  - uid: 18723
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,16.5
       parent: 2
-  - uid: 18725
+  - uid: 18724
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,16.5
       parent: 2
-  - uid: 18726
+  - uid: 18725
     components:
     - type: Transform
       pos: -16.5,21.5
       parent: 2
-  - uid: 18727
+  - uid: 18726
     components:
     - type: Transform
       pos: -15.5,21.5
       parent: 2
-  - uid: 18728
+  - uid: 18727
     components:
     - type: Transform
       pos: -14.5,21.5
       parent: 2
-  - uid: 18729
+  - uid: 18728
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,17.5
       parent: 2
-  - uid: 18730
+  - uid: 18729
     components:
     - type: Transform
       pos: -13.5,21.5
       parent: 2
-  - uid: 18731
+  - uid: 18730
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,50.5
       parent: 2
-  - uid: 18732
+  - uid: 18731
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,-35.5
       parent: 2
-  - uid: 18733
+  - uid: 18732
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-35.5
       parent: 2
-  - uid: 18734
+  - uid: 18733
     components:
     - type: Transform
       pos: 37.5,1.5
       parent: 2
-  - uid: 18735
+  - uid: 18734
     components:
     - type: Transform
       pos: 38.5,1.5
       parent: 2
-  - uid: 18736
+  - uid: 18735
     components:
     - type: Transform
       pos: 40.5,1.5
       parent: 2
-  - uid: 18737
+  - uid: 18736
     components:
     - type: Transform
       pos: 39.5,1.5
       parent: 2
-  - uid: 18738
+  - uid: 18737
     components:
     - type: Transform
       pos: 43.5,-30.5
       parent: 2
-  - uid: 18739
+  - uid: 18738
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 44.5,-23.5
       parent: 2
-  - uid: 18740
+  - uid: 18739
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 43.5,-34.5
       parent: 2
-  - uid: 18741
+  - uid: 18740
     components:
     - type: Transform
       pos: 44.5,-26.5
       parent: 2
-  - uid: 18742
+  - uid: 18741
     components:
     - type: Transform
       pos: 42.5,-15.5
       parent: 2
-  - uid: 18743
+  - uid: 18742
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 44.5,-30.5
       parent: 2
-  - uid: 18744
+  - uid: 18743
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-22.5
       parent: 2
-  - uid: 18745
+  - uid: 18744
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-27.5
       parent: 2
-  - uid: 18746
+  - uid: 18745
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 42.5,-34.5
       parent: 2
-  - uid: 18747
+  - uid: 18746
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-16.5
       parent: 2
-  - uid: 18748
+  - uid: 18747
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-18.5
       parent: 2
-  - uid: 18749
+  - uid: 18748
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-17.5
+      parent: 2
+  - uid: 18749
+    components:
+    - type: Transform
+      pos: 43.5,-15.5
       parent: 2
   - uid: 18750
     components:
@@ -117655,1083 +117659,1083 @@ entities:
   - uid: 18751
     components:
     - type: Transform
-      pos: 43.5,-15.5
-      parent: 2
-  - uid: 18752
-    components:
-    - type: Transform
       pos: 44.5,-19.5
       parent: 2
-  - uid: 18753
+  - uid: 18752
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-33.5
       parent: 2
-  - uid: 18754
+  - uid: 18753
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-32.5
       parent: 2
-  - uid: 18755
+  - uid: 18754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-31.5
       parent: 2
-  - uid: 18756
+  - uid: 18755
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-29.5
       parent: 2
-  - uid: 18757
+  - uid: 18756
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-28.5
       parent: 2
-  - uid: 18758
+  - uid: 18757
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 43.5,-30.5
       parent: 2
-  - uid: 18759
+  - uid: 18758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-21.5
       parent: 2
-  - uid: 18760
+  - uid: 18759
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-20.5
       parent: 2
-  - uid: 18761
+  - uid: 18760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: 43.5,-19.5
+      parent: 2
+  - uid: 18761
+    components:
+    - type: Transform
       pos: 43.5,-19.5
       parent: 2
   - uid: 18762
     components:
     - type: Transform
-      pos: 43.5,-19.5
-      parent: 2
-  - uid: 18763
-    components:
-    - type: Transform
       pos: 50.5,1.5
       parent: 2
-  - uid: 18764
+  - uid: 18763
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 58.5,13.5
       parent: 2
-  - uid: 18765
+  - uid: 18764
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-43.5
       parent: 2
-  - uid: 18766
+  - uid: 18765
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-31.5
       parent: 2
-  - uid: 18767
+  - uid: 18766
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-32.5
       parent: 2
-  - uid: 18768
+  - uid: 18767
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,-31.5
       parent: 2
-  - uid: 18769
+  - uid: 18768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,-32.5
       parent: 2
-  - uid: 18770
+  - uid: 18769
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-34.5
       parent: 2
-  - uid: 18771
+  - uid: 18770
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,-34.5
       parent: 2
-  - uid: 18772
+  - uid: 18771
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,0.5
       parent: 2
-  - uid: 18773
+  - uid: 18772
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,1.5
       parent: 2
-  - uid: 18774
+  - uid: 18773
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,2.5
       parent: 2
-  - uid: 18775
+  - uid: 18774
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 66.5,4.5
       parent: 2
-  - uid: 18776
+  - uid: 18775
     components:
     - type: Transform
       pos: 63.5,5.5
       parent: 2
-  - uid: 18777
+  - uid: 18776
     components:
     - type: Transform
       pos: 64.5,5.5
       parent: 2
-  - uid: 18778
+  - uid: 18777
     components:
     - type: Transform
       pos: 65.5,5.5
       parent: 2
-  - uid: 18779
+  - uid: 18778
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 62.5,-0.5
       parent: 2
-  - uid: 18780
+  - uid: 18779
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 65.5,-0.5
       parent: 2
-  - uid: 18781
+  - uid: 18780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-29.5
       parent: 2
-  - uid: 18782
+  - uid: 18781
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,-8.5
       parent: 2
-  - uid: 18783
+  - uid: 18782
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,-10.5
       parent: 2
-  - uid: 18784
+  - uid: 18783
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,-10.5
       parent: 2
-  - uid: 18785
+  - uid: 18784
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 73.5,-13.5
       parent: 2
-  - uid: 18786
+  - uid: 18785
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,-13.5
       parent: 2
-  - uid: 18787
+  - uid: 18786
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,-13.5
       parent: 2
-  - uid: 18788
+  - uid: 18787
     components:
     - type: Transform
       pos: 67.5,-7.5
       parent: 2
-  - uid: 18789
+  - uid: 18788
     components:
     - type: Transform
       pos: 68.5,-7.5
       parent: 2
-  - uid: 18790
+  - uid: 18789
     components:
     - type: Transform
       pos: 69.5,-7.5
       parent: 2
-  - uid: 18791
+  - uid: 18790
     components:
     - type: Transform
       pos: 71.5,-7.5
       parent: 2
-  - uid: 18792
+  - uid: 18791
     components:
     - type: Transform
       pos: 72.5,-7.5
       parent: 2
-  - uid: 18793
+  - uid: 18792
     components:
     - type: Transform
       pos: 73.5,-7.5
       parent: 2
-  - uid: 18794
+  - uid: 18793
     components:
     - type: Transform
       pos: 74.5,-7.5
       parent: 2
-  - uid: 18795
+  - uid: 18794
     components:
     - type: Transform
       pos: 75.5,-7.5
       parent: 2
-  - uid: 18796
+  - uid: 18795
     components:
     - type: Transform
       pos: 70.5,-7.5
       parent: 2
-  - uid: 18797
+  - uid: 18796
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 79.5,-26.5
       parent: 2
-  - uid: 18798
+  - uid: 18797
     components:
     - type: Transform
       pos: 79.5,-22.5
       parent: 2
-  - uid: 18799
+  - uid: 18798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 80.5,-30.5
       parent: 2
-  - uid: 18800
+  - uid: 18799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 85.5,-30.5
       parent: 2
-  - uid: 18801
+  - uid: 18800
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-11.5
       parent: 2
-  - uid: 18802
+  - uid: 18801
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-12.5
       parent: 2
-  - uid: 18803
+  - uid: 18802
     components:
     - type: Transform
       pos: 85.5,-10.5
       parent: 2
-  - uid: 18804
+  - uid: 18803
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 79.5,-30.5
       parent: 2
-  - uid: 18805
+  - uid: 18804
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-28.5
       parent: 2
-  - uid: 18806
+  - uid: 18805
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,22.5
       parent: 2
-  - uid: 18807
+  - uid: 18806
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,23.5
       parent: 2
-  - uid: 18808
+  - uid: 18807
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,24.5
       parent: 2
-  - uid: 18809
+  - uid: 18808
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,26.5
       parent: 2
-  - uid: 18810
+  - uid: 18809
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,27.5
       parent: 2
-  - uid: 18811
+  - uid: 18810
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,28.5
       parent: 2
-  - uid: 18812
+  - uid: 18811
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,29.5
       parent: 2
-  - uid: 18813
+  - uid: 18812
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,30.5
       parent: 2
-  - uid: 18814
+  - uid: 18813
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,31.5
       parent: 2
-  - uid: 18815
+  - uid: 18814
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,32.5
       parent: 2
-  - uid: 18816
+  - uid: 18815
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,33.5
       parent: 2
-  - uid: 18817
+  - uid: 18816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,25.5
       parent: 2
-  - uid: 18818
+  - uid: 18817
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,34.5
       parent: 2
-  - uid: 18819
+  - uid: 18818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,36.5
       parent: 2
-  - uid: 18820
+  - uid: 18819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,35.5
       parent: 2
-  - uid: 18821
+  - uid: 18820
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,35.5
       parent: 2
-  - uid: 18822
+  - uid: 18821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,33.5
       parent: 2
-  - uid: 18823
+  - uid: 18822
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,34.5
       parent: 2
-  - uid: 18824
+  - uid: 18823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,36.5
       parent: 2
-  - uid: 18825
+  - uid: 18824
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,32.5
       parent: 2
-  - uid: 18826
+  - uid: 18825
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,31.5
       parent: 2
-  - uid: 18827
+  - uid: 18826
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,30.5
       parent: 2
-  - uid: 18828
+  - uid: 18827
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,28.5
       parent: 2
-  - uid: 18829
+  - uid: 18828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,27.5
       parent: 2
-  - uid: 18830
+  - uid: 18829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,29.5
       parent: 2
-  - uid: 18831
+  - uid: 18830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,25.5
       parent: 2
-  - uid: 18832
+  - uid: 18831
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,26.5
       parent: 2
-  - uid: 18833
+  - uid: 18832
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,22.5
       parent: 2
-  - uid: 18834
+  - uid: 18833
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,23.5
       parent: 2
-  - uid: 18835
+  - uid: 18834
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,24.5
       parent: 2
-  - uid: 18836
+  - uid: 18835
     components:
     - type: Transform
       pos: 65.5,72.5
       parent: 2
-  - uid: 18837
+  - uid: 18836
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 65.5,70.5
       parent: 2
-  - uid: 18838
+  - uid: 18837
     components:
     - type: Transform
       pos: 65.5,64.5
       parent: 2
-  - uid: 18839
+  - uid: 18838
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 65.5,62.5
       parent: 2
-  - uid: 18840
+  - uid: 18839
     components:
     - type: Transform
       pos: 65.5,58.5
+      parent: 2
+  - uid: 18840
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 60.5,21.5
       parent: 2
   - uid: 18841
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 60.5,21.5
+      pos: 61.5,21.5
       parent: 2
   - uid: 18842
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 61.5,21.5
+      pos: 62.5,21.5
       parent: 2
   - uid: 18843
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 62.5,21.5
+      pos: 68.5,21.5
       parent: 2
   - uid: 18844
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 68.5,21.5
+      pos: 60.5,21.5
       parent: 2
   - uid: 18845
     components:
     - type: Transform
-      pos: 60.5,21.5
+      pos: 61.5,21.5
       parent: 2
   - uid: 18846
     components:
     - type: Transform
-      pos: 61.5,21.5
+      pos: 62.5,21.5
       parent: 2
   - uid: 18847
     components:
     - type: Transform
-      pos: 62.5,21.5
+      pos: 68.5,21.5
       parent: 2
   - uid: 18848
     components:
     - type: Transform
-      pos: 68.5,21.5
+      pos: 61.5,16.5
       parent: 2
   - uid: 18849
     components:
     - type: Transform
-      pos: 61.5,16.5
+      pos: 62.5,16.5
       parent: 2
   - uid: 18850
     components:
     - type: Transform
-      pos: 62.5,16.5
+      pos: 66.5,16.5
       parent: 2
   - uid: 18851
     components:
     - type: Transform
-      pos: 66.5,16.5
+      pos: 65.5,16.5
       parent: 2
   - uid: 18852
     components:
     - type: Transform
-      pos: 65.5,16.5
+      pos: 68.5,16.5
       parent: 2
   - uid: 18853
     components:
     - type: Transform
-      pos: 68.5,16.5
-      parent: 2
-  - uid: 18854
-    components:
-    - type: Transform
       pos: 64.5,16.5
       parent: 2
-  - uid: 18855
+  - uid: 18854
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,4.5
       parent: 2
-  - uid: 18856
+  - uid: 18855
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,4.5
       parent: 2
-  - uid: 18857
+  - uid: 18856
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,4.5
       parent: 2
-  - uid: 18858
+  - uid: 18857
     components:
     - type: Transform
       pos: 10.5,46.5
       parent: 2
-  - uid: 18859
+  - uid: 18858
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,28.5
       parent: 2
-  - uid: 18860
+  - uid: 18859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,29.5
       parent: 2
-  - uid: 18861
+  - uid: 18860
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,18.5
       parent: 2
-  - uid: 18862
+  - uid: 18861
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,19.5
       parent: 2
-  - uid: 18863
+  - uid: 18862
     components:
     - type: Transform
       pos: 51.5,1.5
       parent: 2
-  - uid: 18864
+  - uid: 18863
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-10.5
       parent: 2
-  - uid: 18865
+  - uid: 18864
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,-14.5
       parent: 2
-  - uid: 18866
+  - uid: 18865
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-11.5
       parent: 2
-  - uid: 18867
+  - uid: 18866
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-12.5
       parent: 2
-  - uid: 18868
+  - uid: 18867
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,-15.5
       parent: 2
-  - uid: 18869
+  - uid: 18868
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,-33.5
       parent: 2
-  - uid: 18870
+  - uid: 18869
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,-43.5
       parent: 2
-  - uid: 18871
+  - uid: 18870
     components:
     - type: Transform
       pos: 36.5,-31.5
       parent: 2
-  - uid: 18872
+  - uid: 18871
     components:
     - type: Transform
       pos: 37.5,-27.5
       parent: 2
-  - uid: 18873
+  - uid: 18872
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,-29.5
       parent: 2
-  - uid: 18874
+  - uid: 18873
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,-22.5
       parent: 2
-  - uid: 18875
+  - uid: 18874
     components:
     - type: Transform
       pos: 37.5,-20.5
       parent: 2
-  - uid: 18876
+  - uid: 18875
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,-43.5
       parent: 2
-  - uid: 18877
+  - uid: 18876
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,-43.5
       parent: 2
-  - uid: 18878
+  - uid: 18877
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-43.5
       parent: 2
-  - uid: 18879
+  - uid: 18878
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,-43.5
       parent: 2
-  - uid: 18880
+  - uid: 18879
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-43.5
       parent: 2
-  - uid: 18881
+  - uid: 18880
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,-43.5
       parent: 2
-  - uid: 18882
+  - uid: 18881
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-43.5
       parent: 2
-  - uid: 18883
+  - uid: 18882
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-43.5
       parent: 2
-  - uid: 18884
+  - uid: 18883
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-43.5
       parent: 2
-  - uid: 18885
+  - uid: 18884
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-50.5
       parent: 2
-  - uid: 18886
+  - uid: 18885
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-47.5
       parent: 2
-  - uid: 18887
+  - uid: 18886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-46.5
       parent: 2
-  - uid: 18888
+  - uid: 18887
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-45.5
       parent: 2
-  - uid: 18889
+  - uid: 18888
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-44.5
       parent: 2
-  - uid: 18890
+  - uid: 18889
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-43.5
       parent: 2
-  - uid: 18891
+  - uid: 18890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-42.5
       parent: 2
-  - uid: 18892
+  - uid: 18891
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-41.5
       parent: 2
-  - uid: 18893
+  - uid: 18892
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,-48.5
       parent: 2
-  - uid: 18894
+  - uid: 18893
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-50.5
       parent: 2
-  - uid: 18895
+  - uid: 18894
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-48.5
       parent: 2
-  - uid: 18896
+  - uid: 18895
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-46.5
       parent: 2
-  - uid: 18897
+  - uid: 18896
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-45.5
       parent: 2
-  - uid: 18898
+  - uid: 18897
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-44.5
       parent: 2
-  - uid: 18899
+  - uid: 18898
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-43.5
       parent: 2
-  - uid: 18900
+  - uid: 18899
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-42.5
       parent: 2
-  - uid: 18901
+  - uid: 18900
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-47.5
       parent: 2
-  - uid: 18902
+  - uid: 18901
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,-41.5
       parent: 2
-  - uid: 18903
+  - uid: 18902
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-50.5
       parent: 2
-  - uid: 18904
+  - uid: 18903
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-49.5
       parent: 2
-  - uid: 18905
+  - uid: 18904
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-47.5
       parent: 2
-  - uid: 18906
+  - uid: 18905
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-46.5
       parent: 2
-  - uid: 18907
+  - uid: 18906
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-45.5
       parent: 2
-  - uid: 18908
+  - uid: 18907
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-48.5
       parent: 2
-  - uid: 18909
+  - uid: 18908
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-41.5
       parent: 2
-  - uid: 18910
+  - uid: 18909
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-44.5
       parent: 2
-  - uid: 18911
+  - uid: 18910
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-43.5
       parent: 2
-  - uid: 18912
+  - uid: 18911
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-42.5
       parent: 2
-  - uid: 18913
+  - uid: 18912
     components:
     - type: Transform
       pos: 50.5,-40.5
       parent: 2
-  - uid: 18914
+  - uid: 18913
     components:
     - type: Transform
       pos: 86.5,-18.5
       parent: 2
-  - uid: 18915
+  - uid: 18914
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 86.5,-22.5
       parent: 2
-  - uid: 18916
+  - uid: 18915
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 84.5,-20.5
       parent: 2
-  - uid: 18917
+  - uid: 18916
     components:
     - type: Transform
       pos: 74.5,-39.5
       parent: 2
-  - uid: 18918
+  - uid: 18917
     components:
     - type: Transform
       pos: 75.5,-39.5
       parent: 2
-  - uid: 18919
+  - uid: 18918
     components:
     - type: Transform
       pos: 76.5,-39.5
       parent: 2
-  - uid: 18920
+  - uid: 18919
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,-42.5
       parent: 2
-  - uid: 18921
+  - uid: 18920
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,-42.5
       parent: 2
-  - uid: 18922
+  - uid: 18921
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-55.5
       parent: 2
-  - uid: 18923
+  - uid: 18922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-54.5
       parent: 2
-  - uid: 18924
+  - uid: 18923
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-53.5
       parent: 2
-  - uid: 18925
+  - uid: 18924
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-52.5
       parent: 2
-  - uid: 18926
+  - uid: 18925
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-56.5
       parent: 2
-  - uid: 18927
+  - uid: 18926
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-58.5
       parent: 2
-  - uid: 18928
+  - uid: 18927
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-58.5
       parent: 2
-  - uid: 18929
+  - uid: 18928
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-59.5
       parent: 2
-  - uid: 18930
+  - uid: 18929
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-59.5
       parent: 2
-  - uid: 18931
+  - uid: 18930
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-60.5
       parent: 2
-  - uid: 18932
+  - uid: 18931
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-60.5
       parent: 2
-  - uid: 18933
+  - uid: 18932
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-60.5
       parent: 2
-  - uid: 18934
+  - uid: 18933
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-60.5
       parent: 2
-  - uid: 18935
+  - uid: 18934
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-58.5
       parent: 2
-  - uid: 18936
+  - uid: 18935
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-56.5
       parent: 2
-  - uid: 18937
+  - uid: 18936
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-55.5
+      parent: 2
+  - uid: 18937
+    components:
+    - type: Transform
+      pos: 13.5,-54.5
       parent: 2
   - uid: 18938
     components:
@@ -118741,102 +118745,97 @@ entities:
   - uid: 18939
     components:
     - type: Transform
-      pos: 13.5,-54.5
-      parent: 2
-  - uid: 18940
-    components:
-    - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-43.5
       parent: 2
-  - uid: 18941
+  - uid: 18940
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 49.5,-41.5
       parent: 2
-  - uid: 18942
+  - uid: 18941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 57.5,-36.5
       parent: 2
-  - uid: 18943
+  - uid: 18942
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 61.5,-36.5
       parent: 2
-  - uid: 18944
+  - uid: 18943
     components:
     - type: Transform
       pos: 58.5,-40.5
       parent: 2
-  - uid: 18945
+  - uid: 18944
     components:
     - type: Transform
       pos: 59.5,-40.5
       parent: 2
-  - uid: 18946
+  - uid: 18945
     components:
     - type: Transform
       pos: 60.5,-40.5
       parent: 2
-  - uid: 18947
+  - uid: 18946
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,34.5
       parent: 2
-  - uid: 18948
+  - uid: 18947
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,36.5
       parent: 2
-  - uid: 18949
+  - uid: 18948
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,35.5
       parent: 2
-  - uid: 18950
+  - uid: 18949
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,12.5
       parent: 2
-  - uid: 18951
+  - uid: 18950
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,12.5
       parent: 2
-  - uid: 18952
+  - uid: 18951
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,46.5
       parent: 2
-  - uid: 18953
+  - uid: 18952
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,50.5
       parent: 2
-  - uid: 18954
+  - uid: 18953
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,50.5
       parent: 2
-  - uid: 18955
+  - uid: 18954
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,46.5
       parent: 2
-  - uid: 18956
+  - uid: 18955
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -118844,1091 +118843,1091 @@ entities:
       parent: 2
 - proto: RailingCorner
   entities:
-  - uid: 18957
+  - uid: 18956
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,49.5
       parent: 2
-  - uid: 18958
+  - uid: 18957
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,46.5
       parent: 2
-  - uid: 18959
+  - uid: 18958
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,51.5
       parent: 2
-  - uid: 18960
+  - uid: 18959
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,45.5
       parent: 2
-  - uid: 18961
+  - uid: 18960
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,52.5
       parent: 2
-  - uid: 18962
+  - uid: 18961
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,50.5
       parent: 2
-  - uid: 18963
+  - uid: 18962
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,8.5
       parent: 2
-  - uid: 18964
+  - uid: 18963
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,24.5
       parent: 2
-  - uid: 18965
+  - uid: 18964
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,30.5
       parent: 2
-  - uid: 18966
+  - uid: 18965
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,30.5
       parent: 2
-  - uid: 18967
+  - uid: 18966
     components:
     - type: Transform
       pos: -14.5,24.5
       parent: 2
-  - uid: 18968
+  - uid: 18967
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,20.5
       parent: 2
-  - uid: 18969
+  - uid: 18968
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,20.5
       parent: 2
-  - uid: 18970
+  - uid: 18969
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,15.5
       parent: 2
-  - uid: 18971
+  - uid: 18970
     components:
     - type: Transform
       pos: -38.5,15.5
       parent: 2
-  - uid: 18972
+  - uid: 18971
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,20.5
       parent: 2
-  - uid: 18973
+  - uid: 18972
     components:
     - type: Transform
       pos: -60.5,16.5
       parent: 2
-  - uid: 18974
+  - uid: 18973
     components:
     - type: Transform
       pos: 31.5,29.5
       parent: 2
-  - uid: 18975
+  - uid: 18974
     components:
     - type: Transform
       pos: 17.5,-44.5
       parent: 2
-  - uid: 18976
+  - uid: 18975
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-26.5
       parent: 2
-  - uid: 18977
+  - uid: 18976
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-31.5
       parent: 2
-  - uid: 18978
+  - uid: 18977
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,17.5
       parent: 2
-  - uid: 18979
+  - uid: 18978
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,1.5
       parent: 2
-  - uid: 18980
+  - uid: 18979
     components:
     - type: Transform
       pos: 41.5,1.5
       parent: 2
-  - uid: 18981
+  - uid: 18980
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 66.5,3.5
       parent: 2
-  - uid: 18982
+  - uid: 18981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 86.5,-27.5
       parent: 2
-  - uid: 18983
+  - uid: 18982
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 86.5,-13.5
       parent: 2
-  - uid: 18984
+  - uid: 18983
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 72.5,-12.5
       parent: 2
-  - uid: 18985
+  - uid: 18984
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 71.5,-11.5
       parent: 2
-  - uid: 18986
+  - uid: 18985
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 70.5,-10.5
       parent: 2
-  - uid: 18987
+  - uid: 18986
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,-9.5
       parent: 2
-  - uid: 18988
+  - uid: 18987
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 81.5,-29.5
       parent: 2
-  - uid: 18989
+  - uid: 18988
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 84.5,-29.5
       parent: 2
-  - uid: 18990
+  - uid: 18989
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 64.5,72.5
       parent: 2
-  - uid: 18991
+  - uid: 18990
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 64.5,58.5
       parent: 2
-  - uid: 18992
+  - uid: 18991
     components:
     - type: Transform
       pos: 66.5,58.5
       parent: 2
-  - uid: 18993
+  - uid: 18992
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,62.5
       parent: 2
-  - uid: 18994
+  - uid: 18993
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,62.5
       parent: 2
-  - uid: 18995
+  - uid: 18994
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 64.5,64.5
       parent: 2
-  - uid: 18996
+  - uid: 18995
     components:
     - type: Transform
       pos: 66.5,64.5
       parent: 2
-  - uid: 18997
+  - uid: 18996
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,70.5
       parent: 2
-  - uid: 18998
+  - uid: 18997
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,70.5
       parent: 2
-  - uid: 18999
+  - uid: 18998
     components:
     - type: Transform
       pos: 66.5,72.5
       parent: 2
-  - uid: 19000
+  - uid: 18999
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 60.5,16.5
       parent: 2
-  - uid: 19001
+  - uid: 19000
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-7.5
       parent: 2
-  - uid: 19002
+  - uid: 19001
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-6.5
       parent: 2
-  - uid: 19003
+  - uid: 19002
     components:
     - type: Transform
       pos: -22.5,-7.5
       parent: 2
-  - uid: 19004
+  - uid: 19003
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-6.5
       parent: 2
-  - uid: 19005
+  - uid: 19004
     components:
     - type: Transform
       pos: -19.5,-7.5
       parent: 2
-  - uid: 19006
+  - uid: 19005
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-13.5
       parent: 2
-  - uid: 19007
+  - uid: 19006
     components:
     - type: Transform
       pos: 56.5,-51.5
       parent: 2
-  - uid: 19008
+  - uid: 19007
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 51.5,-51.5
       parent: 2
-  - uid: 19009
+  - uid: 19008
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 85.5,-21.5
       parent: 2
-  - uid: 19010
+  - uid: 19009
     components:
     - type: Transform
       pos: 85.5,-19.5
       parent: 2
-  - uid: 19011
+  - uid: 19010
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-51.5
       parent: 2
-  - uid: 19012
+  - uid: 19011
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-57.5
       parent: 2
-  - uid: 19013
+  - uid: 19012
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-58.5
       parent: 2
-  - uid: 19014
+  - uid: 19013
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-59.5
       parent: 2
-  - uid: 19015
+  - uid: 19014
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-59.5
       parent: 2
-  - uid: 19016
+  - uid: 19015
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-58.5
       parent: 2
-  - uid: 19017
+  - uid: 19016
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,-57.5
       parent: 2
-  - uid: 19018
+  - uid: 19017
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-52.5
       parent: 2
-  - uid: 19019
+  - uid: 19018
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-54.5
       parent: 2
-  - uid: 19020
+  - uid: 19019
     components:
     - type: Transform
       pos: 3.5,-52.5
       parent: 2
 - proto: RailingCornerSmall
   entities:
-  - uid: 19021
+  - uid: 19020
     components:
     - type: Transform
       pos: 18.5,-5.5
       parent: 2
-  - uid: 19022
+  - uid: 19021
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-1.5
       parent: 2
+  - uid: 19022
+    components:
+    - type: Transform
+      pos: 18.5,-3.5
+      parent: 2
   - uid: 19023
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 18.5,-3.5
       parent: 2
   - uid: 19024
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: -31.5,40.5
       parent: 2
   - uid: 19025
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -31.5,40.5
+      pos: -29.5,38.5
       parent: 2
   - uid: 19026
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,38.5
-      parent: 2
-  - uid: 19027
-    components:
-    - type: Transform
       pos: -32.5,51.5
       parent: 2
-  - uid: 19028
+  - uid: 19027
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,46.5
       parent: 2
-  - uid: 19029
+  - uid: 19028
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,51.5
       parent: 2
-  - uid: 19030
+  - uid: 19029
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,46.5
       parent: 2
-  - uid: 19031
+  - uid: 19030
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,51.5
       parent: 2
-  - uid: 19032
+  - uid: 19031
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,46.5
       parent: 2
-  - uid: 19033
+  - uid: 19032
     components:
     - type: Transform
       pos: 1.5,-43.5
       parent: 2
-  - uid: 19034
+  - uid: 19033
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,49.5
       parent: 2
-  - uid: 19035
+  - uid: 19034
     components:
     - type: Transform
       pos: -47.5,10.5
       parent: 2
-  - uid: 19036
+  - uid: 19035
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,10.5
       parent: 2
-  - uid: 19037
+  - uid: 19036
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,15.5
       parent: 2
-  - uid: 19038
+  - uid: 19037
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -43.5,15.5
       parent: 2
-  - uid: 19039
+  - uid: 19038
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,20.5
       parent: 2
-  - uid: 19040
+  - uid: 19039
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,20.5
       parent: 2
-  - uid: 19041
+  - uid: 19040
     components:
     - type: Transform
       pos: -44.5,20.5
       parent: 2
-  - uid: 19042
+  - uid: 19041
     components:
     - type: Transform
       pos: -40.5,20.5
       parent: 2
-  - uid: 19043
+  - uid: 19042
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,15.5
       parent: 2
-  - uid: 19044
+  - uid: 19043
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,15.5
       parent: 2
-  - uid: 19045
+  - uid: 19044
     components:
     - type: Transform
       pos: -59.5,17.5
       parent: 2
-  - uid: 19046
+  - uid: 19045
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,19.5
       parent: 2
-  - uid: 19047
+  - uid: 19046
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,24.5
       parent: 2
-  - uid: 19048
+  - uid: 19047
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -64.5,30.5
       parent: 2
-  - uid: 19049
+  - uid: 19048
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -55.5,30.5
       parent: 2
-  - uid: 19050
+  - uid: 19049
     components:
     - type: Transform
       pos: -54.5,30.5
       parent: 2
-  - uid: 19051
+  - uid: 19050
     components:
     - type: Transform
       pos: -51.5,30.5
       parent: 2
-  - uid: 19052
+  - uid: 19051
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -52.5,30.5
       parent: 2
-  - uid: 19053
+  - uid: 19052
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -43.5,32.5
       parent: 2
-  - uid: 19054
+  - uid: 19053
     components:
     - type: Transform
       pos: -43.5,29.5
       parent: 2
-  - uid: 19055
+  - uid: 19054
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,29.5
       parent: 2
-  - uid: 19056
+  - uid: 19055
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,32.5
       parent: 2
-  - uid: 19057
+  - uid: 19056
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,18.5
       parent: 2
-  - uid: 19058
+  - uid: 19057
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,30.5
       parent: 2
-  - uid: 19059
+  - uid: 19058
     components:
     - type: Transform
       pos: -14.5,16.5
       parent: 2
-  - uid: 19060
+  - uid: 19059
     components:
     - type: Transform
       pos: 9.5,-43.5
       parent: 2
-  - uid: 19061
+  - uid: 19060
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-43.5
       parent: 2
-  - uid: 19062
+  - uid: 19061
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-43.5
       parent: 2
-  - uid: 19063
+  - uid: 19062
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-43.5
       parent: 2
-  - uid: 19064
+  - uid: 19063
     components:
     - type: Transform
       pos: 13.5,-43.5
       parent: 2
-  - uid: 19065
+  - uid: 19064
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-43.5
       parent: 2
-  - uid: 19066
+  - uid: 19065
     components:
     - type: Transform
       pos: 17.5,-43.5
       parent: 2
-  - uid: 19067
+  - uid: 19066
     components:
     - type: Transform
       pos: -17.5,30.5
       parent: 2
-  - uid: 19068
+  - uid: 19067
     components:
     - type: Transform
       pos: 18.5,-33.5
       parent: 2
-  - uid: 19069
+  - uid: 19068
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-24.5
       parent: 2
-  - uid: 19070
+  - uid: 19069
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,12.5
       parent: 2
-  - uid: 19071
+  - uid: 19070
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,12.5
       parent: 2
-  - uid: 19072
+  - uid: 19071
     components:
     - type: Transform
       pos: 24.5,9.5
       parent: 2
-  - uid: 19073
+  - uid: 19072
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,9.5
       parent: 2
-  - uid: 19074
+  - uid: 19073
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,24.5
       parent: 2
-  - uid: 19075
+  - uid: 19074
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: -14.5,27.5
+      parent: 2
+  - uid: 19075
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -14.5,27.5
       parent: 2
   - uid: 19076
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -14.5,27.5
+      pos: -17.5,30.5
       parent: 2
   - uid: 19077
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,30.5
+      pos: -20.5,27.5
       parent: 2
   - uid: 19078
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -20.5,27.5
       parent: 2
   - uid: 19079
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,27.5
-      parent: 2
-  - uid: 19080
-    components:
-    - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,16.5
       parent: 2
-  - uid: 19081
+  - uid: 19080
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,21.5
       parent: 2
-  - uid: 19082
+  - uid: 19081
     components:
     - type: Transform
       pos: -12.5,17.5
       parent: 2
-  - uid: 19083
+  - uid: 19082
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,2.5
       parent: 2
-  - uid: 19084
+  - uid: 19083
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 41.5,2.5
       parent: 2
-  - uid: 19085
+  - uid: 19084
     components:
     - type: Transform
       pos: 44.5,-19.5
       parent: 2
-  - uid: 19086
+  - uid: 19085
     components:
     - type: Transform
       pos: 45.5,-23.5
       parent: 2
-  - uid: 19087
+  - uid: 19086
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-19.5
       parent: 2
-  - uid: 19088
+  - uid: 19087
     components:
     - type: Transform
       pos: 45.5,-30.5
       parent: 2
-  - uid: 19089
+  - uid: 19088
     components:
     - type: Transform
       pos: 44.5,-34.5
       parent: 2
-  - uid: 19090
+  - uid: 19089
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,-15.5
       parent: 2
-  - uid: 19091
+  - uid: 19090
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-26.5
       parent: 2
-  - uid: 19092
+  - uid: 19091
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,-30.5
       parent: 2
-  - uid: 19093
+  - uid: 19092
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-43.5
       parent: 2
-  - uid: 19094
+  - uid: 19093
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 48.5,-30.5
       parent: 2
-  - uid: 19095
+  - uid: 19094
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 53.5,-30.5
       parent: 2
-  - uid: 19096
+  - uid: 19095
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 67.5,3.5
       parent: 2
-  - uid: 19097
+  - uid: 19096
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,5.5
       parent: 2
-  - uid: 19098
+  - uid: 19097
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 70.5,-11.5
       parent: 2
-  - uid: 19099
+  - uid: 19098
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 66.5,-9.5
       parent: 2
-  - uid: 19100
+  - uid: 19099
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 67.5,-10.5
       parent: 2
-  - uid: 19101
+  - uid: 19100
     components:
     - type: Transform
       pos: 76.5,-13.5
       parent: 2
-  - uid: 19102
+  - uid: 19101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 72.5,-13.5
       parent: 2
-  - uid: 19103
+  - uid: 19102
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 71.5,-12.5
       parent: 2
-  - uid: 19104
+  - uid: 19103
     components:
     - type: Transform
       pos: 81.5,-30.5
       parent: 2
-  - uid: 19105
+  - uid: 19104
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 84.5,-30.5
       parent: 2
-  - uid: 19106
+  - uid: 19105
     components:
     - type: Transform
       pos: 82.5,-29.5
       parent: 2
-  - uid: 19107
+  - uid: 19106
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 87.5,-13.5
       parent: 2
-  - uid: 19108
+  - uid: 19107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 83.5,-29.5
       parent: 2
-  - uid: 19109
+  - uid: 19108
     components:
     - type: Transform
       pos: 86.5,-30.5
       parent: 2
-  - uid: 19110
+  - uid: 19109
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 86.5,-10.5
       parent: 2
-  - uid: 19111
+  - uid: 19110
     components:
     - type: Transform
       pos: 87.5,-27.5
       parent: 2
-  - uid: 19112
+  - uid: 19111
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 78.5,-30.5
       parent: 2
-  - uid: 19113
+  - uid: 19112
     components:
     - type: Transform
       pos: 63.5,21.5
       parent: 2
-  - uid: 19114
+  - uid: 19113
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
+      pos: 67.5,21.5
+      parent: 2
+  - uid: 19114
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 67.5,21.5
       parent: 2
   - uid: 19115
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 67.5,21.5
+      rot: 1.5707963267948966 rad
+      pos: 63.5,21.5
       parent: 2
   - uid: 19116
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 63.5,21.5
-      parent: 2
-  - uid: 19117
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 60.5,17.5
       parent: 2
-  - uid: 19118
+  - uid: 19117
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,20.5
       parent: 2
-  - uid: 19119
+  - uid: 19118
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -57.5,-13.5
       parent: 2
-  - uid: 19120
+  - uid: 19119
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,8.5
       parent: 2
-  - uid: 19121
+  - uid: 19120
     components:
     - type: Transform
       pos: 27.5,-43.5
       parent: 2
-  - uid: 19122
+  - uid: 19121
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 51.5,-40.5
       parent: 2
-  - uid: 19123
+  - uid: 19122
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 85.5,-22.5
       parent: 2
-  - uid: 19124
+  - uid: 19123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 84.5,-21.5
       parent: 2
-  - uid: 19125
+  - uid: 19124
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 84.5,-19.5
       parent: 2
-  - uid: 19126
+  - uid: 19125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 85.5,-18.5
       parent: 2
-  - uid: 19127
+  - uid: 19126
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-51.5
       parent: 2
-  - uid: 19128
+  - uid: 19127
     components:
     - type: Transform
       pos: 14.5,-57.5
       parent: 2
-  - uid: 19129
+  - uid: 19128
     components:
     - type: Transform
       pos: 13.5,-58.5
       parent: 2
-  - uid: 19130
+  - uid: 19129
     components:
     - type: Transform
       pos: 11.5,-59.5
       parent: 2
-  - uid: 19131
+  - uid: 19130
     components:
     - type: Transform
       pos: 10.5,-60.5
       parent: 2
-  - uid: 19132
+  - uid: 19131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-60.5
       parent: 2
-  - uid: 19133
+  - uid: 19132
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-59.5
       parent: 2
-  - uid: 19134
+  - uid: 19133
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-58.5
       parent: 2
-  - uid: 19135
+  - uid: 19134
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-57.5
       parent: 2
-  - uid: 19136
+  - uid: 19135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-54.5
       parent: 2
-  - uid: 19137
+  - uid: 19136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-44.5
       parent: 2
-  - uid: 19138
+  - uid: 19137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 49.5,-40.5
       parent: 2
-  - uid: 19139
+  - uid: 19138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,-40.5
       parent: 2
-  - uid: 19140
+  - uid: 19139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 62.5,-40.5
       parent: 2
-  - uid: 19141
+  - uid: 19140
     components:
     - type: Transform
       pos: 61.5,-37.5
       parent: 2
-  - uid: 19142
+  - uid: 19141
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 57.5,-37.5
       parent: 2
-  - uid: 19143
+  - uid: 19142
     components:
     - type: Transform
       pos: 17.5,33.5
       parent: 2
-  - uid: 19144
+  - uid: 19143
     components:
     - type: Transform
       pos: 58.5,12.5
       parent: 2
-  - uid: 19145
+  - uid: 19144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,29.5
       parent: 2
-  - uid: 19146
+  - uid: 19145
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -119936,1083 +119935,1083 @@ entities:
       parent: 2
 - proto: RailingRound
   entities:
-  - uid: 19147
+  - uid: 19146
     components:
     - type: Transform
       pos: -9.5,29.5
       parent: 2
-  - uid: 19148
+  - uid: 19147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,32.5
       parent: 2
-  - uid: 19149
+  - uid: 19148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,70.5
       parent: 2
-  - uid: 19150
+  - uid: 19149
     components:
     - type: Transform
       pos: 34.5,65.5
       parent: 2
-  - uid: 19151
+  - uid: 19150
     components:
     - type: Transform
       pos: 37.5,65.5
       parent: 2
-  - uid: 19152
+  - uid: 19151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,59.5
       parent: 2
-  - uid: 19153
+  - uid: 19152
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,59.5
       parent: 2
-  - uid: 19154
+  - uid: 19153
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,41.5
       parent: 2
-  - uid: 19155
+  - uid: 19154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,41.5
       parent: 2
-  - uid: 19156
+  - uid: 19155
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,70.5
       parent: 2
-  - uid: 19157
+  - uid: 19156
     components:
     - type: Transform
       pos: 34.5,55.5
       parent: 2
-  - uid: 19158
+  - uid: 19157
     components:
     - type: Transform
       pos: 37.5,55.5
       parent: 2
 - proto: RandomArtifactSpawner
   entities:
-  - uid: 19159
+  - uid: 19158
     components:
     - type: Transform
       pos: -73.5,-6.5
       parent: 2
-  - uid: 19160
+  - uid: 19159
     components:
     - type: Transform
       pos: -53.5,40.5
       parent: 2
 - proto: RandomArtifactSpawner20
   entities:
-  - uid: 19161
+  - uid: 19160
     components:
     - type: Transform
       pos: -60.5,44.5
       parent: 2
 - proto: RandomDrinkBottle
   entities:
-  - uid: 19162
+  - uid: 19161
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 2
-  - uid: 19163
+  - uid: 19162
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 2
 - proto: RandomInstruments
   entities:
-  - uid: 19164
+  - uid: 19163
     components:
     - type: Transform
       pos: 44.5,2.5
       parent: 2
-  - uid: 19165
+  - uid: 19164
     components:
     - type: Transform
       pos: 44.5,2.5
       parent: 2
 - proto: RandomPosterLegit
   entities:
-  - uid: 19166
+  - uid: 19165
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 2
-  - uid: 19167
+  - uid: 19166
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 2
-  - uid: 19168
+  - uid: 19167
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-  - uid: 19169
+  - uid: 19168
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 19170
+  - uid: 19169
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 2
-  - uid: 19171
+  - uid: 19170
     components:
     - type: Transform
       pos: -5.5,-15.5
       parent: 2
-  - uid: 19172
+  - uid: 19171
     components:
     - type: Transform
       pos: -23.5,24.5
       parent: 2
-  - uid: 19173
+  - uid: 19172
     components:
     - type: Transform
       pos: 0.5,-29.5
       parent: 2
-  - uid: 19174
+  - uid: 19173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-36.5
       parent: 2
-  - uid: 19175
+  - uid: 19174
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 2
-  - uid: 19176
+  - uid: 19175
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 2
-  - uid: 19177
+  - uid: 19176
     components:
     - type: Transform
       pos: 17.5,-1.5
       parent: 2
-  - uid: 19178
+  - uid: 19177
     components:
     - type: Transform
       pos: -19.5,-2.5
       parent: 2
-  - uid: 19179
+  - uid: 19178
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 2
-  - uid: 19180
+  - uid: 19179
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 2
-  - uid: 19181
+  - uid: 19180
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 2
-  - uid: 19182
+  - uid: 19181
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-39.5
       parent: 2
-  - uid: 19183
+  - uid: 19182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-40.5
       parent: 2
-  - uid: 19184
+  - uid: 19183
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-38.5
       parent: 2
-  - uid: 19185
+  - uid: 19184
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 2
-  - uid: 19186
+  - uid: 19185
     components:
     - type: Transform
       pos: -12.5,-14.5
       parent: 2
-  - uid: 19187
+  - uid: 19186
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 2
-  - uid: 19188
+  - uid: 19187
     components:
     - type: Transform
       pos: -11.5,-4.5
       parent: 2
-  - uid: 19189
+  - uid: 19188
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 2
-  - uid: 19190
+  - uid: 19189
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 2
-  - uid: 19191
+  - uid: 19190
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 2
-  - uid: 19192
+  - uid: 19191
     components:
     - type: Transform
       pos: -14.5,11.5
       parent: 2
-  - uid: 19193
+  - uid: 19192
     components:
     - type: Transform
       pos: -20.5,11.5
       parent: 2
-  - uid: 19194
+  - uid: 19193
     components:
     - type: Transform
       pos: -32.5,4.5
       parent: 2
-  - uid: 19195
+  - uid: 19194
     components:
     - type: Transform
       pos: -26.5,-4.5
       parent: 2
-  - uid: 19196
+  - uid: 19195
     components:
     - type: Transform
       pos: -24.5,-2.5
       parent: 2
-  - uid: 19197
+  - uid: 19196
     components:
     - type: Transform
       pos: -32.5,-4.5
       parent: 2
-  - uid: 19198
+  - uid: 19197
     components:
     - type: Transform
       pos: -44.5,2.5
       parent: 2
-  - uid: 19199
+  - uid: 19198
     components:
     - type: Transform
       pos: -47.5,2.5
       parent: 2
-  - uid: 19200
+  - uid: 19199
     components:
     - type: Transform
       pos: -47.5,-2.5
       parent: 2
-  - uid: 19201
+  - uid: 19200
     components:
     - type: Transform
       pos: -53.5,-1.5
       parent: 2
-  - uid: 19202
+  - uid: 19201
     components:
     - type: Transform
       pos: -57.5,-1.5
       parent: 2
-  - uid: 19203
+  - uid: 19202
     components:
     - type: Transform
       pos: -56.5,6.5
       parent: 2
-  - uid: 19204
+  - uid: 19203
     components:
     - type: Transform
       pos: -54.5,6.5
       parent: 2
-  - uid: 19205
+  - uid: 19204
     components:
     - type: Transform
       pos: -44.5,11.5
       parent: 2
-  - uid: 19206
+  - uid: 19205
     components:
     - type: Transform
       pos: -50.5,6.5
       parent: 2
-  - uid: 19207
+  - uid: 19206
     components:
     - type: Transform
       pos: -44.5,6.5
       parent: 2
-  - uid: 19208
+  - uid: 19207
     components:
     - type: Transform
       pos: -47.5,6.5
       parent: 2
-  - uid: 19209
+  - uid: 19208
     components:
     - type: Transform
       pos: -49.5,12.5
       parent: 2
-  - uid: 19210
+  - uid: 19209
     components:
     - type: Transform
       pos: -49.5,23.5
       parent: 2
-  - uid: 19211
+  - uid: 19210
     components:
     - type: Transform
       pos: -55.5,22.5
       parent: 2
-  - uid: 19212
+  - uid: 19211
     components:
     - type: Transform
       pos: -55.5,14.5
       parent: 2
-  - uid: 19213
+  - uid: 19212
     components:
     - type: Transform
       pos: -51.5,14.5
       parent: 2
-  - uid: 19214
+  - uid: 19213
     components:
     - type: Transform
       pos: -51.5,22.5
       parent: 2
-  - uid: 19215
+  - uid: 19214
     components:
     - type: Transform
       pos: -63.5,16.5
       parent: 2
-  - uid: 19216
+  - uid: 19215
     components:
     - type: Transform
       pos: -63.5,21.5
       parent: 2
-  - uid: 19217
+  - uid: 19216
     components:
     - type: Transform
       pos: -58.5,25.5
       parent: 2
-  - uid: 19218
+  - uid: 19217
     components:
     - type: Transform
       pos: -61.5,25.5
       parent: 2
-  - uid: 19219
+  - uid: 19218
     components:
     - type: Transform
       pos: -64.5,25.5
       parent: 2
-  - uid: 19220
+  - uid: 19219
     components:
     - type: Transform
       pos: -70.5,44.5
       parent: 2
-  - uid: 19221
+  - uid: 19220
     components:
     - type: Transform
       pos: -70.5,37.5
       parent: 2
-  - uid: 19222
+  - uid: 19221
     components:
     - type: Transform
       pos: -42.5,38.5
       parent: 2
-  - uid: 19223
+  - uid: 19222
     components:
     - type: Transform
       pos: -42.5,35.5
       parent: 2
-  - uid: 19224
+  - uid: 19223
     components:
     - type: Transform
       pos: -46.5,40.5
       parent: 2
-  - uid: 19225
+  - uid: 19224
     components:
     - type: Transform
       pos: -42.5,26.5
       parent: 2
-  - uid: 19226
+  - uid: 19225
     components:
     - type: Transform
       pos: -49.5,25.5
       parent: 2
-  - uid: 19227
+  - uid: 19226
     components:
     - type: Transform
       pos: -34.5,25.5
       parent: 2
-  - uid: 19228
+  - uid: 19227
     components:
     - type: Transform
       pos: -39.5,33.5
       parent: 2
-  - uid: 19229
+  - uid: 19228
     components:
     - type: Transform
       pos: -23.5,38.5
       parent: 2
-  - uid: 19230
+  - uid: 19229
     components:
     - type: Transform
       pos: -20.5,46.5
       parent: 2
-  - uid: 19231
+  - uid: 19230
     components:
     - type: Transform
       pos: -10.5,46.5
       parent: 2
-  - uid: 19232
+  - uid: 19231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,44.5
       parent: 2
-  - uid: 19233
+  - uid: 19232
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,40.5
       parent: 2
-  - uid: 19234
+  - uid: 19233
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,35.5
       parent: 2
-  - uid: 19235
+  - uid: 19234
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,31.5
       parent: 2
-  - uid: 19236
+  - uid: 19235
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,29.5
       parent: 2
-  - uid: 19237
+  - uid: 19236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,24.5
       parent: 2
-  - uid: 19238
+  - uid: 19237
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,24.5
       parent: 2
-  - uid: 19239
+  - uid: 19238
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,19.5
       parent: 2
-  - uid: 19240
+  - uid: 19239
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,33.5
       parent: 2
-  - uid: 19241
+  - uid: 19240
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,27.5
       parent: 2
-  - uid: 19242
+  - uid: 19241
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,35.5
       parent: 2
-  - uid: 19243
+  - uid: 19242
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,33.5
       parent: 2
-  - uid: 19244
+  - uid: 19243
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,31.5
       parent: 2
-  - uid: 19245
+  - uid: 19244
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,19.5
       parent: 2
-  - uid: 19246
+  - uid: 19245
     components:
     - type: Transform
       pos: 21.5,-23.5
       parent: 2
-  - uid: 19247
+  - uid: 19246
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,35.5
       parent: 2
-  - uid: 19248
+  - uid: 19247
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,31.5
       parent: 2
-  - uid: 19249
+  - uid: 19248
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,29.5
       parent: 2
-  - uid: 19250
+  - uid: 19249
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,23.5
       parent: 2
-  - uid: 19251
+  - uid: 19250
     components:
     - type: Transform
       pos: 7.5,26.5
       parent: 2
-  - uid: 19252
+  - uid: 19251
     components:
     - type: Transform
       pos: 23.5,23.5
       parent: 2
-  - uid: 19253
+  - uid: 19252
     components:
     - type: Transform
       pos: 25.5,27.5
       parent: 2
-  - uid: 19254
+  - uid: 19253
     components:
     - type: Transform
       pos: 25.5,23.5
       parent: 2
-  - uid: 19255
+  - uid: 19254
     components:
     - type: Transform
       pos: 21.5,27.5
       parent: 2
-  - uid: 19256
+  - uid: 19255
     components:
     - type: Transform
       pos: 14.5,27.5
       parent: 2
-  - uid: 19257
+  - uid: 19256
     components:
     - type: Transform
       pos: 31.5,21.5
       parent: 2
-  - uid: 19258
+  - uid: 19257
     components:
     - type: Transform
       pos: 42.5,32.5
       parent: 2
-  - uid: 19259
+  - uid: 19258
     components:
     - type: Transform
       pos: 56.5,25.5
       parent: 2
-  - uid: 19260
+  - uid: 19259
     components:
     - type: Transform
       pos: 35.5,23.5
       parent: 2
-  - uid: 19261
+  - uid: 19260
     components:
     - type: Transform
       pos: 37.5,19.5
       parent: 2
-  - uid: 19262
+  - uid: 19261
     components:
     - type: Transform
       pos: 35.5,6.5
       parent: 2
-  - uid: 19263
+  - uid: 19262
     components:
     - type: Transform
       pos: 39.5,6.5
       parent: 2
-  - uid: 19264
+  - uid: 19263
     components:
     - type: Transform
       pos: 71.5,23.5
       parent: 2
-  - uid: 19265
+  - uid: 19264
     components:
     - type: Transform
       pos: 71.5,13.5
       parent: 2
-  - uid: 19266
+  - uid: 19265
     components:
     - type: Transform
       pos: 63.5,39.5
       parent: 2
-  - uid: 19267
+  - uid: 19266
     components:
     - type: Transform
       pos: 67.5,39.5
       parent: 2
-  - uid: 19268
+  - uid: 19267
     components:
     - type: Transform
       pos: 52.5,-0.5
       parent: 2
-  - uid: 19269
+  - uid: 19268
     components:
     - type: Transform
       pos: 46.5,1.5
       parent: 2
-  - uid: 19270
+  - uid: 19269
     components:
     - type: Transform
       pos: 43.5,-1.5
       parent: 2
-  - uid: 19271
+  - uid: 19270
     components:
     - type: Transform
       pos: 52.5,-5.5
       parent: 2
-  - uid: 19272
+  - uid: 19271
     components:
     - type: Transform
       pos: 57.5,-5.5
       parent: 2
-  - uid: 19273
+  - uid: 19272
     components:
     - type: Transform
       pos: 57.5,-1.5
       parent: 2
-  - uid: 19274
+  - uid: 19273
     components:
     - type: Transform
       pos: 53.5,3.5
       parent: 2
-  - uid: 19275
+  - uid: 19274
     components:
     - type: Transform
       pos: 55.5,3.5
       parent: 2
-  - uid: 19276
+  - uid: 19275
     components:
     - type: Transform
       pos: 66.5,-5.5
       parent: 2
-  - uid: 19277
+  - uid: 19276
     components:
     - type: Transform
       pos: 66.5,-1.5
       parent: 2
-  - uid: 19278
+  - uid: 19277
     components:
     - type: Transform
       pos: 77.5,-10.5
       parent: 2
-  - uid: 19279
+  - uid: 19278
     components:
     - type: Transform
       pos: 77.5,-8.5
       parent: 2
-  - uid: 19280
+  - uid: 19279
     components:
     - type: Transform
       pos: 77.5,-6.5
       parent: 2
-  - uid: 19281
+  - uid: 19280
     components:
     - type: Transform
       pos: 84.5,-9.5
       parent: 2
-  - uid: 19282
+  - uid: 19281
     components:
     - type: Transform
       pos: 82.5,-12.5
       parent: 2
-  - uid: 19283
+  - uid: 19282
     components:
     - type: Transform
       pos: 69.5,-23.5
       parent: 2
-  - uid: 19284
+  - uid: 19283
     components:
     - type: Transform
       pos: 72.5,-17.5
       parent: 2
-  - uid: 19285
+  - uid: 19284
     components:
     - type: Transform
       pos: 69.5,-19.5
       parent: 2
-  - uid: 19286
+  - uid: 19285
     components:
     - type: Transform
       pos: 69.5,-30.5
       parent: 2
-  - uid: 19287
+  - uid: 19286
     components:
     - type: Transform
       pos: 63.5,-35.5
       parent: 2
-  - uid: 19288
+  - uid: 19287
     components:
     - type: Transform
       pos: 66.5,-35.5
       parent: 2
-  - uid: 19289
+  - uid: 19288
     components:
     - type: Transform
       pos: 57.5,-35.5
       parent: 2
-  - uid: 19290
+  - uid: 19289
     components:
     - type: Transform
       pos: 52.5,-35.5
       parent: 2
-  - uid: 19291
+  - uid: 19290
     components:
     - type: Transform
       pos: 49.5,-35.5
       parent: 2
-  - uid: 19292
+  - uid: 19291
     components:
     - type: Transform
       pos: 46.5,-35.5
       parent: 2
-  - uid: 19293
+  - uid: 19292
     components:
     - type: Transform
       pos: 39.5,-30.5
       parent: 2
-  - uid: 19294
+  - uid: 19293
     components:
     - type: Transform
       pos: 40.5,-26.5
       parent: 2
-  - uid: 19295
+  - uid: 19294
     components:
     - type: Transform
       pos: 40.5,-23.5
       parent: 2
-  - uid: 19296
+  - uid: 19295
     components:
     - type: Transform
       pos: 39.5,-19.5
       parent: 2
-  - uid: 19297
+  - uid: 19296
     components:
     - type: Transform
       pos: 33.5,-28.5
       parent: 2
-  - uid: 19298
+  - uid: 19297
     components:
     - type: Transform
       pos: 14.5,-24.5
       parent: 2
-  - uid: 19299
+  - uid: 19298
     components:
     - type: Transform
       pos: 10.5,-24.5
       parent: 2
-  - uid: 19300
+  - uid: 19299
     components:
     - type: Transform
       pos: 7.5,-33.5
       parent: 2
-  - uid: 19301
+  - uid: 19300
     components:
     - type: Transform
       pos: 9.5,-39.5
       parent: 2
-  - uid: 19302
+  - uid: 19301
     components:
     - type: Transform
       pos: 13.5,-39.5
       parent: 2
-  - uid: 19303
+  - uid: 19302
     components:
     - type: Transform
       pos: 0.5,-31.5
       parent: 2
-  - uid: 19304
+  - uid: 19303
     components:
     - type: Transform
       pos: 14.5,-15.5
       parent: 2
-  - uid: 19305
+  - uid: 19304
     components:
     - type: Transform
       pos: 16.5,-5.5
       parent: 2
-  - uid: 19306
+  - uid: 19305
     components:
     - type: Transform
       pos: -47.5,-7.5
       parent: 2
-  - uid: 19307
+  - uid: 19306
     components:
     - type: Transform
       pos: -47.5,-11.5
       parent: 2
-  - uid: 19308
+  - uid: 19307
     components:
     - type: Transform
       pos: -39.5,-9.5
       parent: 2
-  - uid: 19309
+  - uid: 19308
     components:
     - type: Transform
       pos: -60.5,23.5
       parent: 2
-  - uid: 19310
+  - uid: 19309
     components:
     - type: Transform
       pos: -60.5,13.5
       parent: 2
-  - uid: 19311
+  - uid: 19310
     components:
     - type: Transform
       pos: -7.5,36.5
       parent: 2
 - proto: RandomSoap
   entities:
-  - uid: 19312
+  - uid: 19311
     components:
     - type: Transform
       pos: 12.5,-17.5
       parent: 2
 - proto: RandomSpawner100
   entities:
-  - uid: 19313
+  - uid: 19312
     components:
     - type: Transform
       pos: 62.5,-34.5
       parent: 2
-  - uid: 19314
+  - uid: 19313
     components:
     - type: Transform
       pos: 65.5,-33.5
       parent: 2
-  - uid: 19315
+  - uid: 19314
     components:
     - type: Transform
       pos: 63.5,-31.5
       parent: 2
-  - uid: 19316
+  - uid: 19315
     components:
     - type: Transform
       pos: 66.5,-30.5
       parent: 2
-  - uid: 19317
+  - uid: 19316
     components:
     - type: Transform
       pos: 64.5,-30.5
       parent: 2
-  - uid: 19318
+  - uid: 19317
     components:
     - type: Transform
       pos: 64.5,-33.5
       parent: 2
-  - uid: 19319
+  - uid: 19318
     components:
     - type: Transform
       pos: 57.5,-32.5
       parent: 2
-  - uid: 19320
+  - uid: 19319
     components:
     - type: Transform
       pos: 58.5,-33.5
       parent: 2
-  - uid: 19321
+  - uid: 19320
     components:
     - type: Transform
       pos: 59.5,-29.5
       parent: 2
-  - uid: 19322
+  - uid: 19321
     components:
     - type: Transform
       pos: 60.5,-28.5
       parent: 2
-  - uid: 19323
+  - uid: 19322
     components:
     - type: Transform
       pos: 61.5,-27.5
       parent: 2
-  - uid: 19324
+  - uid: 19323
     components:
     - type: Transform
       pos: 63.5,-26.5
       parent: 2
-  - uid: 19325
+  - uid: 19324
     components:
     - type: Transform
       pos: 65.5,-27.5
       parent: 2
-  - uid: 19326
+  - uid: 19325
     components:
     - type: Transform
       pos: 66.5,-25.5
       parent: 2
-  - uid: 19327
+  - uid: 19326
     components:
     - type: Transform
       pos: 67.5,-27.5
       parent: 2
 - proto: RandomVendingDrinks
   entities:
-  - uid: 19328
+  - uid: 19327
     components:
     - type: Transform
       pos: 15.5,10.5
       parent: 2
-  - uid: 19329
+  - uid: 19328
     components:
     - type: Transform
       pos: 15.5,-34.5
       parent: 2
-  - uid: 19330
+  - uid: 19329
     components:
     - type: Transform
       pos: 16.5,-20.5
       parent: 2
-  - uid: 19331
+  - uid: 19330
     components:
     - type: Transform
       pos: 43.5,-0.5
       parent: 2
-  - uid: 19332
+  - uid: 19331
     components:
     - type: Transform
       pos: 55.5,-36.5
       parent: 2
-  - uid: 19333
+  - uid: 19332
     components:
     - type: Transform
       pos: 66.5,-42.5
       parent: 2
-  - uid: 19334
+  - uid: 19333
     components:
     - type: Transform
       pos: -22.5,19.5
       parent: 2
 - proto: RandomVendingSnacks
   entities:
-  - uid: 19335
+  - uid: 19334
     components:
     - type: Transform
       pos: -18.5,-0.5
       parent: 2
-  - uid: 19336
+  - uid: 19335
     components:
     - type: Transform
       pos: -42.5,10.5
       parent: 2
-  - uid: 19337
+  - uid: 19336
     components:
     - type: Transform
       pos: 15.5,9.5
       parent: 2
-  - uid: 19338
+  - uid: 19337
     components:
     - type: Transform
       pos: 16.5,-34.5
       parent: 2
-  - uid: 19339
+  - uid: 19338
     components:
     - type: Transform
       pos: 15.5,-20.5
       parent: 2
-  - uid: 19340
+  - uid: 19339
     components:
     - type: Transform
       pos: 43.5,0.5
       parent: 2
-  - uid: 19341
+  - uid: 19340
     components:
     - type: Transform
       pos: 54.5,-36.5
       parent: 2
-  - uid: 19342
+  - uid: 19341
     components:
     - type: Transform
       pos: 66.5,-41.5
       parent: 2
-  - uid: 19343
+  - uid: 19342
     components:
     - type: Transform
       pos: -22.5,18.5
       parent: 2
 - proto: RandomWoodenSupport
   entities:
-  - uid: 19344
+  - uid: 19343
     components:
     - type: Transform
       pos: -49.5,-18.5
       parent: 2
-  - uid: 19345
+  - uid: 19344
     components:
     - type: Transform
       pos: -57.5,-11.5
       parent: 2
-  - uid: 19346
+  - uid: 19345
     components:
     - type: Transform
       pos: -55.5,-8.5
       parent: 2
 - proto: RCD
   entities:
-  - uid: 19347
+  - uid: 19346
     components:
     - type: Transform
       pos: 36.40911,29.864853
       parent: 2
 - proto: RCDAmmo
   entities:
-  - uid: 19348
+  - uid: 19347
     components:
     - type: Transform
       pos: 36.424736,29.458603
       parent: 2
-  - uid: 19349
+  - uid: 19348
     components:
     - type: Transform
       pos: 36.549736,29.411728
       parent: 2
 - proto: Recycler
   entities:
-  - uid: 19350
+  - uid: 19349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,28.5
       parent: 2
-  - uid: 19351
+  - uid: 19350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -121024,693 +121023,693 @@ entities:
       enabled: True
 - proto: ReinforcedGirder
   entities:
-  - uid: 19352
+  - uid: 19351
     components:
     - type: Transform
       pos: -77.5,32.5
       parent: 2
-  - uid: 19353
+  - uid: 19352
     components:
     - type: Transform
       pos: -75.5,38.5
       parent: 2
-  - uid: 19354
+  - uid: 19353
     components:
     - type: Transform
       pos: -75.5,34.5
       parent: 2
-  - uid: 19355
+  - uid: 19354
     components:
     - type: Transform
       pos: -70.5,51.5
       parent: 2
-  - uid: 19356
+  - uid: 19355
     components:
     - type: Transform
       pos: -63.5,51.5
       parent: 2
-  - uid: 19357
+  - uid: 19356
     components:
     - type: Transform
       pos: -57.5,43.5
       parent: 2
-  - uid: 19358
+  - uid: 19357
     components:
     - type: Transform
       pos: -57.5,48.5
       parent: 2
-  - uid: 19359
+  - uid: 19358
     components:
     - type: Transform
       pos: -63.5,48.5
       parent: 2
-  - uid: 19360
+  - uid: 19359
     components:
     - type: Transform
       pos: -63.5,43.5
       parent: 2
-  - uid: 19361
+  - uid: 19360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,-44.5
       parent: 2
-  - uid: 19362
+  - uid: 19361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-24.5
       parent: 2
-  - uid: 19363
+  - uid: 19362
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-42.5
       parent: 2
-  - uid: 19364
+  - uid: 19363
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -26.5,-33.5
       parent: 2
-  - uid: 19365
+  - uid: 19364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,-42.5
       parent: 2
-  - uid: 19366
+  - uid: 19365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,-44.5
       parent: 2
-  - uid: 19367
+  - uid: 19366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,-42.5
       parent: 2
-  - uid: 19368
+  - uid: 19367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-42.5
       parent: 2
-  - uid: 19369
+  - uid: 19368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-33.5
       parent: 2
-  - uid: 19370
+  - uid: 19369
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -48.5,-24.5
       parent: 2
-  - uid: 19371
+  - uid: 19370
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,-24.5
       parent: 2
-  - uid: 19372
+  - uid: 19371
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,-24.5
       parent: 2
-  - uid: 19373
+  - uid: 19372
     components:
     - type: Transform
       pos: -4.5,58.5
       parent: 2
-  - uid: 19374
+  - uid: 19373
     components:
     - type: Transform
       pos: -15.5,60.5
       parent: 2
-  - uid: 19375
+  - uid: 19374
     components:
     - type: Transform
       pos: -22.5,60.5
       parent: 2
-  - uid: 19376
+  - uid: 19375
     components:
     - type: Transform
       pos: -8.5,60.5
       parent: 2
-  - uid: 19377
+  - uid: 19376
     components:
     - type: Transform
       pos: -26.5,58.5
       parent: 2
-  - uid: 19378
+  - uid: 19377
     components:
     - type: Transform
       pos: -27.5,57.5
       parent: 2
-  - uid: 19379
+  - uid: 19378
     components:
     - type: Transform
       pos: -24.5,59.5
       parent: 2
-  - uid: 19380
+  - uid: 19379
     components:
     - type: Transform
       pos: -10.5,58.5
       parent: 2
-  - uid: 19381
+  - uid: 19380
     components:
     - type: Transform
       pos: -24.5,56.5
       parent: 2
-  - uid: 19382
+  - uid: 19381
     components:
     - type: Transform
       pos: -6.5,56.5
       parent: 2
-  - uid: 19383
+  - uid: 19382
     components:
     - type: Transform
       pos: -20.5,58.5
       parent: 2
-  - uid: 19384
+  - uid: 19383
     components:
     - type: Transform
       pos: -15.5,58.5
       parent: 2
-  - uid: 19385
+  - uid: 19384
     components:
     - type: Transform
       pos: -6.5,59.5
       parent: 2
-  - uid: 19386
+  - uid: 19385
     components:
     - type: Transform
       pos: -3.5,57.5
       parent: 2
-  - uid: 19387
+  - uid: 19386
     components:
     - type: Transform
       pos: -63.5,54.5
       parent: 2
-  - uid: 19388
+  - uid: 19387
     components:
     - type: Transform
       pos: -70.5,54.5
       parent: 2
-  - uid: 19389
+  - uid: 19388
     components:
     - type: Transform
       pos: -74.5,51.5
       parent: 2
-  - uid: 19390
+  - uid: 19389
     components:
     - type: Transform
       pos: -75.5,48.5
       parent: 2
-  - uid: 19391
+  - uid: 19390
     components:
     - type: Transform
       pos: -57.5,54.5
       parent: 2
-  - uid: 19392
+  - uid: 19391
     components:
     - type: Transform
       pos: -51.5,54.5
       parent: 2
-  - uid: 19393
+  - uid: 19392
     components:
     - type: Transform
       pos: -45.5,54.5
       parent: 2
-  - uid: 19394
+  - uid: 19393
     components:
     - type: Transform
       pos: -42.5,51.5
       parent: 2
-  - uid: 19395
+  - uid: 19394
     components:
     - type: Transform
       pos: -40.5,46.5
       parent: 2
-  - uid: 19396
+  - uid: 19395
     components:
     - type: Transform
       pos: -73.5,34.5
       parent: 2
-  - uid: 19397
+  - uid: 19396
     components:
     - type: Transform
       pos: -73.5,25.5
       parent: 2
-  - uid: 19398
+  - uid: 19397
     components:
     - type: Transform
       pos: -67.5,48.5
       parent: 2
-  - uid: 19399
+  - uid: 19398
     components:
     - type: Transform
       pos: -71.5,25.5
       parent: 2
-  - uid: 19400
+  - uid: 19399
     components:
     - type: Transform
       pos: -71.5,34.5
       parent: 2
-  - uid: 19401
+  - uid: 19400
     components:
     - type: Transform
       pos: -73.5,16.5
       parent: 2
-  - uid: 19402
+  - uid: 19401
     components:
     - type: Transform
       pos: -71.5,16.5
       parent: 2
-  - uid: 19403
+  - uid: 19402
     components:
     - type: Transform
       pos: 5.5,52.5
       parent: 2
-  - uid: 19404
+  - uid: 19403
     components:
     - type: Transform
       pos: -38.5,56.5
       parent: 2
-  - uid: 19405
+  - uid: 19404
     components:
     - type: Transform
       pos: -40.5,54.5
       parent: 2
-  - uid: 19406
+  - uid: 19405
     components:
     - type: Transform
       pos: 9.5,51.5
       parent: 2
-  - uid: 19407
+  - uid: 19406
     components:
     - type: Transform
       pos: 11.5,53.5
       parent: 2
-  - uid: 19408
+  - uid: 19407
     components:
     - type: Transform
       pos: 11.5,46.5
       parent: 2
-  - uid: 19409
+  - uid: 19408
     components:
     - type: Transform
       pos: 7.5,53.5
       parent: 2
-  - uid: 19410
+  - uid: 19409
     components:
     - type: Transform
       pos: 3.5,54.5
       parent: 2
-  - uid: 19411
+  - uid: 19410
     components:
     - type: Transform
       pos: -70.5,48.5
       parent: 2
-  - uid: 19412
+  - uid: 19411
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,56.5
       parent: 2
-  - uid: 19413
+  - uid: 19412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,58.5
       parent: 2
-  - uid: 19414
+  - uid: 19413
     components:
     - type: Transform
       pos: 37.5,69.5
       parent: 2
-  - uid: 19415
+  - uid: 19414
     components:
     - type: Transform
       pos: 37.5,66.5
       parent: 2
-  - uid: 19416
+  - uid: 19415
     components:
     - type: Transform
       pos: 34.5,66.5
       parent: 2
-  - uid: 19417
+  - uid: 19416
     components:
     - type: Transform
       pos: 34.5,69.5
       parent: 2
-  - uid: 19418
+  - uid: 19417
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,58.5
       parent: 2
-  - uid: 19419
+  - uid: 19418
     components:
     - type: Transform
       pos: 34.5,51.5
       parent: 2
-  - uid: 19420
+  - uid: 19419
     components:
     - type: Transform
       pos: 34.5,49.5
       parent: 2
-  - uid: 19421
+  - uid: 19420
     components:
     - type: Transform
       pos: 34.5,47.5
       parent: 2
-  - uid: 19422
+  - uid: 19421
     components:
     - type: Transform
       pos: 34.5,45.5
       parent: 2
-  - uid: 19423
+  - uid: 19422
     components:
     - type: Transform
       pos: 37.5,47.5
       parent: 2
-  - uid: 19424
+  - uid: 19423
     components:
     - type: Transform
       pos: 37.5,45.5
       parent: 2
-  - uid: 19425
+  - uid: 19424
     components:
     - type: Transform
       pos: 37.5,51.5
       parent: 2
-  - uid: 19426
+  - uid: 19425
     components:
     - type: Transform
       pos: 37.5,49.5
       parent: 2
-  - uid: 19427
+  - uid: 19426
     components:
     - type: Transform
       pos: 36.5,71.5
       parent: 2
-  - uid: 19428
+  - uid: 19427
     components:
     - type: Transform
       pos: 35.5,71.5
       parent: 2
-  - uid: 19429
+  - uid: 19428
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,56.5
       parent: 2
-  - uid: 19430
+  - uid: 19429
     components:
     - type: Transform
       pos: -77.5,42.5
       parent: 2
-  - uid: 19431
+  - uid: 19430
     components:
     - type: Transform
       pos: -77.5,38.5
       parent: 2
-  - uid: 19432
+  - uid: 19431
     components:
     - type: Transform
       pos: -77.5,34.5
       parent: 2
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 19433
+  - uid: 19432
     components:
     - type: Transform
       pos: 53.5,7.5
       parent: 2
-  - uid: 19434
+  - uid: 19433
     components:
     - type: Transform
       pos: 40.5,14.5
       parent: 2
-  - uid: 19435
+  - uid: 19434
     components:
     - type: Transform
       pos: -5.5,-7.5
       parent: 2
-  - uid: 19436
+  - uid: 19435
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 2
-  - uid: 19437
+  - uid: 19436
     components:
     - type: Transform
       pos: -8.5,-12.5
       parent: 2
-  - uid: 19438
+  - uid: 19437
     components:
     - type: Transform
       pos: -9.5,-12.5
       parent: 2
-  - uid: 19439
+  - uid: 19438
     components:
     - type: Transform
       pos: -49.5,40.5
       parent: 2
-  - uid: 19440
+  - uid: 19439
     components:
     - type: Transform
       pos: -47.5,40.5
       parent: 2
-  - uid: 19441
+  - uid: 19440
     components:
     - type: Transform
       pos: -61.5,43.5
       parent: 2
-  - uid: 19442
+  - uid: 19441
     components:
     - type: Transform
       pos: -59.5,43.5
       parent: 2
-  - uid: 19443
+  - uid: 19442
     components:
     - type: Transform
       pos: -53.5,25.5
       parent: 2
-  - uid: 19444
+  - uid: 19443
     components:
     - type: Transform
       pos: -52.5,25.5
       parent: 2
-  - uid: 19445
+  - uid: 19444
     components:
     - type: Transform
       pos: -54.5,25.5
       parent: 2
-  - uid: 19446
+  - uid: 19445
     components:
     - type: Transform
       pos: -52.5,38.5
       parent: 2
-  - uid: 19447
+  - uid: 19446
     components:
     - type: Transform
       pos: -55.5,39.5
       parent: 2
-  - uid: 19448
+  - uid: 19447
     components:
     - type: Transform
       pos: -51.5,39.5
       parent: 2
-  - uid: 19449
+  - uid: 19448
     components:
     - type: Transform
       pos: -54.5,38.5
       parent: 2
-  - uid: 19450
+  - uid: 19449
     components:
     - type: Transform
       pos: 50.5,14.5
       parent: 2
-  - uid: 19451
+  - uid: 19450
     components:
     - type: Transform
       pos: 51.5,14.5
       parent: 2
-  - uid: 19452
+  - uid: 19451
     components:
     - type: Transform
       pos: 47.5,14.5
       parent: 2
-  - uid: 19453
+  - uid: 19452
     components:
     - type: Transform
       pos: 44.5,14.5
       parent: 2
-  - uid: 19454
+  - uid: 19453
     components:
     - type: Transform
       pos: 42.5,14.5
       parent: 2
-  - uid: 19455
+  - uid: 19454
     components:
     - type: Transform
       pos: 48.5,14.5
       parent: 2
-  - uid: 19456
+  - uid: 19455
     components:
     - type: Transform
       pos: 45.5,14.5
       parent: 2
-  - uid: 19457
+  - uid: 19456
     components:
     - type: Transform
       pos: 55.5,14.5
       parent: 2
-  - uid: 19458
+  - uid: 19457
     components:
     - type: Transform
       pos: 54.5,14.5
       parent: 2
-  - uid: 19459
+  - uid: 19458
     components:
     - type: Transform
       pos: 53.5,14.5
       parent: 2
-  - uid: 19460
+  - uid: 19459
     components:
     - type: Transform
       pos: 56.5,24.5
       parent: 2
-  - uid: 19461
+  - uid: 19460
     components:
     - type: Transform
       pos: 52.5,24.5
       parent: 2
-  - uid: 19462
+  - uid: 19461
     components:
     - type: Transform
       pos: 64.5,43.5
       parent: 2
-  - uid: 19463
+  - uid: 19462
     components:
     - type: Transform
       pos: 63.5,42.5
       parent: 2
-  - uid: 19464
+  - uid: 19463
     components:
     - type: Transform
       pos: 66.5,46.5
       parent: 2
-  - uid: 19465
+  - uid: 19464
     components:
     - type: Transform
       pos: 66.5,47.5
       parent: 2
-  - uid: 19466
+  - uid: 19465
     components:
     - type: Transform
       pos: 64.5,46.5
       parent: 2
-  - uid: 19467
+  - uid: 19466
     components:
     - type: Transform
       pos: 64.5,47.5
       parent: 2
-  - uid: 19468
+  - uid: 19467
     components:
     - type: Transform
       pos: 63.5,46.5
       parent: 2
-  - uid: 19469
+  - uid: 19468
     components:
     - type: Transform
       pos: 63.5,45.5
       parent: 2
-  - uid: 19470
+  - uid: 19469
     components:
     - type: Transform
       pos: 63.5,44.5
       parent: 2
-  - uid: 19471
+  - uid: 19470
     components:
     - type: Transform
       pos: 63.5,43.5
       parent: 2
-  - uid: 19472
+  - uid: 19471
     components:
     - type: Transform
       pos: 67.5,46.5
       parent: 2
-  - uid: 19473
+  - uid: 19472
     components:
     - type: Transform
       pos: 67.5,45.5
       parent: 2
-  - uid: 19474
+  - uid: 19473
     components:
     - type: Transform
       pos: 67.5,44.5
       parent: 2
-  - uid: 19475
+  - uid: 19474
     components:
     - type: Transform
       pos: 67.5,43.5
       parent: 2
-  - uid: 19476
+  - uid: 19475
     components:
     - type: Transform
       pos: 66.5,43.5
       parent: 2
-  - uid: 19477
+  - uid: 19476
     components:
     - type: Transform
       pos: 67.5,42.5
       parent: 2
-  - uid: 19478
+  - uid: 19477
     components:
     - type: Transform
       pos: 54.5,25.5
       parent: 2
-  - uid: 19479
+  - uid: 19478
     components:
     - type: Transform
       pos: 57.5,7.5
       parent: 2
-  - uid: 19480
+  - uid: 19479
     components:
     - type: Transform
       pos: 56.5,7.5
       parent: 2
-  - uid: 19481
+  - uid: 19480
     components:
     - type: Transform
       pos: 54.5,7.5
       parent: 2
-  - uid: 19482
+  - uid: 19481
     components:
     - type: Transform
       pos: -67.5,34.5
       parent: 2
-  - uid: 19483
+  - uid: 19482
     components:
     - type: Transform
       pos: -66.5,34.5
       parent: 2
 - proto: ReinforcedPlasmaWindowDiagonal
   entities:
-  - uid: 19484
+  - uid: 19483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -55.5,38.5
       parent: 2
-  - uid: 19485
+  - uid: 19484
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -121718,2074 +121717,2074 @@ entities:
       parent: 2
 - proto: ReinforcedWindow
   entities:
-  - uid: 19486
+  - uid: 19485
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 2
-  - uid: 19487
+  - uid: 19486
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 2
-  - uid: 19488
+  - uid: 19487
     components:
     - type: Transform
       pos: 17.5,-7.5
       parent: 2
-  - uid: 19489
+  - uid: 19488
     components:
     - type: Transform
       pos: -26.5,17.5
       parent: 2
-  - uid: 19490
+  - uid: 19489
     components:
     - type: Transform
       pos: -27.5,17.5
       parent: 2
-  - uid: 19491
+  - uid: 19490
     components:
     - type: Transform
       pos: 13.5,8.5
       parent: 2
-  - uid: 19492
+  - uid: 19491
     components:
     - type: Transform
       pos: 11.5,8.5
       parent: 2
-  - uid: 19493
+  - uid: 19492
     components:
     - type: Transform
       pos: 11.5,2.5
       parent: 2
-  - uid: 19494
+  - uid: 19493
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 2
-  - uid: 19495
+  - uid: 19494
     components:
     - type: Transform
       pos: 17.5,-6.5
       parent: 2
-  - uid: 19496
+  - uid: 19495
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 2
-  - uid: 19497
+  - uid: 19496
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 2
-  - uid: 19498
+  - uid: 19497
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 2
-  - uid: 19499
+  - uid: 19498
     components:
     - type: Transform
       pos: 17.5,-8.5
       parent: 2
-  - uid: 19500
+  - uid: 19499
     components:
     - type: Transform
       pos: 17.5,-9.5
       parent: 2
-  - uid: 19501
+  - uid: 19500
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 2
-  - uid: 19502
+  - uid: 19501
     components:
     - type: Transform
       pos: 17.5,-3.5
       parent: 2
-  - uid: 19503
+  - uid: 19502
     components:
     - type: Transform
       pos: 14.5,-5.5
       parent: 2
-  - uid: 19504
+  - uid: 19503
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 2
-  - uid: 19505
+  - uid: 19504
     components:
     - type: Transform
       pos: -65.5,42.5
       parent: 2
-  - uid: 19506
+  - uid: 19505
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 2
-  - uid: 19507
+  - uid: 19506
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-  - uid: 19508
+  - uid: 19507
     components:
     - type: Transform
       pos: 17.5,1.5
       parent: 2
-  - uid: 19509
+  - uid: 19508
     components:
     - type: Transform
       pos: 13.5,11.5
       parent: 2
-  - uid: 19510
+  - uid: 19509
     components:
     - type: Transform
       pos: 11.5,11.5
       parent: 2
-  - uid: 19511
+  - uid: 19510
     components:
     - type: Transform
       pos: 5.5,46.5
       parent: 2
-  - uid: 19512
+  - uid: 19511
     components:
     - type: Transform
       pos: 6.5,46.5
       parent: 2
-  - uid: 19513
+  - uid: 19512
     components:
     - type: Transform
       pos: 19.5,-38.5
       parent: 2
-  - uid: 19514
+  - uid: 19513
     components:
     - type: Transform
       pos: 26.5,-38.5
       parent: 2
-  - uid: 19515
+  - uid: 19514
     components:
     - type: Transform
       pos: 23.5,-38.5
       parent: 2
-  - uid: 19516
+  - uid: 19515
     components:
     - type: Transform
       pos: -3.5,51.5
       parent: 2
-  - uid: 19517
+  - uid: 19516
     components:
     - type: Transform
       pos: -9.5,-30.5
       parent: 2
-  - uid: 19518
+  - uid: 19517
     components:
     - type: Transform
       pos: -31.5,47.5
       parent: 2
-  - uid: 19519
+  - uid: 19518
     components:
     - type: Transform
       pos: -21.5,42.5
       parent: 2
-  - uid: 19520
+  - uid: 19519
     components:
     - type: Transform
       pos: -11.5,50.5
       parent: 2
-  - uid: 19521
+  - uid: 19520
     components:
     - type: Transform
       pos: -5.5,51.5
       parent: 2
-  - uid: 19522
+  - uid: 19521
     components:
     - type: Transform
       pos: -2.5,51.5
       parent: 2
-  - uid: 19523
+  - uid: 19522
     components:
     - type: Transform
       pos: -6.5,49.5
       parent: 2
-  - uid: 19524
+  - uid: 19523
     components:
     - type: Transform
       pos: -6.5,47.5
       parent: 2
-  - uid: 19525
+  - uid: 19524
     components:
     - type: Transform
       pos: -20.5,38.5
       parent: 2
-  - uid: 19526
+  - uid: 19525
     components:
     - type: Transform
       pos: -16.5,42.5
       parent: 2
-  - uid: 19527
+  - uid: 19526
     components:
     - type: Transform
       pos: -19.5,42.5
       parent: 2
-  - uid: 19528
+  - uid: 19527
     components:
     - type: Transform
       pos: -19.5,49.5
       parent: 2
-  - uid: 19529
+  - uid: 19528
     components:
     - type: Transform
       pos: -10.5,49.5
       parent: 2
-  - uid: 19530
+  - uid: 19529
     components:
     - type: Transform
       pos: -11.5,42.5
       parent: 2
-  - uid: 19531
+  - uid: 19530
     components:
     - type: Transform
       pos: -19.5,50.5
       parent: 2
-  - uid: 19532
+  - uid: 19531
     components:
     - type: Transform
       pos: -18.5,50.5
       parent: 2
-  - uid: 19533
+  - uid: 19532
     components:
     - type: Transform
       pos: -11.5,49.5
       parent: 2
-  - uid: 19534
+  - uid: 19533
     components:
     - type: Transform
       pos: -4.5,51.5
       parent: 2
-  - uid: 19535
+  - uid: 19534
     components:
     - type: Transform
       pos: -0.5,51.5
       parent: 2
-  - uid: 19536
+  - uid: 19535
     components:
     - type: Transform
       pos: -24.5,43.5
       parent: 2
-  - uid: 19537
+  - uid: 19536
     components:
     - type: Transform
       pos: -20.5,49.5
       parent: 2
-  - uid: 19538
+  - uid: 19537
     components:
     - type: Transform
       pos: -10.5,48.5
       parent: 2
-  - uid: 19539
+  - uid: 19538
     components:
     - type: Transform
       pos: -22.5,42.5
       parent: 2
-  - uid: 19540
+  - uid: 19539
     components:
     - type: Transform
       pos: -30.5,50.5
       parent: 2
-  - uid: 19541
+  - uid: 19540
     components:
     - type: Transform
       pos: -30.5,47.5
       parent: 2
-  - uid: 19542
+  - uid: 19541
     components:
     - type: Transform
       pos: -31.5,50.5
       parent: 2
-  - uid: 19543
+  - uid: 19542
     components:
     - type: Transform
       pos: -24.5,45.5
       parent: 2
-  - uid: 19544
+  - uid: 19543
     components:
     - type: Transform
       pos: -12.5,42.5
       parent: 2
-  - uid: 19545
+  - uid: 19544
     components:
     - type: Transform
       pos: -18.5,42.5
       parent: 2
-  - uid: 19546
+  - uid: 19545
     components:
     - type: Transform
       pos: -14.5,42.5
       parent: 2
-  - uid: 19547
+  - uid: 19546
     components:
     - type: Transform
       pos: -20.5,35.5
       parent: 2
-  - uid: 19548
+  - uid: 19547
     components:
     - type: Transform
       pos: -9.5,42.5
       parent: 2
-  - uid: 19549
+  - uid: 19548
     components:
     - type: Transform
       pos: -8.5,42.5
       parent: 2
-  - uid: 19550
+  - uid: 19549
     components:
     - type: Transform
       pos: -6.5,48.5
       parent: 2
-  - uid: 19551
+  - uid: 19550
     components:
     - type: Transform
       pos: -20.5,48.5
       parent: 2
-  - uid: 19552
+  - uid: 19551
     components:
     - type: Transform
       pos: -1.5,51.5
       parent: 2
-  - uid: 19553
+  - uid: 19552
     components:
     - type: Transform
       pos: -6.5,46.5
       parent: 2
-  - uid: 19554
+  - uid: 19553
     components:
     - type: Transform
       pos: -7.5,33.5
       parent: 2
-  - uid: 19555
+  - uid: 19554
     components:
     - type: Transform
       pos: -12.5,50.5
       parent: 2
-  - uid: 19556
+  - uid: 19555
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 2
-  - uid: 19557
+  - uid: 19556
     components:
     - type: Transform
       pos: -7.5,28.5
       parent: 2
-  - uid: 19558
+  - uid: 19557
     components:
     - type: Transform
       pos: -7.5,29.5
       parent: 2
-  - uid: 19559
+  - uid: 19558
     components:
     - type: Transform
       pos: -7.5,30.5
       parent: 2
-  - uid: 19560
+  - uid: 19559
     components:
     - type: Transform
       pos: -7.5,31.5
       parent: 2
-  - uid: 19561
+  - uid: 19560
     components:
     - type: Transform
       pos: -9.5,54.5
       parent: 2
-  - uid: 19562
+  - uid: 19561
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
-  - uid: 19563
+  - uid: 19562
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 2
-  - uid: 19564
+  - uid: 19563
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 2
-  - uid: 19565
+  - uid: 19564
     components:
     - type: Transform
       pos: -14.5,-1.5
       parent: 2
-  - uid: 19566
+  - uid: 19565
     components:
     - type: Transform
       pos: -15.5,-1.5
       parent: 2
-  - uid: 19567
+  - uid: 19566
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-  - uid: 19568
+  - uid: 19567
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
-  - uid: 19569
+  - uid: 19568
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 2
-  - uid: 19570
+  - uid: 19569
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 2
-  - uid: 19571
+  - uid: 19570
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 2
-  - uid: 19572
+  - uid: 19571
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 2
-  - uid: 19573
+  - uid: 19572
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 2
-  - uid: 19574
+  - uid: 19573
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 2
-  - uid: 19575
+  - uid: 19574
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 2
-  - uid: 19576
+  - uid: 19575
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
-  - uid: 19577
+  - uid: 19576
     components:
     - type: Transform
       pos: -8.5,54.5
       parent: 2
-  - uid: 19578
+  - uid: 19577
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 2
-  - uid: 19579
+  - uid: 19578
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
-  - uid: 19580
+  - uid: 19579
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
-  - uid: 19581
+  - uid: 19580
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 2
-  - uid: 19582
+  - uid: 19581
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 2
-  - uid: 19583
+  - uid: 19582
     components:
     - type: Transform
       pos: -8.5,53.5
       parent: 2
-  - uid: 19584
+  - uid: 19583
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 2
-  - uid: 19585
+  - uid: 19584
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 2
-  - uid: 19586
+  - uid: 19585
     components:
     - type: Transform
       pos: -1.5,-12.5
       parent: 2
-  - uid: 19587
+  - uid: 19586
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 2
-  - uid: 19588
+  - uid: 19587
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 2
-  - uid: 19589
+  - uid: 19588
     components:
     - type: Transform
       pos: -12.5,56.5
       parent: 2
-  - uid: 19590
+  - uid: 19589
     components:
     - type: Transform
       pos: -33.5,6.5
       parent: 2
-  - uid: 19591
+  - uid: 19590
     components:
     - type: Transform
       pos: -33.5,10.5
       parent: 2
-  - uid: 19592
+  - uid: 19591
     components:
     - type: Transform
       pos: -18.5,55.5
       parent: 2
-  - uid: 19593
+  - uid: 19592
     components:
     - type: Transform
       pos: -29.5,4.5
       parent: 2
-  - uid: 19594
+  - uid: 19593
     components:
     - type: Transform
       pos: -28.5,5.5
       parent: 2
-  - uid: 19595
+  - uid: 19594
     components:
     - type: Transform
       pos: -29.5,5.5
       parent: 2
-  - uid: 19596
+  - uid: 19595
     components:
     - type: Transform
       pos: -29.5,3.5
       parent: 2
-  - uid: 19597
+  - uid: 19596
     components:
     - type: Transform
       pos: -29.5,2.5
       parent: 2
-  - uid: 19598
+  - uid: 19597
     components:
     - type: Transform
       pos: -29.5,1.5
       parent: 2
-  - uid: 19599
+  - uid: 19598
     components:
     - type: Transform
       pos: -28.5,1.5
       parent: 2
-  - uid: 19600
+  - uid: 19599
     components:
     - type: Transform
       pos: -37.5,11.5
       parent: 2
-  - uid: 19601
+  - uid: 19600
     components:
     - type: Transform
       pos: -39.5,10.5
       parent: 2
-  - uid: 19602
+  - uid: 19601
     components:
     - type: Transform
       pos: -39.5,4.5
       parent: 2
-  - uid: 19603
+  - uid: 19602
     components:
     - type: Transform
       pos: -39.5,9.5
       parent: 2
-  - uid: 19604
+  - uid: 19603
     components:
     - type: Transform
       pos: -39.5,3.5
       parent: 2
-  - uid: 19605
+  - uid: 19604
     components:
     - type: Transform
       pos: -37.5,2.5
       parent: 2
-  - uid: 19606
+  - uid: 19605
     components:
     - type: Transform
       pos: -36.5,11.5
       parent: 2
-  - uid: 19607
+  - uid: 19606
     components:
     - type: Transform
       pos: -35.5,11.5
       parent: 2
-  - uid: 19608
+  - uid: 19607
     components:
     - type: Transform
       pos: -21.5,54.5
       parent: 2
-  - uid: 19609
+  - uid: 19608
     components:
     - type: Transform
       pos: -58.5,4.5
       parent: 2
-  - uid: 19610
+  - uid: 19609
     components:
     - type: Transform
       pos: 69.5,16.5
       parent: 2
-  - uid: 19611
+  - uid: 19610
     components:
     - type: Transform
       pos: -39.5,-2.5
       parent: 2
-  - uid: 19612
+  - uid: 19611
     components:
     - type: Transform
       pos: -39.5,0.5
       parent: 2
-  - uid: 19613
+  - uid: 19612
     components:
     - type: Transform
       pos: -42.5,2.5
       parent: 2
-  - uid: 19614
+  - uid: 19613
     components:
     - type: Transform
       pos: -40.5,2.5
       parent: 2
-  - uid: 19615
+  - uid: 19614
     components:
     - type: Transform
       pos: -50.5,2.5
       parent: 2
-  - uid: 19616
+  - uid: 19615
     components:
     - type: Transform
       pos: -49.5,2.5
       parent: 2
-  - uid: 19617
+  - uid: 19616
     components:
     - type: Transform
       pos: -56.5,2.5
       parent: 2
-  - uid: 19618
+  - uid: 19617
     components:
     - type: Transform
       pos: -52.5,-0.5
       parent: 2
-  - uid: 19619
+  - uid: 19618
     components:
     - type: Transform
       pos: -58.5,3.5
       parent: 2
-  - uid: 19620
+  - uid: 19619
     components:
     - type: Transform
       pos: -52.5,1.5
       parent: 2
-  - uid: 19621
+  - uid: 19620
     components:
     - type: Transform
       pos: -52.5,0.5
       parent: 2
-  - uid: 19622
+  - uid: 19621
     components:
     - type: Transform
       pos: -58.5,5.5
       parent: 2
-  - uid: 19623
+  - uid: 19622
     components:
     - type: Transform
       pos: -58.5,-0.5
       parent: 2
-  - uid: 19624
+  - uid: 19623
     components:
     - type: Transform
       pos: -58.5,0.5
       parent: 2
-  - uid: 19625
+  - uid: 19624
     components:
     - type: Transform
       pos: -58.5,1.5
       parent: 2
-  - uid: 19626
+  - uid: 19625
     components:
     - type: Transform
       pos: -52.5,3.5
       parent: 2
-  - uid: 19627
+  - uid: 19626
     components:
     - type: Transform
       pos: -52.5,5.5
       parent: 2
-  - uid: 19628
+  - uid: 19627
     components:
     - type: Transform
       pos: -54.5,2.5
       parent: 2
-  - uid: 19629
+  - uid: 19628
     components:
     - type: Transform
       pos: -47.5,0.5
       parent: 2
-  - uid: 19630
+  - uid: 19629
     components:
     - type: Transform
       pos: -47.5,-0.5
       parent: 2
-  - uid: 19631
+  - uid: 19630
     components:
     - type: Transform
       pos: 34.5,40.5
       parent: 2
-  - uid: 19632
+  - uid: 19631
     components:
     - type: Transform
       pos: -39.5,-10.5
       parent: 2
-  - uid: 19633
+  - uid: 19632
     components:
     - type: Transform
       pos: -39.5,-11.5
       parent: 2
-  - uid: 19634
+  - uid: 19633
     components:
     - type: Transform
       pos: 69.5,18.5
       parent: 2
-  - uid: 19635
+  - uid: 19634
     components:
     - type: Transform
       pos: -19.5,55.5
       parent: 2
-  - uid: 19636
+  - uid: 19635
     components:
     - type: Transform
       pos: -15.5,56.5
       parent: 2
-  - uid: 19637
+  - uid: 19636
     components:
     - type: Transform
       pos: -25.5,47.5
       parent: 2
-  - uid: 19638
+  - uid: 19637
     components:
     - type: Transform
       pos: 37.5,40.5
       parent: 2
-  - uid: 19639
+  - uid: 19638
     components:
     - type: Transform
       pos: 34.5,39.5
       parent: 2
-  - uid: 19640
+  - uid: 19639
     components:
     - type: Transform
       pos: 34.5,38.5
       parent: 2
-  - uid: 19641
+  - uid: 19640
     components:
     - type: Transform
       pos: -69.5,27.5
       parent: 2
-  - uid: 19642
+  - uid: 19641
     components:
     - type: Transform
       pos: -69.5,28.5
       parent: 2
-  - uid: 19643
+  - uid: 19642
     components:
     - type: Transform
       pos: -69.5,29.5
       parent: 2
-  - uid: 19644
+  - uid: 19643
     components:
     - type: Transform
       pos: -69.5,30.5
       parent: 2
-  - uid: 19645
+  - uid: 19644
     components:
     - type: Transform
       pos: -69.5,31.5
       parent: 2
-  - uid: 19646
+  - uid: 19645
     components:
     - type: Transform
       pos: -58.5,34.5
       parent: 2
-  - uid: 19647
+  - uid: 19646
     components:
     - type: Transform
       pos: -61.5,34.5
       parent: 2
-  - uid: 19648
+  - uid: 19647
     components:
     - type: Transform
       pos: -64.5,34.5
       parent: 2
-  - uid: 19649
+  - uid: 19648
     components:
     - type: Transform
       pos: -44.5,33.5
       parent: 2
-  - uid: 19650
+  - uid: 19649
     components:
     - type: Transform
       pos: -45.5,33.5
       parent: 2
-  - uid: 19651
+  - uid: 19650
     components:
     - type: Transform
       pos: -42.5,30.5
       parent: 2
-  - uid: 19652
+  - uid: 19651
     components:
     - type: Transform
       pos: -42.5,31.5
       parent: 2
-  - uid: 19653
+  - uid: 19652
     components:
     - type: Transform
       pos: -48.5,44.5
       parent: 2
-  - uid: 19654
+  - uid: 19653
     components:
     - type: Transform
       pos: -48.5,46.5
       parent: 2
-  - uid: 19655
+  - uid: 19654
     components:
     - type: Transform
       pos: -57.5,40.5
       parent: 2
-  - uid: 19656
+  - uid: 19655
     components:
     - type: Transform
       pos: -58.5,40.5
       parent: 2
-  - uid: 19657
+  - uid: 19656
     components:
     - type: Transform
       pos: -58.5,41.5
       parent: 2
-  - uid: 19658
+  - uid: 19657
     components:
     - type: Transform
       pos: -59.5,41.5
       parent: 2
-  - uid: 19659
+  - uid: 19658
     components:
     - type: Transform
       pos: -61.5,41.5
       parent: 2
-  - uid: 19660
+  - uid: 19659
     components:
     - type: Transform
       pos: -62.5,41.5
       parent: 2
-  - uid: 19661
+  - uid: 19660
     components:
     - type: Transform
       pos: -62.5,40.5
       parent: 2
-  - uid: 19662
+  - uid: 19661
     components:
     - type: Transform
       pos: -63.5,40.5
       parent: 2
-  - uid: 19663
+  - uid: 19662
     components:
     - type: Transform
       pos: 69.5,20.5
       parent: 2
-  - uid: 19664
+  - uid: 19663
     components:
     - type: Transform
       pos: 10.5,23.5
       parent: 2
-  - uid: 19665
+  - uid: 19664
     components:
     - type: Transform
       pos: 13.5,23.5
       parent: 2
-  - uid: 19666
+  - uid: 19665
     components:
     - type: Transform
       pos: 14.5,22.5
       parent: 2
-  - uid: 19667
+  - uid: 19666
     components:
     - type: Transform
       pos: 14.5,20.5
       parent: 2
-  - uid: 19668
+  - uid: 19667
     components:
     - type: Transform
       pos: 16.5,16.5
       parent: 2
-  - uid: 19669
+  - uid: 19668
     components:
     - type: Transform
       pos: 17.5,16.5
       parent: 2
-  - uid: 19670
+  - uid: 19669
     components:
     - type: Transform
       pos: 18.5,16.5
       parent: 2
-  - uid: 19671
+  - uid: 19670
     components:
     - type: Transform
       pos: 19.5,16.5
       parent: 2
-  - uid: 19672
+  - uid: 19671
     components:
     - type: Transform
       pos: 21.5,17.5
       parent: 2
-  - uid: 19673
+  - uid: 19672
     components:
     - type: Transform
       pos: 21.5,18.5
       parent: 2
-  - uid: 19674
+  - uid: 19673
     components:
     - type: Transform
       pos: 21.5,19.5
       parent: 2
-  - uid: 19675
+  - uid: 19674
     components:
     - type: Transform
       pos: 18.5,39.5
       parent: 2
-  - uid: 19676
+  - uid: 19675
     components:
     - type: Transform
       pos: 18.5,38.5
       parent: 2
-  - uid: 19677
+  - uid: 19676
     components:
     - type: Transform
       pos: 24.5,39.5
       parent: 2
-  - uid: 19678
+  - uid: 19677
     components:
     - type: Transform
       pos: 24.5,38.5
       parent: 2
-  - uid: 19679
+  - uid: 19678
     components:
     - type: Transform
       pos: 21.5,37.5
       parent: 2
-  - uid: 19680
+  - uid: 19679
     components:
     - type: Transform
       pos: 14.5,37.5
       parent: 2
-  - uid: 19681
+  - uid: 19680
     components:
     - type: Transform
       pos: 15.5,37.5
       parent: 2
-  - uid: 19682
+  - uid: 19681
     components:
     - type: Transform
       pos: 16.5,37.5
       parent: 2
-  - uid: 19683
+  - uid: 19682
     components:
     - type: Transform
       pos: 17.5,37.5
       parent: 2
-  - uid: 19684
+  - uid: 19683
     components:
     - type: Transform
       pos: 24.5,16.5
       parent: 2
-  - uid: 19685
+  - uid: 19684
     components:
     - type: Transform
       pos: 25.5,16.5
       parent: 2
-  - uid: 19686
+  - uid: 19685
     components:
     - type: Transform
       pos: 23.5,16.5
       parent: 2
-  - uid: 19687
+  - uid: 19686
     components:
     - type: Transform
       pos: 27.5,32.5
       parent: 2
-  - uid: 19688
+  - uid: 19687
     components:
     - type: Transform
       pos: 27.5,36.5
       parent: 2
-  - uid: 19689
+  - uid: 19688
     components:
     - type: Transform
       pos: 32.5,-15.5
       parent: 2
-  - uid: 19690
+  - uid: 19689
     components:
     - type: Transform
       pos: 33.5,35.5
       parent: 2
-  - uid: 19691
+  - uid: 19690
     components:
     - type: Transform
       pos: 22.5,-15.5
       parent: 2
-  - uid: 19692
+  - uid: 19691
     components:
     - type: Transform
       pos: 31.5,-15.5
       parent: 2
-  - uid: 19693
+  - uid: 19692
     components:
     - type: Transform
       pos: 25.5,-15.5
       parent: 2
-  - uid: 19694
+  - uid: 19693
     components:
     - type: Transform
       pos: 30.5,-15.5
       parent: 2
-  - uid: 19695
+  - uid: 19694
     components:
     - type: Transform
       pos: 24.5,-15.5
       parent: 2
-  - uid: 19696
+  - uid: 19695
     components:
     - type: Transform
       pos: 29.5,-15.5
       parent: 2
-  - uid: 19697
+  - uid: 19696
     components:
     - type: Transform
       pos: 23.5,-15.5
       parent: 2
-  - uid: 19698
+  - uid: 19697
     components:
     - type: Transform
       pos: 23.5,-34.5
       parent: 2
-  - uid: 19699
+  - uid: 19698
     components:
     - type: Transform
       pos: -14.5,56.5
       parent: 2
-  - uid: 19700
+  - uid: 19699
     components:
     - type: Transform
       pos: 22.5,-34.5
       parent: 2
-  - uid: 19701
+  - uid: 19700
     components:
     - type: Transform
       pos: 24.5,-34.5
       parent: 2
-  - uid: 19702
+  - uid: 19701
     components:
     - type: Transform
       pos: 33.5,-32.5
       parent: 2
-  - uid: 19703
+  - uid: 19702
     components:
     - type: Transform
       pos: 33.5,-33.5
       parent: 2
-  - uid: 19704
+  - uid: 19703
     components:
     - type: Transform
       pos: 33.5,-31.5
       parent: 2
-  - uid: 19705
+  - uid: 19704
     components:
     - type: Transform
       pos: 25.5,-34.5
       parent: 2
-  - uid: 19706
+  - uid: 19705
     components:
     - type: Transform
       pos: 30.5,-34.5
       parent: 2
-  - uid: 19707
+  - uid: 19706
     components:
     - type: Transform
       pos: 31.5,-34.5
       parent: 2
-  - uid: 19708
+  - uid: 19707
     components:
     - type: Transform
       pos: 32.5,-34.5
       parent: 2
-  - uid: 19709
+  - uid: 19708
     components:
     - type: Transform
       pos: 29.5,-34.5
       parent: 2
-  - uid: 19710
+  - uid: 19709
     components:
     - type: Transform
       pos: 21.5,-33.5
       parent: 2
-  - uid: 19711
+  - uid: 19710
     components:
     - type: Transform
       pos: 21.5,-32.5
       parent: 2
-  - uid: 19712
+  - uid: 19711
     components:
     - type: Transform
       pos: 21.5,-31.5
       parent: 2
-  - uid: 19713
+  - uid: 19712
     components:
     - type: Transform
       pos: 21.5,-27.5
       parent: 2
-  - uid: 19714
+  - uid: 19713
     components:
     - type: Transform
       pos: 21.5,-26.5
       parent: 2
-  - uid: 19715
+  - uid: 19714
     components:
     - type: Transform
       pos: 21.5,-25.5
       parent: 2
-  - uid: 19716
+  - uid: 19715
     components:
     - type: Transform
       pos: 21.5,-24.5
       parent: 2
-  - uid: 19717
+  - uid: 19716
     components:
     - type: Transform
       pos: 21.5,-20.5
       parent: 2
-  - uid: 19718
+  - uid: 19717
     components:
     - type: Transform
       pos: 21.5,-19.5
       parent: 2
-  - uid: 19719
+  - uid: 19718
     components:
     - type: Transform
       pos: 21.5,-17.5
       parent: 2
-  - uid: 19720
+  - uid: 19719
     components:
     - type: Transform
       pos: 21.5,-16.5
       parent: 2
-  - uid: 19721
+  - uid: 19720
     components:
     - type: Transform
       pos: 33.5,-16.5
       parent: 2
-  - uid: 19722
+  - uid: 19721
     components:
     - type: Transform
       pos: 33.5,-17.5
       parent: 2
-  - uid: 19723
+  - uid: 19722
     components:
     - type: Transform
       pos: 33.5,-19.5
       parent: 2
-  - uid: 19724
+  - uid: 19723
     components:
     - type: Transform
       pos: 33.5,-20.5
       parent: 2
-  - uid: 19725
+  - uid: 19724
     components:
     - type: Transform
       pos: 33.5,-24.5
       parent: 2
-  - uid: 19726
+  - uid: 19725
     components:
     - type: Transform
       pos: 33.5,-25.5
       parent: 2
-  - uid: 19727
+  - uid: 19726
     components:
     - type: Transform
       pos: 33.5,-26.5
       parent: 2
-  - uid: 19728
+  - uid: 19727
     components:
     - type: Transform
       pos: 33.5,-27.5
       parent: 2
-  - uid: 19729
+  - uid: 19728
     components:
     - type: Transform
       pos: 51.5,-13.5
       parent: 2
-  - uid: 19730
+  - uid: 19729
     components:
     - type: Transform
       pos: 49.5,-12.5
       parent: 2
-  - uid: 19731
+  - uid: 19730
     components:
     - type: Transform
       pos: 43.5,-12.5
       parent: 2
-  - uid: 19732
+  - uid: 19731
     components:
     - type: Transform
       pos: 44.5,-12.5
       parent: 2
-  - uid: 19733
+  - uid: 19732
     components:
     - type: Transform
       pos: 48.5,-12.5
       parent: 2
-  - uid: 19734
+  - uid: 19733
     components:
     - type: Transform
       pos: 51.5,-14.5
       parent: 2
-  - uid: 19735
+  - uid: 19734
     components:
     - type: Transform
       pos: 41.5,-14.5
       parent: 2
-  - uid: 19736
+  - uid: 19735
     components:
     - type: Transform
       pos: 42.5,-13.5
       parent: 2
-  - uid: 19737
+  - uid: 19736
     components:
     - type: Transform
       pos: 41.5,-13.5
       parent: 2
-  - uid: 19738
+  - uid: 19737
     components:
     - type: Transform
       pos: 50.5,-13.5
       parent: 2
-  - uid: 19739
+  - uid: 19738
     components:
     - type: Transform
       pos: -14.5,34.5
       parent: 2
-  - uid: 19740
+  - uid: 19739
     components:
     - type: Transform
       pos: -13.5,34.5
       parent: 2
-  - uid: 19741
+  - uid: 19740
     components:
     - type: Transform
       pos: -16.5,34.5
       parent: 2
-  - uid: 19742
+  - uid: 19741
     components:
     - type: Transform
       pos: -16.5,56.5
       parent: 2
-  - uid: 19743
+  - uid: 19742
     components:
     - type: Transform
       pos: -18.5,56.5
       parent: 2
-  - uid: 19744
+  - uid: 19743
     components:
     - type: Transform
       pos: -17.5,56.5
       parent: 2
-  - uid: 19745
+  - uid: 19744
     components:
     - type: Transform
       pos: -15.5,34.5
       parent: 2
-  - uid: 19746
+  - uid: 19745
     components:
     - type: Transform
       pos: -17.5,34.5
       parent: 2
-  - uid: 19747
+  - uid: 19746
     components:
     - type: Transform
       pos: -25.5,48.5
       parent: 2
-  - uid: 19748
+  - uid: 19747
     components:
     - type: Transform
       pos: -25.5,50.5
       parent: 2
-  - uid: 19749
+  - uid: 19748
     components:
     - type: Transform
       pos: -7.5,53.5
       parent: 2
-  - uid: 19750
+  - uid: 19749
     components:
     - type: Transform
       pos: -7.5,52.5
       parent: 2
-  - uid: 19751
+  - uid: 19750
     components:
     - type: Transform
       pos: -22.5,53.5
       parent: 2
-  - uid: 19752
+  - uid: 19751
     components:
     - type: Transform
       pos: -23.5,53.5
       parent: 2
-  - uid: 19753
+  - uid: 19752
     components:
     - type: Transform
       pos: -23.5,52.5
       parent: 2
-  - uid: 19754
+  - uid: 19753
     components:
     - type: Transform
       pos: 64.5,-15.5
       parent: 2
-  - uid: 19755
+  - uid: 19754
     components:
     - type: Transform
       pos: 65.5,-15.5
       parent: 2
-  - uid: 19756
+  - uid: 19755
     components:
     - type: Transform
       pos: 62.5,-15.5
       parent: 2
-  - uid: 19757
+  - uid: 19756
     components:
     - type: Transform
       pos: 59.5,-15.5
       parent: 2
-  - uid: 19758
+  - uid: 19757
     components:
     - type: Transform
       pos: 57.5,-15.5
       parent: 2
-  - uid: 19759
+  - uid: 19758
     components:
     - type: Transform
       pos: 52.5,-15.5
       parent: 2
-  - uid: 19760
+  - uid: 19759
     components:
     - type: Transform
       pos: 60.5,-15.5
       parent: 2
-  - uid: 19761
+  - uid: 19760
     components:
     - type: Transform
       pos: 63.5,-15.5
       parent: 2
-  - uid: 19762
+  - uid: 19761
     components:
     - type: Transform
       pos: 58.5,-15.5
       parent: 2
-  - uid: 19763
+  - uid: 19762
     components:
     - type: Transform
       pos: 53.5,-15.5
       parent: 2
-  - uid: 19764
+  - uid: 19763
     components:
     - type: Transform
       pos: 55.5,-15.5
       parent: 2
-  - uid: 19765
+  - uid: 19764
     components:
     - type: Transform
       pos: 54.5,-15.5
       parent: 2
-  - uid: 19766
+  - uid: 19765
     components:
     - type: Transform
       pos: -24.5,52.5
       parent: 2
-  - uid: 19767
+  - uid: 19766
     components:
     - type: Transform
       pos: -22.5,54.5
       parent: 2
-  - uid: 19768
+  - uid: 19767
     components:
     - type: Transform
       pos: -13.5,56.5
       parent: 2
-  - uid: 19769
+  - uid: 19768
     components:
     - type: Transform
       pos: -11.5,55.5
       parent: 2
-  - uid: 19770
+  - uid: 19769
     components:
     - type: Transform
       pos: -12.5,55.5
       parent: 2
-  - uid: 19771
+  - uid: 19770
     components:
     - type: Transform
       pos: 61.5,3.5
       parent: 2
-  - uid: 19772
+  - uid: 19771
     components:
     - type: Transform
       pos: 61.5,1.5
       parent: 2
-  - uid: 19773
+  - uid: 19772
     components:
     - type: Transform
       pos: 61.5,2.5
       parent: 2
-  - uid: 19774
+  - uid: 19773
     components:
     - type: Transform
       pos: 61.5,-0.5
       parent: 2
-  - uid: 19775
+  - uid: 19774
     components:
     - type: Transform
       pos: 61.5,0.5
       parent: 2
-  - uid: 19776
+  - uid: 19775
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
-  - uid: 19777
+  - uid: 19776
     components:
     - type: Transform
       pos: 40.5,33.5
       parent: 2
-  - uid: 19778
+  - uid: 19777
     components:
     - type: Transform
       pos: 87.5,-16.5
       parent: 2
-  - uid: 19779
+  - uid: 19778
     components:
     - type: Transform
       pos: 87.5,-24.5
       parent: 2
-  - uid: 19780
+  - uid: 19779
     components:
     - type: Transform
       pos: 78.5,-27.5
       parent: 2
-  - uid: 19781
+  - uid: 19780
     components:
     - type: Transform
       pos: 78.5,-22.5
       parent: 2
-  - uid: 19782
+  - uid: 19781
     components:
     - type: Transform
       pos: 77.5,-29.5
       parent: 2
-  - uid: 19783
+  - uid: 19782
     components:
     - type: Transform
       pos: 78.5,-28.5
       parent: 2
-  - uid: 19784
+  - uid: 19783
     components:
     - type: Transform
       pos: 78.5,-29.5
       parent: 2
-  - uid: 19785
+  - uid: 19784
     components:
     - type: Transform
       pos: 78.5,-21.5
       parent: 2
-  - uid: 19786
+  - uid: 19785
     components:
     - type: Transform
       pos: 77.5,-21.5
       parent: 2
-  - uid: 19787
+  - uid: 19786
     components:
     - type: Transform
       pos: 78.5,-26.5
       parent: 2
-  - uid: 19788
+  - uid: 19787
     components:
     - type: Transform
       pos: 39.5,10.5
       parent: 2
-  - uid: 19789
+  - uid: 19788
     components:
     - type: Transform
       pos: 43.5,24.5
       parent: 2
-  - uid: 19790
+  - uid: 19789
     components:
     - type: Transform
       pos: 51.5,23.5
       parent: 2
-  - uid: 19791
+  - uid: 19790
     components:
     - type: Transform
       pos: 39.5,7.5
       parent: 2
-  - uid: 19792
+  - uid: 19791
     components:
     - type: Transform
       pos: 35.5,7.5
       parent: 2
-  - uid: 19793
+  - uid: 19792
     components:
     - type: Transform
       pos: 35.5,10.5
       parent: 2
-  - uid: 19794
+  - uid: 19793
     components:
     - type: Transform
       pos: 35.5,16.5
       parent: 2
-  - uid: 19795
+  - uid: 19794
     components:
     - type: Transform
       pos: 37.5,21.5
       parent: 2
-  - uid: 19796
+  - uid: 19795
     components:
     - type: Transform
       pos: 33.5,12.5
       parent: 2
-  - uid: 19797
+  - uid: 19796
     components:
     - type: Transform
       pos: 30.5,12.5
       parent: 2
-  - uid: 19798
+  - uid: 19797
     components:
     - type: Transform
       pos: 42.5,26.5
       parent: 2
-  - uid: 19799
+  - uid: 19798
     components:
     - type: Transform
       pos: 42.5,25.5
       parent: 2
-  - uid: 19800
+  - uid: 19799
     components:
     - type: Transform
       pos: 38.5,23.5
       parent: 2
-  - uid: 19801
+  - uid: 19800
     components:
     - type: Transform
       pos: 40.5,23.5
       parent: 2
-  - uid: 19802
+  - uid: 19801
     components:
     - type: Transform
       pos: 37.5,28.5
       parent: 2
-  - uid: 19803
+  - uid: 19802
     components:
     - type: Transform
       pos: 38.5,28.5
       parent: 2
-  - uid: 19804
+  - uid: 19803
     components:
     - type: Transform
       pos: 48.5,20.5
       parent: 2
-  - uid: 19805
+  - uid: 19804
     components:
     - type: Transform
       pos: 48.5,22.5
       parent: 2
-  - uid: 19806
+  - uid: 19805
     components:
     - type: Transform
       pos: 48.5,21.5
       parent: 2
-  - uid: 19807
+  - uid: 19806
     components:
     - type: Transform
       pos: 49.5,23.5
       parent: 2
-  - uid: 19808
+  - uid: 19807
     components:
     - type: Transform
       pos: 50.5,23.5
       parent: 2
-  - uid: 19809
+  - uid: 19808
     components:
     - type: Transform
       pos: 43.5,29.5
       parent: 2
-  - uid: 19810
+  - uid: 19809
     components:
     - type: Transform
       pos: 44.5,29.5
       parent: 2
-  - uid: 19811
+  - uid: 19810
     components:
     - type: Transform
       pos: 45.5,29.5
       parent: 2
-  - uid: 19812
+  - uid: 19811
     components:
     - type: Transform
       pos: 47.5,29.5
       parent: 2
-  - uid: 19813
+  - uid: 19812
     components:
     - type: Transform
       pos: 48.5,29.5
       parent: 2
-  - uid: 19814
+  - uid: 19813
     components:
     - type: Transform
       pos: 46.5,29.5
       parent: 2
-  - uid: 19815
+  - uid: 19814
     components:
     - type: Transform
       pos: 49.5,29.5
       parent: 2
-  - uid: 19816
+  - uid: 19815
     components:
     - type: Transform
       pos: 54.5,29.5
       parent: 2
-  - uid: 19817
+  - uid: 19816
     components:
     - type: Transform
       pos: 56.5,29.5
       parent: 2
-  - uid: 19818
+  - uid: 19817
     components:
     - type: Transform
       pos: 46.5,24.5
       parent: 2
-  - uid: 19819
+  - uid: 19818
     components:
     - type: Transform
       pos: 78.5,18.5
       parent: 2
-  - uid: 19820
+  - uid: 19819
     components:
     - type: Transform
       pos: 78.5,17.5
       parent: 2
-  - uid: 19821
+  - uid: 19820
     components:
     - type: Transform
       pos: 78.5,20.5
       parent: 2
-  - uid: 19822
+  - uid: 19821
     components:
     - type: Transform
       pos: 78.5,19.5
       parent: 2
-  - uid: 19823
+  - uid: 19822
     components:
     - type: Transform
       pos: 78.5,16.5
       parent: 2
-  - uid: 19824
+  - uid: 19823
     components:
     - type: Transform
       pos: -13.5,-25.5
       parent: 2
-  - uid: 19825
+  - uid: 19824
     components:
     - type: Transform
       pos: -9.5,17.5
       parent: 2
-  - uid: 19826
+  - uid: 19825
     components:
     - type: Transform
       pos: -8.5,17.5
       parent: 2
-  - uid: 19827
+  - uid: 19826
     components:
     - type: Transform
       pos: -7.5,17.5
       parent: 2
-  - uid: 19828
+  - uid: 19827
     components:
     - type: Transform
       pos: -6.5,17.5
       parent: 2
-  - uid: 19829
+  - uid: 19828
     components:
     - type: Transform
       pos: -12.5,-28.5
       parent: 2
-  - uid: 19830
+  - uid: 19829
     components:
     - type: Transform
       pos: -13.5,-28.5
       parent: 2
-  - uid: 19831
+  - uid: 19830
     components:
     - type: Transform
       pos: -13.5,-27.5
       parent: 2
-  - uid: 19832
+  - uid: 19831
     components:
     - type: Transform
       pos: -13.5,-26.5
       parent: 2
-  - uid: 19833
+  - uid: 19832
     components:
     - type: Transform
       pos: -11.5,-28.5
       parent: 2
-  - uid: 19834
+  - uid: 19833
     components:
     - type: Transform
       pos: 68.5,-32.5
       parent: 2
-  - uid: 19835
+  - uid: 19834
     components:
     - type: Transform
       pos: -11.5,-27.5
       parent: 2
-  - uid: 19836
+  - uid: 19835
     components:
     - type: Transform
       pos: -27.5,-23.5
       parent: 2
-  - uid: 19837
+  - uid: 19836
     components:
     - type: Transform
       pos: -26.5,-23.5
       parent: 2
-  - uid: 19838
+  - uid: 19837
     components:
     - type: Transform
       pos: -25.5,-23.5
       parent: 2
-  - uid: 19839
+  - uid: 19838
     components:
     - type: Transform
       pos: -25.5,-22.5
       parent: 2
-  - uid: 19840
+  - uid: 19839
     components:
     - type: Transform
       pos: -25.5,-21.5
       parent: 2
-  - uid: 19841
+  - uid: 19840
     components:
     - type: Transform
       pos: -18.5,-23.5
       parent: 2
-  - uid: 19842
+  - uid: 19841
     components:
     - type: Transform
       pos: -19.5,-23.5
       parent: 2
-  - uid: 19843
+  - uid: 19842
     components:
     - type: Transform
       pos: -20.5,-23.5
       parent: 2
-  - uid: 19844
+  - uid: 19843
     components:
     - type: Transform
       pos: -20.5,-22.5
       parent: 2
-  - uid: 19845
+  - uid: 19844
     components:
     - type: Transform
       pos: -20.5,-21.5
       parent: 2
-  - uid: 19846
+  - uid: 19845
     components:
     - type: Transform
       pos: -21.5,-20.5
       parent: 2
-  - uid: 19847
+  - uid: 19846
     components:
     - type: Transform
       pos: -22.5,-20.5
       parent: 2
-  - uid: 19848
+  - uid: 19847
     components:
     - type: Transform
       pos: -23.5,-20.5
       parent: 2
-  - uid: 19849
+  - uid: 19848
     components:
     - type: Transform
       pos: -24.5,-20.5
       parent: 2
-  - uid: 19850
+  - uid: 19849
     components:
     - type: Transform
       pos: -19.5,-20.5
       parent: 2
-  - uid: 19851
+  - uid: 19850
     components:
     - type: Transform
       pos: 67.5,-32.5
       parent: 2
-  - uid: 19852
+  - uid: 19851
     components:
     - type: Transform
       pos: -11.5,-33.5
       parent: 2
-  - uid: 19853
+  - uid: 19852
     components:
     - type: Transform
       pos: -10.5,-33.5
       parent: 2
-  - uid: 19854
+  - uid: 19853
     components:
     - type: Transform
       pos: -41.5,-17.5
       parent: 2
-  - uid: 19855
+  - uid: 19854
     components:
     - type: Transform
       pos: -39.5,-17.5
       parent: 2
-  - uid: 19856
+  - uid: 19855
     components:
     - type: Transform
       pos: -38.5,-17.5
       parent: 2
-  - uid: 19857
+  - uid: 19856
     components:
     - type: Transform
       pos: -36.5,-17.5
       parent: 2
-  - uid: 19858
+  - uid: 19857
     components:
     - type: Transform
       pos: -38.5,-23.5
       parent: 2
-  - uid: 19859
+  - uid: 19858
     components:
     - type: Transform
       pos: -36.5,-23.5
       parent: 2
-  - uid: 19860
+  - uid: 19859
     components:
     - type: Transform
       pos: -5.5,-27.5
       parent: 2
-  - uid: 19861
+  - uid: 19860
     components:
     - type: Transform
       pos: -38.5,39.5
       parent: 2
-  - uid: 19862
+  - uid: 19861
     components:
     - type: Transform
       pos: -40.5,39.5
       parent: 2
-  - uid: 19863
+  - uid: 19862
     components:
     - type: Transform
       pos: -39.5,39.5
       parent: 2
-  - uid: 19864
+  - uid: 19863
     components:
     - type: Transform
       pos: -37.5,39.5
       parent: 2
-  - uid: 19865
+  - uid: 19864
     components:
     - type: Transform
       pos: -36.5,39.5
       parent: 2
-  - uid: 19866
+  - uid: 19865
     components:
     - type: Transform
       pos: -34.5,39.5
       parent: 2
-  - uid: 19867
+  - uid: 19866
     components:
     - type: Transform
       pos: 25.5,-38.5
       parent: 2
-  - uid: 19868
+  - uid: 19867
     components:
     - type: Transform
       pos: 18.5,-38.5
       parent: 2
-  - uid: 19869
+  - uid: 19868
     components:
     - type: Transform
       pos: 28.5,-42.5
       parent: 2
-  - uid: 19870
+  - uid: 19869
     components:
     - type: Transform
       pos: 27.5,-41.5
       parent: 2
-  - uid: 19871
+  - uid: 19870
     components:
     - type: Transform
       pos: 27.5,-40.5
       parent: 2
-  - uid: 19872
+  - uid: 19871
     components:
     - type: Transform
       pos: 29.5,-42.5
       parent: 2
-  - uid: 19873
+  - uid: 19872
     components:
     - type: Transform
       pos: 30.5,-42.5
       parent: 2
-  - uid: 19874
+  - uid: 19873
     components:
     - type: Transform
       pos: 22.5,-38.5
       parent: 2
-  - uid: 19875
+  - uid: 19874
     components:
     - type: Transform
       pos: 21.5,-38.5
       parent: 2
-  - uid: 19876
+  - uid: 19875
     components:
     - type: Transform
       pos: 27.5,-39.5
       parent: 2
-  - uid: 19877
+  - uid: 19876
     components:
     - type: Transform
       pos: 36.5,-39.5
       parent: 2
-  - uid: 19878
+  - uid: 19877
     components:
     - type: Transform
       pos: 67.5,-33.5
       parent: 2
-  - uid: 19879
+  - uid: 19878
     components:
     - type: Transform
       pos: 67.5,-34.5
       parent: 2
-  - uid: 19880
+  - uid: 19879
     components:
     - type: Transform
       pos: -6.5,52.5
       parent: 2
-  - uid: 19881
+  - uid: 19880
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 2
-  - uid: 19882
+  - uid: 19881
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 2
-  - uid: 19883
+  - uid: 19882
     components:
     - type: Transform
       pos: 39.5,33.5
       parent: 2
-  - uid: 19884
+  - uid: 19883
     components:
     - type: Transform
       pos: 38.5,35.5
       parent: 2
-  - uid: 19885
+  - uid: 19884
     components:
     - type: Transform
       pos: 38.5,36.5
       parent: 2
-  - uid: 19886
+  - uid: 19885
     components:
     - type: Transform
       pos: 38.5,37.5
       parent: 2
-  - uid: 19887
+  - uid: 19886
     components:
     - type: Transform
       pos: 38.5,40.5
       parent: 2
-  - uid: 19888
+  - uid: 19887
     components:
     - type: Transform
       pos: 6.5,11.5
       parent: 2
-  - uid: 19889
+  - uid: 19888
     components:
     - type: Transform
       pos: 10.5,6.5
       parent: 2
-  - uid: 19890
+  - uid: 19889
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 2
-  - uid: 19891
+  - uid: 19890
     components:
     - type: Transform
       pos: 7.5,11.5
       parent: 2
-  - uid: 19892
+  - uid: 19891
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 2
-  - uid: 19893
+  - uid: 19892
     components:
     - type: Transform
       pos: 16.5,-1.5
       parent: 2
-  - uid: 19894
+  - uid: 19893
     components:
     - type: Transform
       pos: 15.5,-1.5
       parent: 2
-  - uid: 19895
+  - uid: 19894
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 2
-  - uid: 19896
+  - uid: 19895
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 2
-  - uid: 19897
+  - uid: 19896
     components:
     - type: Transform
       pos: -65.5,43.5
       parent: 2
-  - uid: 19898
+  - uid: 19897
     components:
     - type: Transform
       pos: -65.5,41.5
       parent: 2
 - proto: RemoteSignaller
   entities:
-  - uid: 19899
+  - uid: 19898
     components:
     - type: MetaData
       name: bedroom blast doors
@@ -123803,55 +123802,55 @@ entities:
         950:
         - - Pressed
           - Toggle
-  - uid: 19900
+  - uid: 19899
     components:
     - type: Transform
       pos: -34.65559,27.559319
       parent: 2
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 19901
+  - uid: 19900
     components:
     - type: Transform
       pos: -49.5,43.5
       parent: 2
 - proto: ResearchComputerCircuitboard
   entities:
-  - uid: 19902
+  - uid: 19901
     components:
     - type: Transform
       pos: 3.7333322,20.619427
       parent: 2
 - proto: Retractor
   entities:
-  - uid: 19903
+  - uid: 19902
     components:
     - type: Transform
       pos: -45.494118,8.488342
       parent: 2
 - proto: RevolverCapGun
   entities:
-  - uid: 19904
+  - uid: 19903
     components:
     - type: Transform
       pos: -6.5018587,39.566113
       parent: 2
-  - uid: 19905
+  - uid: 19904
     components:
     - type: Transform
       pos: 21.545708,-6.2727547
       parent: 2
-  - uid: 19906
+  - uid: 19905
     components:
     - type: Transform
       pos: 8.529913,-39.59766
       parent: 2
-  - uid: 19907
+  - uid: 19906
     components:
     - type: Transform
       pos: -3.7343574,19.683527
       parent: 2
-  - uid: 19908
+  - uid: 19907
     components:
     - type: Transform
       pos: 4.6066175,-18.183628
@@ -123867,282 +123866,282 @@ entities:
       inSlotFlag: BACK
     - type: Physics
       canCollide: False
-  - uid: 19909
+  - uid: 19908
     components:
     - type: Transform
       pos: -25.489525,32.42608
       parent: 2
-  - uid: 19910
+  - uid: 19909
     components:
     - type: Transform
       pos: 23.54879,5.4814196
       parent: 2
-  - uid: 19911
+  - uid: 19910
     components:
     - type: Transform
       pos: 39.25823,4.5107894
       parent: 2
-  - uid: 19912
+  - uid: 19911
     components:
     - type: Transform
       pos: 7.4569874,35.450542
       parent: 2
 - proto: RubberStampApproved
   entities:
-  - uid: 19913
+  - uid: 19912
     components:
     - type: Transform
       pos: -21.320812,41.516605
       parent: 2
 - proto: RubberStampDenied
   entities:
-  - uid: 19914
+  - uid: 19913
     components:
     - type: Transform
       pos: -21.503101,41.75098
       parent: 2
 - proto: SalvageMagnet
   entities:
-  - uid: 19915
+  - uid: 19914
     components:
     - type: Transform
       pos: 37.5,39.5
       parent: 2
 - proto: SaxophoneInstrument
   entities:
-  - uid: 19916
+  - uid: 19915
     components:
     - type: Transform
       pos: -77.48821,-2.7215095
       parent: 2
 - proto: Scalpel
   entities:
-  - uid: 19917
+  - uid: 19916
     components:
     - type: Transform
       pos: -45.509743,8.707092
       parent: 2
-  - uid: 19918
+  - uid: 19917
     components:
     - type: Transform
       pos: -55.421375,-16.550985
       parent: 2
 - proto: ScalpelShiv
   entities:
-  - uid: 19919
+  - uid: 19918
     components:
     - type: Transform
       pos: 3.514542,-12.504271
       parent: 2
-  - uid: 19920
+  - uid: 19919
     components:
     - type: Transform
       pos: -55.427135,-16.25411
       parent: 2
 - proto: ScrapMedkit
   entities:
-  - uid: 19921
+  - uid: 19920
     components:
     - type: Transform
       pos: -20.567188,-19.376364
       parent: 2
-  - uid: 19922
+  - uid: 19921
     components:
     - type: Transform
       pos: -54.50527,-15.06661
       parent: 2
 - proto: Screen
   entities:
-  - uid: 19923
+  - uid: 19922
     components:
     - type: Transform
       pos: 87.5,-14.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19924
+  - uid: 19923
     components:
     - type: Transform
       pos: 27.5,-15.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19925
+  - uid: 19924
     components:
     - type: Transform
       pos: 21.5,-8.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19926
+  - uid: 19925
     components:
     - type: Transform
       pos: 51.5,-15.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19927
+  - uid: 19926
     components:
     - type: Transform
       pos: 61.5,-15.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19928
+  - uid: 19927
     components:
     - type: Transform
       pos: 57.5,-7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19929
+  - uid: 19928
     components:
     - type: Transform
       pos: 70.5,-17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19930
+  - uid: 19929
     components:
     - type: Transform
       pos: 87.5,-26.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19931
+  - uid: 19930
     components:
     - type: Transform
       pos: 87.5,-18.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19932
+  - uid: 19931
     components:
     - type: Transform
       pos: 87.5,-22.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19933
+  - uid: 19932
     components:
     - type: Transform
       pos: -26.5,5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19934
+  - uid: 19933
     components:
     - type: Transform
       pos: 78.5,-12.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19935
+  - uid: 19934
     components:
     - type: Transform
       pos: 29.5,2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19936
+  - uid: 19935
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19937
+  - uid: 19936
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19938
+  - uid: 19937
     components:
     - type: Transform
       pos: -12.5,18.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19939
+  - uid: 19938
     components:
     - type: Transform
       pos: -11.5,27.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19940
+  - uid: 19939
     components:
     - type: Transform
       pos: -23.5,28.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19941
+  - uid: 19940
     components:
     - type: Transform
       pos: -18.5,27.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19942
+  - uid: 19941
     components:
     - type: Transform
       pos: -34.5,22.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19943
+  - uid: 19942
     components:
     - type: Transform
       pos: -43.5,24.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19944
+  - uid: 19943
     components:
     - type: Transform
       pos: -46.5,11.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19945
+  - uid: 19944
     components:
     - type: Transform
       pos: -35.5,-4.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19946
+  - uid: 19945
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19947
+  - uid: 19946
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19948
+  - uid: 19947
     components:
     - type: Transform
       pos: 27.5,16.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19949
+  - uid: 19948
     components:
     - type: Transform
       pos: 48.5,23.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 19950
+  - uid: 19949
     components:
     - type: Transform
       pos: -45.5,40.5
@@ -124151,19 +124150,19 @@ entities:
       fixtures: {}
 - proto: Screwdriver
   entities:
-  - uid: 19951
+  - uid: 19950
     components:
     - type: Transform
       pos: -46.791557,30.780184
       parent: 2
-  - uid: 19952
+  - uid: 19951
     components:
     - type: Transform
       pos: -46.697807,30.592684
       parent: 2
 - proto: SecurityTechFab
   entities:
-  - uid: 19953
+  - uid: 19952
     components:
     - type: Transform
       pos: -10.5,-7.5
@@ -124177,76 +124176,81 @@ entities:
       - Biochemical
 - proto: SecurityTechFabCircuitboard
   entities:
-  - uid: 19954
+  - uid: 19953
     components:
     - type: Transform
       pos: 6.5508056,18.497473
       parent: 2
 - proto: SeedExtractor
   entities:
-  - uid: 19955
+  - uid: 19954
     components:
     - type: Transform
       pos: 9.5,-5.5
       parent: 2
-  - uid: 19956
+  - uid: 19955
     components:
     - type: Transform
       pos: 60.5,0.5
       parent: 2
 - proto: ShardGlass
   entities:
-  - uid: 19957
+  - uid: 19956
     components:
     - type: Transform
       pos: 63.97458,-28.461584
       parent: 2
-  - uid: 19958
+  - uid: 19957
     components:
     - type: Transform
       pos: 62.458954,-29.961584
       parent: 2
-  - uid: 19959
+  - uid: 19958
     components:
     - type: Transform
       pos: 62.583954,-30.274084
       parent: 2
-  - uid: 19960
+  - uid: 19959
     components:
     - type: Transform
       pos: 60.583954,-33.75846
       parent: 2
-  - uid: 19961
+  - uid: 19960
     components:
     - type: Transform
       pos: 59.84958,-31.977211
       parent: 2
-  - uid: 19962
+  - uid: 19961
     components:
     - type: Transform
       pos: 58.84958,-33.992836
       parent: 2
-  - uid: 19963
+  - uid: 19962
     components:
     - type: Transform
       pos: 60.802704,-29.13346
       parent: 2
-  - uid: 19964
+  - uid: 19963
     components:
     - type: Transform
       pos: 66.56833,-26.78971
       parent: 2
-  - uid: 19965
+  - uid: 19964
     components:
     - type: Transform
       pos: 65.69333,-27.35221
       parent: 2
 - proto: SheetGlass
   entities:
-  - uid: 19966
+  - uid: 19965
     components:
     - type: Transform
       pos: -60.526897,31.574072
+      parent: 2
+  - uid: 19966
+    components:
+    - type: Transform
+      pos: -43.462337,25.554003
       parent: 2
   - uid: 19967
     components:
@@ -124256,37 +124260,32 @@ entities:
   - uid: 19968
     components:
     - type: Transform
-      pos: -43.462337,25.554003
+      pos: 20.295801,17.59948
       parent: 2
   - uid: 19969
     components:
     - type: Transform
-      pos: 20.295801,17.59948
+      pos: 3.5,-33.5
       parent: 2
   - uid: 19970
     components:
     - type: Transform
-      pos: 3.5,-33.5
-      parent: 2
-  - uid: 19971
-    components:
-    - type: Transform
       pos: 41.591076,24.442621
       parent: 2
-  - uid: 19972
+  - uid: 19971
     components:
     - type: Transform
       pos: 43.5,26.5
       parent: 2
 - proto: SheetPlasma
   entities:
-  - uid: 19973
+  - uid: 19972
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5195332,41.467716
       parent: 2
-  - uid: 19974
+  - uid: 19973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -124303,22 +124302,27 @@ entities:
     - type: InsideEntityStorage
 - proto: SheetPlasteel
   entities:
-  - uid: 19975
+  - uid: 19974
     components:
     - type: Transform
       pos: 20.733301,17.63073
       parent: 2
 - proto: SheetPlastic
   entities:
-  - uid: 19976
+  - uid: 19975
     components:
     - type: Transform
       pos: -11.354582,-7.4687614
       parent: 2
-  - uid: 19977
+  - uid: 19976
     components:
     - type: Transform
       pos: -60.401897,31.714697
+      parent: 2
+  - uid: 19977
+    components:
+    - type: Transform
+      pos: -43.446712,25.554003
       parent: 2
   - uid: 19978
     components:
@@ -124328,44 +124332,44 @@ entities:
   - uid: 19979
     components:
     - type: Transform
-      pos: -43.446712,25.554003
-      parent: 2
-  - uid: 19980
-    components:
-    - type: Transform
       pos: 19.952051,17.63073
       parent: 2
-  - uid: 19981
+  - uid: 19980
     components:
     - type: Transform
       pos: 41.591076,24.380121
       parent: 2
 - proto: SheetSteel
   entities:
-  - uid: 19982
+  - uid: 19981
     components:
     - type: Transform
       pos: 0.50299597,9.497643
       parent: 2
-  - uid: 19983
+  - uid: 19982
     components:
     - type: Transform
       pos: -11.588957,-7.4062614
       parent: 2
-  - uid: 19984
+  - uid: 19983
     components:
     - type: Transform
       pos: -56.481823,-1.511231
       parent: 2
-  - uid: 19985
+  - uid: 19984
     components:
     - type: Transform
       pos: 19.467676,17.583855
       parent: 2
-  - uid: 19986
+  - uid: 19985
     components:
     - type: Transform
       pos: -60.596622,31.714697
+      parent: 2
+  - uid: 19986
+    components:
+    - type: Transform
+      pos: -43.462337,25.554003
       parent: 2
   - uid: 19987
     components:
@@ -124375,41 +124379,36 @@ entities:
   - uid: 19988
     components:
     - type: Transform
-      pos: -43.462337,25.554003
+      pos: 3.5,-33.5
       parent: 2
   - uid: 19989
     components:
     - type: Transform
-      pos: 3.5,-33.5
+      pos: 30.5,15.5
       parent: 2
   - uid: 19990
     components:
     - type: Transform
-      pos: 30.5,15.5
+      pos: 41.528576,24.505121
       parent: 2
   - uid: 19991
     components:
     - type: Transform
-      pos: 41.528576,24.505121
+      pos: 46.53861,28.539917
       parent: 2
   - uid: 19992
     components:
     - type: Transform
-      pos: 46.53861,28.539917
-      parent: 2
-  - uid: 19993
-    components:
-    - type: Transform
       pos: 59.374004,9.711176
       parent: 2
-  - uid: 19994
+  - uid: 19993
     components:
     - type: Transform
       pos: 59.69997,9.711176
       parent: 2
 - proto: SheetUranium
   entities:
-  - uid: 19995
+  - uid: 19994
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -124417,7 +124416,7 @@ entities:
       parent: 2
 - proto: ShelfBar
   entities:
-  - uid: 19996
+  - uid: 19995
     components:
     - type: Transform
       pos: 33.5,-1.5
@@ -124426,34 +124425,34 @@ entities:
       fixtures: {}
 - proto: Shovel
   entities:
-  - uid: 19997
+  - uid: 19996
     components:
     - type: Transform
       pos: -1.5345926,25.534763
       parent: 2
 - proto: ShowcaseRobot
   entities:
-  - uid: 19998
+  - uid: 19997
     components:
     - type: Transform
       pos: -14.5,35.5
       parent: 2
 - proto: ShowcaseRobotAntique
   entities:
-  - uid: 19999
+  - uid: 19998
     components:
     - type: Transform
       pos: -16.5,35.5
       parent: 2
 - proto: ShuttersNormalOpen
   entities:
-  - uid: 20000
+  - uid: 19999
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,11.5
       parent: 2
-  - uid: 20001
+  - uid: 20000
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124461,7 +124460,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20002
+  - uid: 20001
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124469,7 +124468,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20003
+  - uid: 20002
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124477,7 +124476,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20004
+  - uid: 20003
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124485,263 +124484,263 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20005
+  - uid: 20004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,11.5
       parent: 2
-  - uid: 20006
+  - uid: 20005
     components:
     - type: Transform
       pos: -30.5,47.5
       parent: 2
-  - uid: 20007
+  - uid: 20006
     components:
     - type: Transform
       pos: -31.5,47.5
       parent: 2
-  - uid: 20008
+  - uid: 20007
     components:
     - type: Transform
       pos: -31.5,50.5
       parent: 2
-  - uid: 20009
+  - uid: 20008
     components:
     - type: Transform
       pos: -30.5,50.5
       parent: 2
-  - uid: 20010
+  - uid: 20009
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,49.5
       parent: 2
-  - uid: 20011
+  - uid: 20010
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,48.5
       parent: 2
-  - uid: 20012
+  - uid: 20011
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,47.5
       parent: 2
-  - uid: 20013
+  - uid: 20012
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -25.5,50.5
       parent: 2
-  - uid: 20014
+  - uid: 20013
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,3.5
       parent: 2
-  - uid: 20015
+  - uid: 20014
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-  - uid: 20016
+  - uid: 20015
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 2
-  - uid: 20017
+  - uid: 20016
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
-  - uid: 20018
+  - uid: 20017
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 2
-  - uid: 20019
+  - uid: 20018
     components:
     - type: Transform
       pos: -15.5,-1.5
       parent: 2
-  - uid: 20020
+  - uid: 20019
     components:
     - type: Transform
       pos: -14.5,-1.5
       parent: 2
-  - uid: 20021
+  - uid: 20020
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 2
-  - uid: 20022
+  - uid: 20021
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
-  - uid: 20023
+  - uid: 20022
     components:
     - type: Transform
       pos: -37.5,11.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20024
+  - uid: 20023
     components:
     - type: Transform
       pos: -36.5,11.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20025
+  - uid: 20024
     components:
     - type: Transform
       pos: -35.5,11.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 20026
+  - uid: 20025
     components:
     - type: Transform
       pos: 6.5,-42.5
       parent: 2
-  - uid: 20027
+  - uid: 20026
     components:
     - type: Transform
       pos: 7.5,-42.5
       parent: 2
-  - uid: 20028
+  - uid: 20027
     components:
     - type: Transform
       pos: 8.5,-42.5
       parent: 2
-  - uid: 20029
+  - uid: 20028
     components:
     - type: Transform
       pos: 11.5,-42.5
       parent: 2
-  - uid: 20030
+  - uid: 20029
     components:
     - type: Transform
       pos: 12.5,-42.5
       parent: 2
-  - uid: 20031
+  - uid: 20030
     components:
     - type: Transform
       pos: 10.5,-42.5
       parent: 2
-  - uid: 20032
+  - uid: 20031
     components:
     - type: Transform
       pos: 14.5,-42.5
       parent: 2
-  - uid: 20033
+  - uid: 20032
     components:
     - type: Transform
       pos: 15.5,-42.5
       parent: 2
-  - uid: 20034
+  - uid: 20033
     components:
     - type: Transform
       pos: 16.5,-42.5
       parent: 2
-  - uid: 20035
+  - uid: 20034
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-29.5
       parent: 2
-  - uid: 20036
+  - uid: 20035
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-28.5
       parent: 2
-  - uid: 20037
+  - uid: 20036
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-27.5
       parent: 2
-  - uid: 20038
+  - uid: 20037
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-22.5
       parent: 2
-  - uid: 20039
+  - uid: 20038
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-21.5
       parent: 2
-  - uid: 20040
+  - uid: 20039
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-20.5
       parent: 2
-  - uid: 20041
+  - uid: 20040
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-18.5
       parent: 2
-  - uid: 20042
+  - uid: 20041
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-17.5
       parent: 2
-  - uid: 20043
+  - uid: 20042
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-16.5
       parent: 2
-  - uid: 20044
+  - uid: 20043
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-31.5
       parent: 2
-  - uid: 20045
+  - uid: 20044
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-32.5
       parent: 2
-  - uid: 20046
+  - uid: 20045
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 41.5,-33.5
       parent: 2
-  - uid: 20047
+  - uid: 20046
     components:
     - type: Transform
       pos: -30.5,17.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20048
+  - uid: 20047
     components:
     - type: Transform
       pos: -31.5,17.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20049
+  - uid: 20048
     components:
     - type: Transform
       pos: -29.5,17.5
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20050
+  - uid: 20049
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124749,7 +124748,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20051
+  - uid: 20050
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124757,7 +124756,7 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20052
+  - uid: 20051
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124765,49 +124764,49 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 3
-  - uid: 20053
+  - uid: 20052
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,11.5
       parent: 2
-  - uid: 20054
+  - uid: 20053
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,11.5
       parent: 2
-  - uid: 20055
+  - uid: 20054
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,11.5
       parent: 2
-  - uid: 20056
+  - uid: 20055
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,11.5
       parent: 2
-  - uid: 20057
+  - uid: 20056
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,11.5
       parent: 2
-  - uid: 20058
+  - uid: 20057
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,11.5
       parent: 2
-  - uid: 20059
+  - uid: 20058
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,11.5
       parent: 2
-  - uid: 20060
+  - uid: 20059
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -124815,31 +124814,31 @@ entities:
       parent: 2
 - proto: ShuttersRadiationOpen
   entities:
-  - uid: 20061
+  - uid: 20060
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 78.5,16.5
       parent: 2
-  - uid: 20062
+  - uid: 20061
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 78.5,17.5
       parent: 2
-  - uid: 20063
+  - uid: 20062
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 78.5,18.5
       parent: 2
-  - uid: 20064
+  - uid: 20063
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 78.5,19.5
       parent: 2
-  - uid: 20065
+  - uid: 20064
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124847,73 +124846,73 @@ entities:
       parent: 2
 - proto: ShuttersWindow
   entities:
-  - uid: 20066
+  - uid: 20065
     components:
     - type: Transform
       pos: -61.5,42.5
       parent: 2
-  - uid: 20067
+  - uid: 20066
     components:
     - type: Transform
       pos: -59.5,42.5
       parent: 2
 - proto: ShuttersWindowOpen
   entities:
-  - uid: 20068
+  - uid: 20067
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 2
-  - uid: 20069
+  - uid: 20068
     components:
     - type: Transform
       pos: 43.5,-7.5
       parent: 2
-  - uid: 20070
+  - uid: 20069
     components:
     - type: Transform
       pos: 44.5,-7.5
       parent: 2
-  - uid: 20071
+  - uid: 20070
     components:
     - type: Transform
       pos: 45.5,-7.5
       parent: 2
-  - uid: 20072
+  - uid: 20071
     components:
     - type: Transform
       pos: 46.5,-7.5
       parent: 2
-  - uid: 20073
+  - uid: 20072
     components:
     - type: Transform
       pos: 47.5,-7.5
       parent: 2
-  - uid: 20074
+  - uid: 20073
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-6.5
       parent: 2
-  - uid: 20075
+  - uid: 20074
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-5.5
       parent: 2
-  - uid: 20076
+  - uid: 20075
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-4.5
       parent: 2
-  - uid: 20077
+  - uid: 20076
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-3.5
       parent: 2
-  - uid: 20078
+  - uid: 20077
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124921,7 +124920,7 @@ entities:
       parent: 2
 - proto: SignAiUpload
   entities:
-  - uid: 20079
+  - uid: 20078
     components:
     - type: Transform
       pos: -7.5,41.5
@@ -124930,7 +124929,7 @@ entities:
       fixtures: {}
 - proto: SignalButton
   entities:
-  - uid: 20080
+  - uid: 20079
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124938,14 +124937,14 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20068:
+        20067:
         - - Pressed
           - Toggle
     - type: Fixtures
       fixtures: {}
 - proto: SignalButtonDirectional
   entities:
-  - uid: 20081
+  - uid: 20080
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124958,17 +124957,14 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20082
+  - uid: 20081
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20014:
-        - - Pressed
-          - Toggle
-        20018:
+        20013:
         - - Pressed
           - Toggle
         20017:
@@ -124980,9 +124976,12 @@ entities:
         20015:
         - - Pressed
           - Toggle
+        20014:
+        - - Pressed
+          - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20083
+  - uid: 20082
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -124990,21 +124989,21 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
+        20018:
+        - - Pressed
+          - Toggle
         20019:
-        - - Pressed
-          - Toggle
-        20020:
-        - - Pressed
-          - Toggle
-        20022:
         - - Pressed
           - Toggle
         20021:
         - - Pressed
           - Toggle
+        20020:
+        - - Pressed
+          - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20084
+  - uid: 20083
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125017,7 +125016,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20085
+  - uid: 20084
     components:
     - type: Transform
       pos: 78.5,-10.5
@@ -125029,7 +125028,7 @@ entities:
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20086
+  - uid: 20085
     components:
     - type: Transform
       pos: 78.5,-8.5
@@ -125041,7 +125040,7 @@ entities:
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20087
+  - uid: 20086
     components:
     - type: Transform
       pos: 78.5,-6.5
@@ -125053,7 +125052,7 @@ entities:
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20088
+  - uid: 20087
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125066,7 +125065,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20089
+  - uid: 20088
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125079,7 +125078,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20090
+  - uid: 20089
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125092,7 +125091,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20091
+  - uid: 20090
     components:
     - type: MetaData
       desc: Opens and closes the radiation shutters.
@@ -125103,6 +125102,9 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
+        20060:
+        - - Pressed
+          - Toggle
         20061:
         - - Pressed
           - Toggle
@@ -125115,12 +125117,9 @@ entities:
         20064:
         - - Pressed
           - Toggle
-        20065:
-        - - Pressed
-          - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20092
+  - uid: 20091
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125135,7 +125134,7 @@ entities:
       fixtures: {}
 - proto: SignalSwitch
   entities:
-  - uid: 20093
+  - uid: 20092
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125143,22 +125142,22 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
+        20005:
+        - - Off
+          - Open
+        - - On
+          - Close
         20006:
         - - Off
           - Open
         - - On
           - Close
-        20007:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20009:
-        - - Off
-          - Open
-        - - On
-          - Close
         20008:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20007:
         - - Off
           - Open
         - - On
@@ -125173,22 +125172,22 @@ entities:
           - Open
         - - On
           - Close
-        20012:
-        - - Off
-          - Open
-        - - On
-          - Close
         20011:
-        - - On
-          - Close
         - - Off
           - Open
+        - - On
+          - Close
         20010:
+        - - On
+          - Close
+        - - Off
+          - Open
+        20009:
         - - Off
           - Open
         - - On
           - Close
-        20013:
+        20012:
         - - Off
           - Open
         - - On
@@ -125197,7 +125196,7 @@ entities:
       fixtures: {}
 - proto: SignalSwitchDirectional
   entities:
-  - uid: 20094
+  - uid: 20093
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125205,17 +125204,7 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20003:
-        - - On
-          - Open
-        - - Off
-          - Close
         20002:
-        - - On
-          - Open
-        - - Off
-          - Close
-        20004:
         - - On
           - Open
         - - Off
@@ -125225,9 +125214,19 @@ entities:
           - Open
         - - Off
           - Close
+        20003:
+        - - On
+          - Open
+        - - Off
+          - Close
+        20000:
+        - - On
+          - Open
+        - - Off
+          - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20095
+  - uid: 20094
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -125235,17 +125234,41 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20000:
+        19999:
         - - On
           - Open
         - - Off
           - Close
-        20005:
+        20004:
+        - - On
+          - Open
+        - - Off
+          - Close
+        20055:
         - - On
           - Open
         - - Off
           - Close
         20056:
+        - - On
+          - Open
+        - - Off
+          - Close
+    - type: Fixtures
+      fixtures: {}
+  - uid: 20095
+    components:
+    - type: Transform
+      pos: 13.5,8.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        20059:
+        - - On
+          - Open
+        - - Off
+          - Close
+        20058:
         - - On
           - Open
         - - Off
@@ -125258,30 +125281,6 @@ entities:
     - type: Fixtures
       fixtures: {}
   - uid: 20096
-    components:
-    - type: Transform
-      pos: 13.5,8.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        20060:
-        - - On
-          - Open
-        - - Off
-          - Close
-        20059:
-        - - On
-          - Open
-        - - Off
-          - Close
-        20058:
-        - - On
-          - Open
-        - - Off
-          - Close
-    - type: Fixtures
-      fixtures: {}
-  - uid: 20097
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125306,7 +125305,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20098
+  - uid: 20097
     components:
     - type: Transform
       pos: 4.5,46.5
@@ -125330,7 +125329,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20099
+  - uid: 20098
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125350,7 +125349,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20100
+  - uid: 20099
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125358,17 +125357,17 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20055:
-        - - On
-          - Open
-        - - Off
-          - Close
         20054:
         - - On
           - Open
         - - Off
           - Close
         20053:
+        - - On
+          - Open
+        - - Off
+          - Close
+        20052:
         - - On
           - Open
         - - Off
@@ -125390,7 +125389,7 @@ entities:
           - Open
     - type: Fixtures
       fixtures: {}
-  - uid: 20101
+  - uid: 20100
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125398,37 +125397,37 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
+        20022:
+        - - Status
+          - Toggle
         20023:
         - - Status
           - Toggle
         20024:
         - - Status
           - Toggle
-        20025:
-        - - Status
-          - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20102
+  - uid: 20101
     components:
     - type: Transform
       pos: -62.5,40.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20066:
+        20065:
         - - On
           - Close
         - - Off
           - Open
-        20067:
+        20066:
         - - Off
           - Open
         - - On
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20103
+  - uid: 20102
     components:
     - type: Transform
       pos: -58.5,40.5
@@ -125452,7 +125451,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20104
+  - uid: 20103
     components:
     - type: Transform
       pos: -52.5,38.5
@@ -125476,7 +125475,7 @@ entities:
           - Open
     - type: Fixtures
       fixtures: {}
-  - uid: 20105
+  - uid: 20104
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -125484,22 +125483,17 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
+        20049:
+        - - On
+          - Close
+        - - Off
+          - Open
         20050:
-        - - On
-          - Close
         - - Off
           - Open
+        - - On
+          - Close
         20051:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20052:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20048:
         - - Off
           - Open
         - - On
@@ -125509,14 +125503,19 @@ entities:
           - Open
         - - On
           - Close
-        20049:
+        20046:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20048:
         - - Off
           - Open
         - - On
           - Toggle
     - type: Fixtures
       fixtures: {}
-  - uid: 20106
+  - uid: 20105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125524,17 +125523,17 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20028:
-        - - Off
-          - Open
-        - - On
-          - Close
         20027:
         - - Off
           - Open
         - - On
           - Close
         20026:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20025:
         - - Off
           - Open
         - - On
@@ -125551,7 +125550,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20107
+  - uid: 20106
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125559,17 +125558,17 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20030:
-        - - Off
-          - Open
-        - - On
-          - Close
         20029:
         - - Off
           - Open
         - - On
           - Close
-        20031:
+        20028:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20030:
         - - Off
           - Open
         - - On
@@ -125586,7 +125585,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20108
+  - uid: 20107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125594,17 +125593,17 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20034:
-        - - Off
-          - Open
-        - - On
-          - Close
         20033:
         - - Off
           - Open
         - - On
           - Close
         20032:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20031:
         - - Off
           - Open
         - - On
@@ -125621,7 +125620,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20109
+  - uid: 20108
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125629,7 +125628,7 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20046:
+        20045:
         - - Off
           - Open
         - - On
@@ -125639,12 +125638,12 @@ entities:
           - DoorBolt
         - - Off
           - DoorBolt
-        20045:
+        20044:
         - - Off
           - Open
         - - On
           - Close
-        20044:
+        20043:
         - - Off
           - Open
         - - On
@@ -125656,7 +125655,7 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20110
+  - uid: 20109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125669,7 +125668,7 @@ entities:
           - DoorBolt
         - - On
           - DoorBolt
-        20035:
+        20034:
         - - Off
           - Open
         - - On
@@ -125679,7 +125678,41 @@ entities:
           - DoorBolt
         - - Off
           - DoorBolt
+        20035:
+        - - Off
+          - Open
+        - - On
+          - Close
         20036:
+        - - Off
+          - Open
+        - - On
+          - Close
+    - type: Fixtures
+      fixtures: {}
+  - uid: 20110
+    components:
+    - type: Transform
+      pos: 41.5,-19.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        269:
+        - - On
+          - DoorBolt
+        - - Off
+          - DoorBolt
+        20039:
+        - - Off
+          - Open
+        - - On
+          - Close
+        86:
+        - - Off
+          - DoorBolt
+        - - On
+          - DoorBolt
+        20038:
         - - Off
           - Open
         - - On
@@ -125694,55 +125727,21 @@ entities:
   - uid: 20111
     components:
     - type: Transform
-      pos: 41.5,-19.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        269:
-        - - On
-          - DoorBolt
-        - - Off
-          - DoorBolt
-        20040:
-        - - Off
-          - Open
-        - - On
-          - Close
-        86:
-        - - Off
-          - DoorBolt
-        - - On
-          - DoorBolt
-        20039:
-        - - Off
-          - Open
-        - - On
-          - Close
-        20038:
-        - - Off
-          - Open
-        - - On
-          - Close
-    - type: Fixtures
-      fixtures: {}
-  - uid: 20112
-    components:
-    - type: Transform
       pos: 40.5,-15.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        20043:
-        - - Off
-          - Open
-        - - On
-          - Close
         20042:
         - - Off
           - Open
         - - On
           - Close
         20041:
+        - - Off
+          - Open
+        - - On
+          - Close
+        20040:
         - - Off
           - Open
         - - On
@@ -125759,14 +125758,14 @@ entities:
           - DoorBolt
     - type: Fixtures
       fixtures: {}
-  - uid: 20113
+  - uid: 20112
     components:
     - type: Transform
       pos: 42.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20114
+  - uid: 20113
     components:
     - type: Transform
       pos: 21.2172,40.498383
@@ -125785,7 +125784,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20115
+  - uid: 20114
     components:
     - type: Transform
       pos: 21.749607,40.498383
@@ -125804,7 +125803,7 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 20116
+  - uid: 20115
     components:
     - type: Transform
       pos: 54.5,14.5
@@ -125830,7 +125829,7 @@ entities:
       fixtures: {}
 - proto: SignAnomaly
   entities:
-  - uid: 20117
+  - uid: 20116
     components:
     - type: Transform
       pos: -49.5,33.5
@@ -125839,7 +125838,7 @@ entities:
       fixtures: {}
 - proto: SignAnomaly2
   entities:
-  - uid: 20118
+  - uid: 20117
     components:
     - type: Transform
       pos: -49.5,31.5
@@ -125848,7 +125847,7 @@ entities:
       fixtures: {}
 - proto: SignArmory
   entities:
-  - uid: 20119
+  - uid: 20118
     components:
     - type: Transform
       pos: -5.5,-9.5
@@ -125857,28 +125856,28 @@ entities:
       fixtures: {}
 - proto: SignArrivals
   entities:
-  - uid: 20120
+  - uid: 20119
     components:
     - type: Transform
       pos: 32.5,-30.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20121
+  - uid: 20120
     components:
     - type: Transform
       pos: 32.5,-23.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20122
+  - uid: 20121
     components:
     - type: Transform
       pos: 22.5,-21.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20123
+  - uid: 20122
     components:
     - type: Transform
       pos: 22.5,-28.5
@@ -125887,7 +125886,7 @@ entities:
       fixtures: {}
 - proto: SignBar
   entities:
-  - uid: 20124
+  - uid: 20123
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -125895,7 +125894,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20125
+  - uid: 20124
     components:
     - type: Transform
       pos: 35.5,-1.5
@@ -125904,7 +125903,7 @@ entities:
       fixtures: {}
 - proto: SignBath
   entities:
-  - uid: 20126
+  - uid: 20125
     components:
     - type: Transform
       pos: 3.5,-38.5
@@ -125913,7 +125912,7 @@ entities:
       fixtures: {}
 - proto: SignBridge
   entities:
-  - uid: 20127
+  - uid: 20126
     components:
     - type: Transform
       pos: -16.5,27.5
@@ -125922,7 +125921,7 @@ entities:
       fixtures: {}
 - proto: SignBrigmed
   entities:
-  - uid: 20128
+  - uid: 20127
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125932,14 +125931,14 @@ entities:
       fixtures: {}
 - proto: SignCargo
   entities:
-  - uid: 20129
+  - uid: 20128
     components:
     - type: Transform
       pos: 14.5,18.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20130
+  - uid: 20129
     components:
     - type: Transform
       pos: 18.5,23.5
@@ -125948,7 +125947,7 @@ entities:
       fixtures: {}
 - proto: SignCargoDock
   entities:
-  - uid: 20131
+  - uid: 20130
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -125958,7 +125957,7 @@ entities:
       fixtures: {}
 - proto: SignChapel
   entities:
-  - uid: 20132
+  - uid: 20131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125966,7 +125965,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20133
+  - uid: 20132
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -125976,7 +125975,7 @@ entities:
       fixtures: {}
 - proto: SignChem
   entities:
-  - uid: 20134
+  - uid: 20133
     components:
     - type: Transform
       pos: -39.5,6.5
@@ -125985,7 +125984,7 @@ entities:
       fixtures: {}
 - proto: SignDangerMed
   entities:
-  - uid: 20135
+  - uid: 20134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -125993,7 +125992,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20136
+  - uid: 20135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126001,7 +126000,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20137
+  - uid: 20136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126011,7 +126010,7 @@ entities:
       fixtures: {}
 - proto: SignDetective
   entities:
-  - uid: 20138
+  - uid: 20137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126021,14 +126020,14 @@ entities:
       fixtures: {}
 - proto: SignDirectionalEscapePod
   entities:
-  - uid: 20139
+  - uid: 20138
     components:
     - type: Transform
       pos: 18.5,-34.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20140
+  - uid: 20139
     components:
     - type: Transform
       pos: 36.5,-34.5
@@ -126037,7 +126036,7 @@ entities:
       fixtures: {}
 - proto: SignDisposalProper
   entities:
-  - uid: 20141
+  - uid: 20140
     components:
     - type: Transform
       pos: -6.5,-26.5
@@ -126046,7 +126045,7 @@ entities:
       fixtures: {}
 - proto: SignElectricalMed
   entities:
-  - uid: 20142
+  - uid: 20141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126056,7 +126055,7 @@ entities:
       fixtures: {}
 - proto: SignEngine
   entities:
-  - uid: 20143
+  - uid: 20142
     components:
     - type: Transform
       pos: 50.5,29.5
@@ -126065,7 +126064,7 @@ entities:
       fixtures: {}
 - proto: SignEscapePods
   entities:
-  - uid: 20144
+  - uid: 20143
     components:
     - type: Transform
       pos: 27.5,-38.5
@@ -126074,7 +126073,7 @@ entities:
       fixtures: {}
 - proto: SignEVA
   entities:
-  - uid: 20145
+  - uid: 20144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126084,28 +126083,28 @@ entities:
       fixtures: {}
 - proto: SignHead
   entities:
-  - uid: 20146
+  - uid: 20145
     components:
     - type: Transform
       pos: -6.5,45.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20147
+  - uid: 20146
     components:
     - type: Transform
       pos: -42.5,29.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20148
+  - uid: 20147
     components:
     - type: Transform
       pos: 21.5,20.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20149
+  - uid: 20148
     components:
     - type: Transform
       pos: 39.5,28.5
@@ -126114,7 +126113,7 @@ entities:
       fixtures: {}
 - proto: SignHydro1
   entities:
-  - uid: 20150
+  - uid: 20149
     components:
     - type: Transform
       pos: 61.5,-7.5
@@ -126123,7 +126122,7 @@ entities:
       fixtures: {}
 - proto: SignInterrogation
   entities:
-  - uid: 20151
+  - uid: 20150
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126133,7 +126132,7 @@ entities:
       fixtures: {}
 - proto: SignJanitor
   entities:
-  - uid: 20152
+  - uid: 20151
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126143,7 +126142,7 @@ entities:
       fixtures: {}
 - proto: SignKiddiePlaque
   entities:
-  - uid: 20153
+  - uid: 20152
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126153,14 +126152,14 @@ entities:
       fixtures: {}
 - proto: SignKitchen
   entities:
-  - uid: 20154
+  - uid: 20153
     components:
     - type: Transform
       pos: 41.5,-1.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20155
+  - uid: 20154
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126170,7 +126169,7 @@ entities:
       fixtures: {}
 - proto: SignLawyer
   entities:
-  - uid: 20156
+  - uid: 20155
     components:
     - type: Transform
       pos: -16.5,11.5
@@ -126179,7 +126178,7 @@ entities:
       fixtures: {}
 - proto: SignMagneticsMed
   entities:
-  - uid: 20157
+  - uid: 20156
     components:
     - type: Transform
       pos: 38.5,39.5
@@ -126188,7 +126187,7 @@ entities:
       fixtures: {}
 - proto: SignMaterials
   entities:
-  - uid: 20158
+  - uid: 20157
     components:
     - type: Transform
       pos: 2.5,17.5
@@ -126197,14 +126196,14 @@ entities:
       fixtures: {}
 - proto: SignMedical
   entities:
-  - uid: 20159
+  - uid: 20158
     components:
     - type: Transform
       pos: -25.5,11.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20160
+  - uid: 20159
     components:
     - type: Transform
       pos: -33.5,11.5
@@ -126213,7 +126212,7 @@ entities:
       fixtures: {}
 - proto: SignMining
   entities:
-  - uid: 20161
+  - uid: 20160
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126223,7 +126222,7 @@ entities:
       fixtures: {}
 - proto: SignMorgue
   entities:
-  - uid: 20162
+  - uid: 20161
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126233,7 +126232,7 @@ entities:
       fixtures: {}
 - proto: SignPlaque
   entities:
-  - uid: 20163
+  - uid: 20162
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126243,7 +126242,7 @@ entities:
       fixtures: {}
 - proto: SignPsychology
   entities:
-  - uid: 20164
+  - uid: 20163
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126253,14 +126252,14 @@ entities:
       fixtures: {}
 - proto: SignRobo
   entities:
-  - uid: 20165
+  - uid: 20164
     components:
     - type: Transform
       pos: -65.5,34.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20166
+  - uid: 20165
     components:
     - type: Transform
       pos: -57.5,31.5
@@ -126269,7 +126268,7 @@ entities:
       fixtures: {}
 - proto: SignSalvage
   entities:
-  - uid: 20167
+  - uid: 20166
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126279,119 +126278,119 @@ entities:
       fixtures: {}
 - proto: SignShock
   entities:
-  - uid: 20168
+  - uid: 20167
     components:
     - type: Transform
       pos: 55.5,48.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20169
+  - uid: 20168
     components:
     - type: Transform
       pos: 61.5,56.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20170
+  - uid: 20169
     components:
     - type: Transform
       pos: 56.5,53.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20171
+  - uid: 20170
     components:
     - type: Transform
       pos: 69.5,56.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20172
+  - uid: 20171
     components:
     - type: Transform
       pos: 74.5,53.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20173
+  - uid: 20172
     components:
     - type: Transform
       pos: 75.5,48.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20174
+  - uid: 20173
     components:
     - type: Transform
       pos: 59.5,34.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20175
+  - uid: 20174
     components:
     - type: Transform
       pos: 61.5,22.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20176
+  - uid: 20175
     components:
     - type: Transform
       pos: 69.5,22.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20177
+  - uid: 20176
     components:
     - type: Transform
       pos: 71.5,34.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20178
+  - uid: 20177
     components:
     - type: Transform
       pos: 59.5,29.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20179
+  - uid: 20178
     components:
     - type: Transform
       pos: 59.5,39.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20180
+  - uid: 20179
     components:
     - type: Transform
       pos: 71.5,39.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20181
+  - uid: 20180
     components:
     - type: Transform
       pos: 71.5,26.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20182
+  - uid: 20181
     components:
     - type: Transform
       pos: 62.5,14.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20183
+  - uid: 20182
     components:
     - type: Transform
       pos: 61.5,9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20184
+  - uid: 20183
     components:
     - type: Transform
       pos: 70.5,14.5
@@ -126400,7 +126399,7 @@ entities:
       fixtures: {}
 - proto: SignSurgery
   entities:
-  - uid: 20185
+  - uid: 20184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126410,7 +126409,7 @@ entities:
       fixtures: {}
 - proto: SignVault
   entities:
-  - uid: 20186
+  - uid: 20185
     components:
     - type: Transform
       pos: -23.5,32.5
@@ -126419,7 +126418,7 @@ entities:
       fixtures: {}
 - proto: SignXenobio
   entities:
-  - uid: 20187
+  - uid: 20186
     components:
     - type: Transform
       pos: -65.5,37.5
@@ -126428,32 +126427,32 @@ entities:
       fixtures: {}
 - proto: SingularityGenerator
   entities:
-  - uid: 20188
+  - uid: 20187
     components:
     - type: Transform
       pos: 74.5,22.5
       parent: 2
 - proto: Sink
   entities:
-  - uid: 20189
+  - uid: 20188
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-1.5
       parent: 2
-  - uid: 20190
+  - uid: 20189
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 54.5,-6.5
       parent: 2
-  - uid: 20191
+  - uid: 20190
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 49.5,-6.5
       parent: 2
-  - uid: 20192
+  - uid: 20191
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -126461,65 +126460,65 @@ entities:
       parent: 2
 - proto: SinkStemless
   entities:
-  - uid: 20193
+  - uid: 20192
     components:
     - type: Transform
       pos: -3.5,-41.5
       parent: 2
-  - uid: 20194
+  - uid: 20193
     components:
     - type: Transform
       pos: -3.5,-39.5
       parent: 2
-  - uid: 20195
+  - uid: 20194
     components:
     - type: Transform
       pos: -3.5,-37.5
       parent: 2
-  - uid: 20196
+  - uid: 20195
     components:
     - type: Transform
       pos: -3.5,-35.5
       parent: 2
 - proto: SinkStemlessWater
   entities:
-  - uid: 20197
+  - uid: 20196
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-41.5
       parent: 2
-  - uid: 20198
+  - uid: 20197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-39.5
       parent: 2
-  - uid: 20199
+  - uid: 20198
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 68.5,-30.5
       parent: 2
-  - uid: 20200
+  - uid: 20199
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 78.5,-9.5
       parent: 2
-  - uid: 20201
+  - uid: 20200
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 78.5,-11.5
       parent: 2
-  - uid: 20202
+  - uid: 20201
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 78.5,-7.5
       parent: 2
-  - uid: 20203
+  - uid: 20202
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126527,83 +126526,83 @@ entities:
       parent: 2
 - proto: SinkWide
   entities:
-  - uid: 20204
+  - uid: 20203
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-13.5
       parent: 2
-  - uid: 20205
+  - uid: 20204
     components:
     - type: Transform
       pos: 35.5,-2.5
       parent: 2
-  - uid: 20206
+  - uid: 20205
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,40.5
       parent: 2
-  - uid: 20207
+  - uid: 20206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,5.5
       parent: 2
-  - uid: 20208
+  - uid: 20207
     components:
     - type: Transform
       pos: -36.5,10.5
       parent: 2
-  - uid: 20209
+  - uid: 20208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -43.5,-12.5
       parent: 2
-  - uid: 20210
+  - uid: 20209
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,-12.5
       parent: 2
-  - uid: 20211
+  - uid: 20210
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,26.5
       parent: 2
-  - uid: 20212
+  - uid: 20211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -67.5,26.5
       parent: 2
-  - uid: 20213
+  - uid: 20212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-38.5
       parent: 2
-  - uid: 20214
+  - uid: 20213
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 58.5,-5.5
       parent: 2
-  - uid: 20215
+  - uid: 20214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 83.5,-10.5
       parent: 2
-  - uid: 20216
+  - uid: 20215
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-17.5
       parent: 2
-  - uid: 20217
+  - uid: 20216
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126611,7 +126610,7 @@ entities:
       parent: 2
 - proto: SLVendingMachineEngi
   entities:
-  - uid: 20218
+  - uid: 20217
     components:
     - type: Transform
       pos: 43.5,25.5
@@ -126620,7 +126619,7 @@ entities:
       processingListings: {}
 - proto: SLVendingMachineFashion
   entities:
-  - uid: 20219
+  - uid: 20218
     components:
     - type: Transform
       pos: 7.5,-34.5
@@ -126629,44 +126628,47 @@ entities:
       processingListings: {}
 - proto: SLVendingMachineHugDispenser
   entities:
-  - uid: 20220
+  - uid: 20219
     components:
     - type: Transform
       pos: 42.5,-12.5
       parent: 2
 - proto: SLVendingMachineMedical
   entities:
-  - uid: 20221
+  - uid: 17475
     components:
     - type: Transform
-      pos: -46.5,-9.5
+      pos: -38.5,-3.5
       parent: 2
-    - type: StockLimitedProcessing
-      processingListings: {}
 - proto: SLVendingMachineMining
   entities:
-  - uid: 20222
+  - uid: 20221
     components:
     - type: Transform
       pos: 28.5,31.5
       parent: 2
 - proto: SLVendingMachineSalvage
   entities:
-  - uid: 20223
+  - uid: 20222
     components:
     - type: Transform
       pos: 28.5,33.5
       parent: 2
 - proto: SLVendingMachineSecurity
   entities:
-  - uid: 20224
+  - uid: 20223
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 2
 - proto: SmartFridge
   entities:
-  - uid: 20225
+  - uid: 20220
+    components:
+    - type: Transform
+      pos: -46.5,-9.5
+      parent: 2
+  - uid: 20224
     components:
     - type: Transform
       pos: -34.5,2.5
@@ -126674,116 +126676,111 @@ entities:
   - uid: 20226
     components:
     - type: Transform
-      pos: -44.5,-5.5
-      parent: 2
-  - uid: 20227
-    components:
-    - type: Transform
       pos: 48.5,-4.5
       parent: 2
 - proto: SMESAdvanced
   entities:
-  - uid: 20228
+  - uid: 20227
     components:
     - type: Transform
       pos: 46.5,21.5
       parent: 2
-  - uid: 20229
+  - uid: 20228
     components:
     - type: Transform
       pos: 46.5,22.5
       parent: 2
-  - uid: 20230
+  - uid: 20229
     components:
     - type: Transform
       pos: 46.5,20.5
       parent: 2
-  - uid: 20231
+  - uid: 20230
     components:
     - type: Transform
       pos: 46.5,23.5
       parent: 2
-  - uid: 20232
+  - uid: 20231
     components:
     - type: Transform
       pos: 64.5,50.5
       parent: 2
-  - uid: 20233
+  - uid: 20232
     components:
     - type: Transform
       pos: 77.5,15.5
       parent: 2
 - proto: SMESBasic
   entities:
-  - uid: 20234
+  - uid: 20233
     components:
     - type: Transform
       pos: -4.5,41.5
       parent: 2
-  - uid: 20235
+  - uid: 20234
     components:
     - type: Transform
       pos: -16.5,-10.5
       parent: 2
-  - uid: 20236
+  - uid: 20235
     components:
     - type: Transform
       pos: -37.5,-19.5
       parent: 2
 - proto: SnowBattlemap
   entities:
-  - uid: 20237
+  - uid: 20236
     components:
     - type: Transform
       pos: 69.54626,-42.478077
       parent: 2
 - proto: SodaDispenser
   entities:
-  - uid: 20238
+  - uid: 20237
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 2
-  - uid: 20239
+  - uid: 20238
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 2
-  - uid: 20240
+  - uid: 20239
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,-3.5
       parent: 2
-  - uid: 20241
+  - uid: 20240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 66.5,-32.5
       parent: 2
-  - uid: 20242
+  - uid: 20241
     components:
     - type: Transform
       pos: -38.5,38.5
       parent: 2
 - proto: SofaCorner
   entities:
-  - uid: 20243
+  - uid: 20242
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 2
 - proto: SofaEndLeft
   entities:
-  - uid: 20244
+  - uid: 20243
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 2
 - proto: SofaEndLeftBrown
   entities:
-  - uid: 20245
+  - uid: 20244
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126791,7 +126788,7 @@ entities:
       parent: 2
 - proto: SofaEndRight
   entities:
-  - uid: 20246
+  - uid: 20245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126799,7 +126796,7 @@ entities:
       parent: 2
 - proto: SofaEndRightBrown
   entities:
-  - uid: 20247
+  - uid: 20246
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -126807,7 +126804,7 @@ entities:
       parent: 2
 - proto: SofaFancyEndLeft
   entities:
-  - uid: 20248
+  - uid: 20247
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126815,7 +126812,7 @@ entities:
       parent: 2
 - proto: SofaFancyEndRight
   entities:
-  - uid: 20249
+  - uid: 20248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -126823,2384 +126820,2394 @@ entities:
       parent: 2
 - proto: SofaMiddle
   entities:
-  - uid: 20250
+  - uid: 20249
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 2
 - proto: SolarPanel
   entities:
-  - uid: 20251
+  - uid: 20250
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,73.5
       parent: 2
-  - uid: 20252
+  - uid: 20251
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,58.5
       parent: 2
-  - uid: 20253
+  - uid: 20252
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,73.5
       parent: 2
-  - uid: 20254
+  - uid: 20253
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,72.5
       parent: 2
-  - uid: 20255
+  - uid: 20254
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,72.5
       parent: 2
-  - uid: 20256
+  - uid: 20255
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,70.5
       parent: 2
-  - uid: 20257
+  - uid: 20256
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,70.5
       parent: 2
-  - uid: 20258
+  - uid: 20257
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,70.5
       parent: 2
-  - uid: 20259
+  - uid: 20258
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,68.5
       parent: 2
-  - uid: 20260
+  - uid: 20259
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,68.5
       parent: 2
-  - uid: 20261
+  - uid: 20260
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,68.5
       parent: 2
-  - uid: 20262
+  - uid: 20261
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,68.5
       parent: 2
-  - uid: 20263
+  - uid: 20262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,66.5
       parent: 2
-  - uid: 20264
+  - uid: 20263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,66.5
       parent: 2
-  - uid: 20265
+  - uid: 20264
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,66.5
       parent: 2
-  - uid: 20266
+  - uid: 20265
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,66.5
       parent: 2
-  - uid: 20267
+  - uid: 20266
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,64.5
       parent: 2
-  - uid: 20268
+  - uid: 20267
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,64.5
       parent: 2
-  - uid: 20269
+  - uid: 20268
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,64.5
       parent: 2
-  - uid: 20270
+  - uid: 20269
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,64.5
       parent: 2
-  - uid: 20271
+  - uid: 20270
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,64.5
       parent: 2
-  - uid: 20272
+  - uid: 20271
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,62.5
       parent: 2
-  - uid: 20273
+  - uid: 20272
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,62.5
       parent: 2
-  - uid: 20274
+  - uid: 20273
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,62.5
       parent: 2
-  - uid: 20275
+  - uid: 20274
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,62.5
       parent: 2
-  - uid: 20276
+  - uid: 20275
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,62.5
       parent: 2
-  - uid: 20277
+  - uid: 20276
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,62.5
       parent: 2
-  - uid: 20278
+  - uid: 20277
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,60.5
       parent: 2
-  - uid: 20279
+  - uid: 20278
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,60.5
       parent: 2
-  - uid: 20280
+  - uid: 20279
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,60.5
       parent: 2
-  - uid: 20281
+  - uid: 20280
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,60.5
       parent: 2
-  - uid: 20282
+  - uid: 20281
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,60.5
       parent: 2
-  - uid: 20283
+  - uid: 20282
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,60.5
       parent: 2
-  - uid: 20284
+  - uid: 20283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,60.5
       parent: 2
-  - uid: 20285
+  - uid: 20284
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,58.5
       parent: 2
-  - uid: 20286
+  - uid: 20285
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,58.5
       parent: 2
-  - uid: 20287
+  - uid: 20286
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,58.5
       parent: 2
-  - uid: 20288
+  - uid: 20287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,58.5
       parent: 2
-  - uid: 20289
+  - uid: 20288
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,58.5
       parent: 2
-  - uid: 20290
+  - uid: 20289
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,58.5
       parent: 2
-  - uid: 20291
+  - uid: 20290
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,58.5
       parent: 2
-  - uid: 20292
+  - uid: 20291
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,57.5
       parent: 2
-  - uid: 20293
+  - uid: 20292
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,57.5
       parent: 2
-  - uid: 20294
+  - uid: 20293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,56.5
       parent: 2
-  - uid: 20295
+  - uid: 20294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,58.5
       parent: 2
-  - uid: 20296
+  - uid: 20295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,58.5
       parent: 2
-  - uid: 20297
+  - uid: 20296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,58.5
       parent: 2
-  - uid: 20298
+  - uid: 20297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 72.5,58.5
       parent: 2
-  - uid: 20299
+  - uid: 20298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 73.5,58.5
       parent: 2
-  - uid: 20300
+  - uid: 20299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,58.5
       parent: 2
-  - uid: 20301
+  - uid: 20300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,57.5
       parent: 2
-  - uid: 20302
+  - uid: 20301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,57.5
       parent: 2
-  - uid: 20303
+  - uid: 20302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 75.5,56.5
       parent: 2
-  - uid: 20304
+  - uid: 20303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,60.5
       parent: 2
-  - uid: 20305
+  - uid: 20304
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,60.5
       parent: 2
-  - uid: 20306
+  - uid: 20305
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,60.5
       parent: 2
-  - uid: 20307
+  - uid: 20306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 72.5,60.5
       parent: 2
-  - uid: 20308
+  - uid: 20307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 73.5,60.5
       parent: 2
-  - uid: 20309
+  - uid: 20308
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 74.5,60.5
       parent: 2
-  - uid: 20310
+  - uid: 20309
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,60.5
       parent: 2
-  - uid: 20311
+  - uid: 20310
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,62.5
       parent: 2
-  - uid: 20312
+  - uid: 20311
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,62.5
       parent: 2
-  - uid: 20313
+  - uid: 20312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,62.5
       parent: 2
-  - uid: 20314
+  - uid: 20313
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,62.5
       parent: 2
-  - uid: 20315
+  - uid: 20314
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 72.5,62.5
       parent: 2
-  - uid: 20316
+  - uid: 20315
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 73.5,62.5
       parent: 2
-  - uid: 20317
+  - uid: 20316
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,64.5
       parent: 2
-  - uid: 20318
+  - uid: 20317
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,64.5
       parent: 2
-  - uid: 20319
+  - uid: 20318
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,64.5
       parent: 2
-  - uid: 20320
+  - uid: 20319
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 72.5,64.5
       parent: 2
-  - uid: 20321
+  - uid: 20320
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,64.5
       parent: 2
-  - uid: 20322
+  - uid: 20321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,66.5
       parent: 2
-  - uid: 20323
+  - uid: 20322
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,66.5
       parent: 2
-  - uid: 20324
+  - uid: 20323
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,66.5
       parent: 2
-  - uid: 20325
+  - uid: 20324
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,66.5
       parent: 2
-  - uid: 20326
+  - uid: 20325
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,68.5
       parent: 2
-  - uid: 20327
+  - uid: 20326
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,68.5
       parent: 2
-  - uid: 20328
+  - uid: 20327
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 71.5,68.5
       parent: 2
-  - uid: 20329
+  - uid: 20328
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,68.5
       parent: 2
-  - uid: 20330
+  - uid: 20329
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,70.5
       parent: 2
-  - uid: 20331
+  - uid: 20330
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,70.5
       parent: 2
-  - uid: 20332
+  - uid: 20331
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 70.5,70.5
       parent: 2
-  - uid: 20333
+  - uid: 20332
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,72.5
       parent: 2
-  - uid: 20334
+  - uid: 20333
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 69.5,72.5
       parent: 2
-  - uid: 20335
+  - uid: 20334
     components:
     - type: Transform
       pos: -44.5,-40.5
       parent: 2
-  - uid: 20336
+  - uid: 20335
     components:
     - type: Transform
       pos: -42.5,-34.5
       parent: 2
-  - uid: 20337
+  - uid: 20336
     components:
     - type: Transform
       pos: -41.5,-38.5
       parent: 2
-  - uid: 20338
+  - uid: 20337
     components:
     - type: Transform
       pos: -46.5,-40.5
       parent: 2
-  - uid: 20339
+  - uid: 20338
     components:
     - type: Transform
       pos: -42.5,-38.5
       parent: 2
-  - uid: 20340
+  - uid: 20339
     components:
     - type: Transform
       pos: -43.5,-38.5
       parent: 2
-  - uid: 20341
+  - uid: 20340
     components:
     - type: Transform
       pos: -45.5,-40.5
       parent: 2
-  - uid: 20342
+  - uid: 20341
     components:
     - type: Transform
       pos: -42.5,-40.5
       parent: 2
-  - uid: 20343
+  - uid: 20342
     components:
     - type: Transform
       pos: -45.5,-38.5
       parent: 2
-  - uid: 20344
+  - uid: 20343
     components:
     - type: Transform
       pos: -46.5,-38.5
       parent: 2
-  - uid: 20345
+  - uid: 20344
     components:
     - type: Transform
       pos: -39.5,-40.5
       parent: 2
-  - uid: 20346
+  - uid: 20345
     components:
     - type: Transform
       pos: -40.5,-40.5
       parent: 2
-  - uid: 20347
+  - uid: 20346
     components:
     - type: Transform
       pos: -41.5,-40.5
       parent: 2
-  - uid: 20348
+  - uid: 20347
     components:
     - type: Transform
       pos: -43.5,-40.5
       parent: 2
-  - uid: 20349
+  - uid: 20348
     components:
     - type: Transform
       pos: -40.5,-38.5
       parent: 2
-  - uid: 20350
+  - uid: 20349
     components:
     - type: Transform
       pos: -41.5,-34.5
       parent: 2
-  - uid: 20351
+  - uid: 20350
     components:
     - type: Transform
       pos: -43.5,-36.5
       parent: 2
-  - uid: 20352
+  - uid: 20351
     components:
     - type: Transform
       pos: -35.5,-36.5
       parent: 2
-  - uid: 20353
+  - uid: 20352
     components:
     - type: Transform
       pos: -44.5,-38.5
       parent: 2
-  - uid: 20354
+  - uid: 20353
     components:
     - type: Transform
       pos: -39.5,-38.5
       parent: 2
-  - uid: 20355
+  - uid: 20354
     components:
     - type: Transform
       pos: -42.5,-36.5
       parent: 2
-  - uid: 20356
+  - uid: 20355
     components:
     - type: Transform
       pos: -41.5,-36.5
       parent: 2
-  - uid: 20357
+  - uid: 20356
     components:
     - type: Transform
       pos: -40.5,-36.5
       parent: 2
-  - uid: 20358
+  - uid: 20357
     components:
     - type: Transform
       pos: -39.5,-36.5
       parent: 2
-  - uid: 20359
+  - uid: 20358
     components:
     - type: Transform
       pos: -43.5,-34.5
       parent: 2
-  - uid: 20360
+  - uid: 20359
     components:
     - type: Transform
       pos: -44.5,-34.5
       parent: 2
-  - uid: 20361
+  - uid: 20360
     components:
     - type: Transform
       pos: -45.5,-36.5
       parent: 2
-  - uid: 20362
+  - uid: 20361
     components:
     - type: Transform
       pos: -46.5,-34.5
       parent: 2
-  - uid: 20363
+  - uid: 20362
     components:
     - type: Transform
       pos: -44.5,-36.5
       parent: 2
-  - uid: 20364
+  - uid: 20363
     components:
     - type: Transform
       pos: -46.5,-36.5
       parent: 2
-  - uid: 20365
+  - uid: 20364
     components:
     - type: Transform
       pos: -45.5,-34.5
       parent: 2
-  - uid: 20366
+  - uid: 20365
     components:
     - type: Transform
       pos: -40.5,-34.5
       parent: 2
-  - uid: 20367
+  - uid: 20366
     components:
     - type: Transform
       pos: -39.5,-34.5
       parent: 2
-  - uid: 20368
+  - uid: 20367
     components:
     - type: Transform
       pos: -39.5,-32.5
       parent: 2
-  - uid: 20369
+  - uid: 20368
     components:
     - type: Transform
       pos: -40.5,-32.5
       parent: 2
-  - uid: 20370
+  - uid: 20369
     components:
     - type: Transform
       pos: -41.5,-32.5
       parent: 2
-  - uid: 20371
+  - uid: 20370
     components:
     - type: Transform
       pos: -42.5,-32.5
       parent: 2
-  - uid: 20372
+  - uid: 20371
     components:
     - type: Transform
       pos: -43.5,-32.5
       parent: 2
-  - uid: 20373
+  - uid: 20372
     components:
     - type: Transform
       pos: -45.5,-32.5
       parent: 2
-  - uid: 20374
+  - uid: 20373
     components:
     - type: Transform
       pos: -46.5,-32.5
       parent: 2
-  - uid: 20375
+  - uid: 20374
     components:
     - type: Transform
       pos: -44.5,-32.5
       parent: 2
-  - uid: 20376
+  - uid: 20375
     components:
     - type: Transform
       pos: -46.5,-30.5
       parent: 2
-  - uid: 20377
+  - uid: 20376
     components:
     - type: Transform
       pos: -45.5,-30.5
       parent: 2
-  - uid: 20378
+  - uid: 20377
     components:
     - type: Transform
       pos: -43.5,-30.5
       parent: 2
-  - uid: 20379
+  - uid: 20378
     components:
     - type: Transform
       pos: -42.5,-30.5
       parent: 2
-  - uid: 20380
+  - uid: 20379
     components:
     - type: Transform
       pos: -41.5,-30.5
       parent: 2
-  - uid: 20381
+  - uid: 20380
     components:
     - type: Transform
       pos: -40.5,-30.5
       parent: 2
-  - uid: 20382
+  - uid: 20381
     components:
     - type: Transform
       pos: -39.5,-30.5
       parent: 2
-  - uid: 20383
+  - uid: 20382
     components:
     - type: Transform
       pos: -44.5,-30.5
       parent: 2
-  - uid: 20384
+  - uid: 20383
     components:
     - type: Transform
       pos: -39.5,-28.5
       parent: 2
-  - uid: 20385
+  - uid: 20384
     components:
     - type: Transform
       pos: -40.5,-28.5
       parent: 2
-  - uid: 20386
+  - uid: 20385
     components:
     - type: Transform
       pos: -41.5,-28.5
       parent: 2
-  - uid: 20387
+  - uid: 20386
     components:
     - type: Transform
       pos: -42.5,-28.5
       parent: 2
-  - uid: 20388
+  - uid: 20387
     components:
     - type: Transform
       pos: -44.5,-28.5
       parent: 2
-  - uid: 20389
+  - uid: 20388
     components:
     - type: Transform
       pos: -45.5,-28.5
       parent: 2
-  - uid: 20390
+  - uid: 20389
     components:
     - type: Transform
       pos: -46.5,-28.5
       parent: 2
-  - uid: 20391
+  - uid: 20390
     components:
     - type: Transform
       pos: -43.5,-28.5
       parent: 2
-  - uid: 20392
+  - uid: 20391
     components:
     - type: Transform
       pos: -46.5,-26.5
       parent: 2
-  - uid: 20393
+  - uid: 20392
     components:
     - type: Transform
       pos: -45.5,-26.5
       parent: 2
-  - uid: 20394
+  - uid: 20393
     components:
     - type: Transform
       pos: -44.5,-26.5
       parent: 2
-  - uid: 20395
+  - uid: 20394
     components:
     - type: Transform
       pos: -43.5,-26.5
       parent: 2
-  - uid: 20396
+  - uid: 20395
     components:
     - type: Transform
       pos: -42.5,-26.5
       parent: 2
-  - uid: 20397
+  - uid: 20396
     components:
     - type: Transform
       pos: -41.5,-26.5
       parent: 2
-  - uid: 20398
+  - uid: 20397
     components:
     - type: Transform
       pos: -40.5,-26.5
       parent: 2
-  - uid: 20399
+  - uid: 20398
     components:
     - type: Transform
       pos: -39.5,-26.5
       parent: 2
-  - uid: 20400
+  - uid: 20399
     components:
     - type: Transform
       pos: -34.5,-26.5
       parent: 2
-  - uid: 20401
+  - uid: 20400
     components:
     - type: Transform
       pos: -33.5,-26.5
       parent: 2
-  - uid: 20402
+  - uid: 20401
     components:
     - type: Transform
       pos: -32.5,-26.5
       parent: 2
-  - uid: 20403
+  - uid: 20402
     components:
     - type: Transform
       pos: -30.5,-26.5
       parent: 2
-  - uid: 20404
+  - uid: 20403
     components:
     - type: Transform
       pos: -29.5,-26.5
       parent: 2
-  - uid: 20405
+  - uid: 20404
     components:
     - type: Transform
       pos: -28.5,-26.5
       parent: 2
-  - uid: 20406
+  - uid: 20405
     components:
     - type: Transform
       pos: -31.5,-26.5
       parent: 2
-  - uid: 20407
+  - uid: 20406
     components:
     - type: Transform
       pos: -35.5,-26.5
       parent: 2
-  - uid: 20408
+  - uid: 20407
     components:
     - type: Transform
       pos: -35.5,-28.5
       parent: 2
-  - uid: 20409
+  - uid: 20408
     components:
     - type: Transform
       pos: -34.5,-28.5
       parent: 2
-  - uid: 20410
+  - uid: 20409
     components:
     - type: Transform
       pos: -33.5,-28.5
       parent: 2
-  - uid: 20411
+  - uid: 20410
     components:
     - type: Transform
       pos: -31.5,-28.5
       parent: 2
-  - uid: 20412
+  - uid: 20411
     components:
     - type: Transform
       pos: -30.5,-28.5
       parent: 2
-  - uid: 20413
+  - uid: 20412
     components:
     - type: Transform
       pos: -29.5,-28.5
       parent: 2
-  - uid: 20414
+  - uid: 20413
     components:
     - type: Transform
       pos: -28.5,-28.5
       parent: 2
-  - uid: 20415
+  - uid: 20414
     components:
     - type: Transform
       pos: -32.5,-28.5
       parent: 2
-  - uid: 20416
+  - uid: 20415
     components:
     - type: Transform
       pos: -28.5,-30.5
       parent: 2
-  - uid: 20417
+  - uid: 20416
     components:
     - type: Transform
       pos: -29.5,-30.5
       parent: 2
-  - uid: 20418
+  - uid: 20417
     components:
     - type: Transform
       pos: -30.5,-30.5
       parent: 2
-  - uid: 20419
+  - uid: 20418
     components:
     - type: Transform
       pos: -32.5,-30.5
       parent: 2
-  - uid: 20420
+  - uid: 20419
     components:
     - type: Transform
       pos: -33.5,-30.5
       parent: 2
-  - uid: 20421
+  - uid: 20420
     components:
     - type: Transform
       pos: -34.5,-30.5
       parent: 2
-  - uid: 20422
+  - uid: 20421
     components:
     - type: Transform
       pos: -35.5,-30.5
       parent: 2
-  - uid: 20423
+  - uid: 20422
     components:
     - type: Transform
       pos: -31.5,-30.5
       parent: 2
-  - uid: 20424
+  - uid: 20423
     components:
     - type: Transform
       pos: -35.5,-32.5
       parent: 2
-  - uid: 20425
+  - uid: 20424
     components:
     - type: Transform
       pos: -34.5,-32.5
       parent: 2
-  - uid: 20426
+  - uid: 20425
     components:
     - type: Transform
       pos: -33.5,-32.5
       parent: 2
-  - uid: 20427
+  - uid: 20426
     components:
     - type: Transform
       pos: -32.5,-32.5
       parent: 2
-  - uid: 20428
+  - uid: 20427
     components:
     - type: Transform
       pos: -30.5,-32.5
       parent: 2
-  - uid: 20429
+  - uid: 20428
     components:
     - type: Transform
       pos: -29.5,-32.5
       parent: 2
-  - uid: 20430
+  - uid: 20429
     components:
     - type: Transform
       pos: -28.5,-32.5
       parent: 2
-  - uid: 20431
+  - uid: 20430
     components:
     - type: Transform
       pos: -31.5,-32.5
       parent: 2
-  - uid: 20432
+  - uid: 20431
     components:
     - type: Transform
       pos: -28.5,-34.5
       parent: 2
-  - uid: 20433
+  - uid: 20432
     components:
     - type: Transform
       pos: -29.5,-34.5
       parent: 2
-  - uid: 20434
+  - uid: 20433
     components:
     - type: Transform
       pos: -30.5,-34.5
       parent: 2
-  - uid: 20435
+  - uid: 20434
     components:
     - type: Transform
       pos: -33.5,-34.5
       parent: 2
-  - uid: 20436
+  - uid: 20435
     components:
     - type: Transform
       pos: -32.5,-34.5
       parent: 2
-  - uid: 20437
+  - uid: 20436
     components:
     - type: Transform
       pos: -34.5,-34.5
       parent: 2
-  - uid: 20438
+  - uid: 20437
     components:
     - type: Transform
       pos: -35.5,-34.5
       parent: 2
-  - uid: 20439
+  - uid: 20438
     components:
     - type: Transform
       pos: -31.5,-34.5
       parent: 2
-  - uid: 20440
+  - uid: 20439
     components:
     - type: Transform
       pos: -34.5,-36.5
       parent: 2
-  - uid: 20441
+  - uid: 20440
     components:
     - type: Transform
       pos: -33.5,-36.5
       parent: 2
-  - uid: 20442
+  - uid: 20441
     components:
     - type: Transform
       pos: -31.5,-36.5
       parent: 2
-  - uid: 20443
+  - uid: 20442
     components:
     - type: Transform
       pos: -30.5,-36.5
       parent: 2
-  - uid: 20444
+  - uid: 20443
     components:
     - type: Transform
       pos: -29.5,-36.5
       parent: 2
-  - uid: 20445
+  - uid: 20444
     components:
     - type: Transform
       pos: -28.5,-36.5
       parent: 2
-  - uid: 20446
+  - uid: 20445
     components:
     - type: Transform
       pos: -32.5,-36.5
       parent: 2
-  - uid: 20447
+  - uid: 20446
     components:
     - type: Transform
       pos: -28.5,-38.5
       parent: 2
-  - uid: 20448
+  - uid: 20447
     components:
     - type: Transform
       pos: -30.5,-38.5
       parent: 2
-  - uid: 20449
+  - uid: 20448
     components:
     - type: Transform
       pos: -31.5,-38.5
       parent: 2
-  - uid: 20450
+  - uid: 20449
     components:
     - type: Transform
       pos: -32.5,-38.5
       parent: 2
-  - uid: 20451
+  - uid: 20450
     components:
     - type: Transform
       pos: -33.5,-38.5
       parent: 2
-  - uid: 20452
+  - uid: 20451
     components:
     - type: Transform
       pos: -34.5,-38.5
       parent: 2
-  - uid: 20453
+  - uid: 20452
     components:
     - type: Transform
       pos: -35.5,-38.5
       parent: 2
-  - uid: 20454
+  - uid: 20453
     components:
     - type: Transform
       pos: -29.5,-38.5
       parent: 2
-  - uid: 20455
+  - uid: 20454
     components:
     - type: Transform
       pos: -35.5,-40.5
       parent: 2
-  - uid: 20456
+  - uid: 20455
     components:
     - type: Transform
       pos: -33.5,-40.5
       parent: 2
-  - uid: 20457
+  - uid: 20456
     components:
     - type: Transform
       pos: -32.5,-40.5
       parent: 2
-  - uid: 20458
+  - uid: 20457
     components:
     - type: Transform
       pos: -34.5,-40.5
       parent: 2
-  - uid: 20459
+  - uid: 20458
     components:
     - type: Transform
       pos: -30.5,-40.5
       parent: 2
-  - uid: 20460
+  - uid: 20459
     components:
     - type: Transform
       pos: -29.5,-40.5
       parent: 2
-  - uid: 20461
+  - uid: 20460
     components:
     - type: Transform
       pos: -31.5,-40.5
       parent: 2
-  - uid: 20462
+  - uid: 20461
     components:
     - type: Transform
       pos: -28.5,-40.5
       parent: 2
 - proto: SolarTracker
   entities:
-  - uid: 20463
+  - uid: 20462
     components:
     - type: Transform
       pos: 63.5,75.5
       parent: 2
-  - uid: 20464
+  - uid: 20463
     components:
     - type: Transform
       pos: 67.5,75.5
       parent: 2
-  - uid: 20465
+  - uid: 20464
     components:
     - type: Transform
       pos: -37.5,-42.5
       parent: 2
 - proto: SolidSecretDoor
   entities:
-  - uid: 20466
+  - uid: 20465
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-18.5
       parent: 2
-  - uid: 20467
+  - uid: 20466
     components:
     - type: Transform
       pos: 11.5,29.5
       parent: 2
 - proto: SpaceCash
   entities:
-  - uid: 20468
+  - uid: 20467
     components:
     - type: Transform
       pos: -25.535286,28.743128
       parent: 2
-  - uid: 20469
+  - uid: 20468
     components:
     - type: Transform
       pos: -25.472786,28.618128
       parent: 2
-  - uid: 20470
+  - uid: 20469
     components:
     - type: Transform
       pos: -25.39466,28.430628
       parent: 2
 - proto: SpawnMechPaddyFilled
   entities:
-  - uid: 20471
+  - uid: 20470
     components:
     - type: Transform
       pos: -11.5,-15.5
       parent: 2
 - proto: SpawnMechRipley
   entities:
-  - uid: 20472
+  - uid: 20471
     components:
     - type: Transform
       pos: 20.5,19.5
       parent: 2
 - proto: SpawnMobCarp
   entities:
-  - uid: 20473
+  - uid: 20472
     components:
     - type: Transform
       pos: -75.5,-2.5
       parent: 2
-  - uid: 20474
+  - uid: 20473
     components:
     - type: Transform
       pos: -70.5,-5.5
       parent: 2
 - proto: SpawnMobCarpHolo
   entities:
-  - uid: 20475
+  - uid: 20474
     components:
     - type: Transform
       pos: 82.5,-47.5
       parent: 2
 - proto: SpawnMobCat
   entities:
-  - uid: 20476
+  - uid: 20475
     components:
     - type: Transform
       pos: -48.5,1.5
       parent: 2
 - proto: SpawnMobCatKitten
   entities:
-  - uid: 20477
+  - uid: 20476
     components:
     - type: Transform
       pos: 4.5,-55.5
       parent: 2
 - proto: SpawnMobCorgi
   entities:
-  - uid: 20478
+  - uid: 20477
     components:
     - type: Transform
       pos: -6.5,23.5
       parent: 2
 - proto: SpawnMobCow
   entities:
-  - uid: 20479
+  - uid: 20478
     components:
     - type: Transform
       pos: 50.5,2.5
       parent: 2
-  - uid: 20480
+  - uid: 20479
     components:
     - type: Transform
       pos: 66.5,1.5
       parent: 2
 - proto: SpawnMobFoxRenault
   entities:
-  - uid: 20481
+  - uid: 20480
     components:
     - type: Transform
       pos: 1.5,46.5
       parent: 2
 - proto: SpawnMobFrog
   entities:
-  - uid: 20482
+  - uid: 20481
     components:
     - type: Transform
       pos: -38.5,-10.5
       parent: 2
-  - uid: 20483
+  - uid: 20482
     components:
     - type: Transform
       pos: -38.5,-11.5
       parent: 2
 - proto: SpawnMobGoat
   entities:
-  - uid: 20484
+  - uid: 20483
     components:
     - type: Transform
       pos: 62.5,3.5
       parent: 2
 - proto: SpawnMobHonkBot
   entities:
-  - uid: 20485
+  - uid: 20484
     components:
     - type: Transform
       pos: 23.5,3.5
       parent: 2
 - proto: SpawnMobKangarooWillow
   entities:
-  - uid: 20486
+  - uid: 20485
     components:
     - type: Transform
       pos: 50.5,-32.5
       parent: 2
 - proto: SpawnMobLizard
   entities:
-  - uid: 20487
+  - uid: 20486
     components:
     - type: Transform
       pos: 79.5,-44.5
       parent: 2
 - proto: SpawnMobMcGriff
   entities:
-  - uid: 20488
+  - uid: 20487
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 2
 - proto: SpawnMobParrot
   entities:
-  - uid: 20489
+  - uid: 20488
     components:
     - type: Transform
       pos: 23.5,-6.5
       parent: 2
-  - uid: 20490
+  - uid: 20489
     components:
     - type: Transform
       pos: 36.5,31.5
       parent: 2
 - proto: SpawnMobPenguin
   entities:
-  - uid: 20491
+  - uid: 20490
     components:
     - type: Transform
       pos: 70.5,-9.5
       parent: 2
-  - uid: 20492
+  - uid: 20491
     components:
     - type: Transform
       pos: 74.5,-9.5
       parent: 2
-  - uid: 20493
+  - uid: 20492
     components:
     - type: Transform
       pos: 74.5,-11.5
       parent: 2
-  - uid: 20494
+  - uid: 20493
     components:
     - type: Transform
       pos: 72.5,-8.5
       parent: 2
-  - uid: 20495
+  - uid: 20494
     components:
     - type: Transform
       pos: 28.5,25.5
       parent: 2
-  - uid: 20496
+  - uid: 20495
     components:
     - type: Transform
       pos: 30.5,25.5
       parent: 2
-  - uid: 20497
+  - uid: 20496
     components:
     - type: Transform
       pos: 32.5,26.5
       parent: 2
-  - uid: 20498
+  - uid: 20497
     components:
     - type: Transform
       pos: 33.5,24.5
       parent: 2
-  - uid: 20499
+  - uid: 20498
     components:
     - type: Transform
       pos: 27.5,26.5
       parent: 2
-  - uid: 20500
+  - uid: 20499
     components:
     - type: Transform
       pos: 34.5,25.5
       parent: 2
 - proto: SpawnMobRaccoonMorticia
   entities:
-  - uid: 20501
+  - uid: 20500
     components:
     - type: Transform
       pos: 25.5,22.5
       parent: 2
 - proto: SpawnMobShiva
   entities:
-  - uid: 20502
+  - uid: 20501
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 2
 - proto: SpawnMobWalter
   entities:
-  - uid: 20503
+  - uid: 20502
     components:
     - type: Transform
       pos: -38.5,6.5
       parent: 2
 - proto: SpawnPointAssistant
   entities:
-  - uid: 20504
+  - uid: 20503
     components:
     - type: Transform
       pos: 49.5,-20.5
       parent: 2
-  - uid: 20505
+  - uid: 20504
     components:
     - type: Transform
       pos: 49.5,-19.5
       parent: 2
-  - uid: 20506
+  - uid: 20505
     components:
     - type: Transform
       pos: 55.5,-33.5
       parent: 2
-  - uid: 20507
+  - uid: 20506
     components:
     - type: Transform
       pos: 50.5,-25.5
       parent: 2
-  - uid: 20508
+  - uid: 20507
     components:
     - type: Transform
       pos: 60.5,-22.5
       parent: 2
-  - uid: 20509
+  - uid: 20508
     components:
     - type: Transform
       pos: 53.5,-16.5
       parent: 2
-  - uid: 20510
+  - uid: 20509
     components:
     - type: Transform
       pos: 5.5,-36.5
       parent: 2
-  - uid: 20511
+  - uid: 20510
     components:
     - type: Transform
       pos: 6.5,-36.5
       parent: 2
-  - uid: 20512
+  - uid: 20511
     components:
     - type: Transform
       pos: 7.5,-36.5
       parent: 2
-  - uid: 20513
+  - uid: 20512
     components:
     - type: Transform
       pos: 8.5,-36.5
       parent: 2
-  - uid: 20514
+  - uid: 20513
     components:
     - type: Transform
       pos: 9.5,-36.5
       parent: 2
-  - uid: 20515
+  - uid: 20514
     components:
     - type: Transform
       pos: 10.5,-36.5
       parent: 2
-  - uid: 20516
+  - uid: 20515
     components:
     - type: Transform
       pos: 11.5,-36.5
       parent: 2
-  - uid: 20517
+  - uid: 20516
     components:
     - type: Transform
       pos: 12.5,-36.5
       parent: 2
-  - uid: 20518
+  - uid: 20517
     components:
     - type: Transform
       pos: 13.5,-36.5
       parent: 2
-  - uid: 20519
+  - uid: 20518
     components:
     - type: Transform
       pos: 14.5,-36.5
       parent: 2
-  - uid: 20520
+  - uid: 20519
     components:
     - type: Transform
       pos: 3.5,-31.5
       parent: 2
-  - uid: 20521
+  - uid: 20520
     components:
     - type: Transform
       pos: 3.5,-30.5
       parent: 2
-  - uid: 20522
+  - uid: 20521
     components:
     - type: Transform
       pos: 3.5,-29.5
       parent: 2
-  - uid: 20523
+  - uid: 20522
     components:
     - type: Transform
       pos: -0.5,-39.5
       parent: 2
-  - uid: 20524
+  - uid: 20523
     components:
     - type: Transform
       pos: -0.5,-38.5
       parent: 2
-  - uid: 20525
+  - uid: 20524
     components:
     - type: Transform
       pos: -0.5,-37.5
       parent: 2
-  - uid: 20526
+  - uid: 20525
     components:
     - type: Transform
       pos: 3.5,-40.5
       parent: 2
-  - uid: 20527
+  - uid: 20526
     components:
     - type: Transform
       pos: 7.5,-40.5
       parent: 2
-  - uid: 20528
+  - uid: 20527
     components:
     - type: Transform
       pos: 11.5,-40.5
       parent: 2
-  - uid: 20529
+  - uid: 20528
     components:
     - type: Transform
       pos: 15.5,-40.5
       parent: 2
-  - uid: 20530
+  - uid: 20529
     components:
     - type: Transform
       pos: 40.5,-28.5
       parent: 2
-  - uid: 20531
+  - uid: 20530
     components:
     - type: Transform
       pos: 40.5,-21.5
       parent: 2
-  - uid: 20532
+  - uid: 20531
     components:
     - type: Transform
       pos: 39.5,-17.5
       parent: 2
-  - uid: 20533
+  - uid: 20532
     components:
     - type: Transform
       pos: 39.5,-32.5
       parent: 2
-  - uid: 20534
+  - uid: 20533
     components:
     - type: Transform
       pos: 38.5,-6.5
       parent: 2
-  - uid: 20535
+  - uid: 20534
     components:
     - type: Transform
       pos: 38.5,-5.5
       parent: 2
-  - uid: 20536
+  - uid: 20535
     components:
     - type: Transform
       pos: 38.5,-4.5
       parent: 2
-  - uid: 20537
+  - uid: 20536
     components:
     - type: Transform
       pos: 38.5,-3.5
       parent: 2
-  - uid: 20538
+  - uid: 20537
     components:
     - type: Transform
       pos: 38.5,-2.5
       parent: 2
-  - uid: 20539
+  - uid: 20538
     components:
     - type: Transform
       pos: 30.5,-2.5
       parent: 2
-  - uid: 20540
+  - uid: 20539
     components:
     - type: Transform
       pos: 30.5,-3.5
       parent: 2
-  - uid: 20541
+  - uid: 20540
     components:
     - type: Transform
       pos: 30.5,-4.5
       parent: 2
-  - uid: 20542
+  - uid: 20541
     components:
     - type: Transform
       pos: 30.5,-5.5
       parent: 2
-  - uid: 20543
+  - uid: 20542
     components:
     - type: Transform
       pos: 30.5,-6.5
       parent: 2
-  - uid: 20544
+  - uid: 20543
     components:
     - type: Transform
       pos: 32.5,9.5
       parent: 2
-  - uid: 20545
+  - uid: 20544
     components:
     - type: Transform
       pos: 11.5,20.5
       parent: 2
-  - uid: 20546
+  - uid: 20545
     components:
     - type: Transform
       pos: -29.5,8.5
       parent: 2
-  - uid: 20547
+  - uid: 20546
     components:
     - type: Transform
       pos: -57.5,18.5
       parent: 2
-  - uid: 20548
+  - uid: 20547
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 2
 - proto: SpawnPointAtmos
   entities:
-  - uid: 20549
+  - uid: 20548
     components:
     - type: Transform
       pos: 36.5,7.5
       parent: 2
-  - uid: 20550
+  - uid: 20549
     components:
     - type: Transform
       pos: 37.5,7.5
       parent: 2
 - proto: SpawnPointBartender
   entities:
-  - uid: 20551
+  - uid: 20550
     components:
     - type: Transform
       pos: 34.5,3.5
       parent: 2
-  - uid: 20552
+  - uid: 20551
     components:
     - type: Transform
       pos: 34.5,5.5
       parent: 2
 - proto: SpawnPointBlueShield
   entities:
-  - uid: 20553
+  - uid: 20552
     components:
     - type: Transform
       pos: -27.5,49.5
       parent: 2
 - proto: SpawnPointBorg
   entities:
-  - uid: 20554
+  - uid: 20553
     components:
     - type: Transform
       pos: -66.5,32.5
       parent: 2
-  - uid: 20555
+  - uid: 20554
     components:
     - type: Transform
       pos: -67.5,32.5
       parent: 2
-  - uid: 20556
+  - uid: 20555
     components:
     - type: Transform
       pos: -68.5,32.5
       parent: 2
 - proto: SpawnPointBotanist
   entities:
-  - uid: 20557
+  - uid: 20556
     components:
     - type: Transform
       pos: 55.5,1.5
       parent: 2
-  - uid: 20558
+  - uid: 20557
     components:
     - type: Transform
       pos: 54.5,1.5
       parent: 2
-  - uid: 20559
+  - uid: 20558
     components:
     - type: Transform
       pos: 53.5,1.5
       parent: 2
 - proto: SpawnPointBoxer
   entities:
-  - uid: 20560
+  - uid: 20559
     components:
     - type: Transform
       pos: 49.5,-34.5
       parent: 2
-  - uid: 20561
+  - uid: 20560
     components:
     - type: Transform
       pos: 52.5,-31.5
       parent: 2
 - proto: SpawnPointBrigmedic
   entities:
-  - uid: 20562
+  - uid: 20561
     components:
     - type: Transform
       pos: 13.5,5.5
       parent: 2
 - proto: SpawnPointCaptain
   entities:
-  - uid: 20563
+  - uid: 20562
     components:
     - type: Transform
       pos: 4.5,44.5
       parent: 2
 - proto: SpawnPointCargoTechnician
   entities:
-  - uid: 20564
+  - uid: 20563
     components:
     - type: Transform
       pos: 16.5,18.5
       parent: 2
-  - uid: 20565
+  - uid: 20564
     components:
     - type: Transform
       pos: 16.5,19.5
       parent: 2
-  - uid: 20566
+  - uid: 20565
     components:
     - type: Transform
       pos: 16.5,20.5
       parent: 2
-  - uid: 20567
+  - uid: 20566
     components:
     - type: Transform
       pos: 16.5,21.5
       parent: 2
-  - uid: 20568
+  - uid: 20567
     components:
     - type: Transform
       pos: 22.5,25.5
       parent: 2
-  - uid: 20569
+  - uid: 20568
     components:
     - type: Transform
       pos: 23.5,25.5
       parent: 2
-  - uid: 20570
+  - uid: 20569
     components:
     - type: Transform
       pos: 24.5,25.5
       parent: 2
 - proto: SpawnPointChaplain
   entities:
-  - uid: 20571
+  - uid: 20570
     components:
     - type: Transform
       pos: -64.5,17.5
       parent: 2
 - proto: SpawnPointChef
   entities:
-  - uid: 20572
+  - uid: 20571
     components:
     - type: Transform
       pos: 47.5,-6.5
       parent: 2
-  - uid: 20573
+  - uid: 20572
     components:
     - type: Transform
       pos: 48.5,-5.5
       parent: 2
 - proto: SpawnPointChemist
   entities:
-  - uid: 20574
+  - uid: 20573
     components:
     - type: Transform
       pos: -37.5,4.5
       parent: 2
-  - uid: 20575
+  - uid: 20574
     components:
     - type: Transform
       pos: -37.5,9.5
       parent: 2
-  - uid: 20576
+  - uid: 20575
     components:
     - type: Transform
       pos: -34.5,7.5
       parent: 2
 - proto: SpawnPointChiefEngineer
   entities:
-  - uid: 20577
+  - uid: 20576
     components:
     - type: Transform
       pos: -15.5,44.5
       parent: 2
 - proto: SpawnPointChiefMedicalOfficer
   entities:
-  - uid: 20578
+  - uid: 20577
     components:
     - type: Transform
       pos: -17.5,44.5
       parent: 2
 - proto: SpawnPointClown
   entities:
-  - uid: 20579
+  - uid: 20578
     components:
     - type: Transform
       pos: 23.5,4.5
       parent: 2
 - proto: SpawnPointDetective
   entities:
-  - uid: 20580
+  - uid: 20579
     components:
     - type: Transform
       pos: -13.5,-3.5
       parent: 2
 - proto: SpawnPointDutyOfficer
   entities:
-  - uid: 20581
+  - uid: 20580
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 2
-  - uid: 20582
+  - uid: 20581
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 2
-  - uid: 20583
+  - uid: 20582
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 2
 - proto: SpawnPointHeadOfPersonnel
   entities:
-  - uid: 20584
+  - uid: 20583
     components:
     - type: Transform
       pos: -14.5,44.5
       parent: 2
 - proto: SpawnPointHeadOfSecurity
   entities:
-  - uid: 20585
+  - uid: 20584
     components:
     - type: Transform
       pos: -18.5,44.5
       parent: 2
 - proto: SpawnPointHeadOfSecurityWeapon
   entities:
-  - uid: 20586
+  - uid: 20585
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 2
 - proto: SpawnPointIAA
   entities:
-  - uid: 20587
+  - uid: 20586
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
-  - uid: 20588
+  - uid: 20587
     components:
     - type: Transform
       pos: -17.5,8.5
       parent: 2
 - proto: SpawnPointJanitor
   entities:
-  - uid: 20589
+  - uid: 20588
     components:
     - type: Transform
       pos: 13.5,-17.5
       parent: 2
-  - uid: 20590
+  - uid: 20589
     components:
     - type: Transform
       pos: 15.5,-17.5
       parent: 2
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 20591
+  - uid: 20590
     components:
     - type: Transform
       pos: 35.5,-29.5
       parent: 2
-  - uid: 20592
+  - uid: 20591
     components:
     - type: Transform
       pos: 19.5,-29.5
       parent: 2
 - proto: SpawnPointMagistrate
   entities:
-  - uid: 20593
+  - uid: 20592
     components:
     - type: Transform
       pos: -21.5,4.5
       parent: 2
 - proto: SpawnPointmailtech
   entities:
-  - uid: 20594
+  - uid: 20593
     components:
     - type: Transform
       pos: 12.5,24.5
       parent: 2
-  - uid: 20595
+  - uid: 20594
     components:
     - type: Transform
       pos: 11.5,24.5
       parent: 2
 - proto: SpawnPointMedicalDoctor
   entities:
-  - uid: 20596
+  - uid: 20595
     components:
     - type: Transform
       pos: -37.5,-6.5
       parent: 2
-  - uid: 20597
+  - uid: 20596
     components:
     - type: Transform
       pos: -34.5,-6.5
       parent: 2
-  - uid: 20598
+  - uid: 20597
     components:
     - type: Transform
       pos: -31.5,-6.5
       parent: 2
-  - uid: 20599
+  - uid: 20598
     components:
     - type: Transform
       pos: -28.5,-6.5
       parent: 2
-  - uid: 20600
+  - uid: 20599
     components:
     - type: Transform
       pos: -32.5,-3.5
       parent: 2
 - proto: SpawnPointMedicalIntern
   entities:
-  - uid: 20601
+  - uid: 20600
     components:
     - type: Transform
       pos: -54.5,1.5
       parent: 2
-  - uid: 20602
+  - uid: 20601
     components:
     - type: Transform
       pos: -54.5,0.5
       parent: 2
-  - uid: 20603
+  - uid: 20602
     components:
     - type: Transform
       pos: -54.5,-0.5
       parent: 2
-  - uid: 20604
+  - uid: 20603
     components:
     - type: Transform
       pos: -56.5,1.5
       parent: 2
-  - uid: 20605
+  - uid: 20604
     components:
     - type: Transform
       pos: -56.5,0.5
       parent: 2
-  - uid: 20606
+  - uid: 20605
     components:
     - type: Transform
       pos: -56.5,-0.5
       parent: 2
 - proto: SpawnPointMime
   entities:
-  - uid: 20607
+  - uid: 20606
     components:
     - type: Transform
       pos: 23.5,-7.5
       parent: 2
 - proto: SpawnPointminingspecialist
   entities:
-  - uid: 20608
+  - uid: 20607
     components:
     - type: Transform
       pos: 28.5,35.5
       parent: 2
-  - uid: 20609
+  - uid: 20608
     components:
     - type: Transform
       pos: 29.5,35.5
       parent: 2
-  - uid: 20610
+  - uid: 20609
     components:
     - type: Transform
       pos: 29.5,34.5
       parent: 2
-  - uid: 20611
+  - uid: 20610
     components:
     - type: Transform
       pos: 28.5,34.5
       parent: 2
 - proto: SpawnPointMusician
   entities:
-  - uid: 20612
+  - uid: 20611
     components:
     - type: Transform
       pos: 47.5,2.5
       parent: 2
-  - uid: 20613
+  - uid: 20612
     components:
     - type: Transform
       pos: 47.5,4.5
       parent: 2
 - proto: SpawnPointNCT
   entities:
-  - uid: 20614
+  - uid: 20613
     components:
     - type: Transform
       pos: -27.5,20.5
       parent: 2
-  - uid: 20615
+  - uid: 20614
     components:
     - type: Transform
       pos: -26.5,20.5
       parent: 2
 - proto: SpawnPointNtrep
   entities:
-  - uid: 20616
+  - uid: 20615
     components:
     - type: Transform
       pos: -12.5,44.5
       parent: 2
 - proto: SpawnPointObserver
   entities:
-  - uid: 20617
+  - uid: 20616
     components:
     - type: Transform
       pos: -17.5,27.5
       parent: 2
 - proto: SpawnPointParamedic
   entities:
-  - uid: 20618
+  - uid: 20617
     components:
     - type: Transform
       pos: -27.5,3.5
       parent: 2
-  - uid: 20619
+  - uid: 20618
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
 - proto: SpawnPointPerformer
   entities:
-  - uid: 24899
+  - uid: 24898
     components:
     - type: Transform
       pos: 10.5,45.5
       parent: 2
-  - uid: 24901
+  - uid: 24900
     components:
     - type: Transform
       pos: 23.5,-2.5
       parent: 2
-  - uid: 24902
+  - uid: 24901
     components:
     - type: Transform
       pos: 39.5,2.5
       parent: 2
-  - uid: 24903
+  - uid: 24902
     components:
     - type: Transform
       pos: 47.5,-31.5
       parent: 2
-  - uid: 24904
+  - uid: 24903
     components:
     - type: Transform
       pos: 22.5,-1.5
       parent: 2
-  - uid: 24905
+  - uid: 24904
     components:
     - type: Transform
       pos: 24.5,-1.5
       parent: 2
+  - uid: 24906
+    components:
+    - type: Transform
+      pos: 41.5,3.5
+      parent: 2
 - proto: SpawnPointPsychologist
   entities:
-  - uid: 20620
+  - uid: 20619
     components:
     - type: Transform
       pos: -32.5,20.5
       parent: 2
 - proto: SpawnPointQuartermaster
   entities:
-  - uid: 20621
+  - uid: 20620
     components:
     - type: Transform
       pos: -13.5,44.5
       parent: 2
 - proto: SpawnPointResearchAssistant
   entities:
-  - uid: 20622
+  - uid: 20621
     components:
     - type: Transform
       pos: -46.5,38.5
       parent: 2
-  - uid: 20623
+  - uid: 20622
     components:
     - type: Transform
       pos: -45.5,38.5
       parent: 2
-  - uid: 20624
+  - uid: 20623
     components:
     - type: Transform
       pos: -44.5,38.5
       parent: 2
 - proto: SpawnPointResearchDirector
   entities:
-  - uid: 20625
+  - uid: 20624
     components:
     - type: Transform
       pos: -16.5,44.5
       parent: 2
 - proto: SpawnPointRoboticist
   entities:
-  - uid: 20626
+  - uid: 20625
     components:
     - type: Transform
       pos: -62.5,30.5
       parent: 2
-  - uid: 20627
+  - uid: 20626
     components:
     - type: Transform
       pos: -61.5,30.5
       parent: 2
 - proto: SpawnPointSalvageLead
   entities:
-  - uid: 20628
+  - uid: 20627
     components:
     - type: Transform
       pos: 28.5,29.5
       parent: 2
 - proto: SpawnPointSalvageSpecialist
   entities:
-  - uid: 20629
+  - uid: 20628
     components:
     - type: Transform
       pos: 31.5,34.5
       parent: 2
-  - uid: 20630
+  - uid: 20629
     components:
     - type: Transform
       pos: 32.5,34.5
       parent: 2
-  - uid: 20631
+  - uid: 20630
     components:
     - type: Transform
       pos: 32.5,35.5
       parent: 2
-  - uid: 20632
+  - uid: 20631
     components:
     - type: Transform
       pos: 31.5,35.5
       parent: 2
 - proto: SpawnPointScientist
   entities:
-  - uid: 20633
+  - uid: 20632
     components:
     - type: Transform
       pos: -44.5,37.5
       parent: 2
-  - uid: 20634
+  - uid: 20633
     components:
     - type: Transform
       pos: -44.5,36.5
       parent: 2
-  - uid: 20635
+  - uid: 20634
     components:
     - type: Transform
       pos: -44.5,35.5
       parent: 2
-  - uid: 20636
+  - uid: 20635
     components:
     - type: Transform
       pos: -44.5,34.5
       parent: 2
 - proto: SpawnPointSecurityCadet
   entities:
-  - uid: 20637
+  - uid: 20636
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 2
-  - uid: 20638
+  - uid: 20637
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 2
-  - uid: 20639
+  - uid: 20638
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 2
-  - uid: 20640
+  - uid: 20639
     components:
     - type: Transform
       pos: 8.5,6.5
       parent: 2
-  - uid: 20641
+  - uid: 20640
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 2
-  - uid: 20642
+  - uid: 20641
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 2
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 20643
+  - uid: 20642
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 2
-  - uid: 20644
+  - uid: 20643
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 2
-  - uid: 20645
+  - uid: 20644
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 2
-  - uid: 20646
+  - uid: 20645
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 2
-  - uid: 20647
+  - uid: 20646
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 2
-  - uid: 20648
+  - uid: 20647
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 2
-  - uid: 20649
+  - uid: 20648
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 2
-  - uid: 20650
+  - uid: 20649
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 2
 - proto: SpawnPointServiceWorker
   entities:
-  - uid: 20651
+  - uid: 20650
     components:
     - type: Transform
       pos: -4.5,-41.5
       parent: 2
-  - uid: 20652
+  - uid: 20651
     components:
     - type: Transform
       pos: -4.5,-39.5
       parent: 2
-  - uid: 20653
+  - uid: 20652
     components:
     - type: Transform
       pos: -4.5,-37.5
       parent: 2
-  - uid: 20654
+  - uid: 20653
     components:
     - type: Transform
       pos: -4.5,-35.5
       parent: 2
 - proto: SpawnPointStationEngineer
   entities:
-  - uid: 20655
+  - uid: 20654
     components:
     - type: Transform
       pos: 37.5,26.5
       parent: 2
-  - uid: 20656
+  - uid: 20655
     components:
     - type: Transform
       pos: 38.5,26.5
       parent: 2
-  - uid: 20657
+  - uid: 20656
     components:
     - type: Transform
       pos: 39.5,26.5
       parent: 2
-  - uid: 20658
+  - uid: 20657
     components:
     - type: Transform
       pos: 37.5,25.5
       parent: 2
-  - uid: 20659
+  - uid: 20658
     components:
     - type: Transform
       pos: 38.5,25.5
       parent: 2
-  - uid: 20660
+  - uid: 20659
     components:
     - type: Transform
       pos: 39.5,25.5
       parent: 2
 - proto: SpawnPointSurgeon
   entities:
-  - uid: 20661
+  - uid: 20660
     components:
     - type: Transform
       pos: -43.5,-8.5
       parent: 2
-  - uid: 20662
+  - uid: 20661
     components:
     - type: Transform
       pos: -43.5,-10.5
       parent: 2
 - proto: SpawnPointTechnicalAssistant
   entities:
-  - uid: 20663
+  - uid: 20662
     components:
     - type: Transform
       pos: 40.5,26.5
       parent: 2
-  - uid: 20664
+  - uid: 20663
     components:
     - type: Transform
       pos: 40.5,25.5
       parent: 2
-  - uid: 20665
+  - uid: 20664
     components:
     - type: Transform
       pos: 40.5,24.5
       parent: 2
 - proto: SpawnPointWarden
   entities:
-  - uid: 20666
+  - uid: 20665
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 2
 - proto: SpeedLoaderLightRifle
   entities:
-  - uid: 20667
+  - uid: 20666
     components:
     - type: Transform
       pos: -28.344889,30.29947
       parent: 2
 - proto: SpeedLoaderMagnumFMJ
   entities:
-  - uid: 20668
+  - uid: 20667
     components:
     - type: Transform
       pos: 0.6824219,-19.683615
       parent: 2
 - proto: SprayBottleSpaceCleaner
   entities:
-  - uid: 20669
+  - uid: 20668
     components:
     - type: Transform
       pos: 13.242651,-16.50402
       parent: 2
-  - uid: 20670
+  - uid: 20669
     components:
     - type: Transform
       pos: 13.117651,-16.457146
       parent: 2
 - proto: SprayBottleWater
   entities:
+  - uid: 20670
+    components:
+    - type: Transform
+      pos: 84.4078,-49.27303
+      parent: 2
   - uid: 20671
     components:
     - type: Transform
@@ -129209,225 +129216,220 @@ entities:
   - uid: 20672
     components:
     - type: Transform
-      pos: 84.4078,-49.27303
+      pos: 84.73592,-49.507404
       parent: 2
   - uid: 20673
     components:
     - type: Transform
       pos: 84.73592,-49.507404
       parent: 2
-  - uid: 20674
-    components:
-    - type: Transform
-      pos: 84.73592,-49.507404
-      parent: 2
 - proto: SS13Memorial
   entities:
-  - uid: 20675
+  - uid: 20674
     components:
     - type: Transform
       pos: -53.5,24.5
       parent: 2
 - proto: StairDark
   entities:
-  - uid: 20676
+  - uid: 20675
     components:
     - type: Transform
       pos: -16.5,50.5
       parent: 2
-  - uid: 20677
+  - uid: 20676
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,43.5
       parent: 2
-  - uid: 20678
+  - uid: 20677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,44.5
       parent: 2
-  - uid: 20679
+  - uid: 20678
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,44.5
       parent: 2
-  - uid: 20680
+  - uid: 20679
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,45.5
       parent: 2
-  - uid: 20681
+  - uid: 20680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,43.5
       parent: 2
-  - uid: 20682
+  - uid: 20681
     components:
     - type: Transform
       pos: -15.5,50.5
       parent: 2
-  - uid: 20683
+  - uid: 20682
     components:
     - type: Transform
       pos: -14.5,50.5
       parent: 2
-  - uid: 20684
+  - uid: 20683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,45.5
       parent: 2
-  - uid: 20685
+  - uid: 20684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,7.5
       parent: 2
-  - uid: 20686
+  - uid: 20685
     components:
     - type: Transform
       pos: -68.5,29.5
       parent: 2
-  - uid: 20687
+  - uid: 20686
     components:
     - type: Transform
       pos: -67.5,29.5
       parent: 2
-  - uid: 20688
+  - uid: 20687
     components:
     - type: Transform
       pos: -66.5,29.5
       parent: 2
-  - uid: 20689
+  - uid: 20688
     components:
     - type: Transform
       pos: -65.5,29.5
       parent: 2
-  - uid: 20690
+  - uid: 20689
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-23.5
       parent: 2
-  - uid: 20691
+  - uid: 20690
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-22.5
       parent: 2
-  - uid: 20692
+  - uid: 20691
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-21.5
       parent: 2
-  - uid: 20693
+  - uid: 20692
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-27.5
       parent: 2
-  - uid: 20694
+  - uid: 20693
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-29.5
       parent: 2
-  - uid: 20695
+  - uid: 20694
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-28.5
       parent: 2
-  - uid: 20696
+  - uid: 20695
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-30.5
       parent: 2
-  - uid: 20697
+  - uid: 20696
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,-35.5
       parent: 2
-  - uid: 20698
+  - uid: 20697
     components:
     - type: Transform
       pos: 18.5,-18.5
       parent: 2
-  - uid: 20699
+  - uid: 20698
     components:
     - type: Transform
       pos: 19.5,-18.5
       parent: 2
-  - uid: 20700
+  - uid: 20699
     components:
     - type: Transform
       pos: 20.5,-18.5
       parent: 2
-  - uid: 20701
+  - uid: 20700
     components:
     - type: Transform
       pos: 34.5,-18.5
       parent: 2
-  - uid: 20702
+  - uid: 20701
     components:
     - type: Transform
       pos: 35.5,-18.5
       parent: 2
-  - uid: 20703
+  - uid: 20702
     components:
     - type: Transform
       pos: 36.5,-18.5
       parent: 2
-  - uid: 20704
+  - uid: 20703
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 52.5,21.5
       parent: 2
-  - uid: 20705
+  - uid: 20704
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 52.5,22.5
       parent: 2
-  - uid: 20706
+  - uid: 20705
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,21.5
       parent: 2
-  - uid: 20707
+  - uid: 20706
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,22.5
       parent: 2
-  - uid: 20708
+  - uid: 20707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-32.5
       parent: 2
-  - uid: 20709
+  - uid: 20708
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-35.5
       parent: 2
-  - uid: 20710
+  - uid: 20709
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,-28.5
       parent: 2
-  - uid: 20711
+  - uid: 20710
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129435,48 +129437,48 @@ entities:
       parent: 2
 - proto: Stairs
   entities:
-  - uid: 20712
+  - uid: 20711
     components:
     - type: Transform
       pos: 16.5,-43.5
       parent: 2
-  - uid: 20713
+  - uid: 20712
     components:
     - type: Transform
       pos: 12.5,-43.5
       parent: 2
-  - uid: 20714
+  - uid: 20713
     components:
     - type: Transform
       pos: 8.5,-43.5
       parent: 2
 - proto: StairStageDark
   entities:
-  - uid: 20715
+  - uid: 20714
     components:
     - type: Transform
       pos: -48.5,10.5
       parent: 2
 - proto: StairStageWood
   entities:
-  - uid: 20716
+  - uid: 20715
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,5.5
       parent: 2
-  - uid: 20717
+  - uid: 20716
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,5.5
       parent: 2
-  - uid: 20718
+  - uid: 20717
     components:
     - type: Transform
       pos: -9.5,7.5
       parent: 2
-  - uid: 20719
+  - uid: 20718
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -129484,93 +129486,93 @@ entities:
       parent: 2
 - proto: StairWhite
   entities:
-  - uid: 20720
+  - uid: 20719
     components:
     - type: Transform
       pos: 82.5,-8.5
       parent: 2
-  - uid: 20721
+  - uid: 20720
     components:
     - type: Transform
       pos: 83.5,-8.5
       parent: 2
 - proto: StairWood
   entities:
-  - uid: 20722
+  - uid: 20721
     components:
     - type: Transform
       pos: -5.5,47.5
       parent: 2
-  - uid: 20723
+  - uid: 20722
     components:
     - type: Transform
       pos: -25.5,42.5
       parent: 2
-  - uid: 20724
+  - uid: 20723
     components:
     - type: Transform
       pos: -26.5,42.5
       parent: 2
-  - uid: 20725
+  - uid: 20724
     components:
     - type: Transform
       pos: -4.5,47.5
       parent: 2
-  - uid: 20726
+  - uid: 20725
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,15.5
       parent: 2
-  - uid: 20727
+  - uid: 20726
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,21.5
       parent: 2
-  - uid: 20728
+  - uid: 20727
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,14.5
       parent: 2
-  - uid: 20729
+  - uid: 20728
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,22.5
       parent: 2
-  - uid: 20730
+  - uid: 20729
     components:
     - type: Transform
       pos: 42.5,1.5
       parent: 2
 - proto: StasisBed
   entities:
-  - uid: 20731
+  - uid: 20730
     components:
     - type: Transform
       pos: -25.5,-1.5
       parent: 2
-  - uid: 20732
+  - uid: 20731
     components:
     - type: Transform
       pos: -25.5,-3.5
       parent: 2
-  - uid: 20733
+  - uid: 20732
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 2
 - proto: StationAiFixerComputer
   entities:
-  - uid: 20734
+  - uid: 20733
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,30.5
       parent: 2
-  - uid: 20735
+  - uid: 20734
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129578,7 +129580,7 @@ entities:
       parent: 2
 - proto: StationAiUploadComputer
   entities:
-  - uid: 20736
+  - uid: 20735
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -129593,21 +129595,21 @@ entities:
       - - ResearchDirector
 - proto: StationAnchor
   entities:
-  - uid: 20737
+  - uid: 20736
     components:
     - type: Transform
       pos: 50.5,21.5
       parent: 2
 - proto: StationMap
   entities:
-  - uid: 20738
+  - uid: 20737
     components:
     - type: Transform
       pos: -46.5,24.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20739
+  - uid: 20738
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -129615,7 +129617,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20740
+  - uid: 20739
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -129623,21 +129625,21 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20741
+  - uid: 20740
     components:
     - type: Transform
       pos: -4.5,17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20742
+  - uid: 20741
     components:
     - type: Transform
       pos: 14.5,16.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20743
+  - uid: 20742
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129645,7 +129647,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20744
+  - uid: 20743
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129653,14 +129655,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20745
+  - uid: 20744
     components:
     - type: Transform
       pos: 16.5,-24.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20746
+  - uid: 20745
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129668,7 +129670,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20747
+  - uid: 20746
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129676,21 +129678,21 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20748
+  - uid: 20747
     components:
     - type: Transform
       pos: 53.5,-7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20749
+  - uid: 20748
     components:
     - type: Transform
       pos: 66.5,-7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20750
+  - uid: 20749
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -129698,7 +129700,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20751
+  - uid: 20750
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -129706,14 +129708,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20752
+  - uid: 20751
     components:
     - type: Transform
       pos: 25.5,-8.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 20753
+  - uid: 20752
     components:
     - type: Transform
       pos: -23.5,17.5
@@ -129722,7 +129724,7 @@ entities:
       fixtures: {}
 - proto: StatueBananiumClown
   entities:
-  - uid: 20754
+  - uid: 20753
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -129730,55 +129732,55 @@ entities:
       parent: 2
 - proto: SteelBench
   entities:
-  - uid: 20755
+  - uid: 20754
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 75.5,-26.5
       parent: 2
-  - uid: 20756
+  - uid: 20755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 75.5,-27.5
       parent: 2
-  - uid: 20757
+  - uid: 20756
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 75.5,-28.5
       parent: 2
-  - uid: 20758
+  - uid: 20757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 77.5,-26.5
       parent: 2
-  - uid: 20759
+  - uid: 20758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 77.5,-27.5
       parent: 2
-  - uid: 20760
+  - uid: 20759
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 77.5,-28.5
       parent: 2
-  - uid: 20761
+  - uid: 20760
     components:
     - type: Transform
       pos: 37.5,24.5
       parent: 2
-  - uid: 20762
+  - uid: 20761
     components:
     - type: Transform
       pos: 38.5,24.5
       parent: 2
 - proto: StinkyPlush
   entities:
-  - uid: 20763
+  - uid: 20762
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -129786,382 +129788,382 @@ entities:
       parent: 2
 - proto: Stool
   entities:
-  - uid: 20764
+  - uid: 20763
     components:
     - type: Transform
       pos: 35.504627,-4.315342
       parent: 2
-  - uid: 20765
+  - uid: 20764
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.345122,23.711897
       parent: 2
-  - uid: 20766
+  - uid: 20765
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,2.5
       parent: 2
-  - uid: 20767
+  - uid: 20766
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.594593,-32.37912
       parent: 2
-  - uid: 20768
+  - uid: 20767
     components:
     - type: Transform
       pos: -12.5100155,-26.414732
       parent: 2
 - proto: StoolBar
   entities:
-  - uid: 20769
+  - uid: 20768
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,9.5
       parent: 2
-  - uid: 20770
+  - uid: 20769
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,9.5
       parent: 2
-  - uid: 20771
+  - uid: 20770
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,48.5
       parent: 2
-  - uid: 20772
+  - uid: 20771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,47.5
       parent: 2
-  - uid: 20773
+  - uid: 20772
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,48.5
       parent: 2
-  - uid: 20774
+  - uid: 20773
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,47.5
       parent: 2
-  - uid: 20775
+  - uid: 20774
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,4.5
       parent: 2
-  - uid: 20776
+  - uid: 20775
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,3.5
       parent: 2
-  - uid: 20777
+  - uid: 20776
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-8.5
       parent: 2
-  - uid: 20778
+  - uid: 20777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,-8.5
       parent: 2
-  - uid: 20779
+  - uid: 20778
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-7.5
       parent: 2
-  - uid: 20780
+  - uid: 20779
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-6.5
       parent: 2
-  - uid: 20781
+  - uid: 20780
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-5.5
       parent: 2
-  - uid: 20782
+  - uid: 20781
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-4.5
       parent: 2
-  - uid: 20783
+  - uid: 20782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-3.5
       parent: 2
-  - uid: 20784
+  - uid: 20783
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-2.5
       parent: 2
-  - uid: 20785
+  - uid: 20784
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-1.5
       parent: 2
-  - uid: 20786
+  - uid: 20785
     components:
     - type: Transform
       pos: 31.5,-0.5
       parent: 2
-  - uid: 20787
+  - uid: 20786
     components:
     - type: Transform
       pos: 32.5,-0.5
       parent: 2
-  - uid: 20788
+  - uid: 20787
     components:
     - type: Transform
       pos: 36.5,-0.5
       parent: 2
-  - uid: 20789
+  - uid: 20788
     components:
     - type: Transform
       pos: 37.5,-0.5
       parent: 2
-  - uid: 20790
+  - uid: 20789
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-1.5
       parent: 2
-  - uid: 20791
+  - uid: 20790
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-2.5
       parent: 2
-  - uid: 20792
+  - uid: 20791
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-4.5
       parent: 2
-  - uid: 20793
+  - uid: 20792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-5.5
       parent: 2
-  - uid: 20794
+  - uid: 20793
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-6.5
       parent: 2
-  - uid: 20795
+  - uid: 20794
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-7.5
       parent: 2
-  - uid: 20796
+  - uid: 20795
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-3.5
       parent: 2
-  - uid: 20797
+  - uid: 20796
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,-8.5
       parent: 2
-  - uid: 20798
+  - uid: 20797
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 36.5,-8.5
       parent: 2
-  - uid: 20799
+  - uid: 20798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 44.5,-8.5
       parent: 2
-  - uid: 20800
+  - uid: 20799
     components:
     - type: Transform
       pos: 62.5,-27.5
       parent: 2
-  - uid: 20801
+  - uid: 20800
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 61.5,-28.5
       parent: 2
-  - uid: 20802
+  - uid: 20801
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 61.5,-29.5
       parent: 2
-  - uid: 20803
+  - uid: 20802
     components:
     - type: Transform
       pos: 64.5,-27.5
       parent: 2
-  - uid: 20804
+  - uid: 20803
     components:
     - type: Transform
       pos: 65.5,-27.5
       parent: 2
-  - uid: 20805
+  - uid: 20804
     components:
     - type: Transform
       pos: 63.5,-27.5
       parent: 2
-  - uid: 20806
+  - uid: 20805
     components:
     - type: Transform
       pos: 66.5,-27.5
       parent: 2
-  - uid: 20807
+  - uid: 20806
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 60.5,-30.5
       parent: 2
-  - uid: 20808
+  - uid: 20807
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 60.5,-31.5
       parent: 2
-  - uid: 20809
+  - uid: 20808
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 59.5,-32.5
       parent: 2
-  - uid: 20810
+  - uid: 20809
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 59.5,-33.5
       parent: 2
-  - uid: 20811
+  - uid: 20810
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-3.5
       parent: 2
-  - uid: 20812
+  - uid: 20811
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-6.5
       parent: 2
-  - uid: 20813
+  - uid: 20812
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-5.5
       parent: 2
-  - uid: 20814
+  - uid: 20813
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 43.5,-8.5
       parent: 2
-  - uid: 20815
+  - uid: 20814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 47.5,-8.5
       parent: 2
-  - uid: 20816
+  - uid: 20815
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 46.5,-8.5
       parent: 2
-  - uid: 20817
+  - uid: 20816
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 45.5,-8.5
       parent: 2
-  - uid: 20818
+  - uid: 20817
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,-8.5
       parent: 2
-  - uid: 20819
+  - uid: 20818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,-8.5
       parent: 2
-  - uid: 20820
+  - uid: 20819
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,-8.5
       parent: 2
-  - uid: 20821
+  - uid: 20820
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-2.5
       parent: 2
-  - uid: 20822
+  - uid: 20821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 40.5,-4.5
       parent: 2
-  - uid: 20823
+  - uid: 20822
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -41.5,35.5
       parent: 2
-  - uid: 20824
+  - uid: 20823
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -40.5,35.5
       parent: 2
-  - uid: 20825
+  - uid: 20824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,35.5
       parent: 2
-  - uid: 20826
+  - uid: 20825
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,35.5
       parent: 2
-  - uid: 20827
+  - uid: 20826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,35.5
       parent: 2
-  - uid: 20828
+  - uid: 20827
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130169,17 +130171,17 @@ entities:
       parent: 2
 - proto: StorageCanister
   entities:
-  - uid: 20829
+  - uid: 20828
     components:
     - type: Transform
       pos: -51.5,34.5
       parent: 2
-  - uid: 20830
+  - uid: 20829
     components:
     - type: Transform
       pos: -50.5,34.5
       parent: 2
-  - uid: 20831
+  - uid: 20830
     components:
     - type: Transform
       pos: 50.5,16.5
@@ -130192,91 +130194,91 @@ entities:
     - type: GasCanister
       releaseValve: True
       releasePressure: 100
-  - uid: 20832
+  - uid: 20831
     components:
     - type: Transform
       pos: 46.5,6.5
       parent: 2
-  - uid: 20833
+  - uid: 20832
     components:
     - type: Transform
       pos: 47.5,6.5
       parent: 2
 - proto: SubstationBasic
   entities:
-  - uid: 20834
+  - uid: 20833
     components:
     - type: Transform
       pos: -2.5,41.5
       parent: 2
-  - uid: 20835
+  - uid: 20834
     components:
     - type: Transform
       pos: 66.5,50.5
       parent: 2
-  - uid: 20836
+  - uid: 20835
     components:
     - type: Transform
       pos: 77.5,21.5
       parent: 2
-  - uid: 20837
+  - uid: 20836
     components:
     - type: Transform
       pos: 43.5,23.5
       parent: 2
-  - uid: 20838
+  - uid: 20837
     components:
     - type: Transform
       pos: 6.5,22.5
       parent: 2
-  - uid: 20839
+  - uid: 20838
     components:
     - type: MetaData
       name: substation (Medical)
     - type: Transform
       pos: -25.5,-5.5
       parent: 2
-  - uid: 20840
+  - uid: 20839
     components:
     - type: MetaData
       name: substation (Security)
     - type: Transform
       pos: -16.5,-12.5
       parent: 2
-  - uid: 20841
+  - uid: 20840
     components:
     - type: Transform
       pos: -39.5,-19.5
       parent: 2
-  - uid: 20842
+  - uid: 20841
     components:
     - type: MetaData
       name: substation (Command)
     - type: Transform
       pos: -24.5,26.5
       parent: 2
-  - uid: 20843
+  - uid: 20842
     components:
     - type: MetaData
       name: substation (Arrivals)
     - type: Transform
       pos: 1.5,-23.5
       parent: 2
-  - uid: 20844
+  - uid: 20843
     components:
     - type: MetaData
       name: substation (Science)
     - type: Transform
       pos: -29.5,23.5
       parent: 2
-  - uid: 20845
+  - uid: 20844
     components:
     - type: MetaData
       name: substation (Service)
     - type: Transform
       pos: 16.5,3.5
       parent: 2
-  - uid: 20846
+  - uid: 20845
     components:
     - type: MetaData
       name: substation (Evac)
@@ -130285,7 +130287,7 @@ entities:
       parent: 2
 - proto: SubstationWallBasic
   entities:
-  - uid: 20847
+  - uid: 20846
     components:
     - type: Transform
       pos: 79.5,-42.5
@@ -130390,7 +130392,7 @@ entities:
           - 11165
 - proto: SuitStorageBlueShield
   entities:
-  - uid: 20848
+  - uid: 20847
     components:
     - type: Transform
       pos: -27.5,47.5
@@ -130405,40 +130407,40 @@ entities:
           Nitrogen: 6.568249
 - proto: SuitStorageCE
   entities:
-  - uid: 20849
+  - uid: 20848
     components:
     - type: Transform
       pos: 41.5,29.5
       parent: 2
 - proto: SuitStorageEngi
   entities:
-  - uid: 20850
+  - uid: 20849
     components:
     - type: Transform
       pos: -38.5,-22.5
       parent: 2
-  - uid: 20851
+  - uid: 20850
     components:
     - type: Transform
       pos: -38.5,-21.5
       parent: 2
 - proto: SuitStorageEVAEmergency
   entities:
-  - uid: 20852
+  - uid: 20851
     components:
     - type: Transform
       pos: -39.5,-13.5
       parent: 2
 - proto: SuitStorageHOS
   entities:
-  - uid: 20853
+  - uid: 20852
     components:
     - type: Transform
       pos: -1.5,-13.5
       parent: 2
 - proto: SuitStorageRD
   entities:
-  - uid: 20854
+  - uid: 20853
     components:
     - type: Transform
       pos: -41.5,32.5
@@ -130507,21 +130509,21 @@ entities:
           - 17357
 - proto: SuitStorageWarden
   entities:
-  - uid: 20855
+  - uid: 20854
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
 - proto: SuperSynthesizerInstrument
   entities:
-  - uid: 20856
+  - uid: 20855
     components:
     - type: Transform
       pos: -3.526002,-32.99698
       parent: 2
 - proto: SurveillanceCameraCommand
   entities:
-  - uid: 20857
+  - uid: 20856
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130532,7 +130534,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Sauna
-  - uid: 20858
+  - uid: 20857
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130543,7 +130545,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Bridge West
-  - uid: 20859
+  - uid: 20858
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130554,7 +130556,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Bridge East
-  - uid: 20860
+  - uid: 20859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130565,7 +130567,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Captain's Room
-  - uid: 20861
+  - uid: 20860
     components:
     - type: Transform
       pos: -24.5,36.5
@@ -130575,7 +130577,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Sauna Changing Room
-  - uid: 20862
+  - uid: 20861
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130586,7 +130588,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Showroom
-  - uid: 20863
+  - uid: 20862
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130597,7 +130599,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: NTR's Area
-  - uid: 20864
+  - uid: 20863
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130608,7 +130610,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Captain's Balcony
-  - uid: 20865
+  - uid: 20864
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130619,7 +130621,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: BSO's Room
-  - uid: 20866
+  - uid: 20865
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130630,7 +130632,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Conference Area
-  - uid: 20867
+  - uid: 20866
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130641,7 +130643,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Bridge Main
-  - uid: 20868
+  - uid: 20867
     components:
     - type: Transform
       pos: -2.5,39.5
@@ -130651,7 +130653,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: AI Upload
-  - uid: 20869
+  - uid: 20868
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130662,7 +130664,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Entry Airlock
-  - uid: 20870
+  - uid: 20869
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130673,7 +130675,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: HoP's Office
-  - uid: 20871
+  - uid: 20870
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130684,7 +130686,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: HoP's Bedroom
-  - uid: 20872
+  - uid: 20871
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130695,7 +130697,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: EVA
-  - uid: 20873
+  - uid: 20872
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130706,7 +130708,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Vault
-  - uid: 20874
+  - uid: 20873
     components:
     - type: Transform
       pos: 5.5,43.5
@@ -130716,7 +130718,7 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Captain's Bedroom
-  - uid: 20875
+  - uid: 20874
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130729,7 +130731,7 @@ entities:
       id: NCT Office
 - proto: SurveillanceCameraEngineering
   entities:
-  - uid: 20876
+  - uid: 20875
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130740,7 +130742,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmospherics South
-  - uid: 20877
+  - uid: 20876
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130751,7 +130753,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmospherics Front Desk
-  - uid: 20878
+  - uid: 20877
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130762,7 +130764,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Front Desk
-  - uid: 20879
+  - uid: 20878
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130773,7 +130775,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AI Core Bridge West
-  - uid: 20880
+  - uid: 20879
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130784,7 +130786,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmospherics West
-  - uid: 20881
+  - uid: 20880
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130795,7 +130797,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmospherics North
-  - uid: 20882
+  - uid: 20881
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130806,7 +130808,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Hall
-  - uid: 20883
+  - uid: 20882
     components:
     - type: Transform
       pos: 37.5,24.5
@@ -130816,7 +130818,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Locker Room
-  - uid: 20884
+  - uid: 20883
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130827,7 +130829,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: CE's Bedroom
-  - uid: 20885
+  - uid: 20884
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130838,7 +130840,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: CE's Office
-  - uid: 20886
+  - uid: 20885
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130849,7 +130851,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Main
-  - uid: 20887
+  - uid: 20886
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130860,7 +130862,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Exit Hallway
-  - uid: 20888
+  - uid: 20887
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130871,7 +130873,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Telecomms
-  - uid: 20889
+  - uid: 20888
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130882,7 +130884,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AME
-  - uid: 20890
+  - uid: 20889
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130893,7 +130895,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Outdoor Area
-  - uid: 20891
+  - uid: 20890
     components:
     - type: Transform
       pos: 67.5,17.5
@@ -130903,7 +130905,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engine Entry
-  - uid: 20892
+  - uid: 20891
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130914,7 +130916,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: PA North
-  - uid: 20893
+  - uid: 20892
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130925,7 +130927,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: PA South
-  - uid: 20894
+  - uid: 20893
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130936,7 +130938,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Singularity Engine North
-  - uid: 20895
+  - uid: 20894
     components:
     - type: Transform
       pos: 85.5,11.5
@@ -130946,7 +130948,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Singularity Engine South
-  - uid: 20896
+  - uid: 20895
     components:
     - type: Transform
       pos: 72.5,26.5
@@ -130956,7 +130958,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AI Core Bridge East
-  - uid: 20897
+  - uid: 20896
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -130967,7 +130969,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AI Core Bridge North
-  - uid: 20898
+  - uid: 20897
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -130978,7 +130980,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AI Core West
-  - uid: 20899
+  - uid: 20898
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -130989,7 +130991,7 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: AI Core East
-  - uid: 20900
+  - uid: 20899
     components:
     - type: Transform
       pos: 4.5,18.5
@@ -131001,7 +131003,7 @@ entities:
       id: Tech Vault
 - proto: SurveillanceCameraGeneral
   entities:
-  - uid: 20901
+  - uid: 20900
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131011,7 +131013,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20902
+  - uid: 20901
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131021,7 +131023,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20903
+  - uid: 20902
     components:
     - type: Transform
       pos: 55.5,-34.5
@@ -131030,7 +131032,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20904
+  - uid: 20903
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131040,7 +131042,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20905
+  - uid: 20904
     components:
     - type: Transform
       pos: 68.5,-27.5
@@ -131049,7 +131051,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20906
+  - uid: 20905
     components:
     - type: Transform
       pos: 66.5,-14.5
@@ -131058,7 +131060,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20907
+  - uid: 20906
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131068,7 +131070,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20908
+  - uid: 20907
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131078,7 +131080,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20909
+  - uid: 20908
     components:
     - type: Transform
       pos: 27.5,-14.5
@@ -131087,7 +131089,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20910
+  - uid: 20909
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131097,7 +131099,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20911
+  - uid: 20910
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131107,7 +131109,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20912
+  - uid: 20911
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131117,7 +131119,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20913
+  - uid: 20912
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131127,7 +131129,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20914
+  - uid: 20913
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131137,7 +131139,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20915
+  - uid: 20914
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131147,7 +131149,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20916
+  - uid: 20915
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131157,7 +131159,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20917
+  - uid: 20916
     components:
     - type: Transform
       pos: 21.5,6.5
@@ -131166,7 +131168,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20918
+  - uid: 20917
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131176,7 +131178,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20919
+  - uid: 20918
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131186,7 +131188,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20920
+  - uid: 20919
     components:
     - type: Transform
       pos: -14.5,12.5
@@ -131195,7 +131197,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20921
+  - uid: 20920
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131205,7 +131207,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20922
+  - uid: 20921
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131215,7 +131217,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20923
+  - uid: 20922
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131225,7 +131227,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20924
+  - uid: 20923
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131235,7 +131237,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20925
+  - uid: 20924
     components:
     - type: Transform
       pos: -44.5,12.5
@@ -131244,7 +131246,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20926
+  - uid: 20925
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131254,7 +131256,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20927
+  - uid: 20926
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131264,7 +131266,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20928
+  - uid: 20927
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131274,7 +131276,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20929
+  - uid: 20928
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131284,7 +131286,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20930
+  - uid: 20929
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131294,7 +131296,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20931
+  - uid: 20930
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131304,7 +131306,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20932
+  - uid: 20931
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131314,7 +131316,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20933
+  - uid: 20932
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131324,7 +131326,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraGeneral
       nameSet: True
-  - uid: 20934
+  - uid: 20933
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131332,7 +131334,7 @@ entities:
       parent: 2
 - proto: SurveillanceCameraMedical
   entities:
-  - uid: 20935
+  - uid: 20934
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131343,7 +131345,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Medical Lobby
-  - uid: 20936
+  - uid: 20935
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131354,7 +131356,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Triage Main
-  - uid: 20937
+  - uid: 20936
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131365,7 +131367,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Triage West
-  - uid: 20938
+  - uid: 20937
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131376,7 +131378,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Chemistry
-  - uid: 20939
+  - uid: 20938
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131387,7 +131389,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Triage East
-  - uid: 20940
+  - uid: 20939
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131398,7 +131400,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Surgery
-  - uid: 20941
+  - uid: 20940
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131409,7 +131411,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: CMO's Room
-  - uid: 20942
+  - uid: 20941
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131420,7 +131422,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Medical Locker Room
-  - uid: 20943
+  - uid: 20942
     components:
     - type: Transform
       pos: -44.5,3.5
@@ -131430,7 +131432,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Medical Main Hallway
-  - uid: 20944
+  - uid: 20943
     components:
     - type: Transform
       pos: -46.5,7.5
@@ -131440,7 +131442,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Morgue
-  - uid: 20945
+  - uid: 20944
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131451,7 +131453,7 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Medical Breakroom
-  - uid: 20946
+  - uid: 20945
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131473,70 +131475,70 @@ entities:
     - type: InsideEntityStorage
 - proto: SurveillanceCameraRouterCommand
   entities:
-  - uid: 20947
+  - uid: 20946
     components:
     - type: Transform
       pos: 61.5,45.5
       parent: 2
 - proto: SurveillanceCameraRouterConstructed
   entities:
-  - uid: 20948
+  - uid: 20947
     components:
     - type: Transform
       pos: -28.5,29.5
       parent: 2
 - proto: SurveillanceCameraRouterEngineering
   entities:
-  - uid: 20949
+  - uid: 20948
     components:
     - type: Transform
       pos: 61.5,44.5
       parent: 2
 - proto: SurveillanceCameraRouterGeneral
   entities:
-  - uid: 20950
+  - uid: 20949
     components:
     - type: Transform
       pos: 61.5,42.5
       parent: 2
 - proto: SurveillanceCameraRouterMedical
   entities:
-  - uid: 20951
+  - uid: 20950
     components:
     - type: Transform
       pos: 61.5,41.5
       parent: 2
 - proto: SurveillanceCameraRouterScience
   entities:
-  - uid: 20952
+  - uid: 20951
     components:
     - type: Transform
       pos: 69.5,45.5
       parent: 2
 - proto: SurveillanceCameraRouterSecurity
   entities:
-  - uid: 20953
+  - uid: 20952
     components:
     - type: Transform
       pos: 69.5,44.5
       parent: 2
 - proto: SurveillanceCameraRouterService
   entities:
-  - uid: 20954
+  - uid: 20953
     components:
     - type: Transform
       pos: 69.5,43.5
       parent: 2
 - proto: SurveillanceCameraRouterSupply
   entities:
-  - uid: 20955
+  - uid: 20954
     components:
     - type: Transform
       pos: 69.5,42.5
       parent: 2
 - proto: SurveillanceCameraScience
   entities:
-  - uid: 20956
+  - uid: 20955
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131547,7 +131549,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Server Room
-  - uid: 20957
+  - uid: 20956
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131558,7 +131560,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Science Front Desk
-  - uid: 20958
+  - uid: 20957
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131569,7 +131571,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Anomaly Generator Room
-  - uid: 20959
+  - uid: 20958
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131580,7 +131582,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Robotics East
-  - uid: 20960
+  - uid: 20959
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131591,7 +131593,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Robotics West
-  - uid: 20961
+  - uid: 20960
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131602,7 +131604,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Science Breakroom
-  - uid: 20962
+  - uid: 20961
     components:
     - type: Transform
       pos: -53.5,34.5
@@ -131612,7 +131614,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: Artifact East
-  - uid: 20963
+  - uid: 20962
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131623,7 +131625,7 @@ entities:
       - SurveillanceCameraScience
       nameSet: True
       id: RD's Room
-  - uid: 20964
+  - uid: 20963
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131636,7 +131638,7 @@ entities:
       id: Xenobio
 - proto: SurveillanceCameraSecurity
   entities:
-  - uid: 20965
+  - uid: 20964
     components:
     - type: Transform
       pos: 0.5,6.5
@@ -131646,7 +131648,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Warden's Office
-  - uid: 20966
+  - uid: 20965
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131657,7 +131659,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: HoS's Office
-  - uid: 20967
+  - uid: 20966
     components:
     - type: Transform
       pos: -9.5,-16.5
@@ -131667,7 +131669,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Higher Armory
-  - uid: 20968
+  - uid: 20967
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131678,7 +131680,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Lower Armory
-  - uid: 20969
+  - uid: 20968
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131689,7 +131691,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Interrogation
-  - uid: 20970
+  - uid: 20969
     components:
     - type: Transform
       pos: -11.5,-0.5
@@ -131699,7 +131701,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Detective's Room
-  - uid: 20971
+  - uid: 20970
     components:
     - type: Transform
       pos: -17.5,3.5
@@ -131709,7 +131711,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Law Storage Room
-  - uid: 20972
+  - uid: 20971
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131720,7 +131722,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Magistrate's Office
-  - uid: 20973
+  - uid: 20972
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131731,7 +131733,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Law Office
-  - uid: 20974
+  - uid: 20973
     components:
     - type: Transform
       pos: -10.5,3.5
@@ -131741,7 +131743,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Court
-  - uid: 20975
+  - uid: 20974
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131752,7 +131754,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: HoS's Bedroom
-  - uid: 20976
+  - uid: 20975
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131763,7 +131765,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Security Evac Checkpoint
-  - uid: 20977
+  - uid: 20976
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131771,7 +131773,7 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Locker Room
-  - uid: 20978
+  - uid: 20977
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131779,14 +131781,14 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Brigmed
-  - uid: 20979
+  - uid: 20978
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 2
     - type: SurveillanceCamera
       id: East Hallway
-  - uid: 20980
+  - uid: 20979
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131794,14 +131796,14 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Lounge
-  - uid: 20981
+  - uid: 20980
     components:
     - type: Transform
       pos: 14.5,-9.5
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Visitation
-  - uid: 20982
+  - uid: 20981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131809,7 +131811,7 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Enterance
-  - uid: 20983
+  - uid: 20982
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131817,7 +131819,7 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Kitchen
-  - uid: 20984
+  - uid: 20983
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131825,7 +131827,7 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Closet
-  - uid: 20985
+  - uid: 20984
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131833,7 +131835,7 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Dorm 1
-  - uid: 20986
+  - uid: 20985
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131841,14 +131843,14 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Genpop Dorm 2
-  - uid: 20987
+  - uid: 20986
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 2
     - type: SurveillanceCamera
       id: Security
-  - uid: 20988
+  - uid: 20987
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131858,7 +131860,7 @@ entities:
       id: Warden's Bedroom
 - proto: SurveillanceCameraService
   entities:
-  - uid: 20989
+  - uid: 20988
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131869,7 +131871,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Bartender's Room
-  - uid: 20990
+  - uid: 20989
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131880,7 +131882,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Stage
-  - uid: 20991
+  - uid: 20990
     components:
     - type: Transform
       pos: 35.5,-6.5
@@ -131890,7 +131892,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Bar
-  - uid: 20992
+  - uid: 20991
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131901,7 +131903,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Freezer
-  - uid: 20993
+  - uid: 20992
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131912,7 +131914,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Kitchen
-  - uid: 20994
+  - uid: 20993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131923,7 +131925,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Music Room
-  - uid: 20995
+  - uid: 20994
     components:
     - type: Transform
       pos: 62.5,-6.5
@@ -131933,7 +131935,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Botany
-  - uid: 20996
+  - uid: 20995
     components:
     - type: Transform
       pos: 66.5,-0.5
@@ -131943,7 +131945,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Botany Outdoor
-  - uid: 20997
+  - uid: 20996
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131954,7 +131956,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Janitor's Closet
-  - uid: 20998
+  - uid: 20997
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131965,7 +131967,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Crematorium
-  - uid: 20999
+  - uid: 20998
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -131976,7 +131978,7 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Chapel
-  - uid: 21000
+  - uid: 20999
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -131987,13 +131989,13 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Disposals
-  - uid: 21001
+  - uid: 21000
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -52.5,16.5
       parent: 2
-  - uid: 21002
+  - uid: 21001
     components:
     - type: Transform
       pos: -52.5,15.5
@@ -132005,7 +132007,7 @@ entities:
       id: Chapel Entry
 - proto: SurveillanceCameraSupply
   entities:
-  - uid: 21003
+  - uid: 21002
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -132016,7 +132018,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Cargo Front Desk
-  - uid: 21004
+  - uid: 21003
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -132027,13 +132029,13 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Cargo Bay
-  - uid: 21005
+  - uid: 21004
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,31.5
       parent: 2
-  - uid: 21006
+  - uid: 21005
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -132044,7 +132046,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Salvage Dock
-  - uid: 21007
+  - uid: 21006
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -132055,7 +132057,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Salvage Locker Room
-  - uid: 21008
+  - uid: 21007
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -132066,7 +132068,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Mail Room
-  - uid: 21009
+  - uid: 21008
     components:
     - type: Transform
       pos: 18.5,24.5
@@ -132076,7 +132078,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: Cargo Connector
-  - uid: 21010
+  - uid: 21009
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -132087,7 +132089,7 @@ entities:
       - SurveillanceCameraSupply
       nameSet: True
       id: QM's Office
-  - uid: 21011
+  - uid: 21010
     components:
     - type: Transform
       pos: 28.5,19.5
@@ -132099,38 +132101,38 @@ entities:
       id: QM's Bedroom
 - proto: SurveillanceCameraWirelessRouterConstructed
   entities:
-  - uid: 21012
+  - uid: 21011
     components:
     - type: Transform
       pos: 69.5,41.5
       parent: 2
 - proto: SurveillanceCameraWirelessRouterEntertainment
   entities:
-  - uid: 21013
+  - uid: 21012
     components:
     - type: Transform
       pos: 61.5,43.5
       parent: 2
 - proto: SusPlushie
   entities:
-  - uid: 21014
+  - uid: 21013
     components:
     - type: Transform
       pos: -30.748,41.053074
       parent: 2
-  - uid: 21015
+  - uid: 21014
     components:
     - type: Transform
       pos: 4.4347425,-19.480503
       parent: 2
-  - uid: 21016
+  - uid: 21015
     components:
     - type: Transform
       pos: -49.749134,-8.31368
       parent: 2
 - proto: SyndicateMicrowave
   entities:
-  - uid: 21017
+  - uid: 21016
     components:
     - type: Transform
       pos: 85.5,-39.5
@@ -132143,656 +132145,661 @@ entities:
       parent: 15734
     - type: Physics
       canCollide: False
-  - uid: 21018
+  - uid: 21017
     components:
     - type: Transform
       pos: -27.500624,-12.448242
       parent: 2
-  - uid: 21019
+  - uid: 21018
     components:
     - type: Transform
       pos: -66.49377,42.6762
       parent: 2
 - proto: Table
   entities:
-  - uid: 21020
+  - uid: 21019
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-2.5
       parent: 2
-  - uid: 21021
+  - uid: 21020
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 2
-  - uid: 21022
+  - uid: 21021
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-2.5
       parent: 2
-  - uid: 21023
+  - uid: 21022
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 2
-  - uid: 21024
+  - uid: 21023
     components:
     - type: Transform
       pos: -45.5,5.5
       parent: 2
-  - uid: 21025
+  - uid: 21024
     components:
     - type: Transform
       pos: -25.5,45.5
       parent: 2
-  - uid: 21026
+  - uid: 21025
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
-  - uid: 21027
+  - uid: 21026
     components:
     - type: Transform
       pos: -26.5,45.5
       parent: 2
-  - uid: 21028
+  - uid: 21027
     components:
     - type: Transform
       pos: 51.5,-6.5
       parent: 2
-  - uid: 21029
+  - uid: 21028
     components:
     - type: Transform
       pos: 0.5,41.5
       parent: 2
-  - uid: 21030
+  - uid: 21029
     components:
     - type: Transform
       pos: 51.5,-5.5
       parent: 2
-  - uid: 21031
+  - uid: 21030
     components:
     - type: Transform
       pos: -10.5,1.5
       parent: 2
-  - uid: 21032
+  - uid: 21031
     components:
     - type: Transform
       pos: -9.5,1.5
       parent: 2
-  - uid: 21033
+  - uid: 21032
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 2
-  - uid: 21034
+  - uid: 21033
     components:
     - type: Transform
       pos: -9.5,-5.5
       parent: 2
-  - uid: 21035
+  - uid: 21034
     components:
     - type: Transform
       pos: -9.5,-4.5
       parent: 2
-  - uid: 21036
+  - uid: 21035
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 2
-  - uid: 21037
+  - uid: 21036
     components:
     - type: Transform
       pos: 51.5,0.5
       parent: 2
-  - uid: 21038
+  - uid: 21037
     components:
     - type: Transform
       pos: -33.5,8.5
       parent: 2
-  - uid: 21039
+  - uid: 21038
     components:
     - type: Transform
       pos: -28.5,2.5
       parent: 2
-  - uid: 21040
+  - uid: 21039
     components:
     - type: Transform
       pos: -33.5,3.5
       parent: 2
-  - uid: 21041
+  - uid: 21040
     components:
     - type: Transform
       pos: -33.5,4.5
       parent: 2
-  - uid: 21042
+  - uid: 21041
     components:
     - type: Transform
       pos: -33.5,7.5
       parent: 2
-  - uid: 21043
+  - uid: 21042
     components:
     - type: Transform
       pos: -54.5,-1.5
       parent: 2
-  - uid: 21044
+  - uid: 21043
     components:
     - type: Transform
       pos: -39.5,-5.5
       parent: 2
-  - uid: 21045
+  - uid: 21044
     components:
     - type: Transform
       pos: -51.5,5.5
       parent: 2
-  - uid: 21046
+  - uid: 21045
     components:
     - type: Transform
       pos: -68.5,20.5
       parent: 2
-  - uid: 21047
+  - uid: 21046
     components:
     - type: Transform
       pos: -64.5,20.5
       parent: 2
-  - uid: 21048
+  - uid: 21047
     components:
     - type: Transform
       pos: -68.5,24.5
       parent: 2
-  - uid: 21049
+  - uid: 21048
     components:
     - type: Transform
       pos: -67.5,24.5
       parent: 2
-  - uid: 21050
+  - uid: 21049
     components:
     - type: Transform
       pos: -66.5,24.5
       parent: 2
-  - uid: 21051
+  - uid: 21050
     components:
     - type: Transform
       pos: -68.5,27.5
       parent: 2
-  - uid: 21052
+  - uid: 21051
     components:
     - type: Transform
       pos: -68.5,28.5
       parent: 2
-  - uid: 21053
+  - uid: 21052
     components:
     - type: Transform
       pos: -62.5,31.5
       parent: 2
-  - uid: 21054
+  - uid: 21053
     components:
     - type: Transform
       pos: -60.5,31.5
       parent: 2
-  - uid: 21055
+  - uid: 21054
     components:
     - type: Transform
       pos: -60.5,30.5
       parent: 2
-  - uid: 21056
+  - uid: 21055
     components:
     - type: Transform
       pos: -62.5,27.5
       parent: 2
-  - uid: 21057
+  - uid: 21056
     components:
     - type: Transform
       pos: -61.5,27.5
       parent: 2
-  - uid: 21058
+  - uid: 21057
     components:
     - type: Transform
       pos: -44.5,39.5
       parent: 2
-  - uid: 21059
+  - uid: 21058
     components:
     - type: Transform
       pos: -43.5,39.5
       parent: 2
-  - uid: 21060
+  - uid: 21059
     components:
     - type: Transform
       pos: -43.5,26.5
       parent: 2
-  - uid: 21061
+  - uid: 21060
     components:
     - type: Transform
       pos: -44.5,26.5
       parent: 2
-  - uid: 21062
+  - uid: 21061
     components:
     - type: Transform
       pos: 44.5,28.5
       parent: 2
-  - uid: 21063
+  - uid: 21062
     components:
     - type: Transform
       pos: 45.5,28.5
       parent: 2
-  - uid: 21064
+  - uid: 21063
     components:
     - type: Transform
       pos: -43.5,38.5
       parent: 2
-  - uid: 21065
+  - uid: 21064
     components:
     - type: Transform
       pos: 43.5,28.5
       parent: 2
-  - uid: 21066
+  - uid: 21065
     components:
     - type: Transform
       pos: 12.5,26.5
       parent: 2
-  - uid: 21067
+  - uid: 21066
     components:
     - type: Transform
       pos: 11.5,26.5
       parent: 2
-  - uid: 21068
+  - uid: 21067
     components:
     - type: Transform
       pos: 10.5,26.5
       parent: 2
-  - uid: 21069
+  - uid: 21068
     components:
     - type: Transform
       pos: 20.5,17.5
       parent: 2
-  - uid: 21070
+  - uid: 21069
     components:
     - type: Transform
       pos: 16.5,22.5
       parent: 2
-  - uid: 21071
+  - uid: 21070
     components:
     - type: Transform
       pos: 19.5,17.5
       parent: 2
-  - uid: 21072
+  - uid: 21071
     components:
     - type: Transform
       pos: 25.5,25.5
       parent: 2
-  - uid: 21073
+  - uid: 21072
     components:
     - type: Transform
       pos: 25.5,24.5
       parent: 2
-  - uid: 21074
+  - uid: 21073
     components:
     - type: Transform
       pos: 25.5,26.5
       parent: 2
-  - uid: 21075
+  - uid: 21074
     components:
     - type: Transform
       pos: 2.5,-33.5
       parent: 2
-  - uid: 21076
+  - uid: 21075
     components:
     - type: Transform
       pos: 1.5,-32.5
       parent: 2
-  - uid: 21077
+  - uid: 21076
     components:
     - type: Transform
       pos: 2.5,-32.5
       parent: 2
-  - uid: 21078
+  - uid: 21077
     components:
     - type: Transform
       pos: 1.5,-29.5
       parent: 2
-  - uid: 21079
+  - uid: 21078
     components:
     - type: Transform
       pos: 1.5,-28.5
       parent: 2
-  - uid: 21080
+  - uid: 21079
     components:
     - type: Transform
       pos: 2.5,-28.5
       parent: 2
-  - uid: 21081
+  - uid: 21080
     components:
     - type: Transform
       pos: 5.5,-28.5
       parent: 2
-  - uid: 21082
+  - uid: 21081
     components:
     - type: Transform
       pos: 47.5,-4.5
       parent: 2
-  - uid: 21083
+  - uid: 21082
     components:
     - type: Transform
       pos: 49.5,-3.5
       parent: 2
-  - uid: 21084
+  - uid: 21083
     components:
     - type: Transform
       pos: 47.5,-3.5
       parent: 2
-  - uid: 21085
+  - uid: 21084
     components:
     - type: Transform
       pos: 47.5,-2.5
       parent: 2
-  - uid: 21086
+  - uid: 21085
     components:
     - type: Transform
       pos: 49.5,-1.5
       parent: 2
-  - uid: 21087
+  - uid: 21086
     components:
     - type: Transform
       pos: 47.5,-1.5
       parent: 2
-  - uid: 21088
+  - uid: 21087
     components:
     - type: Transform
       pos: 48.5,-3.5
       parent: 2
-  - uid: 21089
+  - uid: 21088
     components:
     - type: Transform
       pos: 48.5,-2.5
       parent: 2
-  - uid: 21090
+  - uid: 21089
     components:
     - type: Transform
       pos: 49.5,-2.5
       parent: 2
-  - uid: 21091
+  - uid: 21090
     components:
     - type: Transform
       pos: 49.5,-4.5
       parent: 2
-  - uid: 21092
+  - uid: 21091
     components:
     - type: Transform
       pos: 69.5,-42.5
       parent: 2
-  - uid: 21093
+  - uid: 21092
     components:
     - type: Transform
       pos: 69.5,-43.5
       parent: 2
-  - uid: 21094
+  - uid: 21093
     components:
     - type: Transform
       pos: 70.5,-42.5
       parent: 2
-  - uid: 21095
+  - uid: 21094
     components:
     - type: Transform
       pos: 60.5,3.5
       parent: 2
-  - uid: 21096
+  - uid: 21095
     components:
     - type: Transform
       pos: 58.5,3.5
       parent: 2
-  - uid: 21097
+  - uid: 21096
     components:
     - type: Transform
       pos: 57.5,3.5
       parent: 2
-  - uid: 21098
+  - uid: 21097
     components:
     - type: Transform
       pos: 57.5,2.5
       parent: 2
-  - uid: 21099
+  - uid: 21098
     components:
     - type: Transform
       pos: 60.5,-0.5
       parent: 2
-  - uid: 21100
+  - uid: 21099
     components:
     - type: Transform
       pos: 74.5,-22.5
       parent: 2
-  - uid: 21101
+  - uid: 21100
     components:
     - type: Transform
       pos: 38.5,6.5
       parent: 2
-  - uid: 21102
+  - uid: 21101
     components:
     - type: Transform
       pos: 49.5,25.5
       parent: 2
-  - uid: 21103
+  - uid: 21102
     components:
     - type: Transform
       pos: 50.5,25.5
       parent: 2
-  - uid: 21104
+  - uid: 21103
     components:
     - type: Transform
       pos: 64.5,42.5
       parent: 2
-  - uid: 21105
+  - uid: 21104
     components:
     - type: Transform
       pos: 66.5,42.5
       parent: 2
-  - uid: 21106
+  - uid: 21105
     components:
     - type: Transform
       pos: 43.5,27.5
       parent: 2
-  - uid: 21107
+  - uid: 21106
     components:
     - type: Transform
       pos: 13.5,-16.5
       parent: 2
-  - uid: 21108
+  - uid: 21107
     components:
     - type: Transform
       pos: 12.5,-16.5
       parent: 2
-  - uid: 21109
+  - uid: 21108
     components:
     - type: Transform
       pos: 14.5,-16.5
       parent: 2
-  - uid: 21110
+  - uid: 21109
     components:
     - type: Transform
       pos: -29.5,-15.5
       parent: 2
-  - uid: 21111
+  - uid: 21110
     components:
     - type: Transform
       pos: -30.5,-15.5
       parent: 2
-  - uid: 21112
+  - uid: 21111
     components:
     - type: Transform
       pos: 51.5,-0.5
       parent: 2
-  - uid: 21113
+  - uid: 21112
     components:
     - type: Transform
       pos: -26.5,-22.5
       parent: 2
-  - uid: 21114
+  - uid: 21113
     components:
     - type: Transform
       pos: -19.5,-22.5
       parent: 2
-  - uid: 21115
+  - uid: 21114
     components:
     - type: Transform
       pos: -8.5,-22.5
       parent: 2
-  - uid: 21116
+  - uid: 21115
     components:
     - type: Transform
       pos: -19.5,-11.5
       parent: 2
-  - uid: 21117
+  - uid: 21116
     components:
     - type: Transform
       pos: -38.5,-13.5
       parent: 2
-  - uid: 21118
+  - uid: 21117
     components:
     - type: Transform
       pos: -37.5,-13.5
       parent: 2
-  - uid: 21119
+  - uid: 21118
     components:
     - type: Transform
       pos: -34.5,27.5
       parent: 2
-  - uid: 21120
+  - uid: 21119
     components:
     - type: Transform
       pos: -77.5,-3.5
       parent: 2
-  - uid: 21121
+  - uid: 21120
     components:
     - type: Transform
       pos: -77.5,-2.5
       parent: 2
-  - uid: 21122
+  - uid: 21121
     components:
     - type: Transform
       pos: -77.5,-1.5
       parent: 2
-  - uid: 21123
+  - uid: 21122
     components:
     - type: Transform
       pos: 30.5,-35.5
       parent: 2
-  - uid: 21124
+  - uid: 21123
     components:
     - type: Transform
       pos: 78.5,-46.5
       parent: 2
-  - uid: 21125
+  - uid: 21124
     components:
     - type: Transform
       pos: 80.5,-47.5
       parent: 2
-  - uid: 21126
+  - uid: 21125
     components:
     - type: Transform
       pos: 80.5,-48.5
       parent: 2
-  - uid: 21127
+  - uid: 21126
     components:
     - type: Transform
       pos: 65.5,-36.5
       parent: 2
-  - uid: 21128
+  - uid: 21127
     components:
     - type: Transform
       pos: 65.5,-37.5
       parent: 2
-  - uid: 21129
+  - uid: 21128
     components:
     - type: Transform
       pos: 26.5,36.5
       parent: 2
-  - uid: 21130
+  - uid: 21129
     components:
     - type: Transform
       pos: 16.5,24.5
       parent: 2
-  - uid: 21131
+  - uid: 21130
     components:
     - type: Transform
       pos: 17.5,24.5
       parent: 2
-  - uid: 21132
+  - uid: 21131
     components:
     - type: Transform
       pos: 37.5,35.5
       parent: 2
-  - uid: 21133
+  - uid: 21132
     components:
     - type: Transform
       pos: 37.5,37.5
       parent: 2
 - proto: TableCarpet
   entities:
-  - uid: 21134
+  - uid: 21133
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,18.5
       parent: 2
-  - uid: 21135
+  - uid: 21134
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,19.5
       parent: 2
-  - uid: 21136
+  - uid: 21135
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,17.5
       parent: 2
-  - uid: 21137
+  - uid: 21136
     components:
     - type: Transform
       pos: 22.5,19.5
       parent: 2
-  - uid: 21138
+  - uid: 21137
     components:
     - type: Transform
       pos: 22.5,18.5
       parent: 2
-  - uid: 21139
+  - uid: 21138
     components:
     - type: Transform
       pos: 22.5,17.5
       parent: 2
-  - uid: 21140
+  - uid: 21139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,34.5
       parent: 2
-  - uid: 21141
+  - uid: 21140
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,34.5
       parent: 2
-  - uid: 21142
+  - uid: 21141
     components:
     - type: Transform
       pos: 32.5,32.5
       parent: 2
-  - uid: 21143
+  - uid: 21142
     components:
     - type: Transform
       pos: 32.5,31.5
       parent: 2
-  - uid: 21144
+  - uid: 21143
     components:
     - type: Transform
       pos: 32.5,33.5
       parent: 2
-  - uid: 21145
+  - uid: 21144
     components:
     - type: Transform
       pos: 8.5,-15.5
+      parent: 2
+  - uid: 21145
+    components:
+    - type: Transform
+      pos: -14.5,-21.5
       parent: 2
   - uid: 21146
     components:
@@ -132802,139 +132809,134 @@ entities:
   - uid: 21147
     components:
     - type: Transform
-      pos: -14.5,-21.5
-      parent: 2
-  - uid: 21148
-    components:
-    - type: Transform
       pos: 8.5,19.5
       parent: 2
 - proto: TableCounterWood
   entities:
-  - uid: 21149
+  - uid: 21148
     components:
     - type: Transform
       pos: 32.5,-7.5
       parent: 2
-  - uid: 21150
+  - uid: 21149
     components:
     - type: Transform
       pos: 31.5,-2.5
       parent: 2
-  - uid: 21151
+  - uid: 21150
     components:
     - type: Transform
       pos: 31.5,-5.5
       parent: 2
-  - uid: 21152
+  - uid: 21151
     components:
     - type: Transform
       pos: 37.5,-4.5
       parent: 2
-  - uid: 21153
+  - uid: 21152
     components:
     - type: Transform
       pos: 31.5,-3.5
       parent: 2
-  - uid: 21154
+  - uid: 21153
     components:
     - type: Transform
       pos: 37.5,-3.5
       parent: 2
-  - uid: 21155
+  - uid: 21154
     components:
     - type: Transform
       pos: 37.5,-2.5
       parent: 2
-  - uid: 21156
+  - uid: 21155
     components:
     - type: Transform
       pos: 37.5,-6.5
       parent: 2
-  - uid: 21157
+  - uid: 21156
     components:
     - type: Transform
       pos: 37.5,-5.5
       parent: 2
-  - uid: 21158
+  - uid: 21157
     components:
     - type: Transform
       pos: 37.5,-7.5
       parent: 2
-  - uid: 21159
+  - uid: 21158
     components:
     - type: Transform
       pos: 36.5,-1.5
       parent: 2
-  - uid: 21160
+  - uid: 21159
     components:
     - type: Transform
       pos: 37.5,-1.5
       parent: 2
-  - uid: 21161
+  - uid: 21160
     components:
     - type: Transform
       pos: 36.5,-7.5
       parent: 2
-  - uid: 21162
+  - uid: 21161
     components:
     - type: Transform
       pos: 31.5,-7.5
       parent: 2
-  - uid: 21163
+  - uid: 21162
     components:
     - type: Transform
       pos: 31.5,-6.5
       parent: 2
-  - uid: 21164
+  - uid: 21163
     components:
     - type: Transform
       pos: 31.5,-4.5
       parent: 2
-  - uid: 21165
+  - uid: 21164
     components:
     - type: Transform
       pos: 31.5,-1.5
       parent: 2
-  - uid: 21166
+  - uid: 21165
     components:
     - type: Transform
       pos: 32.5,-1.5
       parent: 2
-  - uid: 21167
+  - uid: 21166
     components:
     - type: Transform
       pos: -41.5,36.5
       parent: 2
-  - uid: 21168
+  - uid: 21167
     components:
     - type: Transform
       pos: -40.5,36.5
       parent: 2
-  - uid: 21169
+  - uid: 21168
     components:
     - type: Transform
       pos: -39.5,36.5
       parent: 2
-  - uid: 21170
+  - uid: 21169
     components:
     - type: Transform
       pos: -38.5,36.5
       parent: 2
-  - uid: 21171
+  - uid: 21170
     components:
     - type: Transform
       pos: -37.5,36.5
       parent: 2
 - proto: TableFancyBlue
   entities:
-  - uid: 21172
+  - uid: 21171
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.5,4.5
       parent: 2
-  - uid: 21173
+  - uid: 21172
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -132942,7 +132944,7 @@ entities:
       parent: 2
 - proto: TableFancyPurple
   entities:
-  - uid: 21174
+  - uid: 21173
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -132950,37 +132952,37 @@ entities:
       parent: 2
 - proto: TableFancyRed
   entities:
-  - uid: 21175
+  - uid: 21174
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,22.5
       parent: 2
-  - uid: 21176
+  - uid: 21175
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,14.5
       parent: 2
-  - uid: 21177
+  - uid: 21176
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -57.5,14.5
       parent: 2
-  - uid: 21178
+  - uid: 21177
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,14.5
       parent: 2
-  - uid: 21179
+  - uid: 21178
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,22.5
       parent: 2
-  - uid: 21180
+  - uid: 21179
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -132988,123 +132990,123 @@ entities:
       parent: 2
 - proto: TableGlass
   entities:
-  - uid: 21181
+  - uid: 21180
     components:
     - type: Transform
       pos: -24.5,19.5
       parent: 2
-  - uid: 21182
+  - uid: 21181
     components:
     - type: Transform
       pos: -24.5,20.5
       parent: 2
-  - uid: 21183
+  - uid: 21182
     components:
     - type: Transform
       pos: -46.5,37.5
       parent: 2
-  - uid: 21184
+  - uid: 21183
     components:
     - type: Transform
       pos: -46.5,36.5
       parent: 2
-  - uid: 21185
+  - uid: 21184
     components:
     - type: Transform
       pos: -21.5,41.5
       parent: 2
-  - uid: 21186
+  - uid: 21185
     components:
     - type: Transform
       pos: -22.5,41.5
       parent: 2
-  - uid: 21187
+  - uid: 21186
     components:
     - type: Transform
       pos: -10.5,41.5
       parent: 2
-  - uid: 21188
+  - uid: 21187
     components:
     - type: Transform
       pos: -11.5,41.5
       parent: 2
-  - uid: 21189
+  - uid: 21188
     components:
     - type: Transform
       pos: -56.5,5.5
       parent: 2
-  - uid: 21190
+  - uid: 21189
     components:
     - type: Transform
       pos: -57.5,5.5
       parent: 2
-  - uid: 21191
+  - uid: 21190
     components:
     - type: Transform
       pos: -57.5,3.5
       parent: 2
-  - uid: 21192
+  - uid: 21191
     components:
     - type: Transform
       pos: -53.5,5.5
       parent: 2
-  - uid: 21193
+  - uid: 21192
     components:
     - type: Transform
       pos: -42.5,-12.5
       parent: 2
-  - uid: 21194
+  - uid: 21193
     components:
     - type: Transform
       pos: -41.5,-12.5
       parent: 2
-  - uid: 21195
+  - uid: 21194
     components:
     - type: Transform
       pos: -22.5,-1.5
       parent: 2
-  - uid: 21196
+  - uid: 21195
     components:
     - type: Transform
       pos: -55.5,-16.5
       parent: 2
-  - uid: 21197
+  - uid: 21196
     components:
     - type: Transform
       pos: -55.5,-15.5
       parent: 2
-  - uid: 21198
+  - uid: 21197
     components:
     - type: Transform
       pos: -54.5,-15.5
       parent: 2
-  - uid: 21199
+  - uid: 21198
     components:
     - type: Transform
       pos: -54.5,-14.5
       parent: 2
-  - uid: 21200
+  - uid: 21199
     components:
     - type: Transform
       pos: 85.5,-40.5
       parent: 2
-  - uid: 21201
+  - uid: 21200
     components:
     - type: Transform
       pos: 85.5,-39.5
       parent: 2
-  - uid: 21202
+  - uid: 21201
     components:
     - type: Transform
       pos: -40.5,-3.5
       parent: 2
-  - uid: 21203
+  - uid: 21202
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -67.5,42.5
       parent: 2
-  - uid: 21204
+  - uid: 21203
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -133112,1705 +133114,1705 @@ entities:
       parent: 2
 - proto: TablePlasmaGlass
   entities:
-  - uid: 21205
+  - uid: 21204
     components:
     - type: Transform
       pos: -50.5,32.5
       parent: 2
-  - uid: 21206
+  - uid: 21205
     components:
     - type: Transform
       pos: -50.5,31.5
       parent: 2
-  - uid: 21207
+  - uid: 21206
     components:
     - type: Transform
       pos: -56.5,32.5
       parent: 2
-  - uid: 21208
+  - uid: 21207
     components:
     - type: Transform
       pos: -56.5,31.5
       parent: 2
-  - uid: 21209
+  - uid: 21208
     components:
     - type: Transform
       pos: -50.5,30.5
       parent: 2
-  - uid: 21210
+  - uid: 21209
     components:
     - type: Transform
       pos: -56.5,30.5
       parent: 2
-  - uid: 21211
+  - uid: 21210
     components:
     - type: Transform
       pos: -25.5,-19.5
       parent: 2
-  - uid: 21212
+  - uid: 21211
     components:
     - type: Transform
       pos: -24.5,-19.5
       parent: 2
-  - uid: 21213
+  - uid: 21212
     components:
     - type: Transform
       pos: -21.5,-19.5
       parent: 2
-  - uid: 21214
+  - uid: 21213
     components:
     - type: Transform
       pos: -20.5,-19.5
       parent: 2
-  - uid: 21215
+  - uid: 21214
     components:
     - type: Transform
       pos: -72.5,-2.5
       parent: 2
-  - uid: 21216
+  - uid: 21215
     components:
     - type: Transform
       pos: -71.5,-2.5
       parent: 2
 - proto: TableReinforced
   entities:
-  - uid: 21217
+  - uid: 21216
     components:
     - type: Transform
       pos: 11.5,9.5
       parent: 2
-  - uid: 21218
+  - uid: 21217
     components:
     - type: Transform
       pos: 12.5,11.5
       parent: 2
-  - uid: 21219
+  - uid: 21218
     components:
     - type: Transform
       pos: 11.5,10.5
       parent: 2
-  - uid: 21220
+  - uid: 21219
     components:
     - type: Transform
       pos: -5.5,37.5
       parent: 2
-  - uid: 21221
+  - uid: 21220
     components:
     - type: Transform
       pos: -5.5,35.5
       parent: 2
-  - uid: 21222
+  - uid: 21221
     components:
     - type: Transform
       pos: -5.5,36.5
       parent: 2
-  - uid: 21223
+  - uid: 21222
     components:
     - type: Transform
       pos: -14.5,55.5
       parent: 2
-  - uid: 21224
+  - uid: 21223
     components:
     - type: Transform
       pos: -16.5,55.5
       parent: 2
-  - uid: 21225
+  - uid: 21224
     components:
     - type: Transform
       pos: -11.5,54.5
       parent: 2
-  - uid: 21226
+  - uid: 21225
     components:
     - type: Transform
       pos: -19.5,54.5
       parent: 2
-  - uid: 21227
+  - uid: 21226
     components:
     - type: Transform
       pos: -6.5,41.5
       parent: 2
-  - uid: 21228
+  - uid: 21227
     components:
     - type: Transform
       pos: -6.5,39.5
       parent: 2
-  - uid: 21229
+  - uid: 21228
     components:
     - type: Transform
       pos: -7.5,32.5
       parent: 2
-  - uid: 21230
+  - uid: 21229
     components:
     - type: Transform
       pos: -7.5,50.5
       parent: 2
-  - uid: 21231
+  - uid: 21230
     components:
     - type: Transform
       pos: -7.5,51.5
       parent: 2
-  - uid: 21232
+  - uid: 21231
     components:
     - type: Transform
       pos: -26.5,32.5
       parent: 2
-  - uid: 21233
+  - uid: 21232
     components:
     - type: Transform
       pos: -26.5,28.5
       parent: 2
-  - uid: 21234
+  - uid: 21233
     components:
     - type: Transform
       pos: -27.5,28.5
       parent: 2
-  - uid: 21235
+  - uid: 21234
     components:
     - type: Transform
       pos: -28.5,28.5
       parent: 2
-  - uid: 21236
+  - uid: 21235
     components:
     - type: Transform
       pos: -27.5,32.5
       parent: 2
-  - uid: 21237
+  - uid: 21236
     components:
     - type: Transform
       pos: -28.5,32.5
       parent: 2
-  - uid: 21238
+  - uid: 21237
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
-  - uid: 21239
+  - uid: 21238
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 2
-  - uid: 21240
+  - uid: 21239
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 2
-  - uid: 21241
+  - uid: 21240
     components:
     - type: Transform
       pos: -7.5,-4.5
       parent: 2
-  - uid: 21242
+  - uid: 21241
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 2
-  - uid: 21243
+  - uid: 21242
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 21244
+  - uid: 21243
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 2
-  - uid: 21245
+  - uid: 21244
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 2
-  - uid: 21246
+  - uid: 21245
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 2
-  - uid: 21247
+  - uid: 21246
     components:
     - type: Transform
       pos: -29.5,7.5
       parent: 2
-  - uid: 21248
+  - uid: 21247
     components:
     - type: Transform
       pos: -27.5,7.5
       parent: 2
-  - uid: 21249
+  - uid: 21248
     components:
     - type: Transform
       pos: -33.5,9.5
       parent: 2
-  - uid: 21250
+  - uid: 21249
     components:
     - type: Transform
       pos: -28.5,7.5
       parent: 2
-  - uid: 21251
+  - uid: 21250
     components:
     - type: Transform
       pos: -35.5,2.5
       parent: 2
-  - uid: 21252
+  - uid: 21251
     components:
     - type: Transform
       pos: -36.5,2.5
       parent: 2
-  - uid: 21253
+  - uid: 21252
     components:
     - type: Transform
       pos: -36.5,-1.5
       parent: 2
-  - uid: 21254
+  - uid: 21253
     components:
     - type: Transform
       pos: -36.5,-0.5
       parent: 2
-  - uid: 21255
+  - uid: 21254
     components:
     - type: Transform
       pos: -33.5,-0.5
       parent: 2
-  - uid: 21256
+  - uid: 21255
     components:
     - type: Transform
       pos: -33.5,-1.5
       parent: 2
-  - uid: 21257
+  - uid: 21256
     components:
     - type: Transform
       pos: -45.5,-9.5
       parent: 2
-  - uid: 21258
+  - uid: 21257
     components:
     - type: Transform
       pos: -44.5,-9.5
       parent: 2
-  - uid: 21259
+  - uid: 21258
     components:
     - type: Transform
       pos: -44.5,-8.5
       parent: 2
-  - uid: 21260
+  - uid: 21259
     components:
     - type: Transform
       pos: -44.5,-10.5
       parent: 2
-  - uid: 21261
+  - uid: 21260
     components:
     - type: Transform
       pos: -45.5,24.5
       parent: 2
-  - uid: 21262
+  - uid: 21261
     components:
     - type: Transform
       pos: -44.5,24.5
       parent: 2
-  - uid: 21263
+  - uid: 21262
     components:
     - type: Transform
       pos: 12.5,23.5
       parent: 2
-  - uid: 21264
+  - uid: 21263
     components:
     - type: Transform
       pos: 11.5,23.5
       parent: 2
-  - uid: 21265
+  - uid: 21264
     components:
     - type: Transform
       pos: 14.5,21.5
       parent: 2
-  - uid: 21266
+  - uid: 21265
     components:
     - type: Transform
       pos: 21.5,-7.5
       parent: 2
-  - uid: 21267
+  - uid: 21266
     components:
     - type: Transform
       pos: 21.5,-6.5
       parent: 2
-  - uid: 21268
+  - uid: 21267
     components:
     - type: Transform
       pos: 22.5,-8.5
       parent: 2
-  - uid: 21269
+  - uid: 21268
     components:
     - type: Transform
       pos: 23.5,-8.5
       parent: 2
-  - uid: 21270
+  - uid: 21269
     components:
     - type: Transform
       pos: 24.5,-8.5
       parent: 2
-  - uid: 21271
+  - uid: 21270
     components:
     - type: Transform
       pos: 25.5,-7.5
       parent: 2
-  - uid: 21272
+  - uid: 21271
     components:
     - type: Transform
       pos: 25.5,-6.5
       parent: 2
-  - uid: 21273
+  - uid: 21272
     components:
     - type: Transform
       pos: 21.5,4.5
       parent: 2
-  - uid: 21274
+  - uid: 21273
     components:
     - type: Transform
       pos: 22.5,5.5
       parent: 2
-  - uid: 21275
+  - uid: 21274
     components:
     - type: Transform
       pos: 23.5,5.5
       parent: 2
-  - uid: 21276
+  - uid: 21275
     components:
     - type: Transform
       pos: 24.5,5.5
       parent: 2
-  - uid: 21277
+  - uid: 21276
     components:
     - type: Transform
       pos: 25.5,4.5
       parent: 2
-  - uid: 21278
+  - uid: 21277
     components:
     - type: Transform
       pos: 25.5,3.5
       parent: 2
-  - uid: 21279
+  - uid: 21278
     components:
     - type: Transform
       pos: 43.5,-2.5
       parent: 2
-  - uid: 21280
+  - uid: 21279
     components:
     - type: Transform
       pos: 43.5,-7.5
       parent: 2
-  - uid: 21281
+  - uid: 21280
     components:
     - type: Transform
       pos: 45.5,-7.5
       parent: 2
-  - uid: 21282
+  - uid: 21281
     components:
     - type: Transform
       pos: 46.5,-7.5
       parent: 2
-  - uid: 21283
+  - uid: 21282
     components:
     - type: Transform
       pos: 47.5,-7.5
       parent: 2
-  - uid: 21284
+  - uid: 21283
     components:
     - type: Transform
       pos: 44.5,-7.5
       parent: 2
-  - uid: 21285
+  - uid: 21284
     components:
     - type: Transform
       pos: 41.5,-6.5
       parent: 2
-  - uid: 21286
+  - uid: 21285
     components:
     - type: Transform
       pos: 44.5,-2.5
       parent: 2
-  - uid: 21287
+  - uid: 21286
     components:
     - type: Transform
       pos: 41.5,-5.5
       parent: 2
-  - uid: 21288
+  - uid: 21287
     components:
     - type: Transform
       pos: 41.5,-4.5
       parent: 2
-  - uid: 21289
+  - uid: 21288
     components:
     - type: Transform
       pos: 41.5,-3.5
       parent: 2
-  - uid: 21290
+  - uid: 21289
     components:
     - type: Transform
       pos: 41.5,-2.5
       parent: 2
-  - uid: 21291
+  - uid: 21290
     components:
     - type: Transform
       pos: 44.5,-3.5
       parent: 2
-  - uid: 21292
+  - uid: 21291
     components:
     - type: Transform
       pos: 59.5,-7.5
       parent: 2
-  - uid: 21293
+  - uid: 21292
     components:
     - type: Transform
       pos: 58.5,-7.5
       parent: 2
-  - uid: 21294
+  - uid: 21293
     components:
     - type: Transform
       pos: 60.5,-7.5
       parent: 2
-  - uid: 21295
+  - uid: 21294
     components:
     - type: Transform
       pos: 35.5,9.5
       parent: 2
-  - uid: 21296
+  - uid: 21295
     components:
     - type: Transform
       pos: 35.5,8.5
       parent: 2
-  - uid: 21297
+  - uid: 21296
     components:
     - type: Transform
       pos: 31.5,12.5
       parent: 2
-  - uid: 21298
+  - uid: 21297
     components:
     - type: Transform
       pos: 32.5,12.5
       parent: 2
-  - uid: 21299
+  - uid: 21298
     components:
     - type: Transform
       pos: 30.5,15.5
       parent: 2
-  - uid: 21300
+  - uid: 21299
     components:
     - type: Transform
       pos: 6.5,18.5
       parent: 2
-  - uid: 21301
+  - uid: 21300
     components:
     - type: Transform
       pos: 6.5,19.5
       parent: 2
-  - uid: 21302
+  - uid: 21301
     components:
     - type: Transform
       pos: 6.5,20.5
       parent: 2
-  - uid: 21303
+  - uid: 21302
     components:
     - type: Transform
       pos: 5.5,20.5
       parent: 2
-  - uid: 21304
+  - uid: 21303
     components:
     - type: Transform
       pos: 4.5,20.5
       parent: 2
-  - uid: 21305
+  - uid: 21304
     components:
     - type: Transform
       pos: 3.5,20.5
       parent: 2
-  - uid: 21306
+  - uid: 21305
     components:
     - type: Transform
       pos: 2.5,20.5
       parent: 2
-  - uid: 21307
+  - uid: 21306
     components:
     - type: Transform
       pos: 41.5,25.5
       parent: 2
-  - uid: 21308
+  - uid: 21307
     components:
     - type: Transform
       pos: 36.5,27.5
       parent: 2
-  - uid: 21309
+  - uid: 21308
     components:
     - type: Transform
       pos: 44.5,-4.5
       parent: 2
-  - uid: 21310
+  - uid: 21309
     components:
     - type: Transform
       pos: -3.5,-30.5
       parent: 2
-  - uid: 21311
+  - uid: 21310
     components:
     - type: Transform
       pos: -65.5,9.5
       parent: 2
-  - uid: 21312
+  - uid: 21311
     components:
     - type: Transform
       pos: -64.5,9.5
       parent: 2
-  - uid: 21313
+  - uid: 21312
     components:
     - type: Transform
       pos: -63.5,9.5
       parent: 2
-  - uid: 21314
+  - uid: 21313
     components:
     - type: Transform
       pos: -61.5,9.5
       parent: 2
-  - uid: 21315
+  - uid: 21314
     components:
     - type: Transform
       pos: -62.5,9.5
       parent: 2
-  - uid: 21316
+  - uid: 21315
     components:
     - type: Transform
       pos: -60.5,10.5
       parent: 2
-  - uid: 21317
+  - uid: 21316
     components:
     - type: Transform
       pos: -60.5,11.5
       parent: 2
-  - uid: 21318
+  - uid: 21317
     components:
     - type: Transform
       pos: -63.5,12.5
       parent: 2
-  - uid: 21319
+  - uid: 21318
     components:
     - type: Transform
       pos: -64.5,12.5
       parent: 2
-  - uid: 21320
+  - uid: 21319
     components:
     - type: Transform
       pos: -65.5,12.5
       parent: 2
-  - uid: 21321
+  - uid: 21320
     components:
     - type: Transform
       pos: -66.5,12.5
       parent: 2
-  - uid: 21322
+  - uid: 21321
     components:
     - type: Transform
       pos: -68.5,9.5
       parent: 2
-  - uid: 21323
+  - uid: 21322
     components:
     - type: Transform
       pos: -69.5,9.5
       parent: 2
-  - uid: 21324
+  - uid: 21323
     components:
     - type: Transform
       pos: 84.5,-48.5
       parent: 2
-  - uid: 21325
+  - uid: 21324
     components:
     - type: Transform
       pos: 84.5,-49.5
       parent: 2
-  - uid: 21326
+  - uid: 21325
     components:
     - type: Transform
       pos: 84.5,-47.5
       parent: 2
-  - uid: 21327
+  - uid: 21326
     components:
     - type: Transform
       pos: 83.5,-49.5
       parent: 2
 - proto: TableReinforcedGlass
   entities:
-  - uid: 21328
+  - uid: 21327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,6.5
       parent: 2
-  - uid: 21329
+  - uid: 21328
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,7.5
       parent: 2
-  - uid: 21330
+  - uid: 21329
     components:
     - type: Transform
       pos: 5.5,48.5
       parent: 2
-  - uid: 21331
+  - uid: 21330
     components:
     - type: Transform
       pos: 5.5,47.5
       parent: 2
-  - uid: 21332
+  - uid: 21331
     components:
     - type: Transform
       pos: -6.5,30.5
       parent: 2
-  - uid: 21333
+  - uid: 21332
     components:
     - type: Transform
       pos: -6.5,29.5
       parent: 2
-  - uid: 21334
+  - uid: 21333
     components:
     - type: Transform
       pos: -3.5,33.5
       parent: 2
-  - uid: 21335
+  - uid: 21334
     components:
     - type: Transform
       pos: -7.5,25.5
       parent: 2
-  - uid: 21336
+  - uid: 21335
     components:
     - type: Transform
       pos: -38.5,9.5
       parent: 2
-  - uid: 21337
+  - uid: 21336
     components:
     - type: Transform
       pos: -35.5,7.5
       parent: 2
-  - uid: 21338
+  - uid: 21337
     components:
     - type: Transform
       pos: -37.5,3.5
       parent: 2
-  - uid: 21339
+  - uid: 21338
     components:
     - type: Transform
       pos: -38.5,8.5
       parent: 2
-  - uid: 21340
+  - uid: 21339
     components:
     - type: Transform
       pos: -45.5,8.5
       parent: 2
-  - uid: 21341
+  - uid: 21340
     components:
     - type: Transform
       pos: -47.5,30.5
       parent: 2
-  - uid: 21342
+  - uid: 21341
     components:
     - type: Transform
       pos: -46.5,30.5
       parent: 2
-  - uid: 21343
+  - uid: 21342
     components:
     - type: Transform
       pos: 6.5,-43.5
       parent: 2
-  - uid: 21344
+  - uid: 21343
     components:
     - type: Transform
       pos: 10.5,-43.5
       parent: 2
-  - uid: 21345
+  - uid: 21344
     components:
     - type: Transform
       pos: 14.5,-43.5
       parent: 2
-  - uid: 21346
+  - uid: 21345
     components:
     - type: Transform
       pos: -37.5,8.5
       parent: 2
-  - uid: 21347
+  - uid: 21346
     components:
     - type: Transform
       pos: -67.5,41.5
       parent: 2
-  - uid: 21348
+  - uid: 21347
     components:
     - type: Transform
       pos: -66.5,41.5
       parent: 2
-  - uid: 21349
+  - uid: 21348
     components:
     - type: Transform
       pos: -67.5,40.5
       parent: 2
 - proto: TableStone
   entities:
-  - uid: 21350
+  - uid: 21349
     components:
     - type: Transform
       pos: -29.5,36.5
       parent: 2
-  - uid: 21351
+  - uid: 21350
     components:
     - type: Transform
       pos: -28.5,36.5
       parent: 2
-  - uid: 21352
+  - uid: 21351
     components:
     - type: Transform
       pos: -31.5,41.5
       parent: 2
-  - uid: 21353
+  - uid: 21352
     components:
     - type: Transform
       pos: 13.5,-55.5
       parent: 2
-  - uid: 21354
+  - uid: 21353
     components:
     - type: Transform
       pos: 9.5,-59.5
       parent: 2
-  - uid: 21355
+  - uid: 21354
     components:
     - type: Transform
       pos: 8.5,-59.5
       parent: 2
-  - uid: 21356
+  - uid: 21355
     components:
     - type: Transform
       pos: 3.5,-58.5
       parent: 2
-  - uid: 21357
+  - uid: 21356
     components:
     - type: Transform
       pos: 7.5,-59.5
       parent: 2
-  - uid: 21358
+  - uid: 21357
     components:
     - type: Transform
       pos: 12.5,-55.5
       parent: 2
-  - uid: 21359
+  - uid: 21358
     components:
     - type: Transform
       pos: 13.5,-56.5
       parent: 2
-  - uid: 21360
+  - uid: 21359
     components:
     - type: Transform
       pos: 4.5,-58.5
       parent: 2
-  - uid: 21361
+  - uid: 21360
     components:
     - type: Transform
       pos: -0.5,-56.5
       parent: 2
-  - uid: 21362
+  - uid: 21361
     components:
     - type: Transform
       pos: 0.5,-57.5
       parent: 2
-  - uid: 21363
+  - uid: 21362
     components:
     - type: Transform
       pos: -0.5,-55.5
       parent: 2
 - proto: TableWood
   entities:
-  - uid: 21364
+  - uid: 21363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 2
-  - uid: 21365
+  - uid: 21364
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 2
-  - uid: 21366
+  - uid: 21365
     components:
     - type: Transform
       pos: 15.5,-9.5
       parent: 2
-  - uid: 21367
+  - uid: 21366
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-4.5
       parent: 2
-  - uid: 21368
+  - uid: 21367
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-  - uid: 21369
+  - uid: 21368
     components:
     - type: Transform
       pos: -26.5,19.5
       parent: 2
-  - uid: 21370
+  - uid: 21369
     components:
     - type: Transform
       pos: -27.5,19.5
       parent: 2
-  - uid: 21371
+  - uid: 21370
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 2
-  - uid: 21372
+  - uid: 21371
     components:
     - type: Transform
       pos: 16.5,-9.5
       parent: 2
-  - uid: 21373
+  - uid: 21372
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 2
-  - uid: 21374
+  - uid: 21373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 2
-  - uid: 21375
+  - uid: 21374
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 2
-  - uid: 21376
+  - uid: 21375
     components:
     - type: Transform
       pos: 16.5,-6.5
       parent: 2
-  - uid: 21377
+  - uid: 21376
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 2
-  - uid: 21378
+  - uid: 21377
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 2
-  - uid: 21379
+  - uid: 21378
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 2
-  - uid: 21380
+  - uid: 21379
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 2
-  - uid: 21381
+  - uid: 21380
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 2
-  - uid: 21382
+  - uid: 21381
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 2
-  - uid: 21383
+  - uid: 21382
     components:
     - type: Transform
       pos: 10.5,-19.5
       parent: 2
-  - uid: 21384
+  - uid: 21383
     components:
     - type: Transform
       pos: -0.5,45.5
       parent: 2
-  - uid: 21385
+  - uid: 21384
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,36.5
       parent: 2
-  - uid: 21386
+  - uid: 21385
     components:
     - type: Transform
       pos: -28.5,47.5
       parent: 2
-  - uid: 21387
+  - uid: 21386
     components:
     - type: Transform
       pos: -28.5,50.5
       parent: 2
-  - uid: 21388
+  - uid: 21387
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,48.5
       parent: 2
-  - uid: 21389
+  - uid: 21388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,48.5
       parent: 2
-  - uid: 21390
+  - uid: 21389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,50.5
       parent: 2
-  - uid: 21391
+  - uid: 21390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,50.5
       parent: 2
-  - uid: 21392
+  - uid: 21391
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,37.5
       parent: 2
-  - uid: 21393
+  - uid: 21392
     components:
     - type: Transform
       pos: -16.5,45.5
       parent: 2
-  - uid: 21394
+  - uid: 21393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,37.5
       parent: 2
-  - uid: 21395
+  - uid: 21394
     components:
     - type: Transform
       pos: -1.5,44.5
       parent: 2
-  - uid: 21396
+  - uid: 21395
     components:
     - type: Transform
       pos: -17.5,45.5
       parent: 2
-  - uid: 21397
+  - uid: 21396
     components:
     - type: Transform
       pos: -14.5,45.5
       parent: 2
-  - uid: 21398
+  - uid: 21397
     components:
     - type: Transform
       pos: -14.5,47.5
       parent: 2
-  - uid: 21399
+  - uid: 21398
     components:
     - type: Transform
       pos: -15.5,45.5
       parent: 2
-  - uid: 21400
+  - uid: 21399
     components:
     - type: Transform
       pos: -15.5,47.5
       parent: 2
-  - uid: 21401
+  - uid: 21400
     components:
     - type: Transform
       pos: -13.5,45.5
       parent: 2
-  - uid: 21402
+  - uid: 21401
     components:
     - type: Transform
       pos: -4.5,50.5
       parent: 2
-  - uid: 21403
+  - uid: 21402
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,37.5
       parent: 2
-  - uid: 21404
+  - uid: 21403
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,37.5
       parent: 2
-  - uid: 21405
+  - uid: 21404
     components:
     - type: Transform
       pos: -1.5,43.5
       parent: 2
-  - uid: 21406
+  - uid: 21405
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,38.5
       parent: 2
-  - uid: 21407
+  - uid: 21406
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,38.5
       parent: 2
-  - uid: 21408
+  - uid: 21407
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,38.5
       parent: 2
-  - uid: 21409
+  - uid: 21408
     components:
     - type: Transform
       pos: -10.5,35.5
       parent: 2
-  - uid: 21410
+  - uid: 21409
     components:
     - type: Transform
       pos: -29.5,50.5
       parent: 2
-  - uid: 21411
+  - uid: 21410
     components:
     - type: Transform
       pos: -29.5,47.5
       parent: 2
-  - uid: 21412
+  - uid: 21411
     components:
     - type: Transform
       pos: -16.5,47.5
       parent: 2
-  - uid: 21413
+  - uid: 21412
     components:
     - type: Transform
       pos: -1.5,45.5
       parent: 2
-  - uid: 21414
+  - uid: 21413
     components:
     - type: Transform
       pos: -12.5,45.5
       parent: 2
-  - uid: 21415
+  - uid: 21414
     components:
     - type: Transform
       pos: -5.5,23.5
       parent: 2
-  - uid: 21416
+  - uid: 21415
     components:
     - type: Transform
       pos: -4.5,23.5
       parent: 2
-  - uid: 21417
+  - uid: 21416
     components:
     - type: Transform
       pos: -4.5,24.5
       parent: 2
-  - uid: 21418
+  - uid: 21417
     components:
     - type: Transform
       pos: -18.5,45.5
       parent: 2
-  - uid: 21419
+  - uid: 21418
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,4.5
       parent: 2
-  - uid: 21420
+  - uid: 21419
     components:
     - type: Transform
       pos: -6.5,6.5
       parent: 2
-  - uid: 21421
+  - uid: 21420
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 2
-  - uid: 21422
+  - uid: 21421
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 2
-  - uid: 21423
+  - uid: 21422
     components:
     - type: Transform
       pos: -11.5,6.5
       parent: 2
-  - uid: 21424
+  - uid: 21423
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,4.5
       parent: 2
-  - uid: 21425
+  - uid: 21424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,4.5
       parent: 2
-  - uid: 21426
+  - uid: 21425
     components:
     - type: Transform
       pos: -18.5,10.5
       parent: 2
-  - uid: 21427
+  - uid: 21426
     components:
     - type: Transform
       pos: -17.5,10.5
       parent: 2
-  - uid: 21428
+  - uid: 21427
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,9.5
       parent: 2
-  - uid: 21429
+  - uid: 21428
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 2
-  - uid: 21430
+  - uid: 21429
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 2
-  - uid: 21431
+  - uid: 21430
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,7.5
       parent: 2
-  - uid: 21432
+  - uid: 21431
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,7.5
       parent: 2
-  - uid: 21433
+  - uid: 21432
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 2
-  - uid: 21434
+  - uid: 21433
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 2
-  - uid: 21435
+  - uid: 21434
     components:
     - type: Transform
       pos: -17.5,-4.5
       parent: 2
-  - uid: 21436
+  - uid: 21435
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
-  - uid: 21437
+  - uid: 21436
     components:
     - type: Transform
       pos: -16.5,-4.5
       parent: 2
-  - uid: 21438
+  - uid: 21437
     components:
     - type: Transform
       pos: -18.5,-5.5
       parent: 2
-  - uid: 21439
+  - uid: 21438
     components:
     - type: Transform
       pos: -21.5,2.5
       parent: 2
-  - uid: 21440
+  - uid: 21439
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 2
-  - uid: 21441
+  - uid: 21440
     components:
     - type: Transform
       pos: -21.5,5.5
       parent: 2
-  - uid: 21442
+  - uid: 21441
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 2
-  - uid: 21443
+  - uid: 21442
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 2
-  - uid: 21444
+  - uid: 21443
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-15.5
       parent: 2
-  - uid: 21445
+  - uid: 21444
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-15.5
       parent: 2
-  - uid: 21446
+  - uid: 21445
     components:
     - type: Transform
       pos: -1.5,-16.5
       parent: 2
-  - uid: 21447
+  - uid: 21446
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 2
-  - uid: 21448
+  - uid: 21447
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 2
-  - uid: 21449
+  - uid: 21448
     components:
     - type: Transform
       pos: -2.5,-20.5
       parent: 2
-  - uid: 21450
+  - uid: 21449
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 2
-  - uid: 21451
+  - uid: 21450
     components:
     - type: Transform
       pos: -51.5,-2.5
       parent: 2
-  - uid: 21452
+  - uid: 21451
     components:
     - type: Transform
       pos: -50.5,1.5
       parent: 2
-  - uid: 21453
+  - uid: 21452
     components:
     - type: Transform
       pos: -50.5,0.5
       parent: 2
-  - uid: 21454
+  - uid: 21453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,17.5
       parent: 2
-  - uid: 21455
+  - uid: 21454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,16.5
       parent: 2
-  - uid: 21456
+  - uid: 21455
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,20.5
       parent: 2
-  - uid: 21457
+  - uid: 21456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,19.5
       parent: 2
-  - uid: 21458
+  - uid: 21457
     components:
     - type: Transform
       pos: -61.5,20.5
       parent: 2
-  - uid: 21459
+  - uid: 21458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -66.5,14.5
       parent: 2
-  - uid: 21460
+  - uid: 21459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -67.5,14.5
       parent: 2
-  - uid: 21461
+  - uid: 21460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -68.5,14.5
       parent: 2
-  - uid: 21462
+  - uid: 21461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -68.5,15.5
       parent: 2
-  - uid: 21463
+  - uid: 21462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -68.5,16.5
       parent: 2
-  - uid: 21464
+  - uid: 21463
     components:
     - type: Transform
       pos: -61.5,16.5
       parent: 2
-  - uid: 21465
+  - uid: 21464
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -39.5,32.5
       parent: 2
-  - uid: 21466
+  - uid: 21465
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,32.5
       parent: 2
-  - uid: 21467
+  - uid: 21466
     components:
     - type: Transform
       pos: -38.5,28.5
       parent: 2
-  - uid: 21468
+  - uid: 21467
     components:
     - type: Transform
       pos: -38.5,27.5
       parent: 2
-  - uid: 21469
+  - uid: 21468
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-14.5
       parent: 2
-  - uid: 21470
+  - uid: 21469
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-14.5
       parent: 2
-  - uid: 21471
+  - uid: 21470
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-14.5
       parent: 2
-  - uid: 21472
+  - uid: 21471
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-14.5
       parent: 2
-  - uid: 21473
+  - uid: 21472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,-3.5
       parent: 2
-  - uid: 21474
+  - uid: 21473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,-5.5
       parent: 2
-  - uid: 21475
+  - uid: 21474
     components:
     - type: Transform
       pos: 32.5,3.5
       parent: 2
-  - uid: 21476
+  - uid: 21475
     components:
     - type: Transform
       pos: 37.5,4.5
       parent: 2
-  - uid: 21477
+  - uid: 21476
     components:
     - type: Transform
       pos: 38.5,4.5
       parent: 2
-  - uid: 21478
+  - uid: 21477
     components:
     - type: Transform
       pos: 40.5,4.5
       parent: 2
-  - uid: 21479
+  - uid: 21478
     components:
     - type: Transform
       pos: 42.5,4.5
       parent: 2
-  - uid: 21480
+  - uid: 21479
     components:
     - type: Transform
       pos: 41.5,4.5
       parent: 2
-  - uid: 21481
+  - uid: 21480
     components:
     - type: Transform
       pos: 39.5,4.5
       parent: 2
-  - uid: 21482
+  - uid: 21481
     components:
     - type: Transform
       pos: 30.5,1.5
       parent: 2
-  - uid: 21483
+  - uid: 21482
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 64.5,-28.5
       parent: 2
-  - uid: 21484
+  - uid: 21483
     components:
     - type: Transform
       pos: 65.5,-28.5
       parent: 2
-  - uid: 21485
+  - uid: 21484
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,-28.5
       parent: 2
-  - uid: 21486
+  - uid: 21485
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,-32.5
       parent: 2
-  - uid: 21487
+  - uid: 21486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-32.5
       parent: 2
-  - uid: 21488
+  - uid: 21487
     components:
     - type: Transform
       pos: 66.5,-28.5
       parent: 2
-  - uid: 21489
+  - uid: 21488
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 63.5,-28.5
       parent: 2
-  - uid: 21490
+  - uid: 21489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-31.5
       parent: 2
-  - uid: 21491
+  - uid: 21490
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,-29.5
       parent: 2
-  - uid: 21492
+  - uid: 21491
     components:
     - type: Transform
       pos: 60.5,-34.5
       parent: 2
-  - uid: 21493
+  - uid: 21492
     components:
     - type: Transform
       pos: 60.5,-33.5
       parent: 2
-  - uid: 21494
+  - uid: 21493
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-30.5
       parent: 2
-  - uid: 21495
+  - uid: 21494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,-30.5
       parent: 2
-  - uid: 21496
+  - uid: 21495
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,-33.5
       parent: 2
-  - uid: 21497
+  - uid: 21496
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,-32.5
       parent: 2
-  - uid: 21498
+  - uid: 21497
     components:
     - type: Transform
       pos: 41.5,31.5
       parent: 2
-  - uid: 21499
+  - uid: 21498
     components:
     - type: Transform
       pos: 40.5,31.5
       parent: 2
-  - uid: 21500
+  - uid: 21499
     components:
     - type: Transform
       pos: 39.5,31.5
       parent: 2
-  - uid: 21501
+  - uid: 21500
     components:
     - type: Transform
       pos: 36.5,29.5
       parent: 2
-  - uid: 21502
+  - uid: 21501
     components:
     - type: Transform
       pos: 36.5,30.5
       parent: 2
-  - uid: 21503
+  - uid: 21502
     components:
     - type: Transform
       pos: -31.5,21.5
       parent: 2
-  - uid: 21504
+  - uid: 21503
     components:
     - type: Transform
       pos: -32.5,21.5
       parent: 2
-  - uid: 21505
+  - uid: 21504
     components:
     - type: Transform
       pos: -3.5,19.5
       parent: 2
-  - uid: 21506
+  - uid: 21505
     components:
     - type: Transform
       pos: -4.5,19.5
       parent: 2
-  - uid: 21507
+  - uid: 21506
     components:
     - type: Transform
       pos: -2.5,19.5
       parent: 2
-  - uid: 21508
+  - uid: 21507
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 2
-  - uid: 21509
+  - uid: 21508
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 2
-  - uid: 21510
+  - uid: 21509
     components:
     - type: Transform
       pos: 6.5,-15.5
       parent: 2
-  - uid: 21511
+  - uid: 21510
     components:
     - type: Transform
       pos: 6.5,-14.5
       parent: 2
-  - uid: 21512
+  - uid: 21511
     components:
     - type: Transform
       pos: -20.5,-9.5
       parent: 2
-  - uid: 21513
+  - uid: 21512
     components:
     - type: Transform
       pos: -20.5,-10.5
       parent: 2
-  - uid: 21514
+  - uid: 21513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -58.5,-5.5
       parent: 2
-  - uid: 21515
+  - uid: 21514
     components:
     - type: Transform
       pos: -37.5,38.5
       parent: 2
-  - uid: 21516
+  - uid: 21515
     components:
     - type: Transform
       pos: -41.5,38.5
       parent: 2
-  - uid: 21517
+  - uid: 21516
     components:
     - type: Transform
       pos: -40.5,38.5
       parent: 2
-  - uid: 21518
+  - uid: 21517
     components:
     - type: Transform
       pos: -33.5,38.5
       parent: 2
-  - uid: 21519
+  - uid: 21518
     components:
     - type: Transform
       pos: -33.5,35.5
       parent: 2
-  - uid: 21520
+  - uid: 21519
     components:
     - type: Transform
       pos: -38.5,38.5
       parent: 2
-  - uid: 21521
+  - uid: 21520
     components:
     - type: Transform
       pos: -51.5,-6.5
       parent: 2
-  - uid: 21522
+  - uid: 21521
     components:
     - type: Transform
       pos: -52.5,-6.5
       parent: 2
-  - uid: 21523
+  - uid: 21522
     components:
     - type: Transform
       pos: -57.5,7.5
       parent: 2
-  - uid: 21524
+  - uid: 21523
     components:
     - type: Transform
       pos: -54.5,7.5
       parent: 2
-  - uid: 21525
+  - uid: 21524
     components:
     - type: Transform
       pos: -54.5,8.5
       parent: 2
-  - uid: 21526
+  - uid: 21525
     components:
     - type: Transform
       pos: -57.5,8.5
       parent: 2
-  - uid: 21527
+  - uid: 21526
     components:
     - type: Transform
       pos: 69.5,-34.5
       parent: 2
-  - uid: 21528
+  - uid: 21527
     components:
     - type: Transform
       pos: 69.5,-33.5
       parent: 2
-  - uid: 21529
+  - uid: 21528
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 2
 - proto: TargetDarts
   entities:
-  - uid: 21530
+  - uid: 21529
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 2
 - proto: TargetStrange
   entities:
-  - uid: 21531
+  - uid: 21530
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -134818,7 +134820,7 @@ entities:
       parent: 2
 - proto: TargetSyndicate
   entities:
-  - uid: 21532
+  - uid: 21531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -134826,14 +134828,14 @@ entities:
       parent: 2
 - proto: TegCenter
   entities:
-  - uid: 21533
+  - uid: 21532
     components:
     - type: Transform
       pos: 60.5,11.5
       parent: 2
 - proto: TegCirculator
   entities:
-  - uid: 21534
+  - uid: 21533
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -134841,7 +134843,7 @@ entities:
       parent: 2
     - type: PointLight
       color: '#FF3300FF'
-  - uid: 21535
+  - uid: 21534
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -134851,132 +134853,132 @@ entities:
       color: '#FF3300FF'
 - proto: TelecomServerFilledCargo
   entities:
-  - uid: 21536
+  - uid: 21535
     components:
     - type: Transform
       pos: 54.5,33.5
       parent: 2
 - proto: TelecomServerFilledCommand
   entities:
-  - uid: 21537
+  - uid: 21536
     components:
     - type: Transform
       pos: -28.5,31.5
       parent: 2
 - proto: TelecomServerFilledCommon
   entities:
-  - uid: 21538
+  - uid: 21537
     components:
     - type: Transform
       pos: 54.5,32.5
       parent: 2
 - proto: TelecomServerFilledEngineering
   entities:
-  - uid: 21539
+  - uid: 21538
     components:
     - type: Transform
       pos: 56.5,32.5
       parent: 2
 - proto: TelecomServerFilledLaw
   entities:
-  - uid: 21540
+  - uid: 21539
     components:
     - type: Transform
       pos: 54.5,31.5
       parent: 2
 - proto: TelecomServerFilledMedical
   entities:
-  - uid: 21541
+  - uid: 21540
     components:
     - type: Transform
       pos: 56.5,31.5
       parent: 2
 - proto: TelecomServerFilledScience
   entities:
-  - uid: 21542
+  - uid: 21541
     components:
     - type: Transform
       pos: 54.5,30.5
       parent: 2
 - proto: TelecomServerFilledSecurity
   entities:
-  - uid: 21543
+  - uid: 21542
     components:
     - type: Transform
       pos: 56.5,30.5
       parent: 2
 - proto: TelecomServerFilledService
   entities:
-  - uid: 21544
+  - uid: 21543
     components:
     - type: Transform
       pos: 56.5,33.5
       parent: 2
 - proto: TeslaCoil
   entities:
-  - uid: 21545
+  - uid: 21544
     components:
     - type: Transform
       pos: 85.5,23.5
       parent: 2
-  - uid: 21546
+  - uid: 21545
     components:
     - type: Transform
       pos: 80.5,14.5
       parent: 2
-  - uid: 21547
+  - uid: 21546
     components:
     - type: Transform
       pos: 80.5,22.5
       parent: 2
-  - uid: 21548
+  - uid: 21547
     components:
     - type: Transform
       pos: 90.5,18.5
       parent: 2
-  - uid: 21549
+  - uid: 21548
     components:
     - type: Transform
       pos: 90.5,22.5
       parent: 2
-  - uid: 21550
+  - uid: 21549
     components:
     - type: Transform
       pos: 90.5,21.5
       parent: 2
-  - uid: 21551
+  - uid: 21550
     components:
     - type: Transform
       pos: 90.5,15.5
       parent: 2
-  - uid: 21552
+  - uid: 21551
     components:
     - type: Transform
       pos: 80.5,15.5
       parent: 2
-  - uid: 21553
+  - uid: 21552
     components:
     - type: Transform
       pos: 90.5,14.5
       parent: 2
-  - uid: 21554
+  - uid: 21553
     components:
     - type: Transform
       pos: 85.5,13.5
       parent: 2
-  - uid: 21555
+  - uid: 21554
     components:
     - type: Transform
       pos: 80.5,21.5
       parent: 2
-  - uid: 21556
+  - uid: 21555
     components:
     - type: Transform
       pos: 80.5,18.5
       parent: 2
 - proto: TeslaGenerator
   entities:
-  - uid: 21557
+  - uid: 21556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -134984,174 +134986,174 @@ entities:
       parent: 2
 - proto: TeslaGroundingRod
   entities:
-  - uid: 21558
+  - uid: 21557
     components:
     - type: Transform
       pos: 87.5,13.5
       parent: 2
-  - uid: 21559
+  - uid: 21558
     components:
     - type: Transform
       pos: 83.5,13.5
       parent: 2
-  - uid: 21560
+  - uid: 21559
     components:
     - type: Transform
       pos: 83.5,23.5
       parent: 2
-  - uid: 21561
+  - uid: 21560
     components:
     - type: Transform
       pos: 87.5,23.5
       parent: 2
 - proto: TintedWindow
   entities:
-  - uid: 21562
+  - uid: 21561
     components:
     - type: Transform
       pos: -15.5,6.5
       parent: 2
-  - uid: 21563
+  - uid: 21562
     components:
     - type: Transform
       pos: 11.5,-9.5
       parent: 2
-  - uid: 21564
+  - uid: 21563
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 2
-  - uid: 21565
+  - uid: 21564
     components:
     - type: Transform
       pos: -16.5,6.5
       parent: 2
-  - uid: 21566
+  - uid: 21565
     components:
     - type: Transform
       pos: 9.5,-9.5
       parent: 2
-  - uid: 21567
+  - uid: 21566
     components:
     - type: Transform
       pos: -17.5,6.5
       parent: 2
-  - uid: 21568
+  - uid: 21567
     components:
     - type: Transform
       pos: -18.5,6.5
       parent: 2
-  - uid: 21569
+  - uid: 21568
     components:
     - type: Transform
       pos: -36.5,-4.5
       parent: 2
-  - uid: 21570
+  - uid: 21569
     components:
     - type: Transform
       pos: -33.5,-4.5
       parent: 2
-  - uid: 21571
+  - uid: 21570
     components:
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
-  - uid: 21572
+  - uid: 21571
     components:
     - type: Transform
       pos: -27.5,-4.5
       parent: 2
-  - uid: 21573
+  - uid: 21572
     components:
     - type: Transform
       pos: -44.5,-4.5
       parent: 2
-  - uid: 21574
+  - uid: 21573
     components:
     - type: Transform
       pos: -41.5,-4.5
       parent: 2
-  - uid: 21575
+  - uid: 21574
     components:
     - type: Transform
       pos: -43.5,8.5
       parent: 2
-  - uid: 21576
+  - uid: 21575
     components:
     - type: Transform
       pos: -43.5,10.5
       parent: 2
-  - uid: 21577
+  - uid: 21576
     components:
     - type: Transform
       pos: 11.5,-24.5
       parent: 2
-  - uid: 21578
+  - uid: 21577
     components:
     - type: Transform
       pos: 13.5,-24.5
       parent: 2
-  - uid: 21579
+  - uid: 21578
     components:
     - type: Transform
       pos: 12.5,-24.5
       parent: 2
-  - uid: 21580
+  - uid: 21579
     components:
     - type: Transform
       pos: 2.5,-35.5
       parent: 2
-  - uid: 21581
+  - uid: 21580
     components:
     - type: Transform
       pos: 2.5,-36.5
       parent: 2
-  - uid: 21582
+  - uid: 21581
     components:
     - type: Transform
       pos: 2.5,-37.5
       parent: 2
-  - uid: 21583
+  - uid: 21582
     components:
     - type: Transform
       pos: 81.5,-8.5
       parent: 2
-  - uid: 21584
+  - uid: 21583
     components:
     - type: Transform
       pos: 81.5,-9.5
       parent: 2
-  - uid: 21585
+  - uid: 21584
     components:
     - type: Transform
       pos: 81.5,-10.5
       parent: 2
-  - uid: 21586
+  - uid: 21585
     components:
     - type: Transform
       pos: 81.5,-11.5
       parent: 2
-  - uid: 21587
+  - uid: 21586
     components:
     - type: Transform
       pos: 67.5,-43.5
       parent: 2
-  - uid: 21588
+  - uid: 21587
     components:
     - type: Transform
       pos: 67.5,-45.5
       parent: 2
-  - uid: 21589
+  - uid: 21588
     components:
     - type: Transform
       pos: 67.5,-44.5
       parent: 2
-  - uid: 21590
+  - uid: 21589
     components:
     - type: Transform
       pos: 5.5,-9.5
       parent: 2
-  - uid: 21591
+  - uid: 21590
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -135159,7 +135161,7 @@ entities:
       parent: 2
 - proto: ToiletDirtyWater
   entities:
-  - uid: 21592
+  - uid: 21591
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -135167,55 +135169,55 @@ entities:
       parent: 2
 - proto: ToiletDirtyWaterFilled
   entities:
-  - uid: 21593
+  - uid: 21592
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-35.5
       parent: 2
-  - uid: 21594
+  - uid: 21593
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-41.5
       parent: 2
-  - uid: 21595
+  - uid: 21594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-37.5
       parent: 2
-  - uid: 21596
+  - uid: 21595
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-39.5
       parent: 2
-  - uid: 21597
+  - uid: 21596
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-11.5
       parent: 2
-  - uid: 21598
+  - uid: 21597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-9.5
       parent: 2
-  - uid: 21599
+  - uid: 21598
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 77.5,-7.5
       parent: 2
-  - uid: 21600
+  - uid: 21599
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,-21.5
       parent: 2
-  - uid: 21601
+  - uid: 21600
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -135243,7 +135245,7 @@ entities:
       isOpen: True
 - proto: ToiletGoldenDirtyWater
   entities:
-  - uid: 21602
+  - uid: 21601
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -135251,68 +135253,68 @@ entities:
       parent: 2
 - proto: ToolboxElectricalFilled
   entities:
-  - uid: 21603
+  - uid: 21602
     components:
     - type: Transform
       pos: -7.616148,51.316463
       parent: 2
-  - uid: 21604
+  - uid: 21603
     components:
     - type: Transform
       pos: 1.5252552,-29.005726
       parent: 2
 - proto: ToolboxEmergencyFilled
   entities:
-  - uid: 21605
+  - uid: 21604
     components:
     - type: Transform
       pos: -7.485688,51.806026
       parent: 2
-  - uid: 21606
+  - uid: 21605
     components:
     - type: Transform
       pos: -9.633643,1.7259798
       parent: 2
-  - uid: 21607
+  - uid: 21606
     components:
     - type: Transform
       pos: 1.5408802,-29.286976
       parent: 2
-  - uid: 21608
+  - uid: 21607
     components:
     - type: Transform
       pos: -22.666674,-10.771671
       parent: 2
-  - uid: 21609
+  - uid: 21608
     components:
     - type: Transform
       pos: -51.47452,-6.207698
       parent: 2
 - proto: ToolboxGoldFilled
   entities:
-  - uid: 21610
+  - uid: 21609
     components:
     - type: Transform
       pos: -26.64328,28.591188
       parent: 2
 - proto: ToolboxMechanicalFilled
   entities:
-  - uid: 21611
+  - uid: 21610
     components:
     - type: Transform
       pos: -7.412305,51.536766
       parent: 2
-  - uid: 21612
+  - uid: 21611
     components:
     - type: Transform
       pos: -9.493018,1.5228548
       parent: 2
-  - uid: 21613
+  - uid: 21612
     components:
     - type: Transform
       pos: 1.5565052,-29.5526
       parent: 2
-  - uid: 21614
+  - uid: 21613
     components:
     - type: Transform
       pos: -77.45696,-2.0808845
@@ -135398,173 +135400,179 @@ entities:
           - 17416
 - proto: ToolboxSyndicateFilled
   entities:
-  - uid: 21615
+  - uid: 21614
     components:
     - type: Transform
       pos: -49.48351,-8.673055
       parent: 2
 - proto: TowelColorBlue
   entities:
-  - uid: 21616
+  - uid: 21615
     components:
     - type: Transform
       pos: 82.29385,-10.896404
       parent: 2
 - proto: TowelColorGold
   entities:
-  - uid: 21617
+  - uid: 21616
     components:
     - type: Transform
       pos: -28.63916,28.76595
       parent: 2
 - proto: TowelColorNT
   entities:
-  - uid: 21618
+  - uid: 21617
     components:
     - type: Transform
       pos: 5.514326,41.568054
       parent: 2
 - proto: TowelColorWhite
   entities:
-  - uid: 21619
+  - uid: 21618
     components:
     - type: Transform
       pos: -23.644468,37.682213
       parent: 2
-  - uid: 21620
+  - uid: 21619
     components:
     - type: Transform
       pos: -23.628843,37.463463
       parent: 2
-  - uid: 21621
+  - uid: 21620
     components:
     - type: Transform
       pos: -23.331968,37.479088
       parent: 2
-  - uid: 21622
+  - uid: 21621
     components:
     - type: Transform
       pos: -23.378843,37.713463
       parent: 2
-  - uid: 21623
+  - uid: 21622
     components:
     - type: Transform
       pos: 0.42520165,-41.263172
       parent: 2
-  - uid: 21624
+  - uid: 21623
     components:
     - type: Transform
       pos: 0.70645165,-41.614735
       parent: 2
-  - uid: 21625
+  - uid: 21624
     components:
     - type: Transform
       pos: 12.486158,-55.397842
       parent: 2
-  - uid: 21626
+  - uid: 21625
     components:
     - type: Transform
       pos: 12.658033,-55.507217
       parent: 2
-  - uid: 21627
+  - uid: 21626
     components:
     - type: Transform
       pos: 9.541169,-59.4435
       parent: 2
-  - uid: 21628
+  - uid: 21627
     components:
     - type: Transform
       pos: 9.447419,-59.28725
       parent: 2
-  - uid: 21629
+  - uid: 21628
     components:
     - type: Transform
       pos: 0.33032274,-57.271626
       parent: 2
-  - uid: 21630
+  - uid: 21629
     components:
     - type: Transform
       pos: 0.58032274,-57.427876
       parent: 2
 - proto: ToyAi
   entities:
-  - uid: 21631
+  - uid: 21630
     components:
     - type: Transform
       pos: -5.560234,37.663208
       parent: 2
-  - uid: 21632
+  - uid: 21631
     components:
     - type: Transform
       pos: -6.4991302,41.675488
       parent: 2
 - proto: ToyFigurineCaptain
   entities:
-  - uid: 21633
+  - uid: 21632
     components:
     - type: Transform
       pos: -0.96034086,45.638508
       parent: 2
 - proto: ToyFigurineFootsoldier
   entities:
-  - uid: 21634
+  - uid: 21633
     components:
     - type: Transform
       pos: 70.26308,-42.103077
       parent: 2
 - proto: ToyFigurineSecurity
   entities:
-  - uid: 21635
+  - uid: 21634
     components:
     - type: Transform
       pos: 69.67714,-43.181202
       parent: 2
 - proto: ToyFigurineThief
   entities:
-  - uid: 21636
+  - uid: 21635
     components:
     - type: Transform
       pos: 5.4945135,-15.209955
       parent: 2
 - proto: ToyHammer
   entities:
-  - uid: 21637
+  - uid: 21636
     components:
     - type: Transform
       pos: -5.470999,36.81088
       parent: 2
 - proto: ToySword
   entities:
-  - uid: 21638
+  - uid: 21637
     components:
     - type: Transform
       pos: -2.422716,48.696014
       parent: 2
 - proto: TP14KitchenDeepFryer
   entities:
-  - uid: 21639
+  - uid: 21638
     components:
     - type: Transform
       pos: 50.5,0.5
       parent: 2
 - proto: TP14KitchenDeepFryerTabletop
   entities:
-  - uid: 21640
+  - uid: 21639
     components:
     - type: Transform
       pos: -64.5,12.5
       parent: 2
 - proto: TrashBag
   entities:
-  - uid: 21641
+  - uid: 21640
     components:
     - type: Transform
       pos: -0.16333222,-41.552067
       parent: 2
-  - uid: 21642
+  - uid: 21641
     components:
     - type: Transform
       pos: -1.0894527,-32.384636
+      parent: 2
+  - uid: 21642
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 84.5235,-48.80998
       parent: 2
   - uid: 21643
     components:
@@ -135576,7 +135584,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 84.5235,-48.80998
+      pos: 84.5235,-48.99748
       parent: 2
   - uid: 21645
     components:
@@ -135584,44 +135592,38 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 84.5235,-48.99748
       parent: 2
-  - uid: 21646
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 84.5235,-48.99748
-      parent: 2
 - proto: TrashBagBlue
   entities:
-  - uid: 21647
+  - uid: 21646
     components:
     - type: Transform
       pos: 12.867651,-16.41027
       parent: 2
-  - uid: 21648
+  - uid: 21647
     components:
     - type: Transform
       pos: 12.977026,-16.425896
       parent: 2
-  - uid: 21649
+  - uid: 21648
     components:
     - type: Transform
       pos: 12.820776,-16.44152
       parent: 2
 - proto: TrashBananaPeel
   entities:
-  - uid: 21650
+  - uid: 21649
     components:
     - type: Transform
       pos: 25.39254,4.2626696
       parent: 2
-  - uid: 21651
+  - uid: 21650
     components:
     - type: Transform
       pos: 25.51754,4.2782946
       parent: 2
 - proto: TurnstileGenpopEnter
   entities:
-  - uid: 21652
+  - uid: 21651
     components:
     - type: Transform
       pos: 13.5,-5.5
@@ -135630,7 +135632,7 @@ entities:
       accessListsOriginal:
       - - GenpopEnter
       - - Security
-  - uid: 21653
+  - uid: 21652
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -135642,7 +135644,7 @@ entities:
       - - Security
 - proto: TurnstileGenpopLeave
   entities:
-  - uid: 21654
+  - uid: 21653
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -135652,7 +135654,7 @@ entities:
       accessListsOriginal:
       - - GenpopLeave
       - - Security
-  - uid: 21655
+  - uid: 21654
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -135664,7 +135666,7 @@ entities:
       - - Security
 - proto: TwoWayLever
   entities:
-  - uid: 21656
+  - uid: 21655
     components:
     - type: Transform
       pos: -3.5,-29.5
@@ -135692,7 +135694,7 @@ entities:
           - Reverse
         - - Middle
           - Off
-  - uid: 21657
+  - uid: 21656
     components:
     - type: Transform
       pos: -47.5,42.5
@@ -135706,7 +135708,7 @@ entities:
           - Open
         - - Middle
           - Close
-  - uid: 21658
+  - uid: 21657
     components:
     - type: Transform
       pos: 29.5,29.5
@@ -135727,7 +135729,7 @@ entities:
           - Reverse
         - - Middle
           - Off
-        19350:
+        19349:
         - - Left
           - Forward
         - - Right
@@ -135748,7 +135750,7 @@ entities:
           - Reverse
         - - Middle
           - Off
-  - uid: 21659
+  - uid: 21658
     components:
     - type: Transform
       pos: -7.5,-28.5
@@ -135772,7 +135774,7 @@ entities:
           - Reverse
         - - Middle
           - Off
-        19351:
+        19350:
         - - Left
           - Forward
         - - Right
@@ -135793,7 +135795,7 @@ entities:
           - Reverse
         - - Middle
           - Off
-  - uid: 21660
+  - uid: 21659
     components:
     - type: Transform
       pos: 18.5,36.5
@@ -135835,7 +135837,7 @@ entities:
           - Reverse
         - - Middle
           - Off
-  - uid: 21661
+  - uid: 21660
     components:
     - type: Transform
       pos: 24.5,36.5
@@ -135877,13 +135879,20 @@ entities:
           - Reverse
         - - Middle
           - Off
-  - uid: 21662
+  - uid: 21661
     components:
     - type: Transform
       pos: 71.5,18.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
+        20060:
+        - - Left
+          - Open
+        - - Right
+          - Open
+        - - Middle
+          - Close
         20061:
         - - Left
           - Open
@@ -135912,16 +135921,9 @@ entities:
           - Open
         - - Middle
           - Close
-        20065:
-        - - Left
-          - Open
-        - - Right
-          - Open
-        - - Middle
-          - Close
 - proto: UnfinishedMachineFrame
   entities:
-  - uid: 21663
+  - uid: 21662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -135929,7 +135931,7 @@ entities:
       parent: 2
 - proto: UniformPrinter
   entities:
-  - uid: 21664
+  - uid: 21663
     components:
     - type: Transform
       pos: -3.5,31.5
@@ -135943,198 +135945,198 @@ entities:
       - Biochemical
 - proto: UniformShortsRed
   entities:
-  - uid: 21665
+  - uid: 21664
     components:
     - type: Transform
       pos: 55.696598,-20.45949
       parent: 2
-  - uid: 21666
+  - uid: 21665
     components:
     - type: Transform
       pos: 55.727848,-20.631365
       parent: 2
 - proto: UniformShortsRedWithTop
   entities:
-  - uid: 21667
+  - uid: 21666
     components:
     - type: Transform
       pos: 55.352848,-20.30324
       parent: 2
-  - uid: 21668
+  - uid: 21667
     components:
     - type: Transform
       pos: 55.368473,-20.42824
       parent: 2
 - proto: UprightPianoInstrument
   entities:
-  - uid: 21669
+  - uid: 21668
     components:
     - type: Transform
       pos: -12.5,-27.5
       parent: 2
-  - uid: 21670
+  - uid: 21669
     components:
     - type: Transform
       pos: 45.5,2.5
       parent: 2
 - proto: Urn
   entities:
-  - uid: 21671
+  - uid: 21670
     components:
     - type: Transform
       pos: -1.345153,25.689543
       parent: 2
 - proto: Vaccinator
   entities:
-  - uid: 21672
+  - uid: 21671
     components:
     - type: Transform
       pos: -23.5,-19.5
       parent: 2
 - proto: VendingBarDrobe
   entities:
-  - uid: 21673
+  - uid: 21672
     components:
     - type: Transform
       pos: 30.5,3.5
       parent: 2
-  - uid: 21674
+  - uid: 21673
     components:
     - type: Transform
       pos: 68.5,-31.5
       parent: 2
 - proto: VendingMachineAtmosDrobe
   entities:
-  - uid: 21675
+  - uid: 21674
     components:
     - type: Transform
       pos: 40.5,6.5
       parent: 2
 - proto: VendingMachineBooze
   entities:
-  - uid: 21676
+  - uid: 21675
     components:
     - type: Transform
       pos: 0.5,47.5
       parent: 2
-  - uid: 21677
+  - uid: 21676
     components:
     - type: Transform
       pos: -4.5,26.5
       parent: 2
-  - uid: 21678
+  - uid: 21677
     components:
     - type: Transform
       pos: 34.5,-4.5
       parent: 2
-  - uid: 21679
+  - uid: 21678
     components:
     - type: Transform
       pos: 30.5,5.5
       parent: 2
-  - uid: 21680
+  - uid: 21679
     components:
     - type: Transform
       pos: 66.5,-34.5
       parent: 2
-  - uid: 21681
+  - uid: 21680
     components:
     - type: Transform
       pos: -39.5,38.5
       parent: 2
 - proto: VendingMachineCargoDrobe
   entities:
-  - uid: 21682
+  - uid: 21681
     components:
     - type: Transform
       pos: 18.5,22.5
       parent: 2
-  - uid: 21683
+  - uid: 21682
     components:
     - type: Transform
       pos: 22.5,26.5
       parent: 2
 - proto: VendingMachineCart
   entities:
-  - uid: 21684
+  - uid: 21683
     components:
     - type: Transform
       pos: -3.5,28.5
       parent: 2
 - proto: VendingMachineChang
   entities:
-  - uid: 21685
+  - uid: 21684
     components:
     - type: Transform
       pos: 31.5,-41.5
       parent: 2
 - proto: VendingMachineChapel
   entities:
-  - uid: 21686
+  - uid: 21685
     components:
     - type: Transform
       pos: -68.5,18.5
       parent: 2
 - proto: VendingMachineChefDrobe
   entities:
-  - uid: 21687
+  - uid: 21686
     components:
     - type: Transform
       pos: 48.5,0.5
       parent: 2
 - proto: VendingMachineChefvend
   entities:
-  - uid: 21688
+  - uid: 21687
     components:
     - type: Transform
       pos: 56.5,-6.5
       parent: 2
 - proto: VendingMachineChemDrobe
   entities:
-  - uid: 21689
+  - uid: 21688
     components:
     - type: Transform
       pos: -35.5,10.5
       parent: 2
 - proto: VendingMachineChemicals
   entities:
-  - uid: 21690
+  - uid: 21689
     components:
     - type: Transform
       pos: -34.5,10.5
       parent: 2
 - proto: VendingMachineCigs
   entities:
-  - uid: 21691
+  - uid: 21690
     components:
     - type: Transform
       pos: 11.5,-6.5
       parent: 2
-  - uid: 21692
+  - uid: 21691
     components:
     - type: Transform
       pos: -27.5,45.5
       parent: 2
-  - uid: 21693
+  - uid: 21692
     components:
     - type: Transform
       pos: -18.5,0.5
       parent: 2
-  - uid: 21694
+  - uid: 21693
     components:
     - type: Transform
       pos: 29.5,1.5
       parent: 2
 - proto: VendingMachineClothing
   entities:
-  - uid: 21695
+  - uid: 21694
     components:
     - type: Transform
       pos: 9.5,-34.5
       parent: 2
 - proto: VendingMachineClown
   entities:
-  - uid: 21696
+  - uid: 21695
     components:
     - type: Transform
       pos: 21.5,3.5
@@ -136143,285 +136145,285 @@ entities:
       processingListings: {}
 - proto: VendingMachineCoffee
   entities:
-  - uid: 21697
+  - uid: 21696
     components:
     - type: Transform
       pos: 10.5,-6.5
       parent: 2
-  - uid: 21698
+  - uid: 21697
     components:
     - type: Transform
       pos: -18.5,1.5
       parent: 2
 - proto: VendingMachineCondiments
   entities:
-  - uid: 21699
+  - uid: 21698
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 2
 - proto: VendingMachineDetDrobe
   entities:
-  - uid: 21700
+  - uid: 21699
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 2
 - proto: VendingMachineDinnerware
   entities:
-  - uid: 21701
+  - uid: 21700
     components:
     - type: Transform
       pos: 46.5,0.5
       parent: 2
 - proto: VendingMachineDiscount
   entities:
-  - uid: 21702
+  - uid: 21701
     components:
     - type: Transform
       pos: -55.5,5.5
       parent: 2
 - proto: VendingMachineDonut
   entities:
-  - uid: 21703
+  - uid: 21702
     components:
     - type: Transform
       pos: -11.5,1.5
       parent: 2
 - proto: VendingMachineEngiDrobe
   entities:
-  - uid: 21704
+  - uid: 21703
     components:
     - type: Transform
       pos: 41.5,27.5
       parent: 2
 - proto: VendingMachineEngivend
   entities:
-  - uid: 21705
+  - uid: 21704
     components:
     - type: Transform
       pos: 36.5,24.5
       parent: 2
 - proto: VendingMachineHappyHonk
   entities:
-  - uid: 21706
+  - uid: 21705
     components:
     - type: Transform
       pos: 47.5,0.5
       parent: 2
 - proto: VendingMachineHydrobe
   entities:
-  - uid: 21707
+  - uid: 21706
     components:
     - type: Transform
       pos: 53.5,-0.5
       parent: 2
 - proto: VendingMachineJaniDrobe
   entities:
-  - uid: 21708
+  - uid: 21707
     components:
     - type: Transform
       pos: 16.5,-16.5
       parent: 2
 - proto: VendingMachineLawDrobe
   entities:
-  - uid: 21709
+  - uid: 21708
     components:
     - type: Transform
       pos: -18.5,3.5
       parent: 2
 - proto: VendingMachineMedical
   entities:
-  - uid: 21710
+  - uid: 21709
     components:
     - type: Transform
       pos: -26.5,2.5
       parent: 2
-  - uid: 21711
+  - uid: 21710
     components:
     - type: Transform
       pos: -26.5,-0.5
       parent: 2
 - proto: VendingMachineMedicalBase
   entities:
-  - uid: 21712
+  - uid: 21711
     components:
     - type: Transform
       pos: 50.5,-12.5
       parent: 2
 - proto: VendingMachineMediDrobe
   entities:
-  - uid: 21713
+  - uid: 21712
     components:
     - type: Transform
       pos: -54.5,5.5
       parent: 2
 - proto: VendingMachineNutri
   entities:
-  - uid: 21714
+  - uid: 21713
     components:
     - type: Transform
       pos: 57.5,-0.5
       parent: 2
 - proto: VendingMachinePride
   entities:
-  - uid: 21715
+  - uid: 21714
     components:
     - type: Transform
       pos: 17.5,-14.5
       parent: 2
-  - uid: 21716
+  - uid: 21715
     components:
     - type: Transform
       pos: 50.5,-14.5
       parent: 2
 - proto: VendingMachineRoboDrobe
   entities:
-  - uid: 21717
+  - uid: 21716
     components:
     - type: Transform
       pos: -65.5,33.5
       parent: 2
 - proto: VendingMachineRobotics
   entities:
-  - uid: 21718
+  - uid: 21717
     components:
     - type: Transform
       pos: -68.5,26.5
       parent: 2
-  - uid: 21719
+  - uid: 21718
     components:
     - type: Transform
       pos: 2.5,18.5
       parent: 2
 - proto: VendingMachineSalvage
   entities:
-  - uid: 21720
+  - uid: 21719
     components:
     - type: Transform
       pos: 30.5,36.5
       parent: 2
 - proto: VendingMachineSciDrobe
   entities:
-  - uid: 21721
+  - uid: 21720
     components:
     - type: Transform
       pos: -47.5,39.5
       parent: 2
 - proto: VendingMachineSec
   entities:
-  - uid: 21722
+  - uid: 21721
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 2
 - proto: VendingMachineSecDrobe
   entities:
-  - uid: 21723
+  - uid: 21722
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 2
 - proto: VendingMachineSeeds
   entities:
-  - uid: 21724
+  - uid: 21723
     components:
     - type: Transform
       pos: 57.5,0.5
       parent: 2
 - proto: VendingMachineSeedsUnlocked
   entities:
-  - uid: 21725
+  - uid: 21724
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 2
 - proto: VendingMachineSustenance
   entities:
-  - uid: 21726
+  - uid: 21725
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 21727
+  - uid: 21726
     components:
     - type: Transform
       pos: 70.5,-20.5
       parent: 2
-  - uid: 21728
+  - uid: 21727
     components:
     - type: Transform
       pos: 34.5,36.5
       parent: 2
-  - uid: 21729
+  - uid: 21728
     components:
     - type: Transform
       pos: -8.5,21.5
       parent: 2
-  - uid: 21730
+  - uid: 21729
     components:
     - type: Transform
       pos: 33.5,-35.5
       parent: 2
-  - uid: 21731
+  - uid: 21730
     components:
     - type: Transform
       pos: 55.5,-50.5
       parent: 2
 - proto: VendingMachineTheater
   entities:
-  - uid: 21732
+  - uid: 21731
     components:
     - type: Transform
       pos: 13.5,-9.5
       parent: 2
-  - uid: 21733
+  - uid: 21732
     components:
     - type: Transform
       pos: 8.5,-34.5
       parent: 2
 - proto: VendingMachineWallMedicalCivilian
   entities:
-  - uid: 21734
+  - uid: 21733
     components:
     - type: Transform
       pos: -3.5,17.5
       parent: 2
-  - uid: 21735
+  - uid: 21734
     components:
     - type: Transform
       pos: -12.5,34.5
       parent: 2
-  - uid: 21736
+  - uid: 21735
     components:
     - type: Transform
       pos: 56.5,-7.5
       parent: 2
-  - uid: 21737
+  - uid: 21736
     components:
     - type: Transform
       pos: 79.5,-12.5
       parent: 2
-  - uid: 21738
+  - uid: 21737
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-28.5
       parent: 2
-  - uid: 21739
+  - uid: 21738
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 54.5,-35.5
       parent: 2
-  - uid: 21740
+  - uid: 21739
     components:
     - type: Transform
       pos: 22.5,16.5
       parent: 2
-  - uid: 21741
+  - uid: 21740
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -136429,307 +136431,307 @@ entities:
       parent: 2
 - proto: VendingMachineWinter
   entities:
-  - uid: 21742
+  - uid: 21741
     components:
     - type: Transform
       pos: 6.5,-26.5
       parent: 2
-  - uid: 21743
+  - uid: 21742
     components:
     - type: Transform
       pos: 42.5,-14.5
       parent: 2
-  - uid: 21744
+  - uid: 21743
     components:
     - type: Transform
       pos: 6.5,16.5
       parent: 2
-  - uid: 21745
+  - uid: 21744
     components:
     - type: Transform
       pos: 28.5,13.5
       parent: 2
 - proto: VendingMachineYouTool
   entities:
-  - uid: 21746
+  - uid: 21745
     components:
     - type: Transform
       pos: 4.5,-28.5
       parent: 2
-  - uid: 21747
+  - uid: 21746
     components:
     - type: Transform
       pos: 36.5,25.5
       parent: 2
-  - uid: 21748
+  - uid: 21747
     components:
     - type: Transform
       pos: 31.5,-35.5
       parent: 2
 - proto: WallBasaltCobblebrick
   entities:
-  - uid: 21749
+  - uid: 21748
     components:
     - type: Transform
       pos: -3.5,-62.5
       parent: 2
-  - uid: 21750
+  - uid: 21749
     components:
     - type: Transform
       pos: -6.5,-60.5
       parent: 2
-  - uid: 21751
+  - uid: 21750
     components:
     - type: Transform
       pos: 0.5,-63.5
       parent: 2
-  - uid: 21752
+  - uid: 21751
     components:
     - type: Transform
       pos: -4.5,-61.5
       parent: 2
-  - uid: 21753
+  - uid: 21752
     components:
     - type: Transform
       pos: -3.5,-61.5
       parent: 2
-  - uid: 21754
+  - uid: 21753
     components:
     - type: Transform
       pos: -1.5,-62.5
       parent: 2
-  - uid: 21755
+  - uid: 21754
     components:
     - type: Transform
       pos: -2.5,-62.5
       parent: 2
-  - uid: 21756
+  - uid: 21755
     components:
     - type: Transform
       pos: -0.5,-62.5
       parent: 2
-  - uid: 21757
+  - uid: 21756
     components:
     - type: Transform
       pos: 17.5,-61.5
       parent: 2
-  - uid: 21758
+  - uid: 21757
     components:
     - type: Transform
       pos: -0.5,-63.5
       parent: 2
-  - uid: 21759
+  - uid: 21758
     components:
     - type: Transform
       pos: 2.5,-64.5
       parent: 2
-  - uid: 21760
+  - uid: 21759
     components:
     - type: Transform
       pos: 2.5,-63.5
       parent: 2
-  - uid: 21761
+  - uid: 21760
     components:
     - type: Transform
       pos: 1.5,-63.5
       parent: 2
-  - uid: 21762
+  - uid: 21761
     components:
     - type: Transform
       pos: 6.5,-64.5
       parent: 2
-  - uid: 21763
+  - uid: 21762
     components:
     - type: Transform
       pos: 4.5,-64.5
       parent: 2
-  - uid: 21764
+  - uid: 21763
     components:
     - type: Transform
       pos: 7.5,-65.5
       parent: 2
-  - uid: 21765
+  - uid: 21764
     components:
     - type: Transform
       pos: 5.5,-64.5
       parent: 2
-  - uid: 21766
+  - uid: 21765
     components:
     - type: Transform
       pos: 6.5,-65.5
       parent: 2
-  - uid: 21767
+  - uid: 21766
     components:
     - type: Transform
       pos: 3.5,-64.5
       parent: 2
-  - uid: 21768
+  - uid: 21767
     components:
     - type: Transform
       pos: 8.5,-65.5
       parent: 2
-  - uid: 21769
+  - uid: 21768
     components:
     - type: Transform
       pos: 10.5,-65.5
       parent: 2
-  - uid: 21770
+  - uid: 21769
     components:
     - type: Transform
       pos: 9.5,-65.5
       parent: 2
-  - uid: 21771
+  - uid: 21770
     components:
     - type: Transform
       pos: 12.5,-65.5
       parent: 2
-  - uid: 21772
+  - uid: 21771
     components:
     - type: Transform
       pos: 11.5,-65.5
       parent: 2
-  - uid: 21773
+  - uid: 21772
     components:
     - type: Transform
       pos: 12.5,-64.5
       parent: 2
-  - uid: 21774
+  - uid: 21773
     components:
     - type: Transform
       pos: 13.5,-64.5
       parent: 2
-  - uid: 21775
+  - uid: 21774
     components:
     - type: Transform
       pos: 14.5,-63.5
       parent: 2
-  - uid: 21776
+  - uid: 21775
     components:
     - type: Transform
       pos: 14.5,-64.5
       parent: 2
-  - uid: 21777
+  - uid: 21776
     components:
     - type: Transform
       pos: -4.5,-60.5
       parent: 2
-  - uid: 21778
+  - uid: 21777
     components:
     - type: Transform
       pos: -5.5,-60.5
       parent: 2
-  - uid: 21779
+  - uid: 21778
     components:
     - type: Transform
       pos: 15.5,-63.5
       parent: 2
-  - uid: 21780
+  - uid: 21779
     components:
     - type: Transform
       pos: 16.5,-63.5
       parent: 2
-  - uid: 21781
+  - uid: 21780
     components:
     - type: Transform
       pos: 16.5,-62.5
       parent: 2
-  - uid: 21782
+  - uid: 21781
     components:
     - type: Transform
       pos: 17.5,-62.5
       parent: 2
-  - uid: 21783
+  - uid: 21782
     components:
     - type: Transform
       pos: 19.5,-61.5
       parent: 2
-  - uid: 21784
+  - uid: 21783
     components:
     - type: Transform
       pos: 18.5,-61.5
       parent: 2
 - proto: WallCobblebrick
   entities:
-  - uid: 21785
+  - uid: 21784
     components:
     - type: Transform
       pos: 80.5,-39.5
       parent: 2
-  - uid: 21786
+  - uid: 21785
     components:
     - type: Transform
       pos: 83.5,-37.5
       parent: 2
-  - uid: 21787
+  - uid: 21786
     components:
     - type: Transform
       pos: 79.5,-39.5
       parent: 2
-  - uid: 21788
+  - uid: 21787
     components:
     - type: Transform
       pos: 80.5,-38.5
       parent: 2
-  - uid: 21789
+  - uid: 21788
     components:
     - type: Transform
       pos: 80.5,-37.5
       parent: 2
-  - uid: 21790
+  - uid: 21789
     components:
     - type: Transform
       pos: 81.5,-37.5
       parent: 2
-  - uid: 21791
+  - uid: 21790
     components:
     - type: Transform
       pos: 82.5,-37.5
       parent: 2
-  - uid: 21792
+  - uid: 21791
     components:
     - type: Transform
       pos: 79.5,-49.5
       parent: 2
-  - uid: 21793
+  - uid: 21792
     components:
     - type: Transform
       pos: 80.5,-49.5
       parent: 2
-  - uid: 21794
+  - uid: 21793
     components:
     - type: Transform
       pos: 85.5,-43.5
       parent: 2
-  - uid: 21795
+  - uid: 21794
     components:
     - type: Transform
       pos: 86.5,-42.5
       parent: 2
-  - uid: 21796
+  - uid: 21795
     components:
     - type: Transform
       pos: 86.5,-41.5
       parent: 2
-  - uid: 21797
+  - uid: 21796
     components:
     - type: Transform
       pos: 86.5,-40.5
       parent: 2
-  - uid: 21798
+  - uid: 21797
     components:
     - type: Transform
       pos: 86.5,-43.5
       parent: 2
 - proto: WallmountMassScanner
   entities:
-  - uid: 21799
+  - uid: 21798
     components:
     - type: Transform
       pos: 13.5,16.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 21800
+  - uid: 21799
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -136737,7 +136739,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 21801
+  - uid: 21800
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -136747,7 +136749,7 @@ entities:
       fixtures: {}
 - proto: WallmountTelescreen
   entities:
-  - uid: 21802
+  - uid: 21801
     components:
     - type: Transform
       pos: -0.5,45.5
@@ -136756,7624 +136758,7624 @@ entities:
       fixtures: {}
 - proto: WallReinforced
   entities:
-  - uid: 21803
+  - uid: 21802
     components:
     - type: Transform
       pos: -65.5,36.5
       parent: 2
-  - uid: 21804
+  - uid: 21803
     components:
     - type: Transform
       pos: 10.5,-5.5
       parent: 2
-  - uid: 21805
+  - uid: 21804
     components:
     - type: Transform
       pos: 9.5,-13.5
       parent: 2
-  - uid: 21806
+  - uid: 21805
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 2
-  - uid: 21807
+  - uid: 21806
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-10.5
       parent: 2
-  - uid: 21808
+  - uid: 21807
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-10.5
       parent: 2
-  - uid: 21809
+  - uid: 21808
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-10.5
       parent: 2
-  - uid: 21810
+  - uid: 21809
     components:
     - type: Transform
       pos: 10.5,-4.5
       parent: 2
-  - uid: 21811
+  - uid: 21810
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-10.5
       parent: 2
-  - uid: 21812
+  - uid: 21811
     components:
     - type: Transform
       pos: -70.5,44.5
       parent: 2
-  - uid: 21813
+  - uid: 21812
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 2
-  - uid: 21814
+  - uid: 21813
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,11.5
       parent: 2
-  - uid: 21815
+  - uid: 21814
     components:
     - type: Transform
       pos: 17.5,-10.5
       parent: 2
-  - uid: 21816
+  - uid: 21815
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-17.5
       parent: 2
-  - uid: 21817
+  - uid: 21816
     components:
     - type: Transform
       pos: 12.5,-13.5
       parent: 2
-  - uid: 21818
+  - uid: 21817
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 2
-  - uid: 21819
+  - uid: 21818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-17.5
       parent: 2
-  - uid: 21820
+  - uid: 21819
     components:
     - type: Transform
       pos: 7.5,-13.5
       parent: 2
-  - uid: 21821
+  - uid: 21820
     components:
     - type: Transform
       pos: 5.5,-13.5
       parent: 2
-  - uid: 21822
+  - uid: 21821
     components:
     - type: Transform
       pos: 10.5,-13.5
       parent: 2
-  - uid: 21823
+  - uid: 21822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-10.5
       parent: 2
-  - uid: 21824
+  - uid: 21823
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-11.5
       parent: 2
-  - uid: 21825
+  - uid: 21824
     components:
     - type: Transform
       pos: -71.5,43.5
       parent: 2
-  - uid: 21826
+  - uid: 21825
     components:
     - type: Transform
       pos: -73.5,42.5
       parent: 2
-  - uid: 21827
+  - uid: 21826
     components:
     - type: Transform
       pos: -65.5,47.5
       parent: 2
-  - uid: 21828
+  - uid: 21827
     components:
     - type: Transform
       pos: -69.5,47.5
       parent: 2
-  - uid: 21829
+  - uid: 21828
     components:
     - type: Transform
       pos: -70.5,36.5
       parent: 2
-  - uid: 21830
+  - uid: 21829
     components:
     - type: Transform
       pos: -70.5,34.5
       parent: 2
-  - uid: 21831
+  - uid: 21830
     components:
     - type: Transform
       pos: -70.5,35.5
       parent: 2
-  - uid: 21832
+  - uid: 21831
     components:
     - type: Transform
       pos: -65.5,45.5
       parent: 2
-  - uid: 21833
+  - uid: 21832
     components:
     - type: Transform
       pos: -65.5,46.5
       parent: 2
-  - uid: 21834
+  - uid: 21833
     components:
     - type: Transform
       pos: -65.5,44.5
       parent: 2
-  - uid: 21835
+  - uid: 21834
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-2.5
       parent: 2
-  - uid: 21836
+  - uid: 21835
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-1.5
       parent: 2
-  - uid: 21837
+  - uid: 21836
     components:
     - type: Transform
       pos: 11.5,-13.5
       parent: 2
-  - uid: 21838
+  - uid: 21837
     components:
     - type: Transform
       pos: 12.5,-5.5
       parent: 2
-  - uid: 21839
+  - uid: 21838
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-5.5
       parent: 2
-  - uid: 21840
+  - uid: 21839
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-5.5
       parent: 2
-  - uid: 21841
+  - uid: 21840
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -73.5,43.5
       parent: 2
-  - uid: 21842
+  - uid: 21841
     components:
     - type: Transform
       pos: -70.5,45.5
       parent: 2
-  - uid: 21843
+  - uid: 21842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -70.5,37.5
       parent: 2
-  - uid: 21844
+  - uid: 21843
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 2
-  - uid: 21845
+  - uid: 21844
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-1.5
       parent: 2
-  - uid: 21846
+  - uid: 21845
     components:
     - type: Transform
       pos: 14.5,-1.5
       parent: 2
-  - uid: 21847
+  - uid: 21846
     components:
     - type: Transform
       pos: 9.5,11.5
       parent: 2
-  - uid: 21848
+  - uid: 21847
     components:
     - type: Transform
       pos: 4.5,-13.5
       parent: 2
-  - uid: 21849
+  - uid: 21848
     components:
     - type: Transform
       pos: 58.5,7.5
       parent: 2
-  - uid: 21850
+  - uid: 21849
     components:
     - type: Transform
       pos: 52.5,7.5
       parent: 2
-  - uid: 21851
+  - uid: 21850
     components:
     - type: Transform
       pos: 52.5,5.5
       parent: 2
-  - uid: 21852
+  - uid: 21851
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 57.5,4.5
       parent: 2
-  - uid: 21853
+  - uid: 21852
     components:
     - type: Transform
       pos: 58.5,5.5
       parent: 2
-  - uid: 21854
+  - uid: 21853
     components:
     - type: Transform
       pos: 58.5,6.5
       parent: 2
-  - uid: 21855
+  - uid: 21854
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 53.5,4.5
       parent: 2
-  - uid: 21856
+  - uid: 21855
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,4.5
       parent: 2
-  - uid: 21857
+  - uid: 21856
     components:
     - type: Transform
       pos: 55.5,6.5
       parent: 2
-  - uid: 21858
+  - uid: 21857
     components:
     - type: Transform
       pos: 55.5,7.5
       parent: 2
-  - uid: 21859
+  - uid: 21858
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,5.5
       parent: 2
-  - uid: 21860
+  - uid: 21859
     components:
     - type: Transform
       pos: 52.5,6.5
       parent: 2
-  - uid: 21861
+  - uid: 21860
     components:
     - type: Transform
       pos: 38.5,33.5
       parent: 2
-  - uid: 21862
+  - uid: 21861
     components:
     - type: Transform
       pos: 38.5,38.5
       parent: 2
-  - uid: 21863
+  - uid: 21862
     components:
     - type: Transform
       pos: -12.5,34.5
       parent: 2
-  - uid: 21864
+  - uid: 21863
     components:
     - type: Transform
       pos: 6.5,39.5
       parent: 2
-  - uid: 21865
+  - uid: 21864
     components:
     - type: Transform
       pos: 4.5,39.5
       parent: 2
-  - uid: 21866
+  - uid: 21865
     components:
     - type: Transform
       pos: -6.5,45.5
       parent: 2
-  - uid: 21867
+  - uid: 21866
     components:
     - type: Transform
       pos: 1.5,37.5
       parent: 2
-  - uid: 21868
+  - uid: 21867
     components:
     - type: Transform
       pos: -30.5,45.5
       parent: 2
-  - uid: 21869
+  - uid: 21868
     components:
     - type: Transform
       pos: -24.5,27.5
       parent: 2
-  - uid: 21870
+  - uid: 21869
     components:
     - type: Transform
       pos: 2.5,45.5
       parent: 2
-  - uid: 21871
+  - uid: 21870
     components:
     - type: Transform
       pos: -23.5,27.5
       parent: 2
-  - uid: 21872
+  - uid: 21871
     components:
     - type: Transform
       pos: -6.5,50.5
       parent: 2
-  - uid: 21873
+  - uid: 21872
     components:
     - type: Transform
       pos: 0.5,50.5
       parent: 2
-  - uid: 21874
+  - uid: 21873
     components:
     - type: Transform
       pos: 1.5,40.5
       parent: 2
-  - uid: 21875
+  - uid: 21874
     components:
     - type: Transform
       pos: 0.5,42.5
       parent: 2
-  - uid: 21876
+  - uid: 21875
     components:
     - type: Transform
       pos: 6.5,42.5
       parent: 2
-  - uid: 21877
+  - uid: 21876
     components:
     - type: Transform
       pos: -6.5,51.5
       parent: 2
-  - uid: 21878
+  - uid: 21877
     components:
     - type: Transform
       pos: -0.5,34.5
       parent: 2
-  - uid: 21879
+  - uid: 21878
     components:
     - type: Transform
       pos: 6.5,41.5
       parent: 2
-  - uid: 21880
+  - uid: 21879
     components:
     - type: Transform
       pos: -7.5,34.5
       parent: 2
-  - uid: 21881
+  - uid: 21880
     components:
     - type: Transform
       pos: 58.5,-35.5
       parent: 2
-  - uid: 21882
+  - uid: 21881
     components:
     - type: Transform
       pos: -18.5,38.5
       parent: 2
-  - uid: 21883
+  - uid: 21882
     components:
     - type: Transform
       pos: -29.5,31.5
       parent: 2
-  - uid: 21884
+  - uid: 21883
     components:
     - type: Transform
       pos: -32.5,40.5
       parent: 2
-  - uid: 21885
+  - uid: 21884
     components:
     - type: Transform
       pos: 2.5,36.5
       parent: 2
-  - uid: 21886
+  - uid: 21885
     components:
     - type: Transform
       pos: 5.5,39.5
       parent: 2
-  - uid: 21887
+  - uid: 21886
     components:
     - type: Transform
       pos: -25.5,33.5
       parent: 2
-  - uid: 21888
+  - uid: 21887
     components:
     - type: Transform
       pos: -2.5,33.5
       parent: 2
-  - uid: 21889
+  - uid: 21888
     components:
     - type: Transform
       pos: -30.5,42.5
       parent: 2
-  - uid: 21890
+  - uid: 21889
     components:
     - type: Transform
       pos: -6.5,35.5
       parent: 2
-  - uid: 21891
+  - uid: 21890
     components:
     - type: Transform
       pos: 7.5,44.5
       parent: 2
-  - uid: 21892
+  - uid: 21891
     components:
     - type: Transform
       pos: -32.5,39.5
       parent: 2
-  - uid: 21893
+  - uid: 21892
     components:
     - type: Transform
       pos: -31.5,42.5
       parent: 2
-  - uid: 21894
+  - uid: 21893
     components:
     - type: Transform
       pos: -2.5,38.5
       parent: 2
-  - uid: 21895
+  - uid: 21894
     components:
     - type: Transform
       pos: -23.5,42.5
       parent: 2
-  - uid: 21896
+  - uid: 21895
     components:
     - type: Transform
       pos: 2.5,41.5
       parent: 2
-  - uid: 21897
+  - uid: 21896
     components:
     - type: Transform
       pos: 2.5,40.5
       parent: 2
-  - uid: 21898
+  - uid: 21897
     components:
     - type: Transform
       pos: 2.5,35.5
       parent: 2
-  - uid: 21899
+  - uid: 21898
     components:
     - type: Transform
       pos: 2.5,34.5
       parent: 2
-  - uid: 21900
+  - uid: 21899
     components:
     - type: Transform
       pos: 2.5,39.5
       parent: 2
-  - uid: 21901
+  - uid: 21900
     components:
     - type: Transform
       pos: 2.5,38.5
       parent: 2
-  - uid: 21902
+  - uid: 21901
     components:
     - type: Transform
       pos: 2.5,37.5
       parent: 2
-  - uid: 21903
+  - uid: 21902
     components:
     - type: Transform
       pos: 2.5,43.5
       parent: 2
-  - uid: 21904
+  - uid: 21903
     components:
     - type: Transform
       pos: 0.5,51.5
       parent: 2
-  - uid: 21905
+  - uid: 21904
     components:
     - type: Transform
       pos: -69.5,23.5
       parent: 2
-  - uid: 21906
+  - uid: 21905
     components:
     - type: Transform
       pos: -16.5,38.5
       parent: 2
-  - uid: 21907
+  - uid: 21906
     components:
     - type: Transform
       pos: -14.5,38.5
       parent: 2
-  - uid: 21908
+  - uid: 21907
     components:
     - type: Transform
       pos: -22.5,38.5
       parent: 2
-  - uid: 21909
+  - uid: 21908
     components:
     - type: Transform
       pos: -22.5,37.5
       parent: 2
-  - uid: 21910
+  - uid: 21909
     components:
     - type: Transform
       pos: -12.5,37.5
       parent: 2
-  - uid: 21911
+  - uid: 21910
     components:
     - type: Transform
       pos: -22.5,35.5
       parent: 2
-  - uid: 21912
+  - uid: 21911
     components:
     - type: Transform
       pos: -23.5,33.5
       parent: 2
-  - uid: 21913
+  - uid: 21912
     components:
     - type: Transform
       pos: -24.5,33.5
       parent: 2
-  - uid: 21914
+  - uid: 21913
     components:
     - type: Transform
       pos: -23.5,32.5
       parent: 2
-  - uid: 21915
+  - uid: 21914
     components:
     - type: Transform
       pos: -23.5,31.5
       parent: 2
-  - uid: 21916
+  - uid: 21915
     components:
     - type: Transform
       pos: -23.5,29.5
       parent: 2
-  - uid: 21917
+  - uid: 21916
     components:
     - type: Transform
       pos: -23.5,28.5
       parent: 2
-  - uid: 21918
+  - uid: 21917
     components:
     - type: Transform
       pos: -2.5,35.5
       parent: 2
-  - uid: 21919
+  - uid: 21918
     components:
     - type: Transform
       pos: -7.5,41.5
       parent: 2
-  - uid: 21920
+  - uid: 21919
     components:
     - type: Transform
       pos: -7.5,37.5
       parent: 2
-  - uid: 21921
+  - uid: 21920
     components:
     - type: Transform
       pos: -5.5,41.5
       parent: 2
-  - uid: 21922
+  - uid: 21921
     components:
     - type: Transform
       pos: -7.5,38.5
       parent: 2
-  - uid: 21923
+  - uid: 21922
     components:
     - type: Transform
       pos: -5.5,38.5
       parent: 2
-  - uid: 21924
+  - uid: 21923
     components:
     - type: Transform
       pos: -6.5,38.5
       parent: 2
-  - uid: 21925
+  - uid: 21924
     components:
     - type: Transform
       pos: -1.5,33.5
       parent: 2
-  - uid: 21926
+  - uid: 21925
     components:
     - type: Transform
       pos: 1.5,33.5
       parent: 2
-  - uid: 21927
+  - uid: 21926
     components:
     - type: Transform
       pos: -10.5,54.5
       parent: 2
-  - uid: 21928
+  - uid: 21927
     components:
     - type: Transform
       pos: -10.5,55.5
       parent: 2
-  - uid: 21929
+  - uid: 21928
     components:
     - type: Transform
       pos: -2.5,36.5
       parent: 2
-  - uid: 21930
+  - uid: 21929
     components:
     - type: Transform
       pos: 0.5,52.5
       parent: 2
-  - uid: 21931
+  - uid: 21930
     components:
     - type: Transform
       pos: -1.5,42.5
       parent: 2
-  - uid: 21932
+  - uid: 21931
     components:
     - type: Transform
       pos: -3.5,42.5
       parent: 2
-  - uid: 21933
+  - uid: 21932
     components:
     - type: Transform
       pos: -2.5,42.5
       parent: 2
-  - uid: 21934
+  - uid: 21933
     components:
     - type: Transform
       pos: -4.5,42.5
       parent: 2
-  - uid: 21935
+  - uid: 21934
     components:
     - type: Transform
       pos: 1.5,42.5
       parent: 2
-  - uid: 21936
+  - uid: 21935
     components:
     - type: Transform
       pos: 0.5,33.5
       parent: 2
-  - uid: 21937
+  - uid: 21936
     components:
     - type: Transform
       pos: -23.5,35.5
       parent: 2
-  - uid: 21938
+  - uid: 21937
     components:
     - type: Transform
       pos: -27.5,33.5
       parent: 2
-  - uid: 21939
+  - uid: 21938
     components:
     - type: Transform
       pos: -7.5,42.5
       parent: 2
-  - uid: 21940
+  - uid: 21939
     components:
     - type: Transform
       pos: -5.5,34.5
       parent: 2
-  - uid: 21941
+  - uid: 21940
     components:
     - type: Transform
       pos: -7.5,39.5
       parent: 2
-  - uid: 21942
+  - uid: 21941
     components:
     - type: Transform
       pos: 2.5,33.5
       parent: 2
-  - uid: 21943
+  - uid: 21942
     components:
     - type: Transform
       pos: -20.5,42.5
       parent: 2
-  - uid: 21944
+  - uid: 21943
     components:
     - type: Transform
       pos: -27.5,27.5
       parent: 2
-  - uid: 21945
+  - uid: 21944
     components:
     - type: Transform
       pos: -29.5,33.5
       parent: 2
-  - uid: 21946
+  - uid: 21945
     components:
     - type: Transform
       pos: -10.5,42.5
       parent: 2
-  - uid: 21947
+  - uid: 21946
     components:
     - type: Transform
       pos: -28.5,33.5
       parent: 2
-  - uid: 21948
+  - uid: 21947
     components:
     - type: Transform
       pos: -26.5,33.5
       parent: 2
-  - uid: 21949
+  - uid: 21948
     components:
     - type: Transform
       pos: -29.5,30.5
       parent: 2
-  - uid: 21950
+  - uid: 21949
     components:
     - type: Transform
       pos: -29.5,29.5
       parent: 2
-  - uid: 21951
+  - uid: 21950
     components:
     - type: Transform
       pos: -29.5,32.5
       parent: 2
-  - uid: 21952
+  - uid: 21951
     components:
     - type: Transform
       pos: -30.5,52.5
       parent: 2
-  - uid: 21953
+  - uid: 21952
     components:
     - type: Transform
       pos: 7.5,45.5
       parent: 2
-  - uid: 21954
+  - uid: 21953
     components:
     - type: Transform
       pos: 7.5,43.5
       parent: 2
-  - uid: 21955
+  - uid: 21954
     components:
     - type: Transform
       pos: -32.5,42.5
       parent: 2
-  - uid: 21956
+  - uid: 21955
     components:
     - type: Transform
       pos: 1.5,35.5
       parent: 2
-  - uid: 21957
+  - uid: 21956
     components:
     - type: Transform
       pos: 3.5,42.5
       parent: 2
-  - uid: 21958
+  - uid: 21957
     components:
     - type: Transform
       pos: -5.5,42.5
       parent: 2
-  - uid: 21959
+  - uid: 21958
     components:
     - type: Transform
       pos: 2.5,42.5
       parent: 2
-  - uid: 21960
+  - uid: 21959
     components:
     - type: Transform
       pos: 6.5,40.5
       parent: 2
-  - uid: 21961
+  - uid: 21960
     components:
     - type: Transform
       pos: 1.5,39.5
       parent: 2
-  - uid: 21962
+  - uid: 21961
     components:
     - type: Transform
       pos: 1.5,48.5
       parent: 2
-  - uid: 21963
+  - uid: 21962
     components:
     - type: Transform
       pos: 1.5,36.5
       parent: 2
-  - uid: 21964
+  - uid: 21963
     components:
     - type: Transform
       pos: -6.5,36.5
       parent: 2
-  - uid: 21965
+  - uid: 21964
     components:
     - type: Transform
       pos: 2.5,44.5
       parent: 2
-  - uid: 21966
+  - uid: 21965
     components:
     - type: Transform
       pos: -29.5,28.5
       parent: 2
-  - uid: 21967
+  - uid: 21966
     components:
     - type: Transform
       pos: -0.5,42.5
       parent: 2
-  - uid: 21968
+  - uid: 21967
     components:
     - type: Transform
       pos: -24.5,46.5
       parent: 2
-  - uid: 21969
+  - uid: 21968
     components:
     - type: Transform
       pos: -15.5,38.5
       parent: 2
-  - uid: 21970
+  - uid: 21969
     components:
     - type: Transform
       pos: -2.5,34.5
       parent: 2
-  - uid: 21971
+  - uid: 21970
     components:
     - type: Transform
       pos: -32.5,35.5
       parent: 2
-  - uid: 21972
+  - uid: 21971
     components:
     - type: Transform
       pos: -31.5,35.5
       parent: 2
-  - uid: 21973
+  - uid: 21972
     components:
     - type: Transform
       pos: -30.5,35.5
       parent: 2
-  - uid: 21974
+  - uid: 21973
     components:
     - type: Transform
       pos: -29.5,35.5
       parent: 2
-  - uid: 21975
+  - uid: 21974
     components:
     - type: Transform
       pos: -28.5,35.5
       parent: 2
-  - uid: 21976
+  - uid: 21975
     components:
     - type: Transform
       pos: -27.5,35.5
       parent: 2
-  - uid: 21977
+  - uid: 21976
     components:
     - type: Transform
       pos: -32.5,38.5
       parent: 2
-  - uid: 21978
+  - uid: 21977
     components:
     - type: Transform
       pos: -26.5,35.5
       parent: 2
-  - uid: 21979
+  - uid: 21978
     components:
     - type: Transform
       pos: -32.5,37.5
       parent: 2
-  - uid: 21980
+  - uid: 21979
     components:
     - type: Transform
       pos: -32.5,41.5
       parent: 2
-  - uid: 21981
+  - uid: 21980
     components:
     - type: Transform
       pos: -24.5,35.5
       parent: 2
-  - uid: 21982
+  - uid: 21981
     components:
     - type: Transform
       pos: -32.5,36.5
       parent: 2
-  - uid: 21983
+  - uid: 21982
     components:
     - type: Transform
       pos: -25.5,35.5
       parent: 2
-  - uid: 21984
+  - uid: 21983
     components:
     - type: Transform
       pos: -28.5,43.5
       parent: 2
-  - uid: 21985
+  - uid: 21984
     components:
     - type: Transform
       pos: -28.5,45.5
       parent: 2
-  - uid: 21986
+  - uid: 21985
     components:
     - type: Transform
       pos: -27.5,42.5
       parent: 2
-  - uid: 21987
+  - uid: 21986
     components:
     - type: Transform
       pos: -28.5,42.5
       parent: 2
-  - uid: 21988
+  - uid: 21987
     components:
     - type: Transform
       pos: -28.5,44.5
       parent: 2
-  - uid: 21989
+  - uid: 21988
     components:
     - type: Transform
       pos: -30.5,46.5
       parent: 2
-  - uid: 21990
+  - uid: 21989
     components:
     - type: Transform
       pos: -29.5,46.5
       parent: 2
-  - uid: 21991
+  - uid: 21990
     components:
     - type: Transform
       pos: -30.5,51.5
       parent: 2
-  - uid: 21992
+  - uid: 21991
     components:
     - type: Transform
       pos: -29.5,51.5
       parent: 2
-  - uid: 21993
+  - uid: 21992
     components:
     - type: Transform
       pos: -28.5,51.5
       parent: 2
-  - uid: 21994
+  - uid: 21993
     components:
     - type: Transform
       pos: -27.5,51.5
       parent: 2
-  - uid: 21995
+  - uid: 21994
     components:
     - type: Transform
       pos: -24.5,42.5
       parent: 2
-  - uid: 21996
+  - uid: 21995
     components:
     - type: Transform
       pos: -27.5,46.5
       parent: 2
-  - uid: 21997
+  - uid: 21996
     components:
     - type: Transform
       pos: -28.5,46.5
       parent: 2
-  - uid: 21998
+  - uid: 21997
     components:
     - type: Transform
       pos: -26.5,51.5
       parent: 2
-  - uid: 21999
+  - uid: 21998
     components:
     - type: Transform
       pos: -24.5,51.5
       parent: 2
-  - uid: 22000
+  - uid: 21999
     components:
     - type: Transform
       pos: -25.5,51.5
       parent: 2
-  - uid: 22001
+  - uid: 22000
     components:
     - type: Transform
       pos: -25.5,46.5
       parent: 2
-  - uid: 22002
+  - uid: 22001
     components:
     - type: Transform
       pos: -20.5,54.5
       parent: 2
-  - uid: 22003
+  - uid: 22002
     components:
     - type: Transform
       pos: -20.5,55.5
       parent: 2
-  - uid: 22004
+  - uid: 22003
     components:
     - type: Transform
       pos: -28.5,27.5
       parent: 2
-  - uid: 22005
+  - uid: 22004
     components:
     - type: Transform
       pos: -29.5,42.5
       parent: 2
-  - uid: 22006
+  - uid: 22005
     components:
     - type: Transform
       pos: -29.5,27.5
       parent: 2
-  - uid: 22007
+  - uid: 22006
     components:
     - type: Transform
       pos: -25.5,27.5
       parent: 2
-  - uid: 22008
+  - uid: 22007
     components:
     - type: Transform
       pos: -12.5,35.5
       parent: 2
-  - uid: 22009
+  - uid: 22008
     components:
     - type: Transform
       pos: -18.5,35.5
       parent: 2
-  - uid: 22010
+  - uid: 22009
     components:
     - type: Transform
       pos: -12.5,36.5
       parent: 2
-  - uid: 22011
+  - uid: 22010
     components:
     - type: Transform
       pos: -18.5,36.5
       parent: 2
-  - uid: 22012
+  - uid: 22011
     components:
     - type: Transform
       pos: -18.5,34.5
       parent: 2
-  - uid: 22013
+  - uid: 22012
     components:
     - type: Transform
       pos: -22.5,36.5
       parent: 2
-  - uid: 22014
+  - uid: 22013
     components:
     - type: Transform
       pos: 3.5,39.5
       parent: 2
-  - uid: 22015
+  - uid: 22014
     components:
     - type: Transform
       pos: -10.5,34.5
       parent: 2
-  - uid: 22016
+  - uid: 22015
     components:
     - type: Transform
       pos: -7.5,35.5
       parent: 2
-  - uid: 22017
+  - uid: 22016
     components:
     - type: Transform
       pos: -18.5,37.5
       parent: 2
-  - uid: 22018
+  - uid: 22017
     components:
     - type: Transform
       pos: 2.5,47.5
       parent: 2
-  - uid: 22019
+  - uid: 22018
     components:
     - type: Transform
       pos: 0.5,48.5
       parent: 2
-  - uid: 22020
+  - uid: 22019
     components:
     - type: Transform
       pos: 7.5,42.5
       parent: 2
-  - uid: 22021
+  - uid: 22020
     components:
     - type: Transform
       pos: 1.5,38.5
       parent: 2
-  - uid: 22022
+  - uid: 22021
     components:
     - type: Transform
       pos: -7.5,36.5
       parent: 2
-  - uid: 22023
+  - uid: 22022
     components:
     - type: Transform
       pos: -12.5,38.5
       parent: 2
-  - uid: 22024
+  - uid: 22023
     components:
     - type: Transform
       pos: 0.5,34.5
       parent: 2
-  - uid: 22025
+  - uid: 22024
     components:
     - type: Transform
       pos: 1.5,47.5
       parent: 2
-  - uid: 22026
+  - uid: 22025
     components:
     - type: Transform
       pos: -0.5,33.5
       parent: 2
-  - uid: 22027
+  - uid: 22026
     components:
     - type: Transform
       pos: -3.5,34.5
       parent: 2
-  - uid: 22028
+  - uid: 22027
     components:
     - type: Transform
       pos: -6.5,43.5
       parent: 2
-  - uid: 22029
+  - uid: 22028
     components:
     - type: Transform
       pos: -26.5,46.5
       parent: 2
-  - uid: 22030
+  - uid: 22029
     components:
     - type: Transform
       pos: 1.5,41.5
       parent: 2
-  - uid: 22031
+  - uid: 22030
     components:
     - type: Transform
       pos: 2.5,46.5
       parent: 2
-  - uid: 22032
+  - uid: 22031
     components:
     - type: Transform
       pos: -6.5,37.5
       parent: 2
-  - uid: 22033
+  - uid: 22032
     components:
     - type: Transform
       pos: -1.5,34.5
       parent: 2
-  - uid: 22034
+  - uid: 22033
     components:
     - type: Transform
       pos: -26.5,27.5
       parent: 2
-  - uid: 22035
+  - uid: 22034
     components:
     - type: Transform
       pos: -4.5,34.5
       parent: 2
-  - uid: 22036
+  - uid: 22035
     components:
     - type: Transform
       pos: 1.5,34.5
       parent: 2
-  - uid: 22037
+  - uid: 22036
     components:
     - type: Transform
       pos: 5.5,42.5
       parent: 2
-  - uid: 22038
+  - uid: 22037
     components:
     - type: Transform
       pos: -9.5,34.5
       parent: 2
-  - uid: 22039
+  - uid: 22038
     components:
     - type: Transform
       pos: -8.5,34.5
       parent: 2
-  - uid: 22040
+  - uid: 22039
     components:
     - type: Transform
       pos: -6.5,42.5
       parent: 2
-  - uid: 22041
+  - uid: 22040
     components:
     - type: Transform
       pos: -11.5,34.5
       parent: 2
-  - uid: 22042
+  - uid: 22041
     components:
     - type: Transform
       pos: 7.5,46.5
       parent: 2
-  - uid: 22043
+  - uid: 22042
     components:
     - type: Transform
       pos: 4.5,46.5
       parent: 2
-  - uid: 22044
+  - uid: 22043
     components:
     - type: Transform
       pos: -5.5,39.5
       parent: 2
-  - uid: 22045
+  - uid: 22044
     components:
     - type: Transform
       pos: -6.5,34.5
       parent: 2
-  - uid: 22046
+  - uid: 22045
     components:
     - type: Transform
       pos: -17.5,-6.5
       parent: 2
-  - uid: 22047
+  - uid: 22046
     components:
     - type: Transform
       pos: -11.5,27.5
       parent: 2
-  - uid: 22048
+  - uid: 22047
     components:
     - type: Transform
       pos: -3.5,23.5
       parent: 2
-  - uid: 22049
+  - uid: 22048
     components:
     - type: Transform
       pos: -3.5,24.5
       parent: 2
-  - uid: 22050
+  - uid: 22049
     components:
     - type: Transform
       pos: -3.5,25.5
       parent: 2
-  - uid: 22051
+  - uid: 22050
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 2
-  - uid: 22052
+  - uid: 22051
     components:
     - type: Transform
       pos: -8.5,22.5
       parent: 2
-  - uid: 22053
+  - uid: 22052
     components:
     - type: Transform
       pos: -9.5,22.5
       parent: 2
-  - uid: 22054
+  - uid: 22053
     components:
     - type: Transform
       pos: -5.5,22.5
       parent: 2
-  - uid: 22055
+  - uid: 22054
     components:
     - type: Transform
       pos: -4.5,22.5
       parent: 2
-  - uid: 22056
+  - uid: 22055
     components:
     - type: Transform
       pos: -3.5,22.5
       parent: 2
-  - uid: 22057
+  - uid: 22056
     components:
     - type: Transform
       pos: -11.5,23.5
       parent: 2
-  - uid: 22058
+  - uid: 22057
     components:
     - type: Transform
       pos: -7.5,22.5
       parent: 2
-  - uid: 22059
+  - uid: 22058
     components:
     - type: Transform
       pos: -11.5,24.5
       parent: 2
-  - uid: 22060
+  - uid: 22059
     components:
     - type: Transform
       pos: -11.5,25.5
       parent: 2
-  - uid: 22061
+  - uid: 22060
     components:
     - type: Transform
       pos: -11.5,26.5
       parent: 2
-  - uid: 22062
+  - uid: 22061
     components:
     - type: Transform
       pos: -7.5,27.5
       parent: 2
-  - uid: 22063
+  - uid: 22062
     components:
     - type: Transform
       pos: -2.5,27.5
       parent: 2
-  - uid: 22064
+  - uid: 22063
     components:
     - type: Transform
       pos: -2.5,28.5
       parent: 2
-  - uid: 22065
+  - uid: 22064
     components:
     - type: Transform
       pos: -2.5,29.5
       parent: 2
-  - uid: 22066
+  - uid: 22065
     components:
     - type: Transform
       pos: -2.5,30.5
       parent: 2
-  - uid: 22067
+  - uid: 22066
     components:
     - type: Transform
       pos: -2.5,31.5
       parent: 2
-  - uid: 22068
+  - uid: 22067
     components:
     - type: Transform
       pos: -2.5,32.5
       parent: 2
-  - uid: 22069
+  - uid: 22068
     components:
     - type: Transform
       pos: -6.5,27.5
       parent: 2
-  - uid: 22070
+  - uid: 22069
     components:
     - type: Transform
       pos: -3.5,27.5
       parent: 2
-  - uid: 22071
+  - uid: 22070
     components:
     - type: Transform
       pos: -4.5,27.5
       parent: 2
-  - uid: 22072
+  - uid: 22071
     components:
     - type: Transform
       pos: -10.5,27.5
       parent: 2
-  - uid: 22073
+  - uid: 22072
     components:
     - type: Transform
       pos: -8.5,27.5
       parent: 2
-  - uid: 22074
+  - uid: 22073
     components:
     - type: Transform
       pos: -11.5,22.5
       parent: 2
-  - uid: 22075
+  - uid: 22074
     components:
     - type: Transform
       pos: -6.5,22.5
       parent: 2
-  - uid: 22076
+  - uid: 22075
     components:
     - type: Transform
       pos: -19.5,-0.5
       parent: 2
-  - uid: 22077
+  - uid: 22076
     components:
     - type: Transform
       pos: -14.5,-6.5
       parent: 2
-  - uid: 22078
+  - uid: 22077
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
-  - uid: 22079
+  - uid: 22078
     components:
     - type: Transform
       pos: -19.5,-5.5
       parent: 2
-  - uid: 22080
+  - uid: 22079
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 2
-  - uid: 22081
+  - uid: 22080
     components:
     - type: Transform
       pos: -19.5,1.5
       parent: 2
-  - uid: 22082
+  - uid: 22081
     components:
     - type: Transform
       pos: -19.5,-4.5
       parent: 2
-  - uid: 22083
+  - uid: 22082
     components:
     - type: Transform
       pos: -18.5,-6.5
       parent: 2
-  - uid: 22084
+  - uid: 22083
     components:
     - type: Transform
       pos: -19.5,-2.5
       parent: 2
-  - uid: 22085
+  - uid: 22084
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 2
-  - uid: 22086
+  - uid: 22085
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
-  - uid: 22087
+  - uid: 22086
     components:
     - type: Transform
       pos: -19.5,0.5
       parent: 2
-  - uid: 22088
+  - uid: 22087
     components:
     - type: Transform
       pos: -14.5,6.5
       parent: 2
-  - uid: 22089
+  - uid: 22088
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 2
-  - uid: 22090
+  - uid: 22089
     components:
     - type: Transform
       pos: -10.5,22.5
       parent: 2
-  - uid: 22091
+  - uid: 22090
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 2
-  - uid: 22092
+  - uid: 22091
     components:
     - type: Transform
       pos: -15.5,2.5
       parent: 2
-  - uid: 22093
+  - uid: 22092
     components:
     - type: Transform
       pos: -12.5,-6.5
       parent: 2
-  - uid: 22094
+  - uid: 22093
     components:
     - type: Transform
       pos: -17.5,2.5
       parent: 2
-  - uid: 22095
+  - uid: 22094
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 2
-  - uid: 22096
+  - uid: 22095
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 2
-  - uid: 22097
+  - uid: 22096
     components:
     - type: Transform
       pos: 11.5,-1.5
       parent: 2
-  - uid: 22098
+  - uid: 22097
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 2
-  - uid: 22099
+  - uid: 22098
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
-  - uid: 22100
+  - uid: 22099
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 2
-  - uid: 22101
+  - uid: 22100
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 2
-  - uid: 22102
+  - uid: 22101
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 2
-  - uid: 22103
+  - uid: 22102
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 2
-  - uid: 22104
+  - uid: 22103
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 2
-  - uid: 22105
+  - uid: 22104
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-  - uid: 22106
+  - uid: 22105
     components:
     - type: Transform
       pos: -19.5,-1.5
       parent: 2
-  - uid: 22107
+  - uid: 22106
     components:
     - type: Transform
       pos: -19.5,6.5
       parent: 2
-  - uid: 22108
+  - uid: 22107
     components:
     - type: Transform
       pos: -19.5,5.5
       parent: 2
-  - uid: 22109
+  - uid: 22108
     components:
     - type: Transform
       pos: -19.5,3.5
       parent: 2
-  - uid: 22110
+  - uid: 22109
     components:
     - type: Transform
       pos: -19.5,2.5
       parent: 2
-  - uid: 22111
+  - uid: 22110
     components:
     - type: Transform
       pos: -18.5,2.5
       parent: 2
-  - uid: 22112
+  - uid: 22111
     components:
     - type: Transform
       pos: -19.5,-6.5
       parent: 2
-  - uid: 22113
+  - uid: 22112
     components:
     - type: Transform
       pos: -16.5,-6.5
       parent: 2
-  - uid: 22114
+  - uid: 22113
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 2
-  - uid: 22115
+  - uid: 22114
     components:
     - type: Transform
       pos: -20.5,6.5
       parent: 2
-  - uid: 22116
+  - uid: 22115
     components:
     - type: Transform
       pos: -21.5,6.5
       parent: 2
-  - uid: 22117
+  - uid: 22116
     components:
     - type: Transform
       pos: -22.5,6.5
       parent: 2
-  - uid: 22118
+  - uid: 22117
     components:
     - type: Transform
       pos: -23.5,6.5
       parent: 2
-  - uid: 22119
+  - uid: 22118
     components:
     - type: Transform
       pos: -23.5,3.5
       parent: 2
-  - uid: 22120
+  - uid: 22119
     components:
     - type: Transform
       pos: -23.5,4.5
       parent: 2
-  - uid: 22121
+  - uid: 22120
     components:
     - type: Transform
       pos: -23.5,2.5
       parent: 2
-  - uid: 22122
+  - uid: 22121
     components:
     - type: Transform
       pos: -23.5,1.5
       parent: 2
-  - uid: 22123
+  - uid: 22122
     components:
     - type: Transform
       pos: -23.5,5.5
       parent: 2
-  - uid: 22124
+  - uid: 22123
     components:
     - type: Transform
       pos: -22.5,1.5
       parent: 2
-  - uid: 22125
+  - uid: 22124
     components:
     - type: Transform
       pos: -21.5,1.5
       parent: 2
-  - uid: 22126
+  - uid: 22125
     components:
     - type: Transform
       pos: -20.5,1.5
       parent: 2
-  - uid: 22127
+  - uid: 22126
     components:
     - type: Transform
       pos: -11.5,-6.5
       parent: 2
-  - uid: 22128
+  - uid: 22127
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 2
-  - uid: 22129
+  - uid: 22128
     components:
     - type: Transform
       pos: -14.5,3.5
       parent: 2
-  - uid: 22130
+  - uid: 22129
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 2
-  - uid: 22131
+  - uid: 22130
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
-  - uid: 22132
+  - uid: 22131
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
-  - uid: 22133
+  - uid: 22132
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 2
-  - uid: 22134
+  - uid: 22133
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 2
-  - uid: 22135
+  - uid: 22134
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
-  - uid: 22136
+  - uid: 22135
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 2
-  - uid: 22137
+  - uid: 22136
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 2
-  - uid: 22138
+  - uid: 22137
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 2
-  - uid: 22139
+  - uid: 22138
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 2
-  - uid: 22140
+  - uid: 22139
     components:
     - type: Transform
       pos: 6.5,-13.5
       parent: 2
-  - uid: 22141
+  - uid: 22140
     components:
     - type: Transform
       pos: 50.5,17.5
       parent: 2
-  - uid: 22142
+  - uid: 22141
     components:
     - type: Transform
       pos: 15.5,3.5
       parent: 2
-  - uid: 22143
+  - uid: 22142
     components:
     - type: Transform
       pos: 15.5,4.5
       parent: 2
-  - uid: 22144
+  - uid: 22143
     components:
     - type: Transform
       pos: 15.5,5.5
       parent: 2
-  - uid: 22145
+  - uid: 22144
     components:
     - type: Transform
       pos: 15.5,8.5
       parent: 2
-  - uid: 22146
+  - uid: 22145
     components:
     - type: Transform
       pos: 14.5,9.5
       parent: 2
-  - uid: 22147
+  - uid: 22146
     components:
     - type: Transform
       pos: 14.5,10.5
       parent: 2
-  - uid: 22148
+  - uid: 22147
     components:
     - type: Transform
       pos: 14.5,8.5
       parent: 2
-  - uid: 22149
+  - uid: 22148
     components:
     - type: Transform
       pos: 15.5,6.5
       parent: 2
-  - uid: 22150
+  - uid: 22149
     components:
     - type: Transform
       pos: 15.5,2.5
       parent: 2
-  - uid: 22151
+  - uid: 22150
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 2
-  - uid: 22152
+  - uid: 22151
     components:
     - type: Transform
       pos: 36.5,5.5
       parent: 2
-  - uid: 22153
+  - uid: 22152
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 2
-  - uid: 22154
+  - uid: 22153
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 2
-  - uid: 22155
+  - uid: 22154
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 2
-  - uid: 22156
+  - uid: 22155
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 2
-  - uid: 22157
+  - uid: 22156
     components:
     - type: Transform
       pos: -7.5,-6.5
       parent: 2
-  - uid: 22158
+  - uid: 22157
     components:
     - type: Transform
       pos: -8.5,-6.5
       parent: 2
-  - uid: 22159
+  - uid: 22158
     components:
     - type: Transform
       pos: -9.5,-6.5
       parent: 2
-  - uid: 22160
+  - uid: 22159
     components:
     - type: Transform
       pos: -10.5,-6.5
       parent: 2
-  - uid: 22161
+  - uid: 22160
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,9.5
       parent: 2
-  - uid: 22162
+  - uid: 22161
     components:
     - type: Transform
       pos: -4.5,11.5
       parent: 2
-  - uid: 22163
+  - uid: 22162
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 2
-  - uid: 22164
+  - uid: 22163
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 2
-  - uid: 22165
+  - uid: 22164
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 2
-  - uid: 22166
+  - uid: 22165
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 2
-  - uid: 22167
+  - uid: 22166
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 2
-  - uid: 22168
+  - uid: 22167
     components:
     - type: Transform
       pos: 3.5,-13.5
       parent: 2
-  - uid: 22169
+  - uid: 22168
     components:
     - type: Transform
       pos: 15.5,7.5
       parent: 2
-  - uid: 22170
+  - uid: 22169
     components:
     - type: Transform
       pos: 12.5,-12.5
       parent: 2
-  - uid: 22171
+  - uid: 22170
     components:
     - type: Transform
       pos: 12.5,-11.5
       parent: 2
-  - uid: 22172
+  - uid: 22171
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 2
-  - uid: 22173
+  - uid: 22172
     components:
     - type: Transform
       pos: -5.5,-12.5
       parent: 2
-  - uid: 22174
+  - uid: 22173
     components:
     - type: Transform
       pos: -5.5,-13.5
       parent: 2
-  - uid: 22175
+  - uid: 22174
     components:
     - type: Transform
       pos: -5.5,-14.5
       parent: 2
-  - uid: 22176
+  - uid: 22175
     components:
     - type: Transform
       pos: -5.5,-15.5
       parent: 2
-  - uid: 22177
+  - uid: 22176
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 2
-  - uid: 22178
+  - uid: 22177
     components:
     - type: Transform
       pos: -5.5,-16.5
       parent: 2
-  - uid: 22179
+  - uid: 22178
     components:
     - type: Transform
       pos: -5.5,-17.5
       parent: 2
-  - uid: 22180
+  - uid: 22179
     components:
     - type: Transform
       pos: -4.5,-17.5
       parent: 2
-  - uid: 22181
+  - uid: 22180
     components:
     - type: Transform
       pos: -1.5,-17.5
       parent: 2
-  - uid: 22182
+  - uid: 22181
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 2
-  - uid: 22183
+  - uid: 22182
     components:
     - type: Transform
       pos: -3.5,-17.5
       parent: 2
-  - uid: 22184
+  - uid: 22183
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 2
-  - uid: 22185
+  - uid: 22184
     components:
     - type: Transform
       pos: -5.5,-18.5
       parent: 2
-  - uid: 22186
+  - uid: 22185
     components:
     - type: Transform
       pos: -5.5,-19.5
       parent: 2
-  - uid: 22187
+  - uid: 22186
     components:
     - type: Transform
       pos: -5.5,-20.5
       parent: 2
-  - uid: 22188
+  - uid: 22187
     components:
     - type: Transform
       pos: -5.5,-21.5
       parent: 2
-  - uid: 22189
+  - uid: 22188
     components:
     - type: Transform
       pos: 1.5,-22.5
       parent: 2
-  - uid: 22190
+  - uid: 22189
     components:
     - type: Transform
       pos: -0.5,-22.5
       parent: 2
-  - uid: 22191
+  - uid: 22190
     components:
     - type: Transform
       pos: 0.5,-22.5
       parent: 2
-  - uid: 22192
+  - uid: 22191
     components:
     - type: Transform
       pos: -3.5,-22.5
       parent: 2
-  - uid: 22193
+  - uid: 22192
     components:
     - type: Transform
       pos: -4.5,-22.5
       parent: 2
-  - uid: 22194
+  - uid: 22193
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 2
-  - uid: 22195
+  - uid: 22194
     components:
     - type: Transform
       pos: 1.5,-20.5
       parent: 2
-  - uid: 22196
+  - uid: 22195
     components:
     - type: Transform
       pos: -1.5,-22.5
       parent: 2
-  - uid: 22197
+  - uid: 22196
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 2
-  - uid: 22198
+  - uid: 22197
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 2
-  - uid: 22199
+  - uid: 22198
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 2
-  - uid: 22200
+  - uid: 22199
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 2
-  - uid: 22201
+  - uid: 22200
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 2
-  - uid: 22202
+  - uid: 22201
     components:
     - type: Transform
       pos: -5.5,-22.5
       parent: 2
-  - uid: 22203
+  - uid: 22202
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 2
-  - uid: 22204
+  - uid: 22203
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 2
-  - uid: 22205
+  - uid: 22204
     components:
     - type: Transform
       pos: -7.5,-9.5
       parent: 2
-  - uid: 22206
+  - uid: 22205
     components:
     - type: Transform
       pos: -11.5,-12.5
       parent: 2
-  - uid: 22207
+  - uid: 22206
     components:
     - type: Transform
       pos: -6.5,-12.5
       parent: 2
-  - uid: 22208
+  - uid: 22207
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 2
-  - uid: 22209
+  - uid: 22208
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 2
-  - uid: 22210
+  - uid: 22209
     components:
     - type: Transform
       pos: -12.5,-10.5
       parent: 2
-  - uid: 22211
+  - uid: 22210
     components:
     - type: Transform
       pos: -12.5,-11.5
       parent: 2
-  - uid: 22212
+  - uid: 22211
     components:
     - type: Transform
       pos: -12.5,-12.5
       parent: 2
-  - uid: 22213
+  - uid: 22212
     components:
     - type: Transform
       pos: -12.5,-13.5
       parent: 2
-  - uid: 22214
+  - uid: 22213
     components:
     - type: Transform
       pos: -12.5,-14.5
       parent: 2
-  - uid: 22215
+  - uid: 22214
     components:
     - type: Transform
       pos: -12.5,-15.5
       parent: 2
-  - uid: 22216
+  - uid: 22215
     components:
     - type: Transform
       pos: -12.5,-17.5
       parent: 2
-  - uid: 22217
+  - uid: 22216
     components:
     - type: Transform
       pos: -12.5,-9.5
       parent: 2
-  - uid: 22218
+  - uid: 22217
     components:
     - type: Transform
       pos: -12.5,-16.5
       parent: 2
-  - uid: 22219
+  - uid: 22218
     components:
     - type: Transform
       pos: -11.5,-17.5
       parent: 2
-  - uid: 22220
+  - uid: 22219
     components:
     - type: Transform
       pos: -9.5,-17.5
       parent: 2
-  - uid: 22221
+  - uid: 22220
     components:
     - type: Transform
       pos: -8.5,-17.5
       parent: 2
-  - uid: 22222
+  - uid: 22221
     components:
     - type: Transform
       pos: -7.5,-17.5
       parent: 2
-  - uid: 22223
+  - uid: 22222
     components:
     - type: Transform
       pos: -6.5,-17.5
       parent: 2
-  - uid: 22224
+  - uid: 22223
     components:
     - type: Transform
       pos: -10.5,-17.5
       parent: 2
-  - uid: 22225
+  - uid: 22224
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 2
-  - uid: 22226
+  - uid: 22225
     components:
     - type: Transform
       pos: -7.5,-19.5
       parent: 2
-  - uid: 22227
+  - uid: 22226
     components:
     - type: Transform
       pos: -8.5,-19.5
       parent: 2
-  - uid: 22228
+  - uid: 22227
     components:
     - type: Transform
       pos: -6.5,-19.5
       parent: 2
-  - uid: 22229
+  - uid: 22228
     components:
     - type: Transform
       pos: -10.5,-19.5
       parent: 2
-  - uid: 22230
+  - uid: 22229
     components:
     - type: Transform
       pos: -11.5,-19.5
       parent: 2
-  - uid: 22231
+  - uid: 22230
     components:
     - type: Transform
       pos: -12.5,-19.5
       parent: 2
-  - uid: 22232
+  - uid: 22231
     components:
     - type: Transform
       pos: -13.5,-19.5
       parent: 2
-  - uid: 22233
+  - uid: 22232
     components:
     - type: Transform
       pos: -9.5,-19.5
       parent: 2
-  - uid: 22234
+  - uid: 22233
     components:
     - type: Transform
       pos: -14.5,-19.5
       parent: 2
-  - uid: 22235
+  - uid: 22234
     components:
     - type: Transform
       pos: -14.5,-18.5
       parent: 2
-  - uid: 22236
+  - uid: 22235
     components:
     - type: Transform
       pos: -14.5,-17.5
       parent: 2
-  - uid: 22237
+  - uid: 22236
     components:
     - type: Transform
       pos: -14.5,-16.5
       parent: 2
-  - uid: 22238
+  - uid: 22237
     components:
     - type: Transform
       pos: -14.5,-14.5
       parent: 2
-  - uid: 22239
+  - uid: 22238
     components:
     - type: Transform
       pos: -14.5,-13.5
       parent: 2
-  - uid: 22240
+  - uid: 22239
     components:
     - type: Transform
       pos: -14.5,-12.5
       parent: 2
-  - uid: 22241
+  - uid: 22240
     components:
     - type: Transform
       pos: -14.5,-11.5
       parent: 2
-  - uid: 22242
+  - uid: 22241
     components:
     - type: Transform
       pos: -14.5,-10.5
       parent: 2
-  - uid: 22243
+  - uid: 22242
     components:
     - type: Transform
       pos: -14.5,-9.5
       parent: 2
-  - uid: 22244
+  - uid: 22243
     components:
     - type: Transform
       pos: -14.5,-8.5
       parent: 2
-  - uid: 22245
+  - uid: 22244
     components:
     - type: Transform
       pos: -14.5,-7.5
       parent: 2
-  - uid: 22246
+  - uid: 22245
     components:
     - type: Transform
       pos: -14.5,-15.5
       parent: 2
-  - uid: 22247
+  - uid: 22246
     components:
     - type: Transform
       pos: -33.5,11.5
       parent: 2
-  - uid: 22248
+  - uid: 22247
     components:
     - type: Transform
       pos: -32.5,5.5
       parent: 2
-  - uid: 22249
+  - uid: 22248
     components:
     - type: Transform
       pos: -33.5,5.5
       parent: 2
-  - uid: 22250
+  - uid: 22249
     components:
     - type: Transform
       pos: -32.5,4.5
       parent: 2
-  - uid: 22251
+  - uid: 22250
     components:
     - type: Transform
       pos: -32.5,3.5
       parent: 2
-  - uid: 22252
+  - uid: 22251
     components:
     - type: Transform
       pos: -32.5,2.5
       parent: 2
-  - uid: 22253
+  - uid: 22252
     components:
     - type: Transform
       pos: -34.5,11.5
       parent: 2
-  - uid: 22254
+  - uid: 22253
     components:
     - type: Transform
       pos: -38.5,11.5
       parent: 2
-  - uid: 22255
+  - uid: 22254
     components:
     - type: Transform
       pos: -39.5,11.5
       parent: 2
-  - uid: 22256
+  - uid: 22255
     components:
     - type: Transform
       pos: -39.5,2.5
       parent: 2
-  - uid: 22257
+  - uid: 22256
     components:
     - type: Transform
       pos: -39.5,8.5
       parent: 2
-  - uid: 22258
+  - uid: 22257
     components:
     - type: Transform
       pos: -38.5,2.5
       parent: 2
-  - uid: 22259
+  - uid: 22258
     components:
     - type: Transform
       pos: -39.5,6.5
       parent: 2
-  - uid: 22260
+  - uid: 22259
     components:
     - type: Transform
       pos: -33.5,2.5
       parent: 2
-  - uid: 22261
+  - uid: 22260
     components:
     - type: Transform
       pos: -39.5,5.5
       parent: 2
-  - uid: 22262
+  - uid: 22261
     components:
     - type: Transform
       pos: 69.5,15.5
       parent: 2
-  - uid: 22263
+  - uid: 22262
     components:
     - type: Transform
       pos: -43.5,11.5
       parent: 2
-  - uid: 22264
+  - uid: 22263
     components:
     - type: Transform
       pos: -49.5,11.5
       parent: 2
-  - uid: 22265
+  - uid: 22264
     components:
     - type: Transform
       pos: -40.5,11.5
       parent: 2
-  - uid: 22266
+  - uid: 22265
     components:
     - type: Transform
       pos: -47.5,11.5
       parent: 2
-  - uid: 22267
+  - uid: 22266
     components:
     - type: Transform
       pos: -44.5,11.5
       parent: 2
-  - uid: 22268
+  - uid: 22267
     components:
     - type: Transform
       pos: -42.5,11.5
       parent: 2
-  - uid: 22269
+  - uid: 22268
     components:
     - type: Transform
       pos: -45.5,11.5
       parent: 2
-  - uid: 22270
+  - uid: 22269
     components:
     - type: Transform
       pos: -46.5,11.5
       parent: 2
-  - uid: 22271
+  - uid: 22270
     components:
     - type: Transform
       pos: -58.5,6.5
       parent: 2
-  - uid: 22272
+  - uid: 22271
     components:
     - type: Transform
       pos: -51.5,11.5
       parent: 2
-  - uid: 22273
+  - uid: 22272
     components:
     - type: Transform
       pos: -52.5,11.5
       parent: 2
-  - uid: 22274
+  - uid: 22273
     components:
     - type: Transform
       pos: -47.5,2.5
       parent: 2
-  - uid: 22275
+  - uid: 22274
     components:
     - type: Transform
       pos: -48.5,2.5
       parent: 2
-  - uid: 22276
+  - uid: 22275
     components:
     - type: Transform
       pos: -52.5,2.5
       parent: 2
-  - uid: 22277
+  - uid: 22276
     components:
     - type: Transform
       pos: -51.5,2.5
       parent: 2
-  - uid: 22278
+  - uid: 22277
     components:
     - type: Transform
       pos: -47.5,-2.5
       parent: 2
-  - uid: 22279
+  - uid: 22278
     components:
     - type: Transform
       pos: -47.5,-3.5
       parent: 2
-  - uid: 22280
+  - uid: 22279
     components:
     - type: Transform
       pos: -47.5,1.5
       parent: 2
-  - uid: 22281
+  - uid: 22280
     components:
     - type: Transform
       pos: -50.5,11.5
       parent: 2
-  - uid: 22282
+  - uid: 22281
     components:
     - type: Transform
       pos: -52.5,-2.5
       parent: 2
-  - uid: 22283
+  - uid: 22282
     components:
     - type: Transform
       pos: -52.5,-3.5
       parent: 2
-  - uid: 22284
+  - uid: 22283
     components:
     - type: Transform
       pos: -52.5,-1.5
       parent: 2
-  - uid: 22285
+  - uid: 22284
     components:
     - type: Transform
       pos: -51.5,-3.5
       parent: 2
-  - uid: 22286
+  - uid: 22285
     components:
     - type: Transform
       pos: -50.5,-3.5
       parent: 2
-  - uid: 22287
+  - uid: 22286
     components:
     - type: Transform
       pos: -49.5,-3.5
       parent: 2
-  - uid: 22288
+  - uid: 22287
     components:
     - type: Transform
       pos: -48.5,-3.5
       parent: 2
-  - uid: 22289
+  - uid: 22288
     components:
     - type: Transform
       pos: -58.5,2.5
       parent: 2
-  - uid: 22290
+  - uid: 22289
     components:
     - type: Transform
       pos: -58.5,-1.5
       parent: 2
-  - uid: 22291
+  - uid: 22290
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 2
-  - uid: 22292
+  - uid: 22291
     components:
     - type: Transform
       pos: 70.5,15.5
       parent: 2
-  - uid: 22293
+  - uid: 22292
     components:
     - type: Transform
       pos: -57.5,25.5
       parent: 2
-  - uid: 22294
+  - uid: 22293
     components:
     - type: Transform
       pos: -56.5,25.5
       parent: 2
-  - uid: 22295
+  - uid: 22294
     components:
     - type: Transform
       pos: -57.5,27.5
       parent: 2
-  - uid: 22296
+  - uid: 22295
     components:
     - type: Transform
       pos: -57.5,26.5
       parent: 2
-  - uid: 22297
+  - uid: 22296
     components:
     - type: Transform
       pos: -49.5,27.5
       parent: 2
-  - uid: 22298
+  - uid: 22297
     components:
     - type: Transform
       pos: -49.5,26.5
       parent: 2
-  - uid: 22299
+  - uid: 22298
     components:
     - type: Transform
       pos: -50.5,25.5
       parent: 2
-  - uid: 22300
+  - uid: 22299
     components:
     - type: Transform
       pos: 34.5,37.5
       parent: 2
-  - uid: 22301
+  - uid: 22300
     components:
     - type: Transform
       pos: 37.5,33.5
       parent: 2
-  - uid: 22302
+  - uid: 22301
     components:
     - type: Transform
       pos: 38.5,39.5
       parent: 2
-  - uid: 22303
+  - uid: 22302
     components:
     - type: Transform
       pos: 38.5,34.5
       parent: 2
-  - uid: 22304
+  - uid: 22303
     components:
     - type: Transform
       pos: -68.5,34.5
       parent: 2
-  - uid: 22305
+  - uid: 22304
     components:
     - type: Transform
       pos: -69.5,32.5
       parent: 2
-  - uid: 22306
+  - uid: 22305
     components:
     - type: Transform
       pos: -69.5,33.5
       parent: 2
-  - uid: 22307
+  - uid: 22306
     components:
     - type: Transform
       pos: -69.5,34.5
       parent: 2
-  - uid: 22308
+  - uid: 22307
     components:
     - type: Transform
       pos: -65.5,34.5
       parent: 2
-  - uid: 22309
+  - uid: 22308
     components:
     - type: Transform
       pos: -55.5,33.5
       parent: 2
-  - uid: 22310
+  - uid: 22309
     components:
     - type: Transform
       pos: -54.5,33.5
       parent: 2
-  - uid: 22311
+  - uid: 22310
     components:
     - type: Transform
       pos: -53.5,33.5
       parent: 2
-  - uid: 22312
+  - uid: 22311
     components:
     - type: Transform
       pos: -52.5,33.5
       parent: 2
-  - uid: 22313
+  - uid: 22312
     components:
     - type: Transform
       pos: -51.5,33.5
       parent: 2
-  - uid: 22314
+  - uid: 22313
     components:
     - type: Transform
       pos: -50.5,33.5
       parent: 2
-  - uid: 22315
+  - uid: 22314
     components:
     - type: Transform
       pos: -49.5,33.5
       parent: 2
-  - uid: 22316
+  - uid: 22315
     components:
     - type: Transform
       pos: -42.5,33.5
       parent: 2
-  - uid: 22317
+  - uid: 22316
     components:
     - type: Transform
       pos: -42.5,32.5
       parent: 2
-  - uid: 22318
+  - uid: 22317
     components:
     - type: Transform
       pos: -42.5,29.5
       parent: 2
-  - uid: 22319
+  - uid: 22318
     components:
     - type: Transform
       pos: -42.5,27.5
       parent: 2
-  - uid: 22320
+  - uid: 22319
     components:
     - type: Transform
       pos: -42.5,26.5
       parent: 2
-  - uid: 22321
+  - uid: 22320
     components:
     - type: Transform
       pos: -41.5,33.5
       parent: 2
-  - uid: 22322
+  - uid: 22321
     components:
     - type: Transform
       pos: -40.5,33.5
       parent: 2
-  - uid: 22323
+  - uid: 22322
     components:
     - type: Transform
       pos: -39.5,33.5
       parent: 2
-  - uid: 22324
+  - uid: 22323
     components:
     - type: Transform
       pos: -38.5,33.5
       parent: 2
-  - uid: 22325
+  - uid: 22324
     components:
     - type: Transform
       pos: -37.5,33.5
       parent: 2
-  - uid: 22326
+  - uid: 22325
     components:
     - type: Transform
       pos: -37.5,32.5
       parent: 2
-  - uid: 22327
+  - uid: 22326
     components:
     - type: Transform
       pos: -37.5,31.5
       parent: 2
-  - uid: 22328
+  - uid: 22327
     components:
     - type: Transform
       pos: -37.5,30.5
       parent: 2
-  - uid: 22329
+  - uid: 22328
     components:
     - type: Transform
       pos: -37.5,29.5
       parent: 2
-  - uid: 22330
+  - uid: 22329
     components:
     - type: Transform
       pos: -37.5,28.5
       parent: 2
-  - uid: 22331
+  - uid: 22330
     components:
     - type: Transform
       pos: -37.5,27.5
       parent: 2
-  - uid: 22332
+  - uid: 22331
     components:
     - type: Transform
       pos: -37.5,26.5
       parent: 2
-  - uid: 22333
+  - uid: 22332
     components:
     - type: Transform
       pos: -39.5,26.5
       parent: 2
-  - uid: 22334
+  - uid: 22333
     components:
     - type: Transform
       pos: -40.5,26.5
       parent: 2
-  - uid: 22335
+  - uid: 22334
     components:
     - type: Transform
       pos: -41.5,26.5
       parent: 2
-  - uid: 22336
+  - uid: 22335
     components:
     - type: Transform
       pos: -38.5,26.5
       parent: 2
-  - uid: 22337
+  - uid: 22336
     components:
     - type: Transform
       pos: -50.5,40.5
       parent: 2
-  - uid: 22338
+  - uid: 22337
     components:
     - type: Transform
       pos: -50.5,41.5
       parent: 2
-  - uid: 22339
+  - uid: 22338
     components:
     - type: Transform
       pos: -50.5,42.5
       parent: 2
-  - uid: 22340
+  - uid: 22339
     components:
     - type: Transform
       pos: -50.5,43.5
       parent: 2
-  - uid: 22341
+  - uid: 22340
     components:
     - type: Transform
       pos: -50.5,44.5
       parent: 2
-  - uid: 22342
+  - uid: 22341
     components:
     - type: Transform
       pos: -51.5,40.5
       parent: 2
-  - uid: 22343
+  - uid: 22342
     components:
     - type: Transform
       pos: -51.5,41.5
       parent: 2
-  - uid: 22344
+  - uid: 22343
     components:
     - type: Transform
       pos: -51.5,42.5
       parent: 2
-  - uid: 22345
+  - uid: 22344
     components:
     - type: Transform
       pos: -51.5,43.5
       parent: 2
-  - uid: 22346
+  - uid: 22345
     components:
     - type: Transform
       pos: -51.5,44.5
       parent: 2
-  - uid: 22347
+  - uid: 22346
     components:
     - type: Transform
       pos: -50.5,45.5
       parent: 2
-  - uid: 22348
+  - uid: 22347
     components:
     - type: Transform
       pos: -49.5,44.5
       parent: 2
-  - uid: 22349
+  - uid: 22348
     components:
     - type: Transform
       pos: -49.5,45.5
       parent: 2
-  - uid: 22350
+  - uid: 22349
     components:
     - type: Transform
       pos: -49.5,46.5
       parent: 2
-  - uid: 22351
+  - uid: 22350
     components:
     - type: Transform
       pos: -47.5,44.5
       parent: 2
-  - uid: 22352
+  - uid: 22351
     components:
     - type: Transform
       pos: -47.5,46.5
       parent: 2
-  - uid: 22353
+  - uid: 22352
     components:
     - type: Transform
       pos: -47.5,45.5
       parent: 2
-  - uid: 22354
+  - uid: 22353
     components:
     - type: Transform
       pos: -46.5,45.5
       parent: 2
-  - uid: 22355
+  - uid: 22354
     components:
     - type: Transform
       pos: -46.5,44.5
       parent: 2
-  - uid: 22356
+  - uid: 22355
     components:
     - type: Transform
       pos: -46.5,43.5
       parent: 2
-  - uid: 22357
+  - uid: 22356
     components:
     - type: Transform
       pos: -46.5,42.5
       parent: 2
-  - uid: 22358
+  - uid: 22357
     components:
     - type: Transform
       pos: -46.5,41.5
       parent: 2
-  - uid: 22359
+  - uid: 22358
     components:
     - type: Transform
       pos: -46.5,40.5
       parent: 2
-  - uid: 22360
+  - uid: 22359
     components:
     - type: Transform
       pos: -45.5,40.5
       parent: 2
-  - uid: 22361
+  - uid: 22360
     components:
     - type: Transform
       pos: -45.5,41.5
       parent: 2
-  - uid: 22362
+  - uid: 22361
     components:
     - type: Transform
       pos: -45.5,42.5
       parent: 2
-  - uid: 22363
+  - uid: 22362
     components:
     - type: Transform
       pos: -45.5,43.5
       parent: 2
-  - uid: 22364
+  - uid: 22363
     components:
     - type: Transform
       pos: -45.5,44.5
       parent: 2
-  - uid: 22365
+  - uid: 22364
     components:
     - type: Transform
       pos: -49.5,32.5
       parent: 2
-  - uid: 22366
+  - uid: 22365
     components:
     - type: Transform
       pos: -49.5,31.5
       parent: 2
-  - uid: 22367
+  - uid: 22366
     components:
     - type: Transform
       pos: -62.5,43.5
       parent: 2
-  - uid: 22368
+  - uid: 22367
     components:
     - type: Transform
       pos: -62.5,44.5
       parent: 2
-  - uid: 22369
+  - uid: 22368
     components:
     - type: Transform
       pos: -62.5,45.5
       parent: 2
-  - uid: 22370
+  - uid: 22369
     components:
     - type: Transform
       pos: -62.5,46.5
       parent: 2
-  - uid: 22371
+  - uid: 22370
     components:
     - type: Transform
       pos: -58.5,43.5
       parent: 2
-  - uid: 22372
+  - uid: 22371
     components:
     - type: Transform
       pos: -58.5,44.5
       parent: 2
-  - uid: 22373
+  - uid: 22372
     components:
     - type: Transform
       pos: -58.5,45.5
       parent: 2
-  - uid: 22374
+  - uid: 22373
     components:
     - type: Transform
       pos: -58.5,46.5
       parent: 2
-  - uid: 22375
+  - uid: 22374
     components:
     - type: Transform
       pos: -65.5,39.5
       parent: 2
-  - uid: 22376
+  - uid: 22375
     components:
     - type: Transform
       pos: -65.5,35.5
       parent: 2
-  - uid: 22377
+  - uid: 22376
     components:
     - type: Transform
       pos: -65.5,40.5
       parent: 2
-  - uid: 22378
+  - uid: 22377
     components:
     - type: Transform
       pos: -64.5,40.5
       parent: 2
-  - uid: 22379
+  - uid: 22378
     components:
     - type: Transform
       pos: -56.5,40.5
       parent: 2
-  - uid: 22380
+  - uid: 22379
     components:
     - type: Transform
       pos: -55.5,41.5
       parent: 2
-  - uid: 22381
+  - uid: 22380
     components:
     - type: Transform
       pos: -55.5,40.5
       parent: 2
-  - uid: 22382
+  - uid: 22381
     components:
     - type: Transform
       pos: -55.5,42.5
       parent: 2
-  - uid: 22383
+  - uid: 22382
     components:
     - type: Transform
       pos: -44.5,40.5
       parent: 2
-  - uid: 22384
+  - uid: 22383
     components:
     - type: Transform
       pos: -43.5,40.5
       parent: 2
-  - uid: 22385
+  - uid: 22384
     components:
     - type: Transform
       pos: -42.5,40.5
       parent: 2
-  - uid: 22386
+  - uid: 22385
     components:
     - type: Transform
       pos: 70.5,21.5
       parent: 2
-  - uid: 22387
+  - uid: 22386
     components:
     - type: Transform
       pos: 69.5,21.5
       parent: 2
-  - uid: 22388
+  - uid: 22387
     components:
     - type: Transform
       pos: 1.5,19.5
       parent: 2
-  - uid: 22389
+  - uid: 22388
     components:
     - type: Transform
       pos: 2.5,21.5
       parent: 2
-  - uid: 22390
+  - uid: 22389
     components:
     - type: Transform
       pos: 1.5,20.5
       parent: 2
-  - uid: 22391
+  - uid: 22390
     components:
     - type: Transform
       pos: 1.5,18.5
       parent: 2
-  - uid: 22392
+  - uid: 22391
     components:
     - type: Transform
       pos: 7.5,18.5
       parent: 2
-  - uid: 22393
+  - uid: 22392
     components:
     - type: Transform
       pos: 14.5,11.5
       parent: 2
-  - uid: 22394
+  - uid: 22393
     components:
     - type: Transform
       pos: 7.5,19.5
       parent: 2
-  - uid: 22395
+  - uid: 22394
     components:
     - type: Transform
       pos: 7.5,17.5
       parent: 2
-  - uid: 22396
+  - uid: 22395
     components:
     - type: Transform
       pos: 7.5,21.5
       parent: 2
-  - uid: 22397
+  - uid: 22396
     components:
     - type: Transform
       pos: 7.5,20.5
       parent: 2
-  - uid: 22398
+  - uid: 22397
     components:
     - type: Transform
       pos: 47.5,17.5
       parent: 2
-  - uid: 22399
+  - uid: 22398
     components:
     - type: Transform
       pos: 21.5,16.5
       parent: 2
-  - uid: 22400
+  - uid: 22399
     components:
     - type: Transform
       pos: 21.5,20.5
       parent: 2
-  - uid: 22401
+  - uid: 22400
     components:
     - type: Transform
       pos: 21.5,22.5
       parent: 2
-  - uid: 22402
+  - uid: 22401
     components:
     - type: Transform
       pos: 21.5,23.5
       parent: 2
-  - uid: 22403
+  - uid: 22402
     components:
     - type: Transform
       pos: 18.5,40.5
       parent: 2
-  - uid: 22404
+  - uid: 22403
     components:
     - type: Transform
       pos: 32.5,37.5
       parent: 2
-  - uid: 22405
+  - uid: 22404
     components:
     - type: Transform
       pos: 24.5,40.5
       parent: 2
-  - uid: 22406
+  - uid: 22405
     components:
     - type: Transform
       pos: 24.5,37.5
       parent: 2
-  - uid: 22407
+  - uid: 22406
     components:
     - type: Transform
       pos: 18.5,37.5
       parent: 2
-  - uid: 22408
+  - uid: 22407
     components:
     - type: Transform
       pos: 21.5,40.5
       parent: 2
-  - uid: 22409
+  - uid: 22408
     components:
     - type: Transform
       pos: 13.5,37.5
       parent: 2
-  - uid: 22410
+  - uid: 22409
     components:
     - type: Transform
       pos: 26.5,23.5
       parent: 2
-  - uid: 22411
+  - uid: 22410
     components:
     - type: Transform
       pos: 25.5,23.5
       parent: 2
-  - uid: 22412
+  - uid: 22411
     components:
     - type: Transform
       pos: 24.5,23.5
       parent: 2
-  - uid: 22413
+  - uid: 22412
     components:
     - type: Transform
       pos: 23.5,23.5
       parent: 2
-  - uid: 22414
+  - uid: 22413
     components:
     - type: Transform
       pos: 22.5,23.5
       parent: 2
-  - uid: 22415
+  - uid: 22414
     components:
     - type: Transform
       pos: 27.5,23.5
       parent: 2
-  - uid: 22416
+  - uid: 22415
     components:
     - type: Transform
       pos: 28.5,23.5
       parent: 2
-  - uid: 22417
+  - uid: 22416
     components:
     - type: Transform
       pos: 27.5,20.5
       parent: 2
-  - uid: 22418
+  - uid: 22417
     components:
     - type: Transform
       pos: 27.5,19.5
       parent: 2
-  - uid: 22419
+  - uid: 22418
     components:
     - type: Transform
       pos: 27.5,18.5
       parent: 2
-  - uid: 22420
+  - uid: 22419
     components:
     - type: Transform
       pos: 27.5,17.5
       parent: 2
-  - uid: 22421
+  - uid: 22420
     components:
     - type: Transform
       pos: 27.5,16.5
       parent: 2
-  - uid: 22422
+  - uid: 22421
     components:
     - type: Transform
       pos: 26.5,16.5
       parent: 2
-  - uid: 22423
+  - uid: 22422
     components:
     - type: Transform
       pos: 22.5,16.5
       parent: 2
-  - uid: 22424
+  - uid: 22423
     components:
     - type: Transform
       pos: 29.5,23.5
       parent: 2
-  - uid: 22425
+  - uid: 22424
     components:
     - type: Transform
       pos: 30.5,23.5
       parent: 2
-  - uid: 22426
+  - uid: 22425
     components:
     - type: Transform
       pos: 31.5,23.5
       parent: 2
-  - uid: 22427
+  - uid: 22426
     components:
     - type: Transform
       pos: 31.5,22.5
       parent: 2
-  - uid: 22428
+  - uid: 22427
     components:
     - type: Transform
       pos: 31.5,21.5
       parent: 2
-  - uid: 22429
+  - uid: 22428
     components:
     - type: Transform
       pos: 31.5,20.5
       parent: 2
-  - uid: 22430
+  - uid: 22429
     components:
     - type: Transform
       pos: 31.5,19.5
       parent: 2
-  - uid: 22431
+  - uid: 22430
     components:
     - type: Transform
       pos: 31.5,18.5
       parent: 2
-  - uid: 22432
+  - uid: 22431
     components:
     - type: Transform
       pos: 30.5,18.5
       parent: 2
-  - uid: 22433
+  - uid: 22432
     components:
     - type: Transform
       pos: 29.5,18.5
       parent: 2
-  - uid: 22434
+  - uid: 22433
     components:
     - type: Transform
       pos: 28.5,18.5
       parent: 2
-  - uid: 22435
+  - uid: 22434
     components:
     - type: Transform
       pos: 27.5,22.5
       parent: 2
-  - uid: 22436
+  - uid: 22435
     components:
     - type: Transform
       pos: 27.5,27.5
       parent: 2
-  - uid: 22437
+  - uid: 22436
     components:
     - type: Transform
       pos: 26.5,37.5
       parent: 2
-  - uid: 22438
+  - uid: 22437
     components:
     - type: Transform
       pos: 25.5,37.5
       parent: 2
-  - uid: 22439
+  - uid: 22438
     components:
     - type: Transform
       pos: 27.5,37.5
       parent: 2
-  - uid: 22440
+  - uid: 22439
     components:
     - type: Transform
       pos: 27.5,28.5
       parent: 2
-  - uid: 22441
+  - uid: 22440
     components:
     - type: Transform
       pos: 27.5,33.5
       parent: 2
-  - uid: 22442
+  - uid: 22441
     components:
     - type: Transform
       pos: 27.5,31.5
       parent: 2
-  - uid: 22443
+  - uid: 22442
     components:
     - type: Transform
       pos: 27.5,35.5
       parent: 2
-  - uid: 22444
+  - uid: 22443
     components:
     - type: Transform
       pos: 28.5,27.5
       parent: 2
-  - uid: 22445
+  - uid: 22444
     components:
     - type: Transform
       pos: 29.5,27.5
       parent: 2
-  - uid: 22446
+  - uid: 22445
     components:
     - type: Transform
       pos: 30.5,27.5
       parent: 2
-  - uid: 22447
+  - uid: 22446
     components:
     - type: Transform
       pos: 31.5,27.5
       parent: 2
-  - uid: 22448
+  - uid: 22447
     components:
     - type: Transform
       pos: 32.5,27.5
       parent: 2
-  - uid: 22449
+  - uid: 22448
     components:
     - type: Transform
       pos: 33.5,27.5
       parent: 2
-  - uid: 22450
+  - uid: 22449
     components:
     - type: Transform
       pos: 33.5,28.5
       parent: 2
-  - uid: 22451
+  - uid: 22450
     components:
     - type: Transform
       pos: 33.5,29.5
       parent: 2
-  - uid: 22452
+  - uid: 22451
     components:
     - type: Transform
       pos: 33.5,30.5
       parent: 2
-  - uid: 22453
+  - uid: 22452
     components:
     - type: Transform
       pos: 33.5,31.5
       parent: 2
-  - uid: 22454
+  - uid: 22453
     components:
     - type: Transform
       pos: 33.5,32.5
       parent: 2
-  - uid: 22455
+  - uid: 22454
     components:
     - type: Transform
       pos: 33.5,33.5
       parent: 2
-  - uid: 22456
+  - uid: 22455
     components:
     - type: Transform
       pos: 36.5,33.5
       parent: 2
-  - uid: 22457
+  - uid: 22456
     components:
     - type: Transform
       pos: 34.5,33.5
       parent: 2
-  - uid: 22458
+  - uid: 22457
     components:
     - type: Transform
       pos: 33.5,36.5
       parent: 2
-  - uid: 22459
+  - uid: 22458
     components:
     - type: Transform
       pos: 33.5,37.5
       parent: 2
-  - uid: 22460
+  - uid: 22459
     components:
     - type: Transform
       pos: 31.5,37.5
       parent: 2
-  - uid: 22461
+  - uid: 22460
     components:
     - type: Transform
       pos: 30.5,37.5
       parent: 2
-  - uid: 22462
+  - uid: 22461
     components:
     - type: Transform
       pos: 29.5,37.5
       parent: 2
-  - uid: 22463
+  - uid: 22462
     components:
     - type: Transform
       pos: 28.5,37.5
       parent: 2
-  - uid: 22464
+  - uid: 22463
     components:
     - type: Transform
       pos: 35.5,33.5
       parent: 2
-  - uid: 22465
+  - uid: 22464
     components:
     - type: Transform
       pos: 33.5,-15.5
       parent: 2
-  - uid: 22466
+  - uid: 22465
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 2
-  - uid: 22467
+  - uid: 22466
     components:
     - type: Transform
       pos: 16.5,2.5
       parent: 2
-  - uid: 22468
+  - uid: 22467
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,7.5
       parent: 2
-  - uid: 22469
+  - uid: 22468
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-12.5
       parent: 2
-  - uid: 22470
+  - uid: 22469
     components:
     - type: Transform
       pos: 17.5,2.5
       parent: 2
-  - uid: 22471
+  - uid: 22470
     components:
     - type: Transform
       pos: 27.5,-15.5
       parent: 2
-  - uid: 22472
+  - uid: 22471
     components:
     - type: Transform
       pos: 28.5,-15.5
       parent: 2
-  - uid: 22473
+  - uid: 22472
     components:
     - type: Transform
       pos: 26.5,-15.5
       parent: 2
-  - uid: 22474
+  - uid: 22473
     components:
     - type: Transform
       pos: 21.5,-34.5
       parent: 2
-  - uid: 22475
+  - uid: 22474
     components:
     - type: Transform
       pos: 21.5,-15.5
       parent: 2
-  - uid: 22476
+  - uid: 22475
     components:
     - type: Transform
       pos: 28.5,-34.5
       parent: 2
-  - uid: 22477
+  - uid: 22476
     components:
     - type: Transform
       pos: 17.5,-38.5
       parent: 2
-  - uid: 22478
+  - uid: 22477
     components:
     - type: Transform
       pos: 33.5,-18.5
       parent: 2
-  - uid: 22479
+  - uid: 22478
     components:
     - type: Transform
       pos: 21.5,-28.5
       parent: 2
-  - uid: 22480
+  - uid: 22479
     components:
     - type: Transform
       pos: 22.5,-28.5
       parent: 2
-  - uid: 22481
+  - uid: 22480
     components:
     - type: Transform
       pos: 21.5,-30.5
       parent: 2
-  - uid: 22482
+  - uid: 22481
     components:
     - type: Transform
       pos: 22.5,-30.5
       parent: 2
-  - uid: 22483
+  - uid: 22482
     components:
     - type: Transform
       pos: 32.5,-21.5
       parent: 2
-  - uid: 22484
+  - uid: 22483
     components:
     - type: Transform
       pos: 26.5,-34.5
       parent: 2
-  - uid: 22485
+  - uid: 22484
     components:
     - type: Transform
       pos: 17.5,-42.5
       parent: 2
-  - uid: 22486
+  - uid: 22485
     components:
     - type: Transform
       pos: 27.5,-34.5
       parent: 2
-  - uid: 22487
+  - uid: 22486
     components:
     - type: Transform
       pos: 21.5,-23.5
       parent: 2
-  - uid: 22488
+  - uid: 22487
     components:
     - type: Transform
       pos: 22.5,-23.5
       parent: 2
-  - uid: 22489
+  - uid: 22488
     components:
     - type: Transform
       pos: 22.5,-21.5
       parent: 2
-  - uid: 22490
+  - uid: 22489
     components:
     - type: Transform
       pos: 21.5,-21.5
       parent: 2
-  - uid: 22491
+  - uid: 22490
     components:
     - type: Transform
       pos: 32.5,-30.5
       parent: 2
-  - uid: 22492
+  - uid: 22491
     components:
     - type: Transform
       pos: 33.5,-30.5
       parent: 2
-  - uid: 22493
+  - uid: 22492
     components:
     - type: Transform
       pos: 33.5,-28.5
       parent: 2
-  - uid: 22494
+  - uid: 22493
     components:
     - type: Transform
       pos: 32.5,-28.5
       parent: 2
-  - uid: 22495
+  - uid: 22494
     components:
     - type: Transform
       pos: 33.5,-23.5
       parent: 2
-  - uid: 22496
+  - uid: 22495
     components:
     - type: Transform
       pos: 32.5,-23.5
       parent: 2
-  - uid: 22497
+  - uid: 22496
     components:
     - type: Transform
       pos: 33.5,-21.5
       parent: 2
-  - uid: 22498
+  - uid: 22497
     components:
     - type: Transform
       pos: 33.5,-34.5
       parent: 2
-  - uid: 22499
+  - uid: 22498
     components:
     - type: Transform
       pos: 0.5,-42.5
       parent: 2
-  - uid: 22500
+  - uid: 22499
     components:
     - type: Transform
       pos: -0.5,-42.5
       parent: 2
-  - uid: 22501
+  - uid: 22500
     components:
     - type: Transform
       pos: -1.5,-42.5
       parent: 2
-  - uid: 22502
+  - uid: 22501
     components:
     - type: Transform
       pos: -2.5,-42.5
       parent: 2
-  - uid: 22503
+  - uid: 22502
     components:
     - type: Transform
       pos: -3.5,-42.5
       parent: 2
-  - uid: 22504
+  - uid: 22503
     components:
     - type: Transform
       pos: -4.5,-42.5
       parent: 2
-  - uid: 22505
+  - uid: 22504
     components:
     - type: Transform
       pos: -5.5,-42.5
       parent: 2
-  - uid: 22506
+  - uid: 22505
     components:
     - type: Transform
       pos: -5.5,-41.5
       parent: 2
-  - uid: 22507
+  - uid: 22506
     components:
     - type: Transform
       pos: -5.5,-40.5
       parent: 2
-  - uid: 22508
+  - uid: 22507
     components:
     - type: Transform
       pos: -5.5,-39.5
       parent: 2
-  - uid: 22509
+  - uid: 22508
     components:
     - type: Transform
       pos: -5.5,-38.5
       parent: 2
-  - uid: 22510
+  - uid: 22509
     components:
     - type: Transform
       pos: -5.5,-37.5
       parent: 2
-  - uid: 22511
+  - uid: 22510
     components:
     - type: Transform
       pos: -5.5,-36.5
       parent: 2
-  - uid: 22512
+  - uid: 22511
     components:
     - type: Transform
       pos: -5.5,-35.5
       parent: 2
-  - uid: 22513
+  - uid: 22512
     components:
     - type: Transform
       pos: -5.5,-34.5
       parent: 2
-  - uid: 22514
+  - uid: 22513
     components:
     - type: Transform
       pos: 17.5,-41.5
       parent: 2
-  - uid: 22515
+  - uid: 22514
     components:
     - type: Transform
       pos: 2.5,-24.5
       parent: 2
-  - uid: 22516
+  - uid: 22515
     components:
     - type: Transform
       pos: -29.5,24.5
       parent: 2
-  - uid: 22517
+  - uid: 22516
     components:
     - type: Transform
       pos: 39.5,5.5
       parent: 2
-  - uid: 22518
+  - uid: 22517
     components:
     - type: Transform
       pos: 38.5,5.5
       parent: 2
-  - uid: 22519
+  - uid: 22518
     components:
     - type: Transform
       pos: 40.5,5.5
       parent: 2
-  - uid: 22520
+  - uid: 22519
     components:
     - type: Transform
       pos: 41.5,5.5
       parent: 2
-  - uid: 22521
+  - uid: 22520
     components:
     - type: Transform
       pos: 42.5,5.5
       parent: 2
-  - uid: 22522
+  - uid: 22521
     components:
     - type: Transform
       pos: 43.5,5.5
       parent: 2
-  - uid: 22523
+  - uid: 22522
     components:
     - type: Transform
       pos: 44.5,5.5
       parent: 2
-  - uid: 22524
+  - uid: 22523
     components:
     - type: Transform
       pos: 45.5,5.5
       parent: 2
-  - uid: 22525
+  - uid: 22524
     components:
     - type: Transform
       pos: 37.5,5.5
       parent: 2
-  - uid: 22526
+  - uid: 22525
     components:
     - type: Transform
       pos: 47.5,5.5
       parent: 2
-  - uid: 22527
+  - uid: 22526
     components:
     - type: Transform
       pos: 48.5,5.5
       parent: 2
-  - uid: 22528
+  - uid: 22527
     components:
     - type: Transform
       pos: 46.5,5.5
       parent: 2
-  - uid: 22529
+  - uid: 22528
     components:
     - type: Transform
       pos: 35.5,6.5
       parent: 2
-  - uid: 22530
+  - uid: 22529
     components:
     - type: Transform
       pos: 35.5,5.5
       parent: 2
-  - uid: 22531
+  - uid: 22530
     components:
     - type: Transform
       pos: 48.5,4.5
       parent: 2
-  - uid: 22532
+  - uid: 22531
     components:
     - type: Transform
       pos: 52.5,4.5
       parent: 2
-  - uid: 22533
+  - uid: 22532
     components:
     - type: Transform
       pos: 52.5,3.5
       parent: 2
-  - uid: 22534
+  - uid: 22533
     components:
     - type: Transform
       pos: 51.5,4.5
       parent: 2
-  - uid: 22535
+  - uid: 22534
     components:
     - type: Transform
       pos: 50.5,4.5
       parent: 2
-  - uid: 22536
+  - uid: 22535
     components:
     - type: Transform
       pos: 49.5,4.5
       parent: 2
-  - uid: 22537
+  - uid: 22536
     components:
     - type: Transform
       pos: -31.5,24.5
       parent: 2
-  - uid: 22538
+  - uid: 22537
     components:
     - type: Transform
       pos: 1.5,-24.5
       parent: 2
-  - uid: 22539
+  - uid: 22538
     components:
     - type: Transform
       pos: 66.5,-7.5
       parent: 2
-  - uid: 22540
+  - uid: 22539
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 56.5,4.5
       parent: 2
-  - uid: 22541
+  - uid: 22540
     components:
     - type: Transform
       pos: 54.5,3.5
       parent: 2
-  - uid: 22542
+  - uid: 22541
     components:
     - type: Transform
       pos: 56.5,3.5
       parent: 2
-  - uid: 22543
+  - uid: 22542
     components:
     - type: Transform
       pos: 53.5,3.5
       parent: 2
-  - uid: 22544
+  - uid: 22543
     components:
     - type: Transform
       pos: 55.5,3.5
       parent: 2
-  - uid: 22545
+  - uid: 22544
     components:
     - type: Transform
       pos: 59.5,4.5
       parent: 2
-  - uid: 22546
+  - uid: 22545
     components:
     - type: Transform
       pos: 61.5,4.5
       parent: 2
-  - uid: 22547
+  - uid: 22546
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 54.5,4.5
       parent: 2
-  - uid: 22548
+  - uid: 22547
     components:
     - type: Transform
       pos: 58.5,4.5
       parent: 2
-  - uid: 22549
+  - uid: 22548
     components:
     - type: Transform
       pos: 60.5,4.5
       parent: 2
-  - uid: 22550
+  - uid: 22549
     components:
     - type: Transform
       pos: 66.5,-1.5
       parent: 2
-  - uid: 22551
+  - uid: 22550
     components:
     - type: Transform
       pos: 66.5,-2.5
       parent: 2
-  - uid: 22552
+  - uid: 22551
     components:
     - type: Transform
       pos: 66.5,-3.5
       parent: 2
-  - uid: 22553
+  - uid: 22552
     components:
     - type: Transform
       pos: 66.5,-5.5
       parent: 2
-  - uid: 22554
+  - uid: 22553
     components:
     - type: Transform
       pos: 66.5,-6.5
       parent: 2
-  - uid: 22555
+  - uid: 22554
     components:
     - type: Transform
       pos: 66.5,-4.5
       parent: 2
-  - uid: 22556
+  - uid: 22555
     components:
     - type: Transform
       pos: 28.5,12.5
       parent: 2
-  - uid: 22557
+  - uid: 22556
     components:
     - type: Transform
       pos: 84.5,-10.5
       parent: 2
-  - uid: 22558
+  - uid: 22557
     components:
     - type: Transform
       pos: 84.5,-8.5
       parent: 2
-  - uid: 22559
+  - uid: 22558
     components:
     - type: Transform
       pos: 84.5,-7.5
       parent: 2
-  - uid: 22560
+  - uid: 22559
     components:
     - type: Transform
       pos: 84.5,-6.5
       parent: 2
-  - uid: 22561
+  - uid: 22560
     components:
     - type: Transform
       pos: 84.5,-9.5
       parent: 2
-  - uid: 22562
+  - uid: 22561
     components:
     - type: Transform
       pos: 83.5,-6.5
       parent: 2
-  - uid: 22563
+  - uid: 22562
     components:
     - type: Transform
       pos: 82.5,-6.5
       parent: 2
-  - uid: 22564
+  - uid: 22563
     components:
     - type: Transform
       pos: 81.5,-6.5
       parent: 2
-  - uid: 22565
+  - uid: 22564
     components:
     - type: Transform
       pos: 80.5,-6.5
       parent: 2
-  - uid: 22566
+  - uid: 22565
     components:
     - type: Transform
       pos: 79.5,-6.5
       parent: 2
-  - uid: 22567
+  - uid: 22566
     components:
     - type: Transform
       pos: 78.5,-6.5
       parent: 2
-  - uid: 22568
+  - uid: 22567
     components:
     - type: Transform
       pos: 77.5,-6.5
       parent: 2
-  - uid: 22569
+  - uid: 22568
     components:
     - type: Transform
       pos: 76.5,-6.5
       parent: 2
-  - uid: 22570
+  - uid: 22569
     components:
     - type: Transform
       pos: 76.5,-7.5
       parent: 2
-  - uid: 22571
+  - uid: 22570
     components:
     - type: Transform
       pos: 76.5,-8.5
       parent: 2
-  - uid: 22572
+  - uid: 22571
     components:
     - type: Transform
       pos: 87.5,-18.5
       parent: 2
-  - uid: 22573
+  - uid: 22572
     components:
     - type: Transform
       pos: 87.5,-14.5
       parent: 2
-  - uid: 22574
+  - uid: 22573
     components:
     - type: Transform
       pos: 74.5,-26.5
       parent: 2
-  - uid: 22575
+  - uid: 22574
     components:
     - type: Transform
       pos: 74.5,-27.5
       parent: 2
-  - uid: 22576
+  - uid: 22575
     components:
     - type: Transform
       pos: 74.5,-28.5
       parent: 2
-  - uid: 22577
+  - uid: 22576
     components:
     - type: Transform
       pos: 74.5,-29.5
       parent: 2
-  - uid: 22578
+  - uid: 22577
     components:
     - type: Transform
       pos: 74.5,-25.5
       parent: 2
-  - uid: 22579
+  - uid: 22578
     components:
     - type: Transform
       pos: 74.5,-24.5
       parent: 2
-  - uid: 22580
+  - uid: 22579
     components:
     - type: Transform
       pos: 73.5,-21.5
       parent: 2
-  - uid: 22581
+  - uid: 22580
     components:
     - type: Transform
       pos: 73.5,-24.5
       parent: 2
-  - uid: 22582
+  - uid: 22581
     components:
     - type: Transform
       pos: 73.5,-23.5
       parent: 2
-  - uid: 22583
+  - uid: 22582
     components:
     - type: Transform
       pos: 73.5,-22.5
       parent: 2
-  - uid: 22584
+  - uid: 22583
     components:
     - type: Transform
       pos: 87.5,-22.5
       parent: 2
-  - uid: 22585
+  - uid: 22584
     components:
     - type: Transform
       pos: 87.5,-26.5
       parent: 2
-  - uid: 22586
+  - uid: 22585
     components:
     - type: Transform
       pos: 75.5,-29.5
       parent: 2
-  - uid: 22587
+  - uid: 22586
     components:
     - type: Transform
       pos: 78.5,-23.5
       parent: 2
-  - uid: 22588
+  - uid: 22587
     components:
     - type: Transform
       pos: 76.5,-29.5
       parent: 2
-  - uid: 22589
+  - uid: 22588
     components:
     - type: Transform
       pos: 78.5,-25.5
       parent: 2
-  - uid: 22590
+  - uid: 22589
     components:
     - type: Transform
       pos: -69.5,19.5
       parent: 2
-  - uid: 22591
+  - uid: 22590
     components:
     - type: Transform
       pos: 74.5,-21.5
       parent: 2
-  - uid: 22592
+  - uid: 22591
     components:
     - type: Transform
       pos: 76.5,-21.5
       parent: 2
-  - uid: 22593
+  - uid: 22592
     components:
     - type: Transform
       pos: -69.5,20.5
       parent: 2
-  - uid: 22594
+  - uid: 22593
     components:
     - type: Transform
       pos: -69.5,21.5
       parent: 2
-  - uid: 22595
+  - uid: 22594
     components:
     - type: Transform
       pos: -69.5,22.5
       parent: 2
-  - uid: 22596
+  - uid: 22595
     components:
     - type: Transform
       pos: -69.5,25.5
       parent: 2
-  - uid: 22597
+  - uid: 22596
     components:
     - type: Transform
       pos: -69.5,24.5
       parent: 2
-  - uid: 22598
+  - uid: 22597
     components:
     - type: Transform
       pos: -69.5,18.5
       parent: 2
-  - uid: 22599
+  - uid: 22598
     components:
     - type: Transform
       pos: -69.5,17.5
       parent: 2
-  - uid: 22600
+  - uid: 22599
     components:
     - type: Transform
       pos: -69.5,16.5
       parent: 2
-  - uid: 22601
+  - uid: 22600
     components:
     - type: Transform
       pos: -69.5,15.5
       parent: 2
-  - uid: 22602
+  - uid: 22601
     components:
     - type: Transform
       pos: -69.5,26.5
       parent: 2
-  - uid: 22603
+  - uid: 22602
     components:
     - type: Transform
       pos: 48.5,-35.5
       parent: 2
-  - uid: 22604
+  - uid: 22603
     components:
     - type: Transform
       pos: 76.5,-5.5
       parent: 2
-  - uid: 22605
+  - uid: 22604
     components:
     - type: Transform
       pos: 43.5,-35.5
       parent: 2
-  - uid: 22606
+  - uid: 22605
     components:
     - type: Transform
       pos: 29.5,12.5
       parent: 2
-  - uid: 22607
+  - uid: 22606
     components:
     - type: Transform
       pos: 31.5,16.5
       parent: 2
-  - uid: 22608
+  - uid: 22607
     components:
     - type: Transform
       pos: 30.5,16.5
       parent: 2
-  - uid: 22609
+  - uid: 22608
     components:
     - type: Transform
       pos: 29.5,15.5
       parent: 2
-  - uid: 22610
+  - uid: 22609
     components:
     - type: Transform
       pos: 29.5,13.5
       parent: 2
-  - uid: 22611
+  - uid: 22610
     components:
     - type: Transform
       pos: 29.5,16.5
       parent: 2
-  - uid: 22612
+  - uid: 22611
     components:
     - type: Transform
       pos: 29.5,14.5
       parent: 2
-  - uid: 22613
+  - uid: 22612
     components:
     - type: Transform
       pos: 32.5,16.5
       parent: 2
-  - uid: 22614
+  - uid: 22613
     components:
     - type: Transform
       pos: 39.5,12.5
       parent: 2
-  - uid: 22615
+  - uid: 22614
     components:
     - type: Transform
       pos: 39.5,14.5
       parent: 2
-  - uid: 22616
+  - uid: 22615
     components:
     - type: Transform
       pos: 48.5,17.5
       parent: 2
-  - uid: 22617
+  - uid: 22616
     components:
     - type: Transform
       pos: 39.5,11.5
       parent: 2
-  - uid: 22618
+  - uid: 22617
     components:
     - type: Transform
       pos: 39.5,16.5
       parent: 2
-  - uid: 22619
+  - uid: 22618
     components:
     - type: Transform
       pos: 39.5,15.5
       parent: 2
-  - uid: 22620
+  - uid: 22619
     components:
     - type: Transform
       pos: 41.5,17.5
       parent: 2
-  - uid: 22621
+  - uid: 22620
     components:
     - type: Transform
       pos: 39.5,17.5
       parent: 2
-  - uid: 22622
+  - uid: 22621
     components:
     - type: Transform
       pos: 52.5,17.5
       parent: 2
-  - uid: 22623
+  - uid: 22622
     components:
     - type: Transform
       pos: 51.5,17.5
       parent: 2
-  - uid: 22624
+  - uid: 22623
     components:
     - type: Transform
       pos: 42.5,17.5
       parent: 2
-  - uid: 22625
+  - uid: 22624
     components:
     - type: Transform
       pos: 49.5,17.5
       parent: 2
-  - uid: 22626
+  - uid: 22625
     components:
     - type: Transform
       pos: 46.5,17.5
       parent: 2
-  - uid: 22627
+  - uid: 22626
     components:
     - type: Transform
       pos: 44.5,17.5
       parent: 2
-  - uid: 22628
+  - uid: 22627
     components:
     - type: Transform
       pos: 43.5,17.5
       parent: 2
-  - uid: 22629
+  - uid: 22628
     components:
     - type: Transform
       pos: 45.5,17.5
       parent: 2
-  - uid: 22630
+  - uid: 22629
     components:
     - type: Transform
       pos: 40.5,17.5
       parent: 2
-  - uid: 22631
+  - uid: 22630
     components:
     - type: Transform
       pos: 39.5,6.5
       parent: 2
-  - uid: 22632
+  - uid: 22631
     components:
     - type: Transform
       pos: 38.5,12.5
       parent: 2
-  - uid: 22633
+  - uid: 22632
     components:
     - type: Transform
       pos: 37.5,12.5
       parent: 2
-  - uid: 22634
+  - uid: 22633
     components:
     - type: Transform
       pos: 35.5,12.5
       parent: 2
-  - uid: 22635
+  - uid: 22634
     components:
     - type: Transform
       pos: 56.5,17.5
       parent: 2
-  - uid: 22636
+  - uid: 22635
     components:
     - type: Transform
       pos: 53.5,20.5
       parent: 2
-  - uid: 22637
+  - uid: 22636
     components:
     - type: Transform
       pos: 56.5,15.5
       parent: 2
-  - uid: 22638
+  - uid: 22637
     components:
     - type: Transform
       pos: 42.5,-35.5
       parent: 2
-  - uid: 22639
+  - uid: 22638
     components:
     - type: Transform
       pos: 59.5,14.5
       parent: 2
-  - uid: 22640
+  - uid: 22639
     components:
     - type: Transform
       pos: 60.5,14.5
       parent: 2
-  - uid: 22641
+  - uid: 22640
     components:
     - type: Transform
       pos: 61.5,14.5
       parent: 2
-  - uid: 22642
+  - uid: 22641
     components:
     - type: Transform
       pos: 38.5,19.5
       parent: 2
-  - uid: 22643
+  - uid: 22642
     components:
     - type: Transform
       pos: 37.5,19.5
       parent: 2
-  - uid: 22644
+  - uid: 22643
     components:
     - type: Transform
       pos: 39.5,19.5
       parent: 2
-  - uid: 22645
+  - uid: 22644
     components:
     - type: Transform
       pos: 40.5,19.5
       parent: 2
-  - uid: 22646
+  - uid: 22645
     components:
     - type: Transform
       pos: 41.5,19.5
       parent: 2
-  - uid: 22647
+  - uid: 22646
     components:
     - type: Transform
       pos: 42.5,19.5
       parent: 2
-  - uid: 22648
+  - uid: 22647
     components:
     - type: Transform
       pos: 43.5,19.5
       parent: 2
-  - uid: 22649
+  - uid: 22648
     components:
     - type: Transform
       pos: 44.5,19.5
       parent: 2
-  - uid: 22650
+  - uid: 22649
     components:
     - type: Transform
       pos: 45.5,19.5
       parent: 2
-  - uid: 22651
+  - uid: 22650
     components:
     - type: Transform
       pos: 47.5,19.5
       parent: 2
-  - uid: 22652
+  - uid: 22651
     components:
     - type: Transform
       pos: 48.5,19.5
       parent: 2
-  - uid: 22653
+  - uid: 22652
     components:
     - type: Transform
       pos: 49.5,19.5
       parent: 2
-  - uid: 22654
+  - uid: 22653
     components:
     - type: Transform
       pos: 50.5,19.5
       parent: 2
-  - uid: 22655
+  - uid: 22654
     components:
     - type: Transform
       pos: 51.5,19.5
       parent: 2
-  - uid: 22656
+  - uid: 22655
     components:
     - type: Transform
       pos: 52.5,19.5
       parent: 2
-  - uid: 22657
+  - uid: 22656
     components:
     - type: Transform
       pos: 46.5,19.5
       parent: 2
-  - uid: 22658
+  - uid: 22657
     components:
     - type: Transform
       pos: 56.5,19.5
       parent: 2
-  - uid: 22659
+  - uid: 22658
     components:
     - type: Transform
       pos: 56.5,18.5
       parent: 2
-  - uid: 22660
+  - uid: 22659
     components:
     - type: Transform
       pos: 37.5,17.5
       parent: 2
-  - uid: 22661
+  - uid: 22660
     components:
     - type: Transform
       pos: 37.5,16.5
       parent: 2
-  - uid: 22662
+  - uid: 22661
     components:
     - type: Transform
       pos: 37.5,15.5
       parent: 2
-  - uid: 22663
+  - uid: 22662
     components:
     - type: Transform
       pos: 37.5,18.5
       parent: 2
-  - uid: 22664
+  - uid: 22663
     components:
     - type: Transform
       pos: 37.5,14.5
       parent: 2
-  - uid: 22665
+  - uid: 22664
     components:
     - type: Transform
       pos: 37.5,13.5
       parent: 2
-  - uid: 22666
+  - uid: 22665
     components:
     - type: Transform
       pos: 52.5,18.5
       parent: 2
-  - uid: 22667
+  - uid: 22666
     components:
     - type: Transform
       pos: 33.5,16.5
       parent: 2
-  - uid: 22668
+  - uid: 22667
     components:
     - type: Transform
       pos: 33.5,17.5
       parent: 2
-  - uid: 22669
+  - uid: 22668
     components:
     - type: Transform
       pos: 33.5,19.5
       parent: 2
-  - uid: 22670
+  - uid: 22669
     components:
     - type: Transform
       pos: 33.5,20.5
       parent: 2
-  - uid: 22671
+  - uid: 22670
     components:
     - type: Transform
       pos: 33.5,18.5
       parent: 2
-  - uid: 22672
+  - uid: 22671
     components:
     - type: Transform
       pos: 33.5,22.5
       parent: 2
-  - uid: 22673
+  - uid: 22672
     components:
     - type: Transform
       pos: 33.5,23.5
       parent: 2
-  - uid: 22674
+  - uid: 22673
     components:
     - type: Transform
       pos: 35.5,24.5
       parent: 2
-  - uid: 22675
+  - uid: 22674
     components:
     - type: Transform
       pos: 35.5,25.5
       parent: 2
-  - uid: 22676
+  - uid: 22675
     components:
     - type: Transform
       pos: 35.5,27.5
       parent: 2
-  - uid: 22677
+  - uid: 22676
     components:
     - type: Transform
       pos: 35.5,26.5
       parent: 2
-  - uid: 22678
+  - uid: 22677
     components:
     - type: Transform
       pos: 57.5,32.5
       parent: 2
-  - uid: 22679
+  - uid: 22678
     components:
     - type: Transform
       pos: 58.5,29.5
       parent: 2
-  - uid: 22680
+  - uid: 22679
     components:
     - type: Transform
       pos: 46.5,34.5
       parent: 2
-  - uid: 22681
+  - uid: 22680
     components:
     - type: Transform
       pos: 46.5,16.5
       parent: 2
-  - uid: 22682
+  - uid: 22681
     components:
     - type: Transform
       pos: 41.5,15.5
       parent: 2
-  - uid: 22683
+  - uid: 22682
     components:
     - type: Transform
       pos: 43.5,15.5
       parent: 2
-  - uid: 22684
+  - uid: 22683
     components:
     - type: Transform
       pos: 49.5,15.5
       parent: 2
-  - uid: 22685
+  - uid: 22684
     components:
     - type: Transform
       pos: 41.5,14.5
       parent: 2
-  - uid: 22686
+  - uid: 22685
     components:
     - type: Transform
       pos: 43.5,14.5
       parent: 2
-  - uid: 22687
+  - uid: 22686
     components:
     - type: Transform
       pos: 49.5,14.5
       parent: 2
-  - uid: 22688
+  - uid: 22687
     components:
     - type: Transform
       pos: 52.5,16.5
       parent: 2
-  - uid: 22689
+  - uid: 22688
     components:
     - type: Transform
       pos: 52.5,15.5
       parent: 2
-  - uid: 22690
+  - uid: 22689
     components:
     - type: Transform
       pos: 46.5,15.5
       parent: 2
-  - uid: 22691
+  - uid: 22690
     components:
     - type: Transform
       pos: 46.5,14.5
       parent: 2
-  - uid: 22692
+  - uid: 22691
     components:
     - type: Transform
       pos: 43.5,16.5
       parent: 2
-  - uid: 22693
+  - uid: 22692
     components:
     - type: Transform
       pos: 49.5,16.5
       parent: 2
-  - uid: 22694
+  - uid: 22693
     components:
     - type: Transform
       pos: 41.5,16.5
       parent: 2
-  - uid: 22695
+  - uid: 22694
     components:
     - type: Transform
       pos: 41.5,-35.5
       parent: 2
-  - uid: 22696
+  - uid: 22695
     components:
     - type: Transform
       pos: 47.5,-35.5
       parent: 2
-  - uid: 22697
+  - uid: 22696
     components:
     - type: Transform
       pos: 71.5,4.5
       parent: 2
-  - uid: 22698
+  - uid: 22697
     components:
     - type: Transform
       pos: 71.5,5.5
       parent: 2
-  - uid: 22699
+  - uid: 22698
     components:
     - type: Transform
       pos: 72.5,5.5
       parent: 2
-  - uid: 22700
+  - uid: 22699
     components:
     - type: Transform
       pos: 72.5,6.5
       parent: 2
-  - uid: 22701
+  - uid: 22700
     components:
     - type: Transform
       pos: 73.5,6.5
       parent: 2
-  - uid: 22702
+  - uid: 22701
     components:
     - type: Transform
       pos: 57.5,17.5
       parent: 2
-  - uid: 22703
+  - uid: 22702
     components:
     - type: Transform
       pos: 58.5,17.5
       parent: 2
-  - uid: 22704
+  - uid: 22703
     components:
     - type: Transform
       pos: 58.5,16.5
       parent: 2
-  - uid: 22705
+  - uid: 22704
     components:
     - type: Transform
       pos: 58.5,15.5
       parent: 2
-  - uid: 22706
+  - uid: 22705
     components:
     - type: Transform
       pos: 52.5,14.5
       parent: 2
-  - uid: 22707
+  - uid: 22706
     components:
     - type: Transform
       pos: 52.5,20.5
       parent: 2
-  - uid: 22708
+  - uid: 22707
     components:
     - type: Transform
       pos: 44.5,-35.5
       parent: 2
-  - uid: 22709
+  - uid: 22708
     components:
     - type: Transform
       pos: 49.5,-35.5
       parent: 2
-  - uid: 22710
+  - uid: 22709
     components:
     - type: Transform
       pos: 50.5,-35.5
       parent: 2
-  - uid: 22711
+  - uid: 22710
     components:
     - type: Transform
       pos: 56.5,14.5
       parent: 2
-  - uid: 22712
+  - uid: 22711
     components:
     - type: Transform
       pos: 58.5,14.5
       parent: 2
-  - uid: 22713
+  - uid: 22712
     components:
     - type: Transform
       pos: 54.5,20.5
       parent: 2
-  - uid: 22714
+  - uid: 22713
     components:
     - type: Transform
       pos: 55.5,20.5
       parent: 2
-  - uid: 22715
+  - uid: 22714
     components:
     - type: Transform
       pos: 56.5,20.5
       parent: 2
-  - uid: 22716
+  - uid: 22715
     components:
     - type: Transform
       pos: 35.5,11.5
       parent: 2
-  - uid: 22717
+  - uid: 22716
     components:
     - type: Transform
       pos: 35.5,23.5
       parent: 2
-  - uid: 22718
+  - uid: 22717
     components:
     - type: Transform
       pos: 34.5,23.5
       parent: 2
-  - uid: 22719
+  - uid: 22718
     components:
     - type: Transform
       pos: 4.5,21.5
       parent: 2
-  - uid: 22720
+  - uid: 22719
     components:
     - type: Transform
       pos: 5.5,21.5
       parent: 2
-  - uid: 22721
+  - uid: 22720
     components:
     - type: Transform
       pos: 6.5,21.5
       parent: 2
-  - uid: 22722
+  - uid: 22721
     components:
     - type: Transform
       pos: 3.5,21.5
       parent: 2
-  - uid: 22723
+  - uid: 22722
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 2
-  - uid: 22724
+  - uid: 22723
     components:
     - type: Transform
       pos: 4.5,17.5
       parent: 2
-  - uid: 22725
+  - uid: 22724
     components:
     - type: Transform
       pos: 5.5,17.5
       parent: 2
-  - uid: 22726
+  - uid: 22725
     components:
     - type: Transform
       pos: 6.5,17.5
       parent: 2
-  - uid: 22727
+  - uid: 22726
     components:
     - type: Transform
       pos: 42.5,28.5
       parent: 2
-  - uid: 22728
+  - uid: 22727
     components:
     - type: Transform
       pos: 39.5,28.5
       parent: 2
-  - uid: 22729
+  - uid: 22728
     components:
     - type: Transform
       pos: 41.5,28.5
       parent: 2
-  - uid: 22730
+  - uid: 22729
     components:
     - type: Transform
       pos: 42.5,32.5
       parent: 2
-  - uid: 22731
+  - uid: 22730
     components:
     - type: Transform
       pos: 57.5,34.5
       parent: 2
-  - uid: 22732
+  - uid: 22731
     components:
     - type: Transform
       pos: -4.5,-34.5
       parent: 2
-  - uid: 22733
+  - uid: 22732
     components:
     - type: Transform
       pos: 42.5,31.5
       parent: 2
-  - uid: 22734
+  - uid: 22733
     components:
     - type: Transform
       pos: 36.5,28.5
       parent: 2
-  - uid: 22735
+  - uid: 22734
     components:
     - type: Transform
       pos: 35.5,28.5
       parent: 2
-  - uid: 22736
+  - uid: 22735
     components:
     - type: Transform
       pos: 59.5,21.5
       parent: 2
-  - uid: 22737
+  - uid: 22736
     components:
     - type: Transform
       pos: 59.5,22.5
       parent: 2
-  - uid: 22738
+  - uid: 22737
     components:
     - type: Transform
       pos: 59.5,23.5
       parent: 2
-  - uid: 22739
+  - uid: 22738
     components:
     - type: Transform
       pos: 59.5,20.5
       parent: 2
-  - uid: 22740
+  - uid: 22739
     components:
     - type: Transform
       pos: 59.5,17.5
       parent: 2
-  - uid: 22741
+  - uid: 22740
     components:
     - type: Transform
       pos: 56.5,25.5
       parent: 2
-  - uid: 22742
+  - uid: 22741
     components:
     - type: Transform
       pos: 1.5,21.5
       parent: 2
-  - uid: 22743
+  - uid: 22742
     components:
     - type: Transform
       pos: 47.5,34.5
       parent: 2
-  - uid: 22744
+  - uid: 22743
     components:
     - type: Transform
       pos: 42.5,30.5
       parent: 2
-  - uid: 22745
+  - uid: 22744
     components:
     - type: Transform
       pos: 42.5,29.5
       parent: 2
-  - uid: 22746
+  - uid: 22745
     components:
     - type: Transform
       pos: 58.5,30.5
       parent: 2
-  - uid: 22747
+  - uid: 22746
     components:
     - type: Transform
       pos: 57.5,33.5
       parent: 2
-  - uid: 22748
+  - uid: 22747
     components:
     - type: Transform
       pos: 57.5,30.5
       parent: 2
-  - uid: 22749
+  - uid: 22748
     components:
     - type: Transform
       pos: 57.5,31.5
       parent: 2
-  - uid: 22750
+  - uid: 22749
     components:
     - type: Transform
       pos: 58.5,28.5
       parent: 2
-  - uid: 22751
+  - uid: 22750
     components:
     - type: Transform
       pos: 59.5,28.5
       parent: 2
-  - uid: 22752
+  - uid: 22751
     components:
     - type: Transform
       pos: 59.5,27.5
       parent: 2
-  - uid: 22753
+  - uid: 22752
     components:
     - type: Transform
       pos: 59.5,26.5
       parent: 2
-  - uid: 22754
+  - uid: 22753
     components:
     - type: Transform
       pos: 59.5,25.5
       parent: 2
-  - uid: 22755
+  - uid: 22754
     components:
     - type: Transform
       pos: 59.5,24.5
       parent: 2
-  - uid: 22756
+  - uid: 22755
     components:
     - type: Transform
       pos: 44.5,34.5
       parent: 2
-  - uid: 22757
+  - uid: 22756
     components:
     - type: Transform
       pos: 49.5,34.5
       parent: 2
-  - uid: 22758
+  - uid: 22757
     components:
     - type: Transform
       pos: 43.5,34.5
       parent: 2
-  - uid: 22759
+  - uid: 22758
     components:
     - type: Transform
       pos: 50.5,34.5
       parent: 2
-  - uid: 22760
+  - uid: 22759
     components:
     - type: Transform
       pos: 42.5,33.5
       parent: 2
-  - uid: 22761
+  - uid: 22760
     components:
     - type: Transform
       pos: 42.5,34.5
       parent: 2
-  - uid: 22762
+  - uid: 22761
     components:
     - type: Transform
       pos: 45.5,34.5
       parent: 2
-  - uid: 22763
+  - uid: 22762
     components:
     - type: Transform
       pos: 48.5,23.5
       parent: 2
-  - uid: 22764
+  - uid: 22763
     components:
     - type: Transform
       pos: 42.5,35.5
       parent: 2
-  - uid: 22765
+  - uid: 22764
     components:
     - type: Transform
       pos: 52.5,23.5
       parent: 2
-  - uid: 22766
+  - uid: 22765
     components:
     - type: Transform
       pos: 63.5,56.5
       parent: 2
-  - uid: 22767
+  - uid: 22766
     components:
     - type: Transform
       pos: 51.5,34.5
       parent: 2
-  - uid: 22768
+  - uid: 22767
     components:
     - type: Transform
       pos: 52.5,34.5
       parent: 2
-  - uid: 22769
+  - uid: 22768
     components:
     - type: Transform
       pos: 53.5,34.5
       parent: 2
-  - uid: 22770
+  - uid: 22769
     components:
     - type: Transform
       pos: 54.5,34.5
       parent: 2
-  - uid: 22771
+  - uid: 22770
     components:
     - type: Transform
       pos: 48.5,34.5
       parent: 2
-  - uid: 22772
+  - uid: 22771
     components:
     - type: Transform
       pos: 55.5,34.5
       parent: 2
-  - uid: 22773
+  - uid: 22772
     components:
     - type: Transform
       pos: 43.5,35.5
       parent: 2
-  - uid: 22774
+  - uid: 22773
     components:
     - type: Transform
       pos: 44.5,35.5
       parent: 2
-  - uid: 22775
+  - uid: 22774
     components:
     - type: Transform
       pos: 45.5,35.5
       parent: 2
-  - uid: 22776
+  - uid: 22775
     components:
     - type: Transform
       pos: 47.5,35.5
       parent: 2
-  - uid: 22777
+  - uid: 22776
     components:
     - type: Transform
       pos: 48.5,35.5
       parent: 2
-  - uid: 22778
+  - uid: 22777
     components:
     - type: Transform
       pos: 49.5,35.5
       parent: 2
-  - uid: 22779
+  - uid: 22778
     components:
     - type: Transform
       pos: 50.5,35.5
       parent: 2
-  - uid: 22780
+  - uid: 22779
     components:
     - type: Transform
       pos: 51.5,35.5
       parent: 2
-  - uid: 22781
+  - uid: 22780
     components:
     - type: Transform
       pos: 46.5,35.5
       parent: 2
-  - uid: 22782
+  - uid: 22781
     components:
     - type: Transform
       pos: 52.5,35.5
       parent: 2
-  - uid: 22783
+  - uid: 22782
     components:
     - type: Transform
       pos: 53.5,35.5
       parent: 2
-  - uid: 22784
+  - uid: 22783
     components:
     - type: Transform
       pos: 54.5,35.5
       parent: 2
-  - uid: 22785
+  - uid: 22784
     components:
     - type: Transform
       pos: 55.5,35.5
       parent: 2
-  - uid: 22786
+  - uid: 22785
     components:
     - type: Transform
       pos: 41.5,34.5
       parent: 2
-  - uid: 22787
+  - uid: 22786
     components:
     - type: Transform
       pos: 41.5,33.5
       parent: 2
-  - uid: 22788
+  - uid: 22787
     components:
     - type: Transform
       pos: 51.5,-35.5
       parent: 2
-  - uid: 22789
+  - uid: 22788
     components:
     - type: Transform
       pos: -24.5,-4.5
       parent: 2
-  - uid: 22790
+  - uid: 22789
     components:
     - type: Transform
       pos: 50.5,29.5
       parent: 2
-  - uid: 22791
+  - uid: 22790
     components:
     - type: Transform
       pos: 52.5,29.5
       parent: 2
-  - uid: 22792
+  - uid: 22791
     components:
     - type: Transform
       pos: 53.5,29.5
       parent: 2
-  - uid: 22793
+  - uid: 22792
     components:
     - type: Transform
       pos: 53.5,30.5
       parent: 2
-  - uid: 22794
+  - uid: 22793
     components:
     - type: Transform
       pos: 53.5,31.5
       parent: 2
-  - uid: 22795
+  - uid: 22794
     components:
     - type: Transform
       pos: 53.5,32.5
       parent: 2
-  - uid: 22796
+  - uid: 22795
     components:
     - type: Transform
       pos: 53.5,33.5
       parent: 2
-  - uid: 22797
+  - uid: 22796
     components:
     - type: Transform
       pos: 71.5,40.5
       parent: 2
-  - uid: 22798
+  - uid: 22797
     components:
     - type: Transform
       pos: 63.5,38.5
       parent: 2
-  - uid: 22799
+  - uid: 22798
     components:
     - type: Transform
       pos: 68.5,39.5
       parent: 2
-  - uid: 22800
+  - uid: 22799
     components:
     - type: Transform
       pos: 62.5,39.5
       parent: 2
-  - uid: 22801
+  - uid: 22800
     components:
     - type: Transform
       pos: 64.5,36.5
       parent: 2
-  - uid: 22802
+  - uid: 22801
     components:
     - type: Transform
       pos: 73.5,43.5
       parent: 2
-  - uid: 22803
+  - uid: 22802
     components:
     - type: Transform
       pos: 60.5,42.5
       parent: 2
-  - uid: 22804
+  - uid: 22803
     components:
     - type: Transform
       pos: 60.5,43.5
       parent: 2
-  - uid: 22805
+  - uid: 22804
     components:
     - type: Transform
       pos: 60.5,44.5
       parent: 2
-  - uid: 22806
+  - uid: 22805
     components:
     - type: Transform
       pos: 60.5,45.5
       parent: 2
-  - uid: 22807
+  - uid: 22806
     components:
     - type: Transform
       pos: 60.5,46.5
       parent: 2
-  - uid: 22808
+  - uid: 22807
     components:
     - type: Transform
       pos: 61.5,46.5
       parent: 2
-  - uid: 22809
+  - uid: 22808
     components:
     - type: Transform
       pos: 61.5,47.5
       parent: 2
-  - uid: 22810
+  - uid: 22809
     components:
     - type: Transform
       pos: 61.5,48.5
       parent: 2
-  - uid: 22811
+  - uid: 22810
     components:
     - type: Transform
       pos: 62.5,48.5
       parent: 2
-  - uid: 22812
+  - uid: 22811
     components:
     - type: Transform
       pos: 62.5,49.5
       parent: 2
-  - uid: 22813
+  - uid: 22812
     components:
     - type: Transform
       pos: 62.5,50.5
       parent: 2
-  - uid: 22814
+  - uid: 22813
     components:
     - type: Transform
       pos: 63.5,51.5
       parent: 2
-  - uid: 22815
+  - uid: 22814
     components:
     - type: Transform
       pos: 63.5,52.5
       parent: 2
-  - uid: 22816
+  - uid: 22815
     components:
     - type: Transform
       pos: 64.5,56.5
       parent: 2
-  - uid: 22817
+  - uid: 22816
     components:
     - type: Transform
       pos: 64.5,51.5
       parent: 2
-  - uid: 22818
+  - uid: 22817
     components:
     - type: Transform
       pos: 73.5,42.5
       parent: 2
-  - uid: 22819
+  - uid: 22818
     components:
     - type: Transform
       pos: 66.5,51.5
       parent: 2
-  - uid: 22820
+  - uid: 22819
     components:
     - type: Transform
       pos: 66.5,52.5
       parent: 2
-  - uid: 22821
+  - uid: 22820
     components:
     - type: Transform
       pos: 65.5,52.5
       parent: 2
-  - uid: 22822
+  - uid: 22821
     components:
     - type: Transform
       pos: 73.5,45.5
       parent: 2
-  - uid: 22823
+  - uid: 22822
     components:
     - type: Transform
       pos: 65.5,51.5
       parent: 2
-  - uid: 22824
+  - uid: 22823
     components:
     - type: Transform
       pos: 64.5,52.5
       parent: 2
-  - uid: 22825
+  - uid: 22824
     components:
     - type: Transform
       pos: 67.5,52.5
       parent: 2
-  - uid: 22826
+  - uid: 22825
     components:
     - type: Transform
       pos: 67.5,51.5
       parent: 2
-  - uid: 22827
+  - uid: 22826
     components:
     - type: Transform
       pos: 68.5,50.5
       parent: 2
-  - uid: 22828
+  - uid: 22827
     components:
     - type: Transform
       pos: 68.5,49.5
       parent: 2
-  - uid: 22829
+  - uid: 22828
     components:
     - type: Transform
       pos: 68.5,48.5
       parent: 2
-  - uid: 22830
+  - uid: 22829
     components:
     - type: Transform
       pos: 69.5,48.5
       parent: 2
-  - uid: 22831
+  - uid: 22830
     components:
     - type: Transform
       pos: 69.5,47.5
       parent: 2
-  - uid: 22832
+  - uid: 22831
     components:
     - type: Transform
       pos: 69.5,46.5
       parent: 2
-  - uid: 22833
+  - uid: 22832
     components:
     - type: Transform
       pos: 70.5,46.5
       parent: 2
-  - uid: 22834
+  - uid: 22833
     components:
     - type: Transform
       pos: 70.5,45.5
       parent: 2
-  - uid: 22835
+  - uid: 22834
     components:
     - type: Transform
       pos: 70.5,44.5
       parent: 2
-  - uid: 22836
+  - uid: 22835
     components:
     - type: Transform
       pos: 70.5,43.5
       parent: 2
-  - uid: 22837
+  - uid: 22836
     components:
     - type: Transform
       pos: 70.5,42.5
       parent: 2
-  - uid: 22838
+  - uid: 22837
     components:
     - type: Transform
       pos: 66.5,36.5
       parent: 2
-  - uid: 22839
+  - uid: 22838
     components:
     - type: Transform
       pos: 70.5,39.5
       parent: 2
-  - uid: 22840
+  - uid: 22839
     components:
     - type: Transform
       pos: 59.5,47.5
       parent: 2
-  - uid: 22841
+  - uid: 22840
     components:
     - type: Transform
       pos: 59.5,46.5
       parent: 2
-  - uid: 22842
+  - uid: 22841
     components:
     - type: Transform
       pos: 59.5,45.5
       parent: 2
-  - uid: 22843
+  - uid: 22842
     components:
     - type: Transform
       pos: 59.5,43.5
       parent: 2
-  - uid: 22844
+  - uid: 22843
     components:
     - type: Transform
       pos: 59.5,42.5
       parent: 2
-  - uid: 22845
+  - uid: 22844
     components:
     - type: Transform
       pos: 59.5,41.5
       parent: 2
-  - uid: 22846
+  - uid: 22845
     components:
     - type: Transform
       pos: 59.5,44.5
       parent: 2
-  - uid: 22847
+  - uid: 22846
     components:
     - type: Transform
       pos: 60.5,41.5
       parent: 2
-  - uid: 22848
+  - uid: 22847
     components:
     - type: Transform
       pos: 60.5,40.5
       parent: 2
-  - uid: 22849
+  - uid: 22848
     components:
     - type: Transform
       pos: 61.5,40.5
       parent: 2
-  - uid: 22850
+  - uid: 22849
     components:
     - type: Transform
       pos: 61.5,39.5
       parent: 2
-  - uid: 22851
+  - uid: 22850
     components:
     - type: Transform
       pos: -25.5,-4.5
       parent: 2
-  - uid: 22852
+  - uid: 22851
     components:
     - type: Transform
       pos: 69.5,39.5
       parent: 2
-  - uid: 22853
+  - uid: 22852
     components:
     - type: Transform
       pos: 69.5,40.5
       parent: 2
-  - uid: 22854
+  - uid: 22853
     components:
     - type: Transform
       pos: 70.5,40.5
       parent: 2
-  - uid: 22855
+  - uid: 22854
     components:
     - type: Transform
       pos: 70.5,41.5
       parent: 2
-  - uid: 22856
+  - uid: 22855
     components:
     - type: Transform
       pos: 71.5,41.5
       parent: 2
-  - uid: 22857
+  - uid: 22856
     components:
     - type: Transform
       pos: 71.5,42.5
       parent: 2
-  - uid: 22858
+  - uid: 22857
     components:
     - type: Transform
       pos: 71.5,43.5
       parent: 2
-  - uid: 22859
+  - uid: 22858
     components:
     - type: Transform
       pos: 71.5,44.5
       parent: 2
-  - uid: 22860
+  - uid: 22859
     components:
     - type: Transform
       pos: 71.5,45.5
       parent: 2
-  - uid: 22861
+  - uid: 22860
     components:
     - type: Transform
       pos: 71.5,46.5
       parent: 2
-  - uid: 22862
+  - uid: 22861
     components:
     - type: Transform
       pos: 71.5,47.5
       parent: 2
-  - uid: 22863
+  - uid: 22862
     components:
     - type: Transform
       pos: 70.5,47.5
       parent: 2
-  - uid: 22864
+  - uid: 22863
     components:
     - type: Transform
       pos: 70.5,48.5
       parent: 2
-  - uid: 22865
+  - uid: 22864
     components:
     - type: Transform
       pos: 70.5,49.5
       parent: 2
-  - uid: 22866
+  - uid: 22865
     components:
     - type: Transform
       pos: 69.5,49.5
       parent: 2
-  - uid: 22867
+  - uid: 22866
     components:
     - type: Transform
       pos: 69.5,50.5
       parent: 2
-  - uid: 22868
+  - uid: 22867
     components:
     - type: Transform
       pos: 69.5,51.5
       parent: 2
-  - uid: 22869
+  - uid: 22868
     components:
     - type: Transform
       pos: 68.5,51.5
       parent: 2
-  - uid: 22870
+  - uid: 22869
     components:
     - type: Transform
       pos: 68.5,52.5
       parent: 2
-  - uid: 22871
+  - uid: 22870
     components:
     - type: Transform
       pos: 68.5,54.5
       parent: 2
-  - uid: 22872
+  - uid: 22871
     components:
     - type: Transform
       pos: 62.5,56.5
       parent: 2
-  - uid: 22873
+  - uid: 22872
     components:
     - type: Transform
       pos: 64.5,54.5
       parent: 2
-  - uid: 22874
+  - uid: 22873
     components:
     - type: Transform
       pos: 62.5,54.5
       parent: 2
-  - uid: 22875
+  - uid: 22874
     components:
     - type: Transform
       pos: 68.5,56.5
       parent: 2
-  - uid: 22876
+  - uid: 22875
     components:
     - type: Transform
       pos: 65.5,54.5
       parent: 2
-  - uid: 22877
+  - uid: 22876
     components:
     - type: Transform
       pos: 66.5,54.5
       parent: 2
-  - uid: 22878
+  - uid: 22877
     components:
     - type: Transform
       pos: 63.5,54.5
       parent: 2
-  - uid: 22879
+  - uid: 22878
     components:
     - type: Transform
       pos: 66.5,56.5
       parent: 2
-  - uid: 22880
+  - uid: 22879
     components:
     - type: Transform
       pos: 67.5,54.5
       parent: 2
-  - uid: 22881
+  - uid: 22880
     components:
     - type: Transform
       pos: 65.5,56.5
       parent: 2
-  - uid: 22882
+  - uid: 22881
     components:
     - type: Transform
       pos: 67.5,56.5
       parent: 2
-  - uid: 22883
+  - uid: 22882
     components:
     - type: Transform
       pos: 62.5,52.5
       parent: 2
-  - uid: 22884
+  - uid: 22883
     components:
     - type: Transform
       pos: 62.5,51.5
       parent: 2
-  - uid: 22885
+  - uid: 22884
     components:
     - type: Transform
       pos: 61.5,51.5
       parent: 2
-  - uid: 22886
+  - uid: 22885
     components:
     - type: Transform
       pos: 61.5,50.5
       parent: 2
-  - uid: 22887
+  - uid: 22886
     components:
     - type: Transform
       pos: 61.5,49.5
       parent: 2
-  - uid: 22888
+  - uid: 22887
     components:
     - type: Transform
       pos: 60.5,49.5
       parent: 2
-  - uid: 22889
+  - uid: 22888
     components:
     - type: Transform
       pos: 60.5,48.5
       parent: 2
-  - uid: 22890
+  - uid: 22889
     components:
     - type: Transform
       pos: 60.5,47.5
       parent: 2
-  - uid: 22891
+  - uid: 22890
     components:
     - type: Transform
       pos: 67.5,38.5
       parent: 2
-  - uid: 22892
+  - uid: 22891
     components:
     - type: Transform
       pos: 64.5,37.5
       parent: 2
-  - uid: 22893
+  - uid: 22892
     components:
     - type: Transform
       pos: 66.5,37.5
       parent: 2
-  - uid: 22894
+  - uid: 22893
     components:
     - type: Transform
       pos: 66.5,38.5
       parent: 2
-  - uid: 22895
+  - uid: 22894
     components:
     - type: Transform
       pos: 64.5,38.5
       parent: 2
-  - uid: 22896
+  - uid: 22895
     components:
     - type: Transform
       pos: 63.5,39.5
       parent: 2
-  - uid: 22897
+  - uid: 22896
     components:
     - type: Transform
       pos: 67.5,39.5
       parent: 2
-  - uid: 22898
+  - uid: 22897
     components:
     - type: Transform
       pos: 73.5,41.5
       parent: 2
-  - uid: 22899
+  - uid: 22898
     components:
     - type: Transform
       pos: 69.5,38.5
       parent: 2
-  - uid: 22900
+  - uid: 22899
     components:
     - type: Transform
       pos: 68.5,38.5
       parent: 2
-  - uid: 22901
+  - uid: 22900
     components:
     - type: Transform
       pos: 67.5,37.5
       parent: 2
-  - uid: 22902
+  - uid: 22901
     components:
     - type: Transform
       pos: 63.5,37.5
       parent: 2
-  - uid: 22903
+  - uid: 22902
     components:
     - type: Transform
       pos: 62.5,38.5
       parent: 2
-  - uid: 22904
+  - uid: 22903
     components:
     - type: Transform
       pos: 61.5,38.5
       parent: 2
-  - uid: 22905
+  - uid: 22904
     components:
     - type: Transform
       pos: 60.5,39.5
       parent: 2
-  - uid: 22906
+  - uid: 22905
     components:
     - type: Transform
       pos: 59.5,40.5
       parent: 2
-  - uid: 22907
+  - uid: 22906
     components:
     - type: Transform
       pos: 73.5,47.5
       parent: 2
-  - uid: 22908
+  - uid: 22907
     components:
     - type: Transform
       pos: 73.5,46.5
       parent: 2
-  - uid: 22909
+  - uid: 22908
     components:
     - type: Transform
       pos: 67.5,40.5
       parent: 2
-  - uid: 22910
+  - uid: 22909
     components:
     - type: Transform
       pos: 73.5,44.5
       parent: 2
-  - uid: 22911
+  - uid: 22910
     components:
     - type: Transform
       pos: 57.5,42.5
       parent: 2
-  - uid: 22912
+  - uid: 22911
     components:
     - type: Transform
       pos: 75.5,47.5
       parent: 2
-  - uid: 22913
+  - uid: 22912
     components:
     - type: Transform
       pos: 75.5,46.5
       parent: 2
-  - uid: 22914
+  - uid: 22913
     components:
     - type: Transform
       pos: 75.5,45.5
       parent: 2
-  - uid: 22915
+  - uid: 22914
     components:
     - type: Transform
       pos: 75.5,44.5
       parent: 2
-  - uid: 22916
+  - uid: 22915
     components:
     - type: Transform
       pos: 75.5,43.5
       parent: 2
-  - uid: 22917
+  - uid: 22916
     components:
     - type: Transform
       pos: 75.5,41.5
       parent: 2
-  - uid: 22918
+  - uid: 22917
     components:
     - type: Transform
       pos: 75.5,42.5
       parent: 2
-  - uid: 22919
+  - uid: 22918
     components:
     - type: Transform
       pos: 57.5,47.5
       parent: 2
-  - uid: 22920
+  - uid: 22919
     components:
     - type: Transform
       pos: 57.5,41.5
       parent: 2
-  - uid: 22921
+  - uid: 22920
     components:
     - type: Transform
       pos: 57.5,45.5
       parent: 2
-  - uid: 22922
+  - uid: 22921
     components:
     - type: Transform
       pos: 57.5,43.5
       parent: 2
-  - uid: 22923
+  - uid: 22922
     components:
     - type: Transform
       pos: 63.5,40.5
       parent: 2
-  - uid: 22924
+  - uid: 22923
     components:
     - type: Transform
       pos: 57.5,46.5
       parent: 2
-  - uid: 22925
+  - uid: 22924
     components:
     - type: Transform
       pos: 57.5,44.5
       parent: 2
-  - uid: 22926
+  - uid: 22925
     components:
     - type: Transform
       pos: 55.5,47.5
       parent: 2
-  - uid: 22927
+  - uid: 22926
     components:
     - type: Transform
       pos: 55.5,46.5
       parent: 2
-  - uid: 22928
+  - uid: 22927
     components:
     - type: Transform
       pos: 55.5,45.5
       parent: 2
-  - uid: 22929
+  - uid: 22928
     components:
     - type: Transform
       pos: 55.5,43.5
       parent: 2
-  - uid: 22930
+  - uid: 22929
     components:
     - type: Transform
       pos: 55.5,42.5
       parent: 2
-  - uid: 22931
+  - uid: 22930
     components:
     - type: Transform
       pos: 55.5,41.5
       parent: 2
-  - uid: 22932
+  - uid: 22931
     components:
     - type: Transform
       pos: 55.5,44.5
       parent: 2
-  - uid: 22933
+  - uid: 22932
     components:
     - type: Transform
       pos: 66.5,48.5
       parent: 2
-  - uid: 22934
+  - uid: 22933
     components:
     - type: Transform
       pos: 65.5,48.5
       parent: 2
-  - uid: 22935
+  - uid: 22934
     components:
     - type: Transform
       pos: 64.5,48.5
       parent: 2
-  - uid: 22936
+  - uid: 22935
     components:
     - type: Transform
       pos: 56.5,34.5
       parent: 2
-  - uid: 22937
+  - uid: 22936
     components:
     - type: Transform
       pos: 57.5,35.5
       parent: 2
-  - uid: 22938
+  - uid: 22937
     components:
     - type: Transform
       pos: -26.5,-7.5
       parent: 2
-  - uid: 22939
+  - uid: 22938
     components:
     - type: Transform
       pos: -26.5,-6.5
       parent: 2
-  - uid: 22940
+  - uid: 22939
     components:
     - type: Transform
       pos: -26.5,-4.5
       parent: 2
-  - uid: 22941
+  - uid: 22940
     components:
     - type: Transform
       pos: -26.5,-5.5
       parent: 2
-  - uid: 22942
+  - uid: 22941
     components:
     - type: Transform
       pos: -12.5,18.5
       parent: 2
-  - uid: 22943
+  - uid: 22942
     components:
     - type: Transform
       pos: 56.5,35.5
       parent: 2
-  - uid: 22944
+  - uid: 22943
     components:
     - type: Transform
       pos: -10.5,17.5
       parent: 2
-  - uid: 22945
+  - uid: 22944
     components:
     - type: Transform
       pos: -12.5,21.5
       parent: 2
-  - uid: 22946
+  - uid: 22945
     components:
     - type: Transform
       pos: -12.5,19.5
       parent: 2
-  - uid: 22947
+  - uid: 22946
     components:
     - type: Transform
       pos: 62.5,22.5
       parent: 2
-  - uid: 22948
+  - uid: 22947
     components:
     - type: Transform
       pos: 68.5,22.5
       parent: 2
-  - uid: 22949
+  - uid: 22948
     components:
     - type: Transform
       pos: 68.5,28.5
       parent: 2
-  - uid: 22950
+  - uid: 22949
     components:
     - type: Transform
       pos: 68.5,34.5
       parent: 2
-  - uid: 22951
+  - uid: 22950
     components:
     - type: Transform
       pos: 62.5,34.5
       parent: 2
-  - uid: 22952
+  - uid: 22951
     components:
     - type: Transform
       pos: 57.5,29.5
       parent: 2
-  - uid: 22953
+  - uid: 22952
     components:
     - type: Transform
       pos: -12.5,20.5
       parent: 2
-  - uid: 22954
+  - uid: 22953
     components:
     - type: Transform
       pos: 55.5,25.5
       parent: 2
-  - uid: 22955
+  - uid: 22954
     components:
     - type: Transform
       pos: 53.5,25.5
       parent: 2
-  - uid: 22956
+  - uid: 22955
     components:
     - type: Transform
       pos: 52.5,25.5
       parent: 2
-  - uid: 22957
+  - uid: 22956
     components:
     - type: Transform
       pos: 56.5,23.5
       parent: 2
-  - uid: 22958
+  - uid: 22957
     components:
     - type: Transform
       pos: -11.5,21.5
       parent: 2
-  - uid: 22959
+  - uid: 22958
     components:
     - type: Transform
       pos: -5.5,21.5
       parent: 2
-  - uid: 22960
+  - uid: 22959
     components:
     - type: Transform
       pos: -10.5,18.5
       parent: 2
-  - uid: 22961
+  - uid: 22960
     components:
     - type: Transform
       pos: -5.5,19.5
       parent: 2
-  - uid: 22962
+  - uid: 22961
     components:
     - type: Transform
       pos: -5.5,18.5
       parent: 2
-  - uid: 22963
+  - uid: 22962
     components:
     - type: Transform
       pos: 52.5,-35.5
       parent: 2
-  - uid: 22964
+  - uid: 22963
     components:
     - type: Transform
       pos: 62.5,28.5
       parent: 2
-  - uid: 22965
+  - uid: 22964
     components:
     - type: Transform
       pos: 7.5,22.5
       parent: 2
-  - uid: 22966
+  - uid: 22965
     components:
     - type: Transform
       pos: 7.5,23.5
       parent: 2
-  - uid: 22967
+  - uid: 22966
     components:
     - type: Transform
       pos: 67.5,16.5
       parent: 2
-  - uid: 22968
+  - uid: 22967
     components:
     - type: Transform
       pos: 63.5,16.5
       parent: 2
-  - uid: 22969
+  - uid: 22968
     components:
     - type: Transform
       pos: 7.5,24.5
       parent: 2
-  - uid: 22970
+  - uid: 22969
     components:
     - type: Transform
       pos: 71.5,21.5
       parent: 2
-  - uid: 22971
+  - uid: 22970
     components:
     - type: Transform
       pos: 71.5,22.5
       parent: 2
-  - uid: 22972
+  - uid: 22971
     components:
     - type: Transform
       pos: 46.5,-35.5
       parent: 2
-  - uid: 22973
+  - uid: 22972
     components:
     - type: Transform
       pos: 55.5,-35.5
       parent: 2
-  - uid: 22974
+  - uid: 22973
     components:
     - type: Transform
       pos: 56.5,-35.5
       parent: 2
-  - uid: 22975
+  - uid: 22974
     components:
     - type: Transform
       pos: 54.5,-35.5
       parent: 2
-  - uid: 22976
+  - uid: 22975
     components:
     - type: Transform
       pos: 53.5,-35.5
       parent: 2
-  - uid: 22977
+  - uid: 22976
     components:
     - type: Transform
       pos: 57.5,-35.5
       parent: 2
-  - uid: 22978
+  - uid: 22977
     components:
     - type: Transform
       pos: 60.5,-35.5
       parent: 2
-  - uid: 22979
+  - uid: 22978
     components:
     - type: Transform
       pos: 61.5,-35.5
       parent: 2
-  - uid: 22980
+  - uid: 22979
     components:
     - type: Transform
       pos: 63.5,-35.5
       parent: 2
-  - uid: 22981
+  - uid: 22980
     components:
     - type: Transform
       pos: 71.5,14.5
       parent: 2
-  - uid: 22982
+  - uid: 22981
     components:
     - type: Transform
       pos: 71.5,15.5
       parent: 2
-  - uid: 22983
+  - uid: 22982
     components:
     - type: Transform
       pos: 71.5,11.5
       parent: 2
-  - uid: 22984
+  - uid: 22983
     components:
     - type: Transform
       pos: 71.5,13.5
       parent: 2
-  - uid: 22985
+  - uid: 22984
     components:
     - type: Transform
       pos: 71.5,12.5
       parent: 2
-  - uid: 22986
+  - uid: 22985
     components:
     - type: Transform
       pos: 71.5,23.5
       parent: 2
-  - uid: 22987
+  - uid: 22986
     components:
     - type: Transform
       pos: 71.5,24.5
       parent: 2
-  - uid: 22988
+  - uid: 22987
     components:
     - type: Transform
       pos: 71.5,25.5
       parent: 2
-  - uid: 22989
+  - uid: 22988
     components:
     - type: Transform
       pos: 78.5,21.5
       parent: 2
-  - uid: 22990
+  - uid: 22989
     components:
     - type: Transform
       pos: 78.5,22.5
       parent: 2
-  - uid: 22991
+  - uid: 22990
     components:
     - type: Transform
       pos: 78.5,24.5
       parent: 2
-  - uid: 22992
+  - uid: 22991
     components:
     - type: Transform
       pos: 77.5,24.5
       parent: 2
-  - uid: 22993
+  - uid: 22992
     components:
     - type: Transform
       pos: 75.5,24.5
       parent: 2
-  - uid: 22994
+  - uid: 22993
     components:
     - type: Transform
       pos: 76.5,24.5
       parent: 2
-  - uid: 22995
+  - uid: 22994
     components:
     - type: Transform
       pos: 77.5,22.5
       parent: 2
-  - uid: 22996
+  - uid: 22995
     components:
     - type: Transform
       pos: 75.5,23.5
       parent: 2
-  - uid: 22997
+  - uid: 22996
     components:
     - type: Transform
       pos: 75.5,22.5
       parent: 2
-  - uid: 22998
+  - uid: 22997
     components:
     - type: Transform
       pos: 78.5,15.5
       parent: 2
-  - uid: 22999
+  - uid: 22998
     components:
     - type: Transform
       pos: 78.5,14.5
       parent: 2
-  - uid: 23000
+  - uid: 22999
     components:
     - type: Transform
       pos: 77.5,14.5
       parent: 2
-  - uid: 23001
+  - uid: 23000
     components:
     - type: Transform
       pos: 75.5,14.5
       parent: 2
-  - uid: 23002
+  - uid: 23001
     components:
     - type: Transform
       pos: 75.5,13.5
       parent: 2
-  - uid: 23003
+  - uid: 23002
     components:
     - type: Transform
       pos: 75.5,12.5
       parent: 2
-  - uid: 23004
+  - uid: 23003
     components:
     - type: Transform
       pos: 76.5,12.5
       parent: 2
-  - uid: 23005
+  - uid: 23004
     components:
     - type: Transform
       pos: 77.5,12.5
       parent: 2
-  - uid: 23006
+  - uid: 23005
     components:
     - type: Transform
       pos: 78.5,12.5
       parent: 2
-  - uid: 23007
+  - uid: 23006
     components:
     - type: Transform
       pos: 75.5,25.5
       parent: 2
-  - uid: 23008
+  - uid: 23007
     components:
     - type: Transform
       pos: 74.5,25.5
       parent: 2
-  - uid: 23009
+  - uid: 23008
     components:
     - type: Transform
       pos: 72.5,25.5
       parent: 2
-  - uid: 23010
+  - uid: 23009
     components:
     - type: Transform
       pos: 73.5,25.5
       parent: 2
-  - uid: 23011
+  - uid: 23010
     components:
     - type: Transform
       pos: 75.5,11.5
       parent: 2
-  - uid: 23012
+  - uid: 23011
     components:
     - type: Transform
       pos: 74.5,11.5
       parent: 2
-  - uid: 23013
+  - uid: 23012
     components:
     - type: Transform
       pos: 73.5,11.5
       parent: 2
-  - uid: 23014
+  - uid: 23013
     components:
     - type: Transform
       pos: 72.5,11.5
       parent: 2
-  - uid: 23015
+  - uid: 23014
     components:
     - type: Transform
       pos: 77.5,25.5
       parent: 2
-  - uid: 23016
+  - uid: 23015
     components:
     - type: Transform
       pos: 77.5,11.5
       parent: 2
-  - uid: 23017
+  - uid: 23016
     components:
     - type: Transform
       pos: 78.5,11.5
       parent: 2
-  - uid: 23018
+  - uid: 23017
     components:
     - type: Transform
       pos: 78.5,10.5
       parent: 2
-  - uid: 23019
+  - uid: 23018
     components:
     - type: Transform
       pos: 79.5,10.5
       parent: 2
-  - uid: 23020
+  - uid: 23019
     components:
     - type: Transform
       pos: 80.5,10.5
       parent: 2
-  - uid: 23021
+  - uid: 23020
     components:
     - type: Transform
       pos: 81.5,10.5
       parent: 2
-  - uid: 23022
+  - uid: 23021
     components:
     - type: Transform
       pos: 82.5,10.5
       parent: 2
-  - uid: 23023
+  - uid: 23022
     components:
     - type: Transform
       pos: 83.5,10.5
       parent: 2
-  - uid: 23024
+  - uid: 23023
     components:
     - type: Transform
       pos: 84.5,10.5
       parent: 2
-  - uid: 23025
+  - uid: 23024
     components:
     - type: Transform
       pos: 86.5,10.5
       parent: 2
-  - uid: 23026
+  - uid: 23025
     components:
     - type: Transform
       pos: 87.5,10.5
       parent: 2
-  - uid: 23027
+  - uid: 23026
     components:
     - type: Transform
       pos: 88.5,10.5
       parent: 2
-  - uid: 23028
+  - uid: 23027
     components:
     - type: Transform
       pos: 89.5,10.5
       parent: 2
-  - uid: 23029
+  - uid: 23028
     components:
     - type: Transform
       pos: 90.5,10.5
       parent: 2
-  - uid: 23030
+  - uid: 23029
     components:
     - type: Transform
       pos: 91.5,10.5
       parent: 2
-  - uid: 23031
+  - uid: 23030
     components:
     - type: Transform
       pos: 92.5,10.5
       parent: 2
-  - uid: 23032
+  - uid: 23031
     components:
     - type: Transform
       pos: 85.5,10.5
       parent: 2
-  - uid: 23033
+  - uid: 23032
     components:
     - type: Transform
       pos: 93.5,10.5
       parent: 2
-  - uid: 23034
+  - uid: 23033
     components:
     - type: Transform
       pos: 93.5,12.5
       parent: 2
-  - uid: 23035
+  - uid: 23034
     components:
     - type: Transform
       pos: 93.5,13.5
       parent: 2
-  - uid: 23036
+  - uid: 23035
     components:
     - type: Transform
       pos: 93.5,14.5
       parent: 2
-  - uid: 23037
+  - uid: 23036
     components:
     - type: Transform
       pos: 93.5,11.5
       parent: 2
-  - uid: 23038
+  - uid: 23037
     components:
     - type: Transform
       pos: 93.5,15.5
       parent: 2
-  - uid: 23039
+  - uid: 23038
     components:
     - type: Transform
       pos: 93.5,16.5
       parent: 2
-  - uid: 23040
+  - uid: 23039
     components:
     - type: Transform
       pos: 93.5,17.5
       parent: 2
-  - uid: 23041
+  - uid: 23040
     components:
     - type: Transform
       pos: 93.5,18.5
       parent: 2
-  - uid: 23042
+  - uid: 23041
     components:
     - type: Transform
       pos: 93.5,19.5
       parent: 2
-  - uid: 23043
+  - uid: 23042
     components:
     - type: Transform
       pos: 93.5,20.5
       parent: 2
-  - uid: 23044
+  - uid: 23043
     components:
     - type: Transform
       pos: 93.5,22.5
       parent: 2
-  - uid: 23045
+  - uid: 23044
     components:
     - type: Transform
       pos: 93.5,23.5
       parent: 2
-  - uid: 23046
+  - uid: 23045
     components:
     - type: Transform
       pos: 93.5,24.5
       parent: 2
-  - uid: 23047
+  - uid: 23046
     components:
     - type: Transform
       pos: 93.5,25.5
       parent: 2
-  - uid: 23048
+  - uid: 23047
     components:
     - type: Transform
       pos: 93.5,26.5
       parent: 2
-  - uid: 23049
+  - uid: 23048
     components:
     - type: Transform
       pos: 93.5,21.5
       parent: 2
-  - uid: 23050
+  - uid: 23049
     components:
     - type: Transform
       pos: 92.5,26.5
       parent: 2
-  - uid: 23051
+  - uid: 23050
     components:
     - type: Transform
       pos: 91.5,26.5
       parent: 2
-  - uid: 23052
+  - uid: 23051
     components:
     - type: Transform
       pos: 90.5,26.5
       parent: 2
-  - uid: 23053
+  - uid: 23052
     components:
     - type: Transform
       pos: 89.5,26.5
       parent: 2
-  - uid: 23054
+  - uid: 23053
     components:
     - type: Transform
       pos: 87.5,26.5
       parent: 2
-  - uid: 23055
+  - uid: 23054
     components:
     - type: Transform
       pos: 86.5,26.5
       parent: 2
-  - uid: 23056
+  - uid: 23055
     components:
     - type: Transform
       pos: 85.5,26.5
       parent: 2
-  - uid: 23057
+  - uid: 23056
     components:
     - type: Transform
       pos: 84.5,26.5
       parent: 2
-  - uid: 23058
+  - uid: 23057
     components:
     - type: Transform
       pos: 83.5,26.5
       parent: 2
-  - uid: 23059
+  - uid: 23058
     components:
     - type: Transform
       pos: 82.5,26.5
       parent: 2
-  - uid: 23060
+  - uid: 23059
     components:
     - type: Transform
       pos: 88.5,26.5
       parent: 2
-  - uid: 23061
+  - uid: 23060
     components:
     - type: Transform
       pos: 81.5,26.5
       parent: 2
-  - uid: 23062
+  - uid: 23061
     components:
     - type: Transform
       pos: 80.5,26.5
       parent: 2
-  - uid: 23063
+  - uid: 23062
     components:
     - type: Transform
       pos: 79.5,26.5
       parent: 2
-  - uid: 23064
+  - uid: 23063
     components:
     - type: Transform
       pos: 78.5,26.5
       parent: 2
-  - uid: 23065
+  - uid: 23064
     components:
     - type: Transform
       pos: 78.5,25.5
       parent: 2
-  - uid: 23066
+  - uid: 23065
     components:
     - type: Transform
       pos: 77.5,29.5
       parent: 2
-  - uid: 23067
+  - uid: 23066
     components:
     - type: Transform
       pos: 78.5,29.5
       parent: 2
-  - uid: 23068
+  - uid: 23067
     components:
     - type: Transform
       pos: 79.5,29.5
       parent: 2
-  - uid: 23069
+  - uid: 23068
     components:
     - type: Transform
       pos: 82.5,29.5
       parent: 2
-  - uid: 23070
+  - uid: 23069
     components:
     - type: Transform
       pos: 83.5,29.5
       parent: 2
-  - uid: 23071
+  - uid: 23070
     components:
     - type: Transform
       pos: 84.5,29.5
       parent: 2
-  - uid: 23072
+  - uid: 23071
     components:
     - type: Transform
       pos: 87.5,29.5
       parent: 2
-  - uid: 23073
+  - uid: 23072
     components:
     - type: Transform
       pos: 88.5,29.5
       parent: 2
-  - uid: 23074
+  - uid: 23073
     components:
     - type: Transform
       pos: 89.5,29.5
       parent: 2
-  - uid: 23075
+  - uid: 23074
     components:
     - type: Transform
       pos: 97.5,29.5
       parent: 2
-  - uid: 23076
+  - uid: 23075
     components:
     - type: Transform
       pos: 92.5,29.5
       parent: 2
-  - uid: 23077
+  - uid: 23076
     components:
     - type: Transform
       pos: 93.5,29.5
       parent: 2
-  - uid: 23078
+  - uid: 23077
     components:
     - type: Transform
       pos: 94.5,29.5
       parent: 2
-  - uid: 23079
+  - uid: 23078
     components:
     - type: Transform
       pos: 97.5,28.5
       parent: 2
-  - uid: 23080
+  - uid: 23079
     components:
     - type: Transform
       pos: 97.5,27.5
       parent: 2
-  - uid: 23081
+  - uid: 23080
     components:
     - type: Transform
       pos: 97.5,13.5
       parent: 2
-  - uid: 23082
+  - uid: 23081
     components:
     - type: Transform
       pos: 97.5,24.5
       parent: 2
-  - uid: 23083
+  - uid: 23082
     components:
     - type: Transform
       pos: 97.5,23.5
       parent: 2
-  - uid: 23084
+  - uid: 23083
     components:
     - type: Transform
       pos: 97.5,22.5
       parent: 2
-  - uid: 23085
+  - uid: 23084
     components:
     - type: Transform
       pos: 97.5,14.5
       parent: 2
-  - uid: 23086
+  - uid: 23085
     components:
     - type: Transform
       pos: 97.5,19.5
       parent: 2
-  - uid: 23087
+  - uid: 23086
     components:
     - type: Transform
       pos: 97.5,18.5
       parent: 2
-  - uid: 23088
+  - uid: 23087
     components:
     - type: Transform
       pos: 97.5,17.5
       parent: 2
-  - uid: 23089
+  - uid: 23088
     components:
     - type: Transform
       pos: 97.5,12.5
       parent: 2
-  - uid: 23090
+  - uid: 23089
     components:
     - type: Transform
       pos: 97.5,9.5
       parent: 2
-  - uid: 23091
+  - uid: 23090
     components:
     - type: Transform
       pos: 97.5,8.5
       parent: 2
-  - uid: 23092
+  - uid: 23091
     components:
     - type: Transform
       pos: 97.5,7.5
       parent: 2
-  - uid: 23093
+  - uid: 23092
     components:
     - type: Transform
       pos: 94.5,7.5
       parent: 2
-  - uid: 23094
+  - uid: 23093
     components:
     - type: Transform
       pos: 93.5,7.5
       parent: 2
-  - uid: 23095
+  - uid: 23094
     components:
     - type: Transform
       pos: 92.5,7.5
       parent: 2
-  - uid: 23096
+  - uid: 23095
     components:
     - type: Transform
       pos: 89.5,7.5
       parent: 2
-  - uid: 23097
+  - uid: 23096
     components:
     - type: Transform
       pos: 87.5,7.5
       parent: 2
-  - uid: 23098
+  - uid: 23097
     components:
     - type: Transform
       pos: 88.5,7.5
       parent: 2
-  - uid: 23099
+  - uid: 23098
     components:
     - type: Transform
       pos: 84.5,7.5
       parent: 2
-  - uid: 23100
+  - uid: 23099
     components:
     - type: Transform
       pos: 83.5,7.5
       parent: 2
-  - uid: 23101
+  - uid: 23100
     components:
     - type: Transform
       pos: 82.5,7.5
       parent: 2
-  - uid: 23102
+  - uid: 23101
     components:
     - type: Transform
       pos: 79.5,7.5
       parent: 2
-  - uid: 23103
+  - uid: 23102
     components:
     - type: Transform
       pos: 78.5,7.5
       parent: 2
-  - uid: 23104
+  - uid: 23103
     components:
     - type: Transform
       pos: 77.5,7.5
       parent: 2
-  - uid: 23105
+  - uid: 23104
     components:
     - type: Transform
       pos: 64.5,-35.5
       parent: 2
-  - uid: 23106
+  - uid: 23105
     components:
     - type: Transform
       pos: 66.5,-35.5
       parent: 2
-  - uid: 23107
+  - uid: 23106
     components:
     - type: Transform
       pos: 62.5,-35.5
       parent: 2
-  - uid: 23108
+  - uid: 23107
     components:
     - type: Transform
       pos: 65.5,-35.5
       parent: 2
-  - uid: 23109
+  - uid: 23108
     components:
     - type: Transform
       pos: -15.5,62.5
       parent: 2
-  - uid: 23110
+  - uid: 23109
     components:
     - type: Transform
       pos: 72.5,-35.5
       parent: 2
-  - uid: 23111
+  - uid: 23110
     components:
     - type: Transform
       pos: 4.5,24.5
       parent: 2
-  - uid: 23112
+  - uid: 23111
     components:
     - type: Transform
       pos: 5.5,24.5
       parent: 2
-  - uid: 23113
+  - uid: 23112
     components:
     - type: Transform
       pos: 4.5,23.5
       parent: 2
-  - uid: 23114
+  - uid: 23113
     components:
     - type: Transform
       pos: 6.5,24.5
       parent: 2
-  - uid: 23115
+  - uid: 23114
     components:
     - type: Transform
       pos: -23.5,-4.5
       parent: 2
-  - uid: 23116
+  - uid: 23115
     components:
     - type: Transform
       pos: -25.5,-7.5
       parent: 2
-  - uid: 23117
+  - uid: 23116
     components:
     - type: Transform
       pos: 17.5,-40.5
       parent: 2
-  - uid: 23118
+  - uid: 23117
     components:
     - type: Transform
       pos: -24.5,-7.5
       parent: 2
-  - uid: 23119
+  - uid: 23118
     components:
     - type: Transform
       pos: -23.5,-7.5
       parent: 2
-  - uid: 23120
+  - uid: 23119
     components:
     - type: Transform
       pos: -23.5,-6.5
       parent: 2
-  - uid: 23121
+  - uid: 23120
     components:
     - type: Transform
       pos: -34.5,-17.5
       parent: 2
-  - uid: 23122
+  - uid: 23121
     components:
     - type: Transform
       pos: 71.5,-35.5
       parent: 2
-  - uid: 23123
+  - uid: 23122
     components:
     - type: Transform
       pos: 73.5,-34.5
       parent: 2
-  - uid: 23124
+  - uid: 23123
     components:
     - type: Transform
       pos: 72.5,-34.5
       parent: 2
-  - uid: 23125
+  - uid: 23124
     components:
     - type: Transform
       pos: 73.5,-29.5
       parent: 2
-  - uid: 23126
+  - uid: 23125
     components:
     - type: Transform
       pos: 73.5,-30.5
       parent: 2
-  - uid: 23127
+  - uid: 23126
     components:
     - type: Transform
       pos: 73.5,-31.5
       parent: 2
-  - uid: 23128
+  - uid: 23127
     components:
     - type: Transform
       pos: 73.5,-33.5
       parent: 2
-  - uid: 23129
+  - uid: 23128
     components:
     - type: Transform
       pos: -25.5,-20.5
       parent: 2
-  - uid: 23130
+  - uid: 23129
     components:
     - type: Transform
       pos: -16.5,-9.5
       parent: 2
-  - uid: 23131
+  - uid: 23130
     components:
     - type: Transform
       pos: -17.5,-9.5
       parent: 2
-  - uid: 23132
+  - uid: 23131
     components:
     - type: Transform
       pos: -17.5,-10.5
       parent: 2
-  - uid: 23133
+  - uid: 23132
     components:
     - type: Transform
       pos: -17.5,-11.5
       parent: 2
-  - uid: 23134
+  - uid: 23133
     components:
     - type: Transform
       pos: -17.5,-12.5
       parent: 2
-  - uid: 23135
+  - uid: 23134
     components:
     - type: Transform
       pos: -17.5,-13.5
       parent: 2
-  - uid: 23136
+  - uid: 23135
     components:
     - type: Transform
       pos: -15.5,-13.5
       parent: 2
-  - uid: 23137
+  - uid: 23136
     components:
     - type: Transform
       pos: -16.5,-13.5
       parent: 2
-  - uid: 23138
+  - uid: 23137
     components:
     - type: Transform
       pos: -17.5,-22.5
       parent: 2
-  - uid: 23139
+  - uid: 23138
     components:
     - type: Transform
       pos: -16.5,-22.5
       parent: 2
-  - uid: 23140
+  - uid: 23139
     components:
     - type: Transform
       pos: -15.5,-22.5
       parent: 2
-  - uid: 23141
+  - uid: 23140
     components:
     - type: Transform
       pos: -14.5,-22.5
       parent: 2
-  - uid: 23142
+  - uid: 23141
     components:
     - type: Transform
       pos: -13.5,-22.5
       parent: 2
-  - uid: 23143
+  - uid: 23142
     components:
     - type: Transform
       pos: -13.5,-23.5
       parent: 2
-  - uid: 23144
+  - uid: 23143
     components:
     - type: Transform
       pos: -13.5,-24.5
       parent: 2
-  - uid: 23145
+  - uid: 23144
     components:
     - type: Transform
       pos: -11.5,-29.5
       parent: 2
-  - uid: 23146
+  - uid: 23145
     components:
     - type: Transform
       pos: -5.5,-30.5
       parent: 2
-  - uid: 23147
+  - uid: 23146
     components:
     - type: Transform
       pos: -5.5,-31.5
       parent: 2
-  - uid: 23148
+  - uid: 23147
     components:
     - type: Transform
       pos: 73.5,-32.5
       parent: 2
-  - uid: 23149
+  - uid: 23148
     components:
     - type: Transform
       pos: -28.5,22.5
       parent: 2
-  - uid: 23150
+  - uid: 23149
     components:
     - type: Transform
       pos: 2.5,-23.5
       parent: 2
-  - uid: 23151
+  - uid: 23150
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 2
-  - uid: 23152
+  - uid: 23151
     components:
     - type: Transform
       pos: -11.5,-30.5
       parent: 2
-  - uid: 23153
+  - uid: 23152
     components:
     - type: Transform
       pos: -0.5,-24.5
       parent: 2
-  - uid: 23154
+  - uid: 23153
     components:
     - type: Transform
       pos: -17.5,-23.5
       parent: 2
-  - uid: 23155
+  - uid: 23154
     components:
     - type: Transform
       pos: -28.5,-23.5
       parent: 2
-  - uid: 23156
+  - uid: 23155
     components:
     - type: Transform
       pos: -20.5,-20.5
       parent: 2
-  - uid: 23157
+  - uid: 23156
     components:
     - type: Transform
       pos: -8.5,-31.5
       parent: 2
-  - uid: 23158
+  - uid: 23157
     components:
     - type: Transform
       pos: -9.5,-33.5
       parent: 2
-  - uid: 23159
+  - uid: 23158
     components:
     - type: Transform
       pos: -12.5,-33.5
       parent: 2
-  - uid: 23160
+  - uid: 23159
     components:
     - type: Transform
       pos: 0.5,-24.5
       parent: 2
-  - uid: 23161
+  - uid: 23160
     components:
     - type: Transform
       pos: -8.5,-32.5
       parent: 2
-  - uid: 23162
+  - uid: 23161
     components:
     - type: Transform
       pos: -8.5,-33.5
       parent: 2
-  - uid: 23163
+  - uid: 23162
     components:
     - type: Transform
       pos: -13.5,-33.5
       parent: 2
-  - uid: 23164
+  - uid: 23163
     components:
     - type: Transform
       pos: -39.5,-23.5
       parent: 2
-  - uid: 23165
+  - uid: 23164
     components:
     - type: Transform
       pos: -8.5,-34.5
       parent: 2
-  - uid: 23166
+  - uid: 23165
     components:
     - type: Transform
       pos: -13.5,-21.5
       parent: 2
-  - uid: 23167
+  - uid: 23166
     components:
     - type: Transform
       pos: -35.5,-17.5
       parent: 2
-  - uid: 23168
+  - uid: 23167
     components:
     - type: Transform
       pos: -35.5,-18.5
       parent: 2
-  - uid: 23169
+  - uid: 23168
     components:
     - type: Transform
       pos: -35.5,-19.5
       parent: 2
-  - uid: 23170
+  - uid: 23169
     components:
     - type: Transform
       pos: -35.5,-20.5
       parent: 2
-  - uid: 23171
+  - uid: 23170
     components:
     - type: Transform
       pos: -35.5,-21.5
       parent: 2
-  - uid: 23172
+  - uid: 23171
     components:
     - type: Transform
       pos: -39.5,-21.5
       parent: 2
-  - uid: 23173
+  - uid: 23172
     components:
     - type: Transform
       pos: -35.5,-23.5
       parent: 2
-  - uid: 23174
+  - uid: 23173
     components:
     - type: Transform
       pos: -35.5,-22.5
       parent: 2
-  - uid: 23175
+  - uid: 23174
     components:
     - type: Transform
       pos: -39.5,-22.5
       parent: 2
-  - uid: 23176
+  - uid: 23175
     components:
     - type: Transform
       pos: -40.5,-21.5
       parent: 2
-  - uid: 23177
+  - uid: 23176
     components:
     - type: Transform
       pos: -41.5,-21.5
       parent: 2
-  - uid: 23178
+  - uid: 23177
     components:
     - type: Transform
       pos: -42.5,-21.5
       parent: 2
-  - uid: 23179
+  - uid: 23178
     components:
     - type: Transform
       pos: -42.5,-20.5
       parent: 2
-  - uid: 23180
+  - uid: 23179
     components:
     - type: Transform
       pos: -42.5,-19.5
       parent: 2
-  - uid: 23181
+  - uid: 23180
     components:
     - type: Transform
       pos: -42.5,-17.5
       parent: 2
-  - uid: 23182
+  - uid: 23181
     components:
     - type: Transform
       pos: -42.5,-18.5
       parent: 2
-  - uid: 23183
+  - uid: 23182
     components:
     - type: Transform
       pos: -23.5,24.5
       parent: 2
-  - uid: 23184
+  - uid: 23183
     components:
     - type: Transform
       pos: -23.5,26.5
       parent: 2
-  - uid: 23185
+  - uid: 23184
     components:
     - type: Transform
       pos: -23.5,25.5
       parent: 2
-  - uid: 23186
+  - uid: 23185
     components:
     - type: Transform
       pos: 21.5,-18.5
       parent: 2
-  - uid: 23187
+  - uid: 23186
     components:
     - type: Transform
       pos: 17.5,-39.5
       parent: 2
-  - uid: 23188
+  - uid: 23187
     components:
     - type: Transform
       pos: -14.5,62.5
       parent: 2
-  - uid: 23189
+  - uid: 23188
     components:
     - type: Transform
       pos: -8.5,62.5
       parent: 2
-  - uid: 23190
+  - uid: 23189
     components:
     - type: Transform
       pos: -16.5,62.5
       parent: 2
-  - uid: 23191
+  - uid: 23190
     components:
     - type: Transform
       pos: -21.5,62.5
       parent: 2
-  - uid: 23192
+  - uid: 23191
     components:
     - type: Transform
       pos: -22.5,62.5
       parent: 2
-  - uid: 23193
+  - uid: 23192
     components:
     - type: Transform
       pos: -20.5,62.5
       parent: 2
-  - uid: 23194
+  - uid: 23193
     components:
     - type: Transform
       pos: -10.5,62.5
       parent: 2
-  - uid: 23195
+  - uid: 23194
     components:
     - type: Transform
       pos: -9.5,62.5
       parent: 2
-  - uid: 23196
+  - uid: 23195
     components:
     - type: Transform
       pos: -30.5,44.5
       parent: 2
-  - uid: 23197
+  - uid: 23196
     components:
     - type: Transform
       pos: -41.5,39.5
       parent: 2
-  - uid: 23198
+  - uid: 23197
     components:
     - type: Transform
       pos: -33.5,39.5
       parent: 2
-  - uid: 23199
+  - uid: 23198
     components:
     - type: Transform
       pos: -30.5,43.5
       parent: 2
-  - uid: 23200
+  - uid: 23199
     components:
     - type: Transform
       pos: -32.5,34.5
       parent: 2
-  - uid: 23201
+  - uid: 23200
     components:
     - type: Transform
       pos: -35.5,39.5
       parent: 2
-  - uid: 23202
+  - uid: 23201
     components:
     - type: Transform
       pos: -30.5,24.5
       parent: 2
-  - uid: 23203
+  - uid: 23202
     components:
     - type: Transform
       pos: -28.5,23.5
       parent: 2
-  - uid: 23204
+  - uid: 23203
     components:
     - type: Transform
       pos: -28.5,24.5
       parent: 2
-  - uid: 23205
+  - uid: 23204
     components:
     - type: Transform
       pos: -26.5,26.5
       parent: 2
-  - uid: 23206
+  - uid: 23205
     components:
     - type: Transform
       pos: -26.5,24.5
       parent: 2
-  - uid: 23207
+  - uid: 23206
     components:
     - type: Transform
       pos: -26.5,25.5
       parent: 2
-  - uid: 23208
+  - uid: 23207
     components:
     - type: Transform
       pos: -24.5,24.5
       parent: 2
-  - uid: 23209
+  - uid: 23208
     components:
     - type: Transform
       pos: -76.5,10.5
       parent: 2
-  - uid: 23210
+  - uid: 23209
     components:
     - type: Transform
       pos: -72.5,8.5
       parent: 2
-  - uid: 23211
+  - uid: 23210
     components:
     - type: Transform
       pos: -73.5,8.5
       parent: 2
-  - uid: 23212
+  - uid: 23211
     components:
     - type: Transform
       pos: -74.5,8.5
       parent: 2
-  - uid: 23213
+  - uid: 23212
     components:
     - type: Transform
       pos: -75.5,8.5
       parent: 2
-  - uid: 23214
+  - uid: 23213
     components:
     - type: Transform
       pos: -75.5,9.5
       parent: 2
-  - uid: 23215
+  - uid: 23214
     components:
     - type: Transform
       pos: -75.5,12.5
       parent: 2
-  - uid: 23216
+  - uid: 23215
     components:
     - type: Transform
       pos: -75.5,10.5
       parent: 2
-  - uid: 23217
+  - uid: 23216
     components:
     - type: Transform
       pos: -75.5,13.5
       parent: 2
-  - uid: 23218
+  - uid: 23217
     components:
     - type: Transform
       pos: -75.5,14.5
       parent: 2
-  - uid: 23219
+  - uid: 23218
     components:
     - type: Transform
       pos: -75.5,15.5
       parent: 2
-  - uid: 23220
+  - uid: 23219
     components:
     - type: Transform
       pos: -76.5,12.5
       parent: 2
-  - uid: 23221
+  - uid: 23220
     components:
     - type: Transform
       pos: -74.5,15.5
       parent: 2
-  - uid: 23222
+  - uid: 23221
     components:
     - type: Transform
       pos: -70.5,15.5
       parent: 2
-  - uid: 23223
+  - uid: 23222
     components:
     - type: Transform
       pos: -3.5,-34.5
       parent: 2
-  - uid: 23224
+  - uid: 23223
     components:
     - type: Transform
       pos: 27.5,-38.5
       parent: 2
-  - uid: 23225
+  - uid: 23224
     components:
     - type: Transform
       pos: 27.5,-42.5
       parent: 2
-  - uid: 23226
+  - uid: 23225
     components:
     - type: Transform
       pos: 34.5,-42.5
       parent: 2
-  - uid: 23227
+  - uid: 23226
     components:
     - type: Transform
       pos: 33.5,-42.5
       parent: 2
-  - uid: 23228
+  - uid: 23227
     components:
     - type: Transform
       pos: 32.5,-42.5
       parent: 2
-  - uid: 23229
+  - uid: 23228
     components:
     - type: Transform
       pos: 36.5,-42.5
       parent: 2
-  - uid: 23230
+  - uid: 23229
     components:
     - type: Transform
       pos: 35.5,-42.5
       parent: 2
-  - uid: 23231
+  - uid: 23230
     components:
     - type: Transform
       pos: 31.5,-42.5
       parent: 2
-  - uid: 23232
+  - uid: 23231
     components:
     - type: Transform
       pos: 36.5,-41.5
       parent: 2
-  - uid: 23233
+  - uid: 23232
     components:
     - type: Transform
       pos: 52.5,-51.5
       parent: 2
-  - uid: 23234
+  - uid: 23233
     components:
     - type: Transform
       pos: 55.5,-51.5
       parent: 2
-  - uid: 23235
+  - uid: 23234
     components:
     - type: Transform
       pos: 71.5,-36.5
       parent: 2
-  - uid: 23236
+  - uid: 23235
     components:
     - type: Transform
       pos: 71.5,-37.5
       parent: 2
-  - uid: 23237
+  - uid: 23236
     components:
     - type: Transform
       pos: 71.5,-38.5
       parent: 2
-  - uid: 23238
+  - uid: 23237
     components:
     - type: Transform
       pos: 72.5,-39.5
       parent: 2
-  - uid: 23239
+  - uid: 23238
     components:
     - type: Transform
       pos: 72.5,-38.5
       parent: 2
-  - uid: 23240
+  - uid: 23239
     components:
     - type: Transform
       pos: 73.5,-39.5
       parent: 2
-  - uid: 23241
+  - uid: 23240
     components:
     - type: Transform
       pos: 66.5,-51.5
       parent: 2
-  - uid: 23242
+  - uid: 23241
     components:
     - type: Transform
       pos: 62.5,-51.5
       parent: 2
-  - uid: 23243
+  - uid: 23242
     components:
     - type: Transform
       pos: 64.5,-51.5
       parent: 2
-  - uid: 23244
+  - uid: 23243
     components:
     - type: Transform
       pos: 50.5,-41.5
       parent: 2
-  - uid: 23245
+  - uid: 23244
     components:
     - type: Transform
       pos: 67.5,-46.5
       parent: 2
-  - uid: 23246
+  - uid: 23245
     components:
     - type: Transform
       pos: 68.5,-46.5
       parent: 2
-  - uid: 23247
+  - uid: 23246
     components:
     - type: Transform
       pos: 69.5,-46.5
       parent: 2
-  - uid: 23248
+  - uid: 23247
     components:
     - type: Transform
       pos: 69.5,-45.5
       parent: 2
-  - uid: 23249
+  - uid: 23248
     components:
     - type: Transform
       pos: 70.5,-45.5
       parent: 2
-  - uid: 23250
+  - uid: 23249
     components:
     - type: Transform
       pos: 71.5,-45.5
       parent: 2
-  - uid: 23251
+  - uid: 23250
     components:
     - type: Transform
       pos: 73.5,-42.5
       parent: 2
-  - uid: 23252
+  - uid: 23251
     components:
     - type: Transform
       pos: 72.5,-42.5
       parent: 2
-  - uid: 23253
+  - uid: 23252
     components:
     - type: Transform
       pos: 72.5,-43.5
       parent: 2
-  - uid: 23254
+  - uid: 23253
     components:
     - type: Transform
       pos: 72.5,-44.5
       parent: 2
-  - uid: 23255
+  - uid: 23254
     components:
     - type: Transform
       pos: 71.5,-44.5
       parent: 2
-  - uid: 23256
+  - uid: 23255
     components:
     - type: Transform
       pos: 81.5,-45.5
       parent: 2
-  - uid: 23257
+  - uid: 23256
     components:
     - type: Transform
       pos: 83.5,-45.5
       parent: 2
-  - uid: 23258
+  - uid: 23257
     components:
     - type: Transform
       pos: 81.5,-46.5
       parent: 2
-  - uid: 23259
+  - uid: 23258
     components:
     - type: Transform
       pos: 81.5,-48.5
       parent: 2
-  - uid: 23260
+  - uid: 23259
     components:
     - type: Transform
       pos: 81.5,-47.5
       parent: 2
-  - uid: 23261
+  - uid: 23260
     components:
     - type: Transform
       pos: 84.5,-45.5
       parent: 2
-  - uid: 23262
+  - uid: 23261
     components:
     - type: Transform
       pos: 72.5,-29.5
       parent: 2
-  - uid: 23263
+  - uid: 23262
     components:
     - type: Transform
       pos: 72.5,-28.5
       parent: 2
-  - uid: 23264
+  - uid: 23263
     components:
     - type: Transform
       pos: 72.5,-26.5
       parent: 2
-  - uid: 23265
+  - uid: 23264
     components:
     - type: Transform
       pos: 72.5,-24.5
       parent: 2
-  - uid: 23266
+  - uid: 23265
     components:
     - type: Transform
       pos: 72.5,-25.5
       parent: 2
-  - uid: 23267
+  - uid: 23266
     components:
     - type: Transform
       pos: 17.5,3.5
       parent: 2
-  - uid: 23268
+  - uid: 23267
     components:
     - type: Transform
       pos: 17.5,4.5
       parent: 2
-  - uid: 23269
+  - uid: 23268
     components:
     - type: Transform
       pos: 17.5,5.5
       parent: 2
-  - uid: 23270
+  - uid: 23269
     components:
     - type: Transform
       pos: -49.5,25.5
       parent: 2
-  - uid: 23271
+  - uid: 23270
     components:
     - type: Transform
       pos: 9.5,46.5
       parent: 2
-  - uid: 23272
+  - uid: 23271
     components:
     - type: Transform
       pos: 8.5,46.5
       parent: 2
-  - uid: 23273
+  - uid: 23272
     components:
     - type: Transform
       pos: 4.5,-12.5
       parent: 2
-  - uid: 23274
+  - uid: 23273
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,8.5
       parent: 2
-  - uid: 23275
+  - uid: 23274
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 2
-  - uid: 23276
+  - uid: 23275
     components:
     - type: Transform
       pos: 16.5,-5.5
       parent: 2
-  - uid: 23277
+  - uid: 23276
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 2
-  - uid: 23278
+  - uid: 23277
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 2
-  - uid: 23279
+  - uid: 23278
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,10.5
       parent: 2
-  - uid: 23280
+  - uid: 23279
     components:
     - type: Transform
       pos: -28.5,21.5
       parent: 2
-  - uid: 23281
+  - uid: 23280
     components:
     - type: Transform
       pos: -28.5,20.5
       parent: 2
-  - uid: 23282
+  - uid: 23281
     components:
     - type: Transform
       pos: -28.5,18.5
       parent: 2
-  - uid: 23283
+  - uid: 23282
     components:
     - type: Transform
       pos: -28.5,17.5
       parent: 2
-  - uid: 23284
+  - uid: 23283
     components:
     - type: Transform
       pos: -28.5,19.5
       parent: 2
-  - uid: 23285
+  - uid: 23284
     components:
     - type: Transform
       pos: -24.5,17.5
       parent: 2
-  - uid: 23286
+  - uid: 23285
     components:
     - type: Transform
       pos: -23.5,17.5
       parent: 2
-  - uid: 23287
+  - uid: 23286
     components:
     - type: Transform
       pos: -23.5,20.5
       parent: 2
-  - uid: 23288
+  - uid: 23287
     components:
     - type: Transform
       pos: -23.5,18.5
       parent: 2
-  - uid: 23289
+  - uid: 23288
     components:
     - type: Transform
       pos: -23.5,21.5
       parent: 2
-  - uid: 23290
+  - uid: 23289
     components:
     - type: Transform
       pos: -23.5,19.5
       parent: 2
-  - uid: 23291
+  - uid: 23290
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,3.5
       parent: 2
-  - uid: 23292
+  - uid: 23291
     components:
     - type: Transform
       pos: -26.5,21.5
       parent: 2
-  - uid: 23293
+  - uid: 23292
     components:
     - type: Transform
       pos: -24.5,21.5
       parent: 2
-  - uid: 23294
+  - uid: 23293
     components:
     - type: Transform
       pos: 11.5,-5.5
       parent: 2
-  - uid: 23295
+  - uid: 23294
     components:
     - type: Transform
       pos: 10.5,-2.5
       parent: 2
-  - uid: 23296
+  - uid: 23295
     components:
     - type: Transform
       pos: 12.5,-1.5
       parent: 2
-  - uid: 23297
+  - uid: 23296
     components:
     - type: Transform
       pos: 13.5,-1.5
       parent: 2
-  - uid: 23298
+  - uid: 23297
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 2
-  - uid: 23299
+  - uid: 23298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-10.5
       parent: 2
-  - uid: 23300
+  - uid: 23299
     components:
     - type: Transform
       pos: -27.5,21.5
       parent: 2
-  - uid: 23301
+  - uid: 23300
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-16.5
       parent: 2
-  - uid: 23302
+  - uid: 23301
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 2
-  - uid: 23303
+  - uid: 23302
     components:
     - type: Transform
       pos: -73.5,38.5
       parent: 2
-  - uid: 23304
+  - uid: 23303
     components:
     - type: Transform
       pos: -73.5,39.5
       parent: 2
-  - uid: 23305
+  - uid: 23304
     components:
     - type: Transform
       pos: -73.5,41.5
       parent: 2
-  - uid: 23306
+  - uid: 23305
     components:
     - type: Transform
       pos: -73.5,40.5
       parent: 2
-  - uid: 23307
+  - uid: 23306
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,38.5
       parent: 2
-  - uid: 23308
+  - uid: 23307
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,37.5
       parent: 2
-  - uid: 23309
+  - uid: 23308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -72.5,38.5
       parent: 2
-  - uid: 23310
+  - uid: 23309
     components:
     - type: Transform
       pos: -68.5,47.5
       parent: 2
-  - uid: 23311
+  - uid: 23310
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -72.5,43.5
       parent: 2
-  - uid: 23312
+  - uid: 23311
     components:
     - type: Transform
       pos: -71.5,44.5
       parent: 2
-  - uid: 23313
+  - uid: 23312
     components:
     - type: Transform
       pos: -67.5,47.5
       parent: 2
-  - uid: 23314
+  - uid: 23313
     components:
     - type: Transform
       pos: -70.5,46.5
       parent: 2
-  - uid: 23315
+  - uid: 23314
     components:
     - type: Transform
       pos: -70.5,47.5
       parent: 2
-  - uid: 23316
+  - uid: 23315
     components:
     - type: Transform
       pos: -66.5,47.5
       parent: 2
-  - uid: 23317
+  - uid: 23316
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 2
 - proto: WallReinforcedDiagonal
   entities:
-  - uid: 23318
+  - uid: 23317
     components:
     - type: Transform
       pos: -77.5,12.5
       parent: 2
-  - uid: 23319
+  - uid: 23318
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -144381,5720 +144383,5720 @@ entities:
       parent: 2
 - proto: WallRock
   entities:
-  - uid: 23320
+  - uid: 23319
     components:
     - type: Transform
       pos: 10.5,37.5
       parent: 2
-  - uid: 23321
+  - uid: 23320
     components:
     - type: Transform
       pos: 10.5,39.5
       parent: 2
-  - uid: 23322
+  - uid: 23321
     components:
     - type: Transform
       pos: 10.5,38.5
       parent: 2
-  - uid: 23323
+  - uid: 23322
     components:
     - type: Transform
       pos: 10.5,42.5
       parent: 2
-  - uid: 23324
+  - uid: 23323
     components:
     - type: Transform
       pos: 5.5,36.5
       parent: 2
-  - uid: 23325
+  - uid: 23324
     components:
     - type: Transform
       pos: 11.5,42.5
       parent: 2
-  - uid: 23326
+  - uid: 23325
     components:
     - type: Transform
       pos: 10.5,43.5
       parent: 2
-  - uid: 23327
+  - uid: 23326
     components:
     - type: Transform
       pos: 11.5,40.5
       parent: 2
-  - uid: 23328
+  - uid: 23327
     components:
     - type: Transform
       pos: 9.5,35.5
       parent: 2
-  - uid: 23329
+  - uid: 23328
     components:
     - type: Transform
       pos: 9.5,37.5
       parent: 2
-  - uid: 23330
+  - uid: 23329
     components:
     - type: Transform
       pos: 8.5,45.5
       parent: 2
-  - uid: 23331
+  - uid: 23330
     components:
     - type: Transform
       pos: 9.5,36.5
       parent: 2
-  - uid: 23332
+  - uid: 23331
     components:
     - type: Transform
       pos: 8.5,36.5
       parent: 2
-  - uid: 23333
+  - uid: 23332
     components:
     - type: Transform
       pos: 11.5,39.5
       parent: 2
-  - uid: 23334
+  - uid: 23333
     components:
     - type: Transform
       pos: 7.5,33.5
       parent: 2
-  - uid: 23335
+  - uid: 23334
     components:
     - type: Transform
       pos: 6.5,34.5
       parent: 2
-  - uid: 23336
+  - uid: 23335
     components:
     - type: Transform
       pos: 7.5,40.5
       parent: 2
-  - uid: 23337
+  - uid: 23336
     components:
     - type: Transform
       pos: 6.5,35.5
       parent: 2
-  - uid: 23338
+  - uid: 23337
     components:
     - type: Transform
       pos: 7.5,41.5
       parent: 2
-  - uid: 23339
+  - uid: 23338
     components:
     - type: Transform
       pos: 2.5,30.5
       parent: 2
-  - uid: 23340
+  - uid: 23339
     components:
     - type: Transform
       pos: 6.5,33.5
       parent: 2
-  - uid: 23341
+  - uid: 23340
     components:
     - type: Transform
       pos: 7.5,34.5
       parent: 2
-  - uid: 23342
+  - uid: 23341
     components:
     - type: Transform
       pos: 8.5,35.5
       parent: 2
-  - uid: 23343
+  - uid: 23342
     components:
     - type: Transform
       pos: 7.5,38.5
       parent: 2
-  - uid: 23344
+  - uid: 23343
     components:
     - type: Transform
       pos: 6.5,38.5
       parent: 2
-  - uid: 23345
+  - uid: 23344
     components:
     - type: Transform
       pos: 5.5,38.5
       parent: 2
-  - uid: 23346
+  - uid: 23345
     components:
     - type: Transform
       pos: 4.5,38.5
       parent: 2
-  - uid: 23347
+  - uid: 23346
     components:
     - type: Transform
       pos: 3.5,37.5
       parent: 2
-  - uid: 23348
+  - uid: 23347
     components:
     - type: Transform
       pos: 3.5,36.5
       parent: 2
-  - uid: 23349
+  - uid: 23348
     components:
     - type: Transform
       pos: 7.5,39.5
       parent: 2
-  - uid: 23350
+  - uid: 23349
     components:
     - type: Transform
       pos: 3.5,34.5
       parent: 2
-  - uid: 23351
+  - uid: 23350
     components:
     - type: Transform
       pos: 7.5,36.5
       parent: 2
-  - uid: 23352
+  - uid: 23351
     components:
     - type: Transform
       pos: 3.5,33.5
       parent: 2
-  - uid: 23353
+  - uid: 23352
     components:
     - type: Transform
       pos: 3.5,38.5
       parent: 2
-  - uid: 23354
+  - uid: 23353
     components:
     - type: Transform
       pos: 3.5,35.5
       parent: 2
-  - uid: 23355
+  - uid: 23354
     components:
     - type: Transform
       pos: 8.5,34.5
       parent: 2
-  - uid: 23356
+  - uid: 23355
     components:
     - type: Transform
       pos: 4.5,30.5
       parent: 2
-  - uid: 23357
+  - uid: 23356
     components:
     - type: Transform
       pos: 3.5,32.5
       parent: 2
-  - uid: 23358
+  - uid: 23357
     components:
     - type: Transform
       pos: 8.5,44.5
       parent: 2
-  - uid: 23359
+  - uid: 23358
     components:
     - type: Transform
       pos: 8.5,43.5
       parent: 2
-  - uid: 23360
+  - uid: 23359
     components:
     - type: Transform
       pos: 8.5,41.5
       parent: 2
-  - uid: 23361
+  - uid: 23360
     components:
     - type: Transform
       pos: 8.5,42.5
       parent: 2
-  - uid: 23362
+  - uid: 23361
     components:
     - type: Transform
       pos: 11.5,41.5
       parent: 2
-  - uid: 23363
+  - uid: 23362
     components:
     - type: Transform
       pos: 2.5,32.5
       parent: 2
-  - uid: 23364
+  - uid: 23363
     components:
     - type: Transform
       pos: 1.5,32.5
       parent: 2
-  - uid: 23365
+  - uid: 23364
     components:
     - type: Transform
       pos: -0.5,32.5
       parent: 2
-  - uid: 23366
+  - uid: 23365
     components:
     - type: Transform
       pos: 6.5,36.5
       parent: 2
-  - uid: 23367
+  - uid: 23366
     components:
     - type: Transform
       pos: -1.5,32.5
       parent: 2
-  - uid: 23368
+  - uid: 23367
     components:
     - type: Transform
       pos: 0.5,32.5
       parent: 2
-  - uid: 23369
+  - uid: 23368
     components:
     - type: Transform
       pos: -1.5,31.5
       parent: 2
-  - uid: 23370
+  - uid: 23369
     components:
     - type: Transform
       pos: -1.5,30.5
       parent: 2
-  - uid: 23371
+  - uid: 23370
     components:
     - type: Transform
       pos: -1.5,29.5
       parent: 2
-  - uid: 23372
+  - uid: 23371
     components:
     - type: Transform
       pos: -1.5,28.5
       parent: 2
-  - uid: 23373
+  - uid: 23372
     components:
     - type: Transform
       pos: -1.5,26.5
       parent: 2
-  - uid: 23374
+  - uid: 23373
     components:
     - type: Transform
       pos: -1.5,27.5
       parent: 2
-  - uid: 23375
+  - uid: 23374
     components:
     - type: Transform
       pos: -2.5,26.5
       parent: 2
-  - uid: 23376
+  - uid: 23375
     components:
     - type: Transform
       pos: 5.5,32.5
       parent: 2
-  - uid: 23377
+  - uid: 23376
     components:
     - type: Transform
       pos: -2.5,25.5
       parent: 2
-  - uid: 23378
+  - uid: 23377
     components:
     - type: Transform
       pos: -2.5,24.5
       parent: 2
-  - uid: 23379
+  - uid: 23378
     components:
     - type: Transform
       pos: -2.5,23.5
       parent: 2
-  - uid: 23380
+  - uid: 23379
     components:
     - type: Transform
       pos: -0.5,22.5
       parent: 2
-  - uid: 23381
+  - uid: 23380
     components:
     - type: Transform
       pos: -0.5,23.5
       parent: 2
-  - uid: 23382
+  - uid: 23381
     components:
     - type: Transform
       pos: 0.5,23.5
       parent: 2
-  - uid: 23383
+  - uid: 23382
     components:
     - type: Transform
       pos: 1.5,23.5
       parent: 2
-  - uid: 23384
+  - uid: 23383
     components:
     - type: Transform
       pos: 0.5,26.5
       parent: 2
-  - uid: 23385
+  - uid: 23384
     components:
     - type: Transform
       pos: 1.5,24.5
       parent: 2
-  - uid: 23386
+  - uid: 23385
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 2
-  - uid: 23387
+  - uid: 23386
     components:
     - type: Transform
       pos: 2.5,25.5
       parent: 2
-  - uid: 23388
+  - uid: 23387
     components:
     - type: Transform
       pos: 2.5,26.5
       parent: 2
-  - uid: 23389
+  - uid: 23388
     components:
     - type: Transform
       pos: 0.5,27.5
       parent: 2
-  - uid: 23390
+  - uid: 23389
     components:
     - type: Transform
       pos: 3.5,26.5
       parent: 2
-  - uid: 23391
+  - uid: 23390
     components:
     - type: Transform
       pos: 3.5,27.5
       parent: 2
-  - uid: 23392
+  - uid: 23391
     components:
     - type: Transform
       pos: 1.5,28.5
       parent: 2
-  - uid: 23393
+  - uid: 23392
     components:
     - type: Transform
       pos: 1.5,29.5
       parent: 2
-  - uid: 23394
+  - uid: 23393
     components:
     - type: Transform
       pos: 1.5,30.5
       parent: 2
-  - uid: 23395
+  - uid: 23394
     components:
     - type: Transform
       pos: 0.5,30.5
       parent: 2
-  - uid: 23396
+  - uid: 23395
     components:
     - type: Transform
       pos: 4.5,27.5
       parent: 2
-  - uid: 23397
+  - uid: 23396
     components:
     - type: Transform
       pos: 4.5,28.5
       parent: 2
-  - uid: 23398
+  - uid: 23397
     components:
     - type: Transform
       pos: 5.5,28.5
       parent: 2
-  - uid: 23399
+  - uid: 23398
     components:
     - type: Transform
       pos: 5.5,29.5
       parent: 2
-  - uid: 23400
+  - uid: 23399
     components:
     - type: Transform
       pos: 5.5,30.5
       parent: 2
-  - uid: 23401
+  - uid: 23400
     components:
     - type: Transform
       pos: 5.5,31.5
       parent: 2
-  - uid: 23402
+  - uid: 23401
     components:
     - type: Transform
       pos: 6.5,32.5
       parent: 2
-  - uid: 23403
+  - uid: 23402
     components:
     - type: Transform
       pos: 0.5,28.5
       parent: 2
-  - uid: 23404
+  - uid: 23403
     components:
     - type: Transform
       pos: 67.5,-0.5
       parent: 2
-  - uid: 23405
+  - uid: 23404
     components:
     - type: Transform
       pos: 67.5,-1.5
       parent: 2
-  - uid: 23406
+  - uid: 23405
     components:
     - type: Transform
       pos: 62.5,5.5
       parent: 2
-  - uid: 23407
+  - uid: 23406
     components:
     - type: Transform
       pos: 61.5,5.5
       parent: 2
-  - uid: 23408
+  - uid: 23407
     components:
     - type: Transform
       pos: 60.5,5.5
       parent: 2
-  - uid: 23409
+  - uid: 23408
     components:
     - type: Transform
       pos: -58.5,-4.5
       parent: 2
-  - uid: 23410
+  - uid: 23409
     components:
     - type: Transform
       pos: -43.5,-19.5
       parent: 2
-  - uid: 23411
+  - uid: 23410
     components:
     - type: Transform
       pos: -44.5,-19.5
       parent: 2
-  - uid: 23412
+  - uid: 23411
     components:
     - type: Transform
       pos: -45.5,-19.5
       parent: 2
-  - uid: 23413
+  - uid: 23412
     components:
     - type: Transform
       pos: -45.5,-18.5
       parent: 2
-  - uid: 23414
+  - uid: 23413
     components:
     - type: Transform
       pos: -44.5,-20.5
       parent: 2
-  - uid: 23415
+  - uid: 23414
     components:
     - type: Transform
       pos: -49.5,-19.5
       parent: 2
-  - uid: 23416
+  - uid: 23415
     components:
     - type: Transform
       pos: -50.5,-19.5
       parent: 2
-  - uid: 23417
+  - uid: 23416
     components:
     - type: Transform
       pos: -45.5,-20.5
       parent: 2
-  - uid: 23418
+  - uid: 23417
     components:
     - type: Transform
       pos: -50.5,-18.5
       parent: 2
-  - uid: 23419
+  - uid: 23418
     components:
     - type: Transform
       pos: -51.5,-18.5
       parent: 2
-  - uid: 23420
+  - uid: 23419
     components:
     - type: Transform
       pos: -43.5,-17.5
       parent: 2
-  - uid: 23421
+  - uid: 23420
     components:
     - type: Transform
       pos: -43.5,-16.5
       parent: 2
-  - uid: 23422
+  - uid: 23421
     components:
     - type: Transform
       pos: -43.5,-14.5
       parent: 2
-  - uid: 23423
+  - uid: 23422
     components:
     - type: Transform
       pos: -44.5,-14.5
       parent: 2
-  - uid: 23424
+  - uid: 23423
     components:
     - type: Transform
       pos: -45.5,-14.5
       parent: 2
-  - uid: 23425
+  - uid: 23424
     components:
     - type: Transform
       pos: -46.5,-14.5
       parent: 2
-  - uid: 23426
+  - uid: 23425
     components:
     - type: Transform
       pos: -46.5,-13.5
       parent: 2
-  - uid: 23427
+  - uid: 23426
     components:
     - type: Transform
       pos: -47.5,-13.5
       parent: 2
-  - uid: 23428
+  - uid: 23427
     components:
     - type: Transform
       pos: -48.5,-13.5
       parent: 2
-  - uid: 23429
+  - uid: 23428
     components:
     - type: Transform
       pos: -48.5,-12.5
       parent: 2
-  - uid: 23430
+  - uid: 23429
     components:
     - type: Transform
       pos: -48.5,-11.5
       parent: 2
-  - uid: 23431
+  - uid: 23430
     components:
     - type: Transform
       pos: -48.5,-10.5
       parent: 2
-  - uid: 23432
+  - uid: 23431
     components:
     - type: Transform
       pos: -48.5,-9.5
       parent: 2
-  - uid: 23433
+  - uid: 23432
     components:
     - type: Transform
       pos: -51.5,-19.5
       parent: 2
-  - uid: 23434
+  - uid: 23433
     components:
     - type: Transform
       pos: -52.5,-19.5
       parent: 2
-  - uid: 23435
+  - uid: 23434
     components:
     - type: Transform
       pos: -44.5,-16.5
       parent: 2
-  - uid: 23436
+  - uid: 23435
     components:
     - type: Transform
       pos: -46.5,-18.5
       parent: 2
-  - uid: 23437
+  - uid: 23436
     components:
     - type: Transform
       pos: -48.5,-20.5
       parent: 2
-  - uid: 23438
+  - uid: 23437
     components:
     - type: Transform
       pos: -45.5,-16.5
       parent: 2
-  - uid: 23439
+  - uid: 23438
     components:
     - type: Transform
       pos: -46.5,-20.5
       parent: 2
-  - uid: 23440
+  - uid: 23439
     components:
     - type: Transform
       pos: -47.5,-18.5
       parent: 2
-  - uid: 23441
+  - uid: 23440
     components:
     - type: Transform
       pos: -47.5,-17.5
       parent: 2
-  - uid: 23442
+  - uid: 23441
     components:
     - type: Transform
       pos: -57.5,-16.5
       parent: 2
-  - uid: 23443
+  - uid: 23442
     components:
     - type: Transform
       pos: -50.5,-17.5
       parent: 2
-  - uid: 23444
+  - uid: 23443
     components:
     - type: Transform
       pos: -56.5,-16.5
       parent: 2
-  - uid: 23445
+  - uid: 23444
     components:
     - type: Transform
       pos: -56.5,-15.5
       parent: 2
-  - uid: 23446
+  - uid: 23445
     components:
     - type: Transform
       pos: -56.5,-14.5
       parent: 2
-  - uid: 23447
+  - uid: 23446
     components:
     - type: Transform
       pos: -55.5,-14.5
       parent: 2
-  - uid: 23448
+  - uid: 23447
     components:
     - type: Transform
       pos: -50.5,-15.5
       parent: 2
-  - uid: 23449
+  - uid: 23448
     components:
     - type: Transform
       pos: -50.5,-14.5
       parent: 2
-  - uid: 23450
+  - uid: 23449
     components:
     - type: Transform
       pos: -51.5,-14.5
       parent: 2
-  - uid: 23451
+  - uid: 23450
     components:
     - type: Transform
       pos: -51.5,-13.5
       parent: 2
-  - uid: 23452
+  - uid: 23451
     components:
     - type: Transform
       pos: -52.5,-13.5
       parent: 2
-  - uid: 23453
+  - uid: 23452
     components:
     - type: Transform
       pos: -54.5,-13.5
       parent: 2
-  - uid: 23454
+  - uid: 23453
     components:
     - type: Transform
       pos: -55.5,-13.5
       parent: 2
-  - uid: 23455
+  - uid: 23454
     components:
     - type: Transform
       pos: -49.5,-20.5
       parent: 2
-  - uid: 23456
+  - uid: 23455
     components:
     - type: Transform
       pos: -50.5,-20.5
       parent: 2
-  - uid: 23457
+  - uid: 23456
     components:
     - type: Transform
       pos: -47.5,-20.5
       parent: 2
-  - uid: 23458
+  - uid: 23457
     components:
     - type: Transform
       pos: -43.5,-18.5
       parent: 2
-  - uid: 23459
+  - uid: 23458
     components:
     - type: Transform
       pos: -42.5,-14.5
       parent: 2
-  - uid: 23460
+  - uid: 23459
     components:
     - type: Transform
       pos: -54.5,-12.5
       parent: 2
-  - uid: 23461
+  - uid: 23460
     components:
     - type: Transform
       pos: -56.5,-10.5
       parent: 2
-  - uid: 23462
+  - uid: 23461
     components:
     - type: Transform
       pos: -57.5,-10.5
       parent: 2
-  - uid: 23463
+  - uid: 23462
     components:
     - type: Transform
       pos: -57.5,-9.5
       parent: 2
-  - uid: 23464
+  - uid: 23463
     components:
     - type: Transform
       pos: -58.5,-9.5
       parent: 2
-  - uid: 23465
+  - uid: 23464
     components:
     - type: Transform
       pos: -58.5,-8.5
       parent: 2
-  - uid: 23466
+  - uid: 23465
     components:
     - type: Transform
       pos: -59.5,-8.5
       parent: 2
-  - uid: 23467
+  - uid: 23466
     components:
     - type: Transform
       pos: -60.5,-8.5
       parent: 2
-  - uid: 23468
+  - uid: 23467
     components:
     - type: Transform
       pos: -60.5,-7.5
       parent: 2
-  - uid: 23469
+  - uid: 23468
     components:
     - type: Transform
       pos: -59.5,-7.5
       parent: 2
-  - uid: 23470
+  - uid: 23469
     components:
     - type: Transform
       pos: -58.5,-7.5
       parent: 2
-  - uid: 23471
+  - uid: 23470
     components:
     - type: Transform
       pos: -59.5,-6.5
       parent: 2
-  - uid: 23472
+  - uid: 23471
     components:
     - type: Transform
       pos: -60.5,-6.5
       parent: 2
-  - uid: 23473
+  - uid: 23472
     components:
     - type: Transform
       pos: -61.5,-6.5
       parent: 2
-  - uid: 23474
+  - uid: 23473
     components:
     - type: Transform
       pos: -61.5,-7.5
       parent: 2
-  - uid: 23475
+  - uid: 23474
     components:
     - type: Transform
       pos: -60.5,-5.5
       parent: 2
-  - uid: 23476
+  - uid: 23475
     components:
     - type: Transform
       pos: -59.5,-5.5
       parent: 2
-  - uid: 23477
+  - uid: 23476
     components:
     - type: Transform
       pos: -59.5,-4.5
       parent: 2
-  - uid: 23478
+  - uid: 23477
     components:
     - type: Transform
       pos: -48.5,-6.5
       parent: 2
-  - uid: 23479
+  - uid: 23478
     components:
     - type: Transform
       pos: -48.5,-7.5
       parent: 2
-  - uid: 23480
+  - uid: 23479
     components:
     - type: Transform
       pos: -50.5,-7.5
       parent: 2
-  - uid: 23481
+  - uid: 23480
     components:
     - type: Transform
       pos: -49.5,-7.5
       parent: 2
-  - uid: 23482
+  - uid: 23481
     components:
     - type: Transform
       pos: -51.5,-9.5
       parent: 2
-  - uid: 23483
+  - uid: 23482
     components:
     - type: Transform
       pos: -50.5,-8.5
       parent: 2
-  - uid: 23484
+  - uid: 23483
     components:
     - type: Transform
       pos: -48.5,-8.5
       parent: 2
-  - uid: 23485
+  - uid: 23484
     components:
     - type: Transform
       pos: -49.5,-10.5
       parent: 2
-  - uid: 23486
+  - uid: 23485
     components:
     - type: Transform
       pos: -50.5,-9.5
       parent: 2
-  - uid: 23487
+  - uid: 23486
     components:
     - type: Transform
       pos: -52.5,-9.5
       parent: 2
-  - uid: 23488
+  - uid: 23487
     components:
     - type: Transform
       pos: -53.5,-9.5
       parent: 2
-  - uid: 23489
+  - uid: 23488
     components:
     - type: Transform
       pos: -61.5,-8.5
       parent: 2
-  - uid: 23490
+  - uid: 23489
     components:
     - type: Transform
       pos: -49.5,-9.5
       parent: 2
-  - uid: 23491
+  - uid: 23490
     components:
     - type: Transform
       pos: 76.5,-45.5
       parent: 2
-  - uid: 23492
+  - uid: 23491
     components:
     - type: Transform
       pos: 77.5,-46.5
       parent: 2
-  - uid: 23493
+  - uid: 23492
     components:
     - type: Transform
       pos: 77.5,-45.5
       parent: 2
-  - uid: 23494
+  - uid: 23493
     components:
     - type: Transform
       pos: 77.5,-43.5
       parent: 2
-  - uid: 23495
+  - uid: 23494
     components:
     - type: Transform
       pos: 78.5,-43.5
       parent: 2
-  - uid: 23496
+  - uid: 23495
     components:
     - type: Transform
       pos: 77.5,-44.5
       parent: 2
-  - uid: 23497
+  - uid: 23496
     components:
     - type: Transform
       pos: 81.5,-49.5
       parent: 2
-  - uid: 23498
+  - uid: 23497
     components:
     - type: Transform
       pos: 81.5,-50.5
       parent: 2
-  - uid: 23499
+  - uid: 23498
     components:
     - type: Transform
       pos: 82.5,-50.5
       parent: 2
-  - uid: 23500
+  - uid: 23499
     components:
     - type: Transform
       pos: 83.5,-50.5
       parent: 2
-  - uid: 23501
+  - uid: 23500
     components:
     - type: Transform
       pos: 85.5,-44.5
       parent: 2
-  - uid: 23502
+  - uid: 23501
     components:
     - type: Transform
       pos: 85.5,-45.5
       parent: 2
-  - uid: 23503
+  - uid: 23502
     components:
     - type: Transform
       pos: 85.5,-47.5
       parent: 2
-  - uid: 23504
+  - uid: 23503
     components:
     - type: Transform
       pos: 85.5,-46.5
       parent: 2
 - proto: WallRockBasalt
   entities:
-  - uid: 23505
+  - uid: 23504
     components:
     - type: Transform
       pos: -1.5,-50.5
       parent: 2
-  - uid: 23506
+  - uid: 23505
     components:
     - type: Transform
       pos: 9.5,-53.5
       parent: 2
-  - uid: 23507
+  - uid: 23506
     components:
     - type: Transform
       pos: 1.5,-50.5
       parent: 2
-  - uid: 23508
+  - uid: 23507
     components:
     - type: Transform
       pos: 2.5,-50.5
       parent: 2
-  - uid: 23509
+  - uid: 23508
     components:
     - type: Transform
       pos: 3.5,-50.5
       parent: 2
-  - uid: 23510
+  - uid: 23509
     components:
     - type: Transform
       pos: 3.5,-51.5
       parent: 2
-  - uid: 23511
+  - uid: 23510
     components:
     - type: Transform
       pos: 5.5,-51.5
       parent: 2
-  - uid: 23512
+  - uid: 23511
     components:
     - type: Transform
       pos: 4.5,-51.5
       parent: 2
-  - uid: 23513
+  - uid: 23512
     components:
     - type: Transform
       pos: 6.5,-52.5
       parent: 2
-  - uid: 23514
+  - uid: 23513
     components:
     - type: Transform
       pos: 6.5,-51.5
       parent: 2
-  - uid: 23515
+  - uid: 23514
     components:
     - type: Transform
       pos: 7.5,-52.5
       parent: 2
-  - uid: 23516
+  - uid: 23515
     components:
     - type: Transform
       pos: 8.5,-52.5
       parent: 2
-  - uid: 23517
+  - uid: 23516
     components:
     - type: Transform
       pos: 9.5,-52.5
       parent: 2
-  - uid: 23518
+  - uid: 23517
     components:
     - type: Transform
       pos: 10.5,-53.5
       parent: 2
-  - uid: 23519
+  - uid: 23518
     components:
     - type: Transform
       pos: 11.5,-53.5
       parent: 2
-  - uid: 23520
+  - uid: 23519
     components:
     - type: Transform
       pos: 12.5,-53.5
       parent: 2
-  - uid: 23521
+  - uid: 23520
     components:
     - type: Transform
       pos: 12.5,-52.5
       parent: 2
-  - uid: 23522
+  - uid: 23521
     components:
     - type: Transform
       pos: 13.5,-52.5
       parent: 2
-  - uid: 23523
+  - uid: 23522
     components:
     - type: Transform
       pos: 14.5,-52.5
       parent: 2
-  - uid: 23524
+  - uid: 23523
     components:
     - type: Transform
       pos: 14.5,-53.5
       parent: 2
-  - uid: 23525
+  - uid: 23524
     components:
     - type: Transform
       pos: 15.5,-53.5
       parent: 2
-  - uid: 23526
+  - uid: 23525
     components:
     - type: Transform
       pos: 15.5,-54.5
       parent: 2
-  - uid: 23527
+  - uid: 23526
     components:
     - type: Transform
       pos: 16.5,-54.5
       parent: 2
-  - uid: 23528
+  - uid: 23527
     components:
     - type: Transform
       pos: 16.5,-55.5
       parent: 2
-  - uid: 23529
+  - uid: 23528
     components:
     - type: Transform
       pos: 16.5,-56.5
       parent: 2
-  - uid: 23530
+  - uid: 23529
     components:
     - type: Transform
       pos: 16.5,-57.5
       parent: 2
-  - uid: 23531
+  - uid: 23530
     components:
     - type: Transform
       pos: 15.5,-57.5
       parent: 2
-  - uid: 23532
+  - uid: 23531
     components:
     - type: Transform
       pos: 15.5,-58.5
       parent: 2
-  - uid: 23533
+  - uid: 23532
     components:
     - type: Transform
       pos: 14.5,-58.5
       parent: 2
-  - uid: 23534
+  - uid: 23533
     components:
     - type: Transform
       pos: 14.5,-59.5
       parent: 2
-  - uid: 23535
+  - uid: 23534
     components:
     - type: Transform
       pos: 13.5,-59.5
       parent: 2
-  - uid: 23536
+  - uid: 23535
     components:
     - type: Transform
       pos: 13.5,-60.5
       parent: 2
-  - uid: 23537
+  - uid: 23536
     components:
     - type: Transform
       pos: 12.5,-60.5
       parent: 2
-  - uid: 23538
+  - uid: 23537
     components:
     - type: Transform
       pos: 11.5,-60.5
       parent: 2
-  - uid: 23539
+  - uid: 23538
     components:
     - type: Transform
       pos: 11.5,-61.5
       parent: 2
-  - uid: 23540
+  - uid: 23539
     components:
     - type: Transform
       pos: 10.5,-61.5
       parent: 2
-  - uid: 23541
+  - uid: 23540
     components:
     - type: Transform
       pos: 10.5,-62.5
       parent: 2
-  - uid: 23542
+  - uid: 23541
     components:
     - type: Transform
       pos: 9.5,-62.5
       parent: 2
-  - uid: 23543
+  - uid: 23542
     components:
     - type: Transform
       pos: 8.5,-62.5
       parent: 2
-  - uid: 23544
+  - uid: 23543
     components:
     - type: Transform
       pos: 7.5,-62.5
       parent: 2
-  - uid: 23545
+  - uid: 23544
     components:
     - type: Transform
       pos: 7.5,-61.5
       parent: 2
-  - uid: 23546
+  - uid: 23545
     components:
     - type: Transform
       pos: 6.5,-61.5
       parent: 2
-  - uid: 23547
+  - uid: 23546
     components:
     - type: Transform
       pos: 5.5,-61.5
       parent: 2
-  - uid: 23548
+  - uid: 23547
     components:
     - type: Transform
       pos: 4.5,-61.5
       parent: 2
-  - uid: 23549
+  - uid: 23548
     components:
     - type: Transform
       pos: 4.5,-60.5
       parent: 2
-  - uid: 23550
+  - uid: 23549
     components:
     - type: Transform
       pos: 2.5,-60.5
       parent: 2
-  - uid: 23551
+  - uid: 23550
     components:
     - type: Transform
       pos: 1.5,-60.5
       parent: 2
-  - uid: 23552
+  - uid: 23551
     components:
     - type: Transform
       pos: 1.5,-59.5
       parent: 2
-  - uid: 23553
+  - uid: 23552
     components:
     - type: Transform
       pos: -0.5,-59.5
       parent: 2
-  - uid: 23554
+  - uid: 23553
     components:
     - type: Transform
       pos: 0.5,-59.5
       parent: 2
-  - uid: 23555
+  - uid: 23554
     components:
     - type: Transform
       pos: -1.5,-59.5
       parent: 2
-  - uid: 23556
+  - uid: 23555
     components:
     - type: Transform
       pos: -1.5,-58.5
       parent: 2
-  - uid: 23557
+  - uid: 23556
     components:
     - type: Transform
       pos: -2.5,-58.5
       parent: 2
-  - uid: 23558
+  - uid: 23557
     components:
     - type: Transform
       pos: -2.5,-57.5
       parent: 2
-  - uid: 23559
+  - uid: 23558
     components:
     - type: Transform
       pos: -3.5,-57.5
       parent: 2
-  - uid: 23560
+  - uid: 23559
     components:
     - type: Transform
       pos: -3.5,-56.5
       parent: 2
-  - uid: 23561
+  - uid: 23560
     components:
     - type: Transform
       pos: -4.5,-56.5
       parent: 2
-  - uid: 23562
+  - uid: 23561
     components:
     - type: Transform
       pos: -4.5,-55.5
       parent: 2
-  - uid: 23563
+  - uid: 23562
     components:
     - type: Transform
       pos: -4.5,-54.5
       parent: 2
-  - uid: 23564
+  - uid: 23563
     components:
     - type: Transform
       pos: -4.5,-53.5
       parent: 2
-  - uid: 23565
+  - uid: 23564
     components:
     - type: Transform
       pos: -3.5,-53.5
       parent: 2
-  - uid: 23566
+  - uid: 23565
     components:
     - type: Transform
       pos: -3.5,-52.5
       parent: 2
-  - uid: 23567
+  - uid: 23566
     components:
     - type: Transform
       pos: -2.5,-52.5
       parent: 2
-  - uid: 23568
+  - uid: 23567
     components:
     - type: Transform
       pos: -2.5,-51.5
       parent: 2
-  - uid: 23569
+  - uid: 23568
     components:
     - type: Transform
       pos: -1.5,-51.5
       parent: 2
-  - uid: 23570
+  - uid: 23569
     components:
     - type: Transform
       pos: 3.5,-60.5
       parent: 2
 - proto: WallRockSnow
   entities:
-  - uid: 23571
+  - uid: 23570
     components:
     - type: Transform
       pos: -71.5,-1.5
       parent: 2
-  - uid: 23572
+  - uid: 23571
     components:
     - type: Transform
       pos: -72.5,-1.5
       parent: 2
-  - uid: 23573
+  - uid: 23572
     components:
     - type: Transform
       pos: -73.5,0.5
       parent: 2
-  - uid: 23574
+  - uid: 23573
     components:
     - type: Transform
       pos: -73.5,1.5
       parent: 2
-  - uid: 23575
+  - uid: 23574
     components:
     - type: Transform
       pos: -73.5,2.5
       parent: 2
-  - uid: 23576
+  - uid: 23575
     components:
     - type: Transform
       pos: -75.5,2.5
       parent: 2
-  - uid: 23577
+  - uid: 23576
     components:
     - type: Transform
       pos: -74.5,2.5
       parent: 2
-  - uid: 23578
+  - uid: 23577
     components:
     - type: Transform
       pos: -75.5,1.5
       parent: 2
-  - uid: 23579
+  - uid: 23578
     components:
     - type: Transform
       pos: -76.5,1.5
       parent: 2
-  - uid: 23580
+  - uid: 23579
     components:
     - type: Transform
       pos: -76.5,0.5
       parent: 2
-  - uid: 23581
+  - uid: 23580
     components:
     - type: Transform
       pos: -77.5,0.5
       parent: 2
-  - uid: 23582
+  - uid: 23581
     components:
     - type: Transform
       pos: -77.5,-0.5
       parent: 2
-  - uid: 23583
+  - uid: 23582
     components:
     - type: Transform
       pos: -78.5,-0.5
       parent: 2
-  - uid: 23584
+  - uid: 23583
     components:
     - type: Transform
       pos: -78.5,-1.5
       parent: 2
-  - uid: 23585
+  - uid: 23584
     components:
     - type: Transform
       pos: -79.5,-1.5
       parent: 2
-  - uid: 23586
+  - uid: 23585
     components:
     - type: Transform
       pos: -79.5,-2.5
       parent: 2
-  - uid: 23587
+  - uid: 23586
     components:
     - type: Transform
       pos: -79.5,-3.5
       parent: 2
-  - uid: 23588
+  - uid: 23587
     components:
     - type: Transform
       pos: -78.5,-3.5
       parent: 2
-  - uid: 23589
+  - uid: 23588
     components:
     - type: Transform
       pos: -78.5,-4.5
       parent: 2
-  - uid: 23590
+  - uid: 23589
     components:
     - type: Transform
       pos: -77.5,-4.5
       parent: 2
-  - uid: 23591
+  - uid: 23590
     components:
     - type: Transform
       pos: -77.5,-5.5
       parent: 2
-  - uid: 23592
+  - uid: 23591
     components:
     - type: Transform
       pos: -76.5,-5.5
       parent: 2
-  - uid: 23593
+  - uid: 23592
     components:
     - type: Transform
       pos: -76.5,-6.5
       parent: 2
-  - uid: 23594
+  - uid: 23593
     components:
     - type: Transform
       pos: -75.5,-6.5
       parent: 2
-  - uid: 23595
+  - uid: 23594
     components:
     - type: Transform
       pos: -75.5,-7.5
       parent: 2
-  - uid: 23596
+  - uid: 23595
     components:
     - type: Transform
       pos: -74.5,-7.5
       parent: 2
-  - uid: 23597
+  - uid: 23596
     components:
     - type: Transform
       pos: -73.5,-7.5
       parent: 2
-  - uid: 23598
+  - uid: 23597
     components:
     - type: Transform
       pos: -72.5,-7.5
       parent: 2
-  - uid: 23599
+  - uid: 23598
     components:
     - type: Transform
       pos: -72.5,-6.5
       parent: 2
-  - uid: 23600
+  - uid: 23599
     components:
     - type: Transform
       pos: -71.5,-6.5
       parent: 2
-  - uid: 23601
+  - uid: 23600
     components:
     - type: Transform
       pos: -70.5,-6.5
       parent: 2
-  - uid: 23602
+  - uid: 23601
     components:
     - type: Transform
       pos: -70.5,-7.5
       parent: 2
-  - uid: 23603
+  - uid: 23602
     components:
     - type: Transform
       pos: -69.5,-7.5
       parent: 2
-  - uid: 23604
+  - uid: 23603
     components:
     - type: Transform
       pos: -68.5,-7.5
       parent: 2
-  - uid: 23605
+  - uid: 23604
     components:
     - type: Transform
       pos: -67.5,-6.5
       parent: 2
-  - uid: 23606
+  - uid: 23605
     components:
     - type: Transform
       pos: -68.5,-6.5
       parent: 2
-  - uid: 23607
+  - uid: 23606
     components:
     - type: Transform
       pos: -67.5,-5.5
       parent: 2
-  - uid: 23608
+  - uid: 23607
     components:
     - type: Transform
       pos: -67.5,-4.5
       parent: 2
-  - uid: 23609
+  - uid: 23608
     components:
     - type: Transform
       pos: -68.5,-4.5
       parent: 2
-  - uid: 23610
+  - uid: 23609
     components:
     - type: Transform
       pos: -68.5,-2.5
       parent: 2
-  - uid: 23611
+  - uid: 23610
     components:
     - type: Transform
       pos: -69.5,-2.5
       parent: 2
-  - uid: 23612
+  - uid: 23611
     components:
     - type: Transform
       pos: -70.5,-2.5
       parent: 2
-  - uid: 23613
+  - uid: 23612
     components:
     - type: Transform
       pos: -70.5,-1.5
       parent: 2
-  - uid: 23614
+  - uid: 23613
     components:
     - type: Transform
       pos: -72.5,0.5
       parent: 2
-  - uid: 23615
+  - uid: 23614
     components:
     - type: Transform
       pos: -69.5,-6.5
       parent: 2
-  - uid: 23616
+  - uid: 23615
     components:
     - type: Transform
       pos: -68.5,-5.5
       parent: 2
-  - uid: 23617
+  - uid: 23616
     components:
     - type: Transform
       pos: -78.5,-2.5
       parent: 2
-  - uid: 23618
+  - uid: 23617
     components:
     - type: Transform
       pos: -74.5,1.5
       parent: 2
-  - uid: 23619
+  - uid: 23618
     components:
     - type: Transform
       pos: -75.5,-5.5
       parent: 2
-  - uid: 23620
+  - uid: 23619
     components:
     - type: Transform
       pos: -76.5,-4.5
       parent: 2
-  - uid: 23621
+  - uid: 23620
     components:
     - type: Transform
       pos: 76.5,-42.5
       parent: 2
-  - uid: 23622
+  - uid: 23621
     components:
     - type: Transform
       pos: 75.5,-45.5
       parent: 2
-  - uid: 23623
+  - uid: 23622
     components:
     - type: Transform
       pos: 77.5,-42.5
       parent: 2
-  - uid: 23624
+  - uid: 23623
     components:
     - type: Transform
       pos: 76.5,-43.5
       parent: 2
-  - uid: 23625
+  - uid: 23624
     components:
     - type: Transform
       pos: 76.5,-44.5
       parent: 2
-  - uid: 23626
+  - uid: 23625
     components:
     - type: Transform
       pos: 75.5,-44.5
       parent: 2
-  - uid: 23627
+  - uid: 23626
     components:
     - type: Transform
       pos: 75.5,-46.5
       parent: 2
-  - uid: 23628
+  - uid: 23627
     components:
     - type: Transform
       pos: 76.5,-46.5
       parent: 2
-  - uid: 23629
+  - uid: 23628
     components:
     - type: Transform
       pos: 76.5,-47.5
       parent: 2
-  - uid: 23630
+  - uid: 23629
     components:
     - type: Transform
       pos: 77.5,-47.5
       parent: 2
-  - uid: 23631
+  - uid: 23630
     components:
     - type: Transform
       pos: 77.5,-48.5
       parent: 2
-  - uid: 23632
+  - uid: 23631
     components:
     - type: Transform
       pos: 77.5,-49.5
       parent: 2
-  - uid: 23633
+  - uid: 23632
     components:
     - type: Transform
       pos: 78.5,-49.5
       parent: 2
-  - uid: 23634
+  - uid: 23633
     components:
     - type: Transform
       pos: 78.5,-50.5
       parent: 2
-  - uid: 23635
+  - uid: 23634
     components:
     - type: Transform
       pos: 79.5,-50.5
       parent: 2
-  - uid: 23636
+  - uid: 23635
     components:
     - type: Transform
       pos: 80.5,-50.5
       parent: 2
-  - uid: 23637
+  - uid: 23636
     components:
     - type: Transform
       pos: 80.5,-51.5
       parent: 2
-  - uid: 23638
+  - uid: 23637
     components:
     - type: Transform
       pos: 81.5,-51.5
       parent: 2
-  - uid: 23639
+  - uid: 23638
     components:
     - type: Transform
       pos: 82.5,-51.5
       parent: 2
-  - uid: 23640
+  - uid: 23639
     components:
     - type: Transform
       pos: 84.5,-51.5
       parent: 2
-  - uid: 23641
+  - uid: 23640
     components:
     - type: Transform
       pos: 83.5,-51.5
       parent: 2
-  - uid: 23642
+  - uid: 23641
     components:
     - type: Transform
       pos: 84.5,-50.5
       parent: 2
-  - uid: 23643
+  - uid: 23642
     components:
     - type: Transform
       pos: 85.5,-50.5
       parent: 2
-  - uid: 23644
+  - uid: 23643
     components:
     - type: Transform
       pos: 85.5,-49.5
       parent: 2
-  - uid: 23645
+  - uid: 23644
     components:
     - type: Transform
       pos: 85.5,-48.5
       parent: 2
-  - uid: 23646
+  - uid: 23645
     components:
     - type: Transform
       pos: 86.5,-48.5
       parent: 2
-  - uid: 23647
+  - uid: 23646
     components:
     - type: Transform
       pos: 86.5,-47.5
       parent: 2
-  - uid: 23648
+  - uid: 23647
     components:
     - type: Transform
       pos: 86.5,-46.5
       parent: 2
-  - uid: 23649
+  - uid: 23648
     components:
     - type: Transform
       pos: 86.5,-45.5
       parent: 2
-  - uid: 23650
+  - uid: 23649
     components:
     - type: Transform
       pos: 86.5,-44.5
       parent: 2
-  - uid: 23651
+  - uid: 23650
     components:
     - type: Transform
       pos: 87.5,-43.5
       parent: 2
-  - uid: 23652
+  - uid: 23651
     components:
     - type: Transform
       pos: 87.5,-42.5
       parent: 2
-  - uid: 23653
+  - uid: 23652
     components:
     - type: Transform
       pos: 87.5,-41.5
       parent: 2
-  - uid: 23654
+  - uid: 23653
     components:
     - type: Transform
       pos: 87.5,-40.5
       parent: 2
-  - uid: 23655
+  - uid: 23654
     components:
     - type: Transform
       pos: 87.5,-39.5
       parent: 2
-  - uid: 23656
+  - uid: 23655
     components:
     - type: Transform
       pos: 86.5,-39.5
       parent: 2
-  - uid: 23657
+  - uid: 23656
     components:
     - type: Transform
       pos: 86.5,-38.5
       parent: 2
-  - uid: 23658
+  - uid: 23657
     components:
     - type: Transform
       pos: 85.5,-38.5
       parent: 2
-  - uid: 23659
+  - uid: 23658
     components:
     - type: Transform
       pos: 85.5,-37.5
       parent: 2
-  - uid: 23660
+  - uid: 23659
     components:
     - type: Transform
       pos: 84.5,-37.5
       parent: 2
-  - uid: 23661
+  - uid: 23660
     components:
     - type: Transform
       pos: 84.5,-36.5
       parent: 2
-  - uid: 23662
+  - uid: 23661
     components:
     - type: Transform
       pos: 83.5,-36.5
       parent: 2
-  - uid: 23663
+  - uid: 23662
     components:
     - type: Transform
       pos: 82.5,-36.5
       parent: 2
-  - uid: 23664
+  - uid: 23663
     components:
     - type: Transform
       pos: 81.5,-36.5
       parent: 2
-  - uid: 23665
+  - uid: 23664
     components:
     - type: Transform
       pos: 80.5,-36.5
       parent: 2
-  - uid: 23666
+  - uid: 23665
     components:
     - type: Transform
       pos: 79.5,-36.5
       parent: 2
-  - uid: 23667
+  - uid: 23666
     components:
     - type: Transform
       pos: 79.5,-37.5
       parent: 2
-  - uid: 23668
+  - uid: 23667
     components:
     - type: Transform
       pos: 79.5,-38.5
       parent: 2
-  - uid: 23669
+  - uid: 23668
     components:
     - type: Transform
       pos: 78.5,-38.5
       parent: 2
-  - uid: 23670
+  - uid: 23669
     components:
     - type: Transform
       pos: 78.5,-39.5
       parent: 2
-  - uid: 23671
+  - uid: 23670
     components:
     - type: Transform
       pos: 77.5,-39.5
       parent: 2
-  - uid: 23672
+  - uid: 23671
     components:
     - type: Transform
       pos: 78.5,-42.5
       parent: 2
-  - uid: 23673
+  - uid: 23672
     components:
     - type: Transform
       pos: 87.5,-44.5
       parent: 2
 - proto: WallSolid
   entities:
-  - uid: 23674
+  - uid: 23673
     components:
     - type: Transform
       pos: 8.5,-11.5
       parent: 2
-  - uid: 23675
+  - uid: 23674
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 2
-  - uid: 23676
+  - uid: 23675
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 2
-  - uid: 23677
+  - uid: 23676
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 2
-  - uid: 23678
+  - uid: 23677
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 2
-  - uid: 23679
+  - uid: 23678
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 2
-  - uid: 23680
+  - uid: 23679
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 2
-  - uid: 23681
+  - uid: 23680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-20.5
       parent: 2
-  - uid: 23682
+  - uid: 23681
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-19.5
       parent: 2
-  - uid: 23683
+  - uid: 23682
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 2
-  - uid: 23684
+  - uid: 23683
     components:
     - type: Transform
       pos: 12.5,-9.5
       parent: 2
-  - uid: 23685
+  - uid: 23684
     components:
     - type: Transform
       pos: -40.5,-4.5
       parent: 2
-  - uid: 23686
+  - uid: 23685
     components:
     - type: Transform
       pos: -20.5,46.5
       parent: 2
-  - uid: 23687
+  - uid: 23686
     components:
     - type: Transform
       pos: -20.5,47.5
       parent: 2
-  - uid: 23688
+  - uid: 23687
     components:
     - type: Transform
       pos: -10.5,47.5
       parent: 2
-  - uid: 23689
+  - uid: 23688
     components:
     - type: Transform
       pos: -17.5,50.5
       parent: 2
-  - uid: 23690
+  - uid: 23689
     components:
     - type: Transform
       pos: -10.5,46.5
       parent: 2
-  - uid: 23691
+  - uid: 23690
     components:
     - type: Transform
       pos: -13.5,50.5
       parent: 2
-  - uid: 23692
+  - uid: 23691
     components:
     - type: Transform
       pos: -14.5,11.5
       parent: 2
-  - uid: 23693
+  - uid: 23692
     components:
     - type: Transform
       pos: -14.5,10.5
       parent: 2
-  - uid: 23694
+  - uid: 23693
     components:
     - type: Transform
       pos: -14.5,9.5
       parent: 2
-  - uid: 23695
+  - uid: 23694
     components:
     - type: Transform
       pos: -14.5,8.5
       parent: 2
-  - uid: 23696
+  - uid: 23695
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
-  - uid: 23697
+  - uid: 23696
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 2
-  - uid: 23698
+  - uid: 23697
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 2
-  - uid: 23699
+  - uid: 23698
     components:
     - type: Transform
       pos: -19.5,7.5
       parent: 2
-  - uid: 23700
+  - uid: 23699
     components:
     - type: Transform
       pos: -19.5,8.5
       parent: 2
-  - uid: 23701
+  - uid: 23700
     components:
     - type: Transform
       pos: -19.5,9.5
       parent: 2
-  - uid: 23702
+  - uid: 23701
     components:
     - type: Transform
       pos: -19.5,10.5
       parent: 2
-  - uid: 23703
+  - uid: 23702
     components:
     - type: Transform
       pos: -19.5,11.5
       parent: 2
-  - uid: 23704
+  - uid: 23703
     components:
     - type: Transform
       pos: -25.5,9.5
       parent: 2
-  - uid: 23705
+  - uid: 23704
     components:
     - type: Transform
       pos: -25.5,11.5
       parent: 2
-  - uid: 23706
+  - uid: 23705
     components:
     - type: Transform
       pos: -16.5,11.5
       parent: 2
-  - uid: 23707
+  - uid: 23706
     components:
     - type: Transform
       pos: -25.5,6.5
       parent: 2
-  - uid: 23708
+  - uid: 23707
     components:
     - type: Transform
       pos: -25.5,2.5
       parent: 2
-  - uid: 23709
+  - uid: 23708
     components:
     - type: Transform
       pos: -25.5,4.5
       parent: 2
-  - uid: 23710
+  - uid: 23709
     components:
     - type: Transform
       pos: -25.5,5.5
       parent: 2
-  - uid: 23711
+  - uid: 23710
     components:
     - type: Transform
       pos: -25.5,7.5
       parent: 2
-  - uid: 23712
+  - uid: 23711
     components:
     - type: Transform
       pos: -25.5,1.5
       parent: 2
-  - uid: 23713
+  - uid: 23712
     components:
     - type: Transform
       pos: -25.5,3.5
       parent: 2
-  - uid: 23714
+  - uid: 23713
     components:
     - type: Transform
       pos: -25.5,10.5
       parent: 2
-  - uid: 23715
+  - uid: 23714
     components:
     - type: Transform
       pos: -11.5,-5.5
       parent: 2
-  - uid: 23716
+  - uid: 23715
     components:
     - type: Transform
       pos: -11.5,-4.5
       parent: 2
-  - uid: 23717
+  - uid: 23716
     components:
     - type: Transform
       pos: -11.5,-3.5
       parent: 2
-  - uid: 23718
+  - uid: 23717
     components:
     - type: Transform
       pos: -16.5,-1.5
       parent: 2
-  - uid: 23719
+  - uid: 23718
     components:
     - type: Transform
       pos: -18.5,-1.5
       parent: 2
-  - uid: 23720
+  - uid: 23719
     components:
     - type: Transform
       pos: -10.5,-1.5
       parent: 2
-  - uid: 23721
+  - uid: 23720
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 2
-  - uid: 23722
+  - uid: 23721
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 2
-  - uid: 23723
+  - uid: 23722
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
-  - uid: 23724
+  - uid: 23723
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 2
-  - uid: 23725
+  - uid: 23724
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 2
-  - uid: 23726
+  - uid: 23725
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 2
-  - uid: 23727
+  - uid: 23726
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-1.5
       parent: 2
-  - uid: 23728
+  - uid: 23727
     components:
     - type: Transform
       pos: -9.5,-1.5
       parent: 2
-  - uid: 23729
+  - uid: 23728
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 2
-  - uid: 23730
+  - uid: 23729
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 2
-  - uid: 23731
+  - uid: 23730
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 2
-  - uid: 23732
+  - uid: 23731
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 2
-  - uid: 23733
+  - uid: 23732
     components:
     - type: Transform
       pos: -2.5,22.5
       parent: 2
-  - uid: 23734
+  - uid: 23733
     components:
     - type: Transform
       pos: -63.5,18.5
       parent: 2
-  - uid: 23735
+  - uid: 23734
     components:
     - type: Transform
       pos: -63.5,19.5
       parent: 2
-  - uid: 23736
+  - uid: 23735
     components:
     - type: Transform
       pos: -63.5,17.5
       parent: 2
-  - uid: 23737
+  - uid: 23736
     components:
     - type: Transform
       pos: -26.5,5.5
       parent: 2
-  - uid: 23738
+  - uid: 23737
     components:
     - type: Transform
       pos: -26.5,1.5
       parent: 2
-  - uid: 23739
+  - uid: 23738
     components:
     - type: Transform
       pos: -25.5,-0.5
       parent: 2
-  - uid: 23740
+  - uid: 23739
     components:
     - type: Transform
       pos: -24.5,-0.5
       parent: 2
-  - uid: 23741
+  - uid: 23740
     components:
     - type: Transform
       pos: -29.5,-7.5
       parent: 2
-  - uid: 23742
+  - uid: 23741
     components:
     - type: Transform
       pos: -38.5,-7.5
       parent: 2
-  - uid: 23743
+  - uid: 23742
     components:
     - type: Transform
       pos: -23.5,-0.5
       parent: 2
-  - uid: 23744
+  - uid: 23743
     components:
     - type: Transform
       pos: -38.5,-6.5
       parent: 2
-  - uid: 23745
+  - uid: 23744
     components:
     - type: Transform
       pos: -38.5,-4.5
       parent: 2
-  - uid: 23746
+  - uid: 23745
     components:
     - type: Transform
       pos: -43.5,-4.5
       parent: 2
-  - uid: 23747
+  - uid: 23746
     components:
     - type: Transform
       pos: -38.5,-5.5
       parent: 2
-  - uid: 23748
+  - uid: 23747
     components:
     - type: Transform
       pos: -31.5,-7.5
       parent: 2
-  - uid: 23749
+  - uid: 23748
     components:
     - type: Transform
       pos: -27.5,-7.5
       parent: 2
-  - uid: 23750
+  - uid: 23749
     components:
     - type: Transform
       pos: -33.5,-7.5
       parent: 2
-  - uid: 23751
+  - uid: 23750
     components:
     - type: Transform
       pos: -32.5,-7.5
       parent: 2
-  - uid: 23752
+  - uid: 23751
     components:
     - type: Transform
       pos: -34.5,-7.5
       parent: 2
-  - uid: 23753
+  - uid: 23752
     components:
     - type: Transform
       pos: -35.5,-7.5
       parent: 2
-  - uid: 23754
+  - uid: 23753
     components:
     - type: Transform
       pos: -28.5,-7.5
       parent: 2
-  - uid: 23755
+  - uid: 23754
     components:
     - type: Transform
       pos: -37.5,-7.5
       parent: 2
-  - uid: 23756
+  - uid: 23755
     components:
     - type: Transform
       pos: -30.5,-7.5
       parent: 2
-  - uid: 23757
+  - uid: 23756
     components:
     - type: Transform
       pos: -29.5,-5.5
       parent: 2
-  - uid: 23758
+  - uid: 23757
     components:
     - type: Transform
       pos: -29.5,-6.5
       parent: 2
-  - uid: 23759
+  - uid: 23758
     components:
     - type: Transform
       pos: -32.5,-6.5
       parent: 2
-  - uid: 23760
+  - uid: 23759
     components:
     - type: Transform
       pos: -36.5,-7.5
       parent: 2
-  - uid: 23761
+  - uid: 23760
     components:
     - type: Transform
       pos: -29.5,-4.5
       parent: 2
-  - uid: 23762
+  - uid: 23761
     components:
     - type: Transform
       pos: -32.5,-5.5
       parent: 2
-  - uid: 23763
+  - uid: 23762
     components:
     - type: Transform
       pos: -24.5,-1.5
       parent: 2
-  - uid: 23764
+  - uid: 23763
     components:
     - type: Transform
       pos: -24.5,-3.5
       parent: 2
-  - uid: 23765
+  - uid: 23764
     components:
     - type: Transform
       pos: -24.5,-2.5
       parent: 2
-  - uid: 23766
+  - uid: 23765
     components:
     - type: Transform
       pos: -32.5,-4.5
       parent: 2
-  - uid: 23767
+  - uid: 23766
     components:
     - type: Transform
       pos: -35.5,-6.5
       parent: 2
-  - uid: 23768
+  - uid: 23767
     components:
     - type: Transform
       pos: -35.5,-5.5
       parent: 2
-  - uid: 23769
+  - uid: 23768
     components:
     - type: Transform
       pos: -35.5,-4.5
       parent: 2
-  - uid: 23770
+  - uid: 23769
     components:
     - type: Transform
       pos: -34.5,24.5
       parent: 2
-  - uid: 23771
+  - uid: 23770
     components:
     - type: Transform
       pos: -38.5,-9.5
       parent: 2
-  - uid: 23772
+  - uid: 23771
     components:
     - type: Transform
       pos: -39.5,-9.5
       parent: 2
-  - uid: 23773
+  - uid: 23772
     components:
     - type: Transform
       pos: -46.5,-6.5
       parent: 2
-  - uid: 23774
+  - uid: 23773
     components:
     - type: Transform
       pos: -47.5,-10.5
       parent: 2
-  - uid: 23775
+  - uid: 23774
     components:
     - type: Transform
       pos: -39.5,1.5
       parent: 2
-  - uid: 23776
+  - uid: 23775
     components:
     - type: Transform
       pos: -44.5,6.5
       parent: 2
-  - uid: 23777
+  - uid: 23776
     components:
     - type: Transform
       pos: -39.5,-3.5
       parent: 2
-  - uid: 23778
+  - uid: 23777
     components:
     - type: Transform
       pos: -39.5,-4.5
       parent: 2
-  - uid: 23779
+  - uid: 23778
     components:
     - type: Transform
       pos: -45.5,-4.5
       parent: 2
-  - uid: 23780
+  - uid: 23779
     components:
     - type: Transform
       pos: -43.5,7.5
       parent: 2
-  - uid: 23781
+  - uid: 23780
     components:
     - type: Transform
       pos: -57.5,6.5
       parent: 2
-  - uid: 23782
+  - uid: 23781
     components:
     - type: Transform
       pos: -43.5,2.5
       parent: 2
-  - uid: 23783
+  - uid: 23782
     components:
     - type: Transform
       pos: -52.5,10.5
       parent: 2
-  - uid: 23784
+  - uid: 23783
     components:
     - type: Transform
       pos: -52.5,8.5
       parent: 2
-  - uid: 23785
+  - uid: 23784
     components:
     - type: Transform
       pos: -44.5,2.5
       parent: 2
-  - uid: 23786
+  - uid: 23785
     components:
     - type: Transform
       pos: -52.5,7.5
       parent: 2
-  - uid: 23787
+  - uid: 23786
     components:
     - type: Transform
       pos: -52.5,9.5
       parent: 2
-  - uid: 23788
+  - uid: 23787
     components:
     - type: Transform
       pos: -53.5,6.5
       parent: 2
-  - uid: 23789
+  - uid: 23788
     components:
     - type: Transform
       pos: -52.5,6.5
       parent: 2
-  - uid: 23790
+  - uid: 23789
     components:
     - type: Transform
       pos: -54.5,6.5
       parent: 2
-  - uid: 23791
+  - uid: 23790
     components:
     - type: Transform
       pos: -56.5,6.5
       parent: 2
-  - uid: 23792
+  - uid: 23791
     components:
     - type: Transform
       pos: -46.5,2.5
       parent: 2
-  - uid: 23793
+  - uid: 23792
     components:
     - type: Transform
       pos: -45.5,2.5
       parent: 2
-  - uid: 23794
+  - uid: 23793
     components:
     - type: Transform
       pos: -57.5,2.5
       parent: 2
-  - uid: 23795
+  - uid: 23794
     components:
     - type: Transform
       pos: -53.5,2.5
       parent: 2
-  - uid: 23796
+  - uid: 23795
     components:
     - type: Transform
       pos: -47.5,6.5
       parent: 2
-  - uid: 23797
+  - uid: 23796
     components:
     - type: Transform
       pos: -51.5,6.5
       parent: 2
-  - uid: 23798
+  - uid: 23797
     components:
     - type: Transform
       pos: -50.5,6.5
       parent: 2
-  - uid: 23799
+  - uid: 23798
     components:
     - type: Transform
       pos: -49.5,6.5
       parent: 2
-  - uid: 23800
+  - uid: 23799
     components:
     - type: Transform
       pos: -45.5,6.5
       parent: 2
-  - uid: 23801
+  - uid: 23800
     components:
     - type: Transform
       pos: -46.5,6.5
       parent: 2
-  - uid: 23802
+  - uid: 23801
     components:
     - type: Transform
       pos: -48.5,6.5
       parent: 2
-  - uid: 23803
+  - uid: 23802
     components:
     - type: Transform
       pos: -43.5,6.5
       parent: 2
-  - uid: 23804
+  - uid: 23803
     components:
     - type: Transform
       pos: -55.5,6.5
       parent: 2
-  - uid: 23805
+  - uid: 23804
     components:
     - type: Transform
       pos: -58.5,-2.5
       parent: 2
-  - uid: 23806
+  - uid: 23805
     components:
     - type: Transform
       pos: -45.5,-6.5
       parent: 2
-  - uid: 23807
+  - uid: 23806
     components:
     - type: Transform
       pos: -45.5,-5.5
       parent: 2
-  - uid: 23808
+  - uid: 23807
     components:
     - type: Transform
       pos: -47.5,-7.5
       parent: 2
-  - uid: 23809
+  - uid: 23808
     components:
     - type: Transform
       pos: -47.5,-11.5
       parent: 2
-  - uid: 23810
+  - uid: 23809
     components:
     - type: Transform
       pos: -47.5,-8.5
       parent: 2
-  - uid: 23811
+  - uid: 23810
     components:
     - type: Transform
       pos: -47.5,-9.5
       parent: 2
-  - uid: 23812
+  - uid: 23811
     components:
     - type: Transform
       pos: -53.5,-1.5
       parent: 2
-  - uid: 23813
+  - uid: 23812
     components:
     - type: Transform
       pos: -57.5,-1.5
       parent: 2
-  - uid: 23814
+  - uid: 23813
     components:
     - type: Transform
       pos: -57.5,-2.5
       parent: 2
-  - uid: 23815
+  - uid: 23814
     components:
     - type: Transform
       pos: -56.5,-2.5
       parent: 2
-  - uid: 23816
+  - uid: 23815
     components:
     - type: Transform
       pos: -55.5,-2.5
       parent: 2
-  - uid: 23817
+  - uid: 23816
     components:
     - type: Transform
       pos: -54.5,-2.5
       parent: 2
-  - uid: 23818
+  - uid: 23817
     components:
     - type: Transform
       pos: -53.5,-2.5
       parent: 2
-  - uid: 23819
+  - uid: 23818
     components:
     - type: Transform
       pos: -47.5,-6.5
       parent: 2
-  - uid: 23820
+  - uid: 23819
     components:
     - type: Transform
       pos: -47.5,-12.5
       parent: 2
-  - uid: 23821
+  - uid: 23820
     components:
     - type: Transform
       pos: -46.5,-12.5
       parent: 2
-  - uid: 23822
+  - uid: 23821
     components:
     - type: Transform
       pos: -45.5,-12.5
       parent: 2
-  - uid: 23823
+  - uid: 23822
     components:
     - type: Transform
       pos: -45.5,-13.5
       parent: 2
-  - uid: 23824
+  - uid: 23823
     components:
     - type: Transform
       pos: -44.5,-13.5
       parent: 2
-  - uid: 23825
+  - uid: 23824
     components:
     - type: Transform
       pos: -42.5,-13.5
       parent: 2
-  - uid: 23826
+  - uid: 23825
     components:
     - type: Transform
       pos: -41.5,-13.5
       parent: 2
-  - uid: 23827
+  - uid: 23826
     components:
     - type: Transform
       pos: -40.5,-13.5
       parent: 2
-  - uid: 23828
+  - uid: 23827
     components:
     - type: Transform
       pos: -40.5,-12.5
       parent: 2
-  - uid: 23829
+  - uid: 23828
     components:
     - type: Transform
       pos: -43.5,-13.5
       parent: 2
-  - uid: 23830
+  - uid: 23829
     components:
     - type: Transform
       pos: -39.5,-12.5
       parent: 2
-  - uid: 23831
+  - uid: 23830
     components:
     - type: Transform
       pos: -63.5,21.5
       parent: 2
-  - uid: 23832
+  - uid: 23831
     components:
     - type: Transform
       pos: -37.5,-11.5
       parent: 2
-  - uid: 23833
+  - uid: 23832
     components:
     - type: Transform
       pos: -37.5,-12.5
       parent: 2
-  - uid: 23834
+  - uid: 23833
     components:
     - type: Transform
       pos: -63.5,16.5
       parent: 2
-  - uid: 23835
+  - uid: 23834
     components:
     - type: Transform
       pos: -38.5,-12.5
       parent: 2
-  - uid: 23836
+  - uid: 23835
     components:
     - type: Transform
       pos: -63.5,22.5
       parent: 2
-  - uid: 23837
+  - uid: 23836
     components:
     - type: Transform
       pos: -37.5,-10.5
       parent: 2
-  - uid: 23838
+  - uid: 23837
     components:
     - type: Transform
       pos: -37.5,-9.5
       parent: 2
-  - uid: 23839
+  - uid: 23838
     components:
     - type: Transform
       pos: -49.5,14.5
       parent: 2
-  - uid: 23840
+  - uid: 23839
     components:
     - type: Transform
       pos: -51.5,14.5
       parent: 2
-  - uid: 23841
+  - uid: 23840
     components:
     - type: Transform
       pos: -52.5,14.5
       parent: 2
-  - uid: 23842
+  - uid: 23841
     components:
     - type: Transform
       pos: -53.5,14.5
       parent: 2
-  - uid: 23843
+  - uid: 23842
     components:
     - type: Transform
       pos: -50.5,14.5
       parent: 2
-  - uid: 23844
+  - uid: 23843
     components:
     - type: Transform
       pos: -54.5,14.5
       parent: 2
-  - uid: 23845
+  - uid: 23844
     components:
     - type: Transform
       pos: -56.5,12.5
       parent: 2
-  - uid: 23846
+  - uid: 23845
     components:
     - type: Transform
       pos: -57.5,12.5
       parent: 2
-  - uid: 23847
+  - uid: 23846
     components:
     - type: Transform
       pos: -55.5,12.5
       parent: 2
-  - uid: 23848
+  - uid: 23847
     components:
     - type: Transform
       pos: -55.5,14.5
       parent: 2
-  - uid: 23849
+  - uid: 23848
     components:
     - type: Transform
       pos: -55.5,13.5
       parent: 2
-  - uid: 23850
+  - uid: 23849
     components:
     - type: Transform
       pos: -49.5,22.5
       parent: 2
-  - uid: 23851
+  - uid: 23850
     components:
     - type: Transform
       pos: -50.5,22.5
       parent: 2
-  - uid: 23852
+  - uid: 23851
     components:
     - type: Transform
       pos: -51.5,22.5
       parent: 2
-  - uid: 23853
+  - uid: 23852
     components:
     - type: Transform
       pos: -53.5,22.5
       parent: 2
-  - uid: 23854
+  - uid: 23853
     components:
     - type: Transform
       pos: -54.5,22.5
       parent: 2
-  - uid: 23855
+  - uid: 23854
     components:
     - type: Transform
       pos: -55.5,22.5
       parent: 2
-  - uid: 23856
+  - uid: 23855
     components:
     - type: Transform
       pos: -52.5,22.5
       parent: 2
-  - uid: 23857
+  - uid: 23856
     components:
     - type: Transform
       pos: -58.5,12.5
       parent: 2
-  - uid: 23858
+  - uid: 23857
     components:
     - type: Transform
       pos: -59.5,12.5
       parent: 2
-  - uid: 23859
+  - uid: 23858
     components:
     - type: Transform
       pos: -55.5,23.5
       parent: 2
-  - uid: 23860
+  - uid: 23859
     components:
     - type: Transform
       pos: -55.5,24.5
       parent: 2
-  - uid: 23861
+  - uid: 23860
     components:
     - type: Transform
       pos: -56.5,24.5
       parent: 2
-  - uid: 23862
+  - uid: 23861
     components:
     - type: Transform
       pos: -57.5,24.5
       parent: 2
-  - uid: 23863
+  - uid: 23862
     components:
     - type: Transform
       pos: -58.5,24.5
       parent: 2
-  - uid: 23864
+  - uid: 23863
     components:
     - type: Transform
       pos: -63.5,20.5
       parent: 2
-  - uid: 23865
+  - uid: 23864
     components:
     - type: Transform
       pos: -59.5,24.5
       parent: 2
-  - uid: 23866
+  - uid: 23865
     components:
     - type: Transform
       pos: -60.5,24.5
       parent: 2
-  - uid: 23867
+  - uid: 23866
     components:
     - type: Transform
       pos: -60.5,23.5
       parent: 2
-  - uid: 23868
+  - uid: 23867
     components:
     - type: Transform
       pos: -61.5,23.5
       parent: 2
-  - uid: 23869
+  - uid: 23868
     components:
     - type: Transform
       pos: -62.5,23.5
       parent: 2
-  - uid: 23870
+  - uid: 23869
     components:
     - type: Transform
       pos: -63.5,23.5
       parent: 2
-  - uid: 23871
+  - uid: 23870
     components:
     - type: Transform
       pos: -60.5,13.5
       parent: 2
-  - uid: 23872
+  - uid: 23871
     components:
     - type: Transform
       pos: -61.5,13.5
       parent: 2
-  - uid: 23873
+  - uid: 23872
     components:
     - type: Transform
       pos: -60.5,12.5
       parent: 2
-  - uid: 23874
+  - uid: 23873
     components:
     - type: Transform
       pos: -62.5,13.5
       parent: 2
-  - uid: 23875
+  - uid: 23874
     components:
     - type: Transform
       pos: -63.5,14.5
       parent: 2
-  - uid: 23876
+  - uid: 23875
     components:
     - type: Transform
       pos: -63.5,13.5
       parent: 2
-  - uid: 23877
+  - uid: 23876
     components:
     - type: Transform
       pos: -66.5,19.5
       parent: 2
-  - uid: 23878
+  - uid: 23877
     components:
     - type: Transform
       pos: -65.5,19.5
       parent: 2
-  - uid: 23879
+  - uid: 23878
     components:
     - type: Transform
       pos: -64.5,19.5
       parent: 2
-  - uid: 23880
+  - uid: 23879
     components:
     - type: Transform
       pos: -68.5,19.5
       parent: 2
-  - uid: 23881
+  - uid: 23880
     components:
     - type: Transform
       pos: -68.5,25.5
       parent: 2
-  - uid: 23882
+  - uid: 23881
     components:
     - type: Transform
       pos: -66.5,25.5
       parent: 2
-  - uid: 23883
+  - uid: 23882
     components:
     - type: Transform
       pos: -65.5,25.5
       parent: 2
-  - uid: 23884
+  - uid: 23883
     components:
     - type: Transform
       pos: -64.5,25.5
       parent: 2
-  - uid: 23885
+  - uid: 23884
     components:
     - type: Transform
       pos: -63.5,25.5
       parent: 2
-  - uid: 23886
+  - uid: 23885
     components:
     - type: Transform
       pos: -67.5,25.5
       parent: 2
-  - uid: 23887
+  - uid: 23886
     components:
     - type: Transform
       pos: -63.5,24.5
       parent: 2
-  - uid: 23888
+  - uid: 23887
     components:
     - type: Transform
       pos: -69.5,14.5
       parent: 2
-  - uid: 23889
+  - uid: 23888
     components:
     - type: Transform
       pos: -69.5,13.5
       parent: 2
-  - uid: 23890
+  - uid: 23889
     components:
     - type: Transform
       pos: -64.5,13.5
       parent: 2
-  - uid: 23891
+  - uid: 23890
     components:
     - type: Transform
       pos: -65.5,13.5
       parent: 2
-  - uid: 23892
+  - uid: 23891
     components:
     - type: Transform
       pos: -66.5,13.5
       parent: 2
-  - uid: 23893
+  - uid: 23892
     components:
     - type: Transform
       pos: -67.5,13.5
       parent: 2
-  - uid: 23894
+  - uid: 23893
     components:
     - type: Transform
       pos: -68.5,13.5
       parent: 2
-  - uid: 23895
+  - uid: 23894
     components:
     - type: Transform
       pos: -62.5,25.5
       parent: 2
-  - uid: 23896
+  - uid: 23895
     components:
     - type: Transform
       pos: -61.5,25.5
       parent: 2
-  - uid: 23897
+  - uid: 23896
     components:
     - type: Transform
       pos: -60.5,25.5
       parent: 2
-  - uid: 23898
+  - uid: 23897
     components:
     - type: Transform
       pos: -59.5,25.5
       parent: 2
-  - uid: 23899
+  - uid: 23898
     components:
     - type: Transform
       pos: -58.5,25.5
       parent: 2
-  - uid: 23900
+  - uid: 23899
     components:
     - type: Transform
       pos: -55.5,25.5
       parent: 2
-  - uid: 23901
+  - uid: 23900
     components:
     - type: Transform
       pos: -51.5,25.5
       parent: 2
-  - uid: 23902
+  - uid: 23901
     components:
     - type: Transform
       pos: -49.5,24.5
       parent: 2
-  - uid: 23903
+  - uid: 23902
     components:
     - type: Transform
       pos: -49.5,23.5
       parent: 2
-  - uid: 23904
+  - uid: 23903
     components:
     - type: Transform
       pos: 18.5,-34.5
       parent: 2
-  - uid: 23905
+  - uid: 23904
     components:
     - type: Transform
       pos: 20.5,-34.5
       parent: 2
-  - uid: 23906
+  - uid: 23905
     components:
     - type: Transform
       pos: -57.5,34.5
       parent: 2
-  - uid: 23907
+  - uid: 23906
     components:
     - type: Transform
       pos: -57.5,33.5
       parent: 2
-  - uid: 23908
+  - uid: 23907
     components:
     - type: Transform
       pos: -56.5,33.5
       parent: 2
-  - uid: 23909
+  - uid: 23908
     components:
     - type: Transform
       pos: -57.5,30.5
       parent: 2
-  - uid: 23910
+  - uid: 23909
     components:
     - type: Transform
       pos: -57.5,32.5
       parent: 2
-  - uid: 23911
+  - uid: 23910
     components:
     - type: Transform
       pos: -48.5,33.5
       parent: 2
-  - uid: 23912
+  - uid: 23911
     components:
     - type: Transform
       pos: -43.5,33.5
       parent: 2
-  - uid: 23913
+  - uid: 23912
     components:
     - type: Transform
       pos: -42.5,25.5
       parent: 2
-  - uid: 23914
+  - uid: 23913
     components:
     - type: Transform
       pos: -42.5,24.5
       parent: 2
-  - uid: 23915
+  - uid: 23914
     components:
     - type: Transform
       pos: -43.5,24.5
       parent: 2
-  - uid: 23916
+  - uid: 23915
     components:
     - type: Transform
       pos: -46.5,24.5
       parent: 2
-  - uid: 23917
+  - uid: 23916
     components:
     - type: Transform
       pos: -48.5,24.5
       parent: 2
-  - uid: 23918
+  - uid: 23917
     components:
     - type: Transform
       pos: -49.5,30.5
       parent: 2
-  - uid: 23919
+  - uid: 23918
     components:
     - type: Transform
       pos: -57.5,31.5
       parent: 2
-  - uid: 23920
+  - uid: 23919
     components:
     - type: Transform
       pos: -51.5,24.5
       parent: 2
-  - uid: 23921
+  - uid: 23920
     components:
     - type: Transform
       pos: -51.5,23.5
       parent: 2
-  - uid: 23922
+  - uid: 23921
     components:
     - type: Transform
       pos: -5.5,17.5
       parent: 2
-  - uid: 23923
+  - uid: 23922
     components:
     - type: Transform
       pos: -4.5,17.5
       parent: 2
-  - uid: 23924
+  - uid: 23923
     components:
     - type: Transform
       pos: -3.5,17.5
       parent: 2
-  - uid: 23925
+  - uid: 23924
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 2
-  - uid: 23926
+  - uid: 23925
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 2
-  - uid: 23927
+  - uid: 23926
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 2
-  - uid: 23928
+  - uid: 23927
     components:
     - type: Transform
       pos: 42.5,24.5
       parent: 2
-  - uid: 23929
+  - uid: 23928
     components:
     - type: Transform
       pos: 7.5,16.5
       parent: 2
-  - uid: 23930
+  - uid: 23929
     components:
     - type: Transform
       pos: 8.5,16.5
       parent: 2
-  - uid: 23931
+  - uid: 23930
     components:
     - type: Transform
       pos: 13.5,16.5
       parent: 2
-  - uid: 23932
+  - uid: 23931
     components:
     - type: Transform
       pos: 14.5,16.5
       parent: 2
-  - uid: 23933
+  - uid: 23932
     components:
     - type: Transform
       pos: 15.5,23.5
       parent: 2
-  - uid: 23934
+  - uid: 23933
     components:
     - type: Transform
       pos: 9.5,23.5
       parent: 2
-  - uid: 23935
+  - uid: 23934
     components:
     - type: Transform
       pos: 7.5,26.5
       parent: 2
-  - uid: 23936
+  - uid: 23935
     components:
     - type: Transform
       pos: 7.5,27.5
       parent: 2
-  - uid: 23937
+  - uid: 23936
     components:
     - type: Transform
       pos: 8.5,27.5
       parent: 2
-  - uid: 23938
+  - uid: 23937
     components:
     - type: Transform
       pos: 9.5,27.5
       parent: 2
-  - uid: 23939
+  - uid: 23938
     components:
     - type: Transform
       pos: 10.5,27.5
       parent: 2
-  - uid: 23940
+  - uid: 23939
     components:
     - type: Transform
       pos: 11.5,27.5
       parent: 2
-  - uid: 23941
+  - uid: 23940
     components:
     - type: Transform
       pos: 12.5,27.5
       parent: 2
-  - uid: 23942
+  - uid: 23941
     components:
     - type: Transform
       pos: 13.5,27.5
       parent: 2
-  - uid: 23943
+  - uid: 23942
     components:
     - type: Transform
       pos: 14.5,27.5
       parent: 2
-  - uid: 23944
+  - uid: 23943
     components:
     - type: Transform
       pos: 14.5,26.5
       parent: 2
-  - uid: 23945
+  - uid: 23944
     components:
     - type: Transform
       pos: 14.5,24.5
       parent: 2
-  - uid: 23946
+  - uid: 23945
     components:
     - type: Transform
       pos: 14.5,23.5
       parent: 2
-  - uid: 23947
+  - uid: 23946
     components:
     - type: Transform
       pos: 14.5,18.5
       parent: 2
-  - uid: 23948
+  - uid: 23947
     components:
     - type: Transform
       pos: 15.5,16.5
       parent: 2
-  - uid: 23949
+  - uid: 23948
     components:
     - type: Transform
       pos: 20.5,16.5
       parent: 2
-  - uid: 23950
+  - uid: 23949
     components:
     - type: Transform
       pos: 18.5,23.5
       parent: 2
-  - uid: 23951
+  - uid: 23950
     components:
     - type: Transform
       pos: 12.5,28.5
       parent: 2
-  - uid: 23952
+  - uid: 23951
     components:
     - type: Transform
       pos: 12.5,29.5
       parent: 2
-  - uid: 23953
+  - uid: 23952
     components:
     - type: Transform
       pos: 12.5,30.5
       parent: 2
-  - uid: 23954
+  - uid: 23953
     components:
     - type: Transform
       pos: 12.5,31.5
       parent: 2
-  - uid: 23955
+  - uid: 23954
     components:
     - type: Transform
       pos: 12.5,32.5
       parent: 2
-  - uid: 23956
+  - uid: 23955
     components:
     - type: Transform
       pos: 21.5,27.5
       parent: 2
-  - uid: 23957
+  - uid: 23956
     components:
     - type: Transform
       pos: 22.5,27.5
       parent: 2
-  - uid: 23958
+  - uid: 23957
     components:
     - type: Transform
       pos: 23.5,27.5
       parent: 2
-  - uid: 23959
+  - uid: 23958
     components:
     - type: Transform
       pos: 24.5,27.5
       parent: 2
-  - uid: 23960
+  - uid: 23959
     components:
     - type: Transform
       pos: 25.5,27.5
       parent: 2
-  - uid: 23961
+  - uid: 23960
     components:
     - type: Transform
       pos: 26.5,27.5
       parent: 2
-  - uid: 23962
+  - uid: 23961
     components:
     - type: Transform
       pos: 26.5,26.5
       parent: 2
-  - uid: 23963
+  - uid: 23962
     components:
     - type: Transform
       pos: 26.5,25.5
       parent: 2
-  - uid: 23964
+  - uid: 23963
     components:
     - type: Transform
       pos: 26.5,24.5
       parent: 2
-  - uid: 23965
+  - uid: 23964
     components:
     - type: Transform
       pos: 13.5,36.5
       parent: 2
-  - uid: 23966
+  - uid: 23965
     components:
     - type: Transform
       pos: 13.5,35.5
       parent: 2
-  - uid: 23967
+  - uid: 23966
     components:
     - type: Transform
       pos: 13.5,34.5
       parent: 2
-  - uid: 23968
+  - uid: 23967
     components:
     - type: Transform
       pos: 13.5,33.5
       parent: 2
-  - uid: 23969
+  - uid: 23968
     components:
     - type: Transform
       pos: 13.5,32.5
       parent: 2
-  - uid: 23970
+  - uid: 23969
     components:
     - type: Transform
       pos: 25.5,-8.5
       parent: 2
-  - uid: 23971
+  - uid: 23970
     components:
     - type: Transform
       pos: 25.5,5.5
       parent: 2
-  - uid: 23972
+  - uid: 23971
     components:
     - type: Transform
       pos: 21.5,-8.5
       parent: 2
-  - uid: 23973
+  - uid: 23972
     components:
     - type: Transform
       pos: 21.5,5.5
       parent: 2
-  - uid: 23974
+  - uid: 23973
     components:
     - type: Transform
       pos: 21.5,1.5
       parent: 2
-  - uid: 23975
+  - uid: 23974
     components:
     - type: Transform
       pos: 21.5,-4.5
       parent: 2
-  - uid: 23976
+  - uid: 23975
     components:
     - type: Transform
       pos: 25.5,-4.5
       parent: 2
-  - uid: 23977
+  - uid: 23976
     components:
     - type: Transform
       pos: 5.5,-38.5
       parent: 2
-  - uid: 23978
+  - uid: 23977
     components:
     - type: Transform
       pos: 25.5,1.5
       parent: 2
-  - uid: 23979
+  - uid: 23978
     components:
     - type: Transform
       pos: 17.5,-20.5
       parent: 2
-  - uid: 23980
+  - uid: 23979
     components:
     - type: Transform
       pos: 17.5,-19.5
       parent: 2
-  - uid: 23981
+  - uid: 23980
     components:
     - type: Transform
       pos: 8.5,-33.5
       parent: 2
-  - uid: 23982
+  - uid: 23981
     components:
     - type: Transform
       pos: 16.5,-19.5
       parent: 2
-  - uid: 23983
+  - uid: 23982
     components:
     - type: Transform
       pos: 5.5,-27.5
       parent: 2
-  - uid: 23984
+  - uid: 23983
     components:
     - type: Transform
       pos: 4.5,-27.5
       parent: 2
-  - uid: 23985
+  - uid: 23984
     components:
     - type: Transform
       pos: 15.5,-19.5
       parent: 2
-  - uid: 23986
+  - uid: 23985
     components:
     - type: Transform
       pos: 14.5,-19.5
       parent: 2
-  - uid: 23987
+  - uid: 23986
     components:
     - type: Transform
       pos: 3.5,-27.5
       parent: 2
-  - uid: 23988
+  - uid: 23987
     components:
     - type: Transform
       pos: 1.5,-27.5
       parent: 2
-  - uid: 23989
+  - uid: 23988
     components:
     - type: Transform
       pos: 17.5,-34.5
       parent: 2
-  - uid: 23990
+  - uid: 23989
     components:
     - type: Transform
       pos: 17.5,-35.5
       parent: 2
-  - uid: 23991
+  - uid: 23990
     components:
     - type: Transform
       pos: 7.5,-33.5
       parent: 2
-  - uid: 23992
+  - uid: 23991
     components:
     - type: Transform
       pos: 17.5,-37.5
       parent: 2
-  - uid: 23993
+  - uid: 23992
     components:
     - type: Transform
       pos: 2.5,-27.5
       parent: 2
-  - uid: 23994
+  - uid: 23993
     components:
     - type: Transform
       pos: 6.5,-24.5
       parent: 2
-  - uid: 23995
+  - uid: 23994
     components:
     - type: Transform
       pos: 5.5,-25.5
       parent: 2
-  - uid: 23996
+  - uid: 23995
     components:
     - type: Transform
       pos: 9.5,-40.5
       parent: 2
-  - uid: 23997
+  - uid: 23996
     components:
     - type: Transform
       pos: 17.5,-33.5
       parent: 2
-  - uid: 23998
+  - uid: 23997
     components:
     - type: Transform
       pos: 14.5,-20.5
       parent: 2
-  - uid: 23999
+  - uid: 23998
     components:
     - type: Transform
       pos: 14.5,-24.5
       parent: 2
-  - uid: 24000
+  - uid: 23999
     components:
     - type: Transform
       pos: 4.5,-42.5
       parent: 2
-  - uid: 24001
+  - uid: 24000
     components:
     - type: Transform
       pos: 6.5,-27.5
       parent: 2
-  - uid: 24002
+  - uid: 24001
     components:
     - type: Transform
       pos: 5.5,-24.5
       parent: 2
-  - uid: 24003
+  - uid: 24002
     components:
     - type: Transform
       pos: 12.5,-20.5
       parent: 2
-  - uid: 24004
+  - uid: 24003
     components:
     - type: Transform
       pos: 9.5,-20.5
       parent: 2
-  - uid: 24005
+  - uid: 24004
     components:
     - type: Transform
       pos: 11.5,-20.5
       parent: 2
-  - uid: 24006
+  - uid: 24005
     components:
     - type: Transform
       pos: 13.5,-20.5
       parent: 2
-  - uid: 24007
+  - uid: 24006
     components:
     - type: Transform
       pos: 5.5,-20.5
       parent: 2
-  - uid: 24008
+  - uid: 24007
     components:
     - type: Transform
       pos: 4.5,-20.5
       parent: 2
-  - uid: 24009
+  - uid: 24008
     components:
     - type: Transform
       pos: 10.5,-20.5
       parent: 2
-  - uid: 24010
+  - uid: 24009
     components:
     - type: Transform
       pos: 0.5,-28.5
       parent: 2
-  - uid: 24011
+  - uid: 24010
     components:
     - type: Transform
       pos: 0.5,-33.5
       parent: 2
-  - uid: 24012
+  - uid: 24011
     components:
     - type: Transform
       pos: 0.5,-27.5
       parent: 2
-  - uid: 24013
+  - uid: 24012
     components:
     - type: Transform
       pos: 16.5,-33.5
       parent: 2
-  - uid: 24014
+  - uid: 24013
     components:
     - type: Transform
       pos: 6.5,-34.5
       parent: 2
-  - uid: 24015
+  - uid: 24014
     components:
     - type: Transform
       pos: 2.5,-34.5
       parent: 2
-  - uid: 24016
+  - uid: 24015
     components:
     - type: Transform
       pos: 2.5,-38.5
       parent: 2
-  - uid: 24017
+  - uid: 24016
     components:
     - type: Transform
       pos: 3.5,-38.5
       parent: 2
-  - uid: 24018
+  - uid: 24017
     components:
     - type: Transform
       pos: 6.5,-28.5
       parent: 2
-  - uid: 24019
+  - uid: 24018
     components:
     - type: Transform
       pos: 5.5,-39.5
       parent: 2
-  - uid: 24020
+  - uid: 24019
     components:
     - type: Transform
       pos: 0.5,-32.5
       parent: 2
-  - uid: 24021
+  - uid: 24020
     components:
     - type: Transform
       pos: 5.5,-42.5
       parent: 2
-  - uid: 24022
+  - uid: 24021
     components:
     - type: Transform
       pos: 1.5,-41.5
       parent: 2
-  - uid: 24023
+  - uid: 24022
     components:
     - type: Transform
       pos: 9.5,-41.5
       parent: 2
-  - uid: 24024
+  - uid: 24023
     components:
     - type: Transform
       pos: 6.5,-38.5
       parent: 2
-  - uid: 24025
+  - uid: 24024
     components:
     - type: Transform
       pos: 16.5,-38.5
       parent: 2
-  - uid: 24026
+  - uid: 24025
     components:
     - type: Transform
       pos: 8.5,-38.5
       parent: 2
-  - uid: 24027
+  - uid: 24026
     components:
     - type: Transform
       pos: 9.5,-38.5
       parent: 2
-  - uid: 24028
+  - uid: 24027
     components:
     - type: Transform
       pos: 10.5,-24.5
       parent: 2
-  - uid: 24029
+  - uid: 24028
     components:
     - type: Transform
       pos: 1.5,-33.5
       parent: 2
-  - uid: 24030
+  - uid: 24029
     components:
     - type: Transform
       pos: 1.5,-34.5
       parent: 2
-  - uid: 24031
+  - uid: 24030
     components:
     - type: Transform
       pos: 6.5,-32.5
       parent: 2
-  - uid: 24032
+  - uid: 24031
     components:
     - type: Transform
       pos: 6.5,-33.5
       parent: 2
-  - uid: 24033
+  - uid: 24032
     components:
     - type: Transform
       pos: 5.5,-26.5
       parent: 2
-  - uid: 24034
+  - uid: 24033
     components:
     - type: Transform
       pos: 1.5,-42.5
       parent: 2
-  - uid: 24035
+  - uid: 24034
     components:
     - type: Transform
       pos: 13.5,-41.5
       parent: 2
-  - uid: 24036
+  - uid: 24035
     components:
     - type: Transform
       pos: 13.5,-40.5
       parent: 2
-  - uid: 24037
+  - uid: 24036
     components:
     - type: Transform
       pos: 13.5,-42.5
       parent: 2
-  - uid: 24038
+  - uid: 24037
     components:
     - type: Transform
       pos: 14.5,-38.5
       parent: 2
-  - uid: 24039
+  - uid: 24038
     components:
     - type: Transform
       pos: 10.5,-38.5
       parent: 2
-  - uid: 24040
+  - uid: 24039
     components:
     - type: Transform
       pos: 12.5,-38.5
       parent: 2
-  - uid: 24041
+  - uid: 24040
     components:
     - type: Transform
       pos: 13.5,-38.5
       parent: 2
-  - uid: 24042
+  - uid: 24041
     components:
     - type: Transform
       pos: 1.5,-39.5
       parent: 2
-  - uid: 24043
+  - uid: 24042
     components:
     - type: Transform
       pos: 13.5,-39.5
       parent: 2
-  - uid: 24044
+  - uid: 24043
     components:
     - type: Transform
       pos: 9.5,-42.5
       parent: 2
-  - uid: 24045
+  - uid: 24044
     components:
     - type: Transform
       pos: 1.5,-38.5
       parent: 2
-  - uid: 24046
+  - uid: 24045
     components:
     - type: Transform
       pos: 5.5,-40.5
       parent: 2
-  - uid: 24047
+  - uid: 24046
     components:
     - type: Transform
       pos: 9.5,-39.5
       parent: 2
-  - uid: 24048
+  - uid: 24047
     components:
     - type: Transform
       pos: 5.5,-41.5
       parent: 2
-  - uid: 24049
+  - uid: 24048
     components:
     - type: Transform
       pos: 3.5,-42.5
       parent: 2
-  - uid: 24050
+  - uid: 24049
     components:
     - type: Transform
       pos: 2.5,-42.5
       parent: 2
-  - uid: 24051
+  - uid: 24050
     components:
     - type: Transform
       pos: -1.5,-33.5
       parent: 2
-  - uid: 24052
+  - uid: 24051
     components:
     - type: Transform
       pos: -2.5,-40.5
       parent: 2
-  - uid: 24053
+  - uid: 24052
     components:
     - type: Transform
       pos: -0.5,-33.5
       parent: 2
-  - uid: 24054
+  - uid: 24053
     components:
     - type: Transform
       pos: -2.5,-33.5
       parent: 2
-  - uid: 24055
+  - uid: 24054
     components:
     - type: Transform
       pos: -2.5,-34.5
       parent: 2
-  - uid: 24056
+  - uid: 24055
     components:
     - type: Transform
       pos: -2.5,-36.5
       parent: 2
-  - uid: 24057
+  - uid: 24056
     components:
     - type: Transform
       pos: -3.5,-36.5
       parent: 2
-  - uid: 24058
+  - uid: 24057
     components:
     - type: Transform
       pos: -4.5,-36.5
       parent: 2
-  - uid: 24059
+  - uid: 24058
     components:
     - type: Transform
       pos: -2.5,-38.5
       parent: 2
-  - uid: 24060
+  - uid: 24059
     components:
     - type: Transform
       pos: -3.5,-38.5
       parent: 2
-  - uid: 24061
+  - uid: 24060
     components:
     - type: Transform
       pos: -4.5,-38.5
       parent: 2
-  - uid: 24062
+  - uid: 24061
     components:
     - type: Transform
       pos: -3.5,-40.5
       parent: 2
-  - uid: 24063
+  - uid: 24062
     components:
     - type: Transform
       pos: -4.5,-40.5
       parent: 2
-  - uid: 24064
+  - uid: 24063
     components:
     - type: Transform
       pos: 0.5,-29.5
       parent: 2
-  - uid: 24065
+  - uid: 24064
     components:
     - type: Transform
       pos: 0.5,-31.5
       parent: 2
-  - uid: 24066
+  - uid: 24065
     components:
     - type: Transform
       pos: 9.5,-24.5
       parent: 2
-  - uid: 24067
+  - uid: 24066
     components:
     - type: Transform
       pos: 7.5,-24.5
       parent: 2
-  - uid: 24068
+  - uid: 24067
     components:
     - type: Transform
       pos: 8.5,-24.5
       parent: 2
-  - uid: 24069
+  - uid: 24068
     components:
     - type: Transform
       pos: 15.5,-24.5
       parent: 2
-  - uid: 24070
+  - uid: 24069
     components:
     - type: Transform
       pos: 16.5,-24.5
       parent: 2
-  - uid: 24071
+  - uid: 24070
     components:
     - type: Transform
       pos: 17.5,-24.5
       parent: 2
-  - uid: 24072
+  - uid: 24071
     components:
     - type: Transform
       pos: 16.5,-12.5
       parent: 2
-  - uid: 24073
+  - uid: 24072
     components:
     - type: Transform
       pos: 16.5,-13.5
       parent: 2
-  - uid: 24074
+  - uid: 24073
     components:
     - type: Transform
       pos: 16.5,-14.5
       parent: 2
-  - uid: 24075
+  - uid: 24074
     components:
     - type: Transform
       pos: 17.5,-15.5
       parent: 2
-  - uid: 24076
+  - uid: 24075
     components:
     - type: Transform
       pos: 16.5,-15.5
       parent: 2
-  - uid: 24077
+  - uid: 24076
     components:
     - type: Transform
       pos: 17.5,-16.5
       parent: 2
-  - uid: 24078
+  - uid: 24077
     components:
     - type: Transform
       pos: 17.5,-18.5
       parent: 2
-  - uid: 24079
+  - uid: 24078
     components:
     - type: Transform
       pos: 29.5,2.5
       parent: 2
-  - uid: 24080
+  - uid: 24079
     components:
     - type: Transform
       pos: 33.5,6.5
       parent: 2
-  - uid: 24081
+  - uid: 24080
     components:
     - type: Transform
       pos: 34.5,6.5
       parent: 2
-  - uid: 24082
+  - uid: 24081
     components:
     - type: Transform
       pos: 29.5,5.5
       parent: 2
-  - uid: 24083
+  - uid: 24082
     components:
     - type: Transform
       pos: 29.5,4.5
       parent: 2
-  - uid: 24084
+  - uid: 24083
     components:
     - type: Transform
       pos: 29.5,3.5
       parent: 2
-  - uid: 24085
+  - uid: 24084
     components:
     - type: Transform
       pos: 29.5,6.5
       parent: 2
-  - uid: 24086
+  - uid: 24085
     components:
     - type: Transform
       pos: 31.5,6.5
       parent: 2
-  - uid: 24087
+  - uid: 24086
     components:
     - type: Transform
       pos: 30.5,6.5
       parent: 2
-  - uid: 24088
+  - uid: 24087
     components:
     - type: Transform
       pos: 35.5,4.5
       parent: 2
-  - uid: 24089
+  - uid: 24088
     components:
     - type: Transform
       pos: 32.5,6.5
       parent: 2
-  - uid: 24090
+  - uid: 24089
     components:
     - type: Transform
       pos: 35.5,3.5
       parent: 2
-  - uid: 24091
+  - uid: 24090
     components:
     - type: Transform
       pos: 35.5,2.5
       parent: 2
-  - uid: 24092
+  - uid: 24091
     components:
     - type: Transform
       pos: 31.5,2.5
       parent: 2
-  - uid: 24093
+  - uid: 24092
     components:
     - type: Transform
       pos: 32.5,2.5
       parent: 2
-  - uid: 24094
+  - uid: 24093
     components:
     - type: Transform
       pos: 30.5,2.5
       parent: 2
-  - uid: 24095
+  - uid: 24094
     components:
     - type: Transform
       pos: 34.5,2.5
       parent: 2
-  - uid: 24096
+  - uid: 24095
     components:
     - type: Transform
       pos: 43.5,4.5
       parent: 2
-  - uid: 24097
+  - uid: 24096
     components:
     - type: Transform
       pos: 43.5,2.5
       parent: 2
-  - uid: 24098
+  - uid: 24097
     components:
     - type: Transform
       pos: 43.5,1.5
       parent: 2
-  - uid: 24099
+  - uid: 24098
     components:
     - type: Transform
       pos: 44.5,1.5
       parent: 2
-  - uid: 24100
+  - uid: 24099
     components:
     - type: Transform
       pos: 46.5,1.5
       parent: 2
-  - uid: 24101
+  - uid: 24100
     components:
     - type: Transform
       pos: 47.5,1.5
       parent: 2
-  - uid: 24102
+  - uid: 24101
     components:
     - type: Transform
       pos: 48.5,1.5
       parent: 2
-  - uid: 24103
+  - uid: 24102
     components:
     - type: Transform
       pos: 48.5,2.5
       parent: 2
-  - uid: 24104
+  - uid: 24103
     components:
     - type: Transform
       pos: 48.5,3.5
       parent: 2
-  - uid: 24105
+  - uid: 24104
     components:
     - type: Transform
       pos: 43.5,-1.5
       parent: 2
-  - uid: 24106
+  - uid: 24105
     components:
     - type: Transform
       pos: 44.5,-1.5
       parent: 2
-  - uid: 24107
+  - uid: 24106
     components:
     - type: Transform
       pos: 38.5,-23.5
       parent: 2
-  - uid: 24108
+  - uid: 24107
     components:
     - type: Transform
       pos: 42.5,-1.5
       parent: 2
-  - uid: 24109
+  - uid: 24108
     components:
     - type: Transform
       pos: 37.5,-33.5
       parent: 2
-  - uid: 24110
+  - uid: 24109
     components:
     - type: Transform
       pos: 41.5,-7.5
       parent: 2
-  - uid: 24111
+  - uid: 24110
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 2
-  - uid: 24112
+  - uid: 24111
     components:
     - type: Transform
       pos: 45.5,1.5
       parent: 2
-  - uid: 24113
+  - uid: 24112
     components:
     - type: Transform
       pos: 41.5,-1.5
       parent: 2
-  - uid: 24114
+  - uid: 24113
     components:
     - type: Transform
       pos: 39.5,-23.5
       parent: 2
-  - uid: 24115
+  - uid: 24114
     components:
     - type: Transform
       pos: 36.5,-34.5
       parent: 2
-  - uid: 24116
+  - uid: 24115
     components:
     - type: Transform
       pos: 38.5,-26.5
       parent: 2
-  - uid: 24117
+  - uid: 24116
     components:
     - type: Transform
       pos: 34.5,-34.5
       parent: 2
-  - uid: 24118
+  - uid: 24117
     components:
     - type: Transform
       pos: 38.5,-22.5
       parent: 2
-  - uid: 24119
+  - uid: 24118
     components:
     - type: Transform
       pos: 41.5,-23.5
       parent: 2
-  - uid: 24120
+  - uid: 24119
     components:
     - type: Transform
       pos: 42.5,-23.5
       parent: 2
-  - uid: 24121
+  - uid: 24120
     components:
     - type: Transform
       pos: 37.5,-34.5
       parent: 2
-  - uid: 24122
+  - uid: 24121
     components:
     - type: Transform
       pos: 39.5,-30.5
       parent: 2
-  - uid: 24123
+  - uid: 24122
     components:
     - type: Transform
       pos: 40.5,-23.5
       parent: 2
-  - uid: 24124
+  - uid: 24123
     components:
     - type: Transform
       pos: 40.5,-30.5
       parent: 2
-  - uid: 24125
+  - uid: 24124
     components:
     - type: Transform
       pos: 38.5,-20.5
       parent: 2
-  - uid: 24126
+  - uid: 24125
     components:
     - type: Transform
       pos: 38.5,-30.5
       parent: 2
-  - uid: 24127
+  - uid: 24126
     components:
     - type: Transform
       pos: 37.5,-30.5
       parent: 2
-  - uid: 24128
+  - uid: 24127
     components:
     - type: Transform
       pos: 37.5,-31.5
       parent: 2
-  - uid: 24129
+  - uid: 24128
     components:
     - type: Transform
       pos: 37.5,-16.5
       parent: 2
-  - uid: 24130
+  - uid: 24129
     components:
     - type: Transform
       pos: 37.5,-15.5
       parent: 2
-  - uid: 24131
+  - uid: 24130
     components:
     - type: Transform
       pos: 38.5,-15.5
       parent: 2
-  - uid: 24132
+  - uid: 24131
     components:
     - type: Transform
       pos: 39.5,-15.5
       parent: 2
-  - uid: 24133
+  - uid: 24132
     components:
     - type: Transform
       pos: 40.5,-15.5
       parent: 2
-  - uid: 24134
+  - uid: 24133
     components:
     - type: Transform
       pos: 41.5,-15.5
       parent: 2
-  - uid: 24135
+  - uid: 24134
     components:
     - type: Transform
       pos: 41.5,-19.5
       parent: 2
-  - uid: 24136
+  - uid: 24135
     components:
     - type: Transform
       pos: 38.5,-27.5
       parent: 2
-  - uid: 24137
+  - uid: 24136
     components:
     - type: Transform
       pos: 38.5,-29.5
       parent: 2
-  - uid: 24138
+  - uid: 24137
     components:
     - type: Transform
       pos: 42.5,-30.5
       parent: 2
-  - uid: 24139
+  - uid: 24138
     components:
     - type: Transform
       pos: 41.5,-26.5
       parent: 2
-  - uid: 24140
+  - uid: 24139
     components:
     - type: Transform
       pos: 40.5,-26.5
       parent: 2
-  - uid: 24141
+  - uid: 24140
     components:
     - type: Transform
       pos: 39.5,-26.5
       parent: 2
-  - uid: 24142
+  - uid: 24141
     components:
     - type: Transform
       pos: 42.5,-26.5
       parent: 2
-  - uid: 24143
+  - uid: 24142
     components:
     - type: Transform
       pos: 41.5,-30.5
       parent: 2
-  - uid: 24144
+  - uid: 24143
     components:
     - type: Transform
       pos: 41.5,-34.5
       parent: 2
-  - uid: 24145
+  - uid: 24144
     components:
     - type: Transform
       pos: 40.5,-34.5
       parent: 2
-  - uid: 24146
+  - uid: 24145
     components:
     - type: Transform
       pos: 38.5,-34.5
       parent: 2
-  - uid: 24147
+  - uid: 24146
     components:
     - type: Transform
       pos: 39.5,-34.5
       parent: 2
-  - uid: 24148
+  - uid: 24147
     components:
     - type: Transform
       pos: 37.5,-18.5
       parent: 2
-  - uid: 24149
+  - uid: 24148
     components:
     - type: Transform
       pos: 37.5,-19.5
       parent: 2
-  - uid: 24150
+  - uid: 24149
     components:
     - type: Transform
       pos: 39.5,-19.5
       parent: 2
-  - uid: 24151
+  - uid: 24150
     components:
     - type: Transform
       pos: 40.5,-19.5
       parent: 2
-  - uid: 24152
+  - uid: 24151
     components:
     - type: Transform
       pos: 38.5,-19.5
       parent: 2
-  - uid: 24153
+  - uid: 24152
     components:
     - type: Transform
       pos: 42.5,-19.5
       parent: 2
-  - uid: 24154
+  - uid: 24153
     components:
     - type: Transform
       pos: 43.5,-23.5
       parent: 2
-  - uid: 24155
+  - uid: 24154
     components:
     - type: Transform
       pos: 43.5,-26.5
       parent: 2
-  - uid: 24156
+  - uid: 24155
     components:
     - type: Transform
       pos: 49.5,-7.5
       parent: 2
-  - uid: 24157
+  - uid: 24156
     components:
     - type: Transform
       pos: 52.5,-0.5
       parent: 2
-  - uid: 24158
+  - uid: 24157
     components:
     - type: Transform
       pos: 52.5,-1.5
       parent: 2
-  - uid: 24159
+  - uid: 24158
     components:
     - type: Transform
       pos: 52.5,-3.5
       parent: 2
-  - uid: 24160
+  - uid: 24159
     components:
     - type: Transform
       pos: 52.5,-5.5
       parent: 2
-  - uid: 24161
+  - uid: 24160
     components:
     - type: Transform
       pos: 51.5,-7.5
       parent: 2
-  - uid: 24162
+  - uid: 24161
     components:
     - type: Transform
       pos: 52.5,2.5
       parent: 2
-  - uid: 24163
+  - uid: 24162
     components:
     - type: Transform
       pos: 52.5,-7.5
       parent: 2
-  - uid: 24164
+  - uid: 24163
     components:
     - type: Transform
       pos: 52.5,-6.5
       parent: 2
-  - uid: 24165
+  - uid: 24164
     components:
     - type: Transform
       pos: 52.5,0.5
       parent: 2
-  - uid: 24166
+  - uid: 24165
     components:
     - type: Transform
       pos: 52.5,1.5
       parent: 2
-  - uid: 24167
+  - uid: 24166
     components:
     - type: Transform
       pos: 52.5,-2.5
       parent: 2
-  - uid: 24168
+  - uid: 24167
     components:
     - type: Transform
       pos: 53.5,-7.5
       parent: 2
-  - uid: 24169
+  - uid: 24168
     components:
     - type: Transform
       pos: 54.5,-7.5
       parent: 2
-  - uid: 24170
+  - uid: 24169
     components:
     - type: Transform
       pos: 56.5,-7.5
       parent: 2
-  - uid: 24171
+  - uid: 24170
     components:
     - type: Transform
       pos: 57.5,-7.5
       parent: 2
-  - uid: 24172
+  - uid: 24171
     components:
     - type: Transform
       pos: 57.5,-6.5
       parent: 2
-  - uid: 24173
+  - uid: 24172
     components:
     - type: Transform
       pos: 57.5,-5.5
       parent: 2
-  - uid: 24174
+  - uid: 24173
     components:
     - type: Transform
       pos: 57.5,-4.5
       parent: 2
-  - uid: 24175
+  - uid: 24174
     components:
     - type: Transform
       pos: 57.5,-2.5
       parent: 2
-  - uid: 24176
+  - uid: 24175
     components:
     - type: Transform
       pos: 57.5,-1.5
       parent: 2
-  - uid: 24177
+  - uid: 24176
     components:
     - type: Transform
       pos: 56.5,-1.5
       parent: 2
-  - uid: 24178
+  - uid: 24177
     components:
     - type: Transform
       pos: 55.5,-1.5
       parent: 2
-  - uid: 24179
+  - uid: 24178
     components:
     - type: Transform
       pos: 54.5,-1.5
       parent: 2
-  - uid: 24180
+  - uid: 24179
     components:
     - type: Transform
       pos: 53.5,-1.5
       parent: 2
-  - uid: 24181
+  - uid: 24180
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 2
-  - uid: 24182
+  - uid: 24181
     components:
     - type: Transform
       pos: 8.5,-12.5
       parent: 2
-  - uid: 24183
+  - uid: 24182
     components:
     - type: Transform
       pos: 49.5,-13.5
       parent: 2
-  - uid: 24184
+  - uid: 24183
     components:
     - type: Transform
       pos: 43.5,-13.5
       parent: 2
-  - uid: 24185
+  - uid: 24184
     components:
     - type: Transform
       pos: 68.5,-28.5
       parent: 2
-  - uid: 24186
+  - uid: 24185
     components:
     - type: Transform
       pos: 67.5,-35.5
       parent: 2
-  - uid: 24187
+  - uid: 24186
     components:
     - type: Transform
       pos: 69.5,-32.5
       parent: 2
-  - uid: 24188
+  - uid: 24187
     components:
     - type: Transform
       pos: 69.5,-31.5
       parent: 2
-  - uid: 24189
+  - uid: 24188
     components:
     - type: Transform
       pos: 69.5,-30.5
       parent: 2
-  - uid: 24190
+  - uid: 24189
     components:
     - type: Transform
       pos: 69.5,-29.5
       parent: 2
-  - uid: 24191
+  - uid: 24190
     components:
     - type: Transform
       pos: 69.5,-28.5
       parent: 2
-  - uid: 24192
+  - uid: 24191
     components:
     - type: Transform
       pos: 69.5,-27.5
       parent: 2
-  - uid: 24193
+  - uid: 24192
     components:
     - type: Transform
       pos: 69.5,-24.5
       parent: 2
-  - uid: 24194
+  - uid: 24193
     components:
     - type: Transform
       pos: 69.5,-23.5
       parent: 2
-  - uid: 24195
+  - uid: 24194
     components:
     - type: Transform
       pos: 69.5,-25.5
       parent: 2
-  - uid: 24196
+  - uid: 24195
     components:
     - type: Transform
       pos: 69.5,-22.5
       parent: 2
-  - uid: 24197
+  - uid: 24196
     components:
     - type: Transform
       pos: 69.5,-21.5
       parent: 2
-  - uid: 24198
+  - uid: 24197
     components:
     - type: Transform
       pos: 69.5,-20.5
       parent: 2
-  - uid: 24199
+  - uid: 24198
     components:
     - type: Transform
       pos: 69.5,-19.5
       parent: 2
-  - uid: 24200
+  - uid: 24199
     components:
     - type: Transform
       pos: 69.5,-18.5
       parent: 2
-  - uid: 24201
+  - uid: 24200
     components:
     - type: Transform
       pos: 69.5,-17.5
       parent: 2
-  - uid: 24202
+  - uid: 24201
     components:
     - type: Transform
       pos: 68.5,-17.5
       parent: 2
-  - uid: 24203
+  - uid: 24202
     components:
     - type: Transform
       pos: 67.5,-17.5
       parent: 2
-  - uid: 24204
+  - uid: 24203
     components:
     - type: Transform
       pos: 67.5,-16.5
       parent: 2
-  - uid: 24205
+  - uid: 24204
     components:
     - type: Transform
       pos: 66.5,-16.5
       parent: 2
-  - uid: 24206
+  - uid: 24205
     components:
     - type: Transform
       pos: 66.5,-15.5
       parent: 2
-  - uid: 24207
+  - uid: 24206
     components:
     - type: Transform
       pos: 51.5,-15.5
       parent: 2
-  - uid: 24208
+  - uid: 24207
     components:
     - type: Transform
       pos: 56.5,-15.5
       parent: 2
-  - uid: 24209
+  - uid: 24208
     components:
     - type: Transform
       pos: 61.5,-15.5
       parent: 2
-  - uid: 24210
+  - uid: 24209
     components:
     - type: Transform
       pos: 61.5,-7.5
       parent: 2
-  - uid: 24211
+  - uid: 24210
     components:
     - type: Transform
       pos: 64.5,-7.5
       parent: 2
-  - uid: 24212
+  - uid: 24211
     components:
     - type: Transform
       pos: 65.5,-7.5
       parent: 2
-  - uid: 24213
+  - uid: 24212
     components:
     - type: Transform
       pos: 62.5,-7.5
       parent: 2
-  - uid: 24214
+  - uid: 24213
     components:
     - type: Transform
       pos: 84.5,-12.5
       parent: 2
-  - uid: 24215
+  - uid: 24214
     components:
     - type: Transform
       pos: 84.5,-11.5
       parent: 2
-  - uid: 24216
+  - uid: 24215
     components:
     - type: Transform
       pos: 76.5,-9.5
       parent: 2
-  - uid: 24217
+  - uid: 24216
     components:
     - type: Transform
       pos: 76.5,-10.5
       parent: 2
-  - uid: 24218
+  - uid: 24217
     components:
     - type: Transform
       pos: 76.5,-11.5
       parent: 2
-  - uid: 24219
+  - uid: 24218
     components:
     - type: Transform
       pos: 76.5,-12.5
       parent: 2
-  - uid: 24220
+  - uid: 24219
     components:
     - type: Transform
       pos: 83.5,-12.5
       parent: 2
-  - uid: 24221
+  - uid: 24220
     components:
     - type: Transform
       pos: 82.5,-12.5
       parent: 2
-  - uid: 24222
+  - uid: 24221
     components:
     - type: Transform
       pos: 81.5,-12.5
       parent: 2
-  - uid: 24223
+  - uid: 24222
     components:
     - type: Transform
       pos: 79.5,-12.5
       parent: 2
-  - uid: 24224
+  - uid: 24223
     components:
     - type: Transform
       pos: 78.5,-12.5
       parent: 2
-  - uid: 24225
+  - uid: 24224
     components:
     - type: Transform
       pos: 77.5,-12.5
       parent: 2
-  - uid: 24226
+  - uid: 24225
     components:
     - type: Transform
       pos: 79.5,-10.5
       parent: 2
-  - uid: 24227
+  - uid: 24226
     components:
     - type: Transform
       pos: 78.5,-10.5
       parent: 2
-  - uid: 24228
+  - uid: 24227
     components:
     - type: Transform
       pos: 77.5,-10.5
       parent: 2
-  - uid: 24229
+  - uid: 24228
     components:
     - type: Transform
       pos: 79.5,-8.5
       parent: 2
-  - uid: 24230
+  - uid: 24229
     components:
     - type: Transform
       pos: 78.5,-8.5
       parent: 2
-  - uid: 24231
+  - uid: 24230
     components:
     - type: Transform
       pos: 77.5,-8.5
       parent: 2
-  - uid: 24232
+  - uid: 24231
     components:
     - type: Transform
       pos: 67.5,-42.5
       parent: 2
-  - uid: 24233
+  - uid: 24232
     components:
     - type: Transform
       pos: 70.5,-17.5
       parent: 2
-  - uid: 24234
+  - uid: 24233
     components:
     - type: Transform
       pos: 73.5,-19.5
       parent: 2
-  - uid: 24235
+  - uid: 24234
     components:
     - type: Transform
       pos: 73.5,-20.5
       parent: 2
-  - uid: 24236
+  - uid: 24235
     components:
     - type: Transform
       pos: 72.5,-18.5
       parent: 2
-  - uid: 24237
+  - uid: 24236
     components:
     - type: Transform
       pos: 72.5,-17.5
       parent: 2
-  - uid: 24238
+  - uid: 24237
     components:
     - type: Transform
       pos: 72.5,-19.5
       parent: 2
-  - uid: 24239
+  - uid: 24238
     components:
     - type: Transform
       pos: -11.5,-1.5
       parent: 2
-  - uid: 24240
+  - uid: 24239
     components:
     - type: Transform
       pos: -47.5,-4.5
       parent: 2
-  - uid: 24241
+  - uid: 24240
     components:
     - type: Transform
       pos: -42.5,39.5
       parent: 2
-  - uid: 24242
+  - uid: 24241
     components:
     - type: Transform
       pos: 36.5,23.5
       parent: 2
-  - uid: 24243
+  - uid: 24242
     components:
     - type: Transform
       pos: 37.5,23.5
       parent: 2
-  - uid: 24244
+  - uid: 24243
     components:
     - type: Transform
       pos: -42.5,38.5
       parent: 2
-  - uid: 24245
+  - uid: 24244
     components:
     - type: Transform
       pos: 41.5,23.5
       parent: 2
-  - uid: 24246
+  - uid: 24245
     components:
     - type: Transform
       pos: 42.5,23.5
       parent: 2
-  - uid: 24247
+  - uid: 24246
     components:
     - type: Transform
       pos: -42.5,37.5
       parent: 2
-  - uid: 24248
+  - uid: 24247
     components:
     - type: Transform
       pos: 42.5,27.5
       parent: 2
-  - uid: 24249
+  - uid: 24248
     components:
     - type: Transform
       pos: -42.5,36.5
       parent: 2
-  - uid: 24250
+  - uid: 24249
     components:
     - type: Transform
       pos: -42.5,35.5
       parent: 2
-  - uid: 24251
+  - uid: 24250
     components:
     - type: Transform
       pos: 15.5,-15.5
       parent: 2
-  - uid: 24252
+  - uid: 24251
     components:
     - type: Transform
       pos: 14.5,-15.5
       parent: 2
-  - uid: 24253
+  - uid: 24252
     components:
     - type: Transform
       pos: 13.5,-15.5
       parent: 2
-  - uid: 24254
+  - uid: 24253
     components:
     - type: Transform
       pos: 12.5,-15.5
       parent: 2
-  - uid: 24255
+  - uid: 24254
     components:
     - type: Transform
       pos: 11.5,-19.5
       parent: 2
-  - uid: 24256
+  - uid: 24255
     components:
     - type: Transform
       pos: 11.5,-17.5
       parent: 2
-  - uid: 24257
+  - uid: 24256
     components:
     - type: Transform
       pos: 11.5,-16.5
       parent: 2
-  - uid: 24258
+  - uid: 24257
     components:
     - type: Transform
       pos: 11.5,-15.5
       parent: 2
-  - uid: 24259
+  - uid: 24258
     components:
     - type: Transform
       pos: 44.5,0.5
       parent: 2
-  - uid: 24260
+  - uid: 24259
     components:
     - type: Transform
       pos: -32.5,17.5
       parent: 2
-  - uid: 24261
+  - uid: 24260
     components:
     - type: Transform
       pos: -34.5,17.5
       parent: 2
-  - uid: 24262
+  - uid: 24261
     components:
     - type: Transform
       pos: -34.5,22.5
       parent: 2
-  - uid: 24263
+  - uid: 24262
     components:
     - type: Transform
       pos: -33.5,22.5
       parent: 2
-  - uid: 24264
+  - uid: 24263
     components:
     - type: Transform
       pos: -32.5,22.5
       parent: 2
-  - uid: 24265
+  - uid: 24264
     components:
     - type: Transform
       pos: -30.5,22.5
       parent: 2
-  - uid: 24266
+  - uid: 24265
     components:
     - type: Transform
       pos: -29.5,22.5
       parent: 2
-  - uid: 24267
+  - uid: 24266
     components:
     - type: Transform
       pos: -31.5,22.5
       parent: 2
-  - uid: 24268
+  - uid: 24267
     components:
     - type: Transform
       pos: -34.5,18.5
       parent: 2
-  - uid: 24269
+  - uid: 24268
     components:
     - type: Transform
       pos: -34.5,25.5
       parent: 2
-  - uid: 24270
+  - uid: 24269
     components:
     - type: Transform
       pos: -34.5,26.5
       parent: 2
-  - uid: 24271
+  - uid: 24270
     components:
     - type: Transform
       pos: -35.5,26.5
       parent: 2
-  - uid: 24272
+  - uid: 24271
     components:
     - type: Transform
       pos: -36.5,26.5
       parent: 2
-  - uid: 24273
+  - uid: 24272
     components:
     - type: Transform
       pos: -22.5,17.5
       parent: 2
-  - uid: 24274
+  - uid: 24273
     components:
     - type: Transform
       pos: -22.5,21.5
       parent: 2
-  - uid: 24275
+  - uid: 24274
     components:
     - type: Transform
       pos: -23.5,23.5
       parent: 2
-  - uid: 24276
+  - uid: 24275
     components:
     - type: Transform
       pos: 10.5,28.5
       parent: 2
-  - uid: 24277
+  - uid: 24276
     components:
     - type: Transform
       pos: 10.5,29.5
       parent: 2
-  - uid: 24278
+  - uid: 24277
     components:
     - type: Transform
       pos: 11.5,31.5
       parent: 2
-  - uid: 24279
+  - uid: 24278
     components:
     - type: Transform
       pos: -20.5,11.5
       parent: 2
-  - uid: 24280
+  - uid: 24279
     components:
     - type: Transform
       pos: -34.5,-11.5
       parent: 2
-  - uid: 24281
+  - uid: 24280
     components:
     - type: Transform
       pos: -22.5,11.5
       parent: 2
-  - uid: 24282
+  - uid: 24281
     components:
     - type: Transform
       pos: -23.5,11.5
       parent: 2
-  - uid: 24283
+  - uid: 24282
     components:
     - type: Transform
       pos: -24.5,11.5
       parent: 2
-  - uid: 24284
+  - uid: 24283
     components:
     - type: Transform
       pos: -22.5,8.5
       parent: 2
-  - uid: 24285
+  - uid: 24284
     components:
     - type: Transform
       pos: -22.5,-0.5
       parent: 2
-  - uid: 24286
+  - uid: 24285
     components:
     - type: Transform
       pos: -21.5,-0.5
       parent: 2
-  - uid: 24287
+  - uid: 24286
     components:
     - type: Transform
       pos: -21.5,-4.5
       parent: 2
-  - uid: 24288
+  - uid: 24287
     components:
     - type: Transform
       pos: -22.5,-4.5
       parent: 2
-  - uid: 24289
+  - uid: 24288
     components:
     - type: Transform
       pos: -22.5,7.5
       parent: 2
-  - uid: 24290
+  - uid: 24289
     components:
     - type: Transform
       pos: -22.5,10.5
       parent: 2
-  - uid: 24291
+  - uid: 24290
     components:
     - type: Transform
       pos: -28.5,-11.5
       parent: 2
-  - uid: 24292
+  - uid: 24291
     components:
     - type: Transform
       pos: -32.5,-11.5
       parent: 2
-  - uid: 24293
+  - uid: 24292
     components:
     - type: Transform
       pos: -31.5,-11.5
       parent: 2
-  - uid: 24294
+  - uid: 24293
     components:
     - type: Transform
       pos: -33.5,-11.5
       parent: 2
-  - uid: 24295
+  - uid: 24294
     components:
     - type: Transform
       pos: -30.5,-11.5
       parent: 2
-  - uid: 24296
+  - uid: 24295
     components:
     - type: Transform
       pos: -34.5,-10.5
       parent: 2
-  - uid: 24297
+  - uid: 24296
     components:
     - type: Transform
       pos: -29.5,-11.5
       parent: 2
-  - uid: 24298
+  - uid: 24297
     components:
     - type: Transform
       pos: -28.5,-17.5
       parent: 2
-  - uid: 24299
+  - uid: 24298
     components:
     - type: Transform
       pos: -33.5,-17.5
       parent: 2
-  - uid: 24300
+  - uid: 24299
     components:
     - type: Transform
       pos: -32.5,-17.5
       parent: 2
-  - uid: 24301
+  - uid: 24300
     components:
     - type: Transform
       pos: -31.5,-17.5
       parent: 2
-  - uid: 24302
+  - uid: 24301
     components:
     - type: Transform
       pos: -30.5,-17.5
       parent: 2
-  - uid: 24303
+  - uid: 24302
     components:
     - type: Transform
       pos: -29.5,-17.5
       parent: 2
-  - uid: 24304
+  - uid: 24303
     components:
     - type: Transform
       pos: -27.5,-11.5
       parent: 2
-  - uid: 24305
+  - uid: 24304
     components:
     - type: Transform
       pos: -26.5,-11.5
       parent: 2
-  - uid: 24306
+  - uid: 24305
     components:
     - type: Transform
       pos: -25.5,-11.5
       parent: 2
-  - uid: 24307
+  - uid: 24306
     components:
     - type: Transform
       pos: -24.5,-11.5
       parent: 2
-  - uid: 24308
+  - uid: 24307
     components:
     - type: Transform
       pos: -23.5,-11.5
       parent: 2
-  - uid: 24309
+  - uid: 24308
     components:
     - type: Transform
       pos: -27.5,-10.5
       parent: 2
-  - uid: 24310
+  - uid: 24309
     components:
     - type: Transform
       pos: -23.5,-10.5
       parent: 2
-  - uid: 24311
+  - uid: 24310
     components:
     - type: Transform
       pos: -23.5,-9.5
       parent: 2
-  - uid: 24312
+  - uid: 24311
     components:
     - type: Transform
       pos: -27.5,-9.5
       parent: 2
-  - uid: 24313
+  - uid: 24312
     components:
     - type: Transform
       pos: -26.5,-9.5
       parent: 2
-  - uid: 24314
+  - uid: 24313
     components:
     - type: Transform
       pos: -28.5,-15.5
       parent: 2
-  - uid: 24315
+  - uid: 24314
     components:
     - type: Transform
       pos: -28.5,-12.5
       parent: 2
-  - uid: 24316
+  - uid: 24315
     components:
     - type: Transform
       pos: -25.5,-9.5
       parent: 2
-  - uid: 24317
+  - uid: 24316
     components:
     - type: Transform
       pos: 44.5,-0.5
       parent: 2
-  - uid: 24318
+  - uid: 24317
     components:
     - type: Transform
       pos: 2.5,-26.5
       parent: 2
-  - uid: 24319
+  - uid: 24318
     components:
     - type: Transform
       pos: -18.5,-16.5
       parent: 2
-  - uid: 24320
+  - uid: 24319
     components:
     - type: Transform
       pos: -17.5,-16.5
       parent: 2
-  - uid: 24321
+  - uid: 24320
     components:
     - type: Transform
       pos: -17.5,-18.5
       parent: 2
-  - uid: 24322
+  - uid: 24321
     components:
     - type: Transform
       pos: -17.5,-19.5
       parent: 2
-  - uid: 24323
+  - uid: 24322
     components:
     - type: Transform
       pos: -17.5,-17.5
       parent: 2
-  - uid: 24324
+  - uid: 24323
     components:
     - type: Transform
       pos: -17.5,-20.5
       parent: 2
-  - uid: 24325
+  - uid: 24324
     components:
     - type: Transform
       pos: -17.5,-21.5
       parent: 2
-  - uid: 24326
+  - uid: 24325
     components:
     - type: Transform
       pos: -3.5,-31.5
       parent: 2
-  - uid: 24327
+  - uid: 24326
     components:
     - type: Transform
       pos: -2.5,-31.5
       parent: 2
-  - uid: 24328
+  - uid: 24327
     components:
     - type: Transform
       pos: -2.5,-32.5
       parent: 2
-  - uid: 24329
+  - uid: 24328
     components:
     - type: Transform
       pos: -2.5,-30.5
       parent: 2
-  - uid: 24330
+  - uid: 24329
     components:
     - type: Transform
       pos: -2.5,-29.5
       parent: 2
-  - uid: 24331
+  - uid: 24330
     components:
     - type: Transform
       pos: -2.5,-28.5
       parent: 2
-  - uid: 24332
+  - uid: 24331
     components:
     - type: Transform
       pos: -2.5,-27.5
       parent: 2
-  - uid: 24333
+  - uid: 24332
     components:
     - type: Transform
       pos: -1.5,-27.5
       parent: 2
-  - uid: 24334
+  - uid: 24333
     components:
     - type: Transform
       pos: -0.5,-31.5
       parent: 2
-  - uid: 24335
+  - uid: 24334
     components:
     - type: Transform
       pos: -4.5,-24.5
       parent: 2
-  - uid: 24336
+  - uid: 24335
     components:
     - type: Transform
       pos: -5.5,-24.5
       parent: 2
-  - uid: 24337
+  - uid: 24336
     components:
     - type: Transform
       pos: -2.5,-26.5
       parent: 2
-  - uid: 24338
+  - uid: 24337
     components:
     - type: Transform
       pos: -28.5,-19.5
       parent: 2
-  - uid: 24339
+  - uid: 24338
     components:
     - type: Transform
       pos: -28.5,-20.5
       parent: 2
-  - uid: 24340
+  - uid: 24339
     components:
     - type: Transform
       pos: -28.5,-21.5
       parent: 2
-  - uid: 24341
+  - uid: 24340
     components:
     - type: Transform
       pos: -28.5,-18.5
       parent: 2
-  - uid: 24342
+  - uid: 24341
     components:
     - type: Transform
       pos: -4.5,-26.5
       parent: 2
-  - uid: 24343
+  - uid: 24342
     components:
     - type: Transform
       pos: -3.5,-26.5
       parent: 2
-  - uid: 24344
+  - uid: 24343
     components:
     - type: Transform
       pos: -5.5,-26.5
       parent: 2
-  - uid: 24345
+  - uid: 24344
     components:
     - type: Transform
       pos: -9.5,-26.5
       parent: 2
-  - uid: 24346
+  - uid: 24345
     components:
     - type: Transform
       pos: -6.5,-26.5
       parent: 2
-  - uid: 24347
+  - uid: 24346
     components:
     - type: Transform
       pos: -28.5,-22.5
       parent: 2
-  - uid: 24348
+  - uid: 24347
     components:
     - type: Transform
       pos: -10.5,-26.5
       parent: 2
-  - uid: 24349
+  - uid: 24348
     components:
     - type: Transform
       pos: -6.5,-24.5
       parent: 2
-  - uid: 24350
+  - uid: 24349
     components:
     - type: Transform
       pos: -7.5,-24.5
       parent: 2
-  - uid: 24351
+  - uid: 24350
     components:
     - type: Transform
       pos: -7.5,-23.5
       parent: 2
-  - uid: 24352
+  - uid: 24351
     components:
     - type: Transform
       pos: -7.5,-22.5
       parent: 2
-  - uid: 24353
+  - uid: 24352
     components:
     - type: Transform
       pos: -7.5,-21.5
       parent: 2
-  - uid: 24354
+  - uid: 24353
     components:
     - type: Transform
       pos: -19.5,-16.5
       parent: 2
-  - uid: 24355
+  - uid: 24354
     components:
     - type: Transform
       pos: -20.5,-16.5
       parent: 2
-  - uid: 24356
+  - uid: 24355
     components:
     - type: Transform
       pos: -8.5,-24.5
       parent: 2
-  - uid: 24357
+  - uid: 24356
     components:
     - type: Transform
       pos: -9.5,-24.5
       parent: 2
-  - uid: 24358
+  - uid: 24357
     components:
     - type: Transform
       pos: -20.5,-11.5
       parent: 2
-  - uid: 24359
+  - uid: 24358
     components:
     - type: Transform
       pos: -21.5,-11.5
       parent: 2
-  - uid: 24360
+  - uid: 24359
     components:
     - type: Transform
       pos: -22.5,-11.5
       parent: 2
-  - uid: 24361
+  - uid: 24360
     components:
     - type: Transform
       pos: -12.5,-24.5
       parent: 2
-  - uid: 24362
+  - uid: 24361
     components:
     - type: Transform
       pos: -11.5,-24.5
       parent: 2
-  - uid: 24363
+  - uid: 24362
     components:
     - type: Transform
       pos: -11.5,-26.5
       parent: 2
-  - uid: 24364
+  - uid: 24363
     components:
     - type: Transform
       pos: -20.5,-15.5
       parent: 2
-  - uid: 24365
+  - uid: 24364
     components:
     - type: Transform
       pos: -20.5,-14.5
       parent: 2
-  - uid: 24366
+  - uid: 24365
     components:
     - type: Transform
       pos: -20.5,-13.5
       parent: 2
-  - uid: 24367
+  - uid: 24366
     components:
     - type: Transform
       pos: -20.5,-12.5
       parent: 2
-  - uid: 24368
+  - uid: 24367
     components:
     - type: Transform
       pos: -12.5,-30.5
       parent: 2
-  - uid: 24369
+  - uid: 24368
     components:
     - type: Transform
       pos: -8.5,-30.5
       parent: 2
-  - uid: 24370
+  - uid: 24369
     components:
     - type: Transform
       pos: -13.5,-30.5
       parent: 2
-  - uid: 24371
+  - uid: 24370
     components:
     - type: Transform
       pos: -51.5,-8.5
       parent: 2
-  - uid: 24372
+  - uid: 24371
     components:
     - type: Transform
       pos: -52.5,-8.5
       parent: 2
-  - uid: 24373
+  - uid: 24372
     components:
     - type: Transform
       pos: -53.5,-8.5
       parent: 2
-  - uid: 24374
+  - uid: 24373
     components:
     - type: Transform
       pos: -55.5,-5.5
       parent: 2
-  - uid: 24375
+  - uid: 24374
     components:
     - type: Transform
       pos: -34.5,29.5
       parent: 2
-  - uid: 24376
+  - uid: 24375
     components:
     - type: Transform
       pos: -34.5,30.5
       parent: 2
-  - uid: 24377
+  - uid: 24376
     components:
     - type: Transform
       pos: -33.5,30.5
       parent: 2
-  - uid: 24378
+  - uid: 24377
     components:
     - type: Transform
       pos: -32.5,30.5
       parent: 2
-  - uid: 24379
+  - uid: 24378
     components:
     - type: Transform
       pos: -31.5,30.5
       parent: 2
-  - uid: 24380
+  - uid: 24379
     components:
     - type: Transform
       pos: -30.5,26.5
       parent: 2
-  - uid: 24381
+  - uid: 24380
     components:
     - type: Transform
       pos: -29.5,26.5
       parent: 2
-  - uid: 24382
+  - uid: 24381
     components:
     - type: Transform
       pos: -31.5,26.5
       parent: 2
-  - uid: 24383
+  - uid: 24382
     components:
     - type: Transform
       pos: 36.5,-38.5
       parent: 2
-  - uid: 24384
+  - uid: 24383
     components:
     - type: Transform
       pos: -49.5,12.5
       parent: 2
-  - uid: 24385
+  - uid: 24384
     components:
     - type: Transform
       pos: -60.5,9.5
       parent: 2
-  - uid: 24386
+  - uid: 24385
     components:
     - type: Transform
       pos: -67.5,9.5
       parent: 2
-  - uid: 24387
+  - uid: 24386
     components:
     - type: Transform
       pos: -71.5,9.5
       parent: 2
-  - uid: 24388
+  - uid: 24387
     components:
     - type: Transform
       pos: -71.5,8.5
       parent: 2
-  - uid: 24389
+  - uid: 24388
     components:
     - type: Transform
       pos: -69.5,12.5
       parent: 2
-  - uid: 24390
+  - uid: 24389
     components:
     - type: Transform
       pos: -71.5,12.5
       parent: 2
-  - uid: 24391
+  - uid: 24390
     components:
     - type: Transform
       pos: -70.5,12.5
       parent: 2
-  - uid: 24392
+  - uid: 24391
     components:
     - type: Transform
       pos: -71.5,10.5
       parent: 2
-  - uid: 24393
+  - uid: 24392
     components:
     - type: Transform
       pos: 34.5,-35.5
       parent: 2
-  - uid: 24394
+  - uid: 24393
     components:
     - type: Transform
       pos: 36.5,-35.5
       parent: 2
-  - uid: 24395
+  - uid: 24394
     components:
     - type: Transform
       pos: 36.5,-36.5
       parent: 2
-  - uid: 24396
+  - uid: 24395
     components:
     - type: Transform
       pos: 36.5,-37.5
       parent: 2
-  - uid: 24397
+  - uid: 24396
     components:
     - type: Transform
       pos: 34.5,-37.5
       parent: 2
-  - uid: 24398
+  - uid: 24397
     components:
     - type: Transform
       pos: 33.5,-37.5
       parent: 2
-  - uid: 24399
+  - uid: 24398
     components:
     - type: Transform
       pos: 33.5,-38.5
       parent: 2
-  - uid: 24400
+  - uid: 24399
     components:
     - type: Transform
       pos: 32.5,-41.5
       parent: 2
-  - uid: 24401
+  - uid: 24400
     components:
     - type: Transform
       pos: 32.5,-40.5
       parent: 2
-  - uid: 24402
+  - uid: 24401
     components:
     - type: Transform
       pos: 32.5,-38.5
       parent: 2
-  - uid: 24403
+  - uid: 24402
     components:
     - type: Transform
       pos: 26.5,-35.5
       parent: 2
-  - uid: 24404
+  - uid: 24403
     components:
     - type: Transform
       pos: 27.5,-35.5
       parent: 2
-  - uid: 24405
+  - uid: 24404
     components:
     - type: Transform
       pos: 28.5,-35.5
       parent: 2
-  - uid: 24406
+  - uid: 24405
     components:
     - type: Transform
       pos: 66.5,-36.5
       parent: 2
-  - uid: 24407
+  - uid: 24406
     components:
     - type: Transform
       pos: 66.5,-39.5
       parent: 2
-  - uid: 24408
+  - uid: 24407
     components:
     - type: Transform
       pos: 66.5,-37.5
       parent: 2
-  - uid: 24409
+  - uid: 24408
     components:
     - type: Transform
       pos: 66.5,-40.5
       parent: 2
-  - uid: 24410
+  - uid: 24409
     components:
     - type: Transform
       pos: 67.5,-40.5
       parent: 2
-  - uid: 24411
+  - uid: 24410
     components:
     - type: Transform
       pos: 67.5,-41.5
       parent: 2
-  - uid: 24412
+  - uid: 24411
     components:
     - type: Transform
       pos: 68.5,-40.5
       parent: 2
-  - uid: 24413
+  - uid: 24412
     components:
     - type: Transform
       pos: 70.5,-38.5
       parent: 2
-  - uid: 24414
+  - uid: 24413
     components:
     - type: Transform
       pos: 69.5,-40.5
       parent: 2
-  - uid: 24415
+  - uid: 24414
     components:
     - type: Transform
       pos: 69.5,-38.5
       parent: 2
-  - uid: 24416
+  - uid: 24415
     components:
     - type: Transform
       pos: 83.5,-43.5
       parent: 2
-  - uid: 24417
+  - uid: 24416
     components:
     - type: Transform
       pos: 83.5,-42.5
       parent: 2
-  - uid: 24418
+  - uid: 24417
     components:
     - type: Transform
       pos: 79.5,-42.5
       parent: 2
-  - uid: 24419
+  - uid: 24418
     components:
     - type: Transform
       pos: 80.5,-42.5
       parent: 2
-  - uid: 24420
+  - uid: 24419
     components:
     - type: Transform
       pos: 83.5,-40.5
       parent: 2
-  - uid: 24421
+  - uid: 24420
     components:
     - type: Transform
       pos: 83.5,-41.5
       parent: 2
-  - uid: 24422
+  - uid: 24421
     components:
     - type: Transform
       pos: 83.5,-39.5
       parent: 2
-  - uid: 24423
+  - uid: 24422
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 2
 - proto: WallWood
   entities:
-  - uid: 24424
+  - uid: 24423
     components:
     - type: Transform
       pos: -26.5,38.5
       parent: 2
-  - uid: 24425
+  - uid: 24424
     components:
     - type: Transform
       pos: -24.5,38.5
       parent: 2
-  - uid: 24426
+  - uid: 24425
     components:
     - type: Transform
       pos: -27.5,38.5
       parent: 2
-  - uid: 24427
+  - uid: 24426
     components:
     - type: Transform
       pos: -27.5,39.5
       parent: 2
-  - uid: 24428
+  - uid: 24427
     components:
     - type: Transform
       pos: -27.5,41.5
       parent: 2
-  - uid: 24429
+  - uid: 24428
     components:
     - type: Transform
       pos: -27.5,40.5
       parent: 2
-  - uid: 24430
+  - uid: 24429
     components:
     - type: Transform
       pos: -23.5,38.5
       parent: 2
-  - uid: 24431
+  - uid: 24430
     components:
     - type: Transform
       pos: -27.5,36.5
       parent: 2
-  - uid: 24432
+  - uid: 24431
     components:
     - type: Transform
       pos: -58.5,13.5
       parent: 2
-  - uid: 24433
+  - uid: 24432
     components:
     - type: Transform
       pos: -59.5,13.5
       parent: 2
-  - uid: 24434
+  - uid: 24433
     components:
     - type: Transform
       pos: -59.5,23.5
       parent: 2
-  - uid: 24435
+  - uid: 24434
     components:
     - type: Transform
       pos: -57.5,13.5
       parent: 2
-  - uid: 24436
+  - uid: 24435
     components:
     - type: Transform
       pos: -51.5,20.5
       parent: 2
-  - uid: 24437
+  - uid: 24436
     components:
     - type: Transform
       pos: -51.5,16.5
       parent: 2
-  - uid: 24438
+  - uid: 24437
     components:
     - type: Transform
       pos: -57.5,23.5
       parent: 2
-  - uid: 24439
+  - uid: 24438
     components:
     - type: Transform
       pos: -56.5,13.5
       parent: 2
-  - uid: 24440
+  - uid: 24439
     components:
     - type: Transform
       pos: -56.5,23.5
       parent: 2
-  - uid: 24441
+  - uid: 24440
     components:
     - type: Transform
       pos: -58.5,23.5
       parent: 2
-  - uid: 24442
+  - uid: 24441
     components:
     - type: Transform
       pos: 33.5,-1.5
       parent: 2
-  - uid: 24443
+  - uid: 24442
     components:
     - type: Transform
       pos: 35.5,-1.5
       parent: 2
-  - uid: 24444
+  - uid: 24443
     components:
     - type: Transform
       pos: 35.5,-7.5
       parent: 2
-  - uid: 24445
+  - uid: 24444
     components:
     - type: Transform
       pos: 33.5,-7.5
       parent: 2
-  - uid: 24446
+  - uid: 24445
     components:
     - type: Transform
       pos: -36.5,33.5
       parent: 2
-  - uid: 24447
+  - uid: 24446
     components:
     - type: Transform
       pos: -33.5,33.5
       parent: 2
-  - uid: 24448
+  - uid: 24447
     components:
     - type: Transform
       pos: -32.5,33.5
       parent: 2
-  - uid: 24449
+  - uid: 24448
     components:
     - type: Transform
       pos: -31.5,33.5
       parent: 2
-  - uid: 24450
+  - uid: 24449
     components:
     - type: Transform
       pos: -31.5,34.5
       parent: 2
 - proto: WardrobeBotanistFilled
   entities:
-  - uid: 24451
+  - uid: 24450
     components:
     - type: Transform
       pos: 55.5,-0.5
       parent: 2
 - proto: WardrobeCargoFilled
   entities:
-  - uid: 24452
+  - uid: 24451
     components:
     - type: Transform
       pos: 23.5,24.5
       parent: 2
-  - uid: 24453
+  - uid: 24452
     components:
     - type: Transform
       pos: 22.5,24.5
       parent: 2
 - proto: WardrobeChapelFilled
   entities:
-  - uid: 24454
+  - uid: 24453
     components:
     - type: Transform
       pos: -64.5,18.5
       parent: 2
 - proto: WardrobePrisonFilled
   entities:
-  - uid: 24455
+  - uid: 24454
     components:
     - type: Transform
       pos: 5.5,-12.5
       parent: 2
-  - uid: 24456
+  - uid: 24455
     components:
     - type: Transform
       pos: 9.5,-12.5
       parent: 2
 - proto: WardrobeRoboticsFilled
   entities:
-  - uid: 24457
+  - uid: 24456
     components:
     - type: Transform
       pos: -58.5,31.5
       parent: 2
 - proto: WarningCO2
   entities:
-  - uid: 24458
+  - uid: 24457
     components:
     - type: Transform
       pos: 41.5,14.5
@@ -150103,7 +150105,7 @@ entities:
       fixtures: {}
 - proto: WarningN2
   entities:
-  - uid: 24459
+  - uid: 24458
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -150113,7 +150115,7 @@ entities:
       fixtures: {}
 - proto: WarningN2O
   entities:
-  - uid: 24460
+  - uid: 24459
     components:
     - type: Transform
       pos: 46.5,14.5
@@ -150122,7 +150124,7 @@ entities:
       fixtures: {}
 - proto: WarningO2
   entities:
-  - uid: 24461
+  - uid: 24460
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -150132,7 +150134,7 @@ entities:
       fixtures: {}
 - proto: WarningPlasma
   entities:
-  - uid: 24462
+  - uid: 24461
     components:
     - type: Transform
       pos: 49.5,14.5
@@ -150141,7 +150143,7 @@ entities:
       fixtures: {}
 - proto: WarningTritium
   entities:
-  - uid: 24463
+  - uid: 24462
     components:
     - type: Transform
       pos: 52.5,14.5
@@ -150150,7 +150152,7 @@ entities:
       fixtures: {}
 - proto: WarningWaste
   entities:
-  - uid: 24464
+  - uid: 24463
     components:
     - type: Transform
       pos: 43.5,14.5
@@ -150159,123 +150161,123 @@ entities:
       fixtures: {}
 - proto: WaterCooler
   entities:
-  - uid: 24465
+  - uid: 24464
     components:
     - type: Transform
       pos: -27.5,43.5
       parent: 2
-  - uid: 24466
+  - uid: 24465
     components:
     - type: Transform
       pos: -12.5,1.5
       parent: 2
-  - uid: 24467
+  - uid: 24466
     components:
     - type: Transform
       pos: -17.5,3.5
       parent: 2
-  - uid: 24468
+  - uid: 24467
     components:
     - type: Transform
       pos: -40.5,10.5
       parent: 2
-  - uid: 24469
+  - uid: 24468
     components:
     - type: Transform
       pos: -43.5,32.5
       parent: 2
-  - uid: 24470
+  - uid: 24469
     components:
     - type: Transform
       pos: -41.5,27.5
       parent: 2
-  - uid: 24471
+  - uid: 24470
     components:
     - type: Transform
       pos: 22.5,20.5
       parent: 2
-  - uid: 24472
+  - uid: 24471
     components:
     - type: Transform
       pos: -31.5,18.5
       parent: 2
-  - uid: 24473
+  - uid: 24472
     components:
     - type: Transform
       pos: 26.5,28.5
       parent: 2
-  - uid: 24474
+  - uid: 24473
     components:
     - type: Transform
       pos: 18.5,24.5
       parent: 2
-  - uid: 24475
+  - uid: 24474
     components:
     - type: Transform
       pos: 44.5,-13.5
       parent: 2
-  - uid: 24476
+  - uid: 24475
     components:
     - type: Transform
       pos: 57.5,-34.5
       parent: 2
-  - uid: 24477
+  - uid: 24476
     components:
     - type: Transform
       pos: 3.5,-36.5
       parent: 2
-  - uid: 24478
+  - uid: 24477
     components:
     - type: Transform
       pos: 78.5,-13.5
       parent: 2
-  - uid: 24479
+  - uid: 24478
     components:
     - type: Transform
       pos: 79.5,-29.5
       parent: 2
 - proto: WaterTankFull
   entities:
-  - uid: 24480
+  - uid: 24479
     components:
     - type: Transform
       pos: 70.5,-18.5
       parent: 2
-  - uid: 24481
+  - uid: 24480
     components:
     - type: Transform
       pos: 80.5,-45.5
       parent: 2
 - proto: WaterTankHighCapacity
   entities:
-  - uid: 24482
+  - uid: 24481
     components:
     - type: Transform
       pos: 70.5,-19.5
       parent: 2
-  - uid: 24483
+  - uid: 24482
     components:
     - type: Transform
       pos: 65.5,-1.5
       parent: 2
-  - uid: 24484
+  - uid: 24483
     components:
     - type: Transform
       pos: 58.5,-4.5
       parent: 2
-  - uid: 24485
+  - uid: 24484
     components:
     - type: Transform
       pos: 14.5,-18.5
       parent: 2
 - proto: WaterVaporCanister
   entities:
-  - uid: 24486
+  - uid: 24485
     components:
     - type: Transform
       pos: -31.5,36.5
       parent: 2
-  - uid: 24487
+  - uid: 24486
     components:
     - type: Transform
       pos: 42.5,16.5
@@ -150283,111 +150285,119 @@ entities:
     - type: GasCanister
       releaseValve: True
       releasePressure: 100
-  - uid: 24488
+  - uid: 24487
     components:
     - type: Transform
       pos: 4.5,-52.5
       parent: 2
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 24489
+  - uid: 24488
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 2
-  - uid: 24490
+  - uid: 24489
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 2
-  - uid: 24491
+  - uid: 24490
     components:
     - type: Transform
       pos: -28.5,50.5
       parent: 2
-  - uid: 24492
+  - uid: 24491
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,55.5
       parent: 2
-  - uid: 24493
+  - uid: 24492
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
-  - uid: 24494
+  - uid: 24493
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-2.5
       parent: 2
-  - uid: 24495
+  - uid: 24494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-21.5
       parent: 2
-  - uid: 24496
+  - uid: 24495
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 2
-  - uid: 24497
+  - uid: 24496
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 2
-  - uid: 24498
+  - uid: 24497
     components:
     - type: Transform
       pos: 74.5,-22.5
       parent: 2
-  - uid: 24499
+  - uid: 24498
     components:
     - type: Transform
       pos: 78.5,-46.5
       parent: 2
 - proto: WeaponDisabler
   entities:
-  - uid: 24500
+  - uid: 24499
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.904559,6.5254974
       parent: 2
-  - uid: 24501
+  - uid: 24500
     components:
     - type: Transform
       pos: -11.557469,41.690384
       parent: 2
-  - uid: 24502
+  - uid: 24501
     components:
     - type: Transform
       pos: -11.463719,41.534134
       parent: 2
 - proto: WeaponEnergyTurretAI
   entities:
-  - uid: 24503
+  - uid: 24502
     components:
     - type: Transform
       pos: -0.5,37.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24510
-  - uid: 24504
+      - 24509
+  - uid: 24503
     components:
     - type: Transform
       pos: -4.5,36.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24510
-  - uid: 24505
+      - 24509
+  - uid: 24504
     components:
     - type: Transform
       pos: 0.5,40.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 24509
+  - uid: 24505
+    components:
+    - type: Transform
+      pos: 64.5,45.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
@@ -150395,38 +150405,30 @@ entities:
   - uid: 24506
     components:
     - type: Transform
-      pos: 64.5,45.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 24511
-  - uid: 24507
-    components:
-    - type: Transform
       pos: 66.5,45.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24511
-  - uid: 24508
+      - 24510
+  - uid: 24507
     components:
     - type: Transform
       pos: 65.5,49.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24511
-  - uid: 24509
+      - 24510
+  - uid: 24508
     components:
     - type: Transform
       pos: 65.5,41.5
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24511
+      - 24510
 - proto: WeaponEnergyTurretAIControlPanel
   entities:
-  - uid: 24510
+  - uid: 24509
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -150434,10 +150436,10 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 24504
       - 24503
-      - 24505
-  - uid: 24511
+      - 24502
+      - 24504
+  - uid: 24510
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -150445,13 +150447,13 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 24509
       - 24508
       - 24507
       - 24506
+      - 24505
 - proto: WeaponEnergyTurretSecurity
   entities:
-  - uid: 24512
+  - uid: 24511
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -150459,11 +150461,11 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 24514
       - 24513
+      - 24512
 - proto: WeaponEnergyTurretSecurityControlPanel
   entities:
-  - uid: 24513
+  - uid: 24512
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -150471,8 +150473,8 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 24512
-  - uid: 24514
+      - 24511
+  - uid: 24513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -150480,39 +150482,39 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 24512
+      - 24511
 - proto: WeaponFlareGun
   entities:
-  - uid: 24515
+  - uid: 24514
     components:
     - type: Transform
       pos: -20.984999,-19.411457
       parent: 2
-  - uid: 24516
+  - uid: 24515
     components:
     - type: Transform
       pos: -26.516249,-12.433796
       parent: 2
 - proto: WeaponGrapplingGun
   entities:
-  - uid: 24517
+  - uid: 24516
     components:
     - type: Transform
       pos: -4.4067445,-15.289876
       parent: 2
-  - uid: 24518
+  - uid: 24517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.7513733,-15.439429
       parent: 2
-  - uid: 24519
+  - uid: 24518
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.3138733,-15.439429
       parent: 2
-  - uid: 24520
+  - uid: 24519
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -150520,19 +150522,19 @@ entities:
       parent: 2
 - proto: WeaponProtoKineticAccelerator
   entities:
-  - uid: 24521
+  - uid: 24520
     components:
     - type: Transform
       pos: 32.47036,32.119175
       parent: 2
-  - uid: 24522
+  - uid: 24521
     components:
     - type: Transform
       pos: 32.56411,32.056675
       parent: 2
 - proto: WeaponRevolverInspector
   entities:
-  - uid: 24523
+  - uid: 24522
     components:
     - type: MetaData
       desc: Lucky shot... my turn!
@@ -150542,19 +150544,19 @@ entities:
       parent: 2
 - proto: WeaponRifleFoam
   entities:
-  - uid: 24524
+  - uid: 24523
     components:
     - type: Transform
       pos: 21.530083,-7.6477547
       parent: 2
-  - uid: 24525
+  - uid: 24524
     components:
     - type: Transform
       pos: -14.545835,47.71122
       parent: 2
 - proto: WeaponSniperMosin
   entities:
-  - uid: 24526
+  - uid: 24525
     components:
     - type: MetaData
       desc: Used to shoot people at funerals... legally!
@@ -150566,7 +150568,7 @@ entities:
     - Contraband
 - proto: WeaponSubMachineGunC20r
   entities:
-  - uid: 24527
+  - uid: 24526
     components:
     - type: MetaData
       desc: A notorious sub-machine gun, commonly used by covert syndicate operatives. This one has been bolted to the table.
@@ -150580,7 +150582,7 @@ entities:
     - Contraband
 - proto: WeaponTurretSyndicateBroken
   entities:
-  - uid: 24528
+  - uid: 24527
     components:
     - type: Transform
       pos: 71.5,-39.5
@@ -150601,12 +150603,12 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 24529
+  - uid: 24528
     components:
     - type: Transform
       pos: -31.555325,41.680733
       parent: 2
-  - uid: 24530
+  - uid: 24529
     components:
     - type: Transform
       pos: -31.49825,41.419632
@@ -150621,66 +150623,66 @@ entities:
       canCollide: False
 - proto: WeldingFuelTank
   entities:
-  - uid: 24531
+  - uid: 24530
     components:
     - type: Transform
       pos: 67.5,-31.5
       parent: 2
 - proto: WeldingFuelTankFull
   entities:
-  - uid: 24532
+  - uid: 24531
     components:
     - type: Transform
       pos: 52.5,-50.5
       parent: 2
-  - uid: 24533
+  - uid: 24532
     components:
     - type: Transform
       pos: -58.5,32.5
       parent: 2
-  - uid: 24534
+  - uid: 24533
     components:
     - type: Transform
       pos: 12.5,34.5
       parent: 2
-  - uid: 24535
+  - uid: 24534
     components:
     - type: Transform
       pos: -21.5,7.5
       parent: 2
-  - uid: 24536
+  - uid: 24535
     components:
     - type: Transform
       pos: 13.5,-12.5
       parent: 2
-  - uid: 24537
+  - uid: 24536
     components:
     - type: Transform
       pos: 1.5,-26.5
       parent: 2
-  - uid: 24538
+  - uid: 24537
     components:
     - type: Transform
       pos: -32.5,31.5
       parent: 2
-  - uid: 24539
+  - uid: 24538
     components:
     - type: Transform
       pos: 72.5,-33.5
       parent: 2
-  - uid: 24540
+  - uid: 24539
     components:
     - type: Transform
       pos: 57.5,18.5
       parent: 2
-  - uid: 24541
+  - uid: 24540
     components:
     - type: Transform
       pos: 43.5,30.5
       parent: 2
 - proto: WhiteCane
   entities:
-  - uid: 24542
+  - uid: 24541
     components:
     - type: MetaData
       desc: Its' for fishing! Duh!
@@ -150690,134 +150692,134 @@ entities:
       parent: 2
 - proto: Windoor
   entities:
-  - uid: 24543
+  - uid: 24542
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,11.5
       parent: 2
-  - uid: 24544
+  - uid: 24543
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,7.5
       parent: 2
-  - uid: 24545
+  - uid: 24544
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,11.5
       parent: 2
-  - uid: 24546
+  - uid: 24545
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,9.5
       parent: 2
-  - uid: 24547
+  - uid: 24546
     components:
     - type: Transform
       pos: -35.5,2.5
       parent: 2
-  - uid: 24548
+  - uid: 24547
     components:
     - type: Transform
       pos: -36.5,2.5
       parent: 2
-  - uid: 24549
+  - uid: 24548
     components:
     - type: Transform
       pos: -34.5,2.5
       parent: 2
-  - uid: 24550
+  - uid: 24549
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,-33.5
       parent: 2
-  - uid: 24551
+  - uid: 24550
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 53.5,-33.5
       parent: 2
-  - uid: 24552
+  - uid: 24551
     components:
     - type: Transform
       pos: -20.5,8.5
       parent: 2
-  - uid: 24553
+  - uid: 24552
     components:
     - type: Transform
       pos: -21.5,8.5
       parent: 2
-  - uid: 24554
+  - uid: 24553
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,-9.5
       parent: 2
-  - uid: 24555
+  - uid: 24554
     components:
     - type: Transform
       pos: -18.5,-10.5
       parent: 2
-  - uid: 24556
+  - uid: 24555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,32.5
       parent: 2
-  - uid: 24557
+  - uid: 24556
     components:
     - type: Transform
       pos: -66.5,9.5
       parent: 2
-  - uid: 24558
+  - uid: 24557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -67.5,10.5
       parent: 2
-  - uid: 24559
+  - uid: 24558
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,11.5
       parent: 2
-  - uid: 24560
+  - uid: 24559
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -74.5,-5.5
       parent: 2
-  - uid: 24561
+  - uid: 24560
     components:
     - type: Transform
       pos: -8.5,-28.5
       parent: 2
 - proto: WindoorBarLocked
   entities:
-  - uid: 24562
+  - uid: 24561
     components:
     - type: Transform
       pos: 49.5,1.5
       parent: 2
 - proto: WindoorHydroponicsLocked
   entities:
-  - uid: 24563
+  - uid: 24562
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,-7.5
       parent: 2
-  - uid: 24564
+  - uid: 24563
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 59.5,-7.5
       parent: 2
-  - uid: 24565
+  - uid: 24564
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -150825,19 +150827,19 @@ entities:
       parent: 2
 - proto: WindoorSecure
   entities:
-  - uid: 24566
+  - uid: 24565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,32.5
       parent: 2
-  - uid: 24567
+  - uid: 24566
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,-9.5
       parent: 2
-  - uid: 24568
+  - uid: 24567
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -150845,12 +150847,12 @@ entities:
       parent: 2
 - proto: WindoorSecureArmoryLocked
   entities:
-  - uid: 24569
+  - uid: 24568
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 2
-  - uid: 24570
+  - uid: 24569
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -150858,13 +150860,13 @@ entities:
       parent: 2
 - proto: WindoorSecureAtmosphericsLocked
   entities:
-  - uid: 24571
+  - uid: 24570
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,8.5
       parent: 2
-  - uid: 24572
+  - uid: 24571
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -150872,19 +150874,19 @@ entities:
       parent: 2
 - proto: WindoorSecureCargoLocked
   entities:
-  - uid: 24573
+  - uid: 24572
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,23.5
       parent: 2
-  - uid: 24574
+  - uid: 24573
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,23.5
       parent: 2
-  - uid: 24575
+  - uid: 24574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -150892,25 +150894,25 @@ entities:
       parent: 2
 - proto: WindoorSecureChemistryLocked
   entities:
-  - uid: 24576
+  - uid: 24575
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,9.5
       parent: 2
-  - uid: 24577
+  - uid: 24576
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,2.5
       parent: 2
-  - uid: 24578
+  - uid: 24577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,2.5
       parent: 2
-  - uid: 24579
+  - uid: 24578
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -150918,13 +150920,13 @@ entities:
       parent: 2
 - proto: WindoorSecureEngineeringLocked
   entities:
-  - uid: 24580
+  - uid: 24579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,12.5
       parent: 2
-  - uid: 24581
+  - uid: 24580
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -150932,7 +150934,7 @@ entities:
       parent: 2
 - proto: WindoorSecureHeadOfPersonnelLocked
   entities:
-  - uid: 24582
+  - uid: 24581
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -150940,12 +150942,12 @@ entities:
       parent: 2
 - proto: WindoorSecureMedicalLocked
   entities:
-  - uid: 24583
+  - uid: 24582
     components:
     - type: Transform
       pos: -40.5,-9.5
       parent: 2
-  - uid: 24584
+  - uid: 24583
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -150953,7 +150955,7 @@ entities:
       parent: 2
 - proto: WindoorSecureMiningLocked
   entities:
-  - uid: 24585
+  - uid: 24584
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -150961,7 +150963,7 @@ entities:
       parent: 2
 - proto: WindoorSecureSalvageLocked
   entities:
-  - uid: 24586
+  - uid: 24585
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -150969,7 +150971,7 @@ entities:
       parent: 2
 - proto: WindoorSecureSalvageMiningLocked
   entities:
-  - uid: 24587
+  - uid: 24586
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -150977,13 +150979,13 @@ entities:
       parent: 2
 - proto: WindoorSecureScienceLocked
   entities:
-  - uid: 24588
+  - uid: 24587
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,24.5
       parent: 2
-  - uid: 24589
+  - uid: 24588
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -150991,13 +150993,13 @@ entities:
       parent: 2
 - proto: WindoorSecureSecurityLawyerLocked
   entities:
-  - uid: 24590
+  - uid: 24589
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,6.5
       parent: 2
-  - uid: 24591
+  - uid: 24590
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -151005,35 +151007,35 @@ entities:
       parent: 2
 - proto: WindoorSecureSecurityLocked
   entities:
-  - uid: 24592
+  - uid: 24591
     components:
     - type: Transform
       pos: 12.5,11.5
       parent: 2
-  - uid: 24593
+  - uid: 24592
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,4.5
       parent: 2
-  - uid: 24594
+  - uid: 24593
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 2
-  - uid: 24595
+  - uid: 24594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-2.5
       parent: 2
-  - uid: 24596
+  - uid: 24595
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-11.5
       parent: 2
-  - uid: 24597
+  - uid: 24596
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -151043,34 +151045,34 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -3476.7678
+      secondsUntilStateChange: -3890.819
       state: Opening
     - type: Airlock
       autoClose: False
-  - uid: 24598
+  - uid: 24597
     components:
     - type: Transform
       pos: 76.5,-25.5
       parent: 2
-  - uid: 24599
+  - uid: 24598
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 2
-  - uid: 24600
+  - uid: 24599
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 2
 - proto: WindoorSecureServiceLocked
   entities:
-  - uid: 24601
+  - uid: 24600
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 63.5,-1.5
       parent: 2
-  - uid: 24602
+  - uid: 24601
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -151078,663 +151080,663 @@ entities:
       parent: 2
 - proto: WindoorTheatreLocked
   entities:
-  - uid: 24603
+  - uid: 24602
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,2.5
       parent: 2
-  - uid: 24604
+  - uid: 24603
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,3.5
       parent: 2
-  - uid: 24605
+  - uid: 24604
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,4.5
       parent: 2
-  - uid: 24606
+  - uid: 24605
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,5.5
       parent: 2
-  - uid: 24607
+  - uid: 24606
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,5.5
       parent: 2
-  - uid: 24608
+  - uid: 24607
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,5.5
       parent: 2
-  - uid: 24609
+  - uid: 24608
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,4.5
       parent: 2
-  - uid: 24610
+  - uid: 24609
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,3.5
       parent: 2
-  - uid: 24611
+  - uid: 24610
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,2.5
       parent: 2
-  - uid: 24612
+  - uid: 24611
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-5.5
       parent: 2
-  - uid: 24613
+  - uid: 24612
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-6.5
       parent: 2
-  - uid: 24614
+  - uid: 24613
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-7.5
       parent: 2
-  - uid: 24615
+  - uid: 24614
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,-7.5
       parent: 2
-  - uid: 24616
+  - uid: 24615
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,-6.5
       parent: 2
-  - uid: 24617
+  - uid: 24616
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,-5.5
       parent: 2
-  - uid: 24618
+  - uid: 24617
     components:
     - type: Transform
       pos: 24.5,-8.5
       parent: 2
-  - uid: 24619
+  - uid: 24618
     components:
     - type: Transform
       pos: 23.5,-8.5
       parent: 2
-  - uid: 24620
+  - uid: 24619
     components:
     - type: Transform
       pos: 22.5,-8.5
       parent: 2
 - proto: Window
   entities:
-  - uid: 24621
+  - uid: 24620
     components:
     - type: Transform
       pos: 12.5,-6.5
       parent: 2
-  - uid: 24622
+  - uid: 24621
     components:
     - type: Transform
       pos: -17.5,27.5
       parent: 2
-  - uid: 24623
+  - uid: 24622
     components:
     - type: Transform
       pos: -16.5,27.5
       parent: 2
-  - uid: 24624
+  - uid: 24623
     components:
     - type: Transform
       pos: -18.5,27.5
       parent: 2
-  - uid: 24625
+  - uid: 24624
     components:
     - type: Transform
       pos: -11.5,11.5
       parent: 2
-  - uid: 24626
+  - uid: 24625
     components:
     - type: Transform
       pos: -7.5,11.5
       parent: 2
-  - uid: 24627
+  - uid: 24626
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 2
-  - uid: 24628
+  - uid: 24627
     components:
     - type: Transform
       pos: -18.5,11.5
       parent: 2
-  - uid: 24629
+  - uid: 24628
     components:
     - type: Transform
       pos: -12.5,11.5
       parent: 2
-  - uid: 24630
+  - uid: 24629
     components:
     - type: Transform
       pos: -17.5,11.5
       parent: 2
-  - uid: 24631
+  - uid: 24630
     components:
     - type: Transform
       pos: -13.5,11.5
       parent: 2
-  - uid: 24632
+  - uid: 24631
     components:
     - type: Transform
       pos: -5.5,11.5
       parent: 2
-  - uid: 24633
+  - uid: 24632
     components:
     - type: Transform
       pos: -27.5,11.5
       parent: 2
-  - uid: 24634
+  - uid: 24633
     components:
     - type: Transform
       pos: -26.5,11.5
       parent: 2
-  - uid: 24635
+  - uid: 24634
     components:
     - type: Transform
       pos: -31.5,11.5
       parent: 2
-  - uid: 24636
+  - uid: 24635
     components:
     - type: Transform
       pos: -32.5,11.5
       parent: 2
-  - uid: 24637
+  - uid: 24636
     components:
     - type: Transform
       pos: 22.5,1.5
       parent: 2
-  - uid: 24638
+  - uid: 24637
     components:
     - type: Transform
       pos: -49.5,15.5
       parent: 2
-  - uid: 24639
+  - uid: 24638
     components:
     - type: Transform
       pos: -49.5,20.5
       parent: 2
-  - uid: 24640
+  - uid: 24639
     components:
     - type: Transform
       pos: -49.5,21.5
       parent: 2
-  - uid: 24641
+  - uid: 24640
     components:
     - type: Transform
       pos: -49.5,16.5
       parent: 2
-  - uid: 24642
+  - uid: 24641
     components:
     - type: Transform
       pos: 17.5,23.5
       parent: 2
-  - uid: 24643
+  - uid: 24642
     components:
     - type: Transform
       pos: 16.5,23.5
       parent: 2
-  - uid: 24644
+  - uid: 24643
     components:
     - type: Transform
       pos: 17.5,27.5
       parent: 2
-  - uid: 24645
+  - uid: 24644
     components:
     - type: Transform
       pos: 18.5,27.5
       parent: 2
-  - uid: 24646
+  - uid: 24645
     components:
     - type: Transform
       pos: 21.5,24.5
       parent: 2
-  - uid: 24647
+  - uid: 24646
     components:
     - type: Transform
       pos: 21.5,26.5
       parent: 2
-  - uid: 24648
+  - uid: 24647
     components:
     - type: Transform
       pos: 24.5,-4.5
       parent: 2
-  - uid: 24649
+  - uid: 24648
     components:
     - type: Transform
       pos: 22.5,-4.5
       parent: 2
-  - uid: 24650
+  - uid: 24649
     components:
     - type: Transform
       pos: 24.5,1.5
       parent: 2
-  - uid: 24651
+  - uid: 24650
     components:
     - type: Transform
       pos: 10.5,-27.5
       parent: 2
-  - uid: 24652
+  - uid: 24651
     components:
     - type: Transform
       pos: 10.5,-26.5
       parent: 2
-  - uid: 24653
+  - uid: 24652
     components:
     - type: Transform
       pos: 14.5,-25.5
       parent: 2
-  - uid: 24654
+  - uid: 24653
     components:
     - type: Transform
       pos: 10.5,-25.5
       parent: 2
-  - uid: 24655
+  - uid: 24654
     components:
     - type: Transform
       pos: 10.5,-29.5
       parent: 2
-  - uid: 24656
+  - uid: 24655
     components:
     - type: Transform
       pos: 4.5,-34.5
       parent: 2
-  - uid: 24657
+  - uid: 24656
     components:
     - type: Transform
       pos: 3.5,-34.5
       parent: 2
-  - uid: 24658
+  - uid: 24657
     components:
     - type: Transform
       pos: 5.5,-34.5
       parent: 2
-  - uid: 24659
+  - uid: 24658
     components:
     - type: Transform
       pos: 14.5,-42.5
       parent: 2
-  - uid: 24660
+  - uid: 24659
     components:
     - type: Transform
       pos: 7.5,-42.5
       parent: 2
-  - uid: 24661
+  - uid: 24660
     components:
     - type: Transform
       pos: 10.5,-42.5
       parent: 2
-  - uid: 24662
+  - uid: 24661
     components:
     - type: Transform
       pos: 15.5,-42.5
       parent: 2
-  - uid: 24663
+  - uid: 24662
     components:
     - type: Transform
       pos: 14.5,-26.5
       parent: 2
-  - uid: 24664
+  - uid: 24663
     components:
     - type: Transform
       pos: 14.5,-27.5
       parent: 2
-  - uid: 24665
+  - uid: 24664
     components:
     - type: Transform
       pos: 11.5,-29.5
       parent: 2
-  - uid: 24666
+  - uid: 24665
     components:
     - type: Transform
       pos: 13.5,-29.5
       parent: 2
-  - uid: 24667
+  - uid: 24666
     components:
     - type: Transform
       pos: 14.5,-29.5
       parent: 2
-  - uid: 24668
+  - uid: 24667
     components:
     - type: Transform
       pos: 12.5,-29.5
       parent: 2
-  - uid: 24669
+  - uid: 24668
     components:
     - type: Transform
       pos: 6.5,-42.5
       parent: 2
-  - uid: 24670
+  - uid: 24669
     components:
     - type: Transform
       pos: 11.5,-42.5
       parent: 2
-  - uid: 24671
+  - uid: 24670
     components:
     - type: Transform
       pos: 12.5,-33.5
       parent: 2
-  - uid: 24672
+  - uid: 24671
     components:
     - type: Transform
       pos: 9.5,-33.5
       parent: 2
-  - uid: 24673
+  - uid: 24672
     components:
     - type: Transform
       pos: 15.5,-33.5
       parent: 2
-  - uid: 24674
+  - uid: 24673
     components:
     - type: Transform
       pos: 41.5,-32.5
       parent: 2
-  - uid: 24675
+  - uid: 24674
     components:
     - type: Transform
       pos: 42.5,-7.5
       parent: 2
-  - uid: 24676
+  - uid: 24675
     components:
     - type: Transform
       pos: 48.5,-7.5
       parent: 2
-  - uid: 24677
+  - uid: 24676
     components:
     - type: Transform
       pos: 42.5,-22.5
       parent: 2
-  - uid: 24678
+  - uid: 24677
     components:
     - type: Transform
       pos: 42.5,-21.5
       parent: 2
-  - uid: 24679
+  - uid: 24678
     components:
     - type: Transform
       pos: 41.5,-31.5
       parent: 2
-  - uid: 24680
+  - uid: 24679
     components:
     - type: Transform
       pos: 42.5,-28.5
       parent: 2
-  - uid: 24681
+  - uid: 24680
     components:
     - type: Transform
       pos: 42.5,-27.5
       parent: 2
-  - uid: 24682
+  - uid: 24681
     components:
     - type: Transform
       pos: 41.5,-18.5
       parent: 2
-  - uid: 24683
+  - uid: 24682
     components:
     - type: Transform
       pos: 41.5,-17.5
       parent: 2
-  - uid: 24684
+  - uid: 24683
     components:
     - type: Transform
       pos: 55.5,-21.5
       parent: 2
-  - uid: 24685
+  - uid: 24684
     components:
     - type: Transform
       pos: 56.5,0.5
       parent: 2
-  - uid: 24686
+  - uid: 24685
     components:
     - type: Transform
       pos: 56.5,2.5
       parent: 2
-  - uid: 24687
+  - uid: 24686
     components:
     - type: Transform
       pos: 56.5,-0.5
       parent: 2
-  - uid: 24688
+  - uid: 24687
     components:
     - type: Transform
       pos: -34.5,21.5
       parent: 2
-  - uid: 24689
+  - uid: 24688
     components:
     - type: Transform
       pos: -34.5,20.5
       parent: 2
-  - uid: 24690
+  - uid: 24689
     components:
     - type: Transform
       pos: -34.5,19.5
       parent: 2
-  - uid: 24691
+  - uid: 24690
     components:
     - type: Transform
       pos: -31.5,17.5
       parent: 2
-  - uid: 24692
+  - uid: 24691
     components:
     - type: Transform
       pos: -30.5,17.5
       parent: 2
-  - uid: 24693
+  - uid: 24692
     components:
     - type: Transform
       pos: -29.5,17.5
       parent: 2
-  - uid: 24694
+  - uid: 24693
     components:
     - type: Transform
       pos: -6.5,-30.5
       parent: 2
-  - uid: 24695
+  - uid: 24694
     components:
     - type: Transform
       pos: -7.5,-30.5
       parent: 2
-  - uid: 24696
+  - uid: 24695
     components:
     - type: Transform
       pos: -55.5,-6.5
       parent: 2
-  - uid: 24697
+  - uid: 24696
     components:
     - type: Transform
       pos: -55.5,-7.5
       parent: 2
-  - uid: 24698
+  - uid: 24697
     components:
     - type: Transform
       pos: -54.5,-7.5
       parent: 2
-  - uid: 24699
+  - uid: 24698
     components:
     - type: Transform
       pos: -54.5,-8.5
       parent: 2
 - proto: WindowDirectional
   entities:
-  - uid: 24700
+  - uid: 24699
     components:
     - type: Transform
       pos: 50.5,-24.5
       parent: 2
-  - uid: 24701
+  - uid: 24700
     components:
     - type: Transform
       pos: 51.5,-24.5
+      parent: 2
+  - uid: 24701
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -16.5,-19.5
       parent: 2
   - uid: 24702
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -16.5,-19.5
+      pos: -16.5,-16.5
       parent: 2
   - uid: 24703
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      rot: 1.5707963267948966 rad
       pos: -16.5,-16.5
       parent: 2
   - uid: 24704
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-16.5
       parent: 2
   - uid: 24705
     components:
     - type: Transform
-      pos: -16.5,-16.5
+      rot: 1.5707963267948966 rad
+      pos: -16.5,-19.5
       parent: 2
   - uid: 24706
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-19.5
       parent: 2
   - uid: 24707
     components:
     - type: Transform
-      pos: -16.5,-19.5
+      rot: 3.141592653589793 rad
+      pos: -21.5,-9.5
       parent: 2
   - uid: 24708
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -21.5,-9.5
+      pos: -20.5,-9.5
       parent: 2
   - uid: 24709
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      rot: 1.5707963267948966 rad
       pos: -20.5,-9.5
       parent: 2
   - uid: 24710
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -20.5,-9.5
+      pos: -20.5,-10.5
       parent: 2
   - uid: 24711
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-10.5
-      parent: 2
-  - uid: 24712
-    components:
-    - type: Transform
       pos: -19.5,-10.5
       parent: 2
-  - uid: 24713
+  - uid: 24712
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-13.5
       parent: 2
-  - uid: 24714
+  - uid: 24713
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: -30.5,-9.5
+      parent: 2
+  - uid: 24714
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -30.5,-9.5
       parent: 2
   - uid: 24715
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -30.5,-9.5
-      parent: 2
-  - uid: 24716
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-10.5
       parent: 2
-  - uid: 24717
+  - uid: 24716
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,36.5
       parent: 2
-  - uid: 24718
+  - uid: 24717
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,36.5
       parent: 2
-  - uid: 24719
+  - uid: 24718
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,31.5
       parent: 2
-  - uid: 24720
+  - uid: 24719
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,32.5
       parent: 2
-  - uid: 24721
+  - uid: 24720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,31.5
       parent: 2
-  - uid: 24722
+  - uid: 24721
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.5,-6.5
       parent: 2
-  - uid: 24723
+  - uid: 24722
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.5,-6.5
       parent: 2
-  - uid: 24724
+  - uid: 24723
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-6.5
       parent: 2
-  - uid: 24725
+  - uid: 24724
     components:
     - type: Transform
       pos: -67.5,11.5
       parent: 2
 - proto: WindowFrostedDirectional
   entities:
-  - uid: 24726
+  - uid: 24725
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -151742,807 +151744,807 @@ entities:
       parent: 2
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 24727
+  - uid: 24726
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 2
-  - uid: 24728
+  - uid: 24727
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 2
-  - uid: 24729
+  - uid: 24728
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-2.5
       parent: 2
-  - uid: 24730
+  - uid: 24729
     components:
     - type: Transform
       pos: 37.5,39.5
       parent: 2
-  - uid: 24731
+  - uid: 24730
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,38.5
       parent: 2
-  - uid: 24732
+  - uid: 24731
     components:
     - type: Transform
       pos: -2.5,47.5
       parent: 2
-  - uid: 24733
+  - uid: 24732
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,47.5
       parent: 2
-  - uid: 24734
+  - uid: 24733
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,37.5
       parent: 2
-  - uid: 24735
+  - uid: 24734
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
+      pos: -14.5,37.5
+      parent: 2
+  - uid: 24735
+    components:
+    - type: Transform
       pos: -14.5,37.5
       parent: 2
   - uid: 24736
     components:
     - type: Transform
-      pos: -14.5,37.5
+      rot: 3.141592653589793 rad
+      pos: -11.5,38.5
       parent: 2
   - uid: 24737
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -11.5,38.5
+      pos: -0.5,47.5
       parent: 2
   - uid: 24738
     components:
     - type: Transform
-      pos: -0.5,47.5
-      parent: 2
-  - uid: 24739
-    components:
-    - type: Transform
       pos: -6.5,41.5
       parent: 2
-  - uid: 24740
+  - uid: 24739
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,39.5
       parent: 2
-  - uid: 24741
+  - uid: 24740
     components:
     - type: Transform
       pos: -15.5,37.5
       parent: 2
-  - uid: 24742
+  - uid: 24741
     components:
     - type: Transform
       pos: -16.5,37.5
       parent: 2
-  - uid: 24743
+  - uid: 24742
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,47.5
       parent: 2
-  - uid: 24744
+  - uid: 24743
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: -1.5,47.5
+      parent: 2
+  - uid: 24744
+    components:
+    - type: Transform
       pos: -1.5,47.5
       parent: 2
   - uid: 24745
     components:
     - type: Transform
-      pos: -1.5,47.5
-      parent: 2
-  - uid: 24746
-    components:
-    - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,47.5
       parent: 2
-  - uid: 24747
+  - uid: 24746
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,47.5
       parent: 2
-  - uid: 24748
+  - uid: 24747
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: -3.5,47.5
+      parent: 2
+  - uid: 24748
+    components:
+    - type: Transform
       pos: -3.5,47.5
       parent: 2
   - uid: 24749
     components:
     - type: Transform
-      pos: -3.5,47.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,6.5
       parent: 2
   - uid: 24750
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,6.5
+      pos: -12.5,8.5
       parent: 2
   - uid: 24751
     components:
     - type: Transform
-      pos: -12.5,8.5
-      parent: 2
-  - uid: 24752
-    components:
-    - type: Transform
       pos: -13.5,8.5
       parent: 2
-  - uid: 24753
+  - uid: 24752
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,6.5
       parent: 2
-  - uid: 24754
+  - uid: 24753
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,7.5
       parent: 2
-  - uid: 24755
+  - uid: 24754
     components:
     - type: Transform
       pos: -5.5,8.5
       parent: 2
-  - uid: 24756
+  - uid: 24755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,6.5
       parent: 2
-  - uid: 24757
+  - uid: 24756
     components:
     - type: Transform
       pos: -7.5,8.5
       parent: 2
-  - uid: 24758
+  - uid: 24757
     components:
     - type: Transform
       pos: -11.5,8.5
       parent: 2
-  - uid: 24759
+  - uid: 24758
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,4.5
       parent: 2
-  - uid: 24760
+  - uid: 24759
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: -7.5,4.5
+      parent: 2
+  - uid: 24760
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -7.5,4.5
       parent: 2
   - uid: 24761
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,4.5
+      pos: -7.5,3.5
       parent: 2
   - uid: 24762
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,3.5
-      parent: 2
-  - uid: 24763
-    components:
-    - type: Transform
       pos: -6.5,6.5
       parent: 2
-  - uid: 24764
+  - uid: 24763
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,5.5
       parent: 2
-  - uid: 24765
+  - uid: 24764
     components:
     - type: Transform
       pos: -7.5,6.5
       parent: 2
-  - uid: 24766
+  - uid: 24765
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,7.5
       parent: 2
-  - uid: 24767
+  - uid: 24766
     components:
     - type: Transform
       pos: -6.5,8.5
+      parent: 2
+  - uid: 24767
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 37.5,31.5
       parent: 2
   - uid: 24768
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 37.5,31.5
-      parent: 2
-  - uid: 24769
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
       pos: -8.5,-3.5
       parent: 2
-  - uid: 24770
+  - uid: 24769
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-3.5
       parent: 2
-  - uid: 24771
+  - uid: 24770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-3.5
       parent: 2
-  - uid: 24772
+  - uid: 24771
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-4.5
       parent: 2
-  - uid: 24773
+  - uid: 24772
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-5.5
       parent: 2
-  - uid: 24774
+  - uid: 24773
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 2
-  - uid: 24775
+  - uid: 24774
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
-  - uid: 24776
+  - uid: 24775
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 2
-  - uid: 24777
+  - uid: 24776
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-20.5
       parent: 2
-  - uid: 24778
+  - uid: 24777
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-21.5
       parent: 2
-  - uid: 24779
+  - uid: 24778
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,7.5
       parent: 2
-  - uid: 24780
+  - uid: 24779
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,7.5
       parent: 2
-  - uid: 24781
+  - uid: 24780
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
+      pos: -33.5,8.5
+      parent: 2
+  - uid: 24781
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: -33.5,8.5
       parent: 2
   - uid: 24782
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -33.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -29.5,7.5
       parent: 2
   - uid: 24783
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -29.5,7.5
-      parent: 2
-  - uid: 24784
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,6.5
       parent: 2
-  - uid: 24785
+  - uid: 24784
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-5.5
       parent: 2
-  - uid: 24786
+  - uid: 24785
     components:
     - type: Transform
       pos: -34.5,0.5
       parent: 2
-  - uid: 24787
+  - uid: 24786
     components:
     - type: Transform
       pos: -32.5,0.5
       parent: 2
-  - uid: 24788
+  - uid: 24787
     components:
     - type: Transform
       pos: -33.5,0.5
       parent: 2
-  - uid: 24789
+  - uid: 24788
     components:
     - type: Transform
       pos: -26.5,-0.5
       parent: 2
-  - uid: 24790
+  - uid: 24789
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,-0.5
       parent: 2
-  - uid: 24791
+  - uid: 24790
     components:
     - type: Transform
       pos: -36.5,-1.5
       parent: 2
-  - uid: 24792
+  - uid: 24791
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-7.5
       parent: 2
-  - uid: 24793
+  - uid: 24792
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-6.5
       parent: 2
-  - uid: 24794
+  - uid: 24793
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-8.5
       parent: 2
-  - uid: 24795
+  - uid: 24794
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-9.5
       parent: 2
-  - uid: 24796
+  - uid: 24795
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,-10.5
       parent: 2
-  - uid: 24797
+  - uid: 24796
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,-9.5
       parent: 2
-  - uid: 24798
+  - uid: 24797
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -44.5,-8.5
       parent: 2
-  - uid: 24799
+  - uid: 24798
     components:
     - type: Transform
       pos: -40.5,25.5
       parent: 2
-  - uid: 24800
+  - uid: 24799
     components:
     - type: Transform
       pos: -39.5,25.5
       parent: 2
-  - uid: 24801
+  - uid: 24800
     components:
     - type: Transform
       pos: -36.5,25.5
       parent: 2
-  - uid: 24802
+  - uid: 24801
     components:
     - type: Transform
       pos: -37.5,25.5
       parent: 2
-  - uid: 24803
+  - uid: 24802
     components:
     - type: Transform
       pos: -38.5,25.5
       parent: 2
-  - uid: 24804
+  - uid: 24803
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,39.5
       parent: 2
-  - uid: 24805
+  - uid: 24804
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,34.5
       parent: 2
-  - uid: 24806
+  - uid: 24805
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,34.5
       parent: 2
-  - uid: 24807
+  - uid: 24806
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,-1.5
       parent: 2
-  - uid: 24808
+  - uid: 24807
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,-7.5
       parent: 2
-  - uid: 24809
+  - uid: 24808
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-1.5
       parent: 2
-  - uid: 24810
+  - uid: 24809
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-7.5
       parent: 2
-  - uid: 24811
+  - uid: 24810
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 66.5,-28.5
       parent: 2
-  - uid: 24812
+  - uid: 24811
     components:
     - type: Transform
       pos: 51.5,-30.5
       parent: 2
-  - uid: 24813
+  - uid: 24812
     components:
     - type: Transform
       pos: 49.5,-30.5
       parent: 2
-  - uid: 24814
+  - uid: 24813
     components:
     - type: Transform
       pos: 52.5,-30.5
       parent: 2
-  - uid: 24815
+  - uid: 24814
     components:
     - type: Transform
       pos: 50.5,-30.5
       parent: 2
-  - uid: 24816
+  - uid: 24815
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,23.5
       parent: 2
-  - uid: 24817
+  - uid: 24816
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,-1.5
       parent: 2
-  - uid: 24818
+  - uid: 24817
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 65.5,-1.5
       parent: 2
-  - uid: 24819
+  - uid: 24818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,-1.5
       parent: 2
-  - uid: 24820
+  - uid: 24819
     components:
     - type: Transform
       pos: 77.5,-25.5
       parent: 2
-  - uid: 24821
+  - uid: 24820
     components:
     - type: Transform
       pos: 75.5,-25.5
       parent: 2
-  - uid: 24822
+  - uid: 24821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,22.5
       parent: 2
-  - uid: 24823
+  - uid: 24822
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,20.5
       parent: 2
-  - uid: 24824
+  - uid: 24823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,21.5
       parent: 2
-  - uid: 24825
+  - uid: 24824
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,-10.5
       parent: 2
-  - uid: 24826
+  - uid: 24825
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-16.5
       parent: 2
-  - uid: 24827
+  - uid: 24826
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,-15.5
       parent: 2
-  - uid: 24828
+  - uid: 24827
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,-9.5
       parent: 2
-  - uid: 24829
+  - uid: 24828
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.5,-9.5
       parent: 2
-  - uid: 24830
+  - uid: 24829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,31.5
       parent: 2
-  - uid: 24831
+  - uid: 24830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,32.5
       parent: 2
-  - uid: 24832
+  - uid: 24831
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,27.5
       parent: 2
-  - uid: 24833
+  - uid: 24832
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -65.5,9.5
       parent: 2
-  - uid: 24834
+  - uid: 24833
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -67.5,12.5
       parent: 2
-  - uid: 24835
+  - uid: 24834
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -67.5,11.5
       parent: 2
-  - uid: 24836
+  - uid: 24835
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -67.5,12.5
       parent: 2
-  - uid: 24837
+  - uid: 24836
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -61.5,9.5
       parent: 2
-  - uid: 24838
+  - uid: 24837
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,10.5
       parent: 2
-  - uid: 24839
+  - uid: 24838
     components:
     - type: Transform
       pos: -69.5,9.5
       parent: 2
-  - uid: 24840
+  - uid: 24839
     components:
     - type: Transform
       pos: -68.5,9.5
       parent: 2
-  - uid: 24841
+  - uid: 24840
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -69.5,9.5
       parent: 2
-  - uid: 24842
+  - uid: 24841
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -68.5,9.5
+      parent: 2
+  - uid: 24842
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -73.5,15.5
       parent: 2
   - uid: 24843
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -73.5,15.5
+      pos: -71.5,15.5
       parent: 2
   - uid: 24844
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -71.5,15.5
+      pos: -72.5,15.5
       parent: 2
   - uid: 24845
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -72.5,15.5
+      pos: -73.5,15.5
       parent: 2
   - uid: 24846
     components:
     - type: Transform
-      pos: -73.5,15.5
+      pos: -72.5,15.5
       parent: 2
   - uid: 24847
     components:
     - type: Transform
-      pos: -72.5,15.5
-      parent: 2
-  - uid: 24848
-    components:
-    - type: Transform
       pos: -71.5,15.5
       parent: 2
-  - uid: 24849
+  - uid: 24848
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -73.5,15.5
       parent: 2
-  - uid: 24850
+  - uid: 24849
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -71.5,15.5
       parent: 2
+  - uid: 24850
+    components:
+    - type: Transform
+      pos: -58.5,11.5
+      parent: 2
   - uid: 24851
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -58.5,11.5
       parent: 2
   - uid: 24852
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -58.5,11.5
+      rot: 1.5707963267948966 rad
+      pos: -57.5,11.5
       parent: 2
   - uid: 24853
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,11.5
       parent: 2
   - uid: 24854
     components:
     - type: Transform
-      pos: -57.5,11.5
-      parent: 2
-  - uid: 24855
-    components:
-    - type: Transform
       rot: -1.5707963267948966 rad
       pos: -72.5,-5.5
       parent: 2
-  - uid: 24856
+  - uid: 24855
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -73.5,-5.5
       parent: 2
-  - uid: 24857
+  - uid: 24856
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,30.5
       parent: 2
-  - uid: 24858
+  - uid: 24857
     components:
     - type: Transform
       pos: 37.5,29.5
       parent: 2
-  - uid: 24859
+  - uid: 24858
     components:
     - type: Transform
       pos: -7.5,-28.5
       parent: 2
-  - uid: 24860
+  - uid: 24859
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,-29.5
       parent: 2
-  - uid: 24861
+  - uid: 24860
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,31.5
       parent: 2
-  - uid: 24862
+  - uid: 24861
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,29.5
       parent: 2
-  - uid: 24863
+  - uid: 24862
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,28.5
       parent: 2
-  - uid: 24864
+  - uid: 24863
     components:
     - type: Transform
       pos: 37.5,35.5
       parent: 2
-  - uid: 24865
+  - uid: 24864
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,37.5
       parent: 2
-  - uid: 24866
+  - uid: 24865
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,-2.5
       parent: 2
-  - uid: 24867
+  - uid: 24866
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-2.5
       parent: 2
-  - uid: 24868
+  - uid: 24867
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -152558,177 +152560,177 @@ entities:
       canCollide: False
 - proto: WoodDoor
   entities:
-  - uid: 24869
+  - uid: 24868
     components:
     - type: Transform
       pos: -34.5,33.5
       parent: 2
-  - uid: 24870
+  - uid: 24869
     components:
     - type: Transform
       pos: -35.5,33.5
       parent: 2
 - proto: WoodenBench
   entities:
-  - uid: 24871
+  - uid: 24870
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,39.5
       parent: 2
-  - uid: 24872
+  - uid: 24871
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,37.5
       parent: 2
-  - uid: 24873
+  - uid: 24872
     components:
     - type: Transform
       pos: 50.5,-25.5
       parent: 2
-  - uid: 24874
+  - uid: 24873
     components:
     - type: Transform
       pos: 51.5,-25.5
       parent: 2
-  - uid: 24875
+  - uid: 24874
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 49.5,-18.5
       parent: 2
-  - uid: 24876
+  - uid: 24875
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 49.5,-20.5
       parent: 2
-  - uid: 24877
+  - uid: 24876
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 49.5,-19.5
       parent: 2
-  - uid: 24878
+  - uid: 24877
     components:
     - type: Transform
       pos: 52.5,-16.5
       parent: 2
-  - uid: 24879
+  - uid: 24878
     components:
     - type: Transform
       pos: 53.5,-16.5
       parent: 2
-  - uid: 24880
+  - uid: 24879
     components:
     - type: Transform
       pos: 54.5,-16.5
       parent: 2
-  - uid: 24881
+  - uid: 24880
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,25.5
       parent: 2
-  - uid: 24882
+  - uid: 24881
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -61.5,2.5
       parent: 2
-  - uid: 24883
+  - uid: 24882
     components:
     - type: Transform
       pos: -62.5,5.5
       parent: 2
 - proto: WoodenSupport
   entities:
-  - uid: 24884
+  - uid: 24883
     components:
     - type: Transform
       pos: -51.5,-15.5
       parent: 2
 - proto: WoodenSupportBeam
   entities:
-  - uid: 24885
+  - uid: 24884
     components:
     - type: Transform
       pos: -52.5,-11.5
       parent: 2
 - proto: WoodenSupportWall
   entities:
-  - uid: 24886
+  - uid: 24885
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -52.5,-12.5
       parent: 2
-  - uid: 24887
+  - uid: 24886
     components:
     - type: Transform
       pos: -49.5,-11.5
       parent: 2
 - proto: WoodenSupportWallBroken
   entities:
-  - uid: 24888
+  - uid: 24887
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -52.5,-10.5
       parent: 2
-  - uid: 24889
+  - uid: 24888
     components:
     - type: Transform
       pos: -47.5,-14.5
       parent: 2
 - proto: Wrench
   entities:
-  - uid: 24890
+  - uid: 24889
     components:
     - type: Transform
       pos: -4.4625597,23.570536
       parent: 2
-  - uid: 24891
+  - uid: 24890
     components:
     - type: Transform
       pos: 0.52242017,41.525253
       parent: 2
-  - uid: 24892
+  - uid: 24891
     components:
     - type: Transform
       pos: -50.4697,30.755295
       parent: 2
-  - uid: 24893
+  - uid: 24892
     components:
     - type: Transform
       pos: -50.454075,31.661545
       parent: 2
-  - uid: 24894
+  - uid: 24893
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.422825,30.755295
       parent: 2
-  - uid: 24895
+  - uid: 24894
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.43845,31.661545
       parent: 2
-  - uid: 24896
+  - uid: 24895
     components:
     - type: Transform
       pos: 3.4753227,-53.525745
       parent: 2
-  - uid: 24897
+  - uid: 24896
     components:
     - type: Transform
       pos: 3.6315727,-53.44762
       parent: 2
 - proto: WristwatchGold
   entities:
-  - uid: 24898
+  - uid: 24897
     components:
     - type: Transform
       pos: -27.48703,28.622438

--- a/Resources/Prototypes/_Starlight/Maps/lobster.yml
+++ b/Resources/Prototypes/_Starlight/Maps/lobster.yml
@@ -65,6 +65,7 @@
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
             Musician: [ 2, 2 ]
+            Performer: [ 4, 5 ]
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 3, 6 ]


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- Adds a cryogenic sleep unit in GenPop.
- Adds Performer job slots. Their spawnpoints are mapped mostly near the clown statue by the clown room and the stage, with a few eccentric spawns as usual.
- Moves the Medical Dispenser out of Surgery as requested by the community.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- Supports #3526 
- GenPops are intended to have places to cryo to leave the round
- The Medical Dispenser was behind Surgery access after the Surgery access doors were mapped to Lobster. This was annoying for people who wanted to buy non-surgery things from it. It's been moved, see screenshot.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1103" height="936" alt="image" src="https://github.com/user-attachments/assets/9189219d-b963-4db5-be9c-e3056ea8b726" />

fig. 1 - Cryogenic sleep unit in GenPop

<img width="898" height="902" alt="image" src="https://github.com/user-attachments/assets/789068ba-c400-4872-ac64-3058b0e68594" />

fig. 2 - I moved the Medical Dispenser to Medbay. I moved the SmartFridge in Surgery to fill where the Medical Dispenser was. I then put in a new Surgical Supplies crate to fill in where the Smart Fridge was.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- add: (Lobster) Cryogenic sleep unit in GenPop.
- add: (Lobster) Performer job slots.
- tweak: (Lobster) Moved the Medical Dispenser out of Surgery and into the Medbay.