### PR TITLE
Nanochat logs tweak

### DIFF
--- a/Content.Server/_CD/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_CD/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -146,7 +146,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
         _adminLogger.Add(LogType.Action,
             LogImpact.Low,
-            $"{ToPrettyString(msg.Actor):user} created new NanoChat conversation with #{msg.RecipientNumber:D4} ({msg.Content})");
+            $"{ToPrettyString(msg.Actor):player} created new NanoChat conversation with #{msg.RecipientNumber:D4} ({msg.Content})"); // Starlight Edit: user -> player
 
         var recipientEv = new NanoChatRecipientUpdatedEvent(card);
         RaiseLocalEvent(ref recipientEv);
@@ -196,7 +196,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
         _adminLogger.Add(LogType.Action,
             LogImpact.Low,
-            $"{ToPrettyString(msg.Actor):user} deleted NanoChat conversation with #{msg.RecipientNumber:D4}");
+            $"{ToPrettyString(msg.Actor):player} deleted NanoChat conversation with #{msg.RecipientNumber:D4}"); // Starlight Edit: user -> player
 
         UpdateUIForCard(card);
     }
@@ -261,7 +261,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
         _adminLogger.Add(LogType.Chat,
             LogImpact.Low,
-            $"{ToPrettyString(card):user} sent NanoChat message to {recipientsText}: {msg.Content}{(deliveryFailed ? " [DELIVERY FAILED]" : "")}");
+            $"{ToPrettyString(msg.Actor):player} sent NanoChat message to {recipientsText}: {msg.Content}{(deliveryFailed ? " [DELIVERY FAILED]" : "")}"); // Starlight Edit: user -> player
 
         // Starlight edit Start: Commented out
         // var msgEv = new NanoChatMessageReceivedEvent(card, message);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Ties Nanochat logs to the relevant player, Instead of ID card.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Admins having to search for ID specifically is very annoying and is a pain during replays
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="684" height="323" alt="image" src="https://github.com/user-attachments/assets/74877cb1-2f94-4c09-9dce-208b14a7c3dd" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.