### PR TITLE
Swap the additional puppy from the Hushpup Bundle with a Speedloader

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -459,7 +459,7 @@
   parent: ClothingBackpackDuffelSyndicateBundle
   id: ClothingBackpackDuffelSyndicateFilledHushpup
   name: Hushpup bundle
-  description: Contains the Hushpup, bundled with 2 boxes of buckshot. Quarter included.
+  description: Contains the Hushpup, bundled with a box of buckshot and a speedloader. Quarter included.
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -466,6 +466,6 @@
       storagebase: !type:AllSelector
         children:
         - id: WeaponShotgunHushpup
-          amount: 2 #SL 1 > 2
+        - id: SpeedLoaderMagnumBasic # SL - Speedload > Extra box
         - id: BoxLethalshot
         - id: TreasureCoinIron


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes an issue of the Hushpup Bundle having two puppies instead of the singular pup. Gave the bundle a speed loader instead of an additional box of ammunition.


## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
#3309 sought to buff weapon bundles by including an additional magazine for every weapon. This was intended to try and buff the winrate for Nuclear Operatives who can struggle on high pop with the sheer amount of bodies they have to go through. However for the Hushpup, Conflee accidentally gave the bundle two shotguns instead of two boxes of ammo. This durastically increasing the value of the bundle and was clearly unintended.

Rather than give the bundle an additional box of ammo, essentially giving the bundle 4 additional magazines worth of ammunition. Instead I chose to give it a speed loader which has 7 additional rounds of ammunition. While it also increases the power of the bundle, it doesn't go as far as to double the ammunition available in the bundle. 


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="488" height="247" alt="{9EFBBE58-07F1-4232-BF3E-4263EDA3B7BD}" src="https://github.com/user-attachments/assets/150fede6-9f5f-47a8-bbc6-1489b96227d1" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Huaqas
- fix: The Hushpup Bundle no longer includes an additional pup.
- add: The Hushpup Bundle now includes a speed loader. 
