### PR TITLE
Fland Update 3 - 2026

### DIFF
--- a/Resources/Prototypes/_Starlight/Maps/fland.yml
+++ b/Resources/Prototypes/_Starlight/Maps/fland.yml
@@ -66,7 +66,8 @@
             Assistant: [ -1, -1 ]
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
-            Musician: [ 1, 2 ]
+            Musician: [ 2, 2 ]
+            Performer: [ 2, 3 ]
             #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 3, 4 ]


### PR DESCRIPTION
## Short description
Upkeep on Fland. Added Performer spawn and job slots. Added lattice to prevent Evac from docking at the AI Core Dock. Adjusted AI Vision values on some cameras to limit AI vision into areas intended for antag use- maints, station exterior, etc. Added camera in Salvage Docking Arm. Shifted maints loot slightly. Turned the shit hallway in north engie into a pseudo maints area, and added airlocks so people breaking in through that route can't just walk into SMES. 

## Why we need to add this
Upkeep.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Fland upkeep. Added performer, adjusted Ai visibility into maints, added lattice to prevent Evac docking at the AI Core exterior dock, minor maints loot shuffle.

