### PR TITLE
Mining Shuttle Redesignation

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/Mining/breaker.yml
+++ b/Resources/Maps/_Starlight/Shuttles/Mining/breaker.yml
@@ -23,7 +23,7 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      name: GR-4P3 "Breaker"
+      name: NTMS-42A "Breaker"
     - type: Transform
       pos: -1.2063751,-0.30715814
       parent: invalid


### PR DESCRIPTION


## Short description
Changes the numerical designation of the mining shuttle.

## Why we need to add this
The previous numerical designation was a reference to someone who is no longer part of the server for rather serious reasons and it feels improper to have their name obvious on any mass scanner every shift.
<img width="251" height="132" alt="image" src="https://github.com/user-attachments/assets/22505e8a-fb56-4c10-aa9f-70f76610ead0" />


<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: deltaVelocity
- tweak: Redesignated mining shuttle.

