### PR TITLE
Mech reactor blacklisting

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -54,6 +54,11 @@
       - TrayScanner
       - GasAnalyzer
       - HandLabeler
+    #Starlight Start
+    blacklist:
+      tags:
+      - MechReactor
+    #Starlight End
   - type: ItemMapper
     sprite: &BeltOverlay Clothing/Belt/belt_overlay.rsi
     mapLayers:

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -101,6 +101,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: ContainerContainer
     containers:
       cell_slot: !type:ContainerSlot {}

--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -58,6 +58,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: Item
     heldPrefix: off
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -600,6 +600,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellSmall
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: PowerCellDraw
     drawRate: 2
   - type: ToggleCellDraw
@@ -619,6 +624,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: HideLayerClothing
     layers:
       Hair: HEAD

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -85,6 +85,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: HideLayerClothing
     slots:
     - Hair

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -158,6 +158,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: Tag
     tags: []
 

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -136,6 +136,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: Body
   - type: StatusEffects
     allowed:

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
@@ -58,6 +58,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   parent: [ BaseXenoborgChassis, BaseXenoborgTransponder ]
@@ -153,6 +158,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   parent: [ BaseXenoborgChassis, BaseXenoborgTransponder ]
@@ -210,6 +220,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   parent: [ BaseXenoborgChassis, BaseXenoborgTransponder ]
@@ -267,6 +282,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 
 # xenoborgs empty
@@ -292,6 +312,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHighPrinted
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   parent: XenoborgHeavy
@@ -312,6 +337,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHighPrinted
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   parent: XenoborgScout
@@ -332,6 +362,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHighPrinted
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   parent: XenoborgStealth
@@ -353,3 +388,8 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHighPrinted
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End

--- a/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
@@ -203,6 +203,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMicroreactor
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: Puller
     needsHands: false
   - type: Eye

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -581,6 +581,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: StartingMindRole
     mindRole: "MindRoleSiliconBrain"
     silent: true
@@ -615,6 +620,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHyper
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   id: PlayerBorgSyndicateAssaultGhostRole
@@ -662,6 +672,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHyper
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   id: PlayerBorgSyndicateSaboteurGhostRole
@@ -709,6 +724,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHyper
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   id: PlayerBorgSyndicateMedicalGhostRole
@@ -760,6 +780,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: RandomMetadata
     nameSegments: [NamesBorg]
 
@@ -795,6 +820,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: RandomMetadata
     nameSegments: [NamesBorg]
 
@@ -832,6 +862,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: RandomMetadata
     nameSegments: [NamesBorg]
 
@@ -870,6 +905,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: RandomMetadata
     nameSegments: [NamesBorg]
 
@@ -907,6 +947,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: RandomMetadata
     nameSegments: [NamesBorg]
 
@@ -944,6 +989,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHyper
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: RandomMetadata
     nameSegments: [NamesDeathCommando]
 

--- a/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
@@ -64,6 +64,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: PowerCellSlot
     cellSlotId: cell_slot
   - type: PowerCellDraw

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -18,6 +18,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: Sprite
     sprite: Objects/Devices/Holoprojectors/custodial.rsi
     state: icon
@@ -34,6 +39,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   parent: Holoprojector
@@ -105,6 +115,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   parent: HolofanProjector
@@ -147,6 +162,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   parent: Holoprojector
@@ -176,3 +196,8 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End

--- a/Resources/Prototypes/Entities/Objects/Devices/station_map.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_map.yml
@@ -47,6 +47,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   id: HandheldStationMapUnpowered

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -320,3 +320,8 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -31,6 +31,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellSmall
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: ContainerContainer
     containers:
       cell_slot: !type:ContainerSlot
@@ -177,6 +182,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: GenericVisualizer
     visuals:
       enum.FlashVisuals.Burnt:
@@ -224,6 +234,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: Anchorable
   - type: Damageable
     damageContainer: StructuralInorganic

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -59,6 +59,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   id: DefibrillatorOneHandedUnpowered

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -64,3 +64,8 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -126,6 +126,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   id: AnomalyLocatorWideUnpowered
@@ -161,6 +166,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   name: G.O.R.I.L.L.A. gauntlet

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1570,6 +1570,11 @@
         whitelist:
           components:
           - PowerCell
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: xenoborg-module-module }
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/scanner.yml
@@ -58,6 +58,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   id: AdvancedMineralScannerUnpowered
@@ -102,3 +107,8 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End

--- a/Resources/Prototypes/Entities/Objects/Tools/decoys.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/decoys.yml
@@ -48,6 +48,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: ContainerContainer
     containers:
       cell_slot: !type:ContainerSlot

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -47,6 +47,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: Sprite
     sprite: Objects/Tools/flashlight.rsi
     layers:
@@ -93,6 +98,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: HandheldLight
     addPrefix: false
     wattage: 0.5
@@ -139,3 +149,8 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -50,6 +50,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 - type: entity
   id: HandHeldMassScannerBorg

--- a/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jammer.yml
@@ -36,6 +36,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -54,6 +54,11 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellMedium
+          #Starlight Start
+          blacklist:
+            tags:
+            - MechReactor
+          #Starlight End
     - type: ContainerContainer
       containers:
         cell_slot: !type:ContainerSlot {}

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -140,6 +140,11 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellSmall
+          #Starlight Start
+          blacklist:
+            tags:
+            - MechReactor
+          #Starlight End
 
 - type: entity
   id: PowerCellSlotMediumItem
@@ -155,6 +160,11 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellMedium
+          #Starlight Start
+          blacklist:
+            tags:
+            - MechReactor
+          #Starlight End
 
 - type: entity
   id: PowerCellSlotHighItem
@@ -170,6 +180,11 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHigh
+          #Starlight Start
+          blacklist:
+            tags:
+            - MechReactor
+          #Starlight End
 
 # For entities with a hidden container slot that can be opened with a tool
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -148,6 +148,11 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/booze.yml
@@ -33,6 +33,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   # Starlight end
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/chem.yml
@@ -111,4 +111,9 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   # Starlight-end

--- a/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/soda.yml
@@ -31,6 +31,11 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        #Starlight Start
+        blacklist:
+          tags:
+          - MechReactor
+        #Starlight End
   # Starlight end
 
 - type: entity

--- a/Resources/Prototypes/_Starlight/Admeme/neomoth/event/xenomoproach.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/neomoth/event/xenomoproach.yml
@@ -343,6 +343,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHigh
+          blacklist:
+            tags:
+            - MechReactor
     - type: TypingIndicator
       proto: xenoborg
     - type: Speech
@@ -455,6 +458,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHighPrinted
+          blacklist:
+            tags:
+            - MechReactor
 
 - type: entity
   parent: MobXenomoproach

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Backpacks/tsf.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Backpacks/tsf.yml
@@ -82,3 +82,6 @@
           whitelist:
             tags:
               - PowerCell
+          blacklist:
+            tags:
+            - MechReactor

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Belt/belts.yml
@@ -47,6 +47,9 @@
         - Handcuff
         - BallisticAmmoProvider
         - Ammo
+    blacklist:
+      tags:
+      - MechReactor
   - type: Appearance
   - type: StaticPrice
     price: 1000
@@ -246,6 +249,9 @@
         - Handcuff
         - BallisticAmmoProvider
         - Ammo
+    blacklist:
+      tags:
+      - MechReactor
   - type: ItemMapper
     mapLayers:
       flashbang:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/base_borgi_chassis.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/base_borgi_chassis.yml
@@ -136,6 +136,9 @@
       slots:
         cell_slot:
           name: power-cell-slot-component-slot-name-default
+          blacklist:
+            tags:
+            - MechReactor
     - type: StatusEffects
       allowed:
       - Stun
@@ -279,5 +282,8 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHyper
+          blacklist:
+            tags:
+            - MechReactor
     - type: AccessReader
       access: [["SyndicateAgent"], ["NuclearOperative"]]

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/borgi_chassis.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/borgi_chassis.yml
@@ -28,6 +28,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHigh
+          blacklist:
+            tags:
+            - MechReactor
     - type: StartIonStormed
       ionStormAmount: 3
     - type: IonStormTarget
@@ -43,6 +46,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHigh
+          blacklist:
+            tags:
+            - MechReactor
     - type: ContainerFill
       containers:
         borg_brain:
@@ -62,6 +68,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHigh
+          blacklist:
+            tags:
+            - MechReactor
     - type: ContainerFill
       containers:
         borg_brain:
@@ -78,6 +87,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHigh
+          blacklist:
+            tags:
+            - MechReactor
     - type: ContainerFill
       containers:
         borg_brain:
@@ -252,6 +264,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHyper
+          blacklist:
+            tags:
+            - MechReactor
 
 - type: entity
   parent: XenoBorgiPrinted

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Player/silicon.yml
@@ -21,6 +21,9 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHyper
+        blacklist:
+          tags:
+          - MechReactor
 
 - type: entity
   id: PlayerBorgSyndicateStealthGhostRole
@@ -45,6 +48,9 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        blacklist:
+          tags:
+          - MechReactor
   - type: StartingMindRole
     mindRole: "MindRoleSiliconBrain"
     silent: true
@@ -70,6 +76,9 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHigh
+        blacklist:
+          tags:
+          - MechReactor
   - type: RandomMetadata
     nameSegments: [NamesBorg]
 
@@ -107,6 +116,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHigh
+          blacklist:
+            tags:
+            - MechReactor
           
 - type: entity 
   parent: PlayerXenoBorgHeavyDerelict
@@ -145,6 +157,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHigh
+          blacklist:
+            tags:
+            - MechReactor
 
 - type: entity
   parent: PlayerXenoBorgEngiDerelict
@@ -180,6 +195,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHigh
+          blacklist:
+            tags:
+            - MechReactor
 
 - type: entity
   parent: PlayerXenoborgScoutDerelict
@@ -218,6 +236,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellHigh
+          blacklist:
+            tags:
+            - MechReactor
 
 - type: entity
   parent: PlayerXenoborgStealthDerelict
@@ -254,6 +275,9 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHyper
+        blacklist:
+          tags:
+          - MechReactor
 
 - type: entity
   parent: PlayerBorgChassisTSFBattery

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/ecronizer.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/ecronizer.yml
@@ -25,6 +25,9 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        blacklist:
+          tags:
+          - MechReactor
   - type: Appearance
   - type: StaticPrice
     price: 2000

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/translators.yml
@@ -18,6 +18,9 @@
         cell_slot:
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellMedium
+          blacklist:
+            tags:
+            - MechReactor
     - type: Sprite
       sprite: _Starlight/Objects/Devices/translator.rsi
       state: icon

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Cargo/cyborg.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Cargo/cyborg.yml
@@ -58,6 +58,9 @@
           startingItem: PowerCellMicroreactor
           disableEject: true
           swap: false
+          blacklist:
+            tags:
+            - MechReactor
     - type: Sprite
       sprite: _Starlight/Objects/Specific/Cargo/borg_clamp.rsi
       layers:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_brigmedic_crew_monitor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_brigmedic_crew_monitor.yml
@@ -64,3 +64,6 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        blacklist:
+          tags:
+          - MechReactor

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
@@ -65,3 +65,6 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
+        blacklist:
+          tags:
+          - MechReactor

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
@@ -1118,6 +1118,9 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        blacklist:
+          tags:
+          - MechReactor
   - type: HoloItem
     itemPrototype: HandcuffsHolographic
     chargeUse: 90

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
@@ -653,6 +653,9 @@
           whitelist:
             components:
               - PowerCell
+          blacklist:
+            tags:
+            - MechReactor
             requireAll: true
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellTinyCyber
@@ -713,6 +716,9 @@
           whitelist:
             components:
               - PowerCell
+          blacklist:
+            tags:
+            - MechReactor
             requireAll: true
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellMedium

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/cyberlimb.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/cyberlimb.yml
@@ -138,6 +138,9 @@
           whitelist:
             components:
               - PowerCell
+          blacklist:
+            tags:
+            - MechReactor
             requireAll: true
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellMedium
@@ -229,6 +232,9 @@
           whitelist:
             components:
               - PowerCell
+          blacklist:
+            tags:
+            - MechReactor
             requireAll: true
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellMedium

--- a/Resources/Prototypes/_Starlight/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/base_item.yml
@@ -16,6 +16,9 @@
               - PowerCellTiny
             components:
               - PowerCell
+          blacklist:
+            tags:
+            - MechReactor
             requireAll: true
           name: power-cell-slot-component-slot-name-default
           startingItem: PowerCellTiny

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Plumbing/plumbing_machines.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Plumbing/plumbing_machines.yml
@@ -777,6 +777,9 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+        blacklist:
+          tags:
+          - MechReactor
   - type: ContainerContainer
     containers:
       cell_slot: !type:ContainerSlot


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds blacklists for mechreactors where needed

## Why we need to add this
Apparently, just adding tag blacklists to base items isn't enough, and cell slots are not natively filtered for some reason - so this is necessary for reactors to not fit into, well, everything. >_<
Seriously considering just making the reactors their own comp instead, but at the same time, I want to keep the cross-functionality with regular power cells and that would take extra work - so for now, to stop people from putting these into *everything*... blacklists in bulk. <.< 

## Media (Video/Screenshots)
<img width="369" height="482" alt="image" src="https://github.com/user-attachments/assets/ac0a3902-8a22-4993-a1ed-794b9ed7b800" />

Mech reactor no longer fits into borgs and other items with power cell slots

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Mech Reactors should only fit into mechs now, as was intended.
