### PR TITLE
Adds the soviet SOFT SUIT to the USSP rift.

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/soviet_armaments_crate.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/soviet_armaments_crate.yml
@@ -36,6 +36,8 @@
           weight: 1
         - id: ClothingOuterArmorSovietPlate
           weight: 3
+        - id: ClothingBackpackDuffelSovietEVABundle
+          weight: 7
         - id: WeaponShotgunToz106Extended
           weight: 6
         - id: SpearSteel


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adding the USSP softsuit to the USSP rift

## Why we need to add this
Its barely if at all used. and commies have a hard time of getting space protection.

## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: Scarlet Lightweaver
- add: Added the soviet soft suit to the USSP rift.