### PR TITLE
Fix Atmosian Armor craft

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -119,6 +119,7 @@
     slots: WITHOUT_POCKET
   - type: Tag
     tags:
+    - AtmosFireSuit
     - CorgiWearable
     - WhitelistChameleon
   - type: HideLayerClothing


### PR DESCRIPTION
## Short description
Fixes the crafting of atmosian armor due to the missing tag which made it so the atmos fire suit was unusable in the crafting of the armor.

## Why we need to add this
Currently the crafting of the armor is bugged and it is therefore unobtainable

## Media (Video/Screenshots)

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: DjBoom
- fix: Fixed the crafting of Atmosian Armor.
