### PR TITLE
fix: Lowercase analog clock wallmount name

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -371,7 +371,7 @@
 - type: entity
   parent: PosterBase
   id: PosterLegitClock
-  name: "Clock"
+  name: "clock"
   description: "A wall mounted analog clock. It's so retro, you can't even read it."
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Change the name of the wall-mounted analog clock to lowercase

## Why we need to add this
To be consistent with other items. I see that the analog clock is technically a poster, and posters are title case, but the clock specifically doesn't look like one in-game and clocks generally aren't considered posters on a conceptual level \[citation needed\]. It just seemed a bit jarring to me when I saw it and I wanted to submit a quick proofread.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.