### PR TITLE
fix: Shorten "A chart for eye exams" to "Eye chart"

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -21,7 +21,7 @@
 - type: entity
   parent: PosterBase
   id: PosterLegitEyeChart
-  name: "A chart for eye exams"
+  name: "Eye chart"
   description: "Is that third letter a P or an F?"
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Shortens "A chart for eye exams" to the snappier "Eye chart"

## Why we need to add this
I think it just sounds a bit nicer that way.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- tweak: Changed name of "A chart for eye exams" to shorter version: "Eye chart".