### PR TITLE
The pAI update

### DIFF
--- a/Content.Server/PAI/PAISystem.cs
+++ b/Content.Server/PAI/PAISystem.cs
@@ -9,21 +9,17 @@ using Content.Shared.Popups;
 using Content.Shared.Instruments;
 using Robust.Shared.Random;
 using System.Text;
-using Robust.Server.Containers; //Starlight pAI can open PDAs, see PR #3272
-using Content.Shared.PDA; //Starlight pAI can open PDAs, see PR #3272
-using Robust.Shared.Player; //Starlight pAI can open PDAs, see PR #3272
+
 
 namespace Content.Server.PAI;
 
-public sealed class PAISystem : EntitySystem
+public sealed partial class PAISystem : EntitySystem
 {
     [Dependency] private readonly InstrumentSystem _instrumentSystem = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly ToggleableGhostRoleSystem _toggleableGhostRole = default!;
-    [Dependency] private readonly ContainerSystem _containerSystem = default!; //Starlight pAI can open PDAs, see PR #3272
-    [Dependency] private readonly SharedUserInterfaceSystem _userInterface = default!; //Starlight pAI can open PDAs, see PR #3272
 
     /// <summary>
     /// Possible symbols that can be part of a scrambled pai's name.
@@ -38,7 +34,8 @@ public sealed class PAISystem : EntitySystem
         SubscribeLocalEvent<PAIComponent, MindAddedMessage>(OnMindAdded);
         SubscribeLocalEvent<PAIComponent, MindRemovedMessage>(OnMindRemoved);
         SubscribeLocalEvent<PAIComponent, BeingMicrowavedEvent>(OnMicrowaved);
-        SubscribeLocalEvent<PAIComponent, PAIPDAActionEvent>(OnOpenPda); //Starlight pAI can open PDAs, see PR #3272
+
+        InitializePAISlotting(); // Starlight-edit: PAI's can be slotted into PDAs and computer consoles and use them.
     }
 
     private void OnUseInHand(EntityUid uid, PAIComponent component, UseInHandEvent args)
@@ -125,22 +122,4 @@ public sealed class PAISystem : EntitySystem
                 _metaData.SetEntityName(uid, proto.Name);
         }
     }
-
-    #region Starlight
-    private void OnOpenPda(Entity<PAIComponent> ent, ref PAIPDAActionEvent args)
-    {
-        bool inAContainer = _containerSystem.TryGetContainingContainer(ent.Owner, out var container);
-        if (!inAContainer || container == null) { return; }
-
-        bool containerHasPdaComponent = TryComp<PdaComponent>(container.Owner, out _);
-        bool containerHasUserInterfaceComponent = TryComp<UserInterfaceComponent>(container.Owner, out var ui_comp);
-        bool paiComponentHasPlayerActor = TryComp<ActorComponent>(ent.Owner, out var actor);
-        bool insideValidPda = inAContainer && containerHasPdaComponent && containerHasUserInterfaceComponent && paiComponentHasPlayerActor;
-        if (!insideValidPda || ui_comp == null || actor == null) { return; }
-
-        bool openPdaUiSuccess = _userInterface.TryToggleUi((container.Owner, ui_comp), PdaUiKey.Key, actor.PlayerSession);
-        if (!openPdaUiSuccess) { return; }
-        // Success.
-    }
-    #endregion
 }

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -175,11 +175,13 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
 
     private bool TryPilot(EntityUid user, EntityUid uid)
     {
+        var canUseConsole = _blocker.CanInteract(user, uid) || IsSlottedPAI(user, uid); // Starlight-edit: PAI's can be slotted into consoles, including shuttle consoles.
+
         if (!_tags.HasTag(user, CanPilotTag) ||
             !TryComp<ShuttleConsoleComponent>(uid, out var component) ||
             !this.IsPowered(uid, EntityManager) ||
             !Transform(uid).Anchored ||
-            !_blocker.CanInteract(user, uid))
+            !canUseConsole)
         {
             return false;
         }
@@ -301,7 +303,9 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
             if (comp.Console == null)
                 continue;
 
-            if (!_blocker.CanInteract(uid, comp.Console))
+            var canUseConsole = _blocker.CanInteract(uid, comp.Console.Value) || IsSlottedPAI(uid, comp.Console.Value); // Starlight-edit: PAI's can be slotted into consoles, including shuttle consoles.
+
+            if (!canUseConsole)
             {
                 toRemove.Add((uid, comp));
             }

--- a/Content.Server/_Starlight/PAI/PAISystem.Slotting.cs
+++ b/Content.Server/_Starlight/PAI/PAISystem.Slotting.cs
@@ -1,0 +1,100 @@
+using Content.Shared.Interaction.Events;
+using Content.Shared.PAI;
+using Content.Shared.PDA;
+using Content.Shared.UserInterface;
+using Robust.Server.Containers;
+using Robust.Server.GameObjects;
+using Robust.Shared.Player;
+
+namespace Content.Server.PAI;
+
+public sealed partial class PAISystem
+{
+    [Dependency] private readonly ContainerSystem _containerSystem = default!;
+    [Dependency] private readonly SharedUserInterfaceSystem _userInterface = default!;
+
+    private const string PaiConsoleSlotId = "pai_slot";
+
+    private void InitializePAISlotting()
+    {
+        SubscribeLocalEvent<PAIComponent, PAIPDAActionEvent>(OnOpenPda);
+        SubscribeLocalEvent<PAIComponent, PAIConsoleActionEvent>(OnOpenConsole);
+    }
+
+    private void OnOpenPda(Entity<PAIComponent> ent, ref PAIPDAActionEvent args)
+    {
+        if (!_containerSystem.TryGetContainingContainer(ent.Owner, out var container) || container == null)
+            return;
+
+        if (container.ID != PdaComponent.PdaPaiSlotId || !HasComp<PdaComponent>(container.Owner))
+            return;
+
+        _userInterface.TryToggleUi(container.Owner, PdaUiKey.Key, ent.Owner);
+    }
+
+    private void OnOpenConsole(Entity<PAIComponent> ent, ref PAIConsoleActionEvent args)
+    {
+        if (!_containerSystem.TryGetContainingContainer(ent.Owner, out var container) || container == null)
+            return;
+
+        if (container.ID != PaiConsoleSlotId ||
+            !TryComp<ActivatableUIComponent>(container.Owner, out var activatableUi) ||
+            !TryComp<UserInterfaceComponent>(container.Owner, out var uiComp) ||
+            !TryComp<ActorComponent>(ent.Owner, out var actor) ||
+            activatableUi.Key == null)
+        {
+            return;
+        }
+
+        var wasOpen = _userInterface.IsUiOpen(container.Owner, activatableUi.Key, ent.Owner);
+
+        if (!wasOpen)
+        {
+            if (activatableUi.SingleUser && activatableUi.CurrentSingleUser != null && ent.Owner != activatableUi.CurrentSingleUser)
+            {
+                var message = Loc.GetString("machine-already-in-use", ("machine", container.Owner));
+                _popup.PopupClient(message, container.Owner, ent.Owner);
+                return;
+            }
+
+            var userAttempt = new UserOpenActivatableUIAttemptEvent(ent.Owner, container.Owner, false);
+            RaiseLocalEvent(ent.Owner, userAttempt);
+            if (userAttempt.Cancelled)
+                return;
+
+            var openAttempt = new ActivatableUIOpenAttemptEvent(ent.Owner, false);
+            RaiseLocalEvent(container.Owner, openAttempt);
+            if (openAttempt.Cancelled)
+                return;
+
+            RaiseLocalEvent(container.Owner, new BeforeActivatableUIOpenEvent(ent.Owner));
+
+            if (activatableUi.SingleUser)
+            {
+                activatableUi.CurrentSingleUser = ent.Owner;
+                Dirty(container.Owner, activatableUi);
+                RaiseLocalEvent(container.Owner, new ActivatableUIPlayerChangedEvent());
+            }
+        }
+
+        if (!_userInterface.TryToggleUi((container.Owner, uiComp), activatableUi.Key, actor.PlayerSession))
+            return;
+
+        if (wasOpen)
+            return;
+
+        if (!_userInterface.IsUiOpen(container.Owner, activatableUi.Key, ent.Owner))
+        {
+            if (activatableUi.SingleUser && activatableUi.CurrentSingleUser == ent.Owner)
+            {
+                activatableUi.CurrentSingleUser = null;
+                Dirty(container.Owner, activatableUi);
+                RaiseLocalEvent(container.Owner, new ActivatableUIPlayerChangedEvent());
+            }
+
+            return;
+        }
+
+        RaiseLocalEvent(container.Owner, new AfterActivatableUIOpenEvent(ent.Owner));
+    }
+}

--- a/Content.Server/_Starlight/Physics/MoverController.cs
+++ b/Content.Server/_Starlight/Physics/MoverController.cs
@@ -46,7 +46,7 @@ public sealed class SLMoverController : SharedMoverController
 
     private HandleMobMovementJob _handleMobMovementJob; 
 
-    private Dictionary<EntityUid, (ShuttleComponent, List<(EntityUid, PilotComponent, InputMoverComponent, TransformComponent)>)> _shuttlePilots = new();
+    private Dictionary<EntityUid, (ShuttleComponent, List<(EntityUid, PilotComponent, TransformComponent)>)> _shuttlePilots = new();
 
     public override void Initialize()
     {
@@ -488,12 +488,12 @@ public sealed class SLMoverController : SharedMoverController
 
     private void HandleShuttleMovement(float frameTime)
     {
-        var newPilots = new Dictionary<EntityUid, (ShuttleComponent Shuttle, List<(EntityUid PilotUid, PilotComponent Pilot, InputMoverComponent Mover, TransformComponent ConsoleXform)>)>();
+        var newPilots = new Dictionary<EntityUid, (ShuttleComponent Shuttle, List<(EntityUid PilotUid, PilotComponent Pilot, TransformComponent ConsoleXform)>)>();
 
         // We just mark off their movement and the shuttle itself does its own movement
-        var activePilotQuery = EntityQueryEnumerator<PilotComponent, InputMoverComponent>();
+        var activePilotQuery = EntityQueryEnumerator<PilotComponent>();
         var shuttleQuery = GetEntityQuery<ShuttleComponent>();
-        while (activePilotQuery.MoveNext(out var uid, out var pilot, out var mover))
+        while (activePilotQuery.MoveNext(out var uid, out var pilot))
         {
             var consoleEnt = pilot.Console;
 
@@ -514,11 +514,11 @@ public sealed class SLMoverController : SharedMoverController
 
             if (!newPilots.TryGetValue(gridId!.Value, out var pilots))
             {
-                pilots = (shuttleComponent, new List<(EntityUid, PilotComponent, InputMoverComponent, TransformComponent)>());
+                pilots = (shuttleComponent, new List<(EntityUid, PilotComponent, TransformComponent)>());
                 newPilots[gridId.Value] = pilots;
             }
 
-            pilots.Item2.Add((uid, pilot, mover, xform));
+            pilots.Item2.Add((uid, pilot, xform));
         }
 
         // Reset inputs for non-piloted shuttles.
@@ -550,7 +550,7 @@ public sealed class SLMoverController : SharedMoverController
             var brakeCount = 0;
             var angularCount = 0;
 
-            foreach (var (pilotUid, pilot, _, consoleXform) in pilots)
+            foreach (var (pilotUid, pilot, consoleXform) in pilots)
             {
                 var (strafe, rotation, brakes) = GetPilotVelocityInput(pilot);
 

--- a/Content.Server/_Starlight/Shuttles/Systems/ShuttleConsoleSystem.PAI.cs
+++ b/Content.Server/_Starlight/Shuttles/Systems/ShuttleConsoleSystem.PAI.cs
@@ -1,0 +1,16 @@
+using Robust.Server.Containers;
+
+namespace Content.Server.Shuttles.Systems;
+
+public sealed partial class ShuttleConsoleSystem
+{
+    [Dependency] private readonly ContainerSystem _containerSystem = default!;
+
+    private bool IsSlottedPAI(EntityUid user, EntityUid console)
+    {
+        return _containerSystem.TryGetContainingContainer(user, out var container) &&
+               container != null &&
+               container.Owner == console &&
+               container.ID == "pai_slot";
+    }
+}

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -165,7 +165,10 @@ namespace Content.Shared.Interaction
         private void OnBoundInterfaceInteractAttempt(Entity<UserInterfaceComponent> ent, ref BoundUserInterfaceMessageAttempt ev)
         {
             _uiQuery.TryComp(ev.Target, out var aUiComp);
-            if (!_actionBlockerSystem.CanInteract(ev.Actor, ev.Target))
+
+            var slottedPAI = IsSlottedPAI(ev.Actor, ev.Target);  // Starlight-edit: PAI's can be slotted into and use console BUIs.
+
+            if (!_actionBlockerSystem.CanInteract(ev.Actor, ev.Target) && !slottedPAI) // Starlight-edit: PAI's can be slotted into and use console BUIs.
             {
                 // We permit ghosts to open uis unless explicitly blocked
                 if (ev.Message is not OpenBoundInterfaceMessage
@@ -197,7 +200,7 @@ namespace Content.Shared.Interaction
                 return;
             }
 
-            if (aUiComp.RequiresComplex && !_actionBlockerSystem.CanComplexInteract(ev.Actor))
+            if (aUiComp.RequiresComplex && !_actionBlockerSystem.CanComplexInteract(ev.Actor) && !slottedPAI)
                 ev.Cancel();
         }
 

--- a/Content.Shared/_Starlight/Interaction/SharedInteractionSystem.PAI.cs
+++ b/Content.Shared/_Starlight/Interaction/SharedInteractionSystem.PAI.cs
@@ -1,0 +1,15 @@
+using Content.Shared.PAI;
+
+namespace Content.Shared.Interaction;
+
+public abstract partial class SharedInteractionSystem
+{
+    private bool IsSlottedPAI(EntityUid actor, EntityUid target)
+    {
+        return HasComp<PAIComponent>(actor) &&
+               _containerSystem.TryGetContainingContainer(actor, out var container) &&
+               container != null &&
+               container.Owner == target &&
+               container.ID == "pai_slot";
+    }
+}

--- a/Content.Shared/_Starlight/PAI/PAIComponent.cs
+++ b/Content.Shared/_Starlight/PAI/PAIComponent.cs
@@ -5,3 +5,7 @@ namespace Content.Shared.PAI;
 public sealed partial class PAIPDAActionEvent : InstantActionEvent
 {
 }
+
+public sealed partial class PAIConsoleActionEvent : InstantActionEvent
+{
+}

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -70,6 +70,7 @@
     actions:
     - ActionPAIOpenShop
     - ActionPAIPDA #Starlight pAI can open PDAs, see PR #3272
+    - ActionPAIConsole #Starlight pAI can open consoles
   - type: Store
     name: store-preset-name-pai #Starlight name change for data purity
     categories:
@@ -114,8 +115,10 @@
     tags:
     - SiliconEmotes
   # Starlight Start
+    - CanPilot
   - type: Blindable
   - type: ParentCanBlockVision
+  - type: ContentEye
   # Starlight End
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
@@ -37,6 +37,14 @@
   - type: EdgeConnection
     connectionKey: computers
     allowedDirections: East, West
+  - type: ItemSlots
+    slots:
+      pai_slot:
+        name: Personal AI Device
+        ejectOnInteract: true
+        whitelist:
+          components:
+          - PAI
   # Starlight End
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -155,6 +155,14 @@
         whitelist:
           components:
           - ShuttleDestinationCoordinates
+      # Starlight-start: added PAI slot to shuttle console.
+      pai_slot:
+        name: Personal AI Device
+        ejectOnInteract: true
+        whitelist:
+          components:
+          - PAI
+      # Starlight-end
   - type: ContainerContainer
     containers:
       board: !type:Container

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -103,6 +103,14 @@
           - Bottle
           - PillCanister
           - PatchPack # Starlight-edit
+      # Starlight-start: for PAI slotting
+      pai_slot:
+        name: Personal AI Device
+        ejectOnInteract: true
+        whitelist:
+          components:
+          - PAI
+      # Starlight-end
   - type: SolutionContainerManager
     solutions:
       buffer:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Fun/pai.yml
@@ -13,6 +13,18 @@
       event: !type:PAIPDAActionEvent
 
 - type: entity
+  parent: BaseMentalAction
+  id: ActionPAIConsole
+  name: Access Console
+  description: Opens the console UI if you are slotted in one.
+  components:
+  - type: Action
+    icon: { sprite: Structures/Machines/computers.rsi, state: avionics-systems }
+    itemIconStyle: NoItem
+  - type: InstantAction
+    event: !type:PAIConsoleActionEvent
+    
+- type: entity
   parent: EncryptionKeySyndie
   id: EncryptionKeySyndiePAI
   components:


### PR DESCRIPTION


## Short description
<!-- What do you propose to change with your PR? -->
Adds the ability to slot personal ai into consoles and for them to use those consoles only while slotted. Also changes how slotted pais open UIs from how they did before with PDAs with a new PAIsystem.slotting.cs that now contains the logic for that. Additionally adds contenteye component so pai cameras can lock to a grid instead of spin wildly when on shuttles.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Expands gameplay options for personal ai while still keeping them limited. (a single computer they need to be physically slotted in like a pda) Also the contenteye component is a quality of life tweak for pai belonging to salvage or cargo.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/c18805d7-9e29-4f9c-b9fb-72a1ac43477b

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: katte, FeralCreature
- add: Consoles now have slots for pAI.
- add: pAI can now open consoles they're in.
- tweak: pAI camera snaps to grids now.

