### PR TITLE
Reverts [#3682] Tweak the price of Mechs for Lone Operatives. 

### DIFF
--- a/Resources/Prototypes/_Starlight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/uplink_catalog.yml
@@ -912,7 +912,7 @@
   icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: darkgygax }
   productEntity: CrateCybersunDarkGygaxBundle
   cost:
-    Telecrystal: 40
+    Telecrystal: 30
   categories:
     - UplinkAllies
   conditions:
@@ -928,7 +928,7 @@
   icon: { sprite: /Textures/Objects/Specific/Mech/mecha.rsi, state: mauler }
   productEntity: CrateCybersunMaulerBundle
   cost:
-    Telecrystal: 65 # Butcher Renault and its all yours.
+    Telecrystal: 45
   categories:
     - UplinkAllies
   conditions:


### PR DESCRIPTION
## Short description
This is a revert of the PR that changed the prices to disable the purchasing of a Mauler without attempting to take TC from the stations pets, thieves, or other traitors. This PR also increased the Gygax from 30TC to 40TC.

https://github.com/ss14Starlight/space-station-14/pull/3682

## Why we need to add this
Currently, the attitude of the original PR author was a Beta shift with my mauler that managed to succeed in detonating the nuke. This PR completely guts the chance for operatives to try out the mauler as there is no way you are gutting a pet without spending a single TC.

Further balancing and discussion should have been done before that original PR was made and merged rather than it originally being a complete removal of mechs altogether from loneops. 

Currently, as a Lone Operative you have no fallback to heal the mech. Anyone stalking you from a distance can slowly manage to wittle you down enough that forces you outside of the mech. These mechs are still repairable, so the crew is able to repair and use them against you if you are forced away from your broken mech. With the new mech changes with reactors, it should at least be tested first to see if either the Gygax or Mauler should used more than 50% and 75% of your TC. Currently the purchase of a Mauler lets you buy one set of armour, and a small melee weapon or pistol. 

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl:
- tweak: The Dark Gygax has had it's price reverted to 30 TC for Lone Operatives.
- tweak: The Mauler has had it's price reverted to 45 TC for Lone Operatives.
