### PR TITLE
All At Once Upkeep 2 + Almost All at Once in Live

### DIFF
--- a/Resources/Locale/en-US/_Starlight/gamerules.ftl
+++ b/Resources/Locale/en-US/_Starlight/gamerules.ftl
@@ -15,3 +15,6 @@ vamptraitorling-description = What a horrible night to have a curse
 
 all-at-once-except-zombieteors-title = Almost All at Once
 all-at-once-except-zombieteors-description = It's almost just not your day...
+
+aller-at-once-except-zombieteors-title = Almost Aller at Once
+aller-at-once-except-zombieteors-description = You have fucked up now.

--- a/Resources/Prototypes/_Starlight/game_presets.yml
+++ b/Resources/Prototypes/_Starlight/game_presets.yml
@@ -68,8 +68,7 @@
     - Xenoborgs
     - BasicStationEventScheduler
     - BasicStationEventScheduler # Starlight, ShitStation
-    - MeteorSwarmMildScheduler
-    - MeteorSwarmScheduler
+    - MeteorSwarmScheduler # Meteor mild isn't included in almost aller because in theory the idea is to have a round last more than 10 minutes.
     - RampingStationEventScheduler
     - SpaceTrafficControlEventScheduler
     - SpaceTrafficControlFriendlyEventScheduler
@@ -85,6 +84,7 @@
     - CockroachMigration # Starlight, ShitStation
     - MouseMigration # Starlight, ShitStation
     - SLChangeling # Starlight
+    - Vampire #Starlight
     - SiliconLiberation #Starlight
     - Brighteye #Starlight
     - ThiefGamerule # Starlight, Event Light

--- a/Resources/Prototypes/_Starlight/game_presets.yml
+++ b/Resources/Prototypes/_Starlight/game_presets.yml
@@ -28,7 +28,7 @@
   - allnt
   - allexceptroundenders
   name: all-at-once-except-zombieteors-title
-  minPlayers: 15 # Starlight, for Delta
+  minPlayers: 60
   description: all-at-once-except-zombieteors-description
   showInVote: false
   rules:
@@ -49,3 +49,45 @@
     - Brighteye #Starlight
     - ThiefGamerule # Starlight, Event Light
 
+- type: gamePreset
+  id: AlmostAllerAtOnce
+  alias:
+  - almostallall
+  - allernt
+  - almostbadidea
+  - smallerpunishment
+  name: aller-at-once-except-zombieteors-title
+  description: aller-at-once-except-zombieteors-description
+  showInVote: false #Please god dont do this
+  minPlayers: 60
+  rules:
+    - Nukeops
+    - Traitor
+    - Revolutionary
+    - Wizard
+    - Xenoborgs
+    - BasicStationEventScheduler
+    - BasicStationEventScheduler # Starlight, ShitStation
+    - MeteorSwarmMildScheduler
+    - MeteorSwarmScheduler
+    - RampingStationEventScheduler
+    - SpaceTrafficControlEventScheduler
+    - SpaceTrafficControlFriendlyEventScheduler
+    - BasicRoundstartVariation
+    - BasicRoundstartVariation # Starlight, ShitStation
+    - BasicRoundstartVariation # Starlight, ShitStation
+    - BasicRoundstartVariation # Starlight, ShitStation
+    - BasicRoundstartVariation # Starlight, ShitStation
+    - DerelictGenericCyborgSpawn # Starlight, ShitStation
+    - DerelictGenericCyborgSpawn # Starlight, ShitStation
+    - IonStorm # Starlight, ShitStation
+    - IonStorm # Starlight, ShitStation
+    - CockroachMigration # Starlight, ShitStation
+    - MouseMigration # Starlight, ShitStation
+    - SLChangeling # Starlight
+    - SiliconLiberation #Starlight
+    - Brighteye #Starlight
+    - ThiefGamerule # Starlight, Event Light
+    - LoneOpsSpawn # Starlight
+    - RailroadingTerminator # Starlight
+    - RailroadingMinor # Starlight

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -95,6 +95,7 @@
     - CockroachMigration # Starlight, ShitStation
     - MouseMigration # Starlight, ShitStation
     - SLChangeling # Starlight
+    - Vampire #Starlight
     - SiliconLiberation #Starlight
     - Brighteye #Starlight
     - ThiefGamerule # Starlight, Event Light

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -34,7 +34,7 @@
   alias:
   - all
   name: all-at-once-title
-  minPlayers: 40
+  minPlayers: 50 # Starlight
   description: all-at-once-description
   showInVote: false
   rules:
@@ -67,7 +67,7 @@
   name: aller-at-once-title
   description: aller-at-once-description
   showInVote: false #Please god dont do this
-  minPlayers: 40
+  minPlayers: 50 # Starlight
   rules:
     - Nukeops
     - Traitor

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -34,7 +34,7 @@
   alias:
   - all
   name: all-at-once-title
-  minPlayers: 15 # Starlight, for Delta
+  minPlayers: 40
   description: all-at-once-description
   showInVote: false
   rules:
@@ -67,7 +67,7 @@
   name: aller-at-once-title
   description: aller-at-once-description
   showInVote: false #Please god dont do this
-  minPlayers: 15 # Starlight, for Delta
+  minPlayers: 40
   rules:
     - Nukeops
     - Traitor
@@ -98,6 +98,7 @@
     - SiliconLiberation #Starlight
     - Brighteye #Starlight
     - ThiefGamerule # Starlight, Event Light
+    - LoneOpsSpawn # Starlight
     - RailroadingTerminator # Starlight
     - RailroadingMinor # Starlight
 

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,20 +2,21 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Nukeops: 0.11 # SL
+    Nukeops: 0.105 # SL
     Traitor: 0.22 # SL
     Zombie: 0.10 # SL
     Changeling: 0.05 #SL
     Zombieteors: 0.01 # SL
     Survival: 0.11 # SL
     KesslerSyndrome: 0.01 # SL
-    Revolutionary: 0.11 # SL
+    Revolutionary: 0.105 # SL
     Vampire: 0.05 #SL
     Wizard: 0.04 # SL
     Traitorling: 0.06 #SL
     ShitStation: 0.05 #SL
     Xenoborgs: 0.05 #SL
     Vamptraitorling: 0.03 #SL
+    AlmostAllAtOnce: 0.01 #SL
 
 # Starlight - Beta's Secret Pool
 - type: weightedRandom


### PR DESCRIPTION
## Short description
Updates All/Aller at once again, adds a new variant of Aller, and adds Almost All to Alpha.

## Why we need to add this
All/Aller in theory can't spawn at 40 because Vampire/Zombie requires 50, so this boosts them up to 50.

Adds Almost Aller at Once; it's Aller At Once without Zombies/Kessler. This is not in rotation.

Adds LoneOpsSpawn and Vampire to Aller/Almost Aller at Once.

Adds Almost All at Once (All at Once minus Zombieteors) to Alpha's secret at a 1% rate, removing 0.5% from Nukies and Revs. It's a chaotic round, but without the zombieteors, it might actually *be* a round.


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: Adds a new gamemode, Almost Aller at Once. It's Aller at Once without Zombies/Kessler. Admin only.
- add: Adds Almost All at Once (All at Once minus Zombies and Kessler) to Alpha's Secret Pool at a 1% chance. It requires 60pop.
- tweak: Alpha Secret NukeOps/Revolutionary chance -0.5%.
- tweak: LoneOps and Vampires will now show up in Aller/Almost Aller at Once. Enjoy.
- fix: Changed All/Aller's min players to 50 (not Almost All/Aller), since Vampires and Zombies require 50 players.

