### PR TITLE
CBURN Shuttle item placement tweaks

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/CC-NT/CBURN_Q.yml
+++ b/Resources/Maps/_Starlight/Shuttles/CC-NT/CBURN_Q.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 264.0.0
-  forkId: Starlight
-  forkVersion: 1732131340
-  time: 08/13/2025 22:31:30
-  entityCount: 1370
+  engineVersion: 272.0.0
+  forkId: ""
+  forkVersion: ""
+  time: 03/14/2026 13:22:53
+  entityCount: 1383
 maps: []
 grids:
 - 1
@@ -661,16 +661,19 @@ entities:
             0: 30583
           3,-1:
             0: 30446
+          3,1:
+            1: 8
           4,0:
             1: 4369
           4,1:
             1: 1
           -2,0:
             1: 49681
-            0: 192
+            2: 192
           -2,-1:
             1: 4369
-            0: 49356
+            3: 49152
+            0: 204
           -1,-1:
             0: 57599
           0,-4:
@@ -712,16 +715,17 @@ entities:
             0: 26487
           3,-5:
             0: 30576
+            1: 8
           4,-4:
-            1: 17
+            1: 49
             0: 61440
           4,-3:
-            0: 29683
+            0: 29687
           4,-2:
             0: 62327
           4,-1:
-            0: 243
-            1: 4096
+            0: 247
+            1: 12288
           -2,-4:
             1: 4369
             0: 49356
@@ -743,36 +747,24 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-          - 21.824879
-          - 82.10312
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
         - volume: 2500
           immutable: True
+          moles: {}
+        - volume: 2500
+          temperature: 293.15
           moles:
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
+            Nitrogen: 6666.982
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 6666.982
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: NavMap
+    - type: ExplosionAirtightGrid
 - proto: ActionToggleInternals
   entities:
   - uid: 4
@@ -874,7 +866,7 @@ entities:
       pos: 19.5,-10.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -27449.836
+      secondsUntilStateChange: -28030.514
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -926,53 +918,71 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 33
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-15.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 34
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 35
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 36
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-9.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 37
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 38
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-9.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 39
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-13.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 40
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-1.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: AtmosDeviceFanDirectional
   entities:
   - uid: 41
@@ -1001,31 +1011,31 @@ entities:
       parent: 1
 - proto: AtmosFixNitrogenMarker
   entities:
-  - uid: 1367
+  - uid: 45
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 1
-  - uid: 1368
+  - uid: 46
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
 - proto: AtmosFixOxygenMarker
   entities:
-  - uid: 1369
+  - uid: 47
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 1
-  - uid: 1370
+  - uid: 48
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
 - proto: BackgammonBoard
   entities:
-  - uid: 45
+  - uid: 49
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1033,81 +1043,83 @@ entities:
       parent: 1
 - proto: BarSign
   entities:
-  - uid: 46
+  - uid: 50
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: BedsheetMedical
   entities:
-  - uid: 47
+  - uid: 51
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 1
-  - uid: 48
+  - uid: 52
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 49
+  - uid: 53
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 50
+  - uid: 54
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 1
-  - uid: 51
+  - uid: 55
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
-  - uid: 52
+  - uid: 56
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 53
+  - uid: 57
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
 - proto: BiomassReclaimer
   entities:
-  - uid: 54
+  - uid: 58
     components:
     - type: Transform
       pos: 14.5,-7.5
       parent: 1
-  - uid: 55
+  - uid: 59
     components:
     - type: Transform
       pos: 7.5,-7.5
       parent: 1
 - proto: BlastDoorOpen
   entities:
-  - uid: 56
+  - uid: 60
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-12.5
       parent: 1
-  - uid: 57
+  - uid: 61
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-11.5
       parent: 1
-  - uid: 58
+  - uid: 62
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-  - uid: 59
+  - uid: 63
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1115,42 +1127,42 @@ entities:
       parent: 1
 - proto: Bloodpack
   entities:
-  - uid: 60
+  - uid: 64
     components:
     - type: Transform
       pos: 8.700129,-0.29863083
       parent: 1
-  - uid: 61
+  - uid: 65
     components:
     - type: Transform
       pos: 8.278254,-0.26738083
       parent: 1
-  - uid: 62
+  - uid: 66
     components:
     - type: Transform
       pos: 8.606379,-0.51738083
       parent: 1
-  - uid: 63
+  - uid: 67
     components:
     - type: Transform
       pos: 8.318821,-0.59375
       parent: 1
 - proto: BookBartendersManual
   entities:
-  - uid: 64
+  - uid: 68
     components:
     - type: Transform
       pos: 5.659693,-15.206383
       parent: 1
 - proto: BoozeDispenser
   entities:
-  - uid: 65
+  - uid: 69
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-16.5
       parent: 1
-  - uid: 66
+  - uid: 70
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1158,117 +1170,62 @@ entities:
       parent: 1
 - proto: BorgCharger
   entities:
-  - uid: 67
+  - uid: 71
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 1
-  - uid: 68
+  - uid: 72
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 1
-- proto: BoxBeaker
-  entities:
-  - uid: 70
-    components:
-    - type: Transform
-      parent: 69
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 71
-    components:
-    - type: Transform
-      parent: 69
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: BoxBodyBag
   entities:
-  - uid: 79
+  - uid: 89
     components:
     - type: Transform
       pos: 7.6493506,-5.2510014
       parent: 1
-  - uid: 80
+  - uid: 90
     components:
     - type: Transform
       pos: 7.2274756,-5.4072514
       parent: 1
-  - uid: 81
+  - uid: 91
     components:
     - type: Transform
       pos: 7.7013416,-5.20638
       parent: 1
-  - uid: 82
+  - uid: 92
     components:
     - type: Transform
       pos: 7.3263416,-5.23763
       parent: 1
-  - uid: 83
+  - uid: 93
     components:
     - type: Transform
       pos: 7.7482166,-5.409505
       parent: 1
-  - uid: 84
+  - uid: 94
     components:
     - type: Transform
       pos: 7.3732166,-5.128255
       parent: 1
-  - uid: 85
+  - uid: 95
     components:
     - type: Transform
       pos: 7.6544666,-5.128255
       parent: 1
-  - uid: 86
+  - uid: 96
     components:
     - type: Transform
       pos: 7.2274756,-5.2822514
       parent: 1
-- proto: BoxBottle
-  entities:
-  - uid: 72
-    components:
-    - type: Transform
-      parent: 69
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: BoxPillCanister
-  entities:
-  - uid: 73
-    components:
-    - type: Transform
-      parent: 69
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: BoxShotgunIncendiary
   entities:
-  - uid: 88
-    components:
-    - type: Transform
-      parent: 87
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 89
-    components:
-    - type: Transform
-      parent: 87
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 90
-    components:
-    - type: Transform
-      parent: 87
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
   - uid: 98
     components:
     - type: Transform
@@ -1290,54 +1247,57 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: BoxSyringe
-  entities:
-  - uid: 74
+  - uid: 108
     components:
     - type: Transform
-      parent: 69
+      parent: 107
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: BoxVial
-  entities:
-  - uid: 75
+  - uid: 109
     components:
     - type: Transform
-      parent: 69
+      parent: 107
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 110
+    components:
+    - type: Transform
+      parent: 107
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: Brutepack
   entities:
-  - uid: 107
+  - uid: 117
     components:
     - type: Transform
       pos: 9.1525,-0.55354595
       parent: 1
-  - uid: 108
+  - uid: 118
     components:
     - type: Transform
       pos: 9.668125,-0.50667095
       parent: 1
-  - uid: 109
+  - uid: 119
     components:
     - type: Transform
       pos: 9.574375,-0.35042095
       parent: 1
-  - uid: 110
+  - uid: 120
     components:
     - type: Transform
       pos: 9.230625,-0.30354595
       parent: 1
 - proto: ButtonFrameCautionSecurity
   entities:
-  - uid: 111
+  - uid: 121
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 112
+  - uid: 122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1345,1563 +1305,1563 @@ entities:
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 113
+  - uid: 123
     components:
     - type: Transform
       pos: 16.5,0.5
       parent: 1
-  - uid: 114
+  - uid: 124
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 115
+  - uid: 125
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 116
+  - uid: 126
     components:
     - type: Transform
       pos: 16.5,2.5
       parent: 1
-  - uid: 117
+  - uid: 127
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 118
+  - uid: 128
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 119
+  - uid: 129
     components:
     - type: Transform
       pos: 16.5,3.5
       parent: 1
-  - uid: 120
+  - uid: 130
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 121
+  - uid: 131
     components:
     - type: Transform
       pos: 16.5,-0.5
       parent: 1
-  - uid: 122
+  - uid: 132
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
-  - uid: 123
+  - uid: 133
     components:
     - type: Transform
       pos: 16.5,4.5
       parent: 1
-  - uid: 124
+  - uid: 134
     components:
     - type: Transform
       pos: 16.5,1.5
       parent: 1
-  - uid: 125
+  - uid: 135
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 1
-  - uid: 126
+  - uid: 136
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 1
-  - uid: 127
+  - uid: 137
     components:
     - type: Transform
       pos: -2.5,-15.5
       parent: 1
-  - uid: 128
+  - uid: 138
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 1
-  - uid: 129
+  - uid: 139
     components:
     - type: Transform
       pos: -4.5,-15.5
       parent: 1
-  - uid: 130
+  - uid: 140
     components:
     - type: Transform
       pos: -5.5,-15.5
       parent: 1
-  - uid: 131
+  - uid: 141
     components:
     - type: Transform
       pos: -1.5,-15.5
       parent: 1
-  - uid: 132
+  - uid: 142
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
-  - uid: 133
+  - uid: 143
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 1
-  - uid: 134
+  - uid: 144
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 1
-  - uid: 135
+  - uid: 145
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 1
-  - uid: 136
+  - uid: 146
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
-  - uid: 137
+  - uid: 147
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 1
-  - uid: 138
+  - uid: 148
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
-  - uid: 139
+  - uid: 149
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 1
-  - uid: 140
+  - uid: 150
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
-  - uid: 141
+  - uid: 151
     components:
     - type: Transform
       pos: 14.5,-15.5
       parent: 1
-  - uid: 142
+  - uid: 152
     components:
     - type: Transform
       pos: 12.5,-15.5
       parent: 1
-  - uid: 143
+  - uid: 153
     components:
     - type: Transform
       pos: 11.5,-15.5
       parent: 1
-  - uid: 144
+  - uid: 154
     components:
     - type: Transform
       pos: 10.5,-15.5
       parent: 1
-  - uid: 145
+  - uid: 155
     components:
     - type: Transform
       pos: 9.5,-15.5
       parent: 1
-  - uid: 146
+  - uid: 156
     components:
     - type: Transform
       pos: 8.5,-15.5
       parent: 1
-  - uid: 147
+  - uid: 157
     components:
     - type: Transform
       pos: 7.5,-15.5
       parent: 1
-  - uid: 148
+  - uid: 158
     components:
     - type: Transform
       pos: 6.5,-15.5
       parent: 1
-  - uid: 149
+  - uid: 159
     components:
     - type: Transform
       pos: 13.5,-15.5
       parent: 1
-  - uid: 150
+  - uid: 160
     components:
     - type: Transform
       pos: 6.5,-16.5
       parent: 1
-  - uid: 151
+  - uid: 161
     components:
     - type: Transform
       pos: 6.5,-17.5
       parent: 1
-  - uid: 152
+  - uid: 162
     components:
     - type: Transform
       pos: 6.5,-18.5
       parent: 1
-  - uid: 153
+  - uid: 163
     components:
     - type: Transform
       pos: 13.5,-16.5
       parent: 1
-  - uid: 154
+  - uid: 164
     components:
     - type: Transform
       pos: 13.5,-17.5
       parent: 1
-  - uid: 155
+  - uid: 165
     components:
     - type: Transform
       pos: 13.5,-18.5
       parent: 1
-  - uid: 156
+  - uid: 166
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 1
-  - uid: 157
+  - uid: 167
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 158
+  - uid: 168
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 1
-  - uid: 159
+  - uid: 169
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 160
+  - uid: 170
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 161
+  - uid: 171
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
-  - uid: 162
+  - uid: 172
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 163
+  - uid: 173
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 164
+  - uid: 174
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 165
+  - uid: 175
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 166
+  - uid: 176
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 167
+  - uid: 177
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 168
+  - uid: 178
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 169
+  - uid: 179
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 1
-  - uid: 170
+  - uid: 180
     components:
     - type: Transform
       pos: 15.5,-0.5
       parent: 1
-  - uid: 171
+  - uid: 181
     components:
     - type: Transform
       pos: 14.5,-0.5
       parent: 1
-  - uid: 172
+  - uid: 182
     components:
     - type: Transform
       pos: 13.5,-0.5
       parent: 1
-  - uid: 173
+  - uid: 183
     components:
     - type: Transform
       pos: 12.5,-0.5
       parent: 1
-  - uid: 174
+  - uid: 184
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 1
-  - uid: 175
+  - uid: 185
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 1
-  - uid: 176
+  - uid: 186
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 1
-  - uid: 177
+  - uid: 187
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 1
-  - uid: 178
+  - uid: 188
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 1
-  - uid: 179
+  - uid: 189
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 1
-  - uid: 180
+  - uid: 190
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
-  - uid: 181
+  - uid: 191
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 1
-  - uid: 182
+  - uid: 192
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 1
-  - uid: 183
-    components:
-    - type: Transform
-      pos: 10.5,2.5
-      parent: 1
-  - uid: 184
-    components:
-    - type: Transform
-      pos: 10.5,2.5
-      parent: 1
-  - uid: 185
-    components:
-    - type: Transform
-      pos: 10.5,3.5
-      parent: 1
-  - uid: 186
-    components:
-    - type: Transform
-      pos: 7.5,0.5
-      parent: 1
-  - uid: 187
-    components:
-    - type: Transform
-      pos: 7.5,1.5
-      parent: 1
-  - uid: 188
-    components:
-    - type: Transform
-      pos: 7.5,2.5
-      parent: 1
-  - uid: 189
-    components:
-    - type: Transform
-      pos: 7.5,3.5
-      parent: 1
-  - uid: 190
-    components:
-    - type: Transform
-      pos: 7.5,-0.5
-      parent: 1
-  - uid: 191
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 1
-  - uid: 192
-    components:
-    - type: Transform
-      pos: 5.5,-0.5
-      parent: 1
   - uid: 193
     components:
     - type: Transform
-      pos: 18.5,-9.5
+      pos: 10.5,2.5
       parent: 1
   - uid: 194
     components:
     - type: Transform
-      pos: 17.5,-9.5
+      pos: 10.5,2.5
       parent: 1
   - uid: 195
     components:
     - type: Transform
-      pos: 1.5,-9.5
+      pos: 10.5,3.5
       parent: 1
   - uid: 196
     components:
     - type: Transform
-      pos: 17.5,-8.5
+      pos: 7.5,0.5
       parent: 1
   - uid: 197
     components:
     - type: Transform
-      pos: 17.5,-7.5
+      pos: 7.5,1.5
       parent: 1
   - uid: 198
     components:
     - type: Transform
-      pos: 17.5,-6.5
+      pos: 7.5,2.5
       parent: 1
   - uid: 199
     components:
     - type: Transform
-      pos: 17.5,-5.5
+      pos: 7.5,3.5
       parent: 1
   - uid: 200
     components:
     - type: Transform
-      pos: 17.5,-4.5
+      pos: 7.5,-0.5
       parent: 1
   - uid: 201
     components:
     - type: Transform
-      pos: 17.5,-3.5
+      pos: 6.5,-0.5
       parent: 1
   - uid: 202
     components:
     - type: Transform
-      pos: 17.5,-2.5
+      pos: 5.5,-0.5
       parent: 1
   - uid: 203
     components:
     - type: Transform
-      pos: 17.5,-10.5
+      pos: 18.5,-9.5
       parent: 1
   - uid: 204
     components:
     - type: Transform
-      pos: 17.5,-11.5
+      pos: 17.5,-9.5
       parent: 1
   - uid: 205
     components:
     - type: Transform
-      pos: 17.5,-12.5
+      pos: 1.5,-9.5
       parent: 1
   - uid: 206
     components:
     - type: Transform
-      pos: 0.5,-9.5
+      pos: 17.5,-8.5
       parent: 1
   - uid: 207
     components:
     - type: Transform
-      pos: -0.5,-9.5
+      pos: 17.5,-7.5
       parent: 1
   - uid: 208
     components:
     - type: Transform
-      pos: -0.5,-8.5
+      pos: 17.5,-6.5
       parent: 1
   - uid: 209
     components:
     - type: Transform
-      pos: -0.5,-7.5
+      pos: 17.5,-5.5
       parent: 1
   - uid: 210
     components:
     - type: Transform
-      pos: -0.5,-6.5
+      pos: 17.5,-4.5
       parent: 1
   - uid: 211
     components:
     - type: Transform
-      pos: -0.5,-5.5
+      pos: 17.5,-3.5
       parent: 1
   - uid: 212
     components:
     - type: Transform
-      pos: -0.5,-3.5
+      pos: 17.5,-2.5
       parent: 1
   - uid: 213
     components:
     - type: Transform
-      pos: -0.5,-4.5
+      pos: 17.5,-10.5
       parent: 1
   - uid: 214
     components:
     - type: Transform
-      pos: -1.5,-3.5
+      pos: 17.5,-11.5
       parent: 1
   - uid: 215
     components:
     - type: Transform
-      pos: -2.5,-3.5
+      pos: 17.5,-12.5
       parent: 1
   - uid: 216
     components:
     - type: Transform
-      pos: -3.5,-3.5
+      pos: 0.5,-9.5
       parent: 1
   - uid: 217
     components:
     - type: Transform
-      pos: -4.5,-3.5
+      pos: -0.5,-9.5
       parent: 1
   - uid: 218
     components:
     - type: Transform
-      pos: 0.5,-3.5
+      pos: -0.5,-8.5
       parent: 1
   - uid: 219
     components:
     - type: Transform
-      pos: 1.5,-3.5
+      pos: -0.5,-7.5
       parent: 1
   - uid: 220
     components:
     - type: Transform
-      pos: 2.5,-3.5
+      pos: -0.5,-6.5
       parent: 1
   - uid: 221
     components:
     - type: Transform
-      pos: -0.5,-10.5
+      pos: -0.5,-5.5
       parent: 1
   - uid: 222
     components:
     - type: Transform
-      pos: -0.5,-11.5
+      pos: -0.5,-3.5
       parent: 1
   - uid: 223
     components:
     - type: Transform
-      pos: -4.5,-11.5
+      pos: -0.5,-4.5
       parent: 1
   - uid: 224
     components:
     - type: Transform
-      pos: 0.5,-11.5
+      pos: -1.5,-3.5
       parent: 1
   - uid: 225
     components:
     - type: Transform
-      pos: 1.5,-11.5
+      pos: -2.5,-3.5
       parent: 1
   - uid: 226
     components:
     - type: Transform
-      pos: -3.5,-11.5
+      pos: -3.5,-3.5
       parent: 1
   - uid: 227
     components:
     - type: Transform
-      pos: -2.5,-11.5
+      pos: -4.5,-3.5
       parent: 1
   - uid: 228
     components:
     - type: Transform
-      pos: -1.5,-11.5
+      pos: 0.5,-3.5
       parent: 1
   - uid: 229
     components:
     - type: Transform
-      pos: 2.5,-11.5
+      pos: 1.5,-3.5
       parent: 1
   - uid: 230
     components:
     - type: Transform
-      pos: -1.5,-7.5
+      pos: 2.5,-3.5
       parent: 1
   - uid: 231
     components:
     - type: Transform
-      pos: -2.5,-7.5
+      pos: -0.5,-10.5
       parent: 1
   - uid: 232
     components:
     - type: Transform
-      pos: -3.5,-7.5
+      pos: -0.5,-11.5
       parent: 1
   - uid: 233
     components:
     - type: Transform
-      pos: 15.5,-5.5
+      pos: -4.5,-11.5
       parent: 1
   - uid: 234
     components:
     - type: Transform
-      pos: 14.5,-5.5
+      pos: 0.5,-11.5
       parent: 1
   - uid: 235
     components:
     - type: Transform
-      pos: 13.5,-5.5
+      pos: 1.5,-11.5
       parent: 1
   - uid: 236
     components:
     - type: Transform
-      pos: 12.5,-5.5
+      pos: -3.5,-11.5
       parent: 1
   - uid: 237
     components:
     - type: Transform
-      pos: 11.5,-5.5
+      pos: -2.5,-11.5
       parent: 1
   - uid: 238
     components:
     - type: Transform
-      pos: 10.5,-5.5
+      pos: -1.5,-11.5
       parent: 1
   - uid: 239
     components:
     - type: Transform
-      pos: 9.5,-5.5
+      pos: 2.5,-11.5
       parent: 1
   - uid: 240
     components:
     - type: Transform
-      pos: 9.5,-7.5
+      pos: -1.5,-7.5
       parent: 1
   - uid: 241
     components:
     - type: Transform
-      pos: 9.5,-6.5
+      pos: -2.5,-7.5
       parent: 1
   - uid: 242
     components:
     - type: Transform
-      pos: 9.5,-4.5
+      pos: -3.5,-7.5
       parent: 1
   - uid: 243
     components:
     - type: Transform
-      pos: 9.5,-3.5
+      pos: 15.5,-5.5
       parent: 1
   - uid: 244
     components:
     - type: Transform
-      pos: 12.5,-6.5
+      pos: 14.5,-5.5
       parent: 1
   - uid: 245
     components:
     - type: Transform
-      pos: 12.5,-7.5
+      pos: 13.5,-5.5
       parent: 1
   - uid: 246
     components:
     - type: Transform
-      pos: 12.5,-8.5
+      pos: 12.5,-5.5
       parent: 1
   - uid: 247
     components:
     - type: Transform
-      pos: 9.5,-8.5
+      pos: 11.5,-5.5
       parent: 1
   - uid: 248
     components:
     - type: Transform
-      pos: 13.5,-7.5
+      pos: 10.5,-5.5
       parent: 1
   - uid: 249
     components:
     - type: Transform
-      pos: 8.5,-7.5
+      pos: 9.5,-5.5
       parent: 1
   - uid: 250
     components:
     - type: Transform
-      pos: 9.5,-9.5
+      pos: 9.5,-7.5
       parent: 1
   - uid: 251
     components:
     - type: Transform
-      pos: 12.5,-9.5
+      pos: 9.5,-6.5
       parent: 1
   - uid: 252
     components:
     - type: Transform
-      pos: 4.5,-13.5
+      pos: 9.5,-4.5
       parent: 1
   - uid: 253
     components:
     - type: Transform
-      pos: 4.5,-12.5
+      pos: 9.5,-3.5
       parent: 1
   - uid: 254
     components:
     - type: Transform
-      pos: 4.5,-11.5
+      pos: 12.5,-6.5
       parent: 1
   - uid: 255
     components:
     - type: Transform
-      pos: 5.5,-11.5
+      pos: 12.5,-7.5
       parent: 1
   - uid: 256
     components:
     - type: Transform
-      pos: 6.5,-11.5
+      pos: 12.5,-8.5
       parent: 1
   - uid: 257
     components:
     - type: Transform
-      pos: 8.5,-11.5
+      pos: 9.5,-8.5
       parent: 1
   - uid: 258
     components:
     - type: Transform
-      pos: 9.5,-11.5
+      pos: 13.5,-7.5
       parent: 1
   - uid: 259
     components:
     - type: Transform
-      pos: 10.5,-11.5
+      pos: 8.5,-7.5
       parent: 1
   - uid: 260
     components:
     - type: Transform
-      pos: 7.5,-11.5
+      pos: 9.5,-9.5
       parent: 1
   - uid: 261
     components:
     - type: Transform
-      pos: 11.5,-11.5
+      pos: 12.5,-9.5
       parent: 1
   - uid: 262
     components:
     - type: Transform
-      pos: 12.5,-11.5
+      pos: 4.5,-13.5
       parent: 1
   - uid: 263
     components:
     - type: Transform
-      pos: 13.5,-11.5
+      pos: 4.5,-12.5
       parent: 1
   - uid: 264
     components:
     - type: Transform
-      pos: 14.5,-11.5
+      pos: 4.5,-11.5
       parent: 1
   - uid: 265
     components:
     - type: Transform
-      pos: 6.5,-14.5
+      pos: 5.5,-11.5
       parent: 1
   - uid: 266
     components:
     - type: Transform
-      pos: 11.5,-14.5
+      pos: 6.5,-11.5
       parent: 1
   - uid: 267
     components:
     - type: Transform
-      pos: 18.5,-7.5
+      pos: 8.5,-11.5
       parent: 1
   - uid: 268
     components:
     - type: Transform
-      pos: -2.5,0.5
+      pos: 9.5,-11.5
       parent: 1
   - uid: 269
     components:
     - type: Transform
-      pos: -1.5,0.5
+      pos: 10.5,-11.5
       parent: 1
   - uid: 270
     components:
     - type: Transform
-      pos: -0.5,0.5
+      pos: 7.5,-11.5
       parent: 1
   - uid: 271
     components:
     - type: Transform
-      pos: 0.5,0.5
+      pos: 11.5,-11.5
       parent: 1
   - uid: 272
     components:
     - type: Transform
-      pos: 1.5,0.5
+      pos: 12.5,-11.5
       parent: 1
   - uid: 273
     components:
     - type: Transform
-      pos: 2.5,0.5
+      pos: 13.5,-11.5
       parent: 1
   - uid: 274
     components:
     - type: Transform
-      pos: 3.5,0.5
+      pos: 14.5,-11.5
       parent: 1
   - uid: 275
     components:
     - type: Transform
-      pos: 0.5,1.5
+      pos: 6.5,-14.5
       parent: 1
   - uid: 276
     components:
     - type: Transform
-      pos: 0.5,2.5
+      pos: 11.5,-14.5
       parent: 1
   - uid: 277
     components:
     - type: Transform
-      pos: -3.5,0.5
+      pos: 18.5,-7.5
       parent: 1
   - uid: 278
     components:
     - type: Transform
-      pos: -4.5,0.5
+      pos: -2.5,0.5
       parent: 1
   - uid: 279
     components:
     - type: Transform
-      pos: 0.5,4.5
+      pos: -1.5,0.5
       parent: 1
   - uid: 280
     components:
     - type: Transform
-      pos: -0.5,4.5
+      pos: -0.5,0.5
       parent: 1
   - uid: 281
     components:
     - type: Transform
-      pos: -2.5,4.5
+      pos: 0.5,0.5
       parent: 1
   - uid: 282
     components:
     - type: Transform
-      pos: -1.5,4.5
+      pos: 1.5,0.5
       parent: 1
   - uid: 283
     components:
     - type: Transform
-      pos: 1.5,4.5
+      pos: 2.5,0.5
       parent: 1
   - uid: 284
     components:
     - type: Transform
-      pos: 2.5,4.5
+      pos: 3.5,0.5
       parent: 1
   - uid: 285
     components:
     - type: Transform
-      pos: -4.5,2.5
+      pos: 0.5,1.5
       parent: 1
   - uid: 286
     components:
     - type: Transform
-      pos: -4.5,3.5
+      pos: 0.5,2.5
       parent: 1
   - uid: 287
     components:
     - type: Transform
-      pos: -5.5,3.5
+      pos: -3.5,0.5
       parent: 1
   - uid: 288
     components:
     - type: Transform
-      pos: -5.5,0.5
+      pos: -4.5,0.5
       parent: 1
   - uid: 289
     components:
     - type: Transform
-      pos: -6.5,0.5
+      pos: 0.5,4.5
       parent: 1
   - uid: 290
     components:
     - type: Transform
-      pos: -7.5,0.5
+      pos: -0.5,4.5
       parent: 1
   - uid: 291
     components:
     - type: Transform
-      pos: -7.5,1.5
+      pos: -2.5,4.5
       parent: 1
   - uid: 292
     components:
     - type: Transform
-      pos: -7.5,-0.5
+      pos: -1.5,4.5
       parent: 1
   - uid: 293
     components:
     - type: Transform
-      pos: -7.5,-1.5
+      pos: 1.5,4.5
       parent: 1
   - uid: 294
     components:
     - type: Transform
-      pos: -6.5,-15.5
+      pos: 2.5,4.5
       parent: 1
   - uid: 295
     components:
     - type: Transform
-      pos: -7.5,-15.5
+      pos: -4.5,2.5
       parent: 1
   - uid: 296
     components:
     - type: Transform
-      pos: -7.5,-14.5
+      pos: -4.5,3.5
       parent: 1
   - uid: 297
     components:
     - type: Transform
-      pos: -7.5,-16.5
+      pos: -5.5,3.5
       parent: 1
   - uid: 298
     components:
     - type: Transform
-      pos: -7.5,-13.5
+      pos: -5.5,0.5
       parent: 1
   - uid: 299
     components:
     - type: Transform
-      pos: -4.5,-16.5
+      pos: -6.5,0.5
       parent: 1
   - uid: 300
     components:
     - type: Transform
-      pos: -4.5,-18.5
+      pos: -7.5,0.5
       parent: 1
   - uid: 301
     components:
     - type: Transform
-      pos: -4.5,-17.5
+      pos: -7.5,1.5
       parent: 1
   - uid: 302
     components:
     - type: Transform
-      pos: -5.5,-18.5
+      pos: -7.5,-0.5
       parent: 1
   - uid: 303
     components:
     - type: Transform
-      pos: -0.5,-18.5
+      pos: -7.5,-1.5
       parent: 1
   - uid: 304
     components:
     - type: Transform
-      pos: -0.5,-19.5
+      pos: -6.5,-15.5
       parent: 1
   - uid: 305
     components:
     - type: Transform
-      pos: -1.5,-19.5
+      pos: -7.5,-15.5
       parent: 1
   - uid: 306
     components:
     - type: Transform
-      pos: 15.5,-15.5
+      pos: -7.5,-14.5
       parent: 1
   - uid: 307
     components:
     - type: Transform
-      pos: -2.5,-19.5
+      pos: -7.5,-16.5
       parent: 1
   - uid: 308
     components:
     - type: Transform
-      pos: 0.5,-19.5
+      pos: -7.5,-13.5
       parent: 1
   - uid: 309
     components:
     - type: Transform
-      pos: 1.5,-19.5
+      pos: -4.5,-16.5
       parent: 1
   - uid: 310
     components:
     - type: Transform
-      pos: 2.5,-19.5
+      pos: -4.5,-18.5
       parent: 1
   - uid: 311
     components:
     - type: Transform
-      pos: 16.5,-15.5
+      pos: -4.5,-17.5
       parent: 1
   - uid: 312
     components:
     - type: Transform
-      pos: 16.5,-14.5
+      pos: -5.5,-18.5
       parent: 1
   - uid: 313
     components:
     - type: Transform
-      pos: 16.5,-16.5
+      pos: -0.5,-18.5
       parent: 1
   - uid: 314
     components:
     - type: Transform
-      pos: 16.5,-18.5
+      pos: -0.5,-19.5
       parent: 1
   - uid: 315
     components:
     - type: Transform
-      pos: 16.5,-17.5
+      pos: -1.5,-19.5
       parent: 1
   - uid: 316
     components:
     - type: Transform
-      pos: 16.5,-19.5
+      pos: 15.5,-15.5
       parent: 1
   - uid: 317
     components:
     - type: Transform
-      pos: 17.5,-0.5
+      pos: -2.5,-19.5
       parent: 1
   - uid: 318
+    components:
+    - type: Transform
+      pos: 0.5,-19.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 1.5,-19.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 2.5,-19.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 16.5,-15.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 16.5,-14.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 16.5,-16.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 16.5,-18.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 16.5,-17.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 16.5,-19.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 17.5,-0.5
+      parent: 1
+  - uid: 328
     components:
     - type: Transform
       pos: 17.5,-14.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 319
+  - uid: 329
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 320
+  - uid: 330
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 321
+  - uid: 331
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 322
+  - uid: 332
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 323
+  - uid: 333
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 324
+  - uid: 334
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 325
+  - uid: 335
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 326
+  - uid: 336
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 327
+  - uid: 337
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 328
+  - uid: 338
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
-  - uid: 329
+  - uid: 339
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 330
+  - uid: 340
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 331
+  - uid: 341
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 332
+  - uid: 342
     components:
     - type: Transform
       pos: 14.5,-15.5
       parent: 1
-  - uid: 333
+  - uid: 343
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 334
+  - uid: 344
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 335
+  - uid: 345
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 336
+  - uid: 346
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 337
+  - uid: 347
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 338
+  - uid: 348
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 339
+  - uid: 349
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 340
+  - uid: 350
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 341
+  - uid: 351
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 342
+  - uid: 352
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 343
+  - uid: 353
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
-  - uid: 344
+  - uid: 354
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 345
+  - uid: 355
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 346
+  - uid: 356
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 347
+  - uid: 357
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 348
-    components:
-    - type: Transform
-      pos: 0.5,-14.5
-      parent: 1
-  - uid: 349
-    components:
-    - type: Transform
-      pos: 0.5,-13.5
-      parent: 1
-  - uid: 350
-    components:
-    - type: Transform
-      pos: 0.5,-12.5
-      parent: 1
-  - uid: 351
-    components:
-    - type: Transform
-      pos: 0.5,-11.5
-      parent: 1
-  - uid: 352
-    components:
-    - type: Transform
-      pos: 0.5,-10.5
-      parent: 1
-  - uid: 353
-    components:
-    - type: Transform
-      pos: -2.5,-14.5
-      parent: 1
-  - uid: 354
-    components:
-    - type: Transform
-      pos: -1.5,-14.5
-      parent: 1
-  - uid: 355
-    components:
-    - type: Transform
-      pos: -0.5,-14.5
-      parent: 1
-  - uid: 356
-    components:
-    - type: Transform
-      pos: 0.5,-14.5
-      parent: 1
-  - uid: 357
-    components:
-    - type: Transform
-      pos: -2.5,-13.5
-      parent: 1
   - uid: 358
     components:
     - type: Transform
-      pos: 11.5,-12.5
+      pos: 0.5,-14.5
       parent: 1
   - uid: 359
     components:
     - type: Transform
-      pos: 15.5,-11.5
+      pos: 0.5,-13.5
       parent: 1
   - uid: 360
     components:
     - type: Transform
-      pos: 16.5,-11.5
+      pos: 0.5,-12.5
       parent: 1
   - uid: 361
     components:
     - type: Transform
-      pos: 16.5,-10.5
+      pos: 0.5,-11.5
       parent: 1
   - uid: 362
     components:
     - type: Transform
-      pos: 16.5,-9.5
+      pos: 0.5,-10.5
       parent: 1
   - uid: 363
     components:
     - type: Transform
-      pos: 17.5,-9.5
+      pos: -2.5,-14.5
       parent: 1
   - uid: 364
     components:
     - type: Transform
-      pos: 18.5,-9.5
+      pos: -1.5,-14.5
       parent: 1
   - uid: 365
     components:
     - type: Transform
-      pos: 11.5,-13.5
+      pos: -0.5,-14.5
       parent: 1
   - uid: 366
     components:
     - type: Transform
-      pos: 11.5,-14.5
+      pos: 0.5,-14.5
       parent: 1
   - uid: 367
     components:
     - type: Transform
-      pos: 0.5,-3.5
+      pos: -2.5,-13.5
       parent: 1
   - uid: 368
     components:
     - type: Transform
-      pos: 12.5,-14.5
+      pos: 11.5,-12.5
       parent: 1
   - uid: 369
     components:
     - type: Transform
-      pos: 13.5,-14.5
+      pos: 15.5,-11.5
       parent: 1
   - uid: 370
     components:
     - type: Transform
-      pos: 14.5,-14.5
+      pos: 16.5,-11.5
       parent: 1
   - uid: 371
     components:
     - type: Transform
-      pos: 2.5,-3.5
+      pos: 16.5,-10.5
       parent: 1
   - uid: 372
     components:
     - type: Transform
-      pos: 3.5,-3.5
+      pos: 16.5,-9.5
       parent: 1
   - uid: 373
     components:
     - type: Transform
-      pos: 4.5,-3.5
+      pos: 17.5,-9.5
       parent: 1
   - uid: 374
     components:
     - type: Transform
-      pos: 5.5,-3.5
+      pos: 18.5,-9.5
       parent: 1
   - uid: 375
     components:
     - type: Transform
-      pos: 1.5,-3.5
+      pos: 11.5,-13.5
       parent: 1
   - uid: 376
     components:
     - type: Transform
-      pos: 5.5,-4.5
+      pos: 11.5,-14.5
       parent: 1
   - uid: 377
     components:
     - type: Transform
-      pos: 5.5,-5.5
+      pos: 0.5,-3.5
       parent: 1
   - uid: 378
     components:
     - type: Transform
-      pos: 5.5,-6.5
+      pos: 12.5,-14.5
       parent: 1
   - uid: 379
     components:
     - type: Transform
-      pos: 6.5,-6.5
+      pos: 13.5,-14.5
       parent: 1
   - uid: 380
     components:
     - type: Transform
-      pos: 5.5,-2.5
+      pos: 14.5,-14.5
       parent: 1
   - uid: 381
     components:
     - type: Transform
-      pos: 5.5,-1.5
+      pos: 2.5,-3.5
       parent: 1
   - uid: 382
     components:
     - type: Transform
-      pos: 5.5,-0.5
+      pos: 3.5,-3.5
       parent: 1
   - uid: 383
     components:
     - type: Transform
-      pos: 6.5,-0.5
+      pos: 4.5,-3.5
       parent: 1
   - uid: 384
     components:
     - type: Transform
-      pos: 7.5,-0.5
+      pos: 5.5,-3.5
       parent: 1
   - uid: 385
     components:
     - type: Transform
-      pos: 8.5,-0.5
+      pos: 1.5,-3.5
       parent: 1
   - uid: 386
     components:
     - type: Transform
-      pos: 10.5,-0.5
+      pos: 5.5,-4.5
       parent: 1
   - uid: 387
     components:
     - type: Transform
-      pos: 11.5,-0.5
+      pos: 5.5,-5.5
       parent: 1
   - uid: 388
     components:
     - type: Transform
-      pos: 12.5,-0.5
+      pos: 5.5,-6.5
       parent: 1
   - uid: 389
     components:
     - type: Transform
-      pos: 13.5,-0.5
+      pos: 6.5,-6.5
       parent: 1
   - uid: 390
     components:
     - type: Transform
-      pos: 14.5,-0.5
+      pos: 5.5,-2.5
       parent: 1
   - uid: 391
     components:
     - type: Transform
-      pos: 15.5,-0.5
+      pos: 5.5,-1.5
       parent: 1
   - uid: 392
     components:
     - type: Transform
-      pos: 9.5,-0.5
+      pos: 5.5,-0.5
       parent: 1
   - uid: 393
     components:
     - type: Transform
-      pos: 14.5,-0.5
+      pos: 6.5,-0.5
       parent: 1
   - uid: 394
     components:
     - type: Transform
-      pos: 14.5,-1.5
+      pos: 7.5,-0.5
       parent: 1
   - uid: 395
     components:
     - type: Transform
-      pos: 14.5,-2.5
+      pos: 8.5,-0.5
       parent: 1
   - uid: 396
     components:
     - type: Transform
-      pos: 14.5,-3.5
+      pos: 10.5,-0.5
       parent: 1
   - uid: 397
     components:
     - type: Transform
-      pos: 14.5,-4.5
+      pos: 11.5,-0.5
       parent: 1
   - uid: 398
     components:
     - type: Transform
-      pos: 14.5,-5.5
+      pos: 12.5,-0.5
       parent: 1
   - uid: 399
     components:
     - type: Transform
-      pos: 15.5,-5.5
+      pos: 13.5,-0.5
       parent: 1
   - uid: 400
     components:
     - type: Transform
-      pos: 1.5,-11.5
+      pos: 14.5,-0.5
       parent: 1
   - uid: 401
     components:
     - type: Transform
-      pos: 2.5,-11.5
+      pos: 15.5,-0.5
       parent: 1
   - uid: 402
     components:
     - type: Transform
-      pos: 6.5,-11.5
+      pos: 9.5,-0.5
       parent: 1
   - uid: 403
     components:
     - type: Transform
-      pos: 3.5,-11.5
+      pos: 14.5,-0.5
       parent: 1
   - uid: 404
     components:
     - type: Transform
-      pos: 7.5,-11.5
+      pos: 14.5,-1.5
       parent: 1
   - uid: 405
     components:
     - type: Transform
-      pos: 5.5,-11.5
+      pos: 14.5,-2.5
       parent: 1
   - uid: 406
     components:
     - type: Transform
-      pos: 8.5,-11.5
+      pos: 14.5,-3.5
       parent: 1
   - uid: 407
     components:
     - type: Transform
-      pos: 9.5,-11.5
+      pos: 14.5,-4.5
       parent: 1
   - uid: 408
     components:
     - type: Transform
-      pos: 10.5,-11.5
+      pos: 14.5,-5.5
       parent: 1
   - uid: 409
     components:
     - type: Transform
-      pos: 11.5,-11.5
+      pos: 15.5,-5.5
       parent: 1
   - uid: 410
     components:
     - type: Transform
-      pos: 12.5,-11.5
+      pos: 1.5,-11.5
       parent: 1
   - uid: 411
     components:
     - type: Transform
-      pos: 13.5,-11.5
+      pos: 2.5,-11.5
       parent: 1
   - uid: 412
     components:
     - type: Transform
-      pos: 14.5,-11.5
+      pos: 6.5,-11.5
       parent: 1
   - uid: 413
     components:
     - type: Transform
-      pos: 4.5,-11.5
+      pos: 3.5,-11.5
       parent: 1
   - uid: 414
     components:
     - type: Transform
-      pos: 15.5,-15.5
+      pos: 7.5,-11.5
       parent: 1
   - uid: 415
     components:
     - type: Transform
-      pos: 4.5,-12.5
+      pos: 5.5,-11.5
       parent: 1
   - uid: 416
     components:
     - type: Transform
-      pos: 4.5,-13.5
+      pos: 8.5,-11.5
       parent: 1
   - uid: 417
     components:
     - type: Transform
-      pos: 2.5,0.5
+      pos: 9.5,-11.5
       parent: 1
   - uid: 418
     components:
     - type: Transform
-      pos: 0.5,0.5
+      pos: 10.5,-11.5
       parent: 1
   - uid: 419
     components:
     - type: Transform
-      pos: 1.5,0.5
+      pos: 11.5,-11.5
       parent: 1
   - uid: 420
     components:
     - type: Transform
-      pos: -0.5,0.5
+      pos: 12.5,-11.5
       parent: 1
   - uid: 421
     components:
     - type: Transform
-      pos: -1.5,-1.5
+      pos: 13.5,-11.5
       parent: 1
   - uid: 422
+    components:
+    - type: Transform
+      pos: 14.5,-11.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 15.5,-15.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 432
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 423
+  - uid: 433
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2909,55 +2869,55 @@ entities:
       parent: 1
 - proto: CarpetGreen
   entities:
-  - uid: 424
+  - uid: 434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-15.5
       parent: 1
-  - uid: 425
+  - uid: 435
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-17.5
       parent: 1
-  - uid: 426
+  - uid: 436
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-16.5
       parent: 1
-  - uid: 427
+  - uid: 437
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-17.5
       parent: 1
-  - uid: 428
+  - uid: 438
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-16.5
       parent: 1
-  - uid: 429
+  - uid: 439
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-15.5
       parent: 1
-  - uid: 430
+  - uid: 440
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-15.5
       parent: 1
-  - uid: 431
+  - uid: 441
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-16.5
       parent: 1
-  - uid: 432
+  - uid: 442
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2965,61 +2925,61 @@ entities:
       parent: 1
 - proto: CarpetSBlue
   entities:
-  - uid: 433
+  - uid: 443
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,3.5
       parent: 1
-  - uid: 434
+  - uid: 444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,1.5
       parent: 1
-  - uid: 435
+  - uid: 445
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,2.5
       parent: 1
-  - uid: 436
+  - uid: 446
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,2.5
       parent: 1
-  - uid: 437
+  - uid: 447
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,2.5
       parent: 1
-  - uid: 438
+  - uid: 448
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 1
-  - uid: 439
+  - uid: 449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,2.5
       parent: 1
-  - uid: 440
+  - uid: 450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,3.5
       parent: 1
-  - uid: 441
+  - uid: 451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 1
-  - uid: 442
+  - uid: 452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3027,94 +2987,104 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 443
+  - uid: 453
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 1
-  - uid: 444
+  - uid: 454
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-  - uid: 445
+  - uid: 455
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 1
-  - uid: 446
+  - uid: 456
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-  - uid: 447
+  - uid: 457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 448
+  - uid: 458
     components:
     - type: Transform
       pos: 16.5,-14.5
       parent: 1
-  - uid: 449
+  - uid: 459
     components:
     - type: Transform
       pos: 16.5,-0.5
       parent: 1
 - proto: CentcommComputerComms
   entities:
-  - uid: 450
+  - uid: 460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-3.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: ChairOfficeDark
   entities:
-  - uid: 451
+  - uid: 461
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
 - proto: ChairOfficeLight
   entities:
-  - uid: 452
+  - uid: 462
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,0.5
       parent: 1
-  - uid: 453
+  - uid: 463
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,0.5
       parent: 1
-  - uid: 454
+  - uid: 464
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 1
-  - uid: 455
+  - uid: 465
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 1
-  - uid: 456
+  - uid: 466
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-12.5
       parent: 1
-  - uid: 457
+  - uid: 467
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3122,19 +3092,19 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 458
+  - uid: 468
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-7.5
       parent: 1
-  - uid: 459
+  - uid: 469
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-8.5
       parent: 1
-  - uid: 460
+  - uid: 470
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3142,37 +3112,37 @@ entities:
       parent: 1
 - proto: ChairWood
   entities:
-  - uid: 461
+  - uid: 471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-15.5
       parent: 1
-  - uid: 462
+  - uid: 472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-17.5
       parent: 1
-  - uid: 463
+  - uid: 473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-16.5
       parent: 1
-  - uid: 464
+  - uid: 474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-15.5
       parent: 1
-  - uid: 465
+  - uid: 475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-17.5
       parent: 1
-  - uid: 466
+  - uid: 476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3180,7 +3150,7 @@ entities:
       parent: 1
 - proto: CheckerBoard
   entities:
-  - uid: 467
+  - uid: 477
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3188,28 +3158,93 @@ entities:
       parent: 1
 - proto: ChemDispenser
   entities:
-  - uid: 468
+  - uid: 478
     components:
     - type: Transform
       pos: 4.5,-9.5
       parent: 1
+- proto: ChemistryEmptyBottle01
+  entities:
+  - uid: 83
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 84
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 85
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 86
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 87
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 88
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
 - proto: ChemistryHotplate
   entities:
-  - uid: 469
+  - uid: 479
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
+    - type: ItemPlacer
+      placedEntities:
+      - 1372
+    - type: PlaceableSurface
+      isPlaceable: False
 - proto: ChemMaster
   entities:
-  - uid: 470
+  - uid: 484
     components:
     - type: Transform
-      pos: 4.5,-7.5
+      pos: 3.5,-7.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        beakerSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 485
+        outputSlot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: ChessBoard
   entities:
-  - uid: 471
+  - uid: 481
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3217,151 +3252,44 @@ entities:
       parent: 1
 - proto: CloningPod
   entities:
-  - uid: 472
+  - uid: 482
     components:
     - type: Transform
       pos: 9.5,-8.5
       parent: 1
-  - uid: 473
+  - uid: 483
     components:
     - type: Transform
       pos: 12.5,-8.5
       parent: 1
-- proto: ClosetWall
-  entities:
-  - uid: 69
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-5.5
-      parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 76
-          - 72
-          - 70
-          - 75
-          - 73
-          - 77
-          - 71
-          - 74
-          - 78
-  - uid: 474
-    components:
-    - type: Transform
-      pos: 12.5,-4.5
-      parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 485
-          - 475
-          - 476
-          - 477
-          - 478
-          - 479
-          - 480
-          - 481
-          - 482
-          - 483
-          - 484
-          - 486
-  - uid: 487
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-1.5
-      parent: 1
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 489
-          - 488
-          - 493
-          - 491
-          - 492
-          - 490
 - proto: ClosetWallWardrobeMixedFilled
   entities:
-  - uid: 494
+  - uid: 493
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-10.5
       parent: 1
-  - uid: 495
+    - type: Fixtures
+      fixtures: {}
+  - uid: 494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-10.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1370
+    components:
+    - type: Transform
+      pos: 12.5,-4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: ClothingBackpackWaterTank
   entities:
-  - uid: 496
+  - uid: 495
     components:
     - type: MetaData
       name: Flamethrower
@@ -3373,23 +3301,25 @@ entities:
         item: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 497
+          ent: 496
 - proto: ClothingBeltUtilityEngineering
   entities:
-  - uid: 488
+  - uid: 491
     components:
     - type: Transform
-      parent: 487
+      parent: 486
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 489
+      storage: 486
+  - uid: 492
     components:
     - type: Transform
-      parent: 487
+      parent: 486
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+      storage: 486
 - proto: ClothingEyesGlassesCentComm
   entities:
   - uid: 5
@@ -3399,38 +3329,38 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 499
+  - uid: 498
     components:
     - type: Transform
-      parent: 498
+      parent: 497
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 507
+  - uid: 506
     components:
     - type: Transform
-      parent: 506
+      parent: 505
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 515
+  - uid: 514
     components:
     - type: Transform
-      parent: 514
+      parent: 513
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 523
+  - uid: 522
     components:
     - type: Transform
-      parent: 522
+      parent: 521
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 531
+  - uid: 530
     components:
     - type: Transform
-      parent: 530
+      parent: 529
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -3443,38 +3373,38 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 500
+  - uid: 499
     components:
     - type: Transform
-      parent: 498
+      parent: 497
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 508
+  - uid: 507
     components:
     - type: Transform
-      parent: 506
+      parent: 505
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 516
+  - uid: 515
     components:
     - type: Transform
-      parent: 514
+      parent: 513
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 524
+  - uid: 523
     components:
     - type: Transform
-      parent: 522
+      parent: 521
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 532
+  - uid: 531
     components:
     - type: Transform
-      parent: 530
+      parent: 529
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -3487,38 +3417,38 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 501
+  - uid: 500
     components:
     - type: Transform
-      parent: 498
+      parent: 497
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 509
+  - uid: 508
     components:
     - type: Transform
-      parent: 506
+      parent: 505
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 517
+  - uid: 516
     components:
     - type: Transform
-      parent: 514
+      parent: 513
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 525
+  - uid: 524
     components:
     - type: Transform
-      parent: 522
+      parent: 521
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 533
+  - uid: 532
     components:
     - type: Transform
-      parent: 530
+      parent: 529
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -3531,38 +3461,38 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 502
+  - uid: 501
     components:
     - type: Transform
-      parent: 498
+      parent: 497
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 510
+  - uid: 509
     components:
     - type: Transform
-      parent: 506
+      parent: 505
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 518
+  - uid: 517
     components:
     - type: Transform
-      parent: 514
+      parent: 513
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 526
+  - uid: 525
     components:
     - type: Transform
-      parent: 522
+      parent: 521
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 534
+  - uid: 533
     components:
     - type: Transform
-      parent: 530
+      parent: 529
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -3575,122 +3505,214 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 503
+  - uid: 502
     components:
     - type: Transform
-      parent: 498
+      parent: 497
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 511
+  - uid: 510
     components:
     - type: Transform
-      parent: 506
+      parent: 505
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 519
+  - uid: 518
     components:
     - type: Transform
-      parent: 514
+      parent: 513
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 527
+  - uid: 526
     components:
     - type: Transform
-      parent: 522
+      parent: 521
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 535
+  - uid: 534
     components:
     - type: Transform
-      parent: 530
+      parent: 529
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ComputerCloningConsole
   entities:
-  - uid: 538
+  - uid: 537
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-7.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
     - type: DeviceLinkSource
       linkedPorts:
-        907:
+        906:
         - - MedicalScannerSender
           - MedicalScannerReceiver
-        472:
+        482:
         - - CloningPodSender
           - CloningPodReceiver
-  - uid: 539
+  - uid: 538
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-7.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
     - type: DeviceLinkSource
       linkedPorts:
-        908:
+        907:
         - - MedicalScannerSender
           - MedicalScannerReceiver
-        473:
+        483:
         - - CloningPodSender
           - CloningPodReceiver
 - proto: ComputerComms
   entities:
-  - uid: 540
+  - uid: 539
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: ComputerId
   entities:
-  - uid: 541
+  - uid: 540
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-12.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        IdCardConsole-privilegedId: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        IdCardConsole-targetId: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: ComputerIFF
   entities:
-  - uid: 542
+  - uid: 541
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-11.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: ComputerRadar
   entities:
-  - uid: 543
+  - uid: 542
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-6.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: ComputerShuttle
   entities:
-  - uid: 544
+  - uid: 543
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        disk_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 545
+  - uid: 544
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 1
+    - type: ContainerContainer
+      containers:
+        board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        pai_slot: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: CrateCommandSecure
   entities:
-  - uid: 546
+  - uid: 545
     components:
     - type: MetaData
       name: Ambuzol+ crate
@@ -3708,25 +3730,14 @@ entities:
         immutable: False
         temperature: 293.14673
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
           showEnts: False
           occludes: True
           ents:
-          - 556
           - 555
           - 554
           - 553
@@ -3736,13 +3747,14 @@ entities:
           - 549
           - 548
           - 547
+          - 546
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: CrateFreezer
   entities:
-  - uid: 557
+  - uid: 556
     components:
     - type: Transform
       anchored: True
@@ -3750,7 +3762,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-  - uid: 558
+  - uid: 557
     components:
     - type: Transform
       anchored: True
@@ -3758,7 +3770,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-  - uid: 559
+  - uid: 558
     components:
     - type: Transform
       anchored: True
@@ -3766,7 +3778,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-  - uid: 560
+  - uid: 559
     components:
     - type: Transform
       anchored: True
@@ -3774,7 +3786,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-  - uid: 561
+  - uid: 560
     components:
     - type: Transform
       anchored: True
@@ -3782,7 +3794,7 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-  - uid: 562
+  - uid: 561
     components:
     - type: Transform
       anchored: True
@@ -3792,89 +3804,97 @@ entities:
       bodyType: Static
 - proto: CrateTrashCart
   entities:
-  - uid: 563
+  - uid: 562
     components:
     - type: Transform
       pos: 14.5,-14.5
       parent: 1
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 564
+  - uid: 563
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 1
-  - uid: 565
+    - type: Fixtures
+      fixtures: {}
+  - uid: 564
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 566
+    - type: Fixtures
+      fixtures: {}
+  - uid: 565
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 1
-  - uid: 567
+    - type: Fixtures
+      fixtures: {}
+  - uid: 566
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: DiseaseDiagnoser
   entities:
-  - uid: 568
+  - uid: 567
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
 - proto: DrinkShaker
   entities:
-  - uid: 569
+  - uid: 568
     components:
     - type: Transform
       pos: 5.2650146,-15.313744
       parent: 1
-  - uid: 570
+  - uid: 569
     components:
     - type: Transform
       pos: 5.394068,-15.581383
       parent: 1
 - proto: EmergencyRollerBedSpawnFolded
   entities:
-  - uid: 571
+  - uid: 570
     components:
     - type: Transform
       pos: 12.163195,-0.65625
       parent: 1
-  - uid: 572
+  - uid: 571
     components:
     - type: Transform
       pos: 7.7100697,-0.703125
       parent: 1
-  - uid: 573
+  - uid: 572
     components:
     - type: Transform
       pos: 12.475695,-0.546875
       parent: 1
-  - uid: 574
+  - uid: 573
     components:
     - type: Transform
       pos: 7.3663197,-0.625
       parent: 1
-  - uid: 575
+  - uid: 574
     components:
     - type: Transform
       pos: 7.6631947,-0.203125
       parent: 1
-  - uid: 576
+  - uid: 575
     components:
     - type: Transform
       pos: 12.131945,-0.1875
       parent: 1
 - proto: FaxMachineBase
   entities:
-  - uid: 577
+  - uid: 576
     components:
     - type: Transform
       pos: 0.5,-6.5
@@ -3883,7 +3903,7 @@ entities:
       name: CBURN
 - proto: FloorDrain
   entities:
-  - uid: 578
+  - uid: 577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3891,7 +3911,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 579
+  - uid: 578
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3899,7 +3919,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 580
+  - uid: 579
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3907,7 +3927,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-  - uid: 581
+  - uid: 580
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3917,72 +3937,74 @@ entities:
       fixtures: {}
 - proto: FoodSnackNutribrick
   entities:
-  - uid: 582
+  - uid: 581
     components:
     - type: Transform
       pos: 7.387781,-18.31067
       parent: 1
-  - uid: 583
+  - uid: 582
     components:
     - type: Transform
       pos: 7.497156,-17.982546
       parent: 1
-  - uid: 584
+  - uid: 583
     components:
     - type: Transform
       pos: 7.387781,-17.763796
       parent: 1
-  - uid: 585
+  - uid: 584
     components:
     - type: Transform
       pos: 7.590906,-17.576296
       parent: 1
-  - uid: 586
+  - uid: 585
     components:
     - type: Transform
       pos: 7.340906,-17.24817
       parent: 1
-  - uid: 587
+  - uid: 586
     components:
     - type: Transform
       pos: 7.559656,-16.982546
       parent: 1
-  - uid: 588
+  - uid: 587
     components:
     - type: Transform
       pos: 7.340906,-16.732546
       parent: 1
-  - uid: 589
+  - uid: 588
     components:
     - type: Transform
       pos: 7.669031,-16.56067
       parent: 1
-  - uid: 590
+  - uid: 589
     components:
     - type: Transform
       pos: 7.387781,-16.295046
       parent: 1
-  - uid: 591
+  - uid: 590
     components:
     - type: Transform
       pos: 7.637781,-16.045046
       parent: 1
-  - uid: 592
+  - uid: 591
     components:
     - type: Transform
       pos: 7.294031,-15.904421
       parent: 1
 - proto: FuelDispenser
   entities:
-  - uid: 593
+  - uid: 592
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: GasMinerNitrogen
   entities:
-  - uid: 594
+  - uid: 593
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3990,7 +4012,7 @@ entities:
       parent: 1
 - proto: GasMinerOxygen
   entities:
-  - uid: 595
+  - uid: 594
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3998,7 +4020,7 @@ entities:
       parent: 1
 - proto: GasMixerFlipped
   entities:
-  - uid: 596
+  - uid: 595
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4012,19 +4034,19 @@ entities:
       color: '#0335FCFF'
 - proto: GasPassiveVent
   entities:
-  - uid: 597
+  - uid: 596
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 1
-  - uid: 598
+  - uid: 597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-0.5
       parent: 1
-  - uid: 599
+  - uid: 598
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4034,13 +4056,13 @@ entities:
       color: '#FF1212FF'
 - proto: GasPipeBend
   entities:
-  - uid: 600
+  - uid: 599
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
-  - uid: 601
+  - uid: 600
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4048,20 +4070,20 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 602
+  - uid: 601
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
-  - uid: 603
+  - uid: 602
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 604
+  - uid: 603
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4069,7 +4091,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 605
+  - uid: 604
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4077,7 +4099,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 606
+  - uid: 605
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4085,21 +4107,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 607
+  - uid: 606
     components:
     - type: Transform
       pos: 13.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 608
+  - uid: 607
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 609
+  - uid: 608
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4107,7 +4129,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 610
+  - uid: 609
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4115,7 +4137,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 611
+  - uid: 610
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4123,7 +4145,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 612
+  - uid: 611
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4131,7 +4153,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 613
+  - uid: 612
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4139,7 +4161,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 614
+  - uid: 613
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4147,7 +4169,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 615
+  - uid: 614
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4155,14 +4177,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 616
+  - uid: 615
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 617
+  - uid: 616
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4170,7 +4192,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 618
+  - uid: 617
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4178,7 +4200,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 619
+  - uid: 618
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4186,7 +4208,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 620
+  - uid: 619
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4194,7 +4216,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 621
+  - uid: 620
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4202,7 +4224,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 622
+  - uid: 621
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4210,19 +4232,19 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 623
+  - uid: 622
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 624
+  - uid: 623
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
 - proto: GasPipeFourway
   entities:
-  - uid: 625
+  - uid: 624
     components:
     - type: Transform
       pos: 5.5,-3.5
@@ -4231,7 +4253,7 @@ entities:
       color: '#0335FCFF'
 - proto: GasPipeStraight
   entities:
-  - uid: 626
+  - uid: 625
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4239,7 +4261,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 627
+  - uid: 626
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4247,7 +4269,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 628
+  - uid: 627
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4255,7 +4277,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 629
+  - uid: 628
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4263,7 +4285,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 630
+  - uid: 629
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4271,7 +4293,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 631
+  - uid: 630
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4279,7 +4301,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 632
+  - uid: 631
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4287,7 +4309,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 633
+  - uid: 632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4295,11 +4317,19 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 634
+  - uid: 633
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 634
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -4307,7 +4337,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -0.5,-3.5
+      pos: -1.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -4315,82 +4345,78 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,-3.5
+      pos: -0.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 637
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-10.5
+      pos: 0.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 638
     components:
     - type: Transform
-      pos: 0.5,-4.5
+      pos: 0.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 639
     components:
     - type: Transform
-      pos: 0.5,-5.5
+      pos: 0.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 640
     components:
     - type: Transform
-      pos: 0.5,-6.5
+      anchored: False
+      pos: 0.5,-7.5
       parent: 1
+    - type: Physics
+      canCollide: True
+      bodyType: Dynamic
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 641
-    components:
-    - type: Transform
-      pos: 0.5,-7.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 642
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 643
+  - uid: 642
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 644
+  - uid: 643
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 645
+  - uid: 644
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 646
+  - uid: 645
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 647
+  - uid: 646
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4398,28 +4424,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 648
+  - uid: 647
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 649
+  - uid: 648
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 650
+  - uid: 649
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 651
+  - uid: 650
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4427,7 +4453,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 652
+  - uid: 651
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4435,7 +4461,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 653
+  - uid: 652
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4443,7 +4469,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 654
+  - uid: 653
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4451,7 +4477,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 655
+  - uid: 654
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4459,7 +4485,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 656
+  - uid: 655
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4467,7 +4493,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 657
+  - uid: 656
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4475,7 +4501,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 658
+  - uid: 657
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4483,7 +4509,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 659
+  - uid: 658
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4491,28 +4517,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 660
+  - uid: 659
     components:
     - type: Transform
       pos: 10.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 661
+  - uid: 660
     components:
     - type: Transform
       pos: 10.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 662
+  - uid: 661
     components:
     - type: Transform
       pos: 10.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 663
+  - uid: 662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4520,7 +4546,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 664
+  - uid: 663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4528,7 +4554,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 665
+  - uid: 664
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4536,7 +4562,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 666
+  - uid: 665
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4544,7 +4570,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 667
+  - uid: 666
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4552,7 +4578,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 668
+  - uid: 667
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4560,7 +4586,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 669
+  - uid: 668
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4568,7 +4594,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 670
+  - uid: 669
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4576,7 +4602,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 671
+  - uid: 670
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4584,7 +4610,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 672
+  - uid: 671
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4592,7 +4618,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 673
+  - uid: 672
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4600,7 +4626,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 674
+  - uid: 673
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4608,7 +4634,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 675
+  - uid: 674
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4616,7 +4642,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 676
+  - uid: 675
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4624,7 +4650,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 677
+  - uid: 676
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4632,7 +4658,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 678
+  - uid: 677
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4640,7 +4666,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 679
+  - uid: 678
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4648,7 +4674,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 680
+  - uid: 679
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4656,10 +4682,18 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 681
+  - uid: 680
     components:
     - type: Transform
       pos: 13.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 681
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -4667,19 +4701,11 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 14.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 683
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 684
+  - uid: 683
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4687,21 +4713,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 685
+  - uid: 684
     components:
     - type: Transform
       pos: 13.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 686
+  - uid: 685
     components:
     - type: Transform
       pos: 13.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 687
+  - uid: 686
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4709,7 +4735,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 688
+  - uid: 687
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4717,7 +4743,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 689
+  - uid: 688
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4725,35 +4751,35 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 690
+  - uid: 689
     components:
     - type: Transform
       pos: 13.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 691
+  - uid: 690
     components:
     - type: Transform
       pos: 10.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 692
+  - uid: 691
     components:
     - type: Transform
       pos: 10.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 693
+  - uid: 692
     components:
     - type: Transform
       pos: 14.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 694
+  - uid: 693
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4761,14 +4787,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 695
+  - uid: 694
     components:
     - type: Transform
       pos: 14.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 696
+  - uid: 695
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4776,7 +4802,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 697
+  - uid: 696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4784,7 +4810,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 698
+  - uid: 697
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4792,7 +4818,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 699
+  - uid: 698
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4800,7 +4826,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 700
+  - uid: 699
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4808,7 +4834,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 701
+  - uid: 700
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4816,14 +4842,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 702
+  - uid: 701
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 703
+  - uid: 702
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4831,28 +4857,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 704
+  - uid: 703
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 705
+  - uid: 704
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 706
+  - uid: 705
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 707
+  - uid: 706
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4860,7 +4886,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 708
+  - uid: 707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4868,7 +4894,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 709
+  - uid: 708
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4876,7 +4902,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 710
+  - uid: 709
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4884,7 +4910,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 711
+  - uid: 710
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4892,7 +4918,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 712
+  - uid: 711
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4900,63 +4926,63 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 713
+  - uid: 712
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 714
+  - uid: 713
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 715
+  - uid: 714
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 716
+  - uid: 715
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 717
+  - uid: 716
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 718
+  - uid: 717
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 719
+  - uid: 718
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 720
+  - uid: 719
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 721
+  - uid: 720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4964,28 +4990,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 722
+  - uid: 721
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 723
+  - uid: 722
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 724
+  - uid: 723
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 725
+  - uid: 724
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4993,7 +5019,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 726
+  - uid: 725
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5001,7 +5027,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 727
+  - uid: 726
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5009,7 +5035,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 728
+  - uid: 727
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5017,7 +5043,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 729
+  - uid: 728
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5025,7 +5051,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 730
+  - uid: 729
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5033,7 +5059,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 731
+  - uid: 730
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5041,7 +5067,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 732
+  - uid: 731
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5049,7 +5075,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 733
+  - uid: 732
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5057,7 +5083,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 734
+  - uid: 733
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5065,7 +5091,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 735
+  - uid: 734
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5073,7 +5099,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 736
+  - uid: 735
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5081,7 +5107,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 737
+  - uid: 736
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5089,7 +5115,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 738
+  - uid: 737
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5097,7 +5123,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 739
+  - uid: 738
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5105,7 +5131,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 740
+  - uid: 739
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5113,42 +5139,42 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 741
+  - uid: 740
     components:
     - type: Transform
       pos: 13.5,-10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 742
+  - uid: 741
     components:
     - type: Transform
       pos: 13.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 743
+  - uid: 742
     components:
     - type: Transform
       pos: 12.5,-13.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 744
+  - uid: 743
     components:
     - type: Transform
       pos: 12.5,-14.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 745
+  - uid: 744
     components:
     - type: Transform
       pos: 12.5,-15.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 746
+  - uid: 745
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5156,7 +5182,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 747
+  - uid: 746
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5164,7 +5190,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 748
+  - uid: 747
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5174,13 +5200,13 @@ entities:
       color: '#FF1212FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 749
+  - uid: 748
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-0.5
       parent: 1
-  - uid: 750
+  - uid: 749
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5188,7 +5214,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 751
+  - uid: 750
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5196,7 +5222,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 752
+  - uid: 751
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5204,7 +5230,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 753
+  - uid: 752
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5212,7 +5238,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 754
+  - uid: 753
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5220,28 +5246,28 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 755
+  - uid: 754
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 756
+  - uid: 755
     components:
     - type: Transform
       pos: 9.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 757
+  - uid: 756
     components:
     - type: Transform
       pos: 10.5,-11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 758
+  - uid: 757
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5249,7 +5275,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 759
+  - uid: 758
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5257,14 +5283,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 760
+  - uid: 759
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 761
+  - uid: 760
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5272,7 +5298,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 762
+  - uid: 761
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5280,14 +5306,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 763
+  - uid: 762
     components:
     - type: Transform
       pos: 11.5,-16.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 764
+  - uid: 763
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5295,7 +5321,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 765
+  - uid: 764
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5303,7 +5329,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 766
+  - uid: 765
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5311,14 +5337,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 767
+  - uid: 766
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 768
+  - uid: 767
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5326,14 +5352,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 769
+  - uid: 768
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 770
+  - uid: 769
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5341,7 +5367,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 771
+  - uid: 770
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5349,7 +5375,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 772
+  - uid: 771
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5357,7 +5383,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 773
+  - uid: 772
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5365,21 +5391,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 774
+  - uid: 773
     components:
     - type: Transform
       pos: 13.5,-9.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 775
+  - uid: 774
     components:
     - type: Transform
       pos: 12.5,-12.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 776
+  - uid: 775
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5387,13 +5413,13 @@ entities:
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 777
+  - uid: 776
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 778
+  - uid: 777
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5401,7 +5427,7 @@ entities:
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 779
+  - uid: 778
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5409,7 +5435,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 780
+  - uid: 779
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5417,7 +5443,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 781
+  - uid: 780
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5425,7 +5451,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 782
+  - uid: 781
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5433,7 +5459,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 783
+  - uid: 782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5441,7 +5467,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 784
+  - uid: 783
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5449,7 +5475,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 785
+  - uid: 784
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5457,7 +5483,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 786
+  - uid: 785
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5465,14 +5491,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 787
+  - uid: 786
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 788
+  - uid: 787
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5480,7 +5506,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 789
+  - uid: 788
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5488,7 +5514,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 790
+  - uid: 789
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5496,7 +5522,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 791
+  - uid: 790
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5504,7 +5530,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 792
+  - uid: 791
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5512,7 +5538,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 793
+  - uid: 792
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5520,7 +5546,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 794
+  - uid: 793
     components:
     - type: Transform
       pos: 10.5,-3.5
@@ -5529,14 +5555,14 @@ entities:
       color: '#0335FCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 795
+  - uid: 794
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 796
+  - uid: 795
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5544,14 +5570,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 797
+  - uid: 796
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 798
+  - uid: 797
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5559,7 +5585,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 799
+  - uid: 798
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5567,7 +5593,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 800
+  - uid: 799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5575,7 +5601,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 801
+  - uid: 800
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5583,7 +5609,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 802
+  - uid: 801
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5591,7 +5617,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 803
+  - uid: 802
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5599,14 +5625,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 804
+  - uid: 803
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 805
+  - uid: 804
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5614,14 +5640,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 806
+  - uid: 805
     components:
     - type: Transform
       pos: 9.5,-3.5
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 807
+  - uid: 806
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5629,7 +5655,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 808
+  - uid: 807
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5637,7 +5663,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 809
+  - uid: 808
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5647,61 +5673,61 @@ entities:
       color: '#FF1212FF'
 - proto: Gauze1
   entities:
-  - uid: 810
+  - uid: 809
     components:
     - type: Transform
       pos: 11.575129,-0.48613083
       parent: 1
-  - uid: 811
+  - uid: 810
     components:
     - type: Transform
       pos: 11.528254,-0.25175583
       parent: 1
-  - uid: 812
+  - uid: 811
     components:
     - type: Transform
       pos: 11.278254,-0.51738083
       parent: 1
-  - uid: 813
+  - uid: 812
     components:
     - type: Transform
       pos: 11.247004,-0.25175583
       parent: 1
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 814
+  - uid: 813
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 815
+  - uid: 814
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 816
+  - uid: 815
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 817
+  - uid: 816
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 818
+  - uid: 817
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 819
+  - uid: 818
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
 - proto: GnomePlushie
   entities:
-  - uid: 820
+  - uid: 819
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5709,232 +5735,239 @@ entities:
       parent: 1
 - proto: GoldenBeaker
   entities:
-  - uid: 76
+  - uid: 485
     components:
     - type: Transform
-      parent: 69
+      parent: 484
     - type: Physics
       canCollide: False
-    - type: InsideEntityStorage
+  - uid: 1372
+    components:
+    - type: Transform
+      pos: 3.5128298,-9.258845
+      parent: 1
+    - type: CollisionWake
+      enabled: False
+    - type: Label
 - proto: GravityGeneratorMini
   entities:
-  - uid: 821
+  - uid: 820
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 822
+  - uid: 821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
-  - uid: 823
+  - uid: 822
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-3.5
       parent: 1
-  - uid: 824
+  - uid: 823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-6.5
       parent: 1
-  - uid: 825
+  - uid: 824
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-7.5
       parent: 1
-  - uid: 826
+  - uid: 825
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-8.5
       parent: 1
-  - uid: 827
+  - uid: 826
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-11.5
       parent: 1
-  - uid: 828
+  - uid: 827
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-1.5
       parent: 1
-  - uid: 829
+  - uid: 828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-1.5
       parent: 1
-  - uid: 830
+  - uid: 829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-13.5
       parent: 1
-  - uid: 831
+  - uid: 830
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-13.5
       parent: 1
-  - uid: 832
+  - uid: 831
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 833
+  - uid: 832
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 834
+  - uid: 833
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 835
+  - uid: 834
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-  - uid: 836
+  - uid: 835
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-8.5
       parent: 1
-  - uid: 837
+  - uid: 836
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 1
-  - uid: 838
+  - uid: 837
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
-  - uid: 839
+  - uid: 838
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 840
+  - uid: 839
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-10.5
       parent: 1
-  - uid: 841
+  - uid: 840
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-  - uid: 842
+  - uid: 841
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 843
+  - uid: 842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 1
-  - uid: 844
+  - uid: 843
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
-  - uid: 845
+  - uid: 844
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
-  - uid: 846
+  - uid: 845
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-  - uid: 847
+  - uid: 846
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 1
-  - uid: 848
+  - uid: 847
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-12.5
       parent: 1
-  - uid: 849
+  - uid: 848
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-11.5
       parent: 1
-  - uid: 850
+  - uid: 849
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 851
+  - uid: 850
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-10.5
       parent: 1
-  - uid: 852
+  - uid: 851
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
-  - uid: 853
+  - uid: 852
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-10.5
       parent: 1
-  - uid: 854
+  - uid: 853
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-10.5
       parent: 1
-  - uid: 855
+  - uid: 854
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-17.5
       parent: 1
-  - uid: 856
+  - uid: 855
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-16.5
       parent: 1
-  - uid: 857
+  - uid: 856
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,2.5
       parent: 1
-  - uid: 858
+  - uid: 857
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5942,47 +5975,47 @@ entities:
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 859
+  - uid: 858
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 860
+  - uid: 859
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-10.5
       parent: 1
-  - uid: 861
+  - uid: 860
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 1
-  - uid: 862
+  - uid: 861
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 1
-  - uid: 863
+  - uid: 862
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 1
-  - uid: 864
+  - uid: 863
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 865
+  - uid: 864
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-4.5
       parent: 1
-  - uid: 866
+  - uid: 865
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5990,7 +6023,7 @@ entities:
       parent: 1
 - proto: GunSafeBaseSecure
   entities:
-  - uid: 87
+  - uid: 97
     components:
     - type: MetaData
       name: Shotgun safe
@@ -6003,20 +6036,20 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 90
-          - 96
-          - 95
-          - 94
-          - 93
-          - 92
-          - 91
-          - 88
-          - 89
+          - 100
+          - 106
+          - 105
+          - 104
+          - 103
+          - 102
+          - 101
+          - 98
+          - 99
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 97
+  - uid: 107
     components:
     - type: MetaData
       name: Shotgun safe
@@ -6029,20 +6062,20 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 103
-          - 102
-          - 101
-          - 98
-          - 99
-          - 100
-          - 104
-          - 105
-          - 106
+          - 113
+          - 112
+          - 111
+          - 108
+          - 109
+          - 110
+          - 114
+          - 115
+          - 116
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 867
+  - uid: 866
     components:
     - type: MetaData
       name: Vibroblade safe
@@ -6055,9 +6088,9 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 872
-          - 870
-          - 868
+          - 871
+          - 869
+          - 867
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -6068,19 +6101,9 @@ entities:
         immutable: False
         temperature: 293.147
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-  - uid: 874
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+  - uid: 873
     components:
     - type: MetaData
       name: Vibroblade safe
@@ -6093,9 +6116,9 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 877
-          - 875
-          - 879
+          - 876
+          - 874
+          - 878
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -6106,28 +6129,18 @@ entities:
         immutable: False
         temperature: 293.147
         moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
 - proto: GunSafeLaserCarbine
   entities:
-  - uid: 881
+  - uid: 880
     components:
     - type: MetaData
       name: Laser safe
     - type: Transform
       pos: -1.5,-17.5
       parent: 1
-  - uid: 882
+  - uid: 881
     components:
     - type: MetaData
       name: Laser safe
@@ -6136,41 +6149,41 @@ entities:
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 883
+  - uid: 882
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 1
-  - uid: 884
+  - uid: 883
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-18.5
       parent: 1
-  - uid: 885
+  - uid: 884
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 886
+  - uid: 885
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,0.5
       parent: 1
-  - uid: 887
+  - uid: 886
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-15.5
       parent: 1
-  - uid: 888
+  - uid: 887
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 889
+  - uid: 888
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6178,49 +6191,67 @@ entities:
       parent: 1
 - proto: HandLabeler
   entities:
-  - uid: 77
+  - uid: 1371
     components:
     - type: Transform
-      parent: 69
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: 2.5070717,-7.649927
+      parent: 1
 - proto: HighSecCentralCommandLocked
   entities:
-  - uid: 890
+  - uid: 889
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
-  - uid: 891
+  - uid: 890
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
 - proto: HolopadBluespace
   entities:
-  - uid: 892
+  - uid: 891
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
 - proto: Jukebox
   entities:
-  - uid: 893
+  - uid: 892
     components:
     - type: Transform
       pos: 13.5,-14.5
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 894
+  - uid: 893
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
+- proto: LargeBeaker
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 75
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 76
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
 - proto: LockableButtonCommand
   entities:
-  - uid: 895
+  - uid: 894
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6228,222 +6259,240 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        56:
+        60:
         - - Pressed
           - Toggle
-        57:
+        61:
         - - Pressed
           - Toggle
-        1040:
+        1047:
         - - Pressed
           - Toggle
-        1039:
+        1046:
         - - Pressed
           - Toggle
-        1038:
+        1045:
         - - Pressed
           - Toggle
-        59:
+        63:
         - - Pressed
           - Toggle
-        58:
+        62:
         - - Pressed
           - Toggle
-  - uid: 896
+    - type: Fixtures
+      fixtures: {}
+  - uid: 895
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        58:
+        62:
         - - Pressed
           - Toggle
-        59:
+        63:
         - - Pressed
           - Toggle
-        57:
+        61:
         - - Pressed
           - Toggle
-        56:
+        60:
         - - Pressed
           - Toggle
-        1038:
+        1045:
         - - Pressed
           - Toggle
-        1039:
+        1046:
         - - Pressed
           - Toggle
-        1040:
+        1047:
         - - Pressed
           - Toggle
+    - type: Fixtures
+      fixtures: {}
+- proto: LockerChemistryFilled
+  entities:
+  - uid: 480
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+- proto: LockerWallEvacRepairFilled
+  entities:
+  - uid: 486
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14697
+        moles:
+          Oxygen: 1.8856695
+          Nitrogen: 7.0937095
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 487
+          - 488
+          - 489
+          - 490
+          - 491
+          - 492
+    - type: Fixtures
+      fixtures: {}
 - proto: LockerWallMedicalFilled
   entities:
-  - uid: 897
+  - uid: 896
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: MachineCentrifuge
   entities:
-  - uid: 898
+  - uid: 897
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
 - proto: MachineElectrolysisUnit
   entities:
-  - uid: 899
+  - uid: 898
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
 - proto: MaterialBiomass
   entities:
-  - uid: 475
+  - uid: 1375
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 476
+      pos: 14.282736,-9.247767
+      parent: 1
+  - uid: 1376
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 477
+      pos: 14.520865,-9.247767
+      parent: 1
+  - uid: 1377
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 478
+      pos: 14.73915,-9.237857
+      parent: 1
+  - uid: 1378
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 479
+      pos: 14.262892,-9.416251
+      parent: 1
+  - uid: 1379
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 480
+      pos: 14.520865,-9.396429
+      parent: 1
+  - uid: 1380
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 481
+      pos: 14.749071,-9.396429
+      parent: 1
+  - uid: 1381
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 482
+      pos: 14.262892,-9.5946455
+      parent: 1
+  - uid: 1382
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 483
+      pos: 14.5407095,-9.5946455
+      parent: 1
+  - uid: 1383
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 484
-    components:
-    - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: 14.778838,-9.584735
+      parent: 1
 - proto: MedicalBed
   entities:
-  - uid: 900
+  - uid: 899
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 901
+  - uid: 900
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 1
-  - uid: 902
+  - uid: 901
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 903
+  - uid: 902
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 904
+  - uid: 903
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 1
-  - uid: 905
+  - uid: 904
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 1
-  - uid: 906
+  - uid: 905
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 1
 - proto: MedicalScanner
   entities:
-  - uid: 907
+  - uid: 906
     components:
     - type: Transform
       pos: 9.5,-7.5
       parent: 1
-  - uid: 908
+  - uid: 907
     components:
     - type: Transform
       pos: 12.5,-7.5
       parent: 1
 - proto: MedkitCombatFilled
   entities:
-  - uid: 909
+  - uid: 908
     components:
     - type: Transform
       pos: 8.511875,0.64957905
       parent: 1
-  - uid: 910
+  - uid: 909
     components:
     - type: Transform
       pos: 8.622004,0.54511917
       parent: 1
-  - uid: 911
+  - uid: 910
     components:
     - type: Transform
       pos: 8.450129,0.46699417
       parent: 1
-  - uid: 912
+  - uid: 911
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.3287277,-9.53085
       parent: 1
-  - uid: 913
+  - uid: 912
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6451,7 +6500,7 @@ entities:
       parent: 1
 - proto: MopBucketFull
   entities:
-  - uid: 914
+  - uid: 913
     components:
     - type: Transform
       pos: 14.5,-15.5
@@ -6465,26 +6514,24 @@ entities:
         item_slot: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 915
+          ent: 914
 - proto: MopItem
   entities:
-  - uid: 916
+  - uid: 915
     components:
     - type: Transform
       pos: 14.48557,-15.513462
       parent: 1
 - proto: Multitool
   entities:
-  - uid: 485
+  - uid: 1366
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: 7.3389597,-6.5001574
+      parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 917
+  - uid: 916
     components:
     - type: Transform
       pos: -2.5,1.5
@@ -6498,66 +6545,66 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 504
+  - uid: 503
     components:
     - type: Transform
-      parent: 498
+      parent: 497
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 512
+  - uid: 511
     components:
     - type: Transform
-      parent: 506
+      parent: 505
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 520
+  - uid: 519
     components:
     - type: Transform
-      parent: 514
+      parent: 513
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 528
+  - uid: 527
     components:
     - type: Transform
-      parent: 522
+      parent: 521
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 536
+  - uid: 535
     components:
     - type: Transform
-      parent: 530
+      parent: 529
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: Ointment
   entities:
-  - uid: 918
+  - uid: 917
     components:
     - type: Transform
       pos: 10.18375,-0.33479595
       parent: 1
-  - uid: 919
+  - uid: 918
     components:
     - type: Transform
       pos: 10.511875,-0.58479595
       parent: 1
-  - uid: 920
+  - uid: 919
     components:
     - type: Transform
       pos: 10.68375,-0.33479595
       parent: 1
-  - uid: 921
+  - uid: 920
     components:
     - type: Transform
       pos: 10.215,-0.63167095
       parent: 1
 - proto: OxygenCanister
   entities:
-  - uid: 922
+  - uid: 921
     components:
     - type: Transform
       pos: -2.5,-0.5
@@ -6568,45 +6615,47 @@ entities:
     components:
     - type: Transform
       parent: 2
-    - type: InsideEntityStorage
-  - uid: 505
-    components:
-    - type: Transform
-      parent: 498
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 513
+  - uid: 504
     components:
     - type: Transform
-      parent: 506
+      parent: 497
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 521
+  - uid: 512
     components:
     - type: Transform
-      parent: 514
+      parent: 505
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 529
+  - uid: 520
     components:
     - type: Transform
-      parent: 522
+      parent: 513
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 537
+  - uid: 528
     components:
     - type: Transform
-      parent: 530
+      parent: 521
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 536
+    components:
+    - type: Transform
+      parent: 529
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: PianoInstrument
   entities:
-  - uid: 923
+  - uid: 922
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6614,128 +6663,128 @@ entities:
       parent: 1
 - proto: PigPlushie
   entities:
-  - uid: 924
+  - uid: 923
     components:
     - type: Transform
       pos: 8.525559,-18.20821
       parent: 1
 - proto: PillAmbuzol
   entities:
-  - uid: 925
+  - uid: 924
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.237062,-7.040344
       parent: 1
-  - uid: 926
+  - uid: 925
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.283937,-6.399719
       parent: 1
-  - uid: 927
+  - uid: 926
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.752687,-7.837219
       parent: 1
-  - uid: 928
+  - uid: 927
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.674562,-6.493469
       parent: 1
-  - uid: 929
+  - uid: 928
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.377687,-6.837219
       parent: 1
-  - uid: 930
+  - uid: 929
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.783937,-7.180969
       parent: 1
-  - uid: 931
+  - uid: 930
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.377687,-7.305969
       parent: 1
-  - uid: 932
+  - uid: 931
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.207619,-6.665344
       parent: 1
-  - uid: 933
+  - uid: 932
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.455812,-8.071594
       parent: 1
-  - uid: 934
+  - uid: 933
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.330812,-8.587219
       parent: 1
-  - uid: 935
+  - uid: 934
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.582619,-7.009094
       parent: 1
-  - uid: 936
+  - uid: 935
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.580812,-8.634094
       parent: 1
-  - uid: 937
+  - uid: 936
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.770119,-6.180969
       parent: 1
-  - uid: 938
+  - uid: 937
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.721437,-8.212219
       parent: 1
-  - uid: 939
+  - uid: 938
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.268312,-7.868469
       parent: 1
-  - uid: 940
+  - uid: 939
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.549562,-7.618469
       parent: 1
-  - uid: 941
+  - uid: 940
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.752687,-6.837219
       parent: 1
-  - uid: 942
+  - uid: 941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.237062,-8.290344
       parent: 1
-  - uid: 943
+  - uid: 942
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.190187,-7.477844
       parent: 1
-  - uid: 944
+  - uid: 943
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6743,119 +6792,119 @@ entities:
       parent: 1
 - proto: PillAmbuzolPlus
   entities:
+  - uid: 546
+    components:
+    - type: Transform
+      parent: 545
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
   - uid: 547
     components:
     - type: Transform
-      parent: 546
+      parent: 545
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 548
     components:
     - type: Transform
-      parent: 546
+      parent: 545
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 549
     components:
     - type: Transform
-      parent: 546
+      parent: 545
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 550
     components:
     - type: Transform
-      parent: 546
+      parent: 545
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 551
     components:
     - type: Transform
-      parent: 546
+      parent: 545
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 552
     components:
     - type: Transform
-      parent: 546
+      parent: 545
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 553
     components:
     - type: Transform
-      parent: 546
+      parent: 545
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 554
     components:
     - type: Transform
-      parent: 546
+      parent: 545
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 555
     components:
     - type: Transform
-      parent: 546
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 556
-    components:
-    - type: Transform
-      parent: 546
+      parent: 545
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 945
+  - uid: 944
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-11.5
       parent: 1
-  - uid: 946
+  - uid: 945
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-3.5
       parent: 1
-  - uid: 947
+  - uid: 946
     components:
     - type: Transform
       pos: 18.5,-11.5
       parent: 1
-  - uid: 948
+  - uid: 947
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-16.5
       parent: 1
-  - uid: 949
+  - uid: 948
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-14.5
       parent: 1
-  - uid: 950
+  - uid: 949
     components:
     - type: Transform
       pos: 18.5,-3.5
       parent: 1
-  - uid: 1360
+  - uid: 950
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-14.5
       parent: 1
-  - uid: 1363
+  - uid: 951
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6863,43 +6912,43 @@ entities:
       parent: 1
 - proto: PlasmaWindoorSecureCentralCommandLocked
   entities:
-  - uid: 951
+  - uid: 952
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-2.5
       parent: 1
-  - uid: 952
+  - uid: 953
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-4.5
       parent: 1
-  - uid: 953
+  - uid: 954
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-10.5
       parent: 1
-  - uid: 954
+  - uid: 955
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-12.5
       parent: 1
-  - uid: 955
+  - uid: 956
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-15.5
       parent: 1
-  - uid: 1361
+  - uid: 957
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-15.5
       parent: 1
-  - uid: 1362
+  - uid: 958
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6907,21 +6956,21 @@ entities:
       parent: 1
 - proto: PlushieBee
   entities:
-  - uid: 956
+  - uid: 959
     components:
     - type: Transform
       pos: 8.525559,-16.45821
       parent: 1
 - proto: PlushieHampter
   entities:
-  - uid: 957
+  - uid: 960
     components:
     - type: Transform
       pos: 8.525559,-14.42696
       parent: 1
 - proto: PlushieRouny
   entities:
-  - uid: 958
+  - uid: 961
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6929,199 +6978,201 @@ entities:
       parent: 1
 - proto: PlushieSharkGrey
   entities:
-  - uid: 915
+  - uid: 914
     components:
     - type: Transform
-      parent: 914
+      parent: 913
     - type: Physics
       canCollide: False
 - proto: PosterLegitPeriodicTable
   entities:
-  - uid: 959
+  - uid: 962
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: PottedPlantRandom
   entities:
-  - uid: 960
+  - uid: 963
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 1
-  - uid: 961
+  - uid: 964
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
 - proto: PowerCellMedium
   entities:
-  - uid: 962
+  - uid: 965
     components:
     - type: Transform
       pos: 11.6525,0.55582905
       parent: 1
 - proto: PowerCellRecharger
   entities:
-  - uid: 963
+  - uid: 966
     components:
     - type: Transform
       pos: 11.5,0.5
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 964
+  - uid: 967
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-7.5
       parent: 1
-  - uid: 965
+  - uid: 968
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-9.5
       parent: 1
-  - uid: 966
+  - uid: 969
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-9.5
       parent: 1
-  - uid: 967
+  - uid: 970
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-7.5
       parent: 1
-  - uid: 968
+  - uid: 971
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 969
+  - uid: 972
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 970
+  - uid: 973
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 1
-  - uid: 971
+  - uid: 974
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 972
+  - uid: 975
     components:
     - type: Transform
       pos: 7.5,-14.5
       parent: 1
-  - uid: 973
+  - uid: 976
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-12.5
       parent: 1
-  - uid: 974
-    components:
-    - type: Transform
-      pos: 2.5,-2.5
-      parent: 1
-  - uid: 975
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-12.5
-      parent: 1
-  - uid: 976
-    components:
-    - type: Transform
-      pos: 2.5,-14.5
-      parent: 1
   - uid: 977
     components:
     - type: Transform
-      pos: -4.5,-14.5
+      pos: 2.5,-2.5
       parent: 1
   - uid: 978
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-16.5
+      pos: 2.5,-12.5
       parent: 1
   - uid: 979
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 980
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 1
+  - uid: 981
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-16.5
+      parent: 1
+  - uid: 982
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-17.5
       parent: 1
-  - uid: 980
+  - uid: 983
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-17.5
       parent: 1
-  - uid: 981
+  - uid: 984
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 982
+  - uid: 985
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 983
+  - uid: 986
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-9.5
       parent: 1
-  - uid: 984
+  - uid: 987
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-5.5
       parent: 1
-  - uid: 985
+  - uid: 988
     components:
     - type: Transform
       pos: 12.5,-11.5
       parent: 1
-  - uid: 986
+  - uid: 989
     components:
     - type: Transform
       pos: 9.5,-11.5
       parent: 1
-  - uid: 987
+  - uid: 990
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 1
-  - uid: 988
+  - uid: 991
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-0.5
       parent: 1
-  - uid: 989
+  - uid: 992
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 990
+  - uid: 993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-0.5
       parent: 1
-  - uid: 991
+  - uid: 994
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7129,53 +7180,53 @@ entities:
       parent: 1
 - proto: PoweredlightExterior
   entities:
-  - uid: 992
+  - uid: 995
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,3.5
       parent: 1
-  - uid: 993
+  - uid: 996
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 994
+  - uid: 997
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-18.5
       parent: 1
-  - uid: 995
+  - uid: 998
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,0.5
       parent: 1
-  - uid: 996
+  - uid: 999
     components:
     - type: Transform
       pos: -4.5,-18.5
       parent: 1
-  - uid: 997
+  - uid: 1000
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 1
-  - uid: 998
+  - uid: 1001
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-15.5
       parent: 1
-  - uid: 999
+  - uid: 1002
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,0.5
       parent: 1
-  - uid: 1000
+  - uid: 1003
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7183,23 +7234,23 @@ entities:
       parent: 1
 - proto: PoweredlightLED
   entities:
-  - uid: 1001
+  - uid: 1004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-0.5
       parent: 1
-  - uid: 1002
+  - uid: 1005
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 1
-  - uid: 1003
+  - uid: 1006
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 1004
+  - uid: 1007
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7207,46 +7258,46 @@ entities:
       parent: 1
 - proto: PoweredSmallLight
   entities:
-  - uid: 1005
+  - uid: 1008
     components:
     - type: Transform
       pos: 18.5,-2.5
       parent: 1
-  - uid: 1006
+  - uid: 1009
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-12.5
       parent: 1
-  - uid: 1007
+  - uid: 1010
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 1008
+  - uid: 1011
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-4.5
       parent: 1
-  - uid: 1009
+  - uid: 1012
     components:
     - type: Transform
       pos: 18.5,-10.5
       parent: 1
-  - uid: 1010
+  - uid: 1013
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-12.5
       parent: 1
-  - uid: 1011
+  - uid: 1014
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-3.5
       parent: 1
-  - uid: 1012
+  - uid: 1015
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7254,79 +7305,41 @@ entities:
       parent: 1
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 1013
+  - uid: 1016
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-3.5
       parent: 1
-  - uid: 1014
+  - uid: 1017
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-3.5
       parent: 1
-  - uid: 1015
+  - uid: 1018
     components:
     - type: Transform
       pos: 13.5,-14.5
       parent: 1
-  - uid: 1016
+  - uid: 1019
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,-18.5
       parent: 1
-  - uid: 1017
+  - uid: 1020
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-0.5
       parent: 1
-  - uid: 1018
+  - uid: 1021
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
 - proto: PrototypeVibroblade
-  entities:
-  - uid: 869
-    components:
-    - type: Transform
-      parent: 868
-    - type: Physics
-      canCollide: False
-  - uid: 871
-    components:
-    - type: Transform
-      parent: 870
-    - type: Physics
-      canCollide: False
-  - uid: 873
-    components:
-    - type: Transform
-      parent: 872
-    - type: Physics
-      canCollide: False
-  - uid: 876
-    components:
-    - type: Transform
-      parent: 875
-    - type: Physics
-      canCollide: False
-  - uid: 878
-    components:
-    - type: Transform
-      parent: 877
-    - type: Physics
-      canCollide: False
-  - uid: 880
-    components:
-    - type: Transform
-      parent: 879
-    - type: Physics
-      canCollide: False
-- proto: PrototypeVibrobladeSheath
   entities:
   - uid: 868
     components:
@@ -7334,69 +7347,42 @@ entities:
       parent: 867
     - type: Physics
       canCollide: False
-    - type: ContainerContainer
-      containers:
-        item: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 869
-    - type: InsideEntityStorage
   - uid: 870
     components:
     - type: Transform
-      parent: 867
+      parent: 869
     - type: Physics
       canCollide: False
-    - type: ContainerContainer
-      containers:
-        item: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 871
-    - type: InsideEntityStorage
   - uid: 872
     components:
     - type: Transform
-      parent: 867
+      parent: 871
     - type: Physics
       canCollide: False
-    - type: ContainerContainer
-      containers:
-        item: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 873
-    - type: InsideEntityStorage
   - uid: 875
     components:
     - type: Transform
       parent: 874
     - type: Physics
       canCollide: False
-    - type: ContainerContainer
-      containers:
-        item: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 876
-    - type: InsideEntityStorage
   - uid: 877
     components:
     - type: Transform
-      parent: 874
+      parent: 876
     - type: Physics
       canCollide: False
-    - type: ContainerContainer
-      containers:
-        item: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: 878
-    - type: InsideEntityStorage
   - uid: 879
     components:
     - type: Transform
-      parent: 874
+      parent: 878
+    - type: Physics
+      canCollide: False
+- proto: PrototypeVibrobladeSheath
+  entities:
+  - uid: 867
+    components:
+    - type: Transform
+      parent: 866
     - type: Physics
       canCollide: False
     - type: ContainerContainer
@@ -7404,41 +7390,111 @@ entities:
         item: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 880
+          ent: 868
+    - type: InsideEntityStorage
+  - uid: 869
+    components:
+    - type: Transform
+      parent: 866
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        item: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 870
+    - type: InsideEntityStorage
+  - uid: 871
+    components:
+    - type: Transform
+      parent: 866
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        item: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 872
+    - type: InsideEntityStorage
+  - uid: 874
+    components:
+    - type: Transform
+      parent: 873
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        item: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 875
+    - type: InsideEntityStorage
+  - uid: 876
+    components:
+    - type: Transform
+      parent: 873
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        item: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 877
+    - type: InsideEntityStorage
+  - uid: 878
+    components:
+    - type: Transform
+      parent: 873
+    - type: Physics
+      canCollide: False
+    - type: ContainerContainer
+      containers:
+        item: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 879
     - type: InsideEntityStorage
 - proto: Rack
   entities:
-  - uid: 1019
+  - uid: 1022
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 1
-  - uid: 1020
+  - uid: 1023
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
-  - uid: 1021
+  - uid: 1024
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-14.5
       parent: 1
+  - uid: 1373
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 1
 - proto: RagItem
   entities:
-  - uid: 1022
+  - uid: 1025
     components:
     - type: Transform
       pos: 5.706568,-15.581383
       parent: 1
 - proto: Railing
   entities:
-  - uid: 1023
+  - uid: 1026
     components:
     - type: Transform
       pos: 14.5,-16.5
       parent: 1
-  - uid: 1024
+  - uid: 1027
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7446,12 +7502,12 @@ entities:
       parent: 1
 - proto: RailingCorner
   entities:
-  - uid: 1025
+  - uid: 1028
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 1026
+  - uid: 1029
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7459,31 +7515,31 @@ entities:
       parent: 1
 - proto: RailingCornerSmall
   entities:
-  - uid: 1027
+  - uid: 1030
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 13.5,-16.5
       parent: 1
-  - uid: 1028
+  - uid: 1031
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-10.5
       parent: 1
-  - uid: 1029
+  - uid: 1032
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-4.5
       parent: 1
-  - uid: 1030
+  - uid: 1033
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-10.5
       parent: 1
-  - uid: 1031
+  - uid: 1034
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7491,13 +7547,13 @@ entities:
       parent: 1
 - proto: RailingRound
   entities:
-  - uid: 1032
+  - uid: 1035
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 1
-  - uid: 1033
+  - uid: 1036
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7505,104 +7561,186 @@ entities:
       parent: 1
 - proto: RCD
   entities:
+  - uid: 487
+    components:
+    - type: Transform
+      parent: 486
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 486
+  - uid: 489
+    components:
+    - type: Transform
+      parent: 486
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 486
+- proto: RCDAmmo
+  entities:
+  - uid: 488
+    components:
+    - type: Transform
+      parent: 486
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+      storage: 486
   - uid: 490
     components:
     - type: Transform
-      parent: 487
+      parent: 486
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 491
-    components:
-    - type: Transform
-      parent: 487
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-- proto: RCDAmmo
-  entities:
-  - uid: 492
-    components:
-    - type: Transform
-      parent: 487
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 493
-    components:
-    - type: Transform
-      parent: 487
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      storage: 486
 - proto: SheetPlasma
   entities:
-  - uid: 78
+  - uid: 1369
     components:
     - type: Transform
-      parent: 69
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: 5.5192323,-7.332782
+      parent: 1
 - proto: SheetPlastic
   entities:
-  - uid: 1359
+  - uid: 1037
     components:
     - type: Transform
       pos: -0.46766925,-14.49816
       parent: 1
-  - uid: 1364
+  - uid: 1038
     components:
     - type: Transform
       pos: -0.46766925,-14.49816
       parent: 1
-  - uid: 1365
+  - uid: 1039
     components:
     - type: Transform
       pos: -0.46766925,-14.49816
       parent: 1
-  - uid: 1366
+  - uid: 1040
     components:
     - type: Transform
       pos: -0.46766925,-14.49816
       parent: 1
 - proto: SheetSteel
   entities:
-  - uid: 1034
+  - uid: 1041
     components:
     - type: Transform
       pos: -0.85829425,-14.451285
       parent: 1
-  - uid: 1035
+  - uid: 1042
     components:
     - type: Transform
       pos: -0.85829425,-14.451285
       parent: 1
-  - uid: 1036
+  - uid: 1043
     components:
     - type: Transform
       pos: -0.85829425,-14.451285
       parent: 1
-  - uid: 1037
+  - uid: 1044
     components:
     - type: Transform
       pos: -0.85829425,-14.451285
       parent: 1
+- proto: ShelfChemistry
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-5.5
+      parent: 1
+    - type: Storage
+      storedItems:
+        74:
+          position: 0,0
+          _rotation: South
+        75:
+          position: 2,0
+          _rotation: South
+        76:
+          position: 4,0
+          _rotation: South
+        77:
+          position: 0,3
+          _rotation: South
+        78:
+          position: 1,3
+          _rotation: South
+        79:
+          position: 2,3
+          _rotation: South
+        80:
+          position: 3,3
+          _rotation: South
+        81:
+          position: 4,3
+          _rotation: South
+        82:
+          position: 5,3
+          _rotation: South
+        83:
+          position: 0,4
+          _rotation: South
+        84:
+          position: 1,4
+          _rotation: South
+        85:
+          position: 2,4
+          _rotation: South
+        86:
+          position: 3,4
+          _rotation: South
+        87:
+          position: 4,4
+          _rotation: South
+        88:
+          position: 5,4
+          _rotation: South
+    - type: Lock
+      locked: False
+    - type: ContainerContainer
+      containers:
+        storagebase: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 74
+          - 75
+          - 76
+          - 77
+          - 78
+          - 79
+          - 80
+          - 81
+          - 82
+          - 83
+          - 84
+          - 85
+          - 86
+          - 87
+          - 88
+    - type: Fixtures
+      fixtures: {}
 - proto: ShuttersWindowOpen
   entities:
-  - uid: 1038
+  - uid: 1045
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-6.5
       parent: 1
-  - uid: 1039
+  - uid: 1046
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 1
-  - uid: 1040
+  - uid: 1047
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7610,216 +7748,216 @@ entities:
       parent: 1
 - proto: ShuttleWindow
   entities:
-  - uid: 1041
+  - uid: 1048
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-10.5
       parent: 1
-  - uid: 1042
+  - uid: 1049
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-3.5
       parent: 1
-  - uid: 1043
+  - uid: 1050
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-7.5
       parent: 1
-  - uid: 1044
+  - uid: 1051
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-6.5
       parent: 1
-  - uid: 1045
+  - uid: 1052
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-8.5
       parent: 1
-  - uid: 1046
+  - uid: 1053
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-11.5
       parent: 1
-  - uid: 1047
+  - uid: 1054
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-13.5
       parent: 1
-  - uid: 1048
+  - uid: 1055
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-13.5
       parent: 1
-  - uid: 1049
+  - uid: 1056
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-1.5
       parent: 1
-  - uid: 1050
+  - uid: 1057
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-1.5
       parent: 1
-  - uid: 1051
+  - uid: 1058
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,1.5
       parent: 1
-  - uid: 1052
+  - uid: 1059
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 1
-  - uid: 1053
+  - uid: 1060
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,2.5
       parent: 1
-  - uid: 1054
+  - uid: 1061
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-10.5
       parent: 1
-  - uid: 1055
+  - uid: 1062
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 1056
+  - uid: 1063
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 1057
+  - uid: 1064
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 1058
+  - uid: 1065
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 1
-  - uid: 1059
+  - uid: 1066
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-10.5
       parent: 1
-  - uid: 1060
+  - uid: 1067
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
-  - uid: 1061
+  - uid: 1068
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 1
-  - uid: 1062
+  - uid: 1069
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 1
-  - uid: 1063
+  - uid: 1070
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-  - uid: 1064
+  - uid: 1071
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-8.5
       parent: 1
-  - uid: 1065
+  - uid: 1072
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-12.5
       parent: 1
-  - uid: 1066
+  - uid: 1073
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 1
-  - uid: 1067
+  - uid: 1074
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-11.5
       parent: 1
-  - uid: 1068
+  - uid: 1075
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 1
-  - uid: 1069
+  - uid: 1076
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-2.5
       parent: 1
-  - uid: 1070
+  - uid: 1077
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 1
-  - uid: 1071
+  - uid: 1078
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 1
-  - uid: 1072
+  - uid: 1079
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
-  - uid: 1073
+  - uid: 1080
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
-  - uid: 1074
+  - uid: 1081
     components:
     - type: Transform
       pos: 8.5,4.5
       parent: 1
-  - uid: 1075
+  - uid: 1082
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-10.5
       parent: 1
-  - uid: 1076
+  - uid: 1083
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-16.5
       parent: 1
-  - uid: 1077
+  - uid: 1084
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7827,90 +7965,98 @@ entities:
       parent: 1
 - proto: ShuttleWindowDiagonal
   entities:
-  - uid: 1078
+  - uid: 1085
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 1
-  - uid: 1079
+  - uid: 1086
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 1080
+  - uid: 1087
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-5.5
       parent: 1
-  - uid: 1081
+  - uid: 1088
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-4.5
       parent: 1
-  - uid: 1082
+  - uid: 1089
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 1083
+  - uid: 1090
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 1
-  - uid: 1084
+  - uid: 1091
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-10.5
       parent: 1
-  - uid: 1085
+  - uid: 1092
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 1
 - proto: SignBar
   entities:
-  - uid: 1086
+  - uid: 1093
     components:
     - type: Transform
       pos: 13.5,-13.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SignCloning
   entities:
-  - uid: 1087
+  - uid: 1094
     components:
     - type: Transform
       pos: 15.5,-4.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SignMedical
   entities:
-  - uid: 1088
+  - uid: 1095
     components:
     - type: Transform
       pos: 15.5,-1.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SignMorgue
   entities:
-  - uid: 1089
+  - uid: 1096
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-4.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: SinkWide
   entities:
-  - uid: 1090
+  - uid: 1097
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-18.5
       parent: 1
-  - uid: 1091
+  - uid: 1098
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7918,14 +8064,14 @@ entities:
       parent: 1
 - proto: SMESAdvanced
   entities:
-  - uid: 1092
+  - uid: 1099
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
 - proto: SodaDispenser
   entities:
-  - uid: 1093
+  - uid: 1100
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7933,27 +8079,6 @@ entities:
       parent: 1
 - proto: SpeedLoaderShotgunIncendiary
   entities:
-  - uid: 91
-    components:
-    - type: Transform
-      parent: 87
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 92
-    components:
-    - type: Transform
-      parent: 87
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 93
-    components:
-    - type: Transform
-      parent: 87
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
   - uid: 101
     components:
     - type: Transform
@@ -7975,79 +8100,100 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
+  - uid: 111
+    components:
+    - type: Transform
+      parent: 107
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 112
+    components:
+    - type: Transform
+      parent: 107
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 113
+    components:
+    - type: Transform
+      parent: 107
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: StairDark
   entities:
-  - uid: 1094
+  - uid: 1101
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-4.5
       parent: 1
-  - uid: 1095
+  - uid: 1102
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 1096
+  - uid: 1103
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 1
-  - uid: 1097
+  - uid: 1104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-4.5
       parent: 1
-  - uid: 1098
+  - uid: 1105
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 1
-  - uid: 1099
+  - uid: 1106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-4.5
       parent: 1
-  - uid: 1100
+  - uid: 1107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 1
-  - uid: 1101
+  - uid: 1108
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-12.5
       parent: 1
-  - uid: 1102
+  - uid: 1109
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-3.5
       parent: 1
-  - uid: 1103
+  - uid: 1110
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 1
-  - uid: 1104
+  - uid: 1111
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 1105
+  - uid: 1112
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
 - proto: StairStageWood
   entities:
-  - uid: 1106
+  - uid: 1113
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8055,24 +8201,24 @@ entities:
       parent: 1
 - proto: StasisBed
   entities:
-  - uid: 1107
+  - uid: 1114
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 1
-  - uid: 1108
+  - uid: 1115
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 1
-  - uid: 1109
+  - uid: 1116
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 1
 - proto: Stool
   entities:
-  - uid: 1110
+  - uid: 1117
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8080,31 +8226,31 @@ entities:
       parent: 1
 - proto: StoolBar
   entities:
-  - uid: 1111
+  - uid: 1118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-18.5
       parent: 1
-  - uid: 1112
+  - uid: 1119
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-17.5
       parent: 1
-  - uid: 1113
+  - uid: 1120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-16.5
       parent: 1
-  - uid: 1114
+  - uid: 1121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-15.5
       parent: 1
-  - uid: 1115
+  - uid: 1122
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8112,7 +8258,7 @@ entities:
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 1116
+  - uid: 1123
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8138,7 +8284,7 @@ entities:
           - 7
           - 5
           - 9
-  - uid: 498
+  - uid: 497
     components:
     - type: Transform
       pos: -5.5,-14.5
@@ -8149,14 +8295,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 503
+          - 502
+          - 499
           - 500
+          - 503
           - 501
           - 504
-          - 502
-          - 505
-          - 499
-  - uid: 506
+          - 498
+  - uid: 505
     components:
     - type: Transform
       pos: -3.5,-14.5
@@ -8167,14 +8313,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 509
-          - 512
           - 508
-          - 513
-          - 507
-          - 510
           - 511
-  - uid: 514
+          - 507
+          - 512
+          - 506
+          - 509
+          - 510
+  - uid: 513
     components:
     - type: Transform
       pos: -5.5,-16.5
@@ -8185,14 +8331,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 519
           - 518
           - 517
-          - 521
-          - 520
           - 516
+          - 520
+          - 519
           - 515
-  - uid: 522
+          - 514
+  - uid: 521
     components:
     - type: Transform
       pos: -4.5,-16.5
@@ -8203,14 +8349,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 527
           - 526
-          - 528
-          - 524
           - 525
-          - 529
+          - 527
           - 523
-  - uid: 530
+          - 524
+          - 528
+          - 522
+  - uid: 529
     components:
     - type: Transform
       pos: -3.5,-16.5
@@ -8221,23 +8367,23 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 535
-          - 536
           - 534
-          - 532
+          - 535
           - 533
-          - 537
           - 531
+          - 532
+          - 536
+          - 530
 - proto: SurveillanceCameraGeneral
   entities:
-  - uid: 1117
+  - uid: 1124
     components:
     - type: Transform
       pos: 9.5,-9.5
       parent: 1
     - type: SurveillanceCamera
       id: Cloning/Morgue
-  - uid: 1118
+  - uid: 1125
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8245,7 +8391,7 @@ entities:
       parent: 1
     - type: SurveillanceCamera
       id: Bar
-  - uid: 1119
+  - uid: 1126
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8253,7 +8399,7 @@ entities:
       parent: 1
     - type: SurveillanceCamera
       id: Docking South
-  - uid: 1120
+  - uid: 1127
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8261,14 +8407,14 @@ entities:
       parent: 1
     - type: SurveillanceCamera
       id: Docking North
-  - uid: 1121
+  - uid: 1128
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 1
     - type: SurveillanceCamera
       id: Medbay
-  - uid: 1122
+  - uid: 1129
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8276,7 +8422,7 @@ entities:
       parent: 1
     - type: SurveillanceCamera
       id: Armory
-  - uid: 1123
+  - uid: 1130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8284,7 +8430,7 @@ entities:
       parent: 1
     - type: SurveillanceCamera
       id: Chemistry
-  - uid: 1124
+  - uid: 1131
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8292,21 +8438,21 @@ entities:
       parent: 1
     - type: SurveillanceCamera
       id: Bridge North
-  - uid: 1125
+  - uid: 1132
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 1
     - type: SurveillanceCamera
       id: Bridge South
-  - uid: 1126
+  - uid: 1133
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
     - type: SurveillanceCamera
       id: Engineering
-  - uid: 1127
+  - uid: 1134
     components:
     - type: Transform
       pos: 9.5,-12.5
@@ -8315,46 +8461,84 @@ entities:
       id: Hallway South
 - proto: SurveillanceCameraRouterGeneral
   entities:
-  - uid: 1128
+  - uid: 1135
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 1
+- proto: Syringe
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 78
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 79
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 80
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 81
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
+  - uid: 82
+    components:
+    - type: Transform
+      parent: 73
+    - type: Physics
+      canCollide: False
 - proto: Table
   entities:
-  - uid: 1129
+  - uid: 1136
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
-  - uid: 1130
+  - uid: 1137
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 1131
+  - uid: 1138
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 1132
+  - uid: 1139
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 1133
+  - uid: 1140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-8.5
       parent: 1
-  - uid: 1134
+  - uid: 1141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-7.5
       parent: 1
-  - uid: 1135
+  - uid: 1142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8362,268 +8546,278 @@ entities:
       parent: 1
 - proto: TableCounterWood
   entities:
-  - uid: 1136
+  - uid: 1143
     components:
     - type: Transform
       pos: 7.5,-18.5
       parent: 1
-  - uid: 1137
+  - uid: 1144
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 1
-  - uid: 1138
+  - uid: 1145
     components:
     - type: Transform
       pos: 7.5,-16.5
       parent: 1
-  - uid: 1139
+  - uid: 1146
     components:
     - type: Transform
       pos: 7.5,-14.5
       parent: 1
-  - uid: 1140
+  - uid: 1147
     components:
     - type: Transform
       pos: 7.5,-15.5
       parent: 1
 - proto: TableReinforced
   entities:
-  - uid: 1141
+  - uid: 1148
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 1142
+  - uid: 1149
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
-  - uid: 1143
+  - uid: 1150
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 1144
+  - uid: 1151
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
 - proto: TableReinforcedGlass
   entities:
-  - uid: 1145
+  - uid: 1152
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 1
-  - uid: 1146
+  - uid: 1153
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 1
-  - uid: 1147
+  - uid: 1154
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 1
-  - uid: 1148
+  - uid: 1155
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 1
-  - uid: 1149
+  - uid: 1156
     components:
     - type: Transform
       pos: 11.5,0.5
       parent: 1
-  - uid: 1150
+  - uid: 1157
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 1
+  - uid: 1367
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 1374
+    components:
+    - type: Transform
+      pos: 14.5,-9.5
+      parent: 1
 - proto: TableWood
   entities:
-  - uid: 1151
+  - uid: 1158
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-17.5
       parent: 1
-  - uid: 1152
+  - uid: 1159
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-16.5
       parent: 1
-  - uid: 1153
+  - uid: 1160
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-15.5
       parent: 1
-  - uid: 1154
+  - uid: 1161
     components:
     - type: Transform
       pos: 11.5,-17.5
       parent: 1
-  - uid: 1155
+  - uid: 1162
     components:
     - type: Transform
       pos: 11.5,-15.5
       parent: 1
-  - uid: 1156
+  - uid: 1163
     components:
     - type: Transform
       pos: 11.5,-16.5
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 1157
+  - uid: 1164
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,3.5
       parent: 1
-  - uid: 1158
+  - uid: 1165
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-18.5
       parent: 1
-  - uid: 1159
+  - uid: 1166
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-17.5
       parent: 1
-  - uid: 1160
+  - uid: 1167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-16.5
       parent: 1
-  - uid: 1161
+  - uid: 1168
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,1.5
       parent: 1
-  - uid: 1162
+  - uid: 1169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,2.5
       parent: 1
-  - uid: 1163
+  - uid: 1170
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 1
-  - uid: 1164
+  - uid: 1171
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 1165
+  - uid: 1172
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
-  - uid: 1166
+  - uid: 1173
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 1167
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 1
-  - uid: 1168
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,1.5
-      parent: 1
-  - uid: 1169
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,0.5
-      parent: 1
-  - uid: 1170
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-0.5
-      parent: 1
-  - uid: 1171
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-1.5
-      parent: 1
-  - uid: 1172
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-13.5
-      parent: 1
-  - uid: 1173
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-14.5
-      parent: 1
   - uid: 1174
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-15.5
+      pos: 0.5,4.5
       parent: 1
   - uid: 1175
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -7.5,-16.5
+      pos: -7.5,1.5
       parent: 1
   - uid: 1176
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 1
+  - uid: 1177
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 1178
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 1179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-13.5
+      parent: 1
+  - uid: 1180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-14.5
+      parent: 1
+  - uid: 1181
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-15.5
+      parent: 1
+  - uid: 1182
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-16.5
+      parent: 1
+  - uid: 1183
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-19.5
       parent: 1
-  - uid: 1177
+  - uid: 1184
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-19.5
       parent: 1
-  - uid: 1178
+  - uid: 1185
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-19.5
       parent: 1
-  - uid: 1179
+  - uid: 1186
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-19.5
       parent: 1
-  - uid: 1180
+  - uid: 1187
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-19.5
       parent: 1
-  - uid: 1181
+  - uid: 1188
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-14.5
       parent: 1
-  - uid: 1182
+  - uid: 1189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8631,58 +8825,58 @@ entities:
       parent: 1
 - proto: ToyFigurineBartender
   entities:
-  - uid: 1183
+  - uid: 1190
     components:
     - type: Transform
       pos: 7.521824,-14.592514
       parent: 1
 - proto: ToyFigurineMusician
   entities:
-  - uid: 1184
+  - uid: 1191
     components:
     - type: Transform
       pos: 14.500176,-18.295639
       parent: 1
 - proto: TurboItemRecharger
   entities:
-  - uid: 1185
+  - uid: 1192
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
 - proto: Turnstile
   entities:
-  - uid: 1186
+  - uid: 1193
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 1
-  - uid: 1187
+  - uid: 1194
     components:
     - type: Transform
       pos: 13.5,-10.5
       parent: 1
 - proto: TurnstileCommand
   entities:
-  - uid: 1188
+  - uid: 1195
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-11.5
       parent: 1
-  - uid: 1189
+  - uid: 1196
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-  - uid: 1190
+  - uid: 1197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-12.5
       parent: 1
-  - uid: 1191
+  - uid: 1198
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8690,14 +8884,14 @@ entities:
       parent: 1
 - proto: Vaccinator
   entities:
-  - uid: 1192
+  - uid: 1199
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
 - proto: VendingMachineBooze
   entities:
-  - uid: 1193
+  - uid: 1200
     components:
     - type: Transform
       pos: 5.5,-14.5
@@ -8706,7 +8900,7 @@ entities:
     - AccessReader
 - proto: VendingMachineChemicals
   entities:
-  - uid: 1194
+  - uid: 1201
     components:
     - type: Transform
       pos: 5.5,-9.5
@@ -8715,33 +8909,33 @@ entities:
     - AccessReader
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 1195
+  - uid: 1202
     components:
     - type: Transform
       pos: 18.5,-3.5
       parent: 1
-  - uid: 1196
+  - uid: 1203
     components:
     - type: Transform
       pos: 18.5,-11.5
       parent: 1
 - proto: VendingMachineWallMedical
   entities:
-  - uid: 1197
+  - uid: 1204
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
     missingComponents:
     - AccessReader
-  - uid: 1198
+  - uid: 1205
     components:
     - type: Transform
       pos: 13.5,4.5
       parent: 1
     missingComponents:
     - AccessReader
-  - uid: 1199
+  - uid: 1206
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8749,7 +8943,7 @@ entities:
       parent: 1
     missingComponents:
     - AccessReader
-  - uid: 1200
+  - uid: 1207
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8759,719 +8953,719 @@ entities:
     - AccessReader
 - proto: WallShuttle
   entities:
-  - uid: 1201
+  - uid: 1208
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-1.5
       parent: 1
-  - uid: 1202
+  - uid: 1209
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-1.5
       parent: 1
-  - uid: 1203
+  - uid: 1210
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-5.5
       parent: 1
-  - uid: 1204
+  - uid: 1211
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-5.5
       parent: 1
-  - uid: 1205
+  - uid: 1212
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-9.5
       parent: 1
-  - uid: 1206
+  - uid: 1213
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-9.5
       parent: 1
-  - uid: 1207
+  - uid: 1214
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-13.5
       parent: 1
-  - uid: 1208
+  - uid: 1215
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 18.5,-13.5
       parent: 1
-  - uid: 1209
+  - uid: 1216
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-13.5
       parent: 1
-  - uid: 1210
-    components:
-    - type: Transform
-      pos: 13.5,4.5
-      parent: 1
-  - uid: 1211
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-9.5
-      parent: 1
-  - uid: 1212
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-7.5
-      parent: 1
-  - uid: 1213
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-6.5
-      parent: 1
-  - uid: 1214
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-5.5
-      parent: 1
-  - uid: 1215
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-4.5
-      parent: 1
-  - uid: 1216
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-8.5
-      parent: 1
   - uid: 1217
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-10.5
+      pos: 13.5,4.5
       parent: 1
   - uid: 1218
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 15.5,-1.5
+      pos: 15.5,-9.5
       parent: 1
   - uid: 1219
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 14.5,-10.5
+      pos: 15.5,-7.5
       parent: 1
   - uid: 1220
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 15.5,-14.5
+      pos: 15.5,-6.5
       parent: 1
   - uid: 1221
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,-5.5
+      pos: 15.5,-5.5
       parent: 1
   - uid: 1222
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,-4.5
+      pos: 15.5,-4.5
       parent: 1
   - uid: 1223
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,-9.5
+      pos: 15.5,-8.5
       parent: 1
   - uid: 1224
     components:
     - type: Transform
-      pos: 11.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-10.5
       parent: 1
   - uid: 1225
     components:
     - type: Transform
-      pos: 9.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-1.5
       parent: 1
   - uid: 1226
     components:
     - type: Transform
-      pos: 7.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-10.5
       parent: 1
   - uid: 1227
     components:
     - type: Transform
-      pos: 7.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-14.5
       parent: 1
   - uid: 1228
     components:
     - type: Transform
-      pos: 7.5,-2.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-5.5
       parent: 1
   - uid: 1229
     components:
     - type: Transform
-      pos: 7.5,-4.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-4.5
       parent: 1
   - uid: 1230
     components:
     - type: Transform
-      pos: 10.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-9.5
       parent: 1
   - uid: 1231
     components:
     - type: Transform
-      pos: 8.5,-1.5
+      pos: 11.5,-1.5
       parent: 1
   - uid: 1232
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-10.5
+      pos: 9.5,-1.5
       parent: 1
   - uid: 1233
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-10.5
+      pos: 7.5,-1.5
       parent: 1
   - uid: 1234
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-13.5
+      pos: 7.5,-3.5
       parent: 1
   - uid: 1235
     components:
     - type: Transform
-      pos: 2.5,3.5
+      pos: 7.5,-2.5
       parent: 1
   - uid: 1236
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-0.5
+      pos: 7.5,-4.5
       parent: 1
   - uid: 1237
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-9.5
+      pos: 10.5,-1.5
       parent: 1
   - uid: 1238
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-4.5
+      pos: 8.5,-1.5
       parent: 1
   - uid: 1239
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-10.5
+      pos: 6.5,-10.5
       parent: 1
   - uid: 1240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,-10.5
+      pos: 7.5,-10.5
       parent: 1
   - uid: 1241
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-5.5
+      pos: 14.5,-13.5
       parent: 1
   - uid: 1242
     components:
     - type: Transform
-      pos: 3.5,3.5
+      pos: 2.5,3.5
       parent: 1
   - uid: 1243
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -5.5,2.5
+      pos: 15.5,-0.5
       parent: 1
   - uid: 1244
     components:
     - type: Transform
-      pos: 3.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-9.5
       parent: 1
   - uid: 1245
     components:
     - type: Transform
-      pos: 4.5,-0.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
       parent: 1
   - uid: 1246
     components:
     - type: Transform
-      pos: 4.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-10.5
       parent: 1
   - uid: 1247
     components:
     - type: Transform
-      pos: 15.5,3.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-10.5
       parent: 1
   - uid: 1248
     components:
     - type: Transform
-      pos: 4.5,1.5
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-5.5
       parent: 1
   - uid: 1249
     components:
     - type: Transform
-      pos: 4.5,2.5
+      pos: 3.5,3.5
       parent: 1
   - uid: 1250
     components:
     - type: Transform
-      pos: 5.5,-13.5
+      rot: -1.5707963267948966 rad
+      pos: -5.5,2.5
       parent: 1
   - uid: 1251
     components:
     - type: Transform
-      pos: 4.5,-1.5
+      pos: 3.5,-1.5
       parent: 1
   - uid: 1252
     components:
     - type: Transform
-      pos: -0.5,3.5
+      pos: 4.5,-0.5
       parent: 1
   - uid: 1253
     components:
     - type: Transform
-      pos: -1.5,3.5
+      pos: 4.5,0.5
       parent: 1
   - uid: 1254
     components:
     - type: Transform
-      pos: 7.5,4.5
+      pos: 15.5,3.5
       parent: 1
   - uid: 1255
     components:
     - type: Transform
-      pos: 1.5,3.5
+      pos: 4.5,1.5
       parent: 1
   - uid: 1256
     components:
     - type: Transform
-      pos: 0.5,3.5
+      pos: 4.5,2.5
       parent: 1
   - uid: 1257
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 1
+  - uid: 1258
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 1259
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 1260
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 1261
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 1262
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 1263
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 1264
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 1
-  - uid: 1258
+  - uid: 1265
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 1259
+  - uid: 1266
     components:
     - type: Transform
       pos: 15.5,-15.5
       parent: 1
-  - uid: 1260
+  - uid: 1267
     components:
     - type: Transform
       pos: 15.5,-18.5
       parent: 1
-  - uid: 1261
+  - uid: 1268
     components:
     - type: Transform
       pos: 8.5,-19.5
       parent: 1
-  - uid: 1262
+  - uid: 1269
     components:
     - type: Transform
       pos: 13.5,-19.5
       parent: 1
-  - uid: 1263
+  - uid: 1270
     components:
     - type: Transform
       pos: 9.5,-19.5
       parent: 1
-  - uid: 1264
+  - uid: 1271
     components:
     - type: Transform
       pos: 14.5,-19.5
       parent: 1
-  - uid: 1265
+  - uid: 1272
     components:
     - type: Transform
       pos: 11.5,-19.5
       parent: 1
-  - uid: 1266
+  - uid: 1273
     components:
     - type: Transform
       pos: 10.5,-19.5
       parent: 1
-  - uid: 1267
+  - uid: 1274
     components:
     - type: Transform
       pos: 7.5,-19.5
       parent: 1
-  - uid: 1268
+  - uid: 1275
     components:
     - type: Transform
       pos: 12.5,-19.5
       parent: 1
-  - uid: 1269
+  - uid: 1276
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-13.5
       parent: 1
-  - uid: 1270
+  - uid: 1277
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-13.5
       parent: 1
-  - uid: 1271
+  - uid: 1278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
-  - uid: 1272
+  - uid: 1279
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 1273
+  - uid: 1280
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 1
-  - uid: 1274
+  - uid: 1281
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 1275
+  - uid: 1282
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 1276
+  - uid: 1283
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 1
-  - uid: 1277
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 1278
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-3.5
-      parent: 1
-  - uid: 1279
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-6.5
-      parent: 1
-  - uid: 1280
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 1
-  - uid: 1281
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-1.5
-      parent: 1
-  - uid: 1282
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-0.5
-      parent: 1
-  - uid: 1283
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,0.5
-      parent: 1
   - uid: 1284
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,1.5
+      pos: -2.5,-1.5
       parent: 1
   - uid: 1285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,2.5
+      pos: 12.5,-3.5
       parent: 1
   - uid: 1286
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,-8.5
+      pos: 6.5,-6.5
       parent: 1
   - uid: 1287
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 1288
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 1289
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 1290
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 1291
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 1292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 1293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-8.5
+      parent: 1
+  - uid: 1294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
       parent: 1
-  - uid: 1288
+  - uid: 1295
     components:
     - type: Transform
       pos: -6.5,-13.5
       parent: 1
-  - uid: 1289
+  - uid: 1296
     components:
     - type: Transform
       pos: 4.5,-19.5
       parent: 1
-  - uid: 1290
+  - uid: 1297
     components:
     - type: Transform
       pos: 6.5,-19.5
       parent: 1
-  - uid: 1291
+  - uid: 1298
     components:
     - type: Transform
       pos: 4.5,-18.5
       parent: 1
-  - uid: 1292
+  - uid: 1299
     components:
     - type: Transform
       pos: 5.5,-19.5
       parent: 1
-  - uid: 1293
+  - uid: 1300
     components:
     - type: Transform
       pos: 4.5,-17.5
       parent: 1
-  - uid: 1294
+  - uid: 1301
     components:
     - type: Transform
       pos: 4.5,-16.5
       parent: 1
-  - uid: 1295
+  - uid: 1302
     components:
     - type: Transform
       pos: 4.5,-15.5
       parent: 1
-  - uid: 1296
+  - uid: 1303
     components:
     - type: Transform
       pos: 4.5,-14.5
       parent: 1
-  - uid: 1297
-    components:
-    - type: Transform
-      pos: 4.5,-13.5
-      parent: 1
-  - uid: 1298
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-18.5
-      parent: 1
-  - uid: 1299
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-18.5
-      parent: 1
-  - uid: 1300
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,-18.5
-      parent: 1
-  - uid: 1301
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-18.5
-      parent: 1
-  - uid: 1302
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-18.5
-      parent: 1
-  - uid: 1303
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,-18.5
-      parent: 1
   - uid: 1304
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-18.5
+      pos: 4.5,-13.5
       parent: 1
   - uid: 1305
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -3.5,-17.5
+      pos: 3.5,-18.5
       parent: 1
   - uid: 1306
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -5.5,-17.5
+      pos: 2.5,-18.5
       parent: 1
   - uid: 1307
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -4.5,-17.5
+      pos: -2.5,-18.5
       parent: 1
   - uid: 1308
     components:
     - type: Transform
-      pos: -6.5,-16.5
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-18.5
       parent: 1
   - uid: 1309
     components:
     - type: Transform
-      pos: -6.5,-14.5
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-18.5
       parent: 1
   - uid: 1310
     components:
     - type: Transform
-      pos: -6.5,-15.5
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-18.5
       parent: 1
   - uid: 1311
     components:
     - type: Transform
-      pos: -0.5,-13.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-18.5
       parent: 1
   - uid: 1312
     components:
     - type: Transform
-      pos: -2.5,-13.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-17.5
       parent: 1
   - uid: 1313
     components:
     - type: Transform
-      pos: -3.5,-13.5
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-17.5
       parent: 1
   - uid: 1314
     components:
     - type: Transform
-      pos: -4.5,-13.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-17.5
       parent: 1
   - uid: 1315
     components:
     - type: Transform
-      pos: -5.5,-13.5
+      pos: -6.5,-16.5
       parent: 1
   - uid: 1316
     components:
     - type: Transform
-      pos: -1.5,-13.5
+      pos: -6.5,-14.5
       parent: 1
   - uid: 1317
+    components:
+    - type: Transform
+      pos: -6.5,-15.5
+      parent: 1
+  - uid: 1318
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 1
+  - uid: 1319
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 1
+  - uid: 1320
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 1
+  - uid: 1321
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 1
+  - uid: 1322
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 1
+  - uid: 1323
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 1
+  - uid: 1324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-2.5
       parent: 1
-  - uid: 1318
+  - uid: 1325
     components:
     - type: Transform
       pos: 13.5,-13.5
       parent: 1
-  - uid: 1319
+  - uid: 1326
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-10.5
       parent: 1
-  - uid: 1320
+  - uid: 1327
     components:
     - type: Transform
       pos: 12.5,-4.5
       parent: 1
-  - uid: 1321
+  - uid: 1328
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 1
-  - uid: 1322
+  - uid: 1329
     components:
     - type: Transform
       pos: 12.5,-1.5
       parent: 1
-  - uid: 1323
+  - uid: 1330
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,0.5
       parent: 1
-  - uid: 1324
+  - uid: 1331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,4.5
       parent: 1
-  - uid: 1325
+  - uid: 1332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 1326
+  - uid: 1333
     components:
     - type: Transform
       pos: 7.5,-13.5
       parent: 1
-  - uid: 1327
+  - uid: 1334
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 1
-  - uid: 1328
+  - uid: 1335
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,4.5
       parent: 1
-  - uid: 1329
+  - uid: 1336
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-13.5
       parent: 1
-  - uid: 1330
+  - uid: 1337
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 1
-  - uid: 1331
+  - uid: 1338
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9479,69 +9673,69 @@ entities:
       parent: 1
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 1332
+  - uid: 1339
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-10.5
       parent: 1
-  - uid: 1333
+  - uid: 1340
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 1334
+  - uid: 1341
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-19.5
       parent: 1
-  - uid: 1335
+  - uid: 1342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,2.5
       parent: 1
-  - uid: 1336
+  - uid: 1343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,4.5
       parent: 1
-  - uid: 1337
+  - uid: 1344
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 1
-  - uid: 1338
+  - uid: 1345
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 1339
+  - uid: 1346
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 1
-  - uid: 1340
+  - uid: 1347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-19.5
       parent: 1
-  - uid: 1341
+  - uid: 1348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-17.5
       parent: 1
-  - uid: 1342
+  - uid: 1349
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-18.5
       parent: 1
-  - uid: 1343
+  - uid: 1350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -9549,23 +9743,27 @@ entities:
       parent: 1
 - proto: WarningN2
   entities:
-  - uid: 1344
+  - uid: 1351
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: WarningO2
   entities:
-  - uid: 1345
+  - uid: 1352
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: WarpPoint
   entities:
-  - uid: 1346
+  - uid: 1353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9575,27 +9773,6 @@ entities:
       location: CBURN Shuttle
 - proto: WeaponShotgunRiot
   entities:
-  - uid: 94
-    components:
-    - type: Transform
-      parent: 87
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 95
-    components:
-    - type: Transform
-      parent: 87
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-  - uid: 96
-    components:
-    - type: Transform
-      parent: 87
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
   - uid: 104
     components:
     - type: Transform
@@ -9617,79 +9794,100 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: WeaponSprayNozzle
-  entities:
-  - uid: 497
+  - uid: 114
     components:
     - type: Transform
-      parent: 496
+      parent: 107
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 115
+    components:
+    - type: Transform
+      parent: 107
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 116
+    components:
+    - type: Transform
+      parent: 107
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: WeaponSprayNozzle
+  entities:
+  - uid: 496
+    components:
+    - type: Transform
+      parent: 495
     - type: Physics
       canCollide: False
 - proto: WeaponTurretPointDefense
   entities:
-  - uid: 1347
+  - uid: 1354
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,3.5
       parent: 1
-  - uid: 1348
+  - uid: 1355
     components:
     - type: Transform
       pos: -5.5,-18.5
       parent: 1
-  - uid: 1349
+  - uid: 1356
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,4.5
       parent: 1
-  - uid: 1350
+  - uid: 1357
     components:
     - type: Transform
       pos: 16.5,-19.5
       parent: 1
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 1351
+  - uid: 1358
     components:
     - type: Transform
       pos: 11.5,-4.5
       parent: 1
-  - uid: 1352
+  - uid: 1359
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 1
-  - uid: 1353
+  - uid: 1360
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 1354
+  - uid: 1361
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 1355
+  - uid: 1362
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,3.5
       parent: 1
-  - uid: 1356
+  - uid: 1363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,3.5
       parent: 1
-  - uid: 1357
+  - uid: 1364
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,0.5
       parent: 1
-  - uid: 1358
+  - uid: 1365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9697,11 +9895,9 @@ entities:
       parent: 1
 - proto: Wrench
   entities:
-  - uid: 486
+  - uid: 1368
     components:
     - type: Transform
-      parent: 474
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
+      pos: 7.557244,-6.490247
+      parent: 1
 ...


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
- A bunch of important items were in wall lockers on the CBURN shuttle, namely biomass in the Clone Bay and the golden beaker / a stack of plasma in Chemistry.
- This made it really hard for newer players to actually spot where these items are. Grey wall lockers are deceptively hard to spot for players.
- This PR just moves those items out onto tables and racks where it's easy for players to see them.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Quality of life improvement, for both new players and old.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1093" height="860" alt="image" src="https://github.com/user-attachments/assets/f37434e3-7a4a-47c9-bef3-6767f4f095a1" />

fig. 1 - Multitool, wrench, and biomass are out on tables and racks now.

<img width="806" height="790" alt="image" src="https://github.com/user-attachments/assets/a155e17c-c022-4630-84c0-f86bc58d8ef7" />

fig. 2 - Plasma is out on a table. Added a Chemistry locker since it has the usual things Chemistry players expect, like beakers (makes it more obvious where to get stuff from), move the labeler out onto the table. Golden beaker is in plain view now with another pre-loaded into the ChemMaster. Swapped the grey wall locker for the Chemistry shelf, which just has some extra beakers and syringes.

<img width="994" height="745" alt="image" src="https://github.com/user-attachments/assets/82363b4f-9954-4b35-bfa4-959f71ed1e2c" />

fig. 3 - Swapped this grey locker out for a yellow Emergency Shuttle Repair locker, which is a little easier to spot. It still has a spare RCD and RCD Fuel inside of it on top of emergency shuttle repair things.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- tweak: (CBURN) Moved many items out of the wall lockers on the CBURN shuttle. This makes it much easier to spot beakers & plasma in Chemistry and biomass in the Clone Bay when playing an CBURN ghost roles.