### PR TITLE
Adds the Svalinn Laser Pistol to maints loot pools.

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -356,6 +356,8 @@
         weight: .8
       - id: WeaponShotgunMakeshift
         weight: .8
+      - id: WeaponLaserSvalinn # Starlight- The svalinn's 14 dps... I think it's maints loot worthy.
+        weight: .8
       - id: ClothingOuterArmorMakeshift
       - id: WeaponMeleeSwitchblade 
       - id: SpearSteel #Starlight End:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
See the title, genius!

## Why we need to add this
The Svalinn, despite _technically_ being a Security weapon (outside of being mapped in one or two places, it's a secfab item) goes completely unused, because it is, without qualification, kind of dogshit. 7 damage per shot, 2 shots per second, 14 damage per second.

 It is, however, a fun novelty- a battery-powered laser that can become _marginally_ usable as a bargain-bin captain pistol once microreactors are researched.

My motivation for making it a maints item (analogous to the makeshift weapons that it spawns at the same rate as, or the TOZ and Mosin that also spawn) is that while it was originally made in the protolathe, putting an object that is technically sec contra in there (other than the PKA, which is cargo contra and arguably a mining tool) strikes me as wrong. 

Given the item's description:
> A cheap and widely used laser pistol.

It makes sense as the exact sort of thing that'd somehow make its way into a locker in some back maints corridor.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: deltaVelocity
- add: Adds the Svalinn Laser Pistol to the maints locker loot pool, at a rate comparable to makeshift weapons.

