### PR TITLE
Salvage FTL Fix

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -376,6 +376,7 @@ public sealed partial class ShuttleSystem
 
         component = AddComp<FTLComponent>(uid);
         component.State = FTLState.Starting;
+        component.SourceMapUid = Transform(uid).MapUid; // Starlight
         var audio = _audio.PlayPvs(_startupSound, uid);
         _audio.SetGridAudio(audio);
         component.StartupStream = audio?.Entity;
@@ -500,13 +501,53 @@ public sealed partial class ShuttleSystem
 
         if (!Exists(entity.Comp1.TargetCoordinates.EntityId))
         {
-            // Uhh good luck
-            // Pick earliest map?
-            var maps = EntityQuery<MapComponent>().Select(o => o.MapId).ToList();
-            var map = maps.Min(o => o.GetHashCode());
+            // Starlight edit Start: Yeah... Lets not do the first map in the list. 
+            // Fallback chain:
+            // 1) map we started from, 2) any map with a station grid, 3) first map entity.
+            EntityUid? fallbackMap = null;
 
-            mapId = new MapId(map);
-            TryFTLProximity(uid, _mapSystem.GetMap(mapId));
+            if (entity.Comp1.SourceMapUid is { } sourceMap && Exists(sourceMap))
+            {
+                fallbackMap = sourceMap;
+            }
+            else
+            {
+                var stationQuery = EntityQueryEnumerator<StationDataComponent>();
+
+                while (stationQuery.MoveNext(out _, out var stationData) && fallbackMap == null)
+                {
+                    foreach (var grid in stationData.Grids)
+                    {
+                        if (!TryComp<TransformComponent>(grid, out var gridXform))
+                            continue;
+
+                        if (gridXform.MapUid is not { } stationMap || !Exists(stationMap))
+                            continue;
+
+                        fallbackMap = stationMap;
+                        break;
+                    }
+                }
+            }
+
+            if (fallbackMap == null)
+            {
+                var mapQuery = EntityQueryEnumerator<MapComponent>();
+                if (mapQuery.MoveNext(out var firstMap, out _))
+                    fallbackMap = firstMap;
+            }
+
+            if (fallbackMap is { } validFallback)
+            {
+                mapId = _transform.GetMapId(validFallback);
+                TryFTLProximity(uid, validFallback);
+            }
+            else
+            {
+                mapId = xform.MapID;
+                TryFTLProximity(uid, _mapSystem.GetMap(mapId));
+            }
+            // Starlight edit End
         }
         // Docking FTL
         else if (HasComp<MapGridComponent>(target.EntityId) &&

--- a/Content.Shared/Shuttles/Components/FTLComponent.cs
+++ b/Content.Shared/Shuttles/Components/FTLComponent.cs
@@ -44,6 +44,14 @@ public sealed partial class FTLComponent : Component
     [DataField, AutoNetworkedField]
     public Angle TargetAngle;
 
+    // Starlight Start
+    /// <summary>
+    /// Map the shuttle started FTL from.
+    /// </summary>
+    [DataField]
+    public EntityUid? SourceMapUid;
+    // Starlight End
+
     /// <summary>
     /// If we're docking after FTL what is the prioritised dock tag (if applicable).
     /// </summary>


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes a bug where after an expedition Salvage would FTL to the first map in the list.
Instead it now follows this chain on FTL priority:
1. map it started from, 2. any map with a station grid, 3. first map entity (Original).
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Salvage will no longer accidentally FTL to the Nukie Outpost, Central Command or The Brighteyes dark map after an expedition.