### PR TITLE
Hotfix for #3736

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
@@ -4,7 +4,7 @@
     BoxStampsCCDepartments: 3 # Starlight begin #
     BoxStampsCCAdministrative: 3
     MindShieldImplanter: 8
-    DeathRattleImplanter: 6 # Starlight end #
+    DeathRattleImplanterCentcomm: 6 # Starlight end #
     ClothingShoesBootsLaceup: 3
     ClothingShoesBootsJack: 3
     ClothingHandsGlovesCombat: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
@@ -4,7 +4,8 @@
     BoxStampsCCDepartments: 3 # Starlight begin #
     BoxStampsCCAdministrative: 3
     MindShieldImplanter: 8
-    DeathRattleImplanterCentcomm: 6 # Starlight end #
+    DeathRattleImplanterCentcomm: 6
+    BluespaceImplanter: 6 # Starlight end #
     ClothingShoesBootsLaceup: 3
     ClothingShoesBootsJack: 3
     ClothingHandsGlovesCombat: 3


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
fix for #3736 
accidentally gave centcomm vendor the syndicate death rattler

also adds bluespace implanter to centdrobe at admin request

## Media (Video/Screenshots)

corrected + bluespace mplanter
<img width="757" height="565" alt="image" src="https://github.com/user-attachments/assets/83c80e85-f59d-4bc3-8db5-1aa40d5f43b9" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- fix: Centcomm has fixed their source of death rattle implants for their CentDrobes to a CentComm approved variant instead of suspicious Syndicate ones.
- add: Adds Bluespace Implanters to the CentDrobe.
