### PR TITLE
Add non-job playtimes to the PlaytimeStatsWindow

### DIFF
--- a/Content.Client/Info/PlaytimeStats/PlaytimeStatsWindow.cs
+++ b/Content.Client/Info/PlaytimeStats/PlaytimeStatsWindow.cs
@@ -113,6 +113,7 @@ public sealed partial class PlaytimeStatsWindow : FancyWindow
 
         //starlight
         var departmentPlaytimes = _jobRequirementsManager.FetchPlaytimeByDepartments();
+        var miscellaneousPlaytimes = _jobRequirementsManager.FetchPlaytimeMiscellaneous(rolePlaytimes);
         //starlight end
 
         RolesPlaytimeList.RemoveAllChildren();
@@ -131,6 +132,12 @@ public sealed partial class PlaytimeStatsWindow : FancyWindow
             var department = departmentPlaytime.Key;
             var playtime = departmentPlaytime.Value;
             AddRolePlaytimeEntryToTable(Loc.GetString(department.Name), playtime.ToString(), textColor: department.Color); //starlight edit
+        }
+        foreach (var miscellaneousPlaytime in miscellaneousPlaytimes)
+        {
+            var role = miscellaneousPlaytime.Key;
+            var playtime = miscellaneousPlaytime.Value;
+            AddRolePlaytimeEntryToTable(Loc.GetString(role.Name), playtime.ToString(), textColor: Color.LightGray);
         }
         //starlight end
     }

--- a/Content.Client/Info/PlaytimeStats/PlaytimeStatsWindow.cs
+++ b/Content.Client/Info/PlaytimeStats/PlaytimeStatsWindow.cs
@@ -18,6 +18,8 @@ public sealed partial class PlaytimeStatsWindow : FancyWindow
     private ISawmill _sawmill = Logger.GetSawmill("PlaytimeStatsWindow");
     private readonly Color _altColor = Color.FromHex("#292B38");
     private readonly Color _defaultColor = Color.FromHex("#2F2F3B");
+    private readonly Color _antagColor = Color.FromHex("#fe7676");
+    private readonly Color _ghostColor = Color.FromHex("#c996e0");
     private bool _useAltColor;
 
     public PlaytimeStatsWindow()
@@ -109,12 +111,12 @@ public sealed partial class PlaytimeStatsWindow : FancyWindow
 
         OverallPlaytimeLabel.Text = Loc.GetString("ui-playtime-overall", ("time", overallPlaytime));
 
-        var rolePlaytimes = _jobRequirementsManager.FetchPlaytimeByRoles();
-
-        //starlight
+        // Starlight BEGIN
+        var rolePlaytimes = _jobRequirementsManager.FetchPlaytimeByRoles().ToList();
         var departmentPlaytimes = _jobRequirementsManager.FetchPlaytimeByDepartments();
-        var miscellaneousPlaytimes = _jobRequirementsManager.FetchPlaytimeMiscellaneous(rolePlaytimes);
-        //starlight end
+        var antagPlaytimes = _jobRequirementsManager.FetchPlaytimeByAntags();
+        var miscellaneousPlaytimes = _jobRequirementsManager.FetchPlaytimeMiscellaneous(rolePlaytimes, antagPlaytimes);
+        // Starlight END
 
         RolesPlaytimeList.RemoveAllChildren();
         PopulatePlaytimeHeader();
@@ -133,11 +135,15 @@ public sealed partial class PlaytimeStatsWindow : FancyWindow
             var playtime = departmentPlaytime.Value;
             AddRolePlaytimeEntryToTable(Loc.GetString(department.Name), playtime.ToString(), textColor: department.Color); //starlight edit
         }
+        foreach (var antagPlaytime in antagPlaytimes)
+        {
+            AddRolePlaytimeEntryToTable(Loc.GetString(antagPlaytime.Key.Name), antagPlaytime.Value.ToString(), textColor: _antagColor);
+        }
         foreach (var miscellaneousPlaytime in miscellaneousPlaytimes)
         {
             var role = miscellaneousPlaytime.Key;
             var playtime = miscellaneousPlaytime.Value;
-            AddRolePlaytimeEntryToTable(Loc.GetString(role.Name), playtime.ToString(), textColor: Color.LightGray);
+            AddRolePlaytimeEntryToTable(Loc.GetString(role.Name), playtime.ToString(), textColor: _ghostColor);
         }
         //starlight end
     }

--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Shared.CCVar;
 using Content.Shared.Players;
 using Content.Shared.Players.JobWhitelist;
@@ -373,6 +374,28 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
                 continue;
 
             yield return new KeyValuePair<DepartmentPrototype, TimeSpan>(department, departmentTime);
+        }
+    }
+
+    /// <summary>
+    /// Fetches playtime for all PlayTimeTracker prototypes that we don't see in any regular job.
+    /// This covers everything from ghost roles, to antags, to admeme spawns.
+    /// </summary>
+    public IEnumerable<KeyValuePair<PlayTimeTrackerPrototype, TimeSpan>> FetchPlaytimeMiscellaneous(
+        IEnumerable<KeyValuePair<JobPrototype, TimeSpan>> jobPlaytimes)
+    {
+        var trackers = _prototypes.EnumeratePrototypes<PlayTimeTrackerPrototype>();
+        var exclude = new HashSet<string> { "Overall" };
+        exclude.UnionWith(jobPlaytimes.Select(pair => pair.Key.PlayTimeTracker));
+        foreach (var tracker in trackers)
+        {
+            if (exclude.Contains(tracker.ID))
+                continue;
+
+            if (!_mergedRoles.TryGetValue(tracker.ID, out var rolePlaytime))
+                continue;
+            
+            yield return new KeyValuePair<PlayTimeTrackerPrototype, TimeSpan>(tracker, rolePlaytime);
         }
     }
     //starlight end

--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -378,15 +378,37 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
     }
 
     /// <summary>
-    /// Fetches playtime for all PlayTimeTracker prototypes that we don't see in any regular job.
-    /// This covers everything from ghost roles, to antags, to admeme spawns.
+    /// Fetches playtime per antag prototype.
+    /// </summary>b
+    public IEnumerable<KeyValuePair<AntagPrototype, TimeSpan>> FetchPlaytimeByAntags()
+    {
+        var antagsToMap = _prototypes.EnumeratePrototypes<AntagPrototype>();
+        foreach (var antag in antagsToMap)
+        {
+            if (antag.PlayTimeTracker == null)
+                continue;
+            
+            if (_mergedRoles.TryGetValue(antag.PlayTimeTracker, out var time))
+                yield return new KeyValuePair<AntagPrototype, TimeSpan>(antag, time);
+        }
+    }
+
+    /// <summary>
+    /// Fetches playtime for all PlayTimeTracker prototypes that we don't see in any job or antag.
+    /// This covers ghost roles and various admin spawns.
     /// </summary>
     public IEnumerable<KeyValuePair<PlayTimeTrackerPrototype, TimeSpan>> FetchPlaytimeMiscellaneous(
-        IEnumerable<KeyValuePair<JobPrototype, TimeSpan>> jobPlaytimes)
+        IEnumerable<KeyValuePair<JobPrototype, TimeSpan>> jobPlaytimes,
+        IEnumerable<KeyValuePair<AntagPrototype, TimeSpan>> antagPlaytimes)
     {
         var trackers = _prototypes.EnumeratePrototypes<PlayTimeTrackerPrototype>();
         var exclude = new HashSet<string> { "Overall" };
-        exclude.UnionWith(jobPlaytimes.Select(pair => pair.Key.PlayTimeTracker));
+        foreach (var jobPlaytime in jobPlaytimes)
+            exclude.Add(jobPlaytime.Key.PlayTimeTracker);
+        foreach (var antagPlaytime in antagPlaytimes)
+            if (antagPlaytime.Key.PlayTimeTracker != null)
+                exclude.Add(antagPlaytime.Key.PlayTimeTracker);
+        
         foreach (var tracker in trackers)
         {
             if (exclude.Contains(tracker.ID))


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Show all tracked playtimes in the Playtime Stats window.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Currently we're recording heaps, such as antags, but we've not made these visible to the player. There's no reason not to!

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="565" height="739" alt="image" src="https://github.com/user-attachments/assets/a4fba60a-b197-4fab-a288-2de5924db752" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: The Playtime Stats window now shows all your tracked playtime, including antagonists and tracked ghost roles.