### PR TITLE
Mappable Atmos States

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -309,6 +309,7 @@ public sealed class AirAlarmSystem : EntitySystem
     private void OnUpdateAutoMode(EntityUid uid, AirAlarmComponent component, AirAlarmUpdateAutoModeMessage args)
     {
         component.AutoMode = args.Enabled;
+        Dirty(uid, component); // Starlight
 
         _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium, $"{ToPrettyString(args.Actor)} changed {ToPrettyString(uid)} auto mode to {args.Enabled}");
         UpdateUI(uid, component);
@@ -437,6 +438,7 @@ public sealed class AirAlarmSystem : EntitySystem
 
             // send high to new state's port, along with updating the cached state
             component.State = args.AlarmType;
+            Dirty(uid, component); // Starlight
             _deviceLink.SendSignal(uid, GetPort(component), true, source);
         }
 
@@ -478,6 +480,7 @@ public sealed class AirAlarmSystem : EntitySystem
 
 
         controller.CurrentMode = mode;
+        Dirty(uid, controller); // Starlight
 
         // setting it to UI only means we don't have
         // to deal with the issue of not-single-owner

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasFilterSystem.cs
@@ -39,6 +39,7 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
             SubscribeLocalEvent<GasFilterComponent, AtmosDeviceDisabledEvent>(OnFilterLeaveAtmosphere);
             SubscribeLocalEvent<GasFilterComponent, ActivateInWorldEvent>(OnFilterActivate);
             SubscribeLocalEvent<GasFilterComponent, GasAnalyzerScanEvent>(OnFilterAnalyzed);
+            SubscribeLocalEvent<GasFilterComponent, AnchorStateChangedEvent>(OnAnchorChanged); // Starlight
             // Bound UI subscriptions
             SubscribeLocalEvent<GasFilterComponent, GasFilterChangeRateMessage>(OnTransferRateChangeMessage);
             SubscribeLocalEvent<GasFilterComponent, GasFilterSelectGasMessage>(OnSelectGasMessage);
@@ -139,11 +140,22 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
 
             return actualTransferVolume;
         }
-        //starlight end
+
+        private void OnAnchorChanged(EntityUid uid, GasFilterComponent filter, ref AnchorStateChangedEvent args)
+        {
+            if (!args.Anchored)
+            {
+                filter.Enabled = false;
+                UpdateAppearance(uid, filter);
+                _ambientSoundSystem.SetAmbience(uid, false);
+                DirtyUI(uid, filter);
+            }
+        }
+        // Starlight End
 
         private void OnFilterLeaveAtmosphere(EntityUid uid, GasFilterComponent filter, ref AtmosDeviceDisabledEvent args)
         {
-            filter.Enabled = false;
+            // filter.Enabled = false; // Starlight Edit: Moved to OnAnchorChanged
 
             UpdateAppearance(uid, filter);
             _ambientSoundSystem.SetAmbience(uid, false);

--- a/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasMixerSystem.cs
+++ b/Content.Server/Atmos/Piping/Trinary/EntitySystems/GasMixerSystem.cs
@@ -38,6 +38,7 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
             SubscribeLocalEvent<GasMixerComponent, AtmosDeviceUpdateEvent>(OnMixerUpdated);
             SubscribeLocalEvent<GasMixerComponent, ActivateInWorldEvent>(OnMixerActivate);
             SubscribeLocalEvent<GasMixerComponent, GasAnalyzerScanEvent>(OnMixerAnalyzed);
+            SubscribeLocalEvent<GasMixerComponent, AnchorStateChangedEvent>(OnAnchorChanged); // Starlight
             // Bound UI subscriptions
             SubscribeLocalEvent<GasMixerComponent, GasMixerChangeOutputPressureMessage>(OnOutputPressureChangeMessage);
             SubscribeLocalEvent<GasMixerComponent, GasMixerChangeNodePercentageMessage>(OnChangeNodePercentageMessage);
@@ -129,9 +130,21 @@ namespace Content.Server.Atmos.Piping.Trinary.EntitySystems
                 _ambientSoundSystem.SetAmbience(uid, true);
         }
 
+        // Starlight Start
+        private void OnAnchorChanged(EntityUid uid, GasMixerComponent mixer, ref AnchorStateChangedEvent args)
+        {
+            if (!args.Anchored)
+            {
+                mixer.Enabled = false;
+                DirtyUI(uid, mixer);
+                UpdateAppearance(uid, mixer);
+            }
+        }
+        // Starlight End
+
         private void OnMixerLeaveAtmosphere(EntityUid uid, GasMixerComponent mixer, ref AtmosDeviceDisabledEvent args)
         {
-            mixer.Enabled = false;
+            // mixer.Enabled = false; // Starlight Edit: Moved to OnAnchorChanged
 
             DirtyUI(uid, mixer);
             UpdateAppearance(uid, mixer);

--- a/Content.Shared/Atmos/EntitySystems/SharedGasPressurePumpSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedGasPressurePumpSystem.cs
@@ -31,6 +31,7 @@ public abstract class SharedGasPressurePumpSystem : EntitySystem
 
         SubscribeLocalEvent<GasPressurePumpComponent, AtmosDeviceDisabledEvent>(OnPumpLeaveAtmosphere);
         SubscribeLocalEvent<GasPressurePumpComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<GasPressurePumpComponent, AnchorStateChangedEvent>(OnAnchorChanged); // Starlight
     }
 
     private void OnExamined(Entity<GasPressurePumpComponent> ent, ref ExaminedEvent args)
@@ -88,10 +89,24 @@ public abstract class SharedGasPressurePumpSystem : EntitySystem
         UpdateUi(ent);
     }
 
+    // Starlight Start
+    private void OnAnchorChanged(Entity<GasPressurePumpComponent> ent, ref AnchorStateChangedEvent args)
+    {
+        if (!args.Anchored)
+        {
+            ent.Comp.Enabled = false;
+            Dirty(ent);
+            UpdateAppearance(ent);
+        }
+    }
+    // Starlight End
+
     private void OnPumpLeaveAtmosphere(Entity<GasPressurePumpComponent> ent, ref AtmosDeviceDisabledEvent args)
     {
-        ent.Comp.Enabled = false;
-        Dirty(ent);
+        // Starlight edit Start: Moved to OnAnchorChanged
+        // ent.Comp.Enabled = false;
+        // Dirty(ent);
+        // Starlight edit End
         UpdateAppearance(ent);
 
         UserInterfaceSystem.CloseUi(ent.Owner, GasPressurePumpUiKey.Key);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Makes it so mapping can save the state of atmos devices.

Reason why they did not save previously is Wizden made it so the states reset for anchoring on AtmosDeviceDisabledEvent instead of the actual Anchorign event.

And air alarms were missing dirty calls
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Caws request/Technically a bugfix
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- add: Mappers can now save the state of pumps, air alarms, mixers, ect.