### PR TITLE
Chittin language no longer triggers damaged throat

### DIFF
--- a/Content.Server/_Starlight/Traits/Assorted/DamagedThroatComponent.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/DamagedThroatComponent.cs
@@ -25,8 +25,7 @@ public sealed partial class DamagedThroatComponent : Component
     [DataField]
     public List<ProtoId<LanguagePrototype>> ExcludedLanguages = new()
     {
-        "Sign",
-           "Chittin"
+        "Sign","Chittin"
     };
 
     /// <summary>

--- a/Content.Server/_Starlight/Traits/Assorted/DamagedThroatComponent.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/DamagedThroatComponent.cs
@@ -25,7 +25,7 @@ public sealed partial class DamagedThroatComponent : Component
     [DataField]
     public List<ProtoId<LanguagePrototype>> ExcludedLanguages = new()
     {
-        "Sign"
+        "Sign",
            "Chittin"
     };
 

--- a/Content.Server/_Starlight/Traits/Assorted/DamagedThroatComponent.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/DamagedThroatComponent.cs
@@ -20,15 +20,6 @@ public sealed partial class DamagedThroatComponent : Component
     public ProtoId<DamageTypePrototype> DamageType = "Blunt";
 
     /// <summary>
-    ///     Languages that should not trigger damage (e.g., sign language).
-    /// </summary>
-    [DataField]
-    public List<ProtoId<LanguagePrototype>> ExcludedLanguages = new()
-    {
-        "Sign","Chittin"
-    };
-
-    /// <summary>
     ///     The base damage to apply when speaking normally (starts at this value).
     /// </summary>
     [DataField]

--- a/Content.Server/_Starlight/Traits/Assorted/DamagedThroatComponent.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/DamagedThroatComponent.cs
@@ -26,6 +26,7 @@ public sealed partial class DamagedThroatComponent : Component
     public List<ProtoId<LanguagePrototype>> ExcludedLanguages = new()
     {
         "Sign"
+           "Chittin"
     };
 
     /// <summary>

--- a/Content.Server/_Starlight/Traits/Assorted/DamagedThroatSystem.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/DamagedThroatSystem.cs
@@ -31,8 +31,8 @@ public sealed class DamagedThroatSystem : EntitySystem
         if (args.IsWhisper)
             return;
 
-        // Don't damage if using excluded language (e.g., sign language)
-        if (args.Language != null && component.ExcludedLanguages.Contains(args.Language.ID))
+        // Don't damage if using excluded languages (languages that require verbal speech)
+        if (args.Language != null && args.Language.SpeechOverride.RequireSpeech == false)
             return;
 
         // Don't damage if on cooldown

--- a/Content.Server/_Starlight/Traits/Assorted/DamagedThroatSystem.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/DamagedThroatSystem.cs
@@ -32,7 +32,7 @@ public sealed class DamagedThroatSystem : EntitySystem
             return;
 
         // Don't damage if using excluded languages (languages that require verbal speech)
-        if (args.Language != null && args.Language.SpeechOverride.RequireSpeech == false)
+        if (args.Language.SpeechOverride.RequireSpeech == false)
             return;
 
         // Don't damage if on cooldown

--- a/Content.Server/_Starlight/Traits/Assorted/DamagedThroatSystem.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/DamagedThroatSystem.cs
@@ -31,7 +31,7 @@ public sealed class DamagedThroatSystem : EntitySystem
         if (args.IsWhisper)
             return;
 
-        // Don't damage if using excluded languages (languages that require verbal speech)
+        // Don't damage if using excluded languages (languages that don't require verbal speech)
         if (args.Language.SpeechOverride.RequireSpeech == false)
             return;
 


### PR DESCRIPTION
## Short description
This very simple PR changes the Damaged Throat trait to not trigger off of Chittin being used to communicate. Being muted does not stop Chittin from being able to be used, and yet communicating with it triggers damaged throat. This PR stops that weird behavior.

## Why we need to add this
Consistency. Makes logical sense. Why can muted characters speak both Chittin and Sign, but have their throat hurt when they try to use Chittin, despite Chittin not using the throat to speak.

## Media (Video/Screenshots)
Before Change:

https://github.com/user-attachments/assets/5445b3b4-daa5-4e64-95a4-c9c0bc81acb2

After Change:


https://github.com/user-attachments/assets/a2f9b285-5832-475d-945f-29b515e83d99


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: BigfootBravo
- fix: Chittin language no longer triggers damaged throat.
