### PR TITLE
Revert AirAlarm States + Networking

### DIFF
--- a/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
+++ b/Content.Server/Atmos/Monitor/Components/AirAlarmComponent.cs
@@ -5,11 +5,10 @@ using Content.Shared.Atmos.Piping.Unary.Components;
 using Content.Shared.DeviceLinking;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
-using Robust.Shared.GameStates; // Starlight
 
 namespace Content.Server.Atmos.Monitor.Components;
 
-[RegisterComponent, NetworkedComponent] // Starlight Edit: Added NetworkedComponent
+[RegisterComponent]
 public sealed partial class AirAlarmComponent : Component
 {
     [DataField] public AirAlarmMode CurrentMode { get; set; } = AirAlarmMode.Filtering;

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -309,7 +309,6 @@ public sealed class AirAlarmSystem : EntitySystem
     private void OnUpdateAutoMode(EntityUid uid, AirAlarmComponent component, AirAlarmUpdateAutoModeMessage args)
     {
         component.AutoMode = args.Enabled;
-        Dirty(uid, component); // Starlight
 
         _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium, $"{ToPrettyString(args.Actor)} changed {ToPrettyString(uid)} auto mode to {args.Enabled}");
         UpdateUI(uid, component);
@@ -438,7 +437,6 @@ public sealed class AirAlarmSystem : EntitySystem
 
             // send high to new state's port, along with updating the cached state
             component.State = args.AlarmType;
-            Dirty(uid, component); // Starlight
             _deviceLink.SendSignal(uid, GetPort(component), true, source);
         }
 
@@ -480,7 +478,6 @@ public sealed class AirAlarmSystem : EntitySystem
 
 
         controller.CurrentMode = mode;
-        Dirty(uid, controller); // Starlight
 
         // setting it to UI only means we don't have
         // to deal with the issue of not-single-owner


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Reverts AirAlarms saving states and AirAlarms networked. I will get around to redoing them at a later date
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The PR for AirAlarms saving states was merged untested (They were waiting for someone to test them) and turns out they stop Dev from loading.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

No Changelog