### PR TITLE
cosmic cult in the metashield

### DIFF
--- a/Content.Server/_ST/CosmicCult/Abilities/CosmicReturnSystem.cs
+++ b/Content.Server/_ST/CosmicCult/Abilities/CosmicReturnSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Damage;
 using Content.Shared.Mind;
 using Content.Shared.Stunnable;
 using Content.Shared.Damage.Systems;
+using Content.Shared._Starlight.Polymorph.Components;
 
 namespace Content.Server._ST.CosmicCult.Abilities;
 
@@ -30,6 +31,7 @@ public sealed class CosmicReturnSystem : EntitySystem
         if (_mind.TryGetMind(args.User, out var mindId, out var _))
             _mind.TransferTo(mindId, projectionEnt);
         EnsureComp<CosmicBlankComponent>(args.User);
+        EnsureComp<UncryoableComponent>(args.User); //Starlight: autocryo fix
         EnsureComp<CosmicAstralBodyComponent>(projectionEnt, out var astralComp);
         var mind = Comp<MindComponent>(mindId);
         mind.PreventGhosting = true;
@@ -48,6 +50,7 @@ public sealed class CosmicReturnSystem : EntitySystem
         mind.PreventGhosting = false;
         QueueDel(uid);
         RemComp<CosmicBlankComponent>(uid.Comp.OriginalBody);
+        RemComp<UncryoableComponent>(uid.Comp.OriginalBody); //Starlight: autocryo fix
         RemComp<CosmicCultExamineComponent>(uid.Comp.OriginalBody);
     }
 }

--- a/Resources/Documents/en-US/_Starlight/classified/classified_corporate_document_cosmic_cult.txt
+++ b/Resources/Documents/en-US/_Starlight/classified/classified_corporate_document_cosmic_cult.txt
@@ -1,0 +1,28 @@
+[head=1][color=#135285]────────────────────[/color][/head]
+[color=#1b67a5]█▄░░█ ▀▀█▀▀[/color] [head=3] [color=#135285]NanoTrasen[/color][/head]
+[color=#1b67a5]█▀█▄█ ░░█░░[/color] [head=3] [color=#135285]Representative[/color][/head]
+[color=#1b67a5]█░░▀█ ░░█░░[/color]  [color=#aaaaaa][italic]OFFICIAL CORPORATE DOCUMENT[/italic][/color]
+[head=1][color=#135285]────────────────────[/color][/head]
+[head=2][color=#135285][bold]Classified Corporate Document[/bold][/color][/head]
+[head=1][color=#135285]────────────────────[/color][/head]
+[mono]
+[bold]Subject:[/bold] Supernatural readings detected in Starlight Sector
+[bold]Association:[/bold] "The Unknown"
+[bold]Objectives:[/bold] Beckoning the "Curtain Call"
+
+Reports of a newly developing group under the cultist designation have been detected in the Starlight sector. 
+
+Crew is advised to stay within their departments and minimize fraternizing with other crew members as this group has shown itself to be capable of converting crew members to their cause.
+This conversion involves taking a member of crew to their "monument" to interact with glowing sigils inscribed onto the floor.
+
+This monument is described as "undetectable until the process of 'lifting the curtain'" is about to occur. Security is recommended to be wary of groups gathering in hidden or abandoned sections of the station.
+
+De-conversion of cultist members has been successfully documented when using station assigned censers. Censers must be filled with holy water to effectively cleanse a suspected cult member of this unknown corruption.
+Additional censers can be requested from the Cargo department via the [bold]Religious Supplies Crate[/bold].
+
+Preliminary testing shows mindshield implantation prevents conversion up to a threshold detailed further in the report.
+
+Current understanding of cult hierarchy does not clearly define any direct leadership; as such there are no "head" members to be detained. Any crew members under this cult influence are to be treated as a hive mind and must be de-converted individually.[/mono]
+
+
+[head=1][color=#135285]────────────────────[/color][/head]

--- a/Resources/Prototypes/_ST/CosmicCult/Guidebook/antagonist.yml
+++ b/Resources/Prototypes/_ST/CosmicCult/Guidebook/antagonist.yml
@@ -6,6 +6,7 @@
   - CosmicCultMonument
   - CosmicCultInfluences
   - CosmicCultDeconversion
+  - CosmicColossus #Starlight: add colossus to the cosmic cult section.
 
 - type: guideEntry
   id: CosmicCultMonument

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Documents/document_loot_tables.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Documents/document_loot_tables.yml
@@ -7,6 +7,7 @@
       - id: ClassifiedCorporateDocumentNinjas
       - id: ClassifiedCorporateDocumentNukies
       - id: ClassifiedCorporateDocumentRomerol
+      - id: ClassifiedCorporateDocumentCultCosmic
 
 - type: entityTable
   id: CriminalDocumentTable

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Documents/documents.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Documents/documents.yml
@@ -107,6 +107,18 @@
     - type: StealTarget
       stealGroup: CorporateSecretsSteal
 
+- type: entity
+  id: ClassifiedCorporateDocumentCultCosmic
+  name: classified corporate documents
+  suffix: Do Not Map
+  description: A set of highly classified documents containing Corporate Secrets.
+  parent: [ ImportantDocumentGeneric, BaseGrandTheftContraband ]
+  components:
+    - type: TextFilePaperContent
+      fileName: classified_corporate_document_cosmic_cult.txt
+    - type: StealTarget
+      stealGroup: CorporateSecretsSteal
+
 ### Classified Criminal Documents
 
 - type: entity

--- a/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/Clarifications/Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/Clarifications/Metashield.xml
@@ -77,6 +77,8 @@ Romerol is a highly violent contagion that pilots the dead to facilitate its own
 [bold][color=#9819ff]Paradox Clones || [/color][/bold]
 Cracks in reality sometimes result in intrusions from other parallel worlds. This phenominon is exclusive to sectors near the Null Scar, and is a matter of great interest to NanoTrasen. Should a duplicate be discovered it should be observed and studied, and only terminated if it proves to be hostile.
 
+[bold][color=#9819ff]Cults || [/color][/bold]
+Although the concept and existence of 'cults' is known to the Crew, as they have existed since the dawn of time, the specifics of any cult with real power, such as the Cosmic Cult, are kept secret. Often intentionally by the cults themselves. Chaplains hold the most knowledge of the Crew about these sects, having long studied the religions and faiths of the universe.
 
 [bold][color=#9819ff]Nuclear Operatives || [/color][/bold]
 The Syndicate is a shell of its former self, due to their involvement in and defeat during the Pod Wars. They have grown increasingly more irrational and hostile since their resurgence however, and the rumors you have heard about Nuclear attacks are true. You must protect the Warhead onboard your station, and the Authentication Disk to activate it, at all costs. A confirmed attack from Nuclear Operatives is grounds to suspend Corporate Law and Standard Operating Procedure. Contact Central Command immediately to establish Martial Law.

--- a/Resources/ServerInfo/_ST/Guidebook/CosmicCult/CosmicColossus.xml
+++ b/Resources/ServerInfo/_ST/Guidebook/CosmicCult/CosmicColossus.xml
@@ -44,6 +44,6 @@
   <Box>
     <GuideEntityEmbed Entity="CosmicEffigy" Caption=""/>
   </Box>
-  Some Colossi may call forth an [color=#4cabb3]Effigy of Entropy[/color]. The effigy is a dangerously unstable malign anomaly, and should be dealt with by the Epistemics department immediately!
+  Some Colossi may call forth an [color=#4cabb3]Effigy of Entropy[/color]. The effigy is a dangerously unstable malign anomaly, and should be dealt with by the Science department immediately!
 
 </Document>

--- a/Resources/ServerInfo/_ST/Guidebook/CosmicCult/CosmicCultDeconversion.xml
+++ b/Resources/ServerInfo/_ST/Guidebook/CosmicCult/CosmicCultDeconversion.xml
@@ -8,7 +8,7 @@
   When mounting an effort to thwart the [color=#4cabb3]Cosmic Cult[/color], there are several methods the crew might employ to ensure their survival and safety. One of these methods is [color=Yellow]Deconversion[/color].
 
   To [color=Yellow]Deconvert[/color] a cosmic cultist, an [bold]Ardent Censer[/bold] must be used. Censers are fueled with Holy Water, which can be procured from:
-  - Usage of a Bible by a Chaplain or Mystagogue on most containers of water will bless the water, turning it into Holy Water.
+  - Usage of a Bible by a Chaplain on most containers of water will bless the water, turning it into Holy Water.
 
   ## Suppression Methods
   <Box>


### PR DESCRIPTION
## Short description
Adds cosmic cult metashield to the game since it is now up on the wiki

## Why we need to add this
~~So I dont need to print off that stupid document~~
so everyone can refrence it and be on a common ground of "who knows" and "who doesn't know"

## Media (Video/Screenshots)
<img width="529" height="164" alt="image" src="https://github.com/user-attachments/assets/05b76652-3d57-46e6-852e-bac27353072f" />
<img width="505" height="603" alt="image" src="https://github.com/user-attachments/assets/324a677c-8468-4113-bc48-c14e14057055" />
<img width="511" height="439" alt="image" src="https://github.com/user-attachments/assets/af5a8462-4836-4d15-abea-47a7ddda6fb5" />
<img width="494" height="89" alt="image" src="https://github.com/user-attachments/assets/cd61b911-438f-481a-bdb2-f0b1c8fef436" />
<img width="165" height="104" alt="image" src="https://github.com/user-attachments/assets/0cb0ba6d-849b-4ce6-a9aa-e659c63e2ade" />



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- add: Cosmic Cult metashield
- tweak: Cosmic Cult corporate secrets which can now be found in NTRep's locker and count for the steal objective.
- fix: Guidebook mentions of Epistemics are now Science
- fix: The Mystagogue (RD's Alter Ego) is not a licenced chaplain and cannot make holy water.
- fix: The cosmic cult's ghost form no longer cryos them after being used too long
- fix: The Cosmic Colossi guidebook is now in it's propper place 

