### PR TITLE
Fix CycloriteBloodBreakdown reaction test failure

### DIFF
--- a/Content.IntegrationTests/Tests/Chemistry/TryAllReactionsTest.cs
+++ b/Content.IntegrationTests/Tests/Chemistry/TryAllReactionsTest.cs
@@ -108,7 +108,10 @@ namespace Content.IntegrationTests.Tests.Chemistry
                         .ToDictionary(x => x, _ => false);
                     foreach (var (reagent, quantity) in solution.Contents)
                     {
-                        Assert.That(foundProductsMap.TryFirstOrNull(x => x.Key.Key == reagent.Prototype && x.Key.Value == quantity, out var foundProduct));
+                        // Starlight BEGIN: I only added the assertion message.
+                        Assert.That(foundProductsMap.TryFirstOrNull(x => x.Key.Key == reagent.Prototype && x.Key.Value == quantity, out var foundProduct),
+                            $"Reaction {reactionPrototype.ID} ended with reagents {string.Join(",", solution.Contents)} but expected {string.Join(",",reactionPrototype.Products)}");
+                        // Starlight END
                         foundProductsMap[foundProduct.Value.Key] = true;
                     }
 

--- a/Resources/Prototypes/Recipes/Reactions/biological.yml
+++ b/Resources/Prototypes/Recipes/Reactions/biological.yml
@@ -104,8 +104,7 @@
     CycloriteBlood:
       amount: 20
   products:
-    Nitrogen: 3
-    Hydrogen: 3
-    Oxygen: 9
+    Nitrogen: 4
+    Oxygen: 11
     CarbonDioxide: 1
     Protein: 4


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

The reaction `CycloriteBloodBreakdown` causes a test failure because the products of that reaction instantly react. Coolsurf6 said "Just fix it", so I did :).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Test failure real

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Nah

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
