### PR TITLE
Remove the blacklight box loadout option

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -121,7 +121,6 @@
   - CigPackBub
   - PillCanisterPsicodine
   - ClothingDogTags
-  - Boxblacklight
   - PersonalAI
   - GoldenPersonalAI # Starlight end
   - AACTablet # DeltaV

--- a/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
@@ -563,18 +563,6 @@
   groupBy: "pAI"
 
 - type: loadout
-  id: Boxblacklight
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:SpeciesRequirement
-      species:
-      - Shadekin
-  storage:
-    back: 
-      - Boxblacklight
-
-- type: loadout
   id: RoadCone
   effects:
     - !type:JobRequirementLoadoutEffect


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Removes the blacklight box loadout option.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

https://discord.com/channels/1272545509562777621/1477711551560679454

The conclusion "remove the box from loadout" is from the thread. The short version is that having them round start actively nudges the shadekin players to deploy the immediately. By removing them from the loadout they can still be purchased from cargo and/or made from the autolathe, but it makes it so the player has to go out of their way to do it, rather than having the game suggest they replace lights with no other effort required. It just removes that little 'nudge'.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Can't take a screenshot of something that isn't there!

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- remove: The blacklight box loadout option has been removed.
