### PR TITLE
Rule 2 Update

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/CoreRules/RuleSL2.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RulesSL/CoreRules/RuleSL2.xml
@@ -14,5 +14,6 @@ Additionally, using bugs/exploits to gain an unfair advantage is prohibited. Ple
 ## AFK Farming & Antag Rolling
 - AFK farming time for Role Requirements is prohibited—players must actively engage and contribute to the game.
 - Ghosting, suicide, or otherwise leaving the game after failing to get an antagonist role is considered “Antag Rolling” and is not permitted.
+- Ghosting, suicide, or otherwise leaving the round with the intent on taking a mid-round antagonist ghost role is considered “Antag Rolling” and is not permitted.
 
 </Document>


### PR DESCRIPTION
## Short description
Updates Rule 2 to be more explicit about Antag Rolling.

"Ghosting, suicide, or otherwise leaving the round with the intent to take a mid-round antagonist ghost role is considered 'Antag Rolling' and is not permitted"

## Why we need to add this
There is an issue where the letter of the rule and the spirit of the rule didn't match fully.

## Media (Video/Screenshots)
<img width="1105" height="136" alt="image" src="https://github.com/user-attachments/assets/b416e7ae-6e31-41a2-a1bc-c8c837c722c0" />
Line 3 is added.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- tweak: Made Rule 2 more explicit, closing a loophole with Antag Rolling. 

