### PR TITLE
Fix shoelaces pr

### DIFF
--- a/Content.Shared/_Starlight/Shoelaces/Systems/SharedShoelacesSystem.cs
+++ b/Content.Shared/_Starlight/Shoelaces/Systems/SharedShoelacesSystem.cs
@@ -60,9 +60,9 @@ public sealed class SharedShoelacesSystem : EntitySystem
         var user = args.User;
         var parent = Transform(ent).ParentUid;
 
-        if (CanManipulate(user, ent))
+        if (CanManipulate(user, ent) && (ent.Comp.Tied || ent.Comp.TiedTogether))
         {
-            if (user == parent && ent.Comp.Tied)
+            if (user == parent)
             {
                 var selfUntie = new Verb
                 {
@@ -73,7 +73,7 @@ public sealed class SharedShoelacesSystem : EntitySystem
                 args.Verbs.Add(selfUntie);
                 return;
             }
-            else if (ent.Comp.Tied)
+            else
             {
                 var assistUntie = new Verb
                 {
@@ -282,6 +282,8 @@ public sealed class SharedShoelacesSystem : EntitySystem
             _alerts.ShowAlert(parent, ent.Comp.AlertUntied);
             _alerts.ClearAlert(parent, ent.Comp.AlertTiedTogether);
             EnsureComp<ShoelaceTiedComponent>(parent);
+            ent.Comp.Tied = false;
+            ent.Comp.TiedTogether = false;
         }
         _popup.PopupPredicted(Loc.GetString("shoelaces-popup-untie-success"), ent, args.Args.User, PopupType.Medium);
 

--- a/Content.Shared/_Starlight/Shoelaces/Systems/SharedShoelacesSystem.cs
+++ b/Content.Shared/_Starlight/Shoelaces/Systems/SharedShoelacesSystem.cs
@@ -198,8 +198,8 @@ public sealed class SharedShoelacesSystem : EntitySystem
             Dirty(ent, ent.Comp);
             RemComp<ShoelaceTiedComponent>(parentUid);
             _popup.PopupPredicted(Loc.GetString("shoelaces-popup-tying-success-user"), args.Args.User, args.Args.User, PopupType.Medium);
-            if (args.Args.User != parentUid && _net.IsServer)
-                _popup.PopupEntity(Loc.GetString("shoelaces-popup-tying-success-target", ("user", args.Args.User)), ent, Filter.Entities(parentUid), true, PopupType.MediumCaution);
+            if (args.Args.User != parentUid)
+                _popup.PopupPredicted(Loc.GetString("shoelaces-popup-tying-success-target", ("user", args.Args.User)), ent, null, Filter.Entities(parentUid), true, PopupType.MediumCaution);
         }
         else
         {
@@ -207,8 +207,8 @@ public sealed class SharedShoelacesSystem : EntitySystem
             Dirty(ent, ent.Comp);
             _alerts.ShowAlert(parentUid, ent.Comp.AlertTiedTogether);
             _popup.PopupPredicted(Loc.GetString("shoelaces-popup-tying-together-success-user"), args.Args.User, args.Args.User, PopupType.Medium);
-            if (args.Args.User != parentUid && _net.IsServer)
-                _popup.PopupEntity(Loc.GetString("shoelaces-popup-tying-together-success-target", ("user", args.Args.User)), ent, Filter.Entities(parentUid), true, PopupType.MediumCaution);
+            if (args.Args.User != parentUid)
+                _popup.PopupPredicted(Loc.GetString("shoelaces-popup-tying-together-success-target", ("user", args.Args.User)), ent, null, Filter.Entities(parentUid), true, PopupType.MediumCaution);
         }
 
         args.Handled = true;

--- a/Content.Shared/_Starlight/Shoelaces/Systems/SharedShoelacesSystem.cs
+++ b/Content.Shared/_Starlight/Shoelaces/Systems/SharedShoelacesSystem.cs
@@ -198,7 +198,8 @@ public sealed class SharedShoelacesSystem : EntitySystem
             Dirty(ent, ent.Comp);
             RemComp<ShoelaceTiedComponent>(parentUid);
             _popup.PopupPredicted(Loc.GetString("shoelaces-popup-tying-success-user"), args.Args.User, args.Args.User, PopupType.Medium);
-            _popup.PopupPredicted(Loc.GetString("shoelaces-popup-tying-success-target", ("user", args.Args.User)), ent, parentUid, PopupType.MediumCaution);
+            if (args.Args.User != parentUid && _net.IsServer)
+                _popup.PopupEntity(Loc.GetString("shoelaces-popup-tying-success-target", ("user", args.Args.User)), ent, Filter.Entities(parentUid), true, PopupType.MediumCaution);
         }
         else
         {
@@ -206,15 +207,8 @@ public sealed class SharedShoelacesSystem : EntitySystem
             Dirty(ent, ent.Comp);
             _alerts.ShowAlert(parentUid, ent.Comp.AlertTiedTogether);
             _popup.PopupPredicted(Loc.GetString("shoelaces-popup-tying-together-success-user"), args.Args.User, args.Args.User, PopupType.Medium);
-            if (_net.IsServer)
-            {
-                _popup.PopupEntity(
-                    Loc.GetString("shoelaces-popup-tying-together-success-target", ("user", args.Args.User)),
-                    ent,
-                    Filter.Entities(parentUid),
-                    true,
-                    PopupType.MediumCaution);
-            }
+            if (args.Args.User != parentUid && _net.IsServer)
+                _popup.PopupEntity(Loc.GetString("shoelaces-popup-tying-together-success-target", ("user", args.Args.User)), ent, Filter.Entities(parentUid), true, PopupType.MediumCaution);
         }
 
         args.Handled = true;
@@ -308,8 +302,8 @@ public sealed class SharedShoelacesSystem : EntitySystem
             return;
 
         _random.SetSeed(_gameTiming.CurTime.Seconds);
-        if (!tiedShoes.Comp.Tied 
-            && _random.Prob(tiedShoes.Comp.KnockDownChance) 
+        if (!tiedShoes.Comp.Tied
+            && _random.Prob(tiedShoes.Comp.KnockDownChance)
             && _stun.TryKnockdown(ent.Owner, TimeSpan.FromSeconds(ent.Comp.TripKnockdownTime), force: true))
             _popup.PopupPredicted(Loc.GetString("shoelaces-popup-trip"), ent, ent, PopupType.MediumCaution);
         else if (tiedShoes.Comp.TiedTogether && _stun.TryKnockdown(ent.Owner, TimeSpan.FromSeconds(ent.Comp.TripKnockdownTime), force: true))

--- a/Content.Shared/_Starlight/Shoelaces/Systems/SharedShoelacesSystem.cs
+++ b/Content.Shared/_Starlight/Shoelaces/Systems/SharedShoelacesSystem.cs
@@ -6,7 +6,6 @@ using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
-using Content.Shared.Localizations;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Popups;
@@ -35,7 +34,6 @@ public sealed class SharedShoelacesSystem : EntitySystem
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
-    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
     public override void Initialize()

--- a/Content.Shared/_Starlight/Shoelaces/Systems/SharedShoelacesSystem.cs
+++ b/Content.Shared/_Starlight/Shoelaces/Systems/SharedShoelacesSystem.cs
@@ -347,7 +347,7 @@ public sealed class SharedShoelacesSystem : EntitySystem
 
     private void OnShoesEquipped(Entity<ShoelaceTieableComponent> ent, ref GotEquippedEvent args)
     {
-        if (args.Slot != "shoes")
+        if (args.Slot != "shoes" || !_gameTiming.IsFirstTimePredicted)
             return;
 
         if (IsShoelaceTieBlocked(ent.Owner))

--- a/Resources/Locale/en-US/_Starlight/shoelaces/shoelaces.ftl
+++ b/Resources/Locale/en-US/_Starlight/shoelaces/shoelaces.ftl
@@ -5,12 +5,14 @@ shoelaces-verb-untie = Untie shoelaces
 shoelaces-popup-tying-start = You start tying shoelaces.
 shoelaces-popup-tying-together-start = You start tying shoelaces together.
 
-shoelaces-popup-tying-success-user = You tie shoelaces together.
-shoelaces-popup-tying-success-target = {$user} tied your shoelaces together.
-shoelaces-popup-tying-success-others = {$user} ties {$target}'s shoelaces together.
+shoelaces-popup-tying-success-user = You tie shoelaces.
+shoelaces-popup-tying-success-target = {$user} tied your shoelaces.
+
+shoelaces-popup-tying-together-success-user = You tie shoelaces together.
+shoelaces-popup-tying-together-success-target = {$user} tied your shoelaces together.
 
 shoelaces-popup-untie-start = You start untying shoelaces.
-shoelaces-popup-untie-success = You untie your shoelaces.
+shoelaces-popup-untie-success = You untie shoelaces.
 
 shoelaces-popup-trip = You trip over your shoelaces!
 shoelaces-popup-jump-blocked = You can't jump with your shoelaces untied or tied together!

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -1,33 +1,11 @@
+ # Starlight-start: moved into: ClothingShoesBaseUntieable
 - type: entity
   abstract: true
-  parent: Clothing
+  parent: ClothingShoesBaseUntieable
   id: ClothingShoesBase
   components:
-  - type: Clothing
-    slots:
-    - FEET
-  - type: Sprite
-    state: icon
-  - type: Item
-    size: Normal
-  - type: Edible
-    requiresSpecialDigestion: true
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 10
-        reagents:
-        - ReagentId: Fiber
-          Quantity: 10
-  - type: Tag
-    tags:
-    - ClothMade
-    - Recyclable
-    - WhitelistChameleon
-  - type: ProtectedFromStepTriggers
-  # Starlight-start
   - type: ShoelaceTieable
-  # Starlight-end
+# Starlight-end
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -9,8 +9,8 @@
 
 - type: entity
   abstract: true
-  parent: ClothingShoesBase
-  id: ClothingShoesBaseButcherable
+  parent: ClothingShoesBaseUntieable # Starlight-edit
+  id: ClothingShoesBaseButcherableUntieable # Starlight-edit
   components:
   - type: Butcherable
     butcheringType: Knife
@@ -24,8 +24,8 @@
 # stuff common to all military boots
 - type: entity
   abstract: true
-  parent: [ClothingShoesBase, ClothingSlotBase]
-  id: ClothingShoesMilitaryBase
+  parent: [ClothingShoesBaseUntieable, ClothingSlotBase] # Starlight-edit
+  id: ClothingShoesMilitaryBaseUntieable # Starlight-edit
   components:
   - type: Matchbox
   - type: ItemSlots

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingShoesBase, BaseToggleClothing]
+  parent: [ClothingShoesBaseUntieable, BaseToggleClothing] # Starlight-edit: untieable mag boots
   id: ClothingShoesBootsMagBase
   name: magboots
   description: Magnetic boots, often used during extravehicular activity to ensure the user remains safely attached to the vehicle.

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -88,7 +88,7 @@
     price: 3000
 
 - type: entity
-  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband, ClothingShoesMilitaryBase] # Starlight
+  parent: [ClothingShoesBootsMagBase, BaseJetpack, BaseSyndicateContraband, ClothingShoesMilitaryBaseUntieable] # Starlight
   id: ClothingShoesBootsMagSyndie
   name: blood-red magboots
   description: Reverse-engineered from ERT magboots, they have a heavy magnetic pull, integrated thrusters, and are designed for combat. It can hold 0.75 L of gas. # Starlight

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -21,7 +21,7 @@
     sprite: Clothing/Shoes/Misc/leather.rsi
 
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: ClothingShoesBaseButcherableUntieable # Starlight-edit
   id: ClothingShoesSlippers
   name: slippers
   description: Fluffy!
@@ -32,7 +32,7 @@
     sprite: Clothing/Shoes/Misc/slippers.rsi
 
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: ClothingShoesBaseButcherableUntieable # Starlight-edit
   id: ClothingShoeSlippersDuck
   name: ducky slippers
   description: You wish these made quacking sounds as you walked. It's a good thing they don't, though.
@@ -51,7 +51,7 @@
     node: shoes
 
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: ClothingShoesBaseButcherableUntieable # Starlight-edit
   id: ClothingShoeSlippersLizard
   name: lizard plushie slippers
   description: An adorable pair of slippers that resemble a lizardperson. Combine this with some other green clothing and you'll be the coolest crewmember on the station!
@@ -90,7 +90,7 @@
           Quantity: 20
 
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: ClothingShoesBaseButcherableUntieable # Starlight-edit
   id: ClothingShoesTourist
   name: tourist shoes
   description: These cheap sandals don't look very comfortable.
@@ -101,7 +101,7 @@
     sprite: Clothing/Shoes/Misc/tourist.rsi
 
 - type: entity
-  parent: ClothingShoesBaseButcherable
+  parent: ClothingShoesBaseButcherableUntieable # Starlight-edit
   id: ClothingShoesDameDane
   name: yakuza shoes
   description: At last...
@@ -124,7 +124,7 @@
 
 # Starlight edit - Left speed boots with removed lathe recipe as an admeme item
 - type: entity
-  parent: [ClothingShoesBase, PowerCellSlotSmallItem, BaseToggleClothing]
+  parent: [ClothingShoesBaseUntieable, PowerCellSlotSmallItem, BaseToggleClothing]
   id: ClothingShoesBootsSpeed
   name: speed boots
   description: High-tech boots woven with quantum fibers, able to convert electricity into pure speed!
@@ -179,7 +179,7 @@
 # Starlight edit end
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseUntieable # Starlight-edit
   id: ClothingShoesBootsMoon
   name: moon boots
   description: Special anti-gravity boots developed with a speciality blend of lunar rock gel. Shipped from the Netherlands.
@@ -197,7 +197,7 @@
     tags: [ ]
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseUntieable # Starlight-edit
   id: ClothingShoesBootsJump
   name: jump boots
   description: High-tech boots that give you the incredible ability to JUMP! With these boots you can jump over lava, chasms and weird chemicals on the floor!

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -12,7 +12,7 @@
 # stuff common to all clown & jester shoes
 - type: entity
   abstract: true
-  parent: [ClothingShoesBaseButcherable, ClothingSlotBase]
+  parent: [ClothingShoesBaseButcherableUntieable, ClothingSlotBase] # Starlight-edit
   id: ClothingShoesClownBase
   components:
   - type: ItemSlots
@@ -105,7 +105,7 @@
     sprite: Clothing/Shoes/Specific/cult.rsi
 
 - type: entity
-  parent: [ ClothingShoesBase, BaseJanitorContraband ]
+  parent: [ ClothingShoesBaseUntieable, BaseJanitorContraband ] # Starlight-edit
   id: ClothingShoesGaloshes
   name: galoshes
   description: Specialised non-slip rubber boots, designed to reduce janitorial workplace accidents; a tider's treasure.

--- a/Resources/Prototypes/Entities/Clothing/Under/under.yml
+++ b/Resources/Prototypes/Entities/Clothing/Under/under.yml
@@ -2,7 +2,7 @@
 # I would cry if we didn't have them. -swept
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseUntieable # Starlight-edit: Untieable shoes
   id: ClothingUnderSocksBee
   name: bee socks
   description: Make them loins buzz!
@@ -13,7 +13,7 @@
     sprite: Clothing/Under/Socks/bee.rsi
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseUntieable # Starlight-edit: Untieable shoes
   id: ClothingUnderSocksCoder
   name: coder socks
   description: It's time to code sisters!!11!

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -54,3 +54,17 @@
     - Recyclable
     - WhitelistChameleon
   - type: ProtectedFromStepTriggers
+
+- type: entity
+  abstract: true
+  parent: ClothingShoesBaseButcherableUntieable
+  id: ClothingShoesBaseButcherable
+  components:
+  - type: ShoelaceTieable
+
+- type: entity
+  abstract: true
+  parent: ClothingShoesMilitaryBaseUntieable
+  id: ClothingShoesMilitaryBase
+  components:
+  - type: ShoelaceTieable

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   abstract: true
   parent: Clothing
-  id: ClothingShoesBaseUnprotected 
+  id: ClothingShoesBaseUnprotected
   components:
     - type: Clothing
       slots:
@@ -26,3 +26,31 @@
         - ClothMade
         - Recyclable
         - WhitelistChameleon
+
+- type: entity
+  abstract: true
+  parent: Clothing
+  id: ClothingShoesBaseUntieable
+  components:
+  - type: Clothing
+    slots:
+    - FEET
+  - type: Sprite
+    state: icon
+  - type: Item
+    size: Normal
+  - type: Edible
+    requiresSpecialDigestion: true
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 10
+  - type: Tag
+    tags:
+    - ClothMade
+    - Recyclable
+    - WhitelistChameleon
+  - type: ProtectedFromStepTriggers


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Fixes some huge bugs of #3445:

1. Fixed crash when you unequipping shoes and/or knocking down with untied shoelaces.
2. Fixed incorrect/missing tooltips and their duplication.
3. Fixed untie verbs.
4. Fixed bug when magboots, socks, moon boots, speed boots, jump boots, tourist boots, dame dane boots, lizard plushie slippers, ducky slippers, slippers, clown shoes, galoshes have shoelaces.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Bugfix

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Crash fix

https://github.com/user-attachments/assets/75e79d53-2aad-45b7-a78d-0fa718f8714a

### Tooltips and verbs fix

https://github.com/user-attachments/assets/99846286-81f2-4656-b662-4c8c1c6a6ed9


### Magboots and other boots fix

<img width="221" height="301" alt="image" src="https://github.com/user-attachments/assets/07092b96-cd06-429e-bfef-cd929b330266" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rinary
- fix: Fixed shoelaces tooltips.
- fix: Fixed untie shoelaces verb.
- fix: Fixed prediction crash when trying to unequip shoes with shoelaces.
- fix: Fixed bug when magboots, moon boots, speed boots, socks and other specific types of shoes have shoelaces.