### PR TITLE
Use localization keys for status effects

### DIFF
--- a/Resources/Locale/en-US/_Starlight/guidebook/entity-effects/statuseffects.ftl
+++ b/Resources/Locale/en-US/_Starlight/guidebook/entity-effects/statuseffects.ftl
@@ -1,0 +1,1 @@
+﻿entity-effect-status-effect-PoliteLanguage = politeness

--- a/Resources/Locale/en-US/_Starlight/status-effects/body.ftl
+++ b/Resources/Locale/en-US/_Starlight/status-effects/body.ftl
@@ -1,0 +1,7 @@
+﻿status-effect-body-bloodloss = bloodloss
+status-effect-body-numbness = numbness
+status-effect-body-anticoagulant = thin blood
+status-effect-body-hemorrhage = hemorrhage
+status-effect-body-pain-numbness = pain numbness
+status-effect-body-2x-max-stamina = 2x max stamina
+status-effect-body-1.5x-max-stamina = 1.5x max stamina

--- a/Resources/Locale/en-US/_Starlight/status-effects/body.ftl
+++ b/Resources/Locale/en-US/_Starlight/status-effects/body.ftl
@@ -4,4 +4,4 @@ status-effect-body-anticoagulant = thin blood
 status-effect-body-hemorrhage = hemorrhage
 status-effect-body-pain-numbness = pain numbness
 status-effect-body-2x-max-stamina = 2x max stamina
-status-effect-body-1.5x-max-stamina = 1.5x max stamina
+status-effect-body-1-5x-max-stamina = 1.5x max stamina

--- a/Resources/Locale/en-US/_Starlight/status-effects/cybernetics.ftl
+++ b/Resources/Locale/en-US/_Starlight/status-effects/cybernetics.ftl
@@ -1,0 +1,2 @@
+﻿# Starlight effects
+status-effect-cybernetics-cybernetics-disrupted = cybernetics disrupted

--- a/Resources/Locale/en-US/_Starlight/status-effects/misc.ftl
+++ b/Resources/Locale/en-US/_Starlight/status-effects/misc.ftl
@@ -1,0 +1,13 @@
+﻿# Upstream effects
+status-effect-misc-forced-sleep = forced sleep
+status-effect-misc-ssd-sleep = forced sleep
+status-effect-misc-drowsiness = drowsiness
+status-effect-misc-hallucinations = hallucinations
+status-effect-misc-woozy = woozy
+status-effect-misc-drunk = drunk
+
+# Starlight effects
+status-effect-misc-temporary-blindness = temporary blindness
+status-effect-misc-muted = mute
+status-effect-misc-the-dark = the dark
+status-effect-misc-holding-breath = holding breath

--- a/Resources/Locale/en-US/_Starlight/status-effects/movement.ftl
+++ b/Resources/Locale/en-US/_Starlight/status-effects/movement.ftl
@@ -1,0 +1,7 @@
+﻿status-effect-movement-reagent-speed = reagent speed
+status-effect-movement-vomiting-slowdown = vomiting slowdown
+status-effect-movement-taser-slowdown = shot by taser slowdown
+status-effect-movement-flash-slowdown = affected by flash slowdown
+status-effect-movement-stamina-low = stamina low
+status-effect-movement-friction = friction
+status-effect-movement-stunned = stunned

--- a/Resources/Locale/en-US/_Starlight/status-effects/speech.ftl
+++ b/Resources/Locale/en-US/_Starlight/status-effects/speech.ftl
@@ -1,0 +1,5 @@
+﻿status-effect-speech-stutter = stutter
+status-effect-speech-slurred = slurred
+status-effect-speech-scrambled = scrambled
+status-effect-speech-owoaccent = OwO accent
+status-effect-speech-bark = bark accent

--- a/Resources/Prototypes/Entities/StatusEffects/body.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/body.yml
@@ -81,7 +81,7 @@
 - type: entity
   parent: StaminaModifierStatusEffect
   id: StatusEffectStimulantsStamina
-  name: status-effect-body-1.5x-max-stamina # Starlight: Localize
+  name: "status-effect-body-1.5-max-stamina" # Starlight: Localize (in quotes due to the period)
   components:
   - type: StaminaModifierStatusEffect
     modifier: 1.5

--- a/Resources/Prototypes/Entities/StatusEffects/body.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/body.yml
@@ -18,7 +18,7 @@
 - type: entity
   parent: BloodstreamStatusEffectDebuff
   id: StatusEffectBloodloss
-  name: bloodloss
+  name: status-effect-body-bloodloss # Starlight: Localize
   components:
   - type: StutteringAccent
   - type: DrunkStatusEffect
@@ -43,7 +43,7 @@
 - type: entity
   parent: BloodstreamStatusEffectDebuff
   id: StatusEffectAnticoagulant # Decreases the amount of blood coagulation when bleeding.
-  name: thin blood
+  name: status-effect-body-anticoagulant # Starlight: Localize
   components:
   - type: HemophiliaStatusEffect
     bleedReductionMultiplier: 0.33
@@ -52,7 +52,7 @@
 - type: entity
   parent: BloodstreamStatusEffectDebuff
   id: StatusEffectHemorrhage # Increases the amount of blood lost when bleeding.
-  name: hemorrhage
+  name: status-effect-body-hemorrhage # Starlight: Localize
   components:
   - type: HemophiliaStatusEffect
     bleedReductionMultiplier: 1 # We don't want it to also reduce coagulation, it would stack with Anticoagulant.
@@ -61,7 +61,7 @@
 - type: entity
   parent: [ PainNumbnessTraitStatusEffect, MobStatusEffectDebuff ]
   id: StatusEffectPainNumbness
-  name: pain numbness
+  name: status-effect-body-pain-numbness # Starlight: Localize
 
 - type: entity
   parent: MobStatusEffectBase
@@ -75,13 +75,13 @@
 
 - type: entity
   parent: StaminaModifierStatusEffect
-  name: 2x max stamina
+  name: status-effect-body-2x-max-stamina # Starlight: Localize
   id: StatusEffectDesoxyStamina
 
 - type: entity
   parent: StaminaModifierStatusEffect
   id: StatusEffectStimulantsStamina
-  name: 1.5x max stamina
+  name: status-effect-body-1.5x-max-stamina # Starlight: Localize
   components:
   - type: StaminaModifierStatusEffect
     modifier: 1.5

--- a/Resources/Prototypes/Entities/StatusEffects/body.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/body.yml
@@ -81,7 +81,7 @@
 - type: entity
   parent: StaminaModifierStatusEffect
   id: StatusEffectStimulantsStamina
-  name: "status-effect-body-1.5x-max-stamina" # Starlight: Localize (in quotes due to the period)
+  name: status-effect-body-1-5x-max-stamina # Starlight: Localize (in quotes due to the period)
   components:
   - type: StaminaModifierStatusEffect
     modifier: 1.5

--- a/Resources/Prototypes/Entities/StatusEffects/body.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/body.yml
@@ -81,7 +81,7 @@
 - type: entity
   parent: StaminaModifierStatusEffect
   id: StatusEffectStimulantsStamina
-  name: "status-effect-body-1.5-max-stamina" # Starlight: Localize (in quotes due to the period)
+  name: "status-effect-body-1.5x-max-stamina" # Starlight: Localize (in quotes due to the period)
   components:
   - type: StaminaModifierStatusEffect
     modifier: 1.5

--- a/Resources/Prototypes/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/misc.yml
@@ -47,7 +47,7 @@
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectForcedSleeping
-  name: forced sleep
+  name: status-effect-misc-forced-sleep # Starlight: Localize
   components:
   # Starlight START
   - type: StatusEffect
@@ -64,7 +64,7 @@
 - type: entity
   parent: MobStatusEffectBase # Not even rejuvenate can cure SSD...
   id: StatusEffectSSDSleeping
-  name: forced sleep
+  name: status-effect-misc-ssd-sleep # Starlight: Localize
   components:
   - type: ForcedSleepingStatusEffect
   - type: StunnedStatusEffect
@@ -74,7 +74,7 @@
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectDrowsiness
-  name: drowsiness
+  name: status-effect-misc-drowsiness # Starlight: Localize
   components:
   - type: DrowsinessStatusEffect
   # Starlight START
@@ -89,7 +89,7 @@
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectSeeingRainbow
-  name: hallucinations
+  name: status-effect-misc-hallucinations # Starlight: Localize
   components:
   - type: SeeingRainbowsStatusEffect
   # Starlight START
@@ -104,7 +104,7 @@
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectWoozy
-  name: woozy
+  name: status-effect-misc-woozy # Starlight: Localize
   components:
   - type: DrunkStatusEffect
   # Starlight START
@@ -119,4 +119,4 @@
 - type: entity
   parent: [ StatusEffectWoozy, StatusEffectSlurred ]
   id: StatusEffectDrunk
-  name: drunk
+  name: status-effect-misc-drunk # Starlight: Localize

--- a/Resources/Prototypes/Entities/StatusEffects/movement.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/movement.yml
@@ -32,33 +32,33 @@
 - type: entity
   parent: StatusEffectSpeed
   id: ReagentSpeedStatusEffect
-  name: reagent speed
+  name: status-effect-movement-reagent-speed # Starlight: Localize
 
 - type: entity
   parent: StatusEffectSlowdown
   id: VomitingSlowdownStatusEffect
-  name: vomiting slowdown
+  name: status-effect-movement-vomiting-slowdown # Starlight: Localize
 
 - type: entity
   parent: StatusEffectSlowdown
   id: TaserSlowdownStatusEffect
-  name: shot by taser slowdown
+  name: status-effect-movement-taser-slowdown # Starlight: Localize
 
 - type: entity
   parent: StatusEffectSlowdown
   id: FlashSlowdownStatusEffect
-  name: affected by flash slowdown
+  name: status-effect-movement-flash-slowdown # Starlight: Localize
 
 - type: entity
   parent: StatusEffectSlowdown
   id: StatusEffectStaminaLow
-  name: stamina low
+  name: status-effect-movement-stamina-low # STarlight: Localize
 
 # Makes you more slippery, or perhaps less slippery.
 - type: entity
   parent: MobStatusEffectDebuff # Debatable if this should be MobStatusEffectBase or not
   id: StatusEffectFriction
-  name: friction
+  name: status-effect-movement-friction # Starlight: Localize
   components:
   - type: FrictionStatusEffect
 
@@ -67,7 +67,7 @@
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectStunned
-  name: stunned
+  name: status-effect-movement-stunned # Starlight: Localize
   components:
   - type: StatusEffect
     whitelist:

--- a/Resources/Prototypes/Entities/StatusEffects/speech.yml
+++ b/Resources/Prototypes/Entities/StatusEffects/speech.yml
@@ -14,7 +14,7 @@
 - type: entity
   parent: SpeechStatusEffectBase
   id: StatusEffectStutter
-  name: stutter
+  name: status-effect-speech-stutter
   components:
   - type: StutteringAccent
 
@@ -22,7 +22,7 @@
 - type: entity
   parent: SpeechStatusEffectBase
   id: StatusEffectSlurred
-  name: slurred
+  name: status-effect-speech-slurred
   components:
   - type: SlurredAccent
 
@@ -30,7 +30,7 @@
 - type: entity
   parent: SpeechStatusEffectBase
   id: StatusEffectScrambled
-  name: scrambled
+  name: status-effect-speech-scrambled
   components:
   - type: ScrambledAccent
 
@@ -38,7 +38,7 @@
 - type: entity
   parent: SpeechStatusEffectBase
   id: StatusEffectOwO
-  name: owoaccent
+  name: status-effect-speech-owoaccent
   components:
   - type: OwOAccent
 
@@ -46,6 +46,6 @@
 - type: entity
   parent: SpeechStatusEffectBase
   id: StatusEffectBark
-  name: barkaccent
+  name: status-effect-speech-bark
   components:
   - type: BarkAccent

--- a/Resources/Prototypes/_Starlight/Entities/StatusEffects/cybernetics.yml
+++ b/Resources/Prototypes/_Starlight/Entities/StatusEffects/cybernetics.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectCyberneticDisruption
-  name: cybernetics disrupted
+  name: status-effect-cybernetics-cybernetics-disrupted
   components:
   - type: StatusEffect
     whitelist:

--- a/Resources/Prototypes/_Starlight/Entities/StatusEffects/misc.yml
+++ b/Resources/Prototypes/_Starlight/Entities/StatusEffects/misc.yml
@@ -3,7 +3,7 @@
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectTemporaryBlindness
-  name: temporary blindness
+  name: status-effect-misc-temporary-blindness
   components:
   - type: StatusEffect
     whitelist:
@@ -18,7 +18,7 @@
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectMuted
-  name: mute
+  name: status-effect-misc-muted
   components:
     - type: StatusEffect
       whitelist:
@@ -34,7 +34,7 @@
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectTheDark
-  name: the dark
+  name: status-effect-misc-the-dark
   components:
   - type: StatusEffect
     whitelist:
@@ -61,7 +61,7 @@
 - type: entity
   parent: MobStatusEffectDebuff
   id: StatusEffectHeldBreath
-  name: holding breath
+  name: status-effect-misc-holding-breath
   components:
   - type: StatusEffect
     whitelist:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Updates status effects to use localization keys for names.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

https://github.com/ss14Starlight/space-station-14/actions/runs/23341627069/job/67896398746?pr=3786#step:10:720

This keeps popping up in our build/test logs:
<img width="751" height="613" alt="image" src="https://github.com/user-attachments/assets/a463c8cb-84e3-46c0-a3a1-d194a338e30c" />


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

N/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
