### PR TITLE
Increased map vote options

### DIFF
--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Vote.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Vote.cs
@@ -28,7 +28,7 @@ public sealed partial class StarlightCCVars
         CVarDef.Create("vote.votings_delay", 90);
     
     public static readonly CVarDef<int> MapVotingCount = 
-        CVarDef.Create("vote.map_voting_count", 3);
+        CVarDef.Create("vote.map_voting_count", 5);
     
     public static readonly CVarDef<int> RoundVotingCount = 
         CVarDef.Create("vote.round_voting_count", 3);


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
This PR increases the map vote from 3 (+ Secret) to 5 (+ Secret).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Our map pool is really large on Starlight. Sometimes you get the same few maps showing up. A larger map vote means that it's less likely for the exact same ones to show up.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="407" height="165" alt="image" src="https://github.com/user-attachments/assets/eb914c85-03d2-484b-a7cc-64888e0e0e97" />

fig. 1 - Map Vote increased from 3 to 5 (plus Secret).

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- tweak: Map Vote Menu now shows 5 Maps + Secret (up from 3 Maps + Secret).