### PR TITLE
(Hotfix) Migration.yml entry for removed Lionhunter Rifle

### DIFF
--- a/Resources/_Starlight/migration.yml
+++ b/Resources/_Starlight/migration.yml
@@ -72,3 +72,6 @@ ShuttleGunNTSFCyerxa120mm: ShuttleGunCyerxa120mm
 
 #2026-03-11
 WeaponRevolverSnubRevolver: null
+
+#2026-03-21
+WeaponRifleLionhunter: null

--- a/Resources/_Starlight/migration.yml
+++ b/Resources/_Starlight/migration.yml
@@ -74,4 +74,4 @@ ShuttleGunNTSFCyerxa120mm: ShuttleGunCyerxa120mm
 WeaponRevolverSnubRevolver: null
 
 #2026-03-21
-WeaponRifleLionhunter: null
+WeaponRifleLionhunter: WeaponSniperLionhunter


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
#3154 removed the Lionhunter Rifle but did not include a `Migration.yml` entry for it.

This has caused the same issue as #3670 where the removal of the snub-nose prevented event admin grids like the PirateShuttle from loading.

This PR adds a migration entry to remove the Lionhunter Rifle from maps.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Event admins cannot load important event-related grids right now. Important bugfix.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- fix: Fixed custom / event admin grids failing to load.