### PR TITLE
wield only when have 1 free hand or when have bolt closed

### DIFF
--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -195,7 +195,10 @@ public abstract class SharedWieldableSystem : EntitySystem
 
     private void OnUseInHand(EntityUid uid, WieldableComponent component, UseInHandEvent args)
     {
-        if (args.Handled || (TryComp<ChamberMagazineAmmoProviderComponent>(uid, out var chamber) && chamber.BoltClosed == false && _hands.GetEmptyHandCount(args.User) == 0)) // Starlight-edit: wield first only if chamber closed and you don't have free hand(s)
+        if (args.Handled 
+            || (TryComp<ChamberMagazineAmmoProviderComponent>(uid, out var chamber) // Starlight-start
+                && chamber.BoltClosed == false 
+                && _hands.GetEmptyHandCount(args.User) == 0)) // Starlight-end
             return;
 
         if (!component.Wielded)

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -195,7 +195,7 @@ public abstract class SharedWieldableSystem : EntitySystem
 
     private void OnUseInHand(EntityUid uid, WieldableComponent component, UseInHandEvent args)
     {
-        if (args.Handled)
+        if (args.Handled || (TryComp<ChamberMagazineAmmoProviderComponent>(uid, out var chamber) && !chamber.BoltClosed && _hands.GetEmptyHandCount(args.User) == 0))
             return;
 
         if (!component.Wielded)

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -195,7 +195,7 @@ public abstract class SharedWieldableSystem : EntitySystem
 
     private void OnUseInHand(EntityUid uid, WieldableComponent component, UseInHandEvent args)
     {
-        if (args.Handled || (TryComp<ChamberMagazineAmmoProviderComponent>(uid, out var chamber) && !chamber.BoltClosed && _hands.GetEmptyHandCount(args.User) == 0))
+        if (args.Handled || (TryComp<ChamberMagazineAmmoProviderComponent>(uid, out var chamber) && chamber.BoltClosed == false && _hands.GetEmptyHandCount(args.User) == 0))
             return;
 
         if (!component.Wielded)

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -195,7 +195,7 @@ public abstract class SharedWieldableSystem : EntitySystem
 
     private void OnUseInHand(EntityUid uid, WieldableComponent component, UseInHandEvent args)
     {
-        if (args.Handled || (TryComp<ChamberMagazineAmmoProviderComponent>(uid, out var chamber) && chamber.BoltClosed == false && _hands.GetEmptyHandCount(args.User) == 0))
+        if (args.Handled || (TryComp<ChamberMagazineAmmoProviderComponent>(uid, out var chamber) && chamber.BoltClosed == false && _hands.GetEmptyHandCount(args.User) == 0)) // Starlight-edit: wield first only if chamber closed and you don't have free hand(s)
             return;
 
         if (!component.Wielded)


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Makes it so you will wield weapon with chambers first when you have free hand(s) or closed bolt, in another cases you will close bolt first

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

QoL for players

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- tweak: Changed wield logic, now you wield guns with chamber, when you have free hands or when your bolt is closed, in another cases you will close bolt first.