### PR TITLE
Give handheld crew monitors medium batteries, reduce power draw slightly

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: handheld crew monitor
   categories: [ DoNotMap ]
-  parent: [ BaseHandheldComputer, BaseGrandTheftContraband ]
+  parent: [ PowerCellSlotMediumItem, BaseHandheldComputer, BaseGrandTheftContraband ] # Starlight: Medium battery
   # CMO-only bud, don't add more.
   id: HandheldCrewMonitor
   description: A hand-held crew monitor displaying the status of suit sensors.
@@ -33,6 +33,8 @@
         enum.CrewMonitorLayers.Alert:
           True: { visible: true, shader: unshaded }
           False: { visible: false }
+  - type: PowerCellDraw
+    useCharge: 15
   # Starlight END
   - type: ActivatableUI
     key: enum.CrewMonitoringUIKey.Key

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/emergency_crew_monitor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/emergency_crew_monitor.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: emergency crew monitor
-  parent: [ BaseHandheldComputer, BaseMedicalContraband ]
+  parent: [ PowerCellSlotMediumItem, BaseHandheldComputer, BaseMedicalContraband ]
   id: EmergencyHandheldCrewMonitor
   description: A hand-held crew monitor displaying the status of suit sensors of injured crew.
   components:
@@ -49,3 +49,5 @@
     price: 200
   - type: StealTarget
     stealGroup: CrewMonitorCollection
+  - type: PowerCellDraw
+    useCharge: 15

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_brigmedic_crew_monitor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_brigmedic_crew_monitor.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: BrigBuddy™ 5000
-  parent: [ BaseHandheldComputer, BaseSecurityContraband ]
+  parent: [ PowerCellSlotMediumItem, BaseHandheldComputer, BaseSecurityContraband ]
   id: HandheldBrigmedicCrewMonitor
   description: So advanced it only tracks security personnel! Does not monitor emotional stability or competence levels of security members. Use at your own risk!
   components:
@@ -67,3 +67,5 @@
         blacklist:
           tags:
           - MechReactor
+  - type: PowerCellDraw
+    useCharge: 15

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/handheld_bso_crew_monitor.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: CommandFriend™ X-02
-  parent: [ BaseHandheldComputer, BaseBlueShieldContraband, BaseGrandTheftContraband ]
+  parent: [ PowerCellSlotMediumItem, BaseHandheldComputer, BaseBlueShieldContraband, BaseGrandTheftContraband ]
   id: HandheldBSOCrewMonitor
   description: Does not monitor the competence levels of command members.
   components:
@@ -68,3 +68,5 @@
         blacklist:
           tags:
           - MechReactor
+  - type: PowerCellDraw
+    useCharge: 15


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Give handheld crew monitors medium batteries instead of small ones, and draw 25% less power per use.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Suggestion thread: https://discord.com/channels/1272545509562777621/1484916483271295036

Per #3490 the battery use increased quite a lot since every paging event actively drains the battery, even when you don't open the UI. On e.g. nuke op rounds this is especially bad and causes the battery to drain tremendously fast.

Honestly the battery change was already warranted before #3490, hence also the reduction in power use to compensate even a little more.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/685565e9-711e-4daf-8b35-9d0bbe8f7cf3


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: All handheld crew monitors now come with medium batteries.
- tweak: All handheld crew monitors now use 25% less energy per opening of the UI or receiving an alert.
