### PR TITLE
Move "Physical Social Interaction" string to localization file

### DIFF
--- a/Content.Shared/_Starlight/PhysicalSocialInteraction/Systems/PhysicalSocialInteractionSystem.cs
+++ b/Content.Shared/_Starlight/PhysicalSocialInteraction/Systems/PhysicalSocialInteractionSystem.cs
@@ -35,7 +35,7 @@ public sealed class PhysicalSocialInteractionSystem : EntitySystem
             return;
 
         //create a verb subcategory
-        var category = new VerbCategory("Physical Social Interaction", null);
+        var category = new VerbCategory("physical-social-interaction-component-verb", null);
 
         //enumerate all the physical social interaction prototypes
         foreach (var protoid in component.InteractionPrototypes)

--- a/Resources/Locale/en-US/_Starlight/physical-social-interaction-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/physical-social-interaction-component.ftl
@@ -1,3 +1,5 @@
+physical-social-interaction-component-verb = Physical Social Interaction
+
 pet-verb = Pet
 petting-success = You pet { THE($target) } on {POSS-ADJ($target)} head.
 petting-success-others = { CAPITALIZE(THE($user)) } pets {THE($target)} on {POSS-ADJ($target)} head.


### PR DESCRIPTION
## Short description
Fix missing localization for physical social interaction string.

## Why we need to add this
Maintenance; less console clutter from alt-clicking someone.

## Media (Video/Screenshots)
No more of this:
<img width="836" height="24" alt="image" src="https://github.com/user-attachments/assets/6fb73613-9533-4805-ba43-b5d22b658595" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.