### PR TITLE
Refactor and update mob pack quorem system

### DIFF
--- a/Content.Shared/_Starlight/Behaviors/Pack/QuoremCheckComponent.cs
+++ b/Content.Shared/_Starlight/Behaviors/Pack/QuoremCheckComponent.cs
@@ -1,27 +1,50 @@
 ﻿using Content.Shared.NPC.Prototypes;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
-using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
-
-// This component is for mobs with pack behavior traits
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._Starlight.Behaviors.Pack;
-[RegisterComponent, NetworkedComponent]
 
+/// <summary>
+/// Used for mobs that exhibit pack behavior. Entities with this component
+/// are able to join packs. Members of a pack will defend each other if attacked,
+/// and can become hostile upon reaching a specific member count.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
 public sealed partial class QuoremCheckComponent : Component 
 {
-    [DataField] public float DetectionRadius = 5.0f;
-    
-    [DataField] public int QuoremThreshold = 3;
+    /// <summary>
+    /// The next time recruiting into the pack will be attempted.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoPausedField]
+    public TimeSpan NextRecruitAttempt;
 
-    ///[DataField (readOnly:true)] public int CurrentPackSize;
+    /// <summary>
+    /// Minimum length between each recruit attempt.
+    /// </summary>
+    [DataField] public TimeSpan MinRecruitAttemptInterval = TimeSpan.FromSeconds(4);
+
+    /// <summary>
+    /// Maximum length between each recruit attempt.
+    /// </summary>
+    [DataField] public TimeSpan MaxRecruitAttemptInterval = TimeSpan.FromSeconds(6);
+
+    /// <summary>
+    /// The recruit radius, which defines how close other entities have to be to attempt to recruit them.
+    /// </summary>
+    [DataField] public float RecruitRadius = 5.0f;
+    
+    /// <summary>
+    /// The quorem threshold, at which point the pack will be considered sufficiently large.
+    /// </summary>
+    [DataField] public int QuoremThreshold = 3;
 
     [DataField(required: true)] public string PackTag;
 
     [DataField(readOnly: true)] public bool IsHostile;
 
-    ///[DataField] public bool CanRepacify;
     [DataField] public int PackId;
     
     [DataField] public ProtoId<NpcFactionPrototype> QuoremFaction = "Xeno";
@@ -31,7 +54,4 @@ public sealed partial class QuoremCheckComponent : Component
     [DataField] public ProtoId<EntityPrototype>? QuoremEffect;
     
     [DataField] public SoundSpecifier? QuoremSound;
-
-
 }
-

--- a/Content.Shared/_Starlight/Behaviors/Pack/SharedQuoremCheckSystem.cs
+++ b/Content.Shared/_Starlight/Behaviors/Pack/SharedQuoremCheckSystem.cs
@@ -1,37 +1,38 @@
 ﻿using System.Numerics;
-using Content.Shared.Damage;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.NPC.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
-using Robust.Shared.Physics.Events;
-
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Shared._Starlight.Behaviors.Pack;
 
 /// <summary>
-/// This handles deciding whether the pack has reached critical mass
+/// Handles pack recruitment logic and determining whether the pack has reached critical mass.
 /// </summary>
 public abstract class SharedQuoremCheckSystem : EntitySystem
 {
     [Dependency] private readonly NpcFactionSystem _npcFactionSystem = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     protected Dictionary<int, HashSet<EntityUid>> _packGroups = new Dictionary<int, HashSet<EntityUid>>();
     private int _nextId;
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<QuoremCheckComponent, StartCollideEvent>(OnStartCollide);
-        // SubscribeLocalEvent<QuoremCheckComponent, EndCollideEvent>(OnEndCollide);
         SubscribeLocalEvent<QuoremCheckComponent, MobStateChangedEvent>(OnPackmateDeath);
         SubscribeLocalEvent<QuoremCheckComponent, ComponentInit>(OnComponentInit);
-        
     }
 
-    // Provide individuals with pack ids
+    /// <summary>
+    /// Initializes component by providing individuals with pack ids.
+    /// </summary>
     private void OnComponentInit(Entity<QuoremCheckComponent> ent, ref ComponentInit args)
     {
        ent.Comp.PackId = _nextId;
@@ -39,58 +40,101 @@ public abstract class SharedQuoremCheckSystem : EntitySystem
        _nextId ++;
     }
 
-    // Form packs when individuals become close enough
-    private void OnStartCollide(Entity<QuoremCheckComponent> ent, ref StartCollideEvent args)
+    public override void Update(float frameTime)
     {
-        if (args.OurFixtureId != "fix2") 
-            return;
-        
-        if (!TryComp(args.OtherEntity, out QuoremCheckComponent? othercomp))
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<QuoremCheckComponent>();
+        while (query.MoveNext(out var uid, out var component))
+        {
+            if (_timing.CurTime < component.NextRecruitAttempt)
+                continue;
+
+            component.NextRecruitAttempt += _random.Next(component.MinRecruitAttemptInterval, component.MaxRecruitAttemptInterval);
+
+            TryJoinPacksNearby(uid, component);
+        }
+    }
+
+    /// <summary>
+    /// Checks nearby entities for joinable packs, and attempts to join them.
+    /// </summary>
+    private void TryJoinPacksNearby(EntityUid uid, QuoremCheckComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
             return;
 
-        if (ent.Comp.PackTag != othercomp.PackTag)
+        var xform = Transform(uid);
+
+        var partners = new HashSet<Entity<QuoremCheckComponent>>();
+        _entityLookup.GetEntitiesInRange(xform.Coordinates, component.RecruitRadius, partners);
+
+        foreach (var comp in partners)
+        {
+            var partner = comp.Owner;
+            TryJoinPack(uid, partner, component);
+        }
+    }
+
+    /// <summary>
+    /// Try to join the pack of the target.
+    /// </summary>
+    private void TryJoinPack(EntityUid uid, EntityUid targetUid, QuoremCheckComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
             return;
 
-        if (_mobState.IsDead(ent) || _mobState.IsDead(args.OtherEntity))
+        if (uid == targetUid)
             return;
 
-        if (ent.Comp.PackId <= othercomp.PackId)
+        QuoremCheckComponent? targetComponent = null;
+        if (!Resolve(targetUid, ref targetComponent))
             return;
 
-        if (!_packGroups.ContainsKey(ent.Comp.PackId) || !_packGroups.ContainsKey(othercomp.PackId))
+        if (component.PackTag != targetComponent.PackTag)
             return;
-        
+
+        if (component.PackId <= targetComponent.PackId)
+            return;
+
+        if (!_packGroups.ContainsKey(component.PackId) || !_packGroups.ContainsKey(targetComponent.PackId))
+            return;
+
+        if (_mobState.IsDead(uid) || _mobState.IsDead(targetUid))
+            return;
+
         // Remove this pack from the list of packs
-        _packGroups.Remove(ent.Comp.PackId, out var pack);
+        _packGroups.Remove(component.PackId, out var pack);
         
         pack ??= new HashSet<EntityUid>();
         
         // Combine packs
-        _packGroups[othercomp.PackId].UnionWith(pack);
+        _packGroups[targetComponent.PackId].UnionWith(pack);
             
         // How many members are in the pack
-        var packSize = _packGroups[othercomp.PackId].Count;
+        var packSize = _packGroups[targetComponent.PackId].Count;
         
         // Update other pack members
-        foreach (var uid in _packGroups[othercomp.PackId])
+        foreach (var packMemberUid in _packGroups[targetComponent.PackId])
         {
-            UpdateMembership(uid, othercomp.PackId, packSize);
-            
+            UpdateMembership(packMemberUid, targetComponent.PackId, packSize);
         }
-        
     }
 
-    // Update an individual's membership when they enter a new pack
+    /// <summary>
+    /// Update an individual's membership when they enter a new pack
+    /// </summary>
     private void UpdateMembership(EntityUid uid, int newPackId, int packSize)
     {
         if(!TryComp(uid, out QuoremCheckComponent? comp))
             return;
         comp.PackId = newPackId;
         UpdateHostile((uid, comp), packSize);
-        
     }
     
-    // Remove a pack member on death 
+    /// <summary>
+    /// Remove a pack member on death 
+    /// </summary>
     private void OnPackmateDeath(Entity<QuoremCheckComponent> ent, ref MobStateChangedEvent args)
     {
         if (args.NewMobState != MobState.Dead)
@@ -105,31 +149,29 @@ public abstract class SharedQuoremCheckSystem : EntitySystem
         // If there are now 0 members in the pack remove it
         if(pack.Count == 0)
             _packGroups.Remove(ent.Comp.PackId);
-
     }
     
-    // Change faction to a hostile faction
+    /// <summary>
+    /// Change faction to a hostile faction
+    /// </summary>
     private void MakeHostile(Entity<QuoremCheckComponent> ent)
     {
         ent.Comp.IsHostile = true;
         _npcFactionSystem.ClearFactions((ent, null));
         _npcFactionSystem.AddFaction((ent, null), ent.Comp.QuoremFaction);
-        
         var coords = new EntityCoordinates(ent.Owner, new Vector2(0, 1));
         SpawnAttachedTo(ent.Comp.QuoremEffect, coords);
         _audio.PlayPvs(ent.Comp.QuoremSound, ent.Owner);
- 
     }
     
-    // Check to see if the Quorem has been reached. If so become hostile
+    /// <summary>
+    /// Check to see if the Quorem has been reached. If so become hostile
+    /// </summary>
     public void UpdateHostile(Entity<QuoremCheckComponent> ent, int packSize)
     {
-        if (packSize >= ent.Comp.QuoremThreshold)
+        if (packSize >= ent.Comp.QuoremThreshold && !ent.Comp.IsHostile)
         {
             MakeHostile(ent);
         }
-
     }
-    
-    
 }

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/dinosaurs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/dinosaurs.yml
@@ -25,13 +25,6 @@
           - MobMask
         layer:
           - MobLayer
-      fix2:
-        shape:
-          !type:PhysShapeCircle
-          radius: 8
-        hard: false
-        mask: 
-          - MobLayer
   - type: HTN
     rootTask:
       task: SimpleHostileCompound


### PR DESCRIPTION
## Short description
Improves the mob pack system to make it more usable, without side effects.

## Why we need to add this
The quorum system previously worked using mob collision, meaning that mobs required a (very) large collision box in order to be able to add pack members. This unfortunately also triggers other interactions, such as door bumping, which can be very distracting and rather nonsensical.

The updated system instead borrows from the animal husbandry system by periodically checking for mobs sharing the same component instead. This results in an overall more coherent system that will not have other side effects; the only downside is a slight delay when mobs get in proximity before they check to join a pack.

This should also make it feasible to use the system with a wider variety of mobs.

## Media (Video/Screenshots)
### Quorum limit
https://github.com/user-attachments/assets/081dbffe-57f7-4406-aafd-89630cfe531a

### Social aggro
https://github.com/user-attachments/assets/3e3cddd9-fdc9-40ac-b88e-af31b777fd72

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- tweak: Improve mob pack-forming system to not be reliant on mob collision.
- fix: Aggressive mob packs will no longer replay the alert chime each time a new pack member is added.
- fix: Compsognathus mobs will no longer open doors within an 8 tile radius.