### PR TITLE
Chittin tts fix

### DIFF
--- a/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
@@ -169,7 +169,8 @@ public sealed partial class TTSSystem : EntitySystem
         args.Message.Tts ??= args.Message.Text;
         if (!_isEnabled
             || args.Message.Tts.Length > MaxChars
-            || !args.Language.SpeechOverride.RequireSpeech)
+            || (!args.Language.SpeechOverride.RequireSpeech && !args.Language.SpeechOverride.RequireSound)
+            )
             return;
 
         await Task.Yield();

--- a/Content.Shared/_Starlight/Language/LanguagePrototype.cs
+++ b/Content.Shared/_Starlight/Language/LanguagePrototype.cs
@@ -85,11 +85,17 @@ public sealed partial class SpeechOverrideInfo
     public bool AllowRadio = true;
 
     /// <summary>
-    ///     If false, the entity can use this language even when it's unable to speak (i.e. muffled or muted),
-    ///     and accents are not applied to messages in this language.
+    ///     If false, the entity can use this language even when it's unable to speak (i.e. muffled or muted).
     /// </summary>
     [DataField]
     public bool RequireSpeech = true;
+    
+    /// <summary>
+    ///     If false, the entity can use this language even when it's unable to make sound,
+    ///     and accents are not applied to messages in this language.
+    /// </summary>
+    [DataField]
+    public bool RequireSound = true;
 
     /// <summary>
     ///     If true, requires the entity to have usable hands and be able to interact (not be cuffed, etc).

--- a/Content.Shared/_Starlight/Language/LanguagePrototype.cs
+++ b/Content.Shared/_Starlight/Language/LanguagePrototype.cs
@@ -85,7 +85,7 @@ public sealed partial class SpeechOverrideInfo
     public bool AllowRadio = true;
 
     /// <summary>
-    ///     If false, the entity can use this language even when it's unable to speak (i.e. muffled or muted), 
+    ///     If false, the entity can use this language even when it's unable to speak (i.e. muffled or muted),
     ///     and accents are not applied to messages in this language.
     /// </summary>
     [DataField]

--- a/Content.Shared/_Starlight/Language/LanguagePrototype.cs
+++ b/Content.Shared/_Starlight/Language/LanguagePrototype.cs
@@ -85,14 +85,14 @@ public sealed partial class SpeechOverrideInfo
     public bool AllowRadio = true;
 
     /// <summary>
-    ///     If false, the entity can use this language even when it's unable to speak (i.e. muffled or muted).
+    ///     If false, the entity can use this language even when it's unable to speak (i.e. muffled or muted), 
+    ///     and accents are not applied to messages in this language.
     /// </summary>
     [DataField]
     public bool RequireSpeech = true;
     
     /// <summary>
-    ///     If false, the entity can use this language even when it's unable to make sound,
-    ///     and accents are not applied to messages in this language.
+    ///     If false, the entity can use this language even when it's unable to make sound.
     /// </summary>
     [DataField]
     public bool RequireSound = true;

--- a/Resources/Prototypes/_Starlight/Language/Animals/scurretsign.yml
+++ b/Resources/Prototypes/_Starlight/Language/Animals/scurretsign.yml
@@ -5,6 +5,7 @@
   speech:
     allowRadio: false
     requireSpeech: false
+    requireSound:
     requireHands: true
     color: "#dddddd"
     messageWrapOverrides:

--- a/Resources/Prototypes/_Starlight/Language/Animals/scurretsign.yml
+++ b/Resources/Prototypes/_Starlight/Language/Animals/scurretsign.yml
@@ -5,7 +5,7 @@
   speech:
     allowRadio: false
     requireSpeech: false
-    requireSound:
+    requireSound: false
     requireHands: true
     color: "#dddddd"
     messageWrapOverrides:

--- a/Resources/Prototypes/_Starlight/Language/Species/chittin.yml
+++ b/Resources/Prototypes/_Starlight/Language/Species/chittin.yml
@@ -4,6 +4,7 @@
   chatPrefix: chi
   speech:
     requireSpeech: false
+    requireSound: true
     color: "#c64c05"
     messageWrapOverrides:
       Speak: chat-sign-language-message-wrap

--- a/Resources/Prototypes/_Starlight/Language/Species/chittin.yml
+++ b/Resources/Prototypes/_Starlight/Language/Species/chittin.yml
@@ -4,7 +4,6 @@
   chatPrefix: chi
   speech:
     requireSpeech: false
-    requireSound: true
     color: "#c64c05"
     messageWrapOverrides:
       Speak: chat-sign-language-message-wrap

--- a/Resources/Prototypes/_Starlight/Language/generic.yml
+++ b/Resources/Prototypes/_Starlight/Language/generic.yml
@@ -47,6 +47,7 @@
   speech:
     allowRadio: false
     requireSpeech: false
+    requireSound: false
     requireHands: true
     color: "#dddddd"
     messageWrapOverrides:


### PR DESCRIPTION
## Short description
This should make it so chittin will now actually use the tts system to 'speak' the 'words' of it to those who understand it. Also provides a way for more complex languages to be defined, if a language requires sound, not just speech.

**NOTE:** The dev environment does not work with tts, so I sadly could not test this directly.

## Why we need to add this
Chittin is an audible/sound-based language, but chittin does not play even for those who would be able to understand the 'words' created by those who can 'say' it.

## Media (Video/Screenshots)
Not required.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: BigfootBravo
- fix: Chittin now can use the tts system.
