### PR TITLE
Fix issues with station event enumeration

### DIFF
--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -9,8 +9,8 @@ using Content.Shared.GameTicking.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
-using Content.Shared.Station.Components;
-using Robust.Shared.Audio; //Starlight
+using Content.Shared.Station.Components; // Starlight
+using Robust.Shared.Audio; // Starlight
 
 namespace Content.Server.StationEvents.Events;
 
@@ -102,7 +102,16 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         base.Update(frameTime);
 
         var query = EntityQueryEnumerator<StationEventComponent, GameRuleComponent>();
+        // Starlight start - Some StationEvents can add more StationEvents, which causes the upstream
+        // enumeration here to break. Instead, we make a snapshot and iterate through that.
+        var snapshot = new List<(EntityUid uid, StationEventComponent stationEvent, GameRuleComponent ruleData)>();
+        // Starlight end
         while (query.MoveNext(out var uid, out var stationEvent, out var ruleData))
+        // Starlight start
+            snapshot.Add((uid, stationEvent, ruleData));
+
+        foreach (var (uid, stationEvent, ruleData) in snapshot)
+        // Starlight end
         {
             if (!GameTicker.IsGameRuleAdded(uid, ruleData))
                 continue;


### PR DESCRIPTION
## Short description
The update loop for station events relies on an enumerator over station events; this enumerator can get invalidated due to events adding other events, which leads to test failures at a minimum.

## Why we need to add this
This is causing test failures on unrelated PRs

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.