### PR TITLE
Added more things to the autolog

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -1,22 +1,23 @@
+using Content.Server._Starlight.Administration.Systems;
+using Content.Server._Starlight.GameTicking.Rules.Components;
 using Content.Server.Antag;
+using Content.Server.Clothing.Systems;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Speech.Components; // Starlight
 using Content.Server.Zombies;
+using Content.Shared._Starlight.Shadekin;
 using Content.Shared.Administration;
-using Content.Server.Clothing.Systems;
 using Content.Shared.Database;
 using Content.Shared.Humanoid;
 using Content.Shared.Mind.Components;
 using Content.Shared.Roles;
+using Content.Shared.Roles.Components;
 using Content.Shared.Verbs;
+using Robust.Shared.Audio; // Starlight
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
-using Content.Shared.Roles.Components;
-using Content.Server._Starlight.GameTicking.Rules.Components;
-using Content.Shared._Starlight.Shadekin;
-using Content.Server.Speech.Components; // Starlight
-using Robust.Shared.Audio; // Starlight
 
 namespace Content.Server.Administration.Systems;
 
@@ -26,6 +27,7 @@ public sealed partial class AdminVerbSystem
     [Dependency] private readonly ZombieSystem _zombie = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly OutfitSystem _outfit = default!;
+    [Dependency] private readonly AutoDiscordLogSystem _autolog = default!; //Starlight
 
     private static readonly EntProtoId DefaultTraitorRule = "Traitor";
     private static readonly EntProtoId DefaultInitialInfectedRule = "Zombie";
@@ -66,6 +68,7 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _antag.ForceMakeAntag<TraitorRuleComponent>(targetPlayer, DefaultTraitorRule);
+                _autolog.LogToDiscord(string.Join(": ", traitorName, Loc.GetString("admin-verb-make-traitor")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", traitorName, Loc.GetString("admin-verb-make-traitor")),
@@ -81,6 +84,7 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _antag.ForceMakeAntag<ZombieRuleComponent>(targetPlayer, DefaultInitialInfectedRule);
+                _autolog.LogToDiscord(string.Join(": ", initialInfectedName, Loc.GetString("admin-verb-make-initial-infected")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", initialInfectedName, Loc.GetString("admin-verb-make-initial-infected")),
@@ -96,6 +100,7 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _zombie.ZombifyEntity(args.Target);
+                _autolog.LogToDiscord(string.Join(": ", zombieName, Loc.GetString("admin-verb-make-zombie")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", zombieName, Loc.GetString("admin-verb-make-zombie")),
@@ -111,6 +116,7 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _antag.ForceMakeAntag<NukeopsRuleComponent>(targetPlayer, DefaultNukeOpRule);
+                _autolog.LogToDiscord(string.Join(": ", nukeOpName, Loc.GetString("admin-verb-make-nuclear-operative")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", nukeOpName, Loc.GetString("admin-verb-make-nuclear-operative")),
@@ -127,6 +133,7 @@ public sealed partial class AdminVerbSystem
             {
                 // pirates just get an outfit because they don't really have logic associated with them
                 _outfit.SetOutfit(args.Target, PirateGearId);
+                _autolog.LogToDiscord(string.Join(": ", pirateName, Loc.GetString("admin-verb-make-pirate")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", pirateName, Loc.GetString("admin-verb-make-pirate")),
@@ -142,6 +149,7 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _antag.ForceMakeAntag<RevolutionaryRuleComponent>(targetPlayer, DefaultRevsRule);
+                _autolog.LogToDiscord(string.Join(": ", headRevName, Loc.GetString("admin-verb-make-head-rev")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", headRevName, Loc.GetString("admin-verb-make-head-rev")),
@@ -157,6 +165,7 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _antag.ForceMakeAntag<ThiefRuleComponent>(targetPlayer, DefaultThiefRule);
+                _autolog.LogToDiscord(string.Join(": ", thiefName, Loc.GetString("admin-verb-make-thief")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", thiefName, Loc.GetString("admin-verb-make-thief")),
@@ -172,6 +181,7 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _antag.ForceMakeAntag<ChangelingRuleComponent>(targetPlayer, DefaultChangelingRule);
+                _autolog.LogToDiscord(string.Join(": ", changelingName, Loc.GetString("admin-verb-make-changeling-wip")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", changelingName, Loc.GetString("admin-verb-make-changeling-wip")), //SL edit: -wip as we have lings allready
@@ -194,6 +204,7 @@ public sealed partial class AdminVerbSystem
                 paradoxCloneRuleComp.OriginalBody = args.Target; // override the target player
 
                 _gameTicker.StartGameRule(ruleEnt);
+                _autolog.LogToDiscord(string.Join(": ", paradoxCloneName, Loc.GetString("admin-verb-make-paradox-clone")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", paradoxCloneName, Loc.GetString("admin-verb-make-paradox-clone")),
@@ -209,6 +220,7 @@ public sealed partial class AdminVerbSystem
             {
                 // Wizard has no rule components as of writing, but I gotta put something here to satisfy the machine so just make it wizard mind rule :)
                 _antag.ForceMakeAntag<WizardRoleComponent>(targetPlayer, DefaultWizardRule);
+                _autolog.LogToDiscord(string.Join(": ", wizardName, Loc.GetString("admin-verb-make-wizard")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", wizardName, Loc.GetString("admin-verb-make-wizard")),
@@ -224,6 +236,7 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _antag.ForceMakeAntag<NinjaRoleComponent>(targetPlayer, DefaultNinjaRule);
+                _autolog.LogToDiscord(string.Join(": ", ninjaName, Loc.GetString("admin-verb-make-space-ninja")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", ninjaName, Loc.GetString("admin-verb-make-space-ninja")),
@@ -232,7 +245,7 @@ public sealed partial class AdminVerbSystem
 
         if (HasComp<HumanoidAppearanceComponent>(args.Target)) // only humanoids can be cloned
             args.Verbs.Add(paradox);
-
+        /// Starlight START
         Verb ling = new()
         {
             Text = Loc.GetString("admin-verb-text-make-changeling"),
@@ -241,12 +254,13 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _antag.ForceMakeAntag<SLChangelingRuleComponent>(targetPlayer, "SLChangeling");
+                _autolog.LogToDiscord(Loc.GetString("admin-verb-make-changeling"), player.Name);
             },
             Impact = LogImpact.High,
             Message = Loc.GetString("admin-verb-make-changeling"),
         };
         args.Verbs.Add(ling);
-/// Starlight START
+
         Verb vampire = new()
         {
             Text = Loc.GetString("admin-verb-text-make-vampire"),
@@ -255,6 +269,7 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _antag.ForceMakeAntag<VampireRuleComponent>(targetPlayer, DefaultVampireRule);
+                _autolog.LogToDiscord(Loc.GetString("admin-verb-make-vampire"), player.Name);
             },
             Impact = LogImpact.High,
             Message = Loc.GetString("admin-verb-make-vampire"),
@@ -270,6 +285,7 @@ public sealed partial class AdminVerbSystem
             Act = () =>
             {
                 _antag.ForceMakeAntag<SELFRuleComponent>(targetPlayer, DefaultSELFRule);
+                _autolog.LogToDiscord(string.Join(": ", selfagentName, Loc.GetString("admin-verb-make-selfagent")), player.Name);
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", selfagentName, Loc.GetString("admin-verb-make-selfagent")),
@@ -287,6 +303,7 @@ public sealed partial class AdminVerbSystem
                 {
                     _gameTicker.StartGameRule("TheDarkMap"); // The Dark should always be spawned for any brighteye.
                     _antag.ForceMakeAntag<BrighteyeRuleComponent>(targetPlayer, DefaultBrighteyeRule);
+                    _autolog.LogToDiscord(Loc.GetString("admin-verb-make-brighteye"), player.Name);
                 },
                 Impact = LogImpact.High,
                 Message = Loc.GetString("admin-verb-make-brighteye"),
@@ -317,6 +334,7 @@ public sealed partial class AdminVerbSystem
                     Loc.GetString("pirate-crew-briefing"),
                     null,
                     new SoundPathSpecifier("/Audio/Ambience/Antag/pirate_start.ogg"));
+                _autolog.LogToDiscord(string.Join(": ", pirateSLName, Loc.GetString("admin-verb-make-pirate-sl")), player.Name);
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", pirateSLName, Loc.GetString("admin-verb-make-pirate-sl")),

--- a/Content.Server/Administration/UI/AdminAnnounceEui.cs
+++ b/Content.Server/Administration/UI/AdminAnnounceEui.cs
@@ -1,3 +1,4 @@
+using Content.Server._Starlight.Administration.Systems;
 using Content.Server.Administration.Managers;
 using Content.Server.Chat;
 using Content.Server.Chat.Managers;
@@ -13,11 +14,14 @@ namespace Content.Server.Administration.UI
         [Dependency] private readonly IAdminManager _adminManager = default!;
         [Dependency] private readonly IChatManager _chatManager = default!;
         private readonly ChatSystem _chatSystem;
+        private readonly AutoDiscordLogSystem _autoLog; //Starlight
 
         public AdminAnnounceEui()
         {
             IoCManager.InjectDependencies(this);
-            _chatSystem = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>();
+            var entSysMan = IoCManager.Resolve<IEntitySystemManager>(); //Starlight
+            _chatSystem = entSysMan.GetEntitySystem<ChatSystem>(); //Starlight 
+            _autoLog = entSysMan.GetEntitySystem<AutoDiscordLogSystem>(); //Starlight
         }
 
         public override void Opened()
@@ -53,7 +57,8 @@ namespace Content.Server.Administration.UI
                             _chatSystem.DispatchGlobalAnnouncement(doAnnounce.Announcement, doAnnounce.Announcer, colorOverride: Color.Gold);
                             break;
                     }
-
+                    var admin = Player?.Name ?? "Unknown"; //Starlight
+                    _autoLog.LogToDiscord(Loc.GetString("autolog-announce", ("sender", doAnnounce.Announcer), ("message", doAnnounce.Announcement), ("admin", admin)), admin); //Starlight
                     StateDirty();
 
                     if (doAnnounce.CloseAfter)

--- a/Content.Server/AlertLevel/Commands/SetAlertLevelCommand.cs
+++ b/Content.Server/AlertLevel/Commands/SetAlertLevelCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Content.Server._Starlight.Administration.Systems;
 using Content.Server.Administration;
 using Content.Server.Station.Systems;
 using Content.Shared.Administration;
@@ -11,6 +12,7 @@ namespace Content.Server.AlertLevel.Commands
     {
         [Dependency] private readonly AlertLevelSystem _alertLevelSystem = default!;
         [Dependency] private readonly StationSystem _stationSystem = default!;
+        [Dependency] private readonly AutoDiscordLogSystem _autoLog = default!; //Starlight
 
         public override string Command => "setalertlevel";
 
@@ -73,6 +75,9 @@ namespace Content.Server.AlertLevel.Commands
             }
 
             _alertLevelSystem.SetLevel(stationUid.Value, level, true, true, true, locked);
+            if (IsAdmemeAlert(stationUid.Value, level)) //Starlight
+                _autoLog.LogToDiscord(Loc.GetString("autolog-setalertlevel", ("level", level), ("locked", locked), ("admin", player.Name)), player.Name); //Starlight
+            
         }
 
         private string[] GetStationLevelNames(EntityUid station)
@@ -85,5 +90,18 @@ namespace Content.Server.AlertLevel.Commands
 
             return alertLevelComp.AlertLevels.Levels.Keys.ToArray();
         }
+        
+        #region Starlight
+        private bool IsAdmemeAlert(EntityUid station, string level)
+        {
+            if (!EntityManager.TryGetComponent<AlertLevelComponent>(station, out var alertLevelComp))
+                return false;
+
+            if (alertLevelComp.AlertLevels == null)
+                return false;
+
+            return !alertLevelComp.AlertLevels.Levels[level].Selectable;
+        }
+        #endregion
     }
 }

--- a/Content.Server/Announcements/AnnounceCommand.cs
+++ b/Content.Server/Announcements/AnnounceCommand.cs
@@ -1,3 +1,4 @@
+using Content.Server._Starlight.Administration.Systems;
 using Content.Server.Administration;
 using Content.Server.Chat.Systems;
 using Content.Shared.Administration;
@@ -14,6 +15,7 @@ public sealed class AnnounceCommand : LocalizedEntityCommands
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IResourceManager _res = default!;
+    [Dependency] private readonly AutoDiscordLogSystem _autoLog = default!; //Starlight
 
     public override string Command => "announce";
     public override string Description => Loc.GetString("cmd-announce-desc");
@@ -60,6 +62,8 @@ public sealed class AnnounceCommand : LocalizedEntityCommands
 
         _chat.DispatchGlobalAnnouncement(message, sender, true, sound, color);
         shell.WriteLine(Loc.GetString("shell-command-success"));
+        var admin = shell.Player?.Name ?? "Unknown"; //Starlight
+        _autoLog.LogToDiscord(Loc.GetString("autolog-announce", ("sender", sender), ("message", message), ("admin", admin)), admin); //Starlight
     }
 
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)

--- a/Content.Server/GameTicking/Commands/ForceMapCommand.cs
+++ b/Content.Server/GameTicking/Commands/ForceMapCommand.cs
@@ -18,12 +18,14 @@ namespace Content.Server.GameTicking.Commands
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
         [Dependency] private readonly IGameMapManager _gameMapManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-        [Dependency] private readonly AutoDiscordLogSystem _autolog = default!; //Starlight
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!; //Starlight
+        private AutoDiscordLogSystem? _autolog; //Starlight
 
         public override string Command => "setgamemap"; // Starlight-edit
 
         public override void Execute(IConsoleShell shell, string argStr, string[] args)
         {
+            _autolog ??= _entitySystemManager.GetEntitySystem<AutoDiscordLogSystem>(); //Starlight
             if (args.Length != 1)
             {
                 shell.WriteLine(Loc.GetString(Loc.GetString($"shell-need-exactly-one-argument")));

--- a/Content.Server/GameTicking/Commands/ForceMapCommand.cs
+++ b/Content.Server/GameTicking/Commands/ForceMapCommand.cs
@@ -1,4 +1,6 @@
+using System.Data;
 using System.Linq;
+using Content.Server._Starlight.Administration.Systems;
 using Content.Server.Administration;
 using Content.Server.Maps;
 using Content.Shared.Administration;
@@ -16,6 +18,7 @@ namespace Content.Server.GameTicking.Commands
         [Dependency] private readonly IConfigurationManager _configurationManager = default!;
         [Dependency] private readonly IGameMapManager _gameMapManager = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly AutoDiscordLogSystem _autolog = default!; //Starlight
 
         public override string Command => "setgamemap"; // Starlight-edit
 
@@ -37,6 +40,8 @@ namespace Content.Server.GameTicking.Commands
             }
 
             _configurationManager.SetCVar(CCVars.GameMap, name);
+            var adminName = shell.Player?.Name ?? "Unknown"; //Starlight
+            _autolog.LogToDiscord(Loc.GetString("autolog-setgamemap", ("map", name), ("admin", adminName)), adminName); // Starlight
 
             if (string.IsNullOrEmpty(name))
                 shell.WriteLine(Loc.GetString("cmd-forcemap-cleared"));

--- a/Content.Server/Toolshed/Commands/Misc/MsgCommand.cs
+++ b/Content.Server/Toolshed/Commands/Misc/MsgCommand.cs
@@ -1,3 +1,4 @@
+using Content.Server._Starlight.Administration.Systems;
 using Content.Server.Administration;
 using Content.Server.Chat.Managers;
 using Content.Server.Popups;
@@ -16,10 +17,11 @@ namespace Content.Server.Toolshed.Commands.Misc;
 public sealed class MsgCommand : ToolshedCommand
 {
     [Dependency] private IChatManager _chatManager = default!;
-
+    
     private PrayerSystem? _prayer;
     private PopupSystem? _popup;
     private TipsSystem? _tips;
+    private AutoDiscordLogSystem _autoLog = default!; //Starlight
 
     [CommandImplementation("subtle")]
     public IEnumerable<EntityUid> Subtle(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> targets, string popup, string message)
@@ -79,6 +81,7 @@ public sealed class MsgCommand : ToolshedCommand
     public IEnumerable<EntityUid> Tippy([PipedArgument] IEnumerable<EntityUid> targets, string message, EntProtoId prototype, float speakTime, float slideTime, float waddleInterval)
     {
         _tips ??= GetSys<TipsSystem>();
+        _autoLog ??= GetSys<AutoDiscordLogSystem>(); //Starlight
 
         foreach (var ent in targets)
         {
@@ -89,12 +92,14 @@ public sealed class MsgCommand : ToolshedCommand
 
             yield return ent;
         }
+        _autoLog.LogToDiscord(Loc.GetString("autolog-tippy", ("message", message), ("prototype", prototype))); //Starlight
     }
     
     [CommandImplementation("tippy")]
     public IEnumerable<ICommonSession> Tippy([PipedArgument] IEnumerable<ICommonSession> targets, string message, EntProtoId prototype, float speakTime, float slideTime, float waddleInterval)
     {
         _tips ??= GetSys<TipsSystem>();
+        _autoLog ??= GetSys<AutoDiscordLogSystem>(); //Starlight
 
         foreach (var session in targets)
         {
@@ -102,5 +107,6 @@ public sealed class MsgCommand : ToolshedCommand
 
             yield return session;
         }
+        _autoLog.LogToDiscord(Loc.GetString("autolog-tippy", ("message", message), ("prototype", prototype))); //Starlight
     }
 }

--- a/Content.Server/_ST/Administration/StellarAdminVerbSystem.cs
+++ b/Content.Server/_ST/Administration/StellarAdminVerbSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Verbs;
 using Content.Server._ST.CosmicCult.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
+using Content.Server._Starlight.Administration.Systems;
 
 namespace Content.Server._ST.Administration;
 
@@ -14,6 +15,7 @@ public sealed partial class StellarAdminVerbSystem : EntitySystem
 {
     [Dependency] private readonly AntagSelectionSystem _antagSelection = default!;
     [Dependency] private readonly IAdminManager _adminManager = default!;
+    [Dependency] private readonly AutoDiscordLogSystem _autolog = default!; //Starlight
 
     public override void Initialize()
     {
@@ -44,6 +46,7 @@ public sealed partial class StellarAdminVerbSystem : EntitySystem
             Act = () =>
             {
                 _antagSelection.ForceMakeAntag<CosmicCultRuleComponent>(targetPlayer, "CosmicCult");
+                _autolog.LogToDiscord(string.Join(": ", cosmicCultName, Loc.GetString("admin-verb-make-cosmiccultist")), player.Name); //Starlight
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", cosmicCultName, Loc.GetString("admin-verb-make-cosmiccultist")),

--- a/Content.Server/_ST/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_ST/CosmicCult/CosmicCultRuleSystem.cs
@@ -754,6 +754,8 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
             return;
         var cosmicGamerule = cult.Comp;
 
+        if (TerminatingOrDeleted(uid.Owner)) //Starlight-edit: dev-crash
+            return; //Starlight-edit: dev-crash
         _stun.TryAddStunDuration(uid.Owner, TimeSpan.FromSeconds(2));
         foreach (var actionEnt in uid.Comp.ActionEntities) _actions.RemoveAction(actionEnt);
 

--- a/Resources/Locale/en-US/_Starlight/administration/autolog.ftl
+++ b/Resources/Locale/en-US/_Starlight/administration/autolog.ftl
@@ -3,3 +3,7 @@ autolog-discord-footer = Server: {$server} | Round: #{$round} | Round Type: {$ro
 autolog-forcedprototype = Spawned Character: {$character} with ForcedPrototype: {$prototype}
 autolog-admin-mouse = Became Admin Mouse
 autolog-mentor-mouse = Became Mentor Mouse
+
+autolog-setgamemap = Map forced to {$map} by {$admin}
+autolog-announce = {$admin} sent a announcement {$sender} Announcement: {$message}
+autolog-tippy = Sent a tippy {$message} with {$prototype} prototype


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Adds more things to the discord autolog feature

## Why we need to add this
Headmin request

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: walksanatora
- add: Added Tippy to discord autolog.
- add: Added announce and announceui to discord autolog.
- add: Added setgamemap to discord autolog.
- add: Added antag ctrls to discord autolog.
- add: Added setalertlevel of admeme alerts to discord autolog.
- fix: Fixed dev crash upon cosmic cult victory.