### PR TITLE
Make shoelaces tied by default

### DIFF
--- a/Content.Shared/_Starlight/Shoelaces/Components/ShoelaceTieableComponent.cs
+++ b/Content.Shared/_Starlight/Shoelaces/Components/ShoelaceTieableComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Shared._Starlight.Shoelaces.Components;
 public sealed partial class ShoelaceTieableComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public bool Tied = false;
+    public bool Tied = true;
 
     [DataField, AutoNetworkedField]
     public bool TiedTogether = false;


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Make shoelaces tied by default.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

The intent of [the original PR](https://github.com/ss14Starlight/space-station-14/pull/3445) was to add a fun gimmick feature that people can use to make people trip, clown style. (The author even [made a video](https://discord.com/channels/1272545509562777621/1471776367602569398/1475590465075023872) demonstrating _exactly_ that). The current behavior where all shoes are untied by default just makes people trip dozens of times for no added value.

Having them tied by default enables the intended gimmick without otherwise bothering players.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

N/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: Shoelaces are now tied by default.
