### PR TITLE
Snipers spread balance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -5,6 +5,11 @@
   description: A rooty tooty point and shooty.
   abstract: true
   components:
+  # Starlight-start
+  - type: GunWieldBonus
+    maxAngle: -20
+    minAngle: -20
+  # Starlight-end
   - type: RestrictByUserTag
     doestContain:
     - Abductor
@@ -74,9 +79,6 @@
   description: A weapon of the masses, a true relic. The Kardashev-Mosin has served in nearly every armed conflict since its creation 670 years ago. The bolt-action design of the rifle remains virtually identical to its original design, whether used for hunting, sniping, or endless trench warfare. Uses .45 magnum ammo.
   components:
   # Starlight-start
-  - type: GunWieldBonus
-    maxAngle: -10
-    minAngle: -10
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 2
@@ -147,7 +149,7 @@
     maxTransferAmount: 2
   - type: Sharp
     butcherDelayModifier: 2 #It's a bayonet
-  - type: GunRequiresWield
+  #- type: GunRequiresWield Starlight: remove requirement
   - type: StaticPrice
     price: 500
 
@@ -157,11 +159,6 @@
   id: WeaponSniperHristov
   description: For when you absolutely, positively need to make someone regret their life choices from a safe distance. Uses .60 anti-materiel ammo.
   components:
-  # Starlight-start
-  - type: GunWieldBonus
-    maxAngle: -10
-    minAngle: -10
-  # Starlight-end
   - type: Item
     size: Huge
     shape:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -151,9 +151,6 @@
   id: WeaponSniperLionhunter
   description: A one of a kind bolt-action rifle fitted with an integrated scope. Chambered for a proprietary .48 round developed by parties unknown. Built to drop targets at range with authority. Each shot demands a deliberate recycle of the action.
   components:
-  - type: GunWieldBonus
-    maxAngle: -10
-    minAngle: -10
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Rifles/lionhunter_icons.rsi
     layers:


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Makes small changes in sniper rifles spread balance to make them more accurate.


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rinary
- tweak: Changed sniper rifles spread stats. Now they more accurate.(Min angle when wielded 10 => 0, Max angle 15 => 5)