### PR TITLE
Platform Breaking Fix

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/platforms.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/platforms.yml
@@ -10,6 +10,34 @@
     sprite: _Starlight/Structures/platforms.rsi
   - type: InteractionOutline
   - type: Clickable
+  - type: RCDDeconstructable
+    cost: 5
+    delay: 7
+    fx: EffectRCDDeconstruct8
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 350
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+    - trigger:
+        !type:DamageTrigger
+        damage: 175
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+
 
 - type: entity
   parent: CMPlatformBase


### PR DESCRIPTION
## Short description
Makes it so Platforms can be damaged and broken, being slightly weaker than solid walls.

## Why we need to add this
Indestructible things make players mad. 

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Made Platforms able to take damage and be broken. They are slightly weaker than solid walls.

