### PR TITLE
Add explanatory popup messages when biomass reclaimer refuses to work

### DIFF
--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -266,12 +266,11 @@ return false;
                 HasComp<HumanoidAppearanceComponent>(dragged) &&
                 _minds.TryGetMind(dragged, out _, out var mind))
             {
-                if (mind.UserId != null && _playerManager.TryGetSessionById(mind.UserId.Value, out _))
+if (mind.UserId != null && _playerManager.TryGetSessionById(mind.UserId.Value, out _))
                 {
-                    // Starlight BEGIN: Added popup for player feedback 
-                    _popup.PopupEntity(Loc.GetString("biomass-reclaimer-soulful"), reclaimer, PopupType.Large);
-                    return false;
-                } // Starlight END
+                    _popup.PopupEntity(Loc.GetString("biomass-reclaimer-soulful"), reclaimer, PopupType.Large); // Starlight-edit: Added popup for player feedback
+return false;
+                }
             }
 
             return true;

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -243,14 +243,25 @@ namespace Content.Server.Medical.BiomassReclaimer
             if (!isPlant && !HasComp<MobStateComponent>(dragged))
                 return false;
 
+            // Starlight BEGIN: Added popups to inform the player of the refusal reason.
             if (!Transform(reclaimer).Anchored)
+            {
+                _popup.PopupEntity(Loc.GetString("biomass-reclaimer-not-anchored"), reclaimer, PopupType.Large);
                 return false;
+            }
 
             if (TryComp<ApcPowerReceiverComponent>(reclaimer, out var power) && !power.Powered)
+            {
+                _popup.PopupEntity(Loc.GetString("biomass-reclaimer-not-powered"), reclaimer, PopupType.Large);
                 return false;
+            }
 
             if (!isPlant && reclaimer.Comp.SafetyEnabled && !_mobState.IsDead(dragged))
+            {
+                _popup.PopupEntity(Loc.GetString("biomass-reclaimer-safety-on"), reclaimer, PopupType.Large);
                 return false;
+            }
+            // Starlight END
 
             // Reject souled bodies in easy mode.
             if (_configManager.GetCVar(CCVars.BiomassEasyMode) &&
@@ -258,7 +269,11 @@ namespace Content.Server.Medical.BiomassReclaimer
                 _minds.TryGetMind(dragged, out _, out var mind))
             {
                 if (mind.UserId != null && _playerManager.TryGetSessionById(mind.UserId.Value, out _))
+                {
+                    // Starlight BEGIN: Added popup for player feedback 
+                    _popup.PopupEntity(Loc.GetString("biomass-reclaimer-soulful"), reclaimer, PopupType.Large);
                     return false;
+                } // Starlight END
             }
 
             return true;

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -243,25 +243,23 @@ namespace Content.Server.Medical.BiomassReclaimer
             if (!isPlant && !HasComp<MobStateComponent>(dragged))
                 return false;
 
-            // Starlight BEGIN: Added popups to inform the player of the refusal reason.
-            if (!Transform(reclaimer).Anchored)
+if (!Transform(reclaimer).Anchored)
             {
-                _popup.PopupEntity(Loc.GetString("biomass-reclaimer-not-anchored"), reclaimer, PopupType.Large);
-                return false;
+                _popup.PopupEntity(Loc.GetString("biomass-reclaimer-not-anchored"), reclaimer, PopupType.Large); // Starlight-edit: Added popups to inform the player of the refusal reason.
+return false;
             }
 
-            if (TryComp<ApcPowerReceiverComponent>(reclaimer, out var power) && !power.Powered)
+if (TryComp<ApcPowerReceiverComponent>(reclaimer, out var power) && !power.Powered)
             {
-                _popup.PopupEntity(Loc.GetString("biomass-reclaimer-not-powered"), reclaimer, PopupType.Large);
-                return false;
+                _popup.PopupEntity(Loc.GetString("biomass-reclaimer-not-powered"), reclaimer, PopupType.Large); // Starlight-edit: Added popups to inform the player of the refusal reason.
+return false;
             }
 
-            if (!isPlant && reclaimer.Comp.SafetyEnabled && !_mobState.IsDead(dragged))
+if (!isPlant && reclaimer.Comp.SafetyEnabled && !_mobState.IsDead(dragged))
             {
-                _popup.PopupEntity(Loc.GetString("biomass-reclaimer-safety-on"), reclaimer, PopupType.Large);
-                return false;
+                _popup.PopupEntity(Loc.GetString("biomass-reclaimer-safety-on"), reclaimer, PopupType.Large); // Starlight-edit: Added popups to inform the player of the refusal reason.
+return false;
             }
-            // Starlight END
 
             // Reject souled bodies in easy mode.
             if (_configManager.GetCVar(CCVars.BiomassEasyMode) &&

--- a/Resources/Locale/en-US/_Starlight/medical/components/biomass-reclaimer-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/medical/components/biomass-reclaimer-component.ftl
@@ -1,0 +1,4 @@
+﻿biomass-reclaimer-not-anchored = The biomass reclaimer is not anchored!
+biomass-reclaimer-not-powered = The biomass reclaimer is not powered!
+biomass-reclaimer-safety-on = The biomass reclaimer's safety detects life and refuses to work!
+biomass-reclaimer-soulful = This body still has a soul!


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Add explanatory popup messages when biomass reclaimer refuses to work.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

It's a recurring issue that the biomass reclaimer just refuses to work and players don't know why.

One related bug thread: https://discord.com/channels/1272545509562777621/1485160669484421190

On one side, this is just improving the UX for the player.

On the other, there's reason to believe there might be a bug with it refusing to work when it should. A little popup saying why the game is refusing will also make it easier for us to debug in the future.


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/039f6002-ce27-4fad-ad06-38d58e81860c

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Biomass reclaimers now tell you why they are refusing to work via popup text.
