### PR TITLE
Fixed con bag not opening in hand

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Engineering/mat_bag.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Engineering/mat_bag.yml
@@ -27,6 +27,7 @@
     state: icon
   - type: Clothing
     sprite: _FarHorizons/Objects/Specific/Engineering/mat_bag.rsi
+    quickEquip: false #SL
     slots: belt
   - type: Item
     size: Large


### PR DESCRIPTION
whoops

<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
forgot to add one line of yaml
was equipping to belt rather than opening inhand, thats my bad

## Why we need to add this
its annoying, also its just a bug fix

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/34ca0e6e-46a4-4c52-a82c-036e422584db



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Roro
- fix: Fixed Construction bag not quick opening inhand.