### PR TITLE
[Test Break Fix] Limit random nest spawner to 50% chance

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Markers/Spawners/Random/nest.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Markers/Spawners/Random/nest.yml
@@ -17,4 +17,4 @@
       - NestMouse
       - NestMouse
       - NestSnake
-    chance: 50
+    chance: 0.5


### PR DESCRIPTION
## Short description
Previously it was set to `chance: 50`, which means that for every time it runs, it has a 5000% chance of spawning. The tests fail due to that; this PR drops it to a more reasonable 50%.

## Why we need to add this
There's tests failing on starlight-dev right now due to this.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
