### PR TITLE
[Test break fix] Fix non-existent components on CosCult protos

### DIFF
--- a/Resources/Prototypes/_ST/CosmicCult/Objects/censer.yml
+++ b/Resources/Prototypes/_ST/CosmicCult/Objects/censer.yml
@@ -47,7 +47,7 @@
           Quantity: 100
         maxVol: 100
   - type: ItemTogglePointLight
-  - type: ToggleableLightVisuals
+  - type: ToggleableVisuals
     spriteLayer: flame
     inhandVisuals:
       left:

--- a/Resources/Prototypes/_ST/CosmicCult/Tileset/structures.yml
+++ b/Resources/Prototypes/_ST/CosmicCult/Tileset/structures.yml
@@ -159,7 +159,6 @@
         Cold: 40
   - type: InteractionOutline
   - type: Appearance
-  - type: ThrusterVisuals
   - type: Sprite
     sprite: _ST/CosmicCult/Tileset/cosmicthruster.rsi
     layers:


### PR DESCRIPTION
## Short description
These were removed in upstream refactors a while ago, and have been causing test failures on starlight-dev since cosmic cult was merged.

## Why we need to add this
Without this we get test failures due to
```
  Failed PrototypesHaveKnownComponents [1 s]
  Error Message:
   Component ToggleableLightVisuals in prototype CosmicCenser is ignored by both client and serverV
Component ThrusterVisuals in prototype CosmicThruster is ignored by both client and serverV
```

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.