### PR TITLE
Halve the guidebook Necrosol recipe

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -589,15 +589,15 @@
   minTemp: 370
   reactants:
     Blood: # Starlight, Reduced blood requirement for math-related reasons
-      amount: 2
+      amount: 1
     Diphenhydramine: # Starlight, added in place of omnizine
-      amount: 2
+      amount: 1
     Desoxyephedrine: # Starlight, added in place of omnizine
-      amount: 2
+      amount: 1
     Cryoxadone:
-      amount: 2
+      amount: 1
   products:
-    Necrosol: 4 # Starlight, more product due to the amount of the additional reactants
+    Necrosol: 2 # Starlight, more product due to the amount of the additional reactants
 
 - type: reaction
   id: Aloxadone

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -588,16 +588,18 @@
   impact: Medium
   minTemp: 370
   reactants:
-    Blood: # Starlight, Reduced blood requirement for math-related reasons
+  # Starlight-start
+    Blood:
       amount: 1
-    Diphenhydramine: # Starlight, added in place of omnizine
+    Diphenhydramine:
       amount: 1
-    Desoxyephedrine: # Starlight, added in place of omnizine
+    Desoxyephedrine:
       amount: 1
     Cryoxadone:
       amount: 1
   products:
-    Necrosol: 2 # Starlight, more product due to the amount of the additional reactants
+    Necrosol: 2
+  # Starlight-end
 
 - type: reaction
   id: Aloxadone


### PR DESCRIPTION
I saw that the recipe had the inputs and outputs doubled (2+2+2+2=4), so I decided to halve it (1+1+1+1=2). It only affects the guidebook.

## Short description
Halved the recipe for Necrosol, but only visually.

## Why we need to add this
Just for guidebook consistency.

## Media (Video/Screenshots)
<img width="490" height="134" alt="image" src="https://github.com/user-attachments/assets/bae9a5aa-eab0-4069-925b-09cd4a4dd62a" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.