### PR TITLE
Controlled substances update (Corgium)

### DIFF
--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -467,6 +467,9 @@
   group: Toxins
   desc: reagent-desc-corgiessence
   physicalDesc: reagent-physical-desc-fluffy
+  allowedJobs:                # Starlight
+  - Chemist                   # Starlight
+  contrabandSeverity: Major   # Starlight None -> major
   flavor: dogfood
   color: "#ed9715"
   metabolisms:
@@ -512,6 +515,7 @@
   group: Toxins
   desc: reagent-desc-catessence
   physicalDesc: reagent-physical-desc-milky
+  contrabandSeverity: Minor   # Starlight None -> minor
   flavor: cannedtuna
   color: "#d8bed8"
   metabolisms:
@@ -573,6 +577,7 @@
   name: reagent-name-canidessence
   group: Toxins
   desc: reagent-desc-canidessence
+  contrabandSeverity: Minor   # Starlight None -> minor
   physicalDesc: reagent-physical-desc-bubbly
   flavor: dogfood
   color: "#b87333"


### PR DESCRIPTION


<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Updated some chems like Corgium to be controlled substances due to their ability to be used in hostile (and LRP) ways. Get the CMO to sign off before turning yourself into a Corgi

## Why we need to add this
Corgium can be used in hostile (and LRP) ways.

## Media (Video/Screenshots)
<img width="494" height="201" alt="image" src="https://github.com/user-attachments/assets/d12cd2f7-ea7d-4686-8402-286387cdad48" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Born Stellar
- tweak: Corgium and a few other silly chems that can do hard to heal damage have been put on the NT-ISD watch list as illicit chemicals. Use is restricted to Clowns and prescriptions filed by physiologists.
