### PR TITLE
[Test break fix] Cleanup invalid entityuid in Magnus shuttle

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/CC-NT/Decimus_Shuttle_Magnus.yml
+++ b/Resources/Maps/_Starlight/Shuttles/CC-NT/Decimus_Shuttle_Magnus.yml
@@ -4040,7 +4040,6 @@ entities:
       parent: 1
     - type: SpecialRespawn
       stationMap:
-      - invalid
       - 1
 - proto: OperatingTable
   entities:


### PR DESCRIPTION
## Short description
An invalid SpecialRespawn stationMap entry is present on the Magnus shuttle; this PR cleans that up.

## Why we need to add this
This invalid entry is causing test failures

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.