### PR TITLE
[Test break fix] Reapply register fix

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/Furniture/register.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Furniture/register.yml
@@ -16,7 +16,6 @@
     drawdepth: SmallObjects
     sprite: _Starlight/Structures/Furniture/register.rsi
     state: register
-    snapCardinals: true
     noRot: true
     offset: 0, 0.2
   - type: Appearance


### PR DESCRIPTION
## Short description
This reapplies the fix from #3824, which somehow got lost in the StarLight to Starlight move.

## Why we need to add this
This fixes a consistent test failure in main

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
