### PR TITLE
Mechanically disable abilities that get people bwoinked during EOR

### DIFF
--- a/Content.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Server/Changeling/ChangelingSystem.cs
@@ -60,6 +60,7 @@ using Content.Server.Stunnable;
 using Content.Shared.Jittering;
 using System.Linq;
 // Starlight edit start
+using Content.Server.GameTicking;
 using Content.Shared.Body.Components;
 using Content.Shared.Chemistry.Reagent;
 // Starlight edit end
@@ -107,6 +108,7 @@ public sealed partial class ChangelingSystem : EntitySystem
     [Dependency] private readonly SharedJitteringSystem _jitter = default!;
     [Dependency] private readonly NpcFactionSystem _factionSystem = default!;
     [Dependency] private readonly MovementModStatusSystem _movementMod = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!; // Starlight
 
     public static readonly EntProtoId FakeArmbladePrototype = "FakeArmBladeChangeling";
 
@@ -156,7 +158,8 @@ public sealed partial class ChangelingSystem : EntitySystem
             {
                 comp.BiomassNextUpdateTime = _timing.CurTime + comp.BiomassUpdateCooldown;
                 //subtract biomass
-                comp.Biomass -= comp.BiomassDrain;
+                if (_gameTicker.RunLevel < GameRunLevel.PostRound) // Starlight: Only get hungrier when not EOR
+                    comp.Biomass -= comp.BiomassDrain;
                 UpdateBiomass(uid, comp);
                 UpdateAbilities(uid, comp);
             }

--- a/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.cs
+++ b/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Systems;
 using Content.Server.Body.Components;
+using Content.Server.GameTicking;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Popups;
@@ -70,6 +71,7 @@ public sealed partial class VampireSystem : EntitySystem
     [Dependency] private readonly FlammableSystem _flammable = default!;
     [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
     private ISawmill? _sawmill;
     private static readonly ProtoId<DamageGroupPrototype> _bruteGroupId = "Brute";
     private static readonly ProtoId<DamageGroupPrototype> _burnGroupId = "Burn";
@@ -330,7 +332,7 @@ public sealed partial class VampireSystem : EntitySystem
         var wasStarving = before <= 0f;
         var changed = false;
 
-        if (before > 0f)
+        if (before > 0f && _gameTicker.RunLevel < GameRunLevel.PostRound) // No hunger EOR
         {
             comp.BloodFullness = MathF.Max(0f, before - comp.FullnessDecayPerSecond);
             changed = !MathF.Abs(comp.BloodFullness - before).Equals(0f);

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -63,9 +63,8 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     /// </summary>
     private bool IsMindRolePacificationImmune(EntityUid uid)
     {
-        if (!TryComp<MindContainerComponent>(uid, out var mindContainer))
-            return false;
-        if (!TryComp<MindComponent>(mindContainer.Mind, out var mind))
+        if (!TryComp<MindContainerComponent>(uid, out var mindContainer) ||
+            !TryComp<MindComponent>(mindContainer.Mind, out var mind))
             return false;
 
         foreach (var role in _role.MindGetAllRoleInfo((mindContainer.Mind.Value, mind)))
@@ -86,9 +85,8 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     /// </summary>
     private bool IsGhostRolePacificationImmune(EntityUid uid)
     {
-        if (!TryComp<GhostRoleComponent>(uid, out var ghostRole))
-            return false;
-        if (!_proto.TryIndex(ghostRole.JobProto, out var job))
+        if (!TryComp<GhostRoleComponent>(uid, out var ghostRole) ||
+            !_proto.TryIndex(ghostRole.JobProto, out var job))
             return false;
         return job.BypassEorPacification;
     }
@@ -138,10 +136,8 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     
     private void OnValidatePossiblyEorgAction(EntityUid uid, EorgActionComponent component, ref ActionValidateEvent args)
     {
-        if (!_isEnabled)
-            return;
-        if (!TryComp<PreventEorgComponent>(args.User, out _))
-            return;
+        if (!_isEnabled || !_roundedEnded) return;
+        if (!TryComp<PreventEorgComponent>(args.User, out _))  return;
         
         _popup.PopupEntity(Loc.GetString("eorg-action"), args.User, args.User, PopupType.LargeCaution);
         args.Invalid = true;

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -1,10 +1,14 @@
 using Content.Server.GameTicking;
 using Content.Shared._NullLink;
+using Content.Shared._Starlight.GameTicking.Components;
+using Content.Shared.Actions.Components;
+using Content.Shared.Actions.Events;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.GameTicking;
 using Content.Shared.Mech.Components;
 using Content.Shared.Movement.Components;
+using Content.Shared.Popups;
 using Content.Shared.Starlight;
 using Content.Shared.Starlight.CCVar;
 using Robust.Shared.Configuration;
@@ -16,6 +20,7 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly ISharedNullLinkPlayerRolesReqManager _rolesReq = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     private bool _isEnabled = false;
     private bool _roundedEnded = false;
@@ -30,15 +35,15 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnSpawnComplete);
         SubscribeLocalEvent<GotRehydratedEvent>(OnRehydrateEvent);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundCleanup);
+        SubscribeLocalEvent<AntagonisticActionComponent, ActionValidateEvent>(OnValidateAntagonisticAction);
     }
-                                                                                                      
-
 
     private void SpreadPeace(EntityUid target)
     {
         if (!_isEnabled || !_roundedEnded) return;
         if (_rolesReq.IsPeacefulBypass(target)) return;
         EnsureComp<PacifiedComponent>(target);
+        EnsureComp<DisableAntagonismComponent>(target);
     }
 
     private void OnSpawnComplete(PlayerSpawnCompleteEvent ev)
@@ -61,5 +66,16 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         var mechQuery = EntityQueryEnumerator<MechComponent>();
         while (mechQuery.MoveNext(out var uid, out _))
             SpreadPeace(uid);
+    }
+    
+    private void OnValidateAntagonisticAction(EntityUid uid, AntagonisticActionComponent component, ref ActionValidateEvent args)
+    {
+        if (!_isEnabled)
+            return;
+        if (!TryComp<DisableAntagonismComponent>(args.User, out _))
+            return;
+        
+        _popup.PopupEntity(Loc.GetString("peaceful-round-end"), args.User, args.User, PopupType.LargeCaution);
+        args.Invalid = true;
     }
 }

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -50,17 +50,19 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     {
         if (!_isEnabled || !_roundedEnded) return;
         if (_rolesReq.IsPeacefulBypass(target)) return; // OOC bypass (staff, extroles, ..)
-        if (!IsOnPacifiedGrid(target)) return; // Only pacify people on Evac and CC grids.
-        if (IsMindRolePacificationImmune(target)) return; // IC bypass (BSO, ERT, Decimus, CC, ..)
+        if (!IsGridPacificationTarget(target)) return; // Only pacify people on Evac and CC grids.
+        if (IsMindRolePacificationImmune(target)) return; // IC bypass (taken roles of ERT, Decimus, CC, ..)
         if (IsGhostRolePacificationImmune(target)) return; // IC bypass (same as previous, only when ghost role wasn't taken)
         
         EnsureComp<PacifiedComponent>(target);
         EnsureComp<DisableAntagonismComponent>(target);
     }
 
+    /// <summary>
+    /// Checks if the entity has any mind roles that are exempt from pacification.
+    /// </summary>
     private bool IsMindRolePacificationImmune(EntityUid uid)
     {
-        // Checks if the mind has roles that are exempt from pacification.
         if (!TryComp<MindContainerComponent>(uid, out var mindContainer))
             return false;
         if (!TryComp<MindComponent>(mindContainer.Mind, out var mind))
@@ -79,9 +81,11 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         return false;
     }
 
+    /// <summary>
+    /// Checks if the entity has any ghost roles that are exempt from pacification.
+    /// </summary>
     private bool IsGhostRolePacificationImmune(EntityUid uid)
     {
-        // If we don't find any in the mind, check for ghost role jobs.
         if (!TryComp<GhostRoleComponent>(uid, out var ghostRole))
             return false;
         if (!_proto.TryIndex(ghostRole.JobProto, out var job))
@@ -89,7 +93,10 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         return job.BypassEorPacification;
     }
     
-    private bool IsOnPacifiedGrid(EntityUid uid)
+    /// <summary>
+    /// Check whether a grid is a target for pacification. Returns true for Evac and CentComm only.
+    /// </summary>
+    private bool IsGridPacificationTarget(EntityUid uid)
     {
         var xform = Transform(uid);
         var grid = xform.GridUid;

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -43,7 +43,7 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnSpawnComplete);
         SubscribeLocalEvent<GotRehydratedEvent>(OnRehydrateEvent);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundCleanup);
-        SubscribeLocalEvent<AntagonisticActionComponent, ActionValidateEvent>(OnValidateAntagonisticAction);
+        SubscribeLocalEvent<EorgActionComponent, ActionValidateEvent>(OnValidatePossiblyEorgAction);
     }
 
     private void SpreadPeace(EntityUid target)
@@ -55,7 +55,7 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         if (IsGhostRolePacificationImmune(target)) return; // IC bypass (same as previous, only when ghost role wasn't taken)
         
         EnsureComp<PacifiedComponent>(target);
-        EnsureComp<DisableAntagonismComponent>(target);
+        EnsureComp<PreventEorgComponent>(target);
     }
 
     /// <summary>
@@ -136,14 +136,14 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
             SpreadPeace(uid);
     }
     
-    private void OnValidateAntagonisticAction(EntityUid uid, AntagonisticActionComponent component, ref ActionValidateEvent args)
+    private void OnValidatePossiblyEorgAction(EntityUid uid, EorgActionComponent component, ref ActionValidateEvent args)
     {
         if (!_isEnabled)
             return;
-        if (!TryComp<DisableAntagonismComponent>(args.User, out _))
+        if (!TryComp<PreventEorgComponent>(args.User, out _))
             return;
         
-        _popup.PopupEntity(Loc.GetString("peaceful-round-end"), args.User, args.User, PopupType.LargeCaution);
+        _popup.PopupEntity(Loc.GetString("eorg-action"), args.User, args.User, PopupType.LargeCaution);
         args.Invalid = true;
     }
 }

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -1,4 +1,5 @@
 using Content.Server.GameTicking;
+using Content.Server.Shuttles.Components;
 using Content.Shared._NullLink;
 using Content.Shared._Starlight.GameTicking.Components;
 using Content.Shared.Actions.Components;
@@ -42,8 +43,26 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     {
         if (!_isEnabled || !_roundedEnded) return;
         if (_rolesReq.IsPeacefulBypass(target)) return;
+        if (!IsOnPacifiedGrid(target)) return;
+        
         EnsureComp<PacifiedComponent>(target);
         EnsureComp<DisableAntagonismComponent>(target);
+    }
+    
+    private bool IsOnPacifiedGrid(EntityUid uid)
+    {
+        var xform = Transform(uid);
+        var grid = xform.GridUid;
+
+        if (HasComp<StationEmergencyShuttleComponent>(grid))
+            return true; // Evac shuttle/pod = pacified
+        if (HasComp<StationCentcommComponent>(grid))
+            return true; // CC = pacified
+
+        // In all other cases we do not *mechanically* enfore it.
+        // This way station-ending antags can still do their thing,
+        // and sec can still fight back if they're left behind on station.
+        return false;
     }
 
     private void OnSpawnComplete(PlayerSpawnCompleteEvent ev)

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -1,4 +1,5 @@
 using Content.Server.GameTicking;
+using Content.Server.Ghost.Roles.Components;
 using Content.Server.Shuttles.Components;
 using Content.Shared._NullLink;
 using Content.Shared._Starlight.GameTicking.Components;
@@ -8,8 +9,12 @@ using Content.Shared.Chemistry.Components;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.GameTicking;
 using Content.Shared.Mech.Components;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
 using Content.Shared.Movement.Components;
 using Content.Shared.Popups;
+using Content.Shared.Roles;
+using Content.Shared.Roles.Components;
 using Content.Shared.Starlight;
 using Content.Shared.Starlight.CCVar;
 using Robust.Shared.Configuration;
@@ -22,6 +27,8 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly ISharedNullLinkPlayerRolesReqManager _rolesReq = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly SharedRoleSystem _role = default!;
 
     private bool _isEnabled = false;
     private bool _roundedEnded = false;
@@ -42,11 +49,44 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     private void SpreadPeace(EntityUid target)
     {
         if (!_isEnabled || !_roundedEnded) return;
-        if (_rolesReq.IsPeacefulBypass(target)) return;
-        if (!IsOnPacifiedGrid(target)) return;
+        if (_rolesReq.IsPeacefulBypass(target)) return; // OOC bypass (staff, extroles, ..)
+        if (!IsOnPacifiedGrid(target)) return; // Only pacify people on Evac and CC grids.
+        if (IsMindRolePacificationImmune(target)) return; // IC bypass (BSO, ERT, Decimus, CC, ..)
+        if (IsGhostRolePacificationImmune(target)) return; // IC bypass (same as previous, only when ghost role wasn't taken)
         
         EnsureComp<PacifiedComponent>(target);
         EnsureComp<DisableAntagonismComponent>(target);
+    }
+
+    private bool IsMindRolePacificationImmune(EntityUid uid)
+    {
+        // Checks if the mind has roles that are exempt from pacification.
+        if (!TryComp<MindContainerComponent>(uid, out var mindContainer))
+            return false;
+        if (!TryComp<MindComponent>(mindContainer.Mind, out var mind))
+            return false;
+
+        foreach (var role in _role.MindGetAllRoleInfo((mindContainer.Mind.Value, mind)))
+        {
+            if (role.Antagonist)
+                continue;
+            if (!_proto.TryIndex<JobPrototype>(role.Prototype, out var mindJob))
+                continue;
+            if (mindJob.BypassEorPacification)
+                return true;
+        }
+
+        return false;
+    }
+
+    private bool IsGhostRolePacificationImmune(EntityUid uid)
+    {
+        // If we don't find any in the mind, check for ghost role jobs.
+        if (!TryComp<GhostRoleComponent>(uid, out var ghostRole))
+            return false;
+        if (!_proto.TryIndex(ghostRole.JobProto, out var job))
+            return false;
+        return job.BypassEorPacification;
     }
     
     private bool IsOnPacifiedGrid(EntityUid uid)

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -54,9 +54,11 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         var xform = Transform(uid);
         var grid = xform.GridUid;
 
-        if (HasComp<StationEmergencyShuttleComponent>(grid))
-            return true; // Evac shuttle/pod = pacified
-        if (HasComp<StationCentcommComponent>(grid))
+        if (HasComp<EmergencyShuttleComponent>(grid))
+            return true; // Evac shuttle (escape pods don't count for this) = pacified
+        
+        AllEntityQuery<StationCentcommComponent>().MoveNext(out var centcomm);
+        if (centcomm != null && centcomm.Entity == grid)
             return true; // CC = pacified
 
         // In all other cases we do not *mechanically* enfore it.

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -62,9 +62,9 @@ public sealed class EmagSystem : EntitySystem
         if (_tag.HasTag(target, ent.Comp.EmagImmuneTag))
             return false;
 
-        if (HasComp<DisableAntagonismComponent>(user)) // Starlight BEGIN
+        if (HasComp<PreventEorgComponent>(user)) // Starlight BEGIN
         {
-            _popup.PopupClient(Loc.GetString("peaceful-round-end"), user, PopupType.LargeCaution);
+            _popup.PopupClient(Loc.GetString("eorg-action"), user, PopupType.LargeCaution);
             return false;
         } // Starlight END
 

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Starlight.GameTicking.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
@@ -60,6 +61,12 @@ public sealed class EmagSystem : EntitySystem
 
         if (_tag.HasTag(target, ent.Comp.EmagImmuneTag))
             return false;
+
+        if (HasComp<DisableAntagonismComponent>(user)) // Starlight BEGIN
+        {
+            _popup.PopupClient(Loc.GetString("peaceful-round-end"), user, PopupType.LargeCaution);
+            return false;
+        } // Starlight END
 
         Entity<LimitedChargesComponent?> chargesEnt = ent.Owner;
         if (_sharedCharges.IsEmpty(chargesEnt))

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -99,7 +99,7 @@ namespace Content.Shared.Roles
         ///     STARLIGHT: Whether to bypass EOR pacification.
         /// </summary>
         [DataField]
-        public bool BypassEorPacification { get; private set; } = true;
+        public bool BypassEorPacification { get; private set; }
 
         /// <summary>
         ///     The "weight" or importance of this job. If this number is large, the job system will assign this job

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -11,8 +11,7 @@ namespace Content.Shared.Roles
     ///     Describes information for a single job on the station.
     /// </summary>
     [Prototype]
-    public sealed partial class 
-        JobPrototype : IPrototype
+    public sealed partial class JobPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]

--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -11,7 +11,8 @@ namespace Content.Shared.Roles
     ///     Describes information for a single job on the station.
     /// </summary>
     [Prototype]
-    public sealed partial class JobPrototype : IPrototype
+    public sealed partial class 
+        JobPrototype : IPrototype
     {
         [ViewVariables]
         [IdDataField]
@@ -93,6 +94,12 @@ namespace Content.Shared.Roles
 
         [DataField]
         public bool CanBeAntag { get; private set; } = true;
+        
+        /// <summary>
+        ///     STARLIGHT: Whether to bypass EOR pacification.
+        /// </summary>
+        [DataField]
+        public bool BypassEorPacification { get; private set; } = true;
 
         /// <summary>
         ///     The "weight" or importance of this job. If this number is large, the job system will assign this job

--- a/Content.Shared/_Starlight/GameTicking/Components/AntagonisticActionComponent.cs
+++ b/Content.Shared/_Starlight/GameTicking/Components/AntagonisticActionComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.GameTicking.Components;
+
+/// <summary>
+/// Marker component to identify an action as antagonistic. Intended for use in EOR to prevent EORG.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AntagonisticActionComponent : Component
+{
+}

--- a/Content.Shared/_Starlight/GameTicking/Components/AntagonisticActionComponent.cs
+++ b/Content.Shared/_Starlight/GameTicking/Components/AntagonisticActionComponent.cs
@@ -3,9 +3,9 @@
 namespace Content.Shared._Starlight.GameTicking.Components;
 
 /// <summary>
-/// Marker component to identify an action as antagonistic. Intended for use in EOR to prevent EORG.
+/// Marker component to identify an action as being EORG. Intended to be blocked during EOR to prevent EORG.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class AntagonisticActionComponent : Component
+public sealed partial class EorgActionComponent : Component
 {
 }

--- a/Content.Shared/_Starlight/GameTicking/Components/DisableAntagonismComponent.cs
+++ b/Content.Shared/_Starlight/GameTicking/Components/DisableAntagonismComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.GameTicking.Components;
+
+/// <summary>
+/// Marker component to disable antagonism. Intended for use in EOR to prevent EORG.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DisableAntagonismComponent : Component
+{
+}

--- a/Content.Shared/_Starlight/GameTicking/Components/PreventEorgComponent.cs
+++ b/Content.Shared/_Starlight/GameTicking/Components/PreventEorgComponent.cs
@@ -6,6 +6,6 @@ namespace Content.Shared._Starlight.GameTicking.Components;
 /// Marker component to disable antagonism. Intended for use in EOR to prevent EORG.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class DisableAntagonismComponent : Component
+public sealed partial class PreventEorgComponent : Component
 {
 }

--- a/Resources/Locale/en-US/_Starlight/game-ticking/eorg.ftl
+++ b/Resources/Locale/en-US/_Starlight/game-ticking/eorg.ftl
@@ -1,1 +1,1 @@
-﻿peaceful-round-end = That would be end-of-round griefing!
+﻿eorg-action = That would be end-of-round griefing!

--- a/Resources/Locale/en-US/_Starlight/game-ticking/eorg.ftl
+++ b/Resources/Locale/en-US/_Starlight/game-ticking/eorg.ftl
@@ -1,1 +1,1 @@
-﻿peaceful-round-end = I could get in trouble for that!
+﻿peaceful-round-end = That would be end-of-ground griefing!

--- a/Resources/Locale/en-US/_Starlight/game-ticking/eorg.ftl
+++ b/Resources/Locale/en-US/_Starlight/game-ticking/eorg.ftl
@@ -1,1 +1,1 @@
-﻿peaceful-round-end = That would be end-of-ground griefing!
+﻿peaceful-round-end = That would be end-of-round griefing!

--- a/Resources/Locale/en-US/_Starlight/game-ticking/eorg.ftl
+++ b/Resources/Locale/en-US/_Starlight/game-ticking/eorg.ftl
@@ -1,0 +1,1 @@
+﻿peaceful-round-end = I could get in trouble for that!

--- a/Resources/Prototypes/Actions/changeling.yml
+++ b/Resources/Prototypes/Actions/changeling.yml
@@ -36,6 +36,7 @@
   - type: TargetAction
   - type: EntityTargetAction
     event: !type:ChangelingDevourActionEvent
+  - type: AntagonisticAction
 
 - type: entity
   id: ActionChangelingTransform

--- a/Resources/Prototypes/Actions/changeling.yml
+++ b/Resources/Prototypes/Actions/changeling.yml
@@ -36,7 +36,7 @@
   - type: TargetAction
   - type: EntityTargetAction
     event: !type:ChangelingDevourActionEvent
-  - type: AntagonisticAction
+  - type: EorgAction
 
 - type: entity
   id: ActionChangelingTransform

--- a/Resources/Prototypes/Actions/revenant.yml
+++ b/Resources/Prototypes/Actions/revenant.yml
@@ -15,7 +15,7 @@
     icon: Interface/Actions/defile.png
   - type: InstantAction
     event: !type:RevenantDefileActionEvent
-  - type: AntagonisticAction # Starlight
+  - type: EorgAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -28,7 +28,7 @@
     useDelay: 20
   - type: InstantAction
     event: !type:RevenantOverloadLightsActionEvent
-  - type: AntagonisticAction # Starlight
+  - type: EorgAction # Starlight
 
 #- type: entity
 #  parent: BaseAction
@@ -41,7 +41,7 @@
 #    useDelay: 20
 #  - type: InstantAction
 #    event: !type:RevenantBlightActionEvent
-#  - type: AntagonisticAction # Starlight
+#  - type: EorgAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -54,4 +54,4 @@
     useDelay: 20
   - type: InstantAction
     event: !type:RevenantMalfunctionActionEvent
-  - type: AntagonisticAction # Starlight
+  - type: EorgAction # Starlight

--- a/Resources/Prototypes/Actions/revenant.yml
+++ b/Resources/Prototypes/Actions/revenant.yml
@@ -15,6 +15,7 @@
     icon: Interface/Actions/defile.png
   - type: InstantAction
     event: !type:RevenantDefileActionEvent
+  - type: AntagonisticAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -27,6 +28,7 @@
     useDelay: 20
   - type: InstantAction
     event: !type:RevenantOverloadLightsActionEvent
+  - type: AntagonisticAction # Starlight
 
 #- type: entity
 #  parent: BaseAction
@@ -39,6 +41,7 @@
 #    useDelay: 20
 #  - type: InstantAction
 #    event: !type:RevenantBlightActionEvent
+#  - type: AntagonisticAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -51,3 +54,4 @@
     useDelay: 20
   - type: InstantAction
     event: !type:RevenantMalfunctionActionEvent
+  - type: AntagonisticAction # Starlight

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -296,6 +296,7 @@
       tags:
       - Wall
     event: !type:DevourActionEvent
+  - type: AntagonisticAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -313,3 +314,4 @@
     range: 0
   - type: WorldTargetAction
     event: !type:ActionGunShootEvent
+  - type: AntagonisticAction # Starlight

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -274,6 +274,7 @@
     priority: 3
   - type: InstantAction
     event: !type:DragonSpawnRiftActionEvent
+  - type: AntagonisticAction # Starlight
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -274,7 +274,7 @@
     priority: 3
   - type: InstantAction
     event: !type:DragonSpawnRiftActionEvent
-  - type: AntagonisticAction # Starlight
+  - type: EorgAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -297,7 +297,7 @@
       tags:
       - Wall
     event: !type:DevourActionEvent
-  - type: AntagonisticAction # Starlight
+  - type: EorgAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -315,4 +315,4 @@
     range: 0
   - type: WorldTargetAction
     event: !type:ActionGunShootEvent
-  - type: AntagonisticAction # Starlight
+  - type: EorgAction # Starlight

--- a/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
@@ -17,6 +17,7 @@
   icon: "JobIconCBURN"
   supervisors: job-supervisors-centcom
   canBeAntag: false
+  bypassEorPacification: true # Starlight
   accessGroups:
   - AllAccess
   access:

--- a/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
@@ -14,6 +14,7 @@
   icon: "JobIconDeathSquad"
   supervisors: job-supervisors-centcom
   canBeAntag: false
+  bypassEorPacification: true # Starlight
   accessGroups:
   - AllAccess
   access:

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -23,6 +23,7 @@
   icon: "JobIconERTLeader"
   supervisors: job-supervisors-centcom
   canBeAntag: false
+  bypassEorPacification: true # Starlight
   accessGroups:
   - AllAccess
   access:
@@ -130,6 +131,7 @@
   icon: "JobIconERTChaplain"
   supervisors: job-supervisors-centcom
   canBeAntag: false
+  bypassEorPacification: true # Starlight
   accessGroups:
   - AllAccess
   access:
@@ -214,6 +216,7 @@
   icon: "JobIconERTEngineer"
   supervisors: job-supervisors-centcom
   canBeAntag: false
+  bypassEorPacification: true # Starlight
   accessGroups:
   - AllAccess
   access:
@@ -315,6 +318,7 @@
   icon: "JobIconERTSecurity"
   supervisors: job-supervisors-centcom
   canBeAntag: false
+  bypassEorPacification: true # Starlight
   accessGroups:
   - AllAccess
   access:
@@ -516,6 +520,7 @@
   icon: "JobIconERTMedical" #Starlight
   supervisors: job-supervisors-centcom
   canBeAntag: false
+  bypassEorPacification: true # Starlight
   accessGroups:
   - AllAccess
   access:
@@ -622,6 +627,7 @@
   icon: "JobIconERTJanitor"
   supervisors: job-supervisors-centcom
   canBeAntag: false
+  bypassEorPacification: true # Starlight
   accessGroups:
   - AllAccess
   access:

--- a/Resources/Prototypes/_Starlight/Actions/changeling.yml
+++ b/Resources/Prototypes/_Starlight/Actions/changeling.yml
@@ -163,7 +163,7 @@
     chemicalCost: 30
     useInLesserForm: true
     requireAbsorbed: 1
-1
+
 - type: entity
   id: ActionShriekResonant
   name: Resonant Shriek

--- a/Resources/Prototypes/_Starlight/Actions/changeling.yml
+++ b/Resources/Prototypes/_Starlight/Actions/changeling.yml
@@ -163,8 +163,7 @@
     chemicalCost: 30
     useInLesserForm: true
     requireAbsorbed: 1
-  - type: AntagonisticAction
-
+1
 - type: entity
   id: ActionShriekResonant
   name: Resonant Shriek
@@ -183,7 +182,6 @@
     chemicalCost: 30
     useInLesserForm: true
     requireAbsorbed: 1
-  - type: AntagonisticAction
 
 - type: entity
   id: ActionToggleStrainedMuscles
@@ -227,7 +225,6 @@
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
-  - type: AntagonisticAction
 
 - type: entity
   id: ActionStingCryo
@@ -253,7 +250,6 @@
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
-  - type: AntagonisticAction
 
 - type: entity
   id: ActionStingLethargic
@@ -277,7 +273,6 @@
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
-  - type: AntagonisticAction
 
 - type: entity
   id: ActionStingMute
@@ -301,7 +296,6 @@
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
-  - type: AntagonisticAction
 
 - type: entity
   id: ActionStingFakeArmblade
@@ -325,7 +319,6 @@
   - type: ChangelingAction
     chemicalCost: 50
     useInLesserForm: true
-  - type: AntagonisticAction
 
 - type: entity
   id: ActionStingTransform

--- a/Resources/Prototypes/_Starlight/Actions/changeling.yml
+++ b/Resources/Prototypes/_Starlight/Actions/changeling.yml
@@ -40,7 +40,7 @@
   - type: ChangelingAction
     chemicalCost: 25
     useInLesserForm: true
-  - type: AntagonisticAction
+  - type: EorgAction
 
 
 - type: entity
@@ -342,7 +342,7 @@
   - type: ChangelingAction
     chemicalCost: 75
     useInLesserForm: true
-  - type: AntagonisticAction
+  - type: EorgAction
 
 # utility
 - type: entity
@@ -399,7 +399,7 @@
     event: !type:ActionBiodegradeEvent {}
   - type: ChangelingAction
     chemicalCost: 30
-  - type: AntagonisticAction
+  - type: EorgAction
 
 - type: entity
   id: ActionChameleonSkin

--- a/Resources/Prototypes/_Starlight/Actions/changeling.yml
+++ b/Resources/Prototypes/_Starlight/Actions/changeling.yml
@@ -40,6 +40,7 @@
   - type: ChangelingAction
     chemicalCost: 25
     useInLesserForm: true
+  - type: AntagonisticAction
 
 
 - type: entity
@@ -162,6 +163,7 @@
     chemicalCost: 30
     useInLesserForm: true
     requireAbsorbed: 1
+  - type: AntagonisticAction
 
 - type: entity
   id: ActionShriekResonant
@@ -181,6 +183,7 @@
     chemicalCost: 30
     useInLesserForm: true
     requireAbsorbed: 1
+  - type: AntagonisticAction
 
 - type: entity
   id: ActionToggleStrainedMuscles
@@ -224,6 +227,7 @@
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
+  - type: AntagonisticAction
 
 - type: entity
   id: ActionStingCryo
@@ -246,10 +250,10 @@
     event: !type:StingChemEvent {
       chems: { Fresium: 20, ChloralHydrate: 20 }
     }
-
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
+  - type: AntagonisticAction
 
 - type: entity
   id: ActionStingLethargic
@@ -273,6 +277,7 @@
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
+  - type: AntagonisticAction
 
 - type: entity
   id: ActionStingMute
@@ -296,6 +301,7 @@
   - type: ChangelingAction
     chemicalCost: 35
     useInLesserForm: true
+  - type: AntagonisticAction
 
 - type: entity
   id: ActionStingFakeArmblade
@@ -319,6 +325,7 @@
   - type: ChangelingAction
     chemicalCost: 50
     useInLesserForm: true
+  - type: AntagonisticAction
 
 - type: entity
   id: ActionStingTransform
@@ -342,6 +349,7 @@
   - type: ChangelingAction
     chemicalCost: 75
     useInLesserForm: true
+  - type: AntagonisticAction
 
 # utility
 - type: entity
@@ -398,6 +406,7 @@
     event: !type:ActionBiodegradeEvent {}
   - type: ChangelingAction
     chemicalCost: 30
+  - type: AntagonisticAction
 
 - type: entity
   id: ActionChameleonSkin

--- a/Resources/Prototypes/_Starlight/Actions/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Actions/shadekin.yml
@@ -42,6 +42,7 @@
       checkCanInteract: false
     - type: InstantAction
       event: !type:BrighteyePortalActionEvent
+    - type: AntagonisticAction
 
 - type: entity
   id: BrighteyeDarkTrapAction

--- a/Resources/Prototypes/_Starlight/Actions/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Actions/shadekin.yml
@@ -42,7 +42,7 @@
       checkCanInteract: false
     - type: InstantAction
       event: !type:BrighteyePortalActionEvent
-    - type: AntagonisticAction
+    - type: EorgAction
 
 - type: entity
   id: BrighteyeDarkTrapAction
@@ -94,4 +94,4 @@
       itemIconStyle: NoItem
     - type: InstantAction
       event: !type:BrighteyeCreateShadeActionEvent
-    - type: AntagonisticAction
+    - type: EorgAction

--- a/Resources/Prototypes/_Starlight/Actions/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Actions/shadekin.yml
@@ -57,6 +57,7 @@
       itemIconStyle: NoItem
     - type: InstantAction
       event: !type:BrighteyeDarkTrapActionEvent
+    - type: AntagonisticAction
 
 - type: entity
   id: BrighteyeShadeSkipAction
@@ -93,3 +94,4 @@
       itemIconStyle: NoItem
     - type: InstantAction
       event: !type:BrighteyeCreateShadeActionEvent
+    - type: AntagonisticAction

--- a/Resources/Prototypes/_Starlight/Actions/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Actions/shadekin.yml
@@ -58,7 +58,6 @@
       itemIconStyle: NoItem
     - type: InstantAction
       event: !type:BrighteyeDarkTrapActionEvent
-    - type: AntagonisticAction
 
 - type: entity
   id: BrighteyeShadeSkipAction

--- a/Resources/Prototypes/_Starlight/Actions/vampire.yml
+++ b/Resources/Prototypes/_Starlight/Actions/vampire.yml
@@ -142,7 +142,6 @@
       bloodToUnlock: 400
       bloodCost: 30
       requiredClass: Hemomancer
-    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -191,7 +190,6 @@
       bloodToUnlock: 250
       bloodCost: 40
       requiredClass: Hemomancer
-    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -392,7 +390,6 @@
       bloodToUnlock: 400
       bloodCost: 0
       requiredClass: Umbrae
-    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -472,7 +469,6 @@
       bloodToUnlock: 250
       bloodCost: 30
       requiredClass: Dantalion
-    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -709,4 +705,3 @@
       bloodToUnlock: 1000
       bloodCost: 30
       requiredClass: Gargantua
-    - type: AntagonisticAction

--- a/Resources/Prototypes/_Starlight/Actions/vampire.yml
+++ b/Resources/Prototypes/_Starlight/Actions/vampire.yml
@@ -165,7 +165,6 @@
       bloodToUnlock: 250
       bloodCost: 25
       requiredClass: Hemomancer
-    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/_Starlight/Actions/vampire.yml
+++ b/Resources/Prototypes/_Starlight/Actions/vampire.yml
@@ -39,6 +39,7 @@
     - type: VampireAction
       bloodToUnlock: 0
       bloodCost: 0
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -142,6 +143,7 @@
       bloodToUnlock: 400
       bloodCost: 30
       requiredClass: Hemomancer
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -165,6 +167,7 @@
       bloodToUnlock: 250
       bloodCost: 25
       requiredClass: Hemomancer
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -189,6 +192,7 @@
       bloodToUnlock: 250
       bloodCost: 40
       requiredClass: Hemomancer
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -229,6 +233,7 @@
       bloodToUnlock: 800
       bloodCost: 100
       requiredClass: Hemomancer
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -293,6 +298,7 @@
       bloodToUnlock: 200
       bloodCost: 20
       requiredClass: Umbrae
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -342,6 +348,7 @@
       bloodToUnlock: 800
       bloodCost: 50
       requiredClass: Umbrae
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -386,6 +393,7 @@
       bloodToUnlock: 400
       bloodCost: 0
       requiredClass: Umbrae
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -406,6 +414,7 @@
       bloodToUnlock: 1000
       bloodCost: 0
       requiredClass: Umbrae
+    - type: AntagonisticAction
 
 # Dantalion
 
@@ -436,6 +445,7 @@
       bloodToUnlock: 150
       bloodCost: 150
       requiredClass: Dantalion
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -464,6 +474,7 @@
       bloodToUnlock: 250
       bloodCost: 30
       requiredClass: Dantalion
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -492,6 +503,7 @@
       bloodToUnlock: 250
       bloodCost: 30
       requiredClass: Dantalion
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -552,6 +564,7 @@
       bloodToUnlock: 800
       bloodCost: 0
       requiredClass: Dantalion
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -572,6 +585,7 @@
       bloodToUnlock: 1000
       bloodCost: 70
       requiredClass: Dantalion
+    - type: AntagonisticAction
 
 #Gargantua
 
@@ -634,6 +648,7 @@
       bloodToUnlock: 250
       bloodCost: 30
       requiredClass: Gargantua
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -677,6 +692,7 @@
       bloodToUnlock: 800
       bloodCost: 20
       requiredClass: Gargantua
+    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -700,3 +716,4 @@
       bloodToUnlock: 1000
       bloodCost: 30
       requiredClass: Gargantua
+    - type: AntagonisticAction

--- a/Resources/Prototypes/_Starlight/Actions/vampire.yml
+++ b/Resources/Prototypes/_Starlight/Actions/vampire.yml
@@ -229,7 +229,7 @@
       bloodToUnlock: 800
       bloodCost: 100
       requiredClass: Hemomancer
-    - type: AntagonisticAction
+    - type: EorgAction
 
 - type: entity
   parent: BaseAction
@@ -294,7 +294,7 @@
       bloodToUnlock: 200
       bloodCost: 20
       requiredClass: Umbrae
-    - type: AntagonisticAction
+    - type: EorgAction
 
 - type: entity
   parent: BaseAction
@@ -344,7 +344,7 @@
       bloodToUnlock: 800
       bloodCost: 50
       requiredClass: Umbrae
-    - type: AntagonisticAction
+    - type: EorgAction
 
 - type: entity
   parent: BaseAction
@@ -439,7 +439,7 @@
       bloodToUnlock: 150
       bloodCost: 150
       requiredClass: Dantalion
-    - type: AntagonisticAction
+    - type: EorgAction
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/_Starlight/Actions/vampire.yml
+++ b/Resources/Prototypes/_Starlight/Actions/vampire.yml
@@ -39,7 +39,6 @@
     - type: VampireAction
       bloodToUnlock: 0
       bloodCost: 0
-    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -414,7 +413,6 @@
       bloodToUnlock: 1000
       bloodCost: 0
       requiredClass: Umbrae
-    - type: AntagonisticAction
 
 # Dantalion
 
@@ -503,7 +501,6 @@
       bloodToUnlock: 250
       bloodCost: 30
       requiredClass: Dantalion
-    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -564,7 +561,6 @@
       bloodToUnlock: 800
       bloodCost: 0
       requiredClass: Dantalion
-    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -585,7 +581,6 @@
       bloodToUnlock: 1000
       bloodCost: 70
       requiredClass: Dantalion
-    - type: AntagonisticAction
 
 #Gargantua
 
@@ -648,7 +643,6 @@
       bloodToUnlock: 250
       bloodCost: 30
       requiredClass: Gargantua
-    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction
@@ -692,7 +686,6 @@
       bloodToUnlock: 800
       bloodCost: 20
       requiredClass: Gargantua
-    - type: AntagonisticAction
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/decimus.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/decimus.yml
@@ -15,6 +15,7 @@
   rules: job-rules-corporate-aligned
   supervisors: job-supervisors-none
   canBeAntag: false
+  bypassEorPacification: true
   accessGroups:
   - AllAccess
   access:

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/ntncblueshield.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/ntncblueshield.yml
@@ -15,6 +15,7 @@
   rules: job-rules-corporate-aligned
   supervisors: job-supervisors-centcom
   canBeAntag: false
+  bypassEorPacification: true
   accessGroups:
   - AllAccess
   access:

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/ntsf.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/ntsf.yml
@@ -15,6 +15,7 @@
   rules: job-rules-corporate-aligned
   supervisors: job-supervisors-nanotrasen
   canBeAntag: false
+  bypassEorPacification: true
   accessGroups:
   - AllAccess
   access:

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/operator.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/operator.yml
@@ -9,6 +9,7 @@
   rules: job-rules-corporate-aligned
   supervisors: job-supervisors-hos
   canBeAntag: false
+  bypassEorPacification: true
   accessGroups:
   - AllAccess
   access:


### PR DESCRIPTION

## Short description
<!-- What do you propose to change with your PR? -->

Mechanically disable various antag abilities that will 100% get people bwoinked when used:
- Access breakers and Emags
- Actions (e.g. dragon fireball, devour, ...)

Instead it shows them an overhead popup text in red.

## Long description

Adds `PreventEorgComponent` that gets given at the same time as `PacifiedComponent`. It had to be separate since there's various cases where `PacifiedComponent` is present on entities during normal rounds.

### Criteria for getting pacified

- The usual OOC roles are exempt (Staff, ExtRoles, ..)
- Various IC roles are now exempt:
  - ERT
  - CBURN
  - Decimus
  - NanoTrasen Special Forces (NTSF)
  - CentralCommandOfficial
  - CentralCommandOperator
  - NTNCBlueShield (= greenshield)
- Only players on specific grids are targeted for pacification. Players not on these grids are NOT mechanically pacified, but are still subject to EORG rules. (This lets station-ending antags & remnant crew continue RP on-station):
  - Evacuation shuttles
  - CentComm

### Antagonism prevention

As this PR introduces only the framework and a basic set of limitations, a small but impactful set of things are disabled on top of the pre-existing combat pacification:

- Emags of all types (that includes access breakers)
- Space Dragon abilities (all of them)
- Revenant abilities (all of them)
- Changeling:
  - Devour ability (= eating and RR'ing person)
- Vampires:
  - Shadow Boxing (purely damaging ability)
  - Blood Eruption (purely damaging ability)
  - Enthrall (makes someone else an antag)
- Brighteyes:
  - Create Shade (only really breaks lights)
  - Open Portal (it's EOR, it's too late!)

**Please remember this will only be mechanically enforced on Evac and CC.**

I've intentionally avoided marking ambiguous abilities as antagonistic. This is important since various antagonists have abilities that could plausibly be used to avoid capture, rather than direct violence/end of round 'griefing'. We can iterate on this in later revisions.

Toggle abilities are out of scope for now. Support for this can also be added later.

### Miscellaneous changes

- Vampires no longer accumulate hunger EOR.
- Changelings no longer accumulate hunger EOR.

Both of these changes are to make them both not actively incentivized to continue antagonistic behavior during EOR.

## TODOs

### Who this affects

- [x] Staff and ExtRoles are still ignored.
- [x] Mechanically enforce only on crew on Evac (from FTL onwards) and CC. Anyone left on station is not _mechanically_ enforced on; normal rules apply.
  - [x] Q: What about evac pods? A: Not pacified
- [x] Find a way to exclude CC personnel such as ERT or CC commanders if possible.

### What this affects

- [x] Disables emag and access breaker
- [x] Disables various instant Abilities marked as Antagonistic.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

https://github.com/ss14Starlight/space-station-14/pull/3898 suggests adding a turnstile that cannot be emagged.

Instead I suggested doing it at a mechanical level: https://github.com/ss14Starlight/space-station-14/pull/3898#issuecomment-4116557659

So, I'm putting my money where my mouth is.

(Visible for staff only)
- Discussion thread 1: https://discord.com/channels/1272545509562777621/1485987908774006864
- Discussion thread 2 (latest): https://discord.com/channels/1272545509562777621/1486751741033844736

I've gotten lots of amazing feedback from the admins here & in the threads that's made it's way into the current version. A lot of people are excited to see this!

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Emag/Access breaker

https://github.com/user-attachments/assets/505829ab-f74e-4e38-9b2c-9a0fea387df5

### Revenant abilities

https://github.com/user-attachments/assets/2bc56e3b-b111-43a4-8006-5b70a3e8a247

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: End-of-round pacification is now only applied on the Evac shuttle and on CentComm. This makes it easier for station-ending antags and Security to keep doing what they have to do on station. EORG rules still apply.
- tweak: Changelings and Vampires no longer accumulate hunger during EOR.
- add: Various NT and CC jobs are now exempt from EOR pacification (such as ERT).
- add: Emags and authentication disruptors no longer work while the user is EOR pacified.
- add: Some damaging antagonist abilities are disabled while EOR pacified.
