### PR TITLE
Different Doafter times for picking up larger and smaller species

### DIFF
--- a/Content.Shared/_Starlight/Restrict/RestrictNestingItemComponent.cs
+++ b/Content.Shared/_Starlight/Restrict/RestrictNestingItemComponent.cs
@@ -11,5 +11,5 @@ public sealed partial class RestrictNestingItemComponent : Component
     /// How many seconds it takes to pickup an item with this component
     /// </summary>
     [DataField("doAfter")] 
-    public float DoAfter = 5f;
+    public TimeSpan DoAfter = TimeSpan.FromSeconds(5.0);
 }

--- a/Content.Shared/_Starlight/Restrict/RestrictNestingItemComponent.cs
+++ b/Content.Shared/_Starlight/Restrict/RestrictNestingItemComponent.cs
@@ -7,7 +7,9 @@ namespace Content.Shared.Starlight.Restrict;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class RestrictNestingItemComponent : Component
 {
-    //doafter time
-    [DataField]
-    public TimeSpan DoAfter = TimeSpan.FromSeconds(5.0);
+    /// <summary>
+    /// How many seconds it takes to pickup an item with this component
+    /// </summary>
+    [DataField("doAfter")] 
+    public float DoAfter = 5f;
 }

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/base.yml
@@ -12,7 +12,7 @@
     doAfter: 3
   - type: MultiHandedItem
   - type: CanEscapeInventory
-    baseResistTime: 3
+    baseResistTime: 5
   - type: VisualPickupable # Far Horizons start
     offsetFront: 0.0, -0.15
     offsetBack: 0.0, 0.05

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/base.yml
@@ -9,7 +9,7 @@
     shape:
     - 0, 0, 6, 4
   - type: RestrictNestingItem
-    doAfter: 3
+    doAfter: 3.0
   - type: MultiHandedItem
   - type: CanEscapeInventory
     baseResistTime: 5

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/base.yml
@@ -9,9 +9,10 @@
     shape:
     - 0, 0, 6, 4
   - type: RestrictNestingItem
+    doAfter: 3
   - type: MultiHandedItem
   - type: CanEscapeInventory
-    baseResistTime: 2
+    baseResistTime: 3
   - type: VisualPickupable # Far Horizons start
     offsetFront: 0.0, -0.15
     offsetBack: 0.0, 0.05
@@ -28,8 +29,9 @@
     shape:
     - 0, 0, 12, 10 # I'm not sure *what* you'd be able to fit this in.
   - type: RestrictNestingItem
+    doAfter: 7.5
   - type: MultiHandedItem
   - type: CanEscapeInventory
-    baseResistTime: 2
+    baseResistTime: 1.5
   - type: VisualPickupable # Far Horizons, technically
   - type: PickupableSpeedRelay # Far Horizons, technically

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/lagomorph.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/lagomorph.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseMobSpeciesOrganic, BaseSpeciesPickupableLarge]
+  parent: [BaseMobSpeciesOrganic, BaseSpeciesPickupableHuge]
   id: BaseMobLagomorph
   name: Urist McBnuuy
   abstract: true


### PR DESCRIPTION
## Short description
quick PR cause I missed making a comment on #3877
picking up the smaller species (ie the ones we could pick up before) is now 3 seconds from 5, they instead take 5 seconds to escape 
picking up larger species (vulps, cyclorite, diona, shadekin, lagomorphs) takes 7.5 seconds, and they can escape in 1.5 seconds


## Why we need to add this
Picking up a tree should not take the same amount of effort as picking up a cat
the 5 second escape on small species means that (hopefully) kidnapping is still a valid strategy

## Media (Video/Screenshots)
n/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: Kirb
- tweak: Felionoids, avali, dwarves, and resomi are significantly more yoinkable, it takes 3 seconds to pick them up.
- tweak: lagomorphs, vulps, cyclorite, diona and shadekin are actually heavy, and take 7.5 seconds to pick up.

