### PR TITLE
adds ammo types for the topmount SMG mag

### DIFF
--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -43,6 +43,7 @@
   - MagazineBoxRifleIncendiary
   - MagazineDMRIncendiary # Starlight
   - MagazinePistolSubMachineGunIncendiary
+  - MagazinePistolSubMachineGunTopMountedIncendiary # Starlight
   - SpeedLoaderShotgunIncendiary
   radioChannels:
   - Security
@@ -113,6 +114,7 @@
   - BoxShotgunUranium
   - MagazineDMRUranium # Starlight
   - MagazinePistolSubMachineGunUranium
+  - MagazinePistolSubMachineGunTopMountedUranium # Starlight
   - SpeedLoaderShotgunUranium
   radioChannels:
   - Security

--- a/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -153,6 +153,51 @@
   - type: BallisticAmmoProvider
     proto: null
 
+- type: entity
+  id: MagazinePistolSubMachineGunTopMountedHP
+  name: WT550 magazine (.35 auto HP top-mounted)
+  parent: MagazinePistolSubMachineGunTopMounted
+  description: Unconventional 30-round top feeding magazine for the WT550 SMG. Loaded with hollow-point rounds.
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgePistolHP
+
+- type: entity
+  id: MagazinePistolSubMachineGunTopMountedFMJ
+  name: WT550 magazine (.35 auto FMJ top-mounted)
+  parent: MagazinePistolSubMachineGunTopMounted
+  description: Unconventional 30-round top feeding magazine for the WT550 SMG. Loaded with full metal jacket rounds.
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgePistolFMJ
+
+- type: entity
+  id: MagazinePistolSubMachineGunTopMountedAP
+  name: WT550 magazine (.35 auto AP top-mounted)
+  parent: MagazinePistolSubMachineGunTopMounted
+  description: Unconventional 30-round top feeding magazine for the WT550 SMG. Loaded with armor-piercing rounds.
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgePistolAP
+
+- type: entity
+  id: MagazinePistolSubMachineGunTopMountedIncendiary
+  name: WT550 magazine (.35 auto incendiary top-mounted)
+  parent: MagazinePistolSubMachineGunTopMounted
+  description: Unconventional 30-round top feeding magazine for the WT550 SMG. Loaded with incendiary rounds.
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgePistolIncendiary
+
+- type: entity
+  id: MagazinePistolSubMachineGunTopMountedUranium
+  name: WT550 magazine (.35 auto uranium top-mounted)
+  parent: MagazinePistolSubMachineGunTopMounted
+  description: Unconventional 30-round top feeding magazine for the WT550 SMG. Loaded with exotic uranium-core rounds.
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgePistolUranium
+
 #########################################################
 
 - type: entity

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/Packs/security.yml
@@ -101,6 +101,8 @@
   - MagazinePistolSubMachineGunEmpty
   - MagazinePistolSubMachineGunTopMounted
   - MagazinePistolSubMachineGunTopMountedEmpty
+  - MagazinePistolSubMachineGunTopMountedHP
+  - MagazinePistolSubMachineGunTopMountedFMJ
   - MagazinePistolSubMachineGunUzi
   - MagazinePistolSubMachineGunPPSH
 # Rifle
@@ -221,6 +223,9 @@
   - MagazinePistolSubMachineGunIncendiary
   - MagazinePistolSubMachineGunUranium
   - MagazinePistolSubMachineGunAP
+  - MagazinePistolSubMachineGunTopMountedIncendiary
+  - MagazinePistolSubMachineGunTopMountedUranium
+  - MagazinePistolSubMachineGunTopMountedAP
 # Rifle
   - MagazineRifleIncendiary
   - MagazineRifleUranium

--- a/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/smg.yml
+++ b/Resources/Prototypes/_StarLight/Recipes/Lathes/security/ammo/smg.yml
@@ -66,6 +66,44 @@
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
+  id: MagazinePistolSubMachineGunTopMountedHP
+  result: MagazinePistolSubMachineGunTopMountedHP
+  materials:
+    Steel: 300
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazinePistolSubMachineGunTopMountedFMJ
+  result: MagazinePistolSubMachineGunTopMountedFMJ
+  materials:
+    Steel: 300
+
+- type: latheRecipe
+  parent: BaseEmptyAmmoRecipe
+  id: MagazinePistolSubMachineGunTopMountedIncendiary
+  result: MagazinePistolSubMachineGunTopMountedIncendiary
+  materials:
+    Plastic: 310
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazinePistolSubMachineGunTopMountedUranium
+  result: MagazinePistolSubMachineGunTopMountedUranium
+  materials:
+    Plastic: 160
+    Uranium: 310
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazinePistolSubMachineGunTopMountedAP
+  result: MagazinePistolSubMachineGunTopMountedAP
+  materials:
+    Plastic: 150
+    Steel: 150
+    Uranium: 300
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
   id: MagazinePistolSubMachineGunUzi
   result: MagazinePistolSubMachineGunUzi
   materials:

--- a/Resources/Prototypes/_StarLight/Research/arsenal.yml
+++ b/Resources/Prototypes/_StarLight/Research/arsenal.yml
@@ -77,6 +77,7 @@
   - MagazineBoxLightRifleAP
   - MagazineDMRAP
   - MagazinePistolSubMachineGunAP
+  - MagazinePistolSubMachineGunTopMountedAP
   radioChannels:
   - Security
   


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
fixes a oversight

## Why we need to add this
adds the missing mag types for the different ammo research
## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: Scarlet Lightweaver
- add: Added mag types for the wt550 that has been missing for too long
- remove: removed Herobrine.