### PR TITLE
Fix Borgs losing Syndicate Radio when switching chassis type

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -26,10 +26,8 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
         TryComp(ent, out ActiveRadioComponent? activeRadio);
 
         string[] radioChannels = [.. ent.Comp.InherentRadioChannels, .. prototype.RadioChannels,
-            //If the borg has the Syndicate channel already (emagged before picking a chassis), they should not lose it when picking a chassis.
             .. (transmitter != null && transmitter.Channels.Contains("Syndicate")) || (activeRadio != null && activeRadio.Channels.Contains("Syndicate"))
-                ? new[] { "Syndicate" }
-                : []];
+                ? new[] { "Syndicate" } : []]; //If the borg has the Syndicate channel already (emagged before picking a chassis), they should not lose it when picking a chassis.
         
         if (transmitter != null)
         {

--- a/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.Inventory;
 using Content.Shared.Inventory;
+using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
 using Content.Shared.Silicons.Borgs;
 using Content.Shared.Silicons.Borgs.Components;
@@ -22,14 +23,23 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
 
         // Assign radio channels
         //Starlight begin
-        string[] radioChannels = [.. ent.Comp.InherentRadioChannels, .. prototype.RadioChannels];
-        if (TryComp(ent, out IntrinsicRadioTransmitterComponent? transmitter))
+        TryComp(ent, out IntrinsicRadioTransmitterComponent? transmitter);
+        TryComp(ent, out ActiveRadioComponent? activeRadio);
+        
+
+        string[] radioChannels = [.. ent.Comp.InherentRadioChannels, .. prototype.RadioChannels,
+            //If the borg has the Syndicate channel already (emagged before picking a chassis), they should not lose it when picking a chassis.
+            .. ((transmitter != null && transmitter.Channels.Contains("Syndicate")) || (activeRadio != null && activeRadio.Channels.Contains("Syndicate"))
+                ? new[] { "Syndicate" }
+                : [])];
+        
+        if (transmitter != null)
         {
             transmitter.Channels = [.. radioChannels];
             Dirty(ent.Owner, transmitter);
         }
 
-        if (TryComp(ent, out ActiveRadioComponent? activeRadio))
+        if (activeRadio != null)
         {
             activeRadio.Channels = [.. radioChannels];
             Dirty(ent.Owner, activeRadio);

--- a/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Server.Inventory;
 using Content.Shared.Inventory;
-using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
 using Content.Shared.Silicons.Borgs;
 using Content.Shared.Silicons.Borgs.Components;
@@ -25,13 +24,12 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
         //Starlight begin
         TryComp(ent, out IntrinsicRadioTransmitterComponent? transmitter);
         TryComp(ent, out ActiveRadioComponent? activeRadio);
-        
 
         string[] radioChannels = [.. ent.Comp.InherentRadioChannels, .. prototype.RadioChannels,
             //If the borg has the Syndicate channel already (emagged before picking a chassis), they should not lose it when picking a chassis.
-            .. ((transmitter != null && transmitter.Channels.Contains("Syndicate")) || (activeRadio != null && activeRadio.Channels.Contains("Syndicate"))
+            .. (transmitter != null && transmitter.Channels.Contains("Syndicate")) || (activeRadio != null && activeRadio.Channels.Contains("Syndicate"))
                 ? new[] { "Syndicate" }
-                : [])];
+                : []];
         
         if (transmitter != null)
         {


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Fixes a bug where emagged borgs lose their Syndicate radio if their chassis type changes.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
When traitor roboticists are ordered to make a new chassis for a borg that's gone rogue, they will often want to emag them again, typically immediately upon inserting the brain. Picking a chassis type overwrites all radio channels with new channels specific to that chassis, and so the borgs would lose the Syndicate radio. This change checks if they had Syndicate radio before, and if so, adds it to their list of new radio channels.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/8a1bc93a-76b0-499c-88d0-51e90e5b5921


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Ohelig
- fix: Fixes a bug where borgs lose Syndicate radio if emagged before they choose a chassis type.
