### PR TITLE
Nuke player labels 2

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -35,6 +35,7 @@
     - SpiderCraft
     - AnomalyHost
     - Arachnid
+    - NotLabelable # Starlight
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -232,6 +232,7 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
+    - NotLabelable # Starlight, no more labeling people. 
   - type: ActiveInputMover # Starlight
   # Starlight Start: Social Interactions
   - type: PhysicalSocialInteractionGiver

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -22,6 +22,7 @@
     - DoorBumpOpener
     - AnomalyHost
     - Diona
+    - NotLabelable # Starlight
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -30,6 +30,7 @@
   - type: Tag
     tags:
     - Unimplantable # _Starlight
+    - NotLabelable # Starlight
   - type: MobState
   - type: MobThresholds
     thresholds:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Player/abductor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Player/abductor.yml
@@ -11,6 +11,7 @@
       - AbductorScientist
       - CanPilot
       - CantBecomeRevolutionary
+      - NotLabelable
       
 - type: entity
   name: abductor scientist

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Player/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Player/shadekin.yml
@@ -25,3 +25,4 @@
     - DoorBumpOpener
     - AnomalyHost
     - CantBecomeRevolutionary
+    - NotLabelable

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Player/terminator.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Player/terminator.yml
@@ -128,6 +128,7 @@
   - MobCombat
   - MobDamageable
   - MobSiliconBase
+  - BaseSpeciesPickupableLarge # Well, it is big
   id: MobTerminatorEndoskeleton
   # you are now valid
   name: nt-800 "exterminator" endoskeleton
@@ -211,6 +212,7 @@
     - DoorBumpOpener
     # let mind transfer on gib work
     - MindTransferTarget
+    - NotLabelable
   # muh self destruct once complete
   - type: AutoImplant
     implants:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/abductor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/abductor.yml
@@ -32,6 +32,7 @@
     - CanPilot
     - FootstepSound
     - DoorBumpOpener
+    - NotLabelable
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:


### PR DESCRIPTION
## Short description
Makes all the new carriable species no longer labelable.

## Why we need to add this
Forgot to check for #3417 with #3877.

Does not do anything for IPCs/Plasmamen, but neither of them are carriable right now anyways.

You can still label monkeys/kobolds.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: You can no longer label everyone.
- fix: You can now carry Exterminators.
