### PR TITLE
WeaponRifleLionhunter starlight-dev hotfix

### DIFF
--- a/Resources/_Starlight/migration.yml
+++ b/Resources/_Starlight/migration.yml
@@ -67,4 +67,4 @@ ShuttleGunNTSFCyerxa120mm: ShuttleGunCyerxa120mm
 WeaponRevolverSnubRevolver: null
 
 #2026-03-21
-WeaponRifleLionhunter: WeaponSniperLionhunter
+#WeaponRifleLionhunter: WeaponSniperLionhunter

--- a/Resources/_Starlight/migration.yml
+++ b/Resources/_Starlight/migration.yml
@@ -67,4 +67,4 @@ ShuttleGunNTSFCyerxa120mm: ShuttleGunCyerxa120mm
 WeaponRevolverSnubRevolver: null
 
 #2026-03-21
-#WeaponRifleLionhunter: WeaponSniperLionhunter
+#WeaponRifleLionhunter: WeaponSniperLionhunter Re-enable when Shooting 3.0 is back


### PR DESCRIPTION
## Short description
Fixes a FAIL to start on starlight-dev

## Why we need to add this
Migrations error from when shooting 3.0 was reverted.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Fixes WeaponRifleLionhunter migration causing a fail to launch.

