### PR TITLE
Fix unintended recursion in JobRequirements that causes test failure

### DIFF
--- a/Content.Shared/Roles/JobRequirements.cs
+++ b/Content.Shared/Roles/JobRequirements.cs
@@ -68,7 +68,7 @@ public static class JobRequirements
         ProtoId<JobPrototype> job,
         ICommonSession? player,
         IReadOnlyDictionary<string, TimeSpan>? playTimes,
-        [NotNullWhen(false)] out FormattedMessage? reason,
+        out List<FormattedMessage> reason,
         IEntityManager entManager,
         IPrototypeManager protoManager,
         HumanoidCharacterProfile? profile)
@@ -76,7 +76,7 @@ public static class JobRequirements
         if (protoManager.TryIndex(job, out var jobProto))
             return TryRequirementsMet(jobProto, player, playTimes, out reason, entManager, protoManager, profile);
 
-        reason = FormattedMessage.FromUnformatted("Failed to get job prototype");
+        reason = [FormattedMessage.FromUnformatted("Failed to get job prototype")];
         return false;
     }
 }

--- a/Content.Shared/Roles/JobRequirements.cs
+++ b/Content.Shared/Roles/JobRequirements.cs
@@ -68,7 +68,7 @@ public static class JobRequirements
         ProtoId<JobPrototype> job,
         ICommonSession? player,
         IReadOnlyDictionary<string, TimeSpan>? playTimes,
-        out List<FormattedMessage> reason,
+        out List<FormattedMessage> reason, // Starlight: List
         IEntityManager entManager,
         IPrototypeManager protoManager,
         HumanoidCharacterProfile? profile)
@@ -76,7 +76,7 @@ public static class JobRequirements
         if (protoManager.TryIndex(job, out var jobProto))
             return TryRequirementsMet(jobProto, player, playTimes, out reason, entManager, protoManager, profile);
 
-        reason = [FormattedMessage.FromUnformatted("Failed to get job prototype")];
+        reason = [FormattedMessage.FromUnformatted("Failed to get job prototype")]; // Starlight: List
         return false;
     }
 }


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

Fix unintended recursion in JobRequirements that causes test failure introduced by https://github.com/ss14Starlight/space-station-14/pull/3885.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Test failure at least, but possibly also in actual use.

The three `TryRequirementsMet` overloads originally had a call graph of `third overload -> first overload -> second overload` but my change to the method signature of _only_ the first and second made `third overload` recurse endlessly.

**Please wait for tests not to crash from the stack overflow before merging.**

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

N/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
