### PR TITLE
Pie cannons can now be used when pacified

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -104,6 +104,7 @@
     containers:
       storagebase: !type:Container
         ents: []
+  - type: PacifismAllowedGun # Starlight
 
 - type: entity
   name: experimental pie cannon


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Allows you to use pie canons when pacified.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Thieves can't use pie cannons because "it could hurt someone," but pie cannons can only load pies which don't do any damage. This is silly because they can use disablers and other stuff marked with `PacifismAllowedGun`.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="452" height="164" alt="image" src="https://github.com/user-attachments/assets/1142628b-4a12-4b5b-bfbb-ada1221655e9" />

fig. 1 - Before this PR, you couldn't fire the pie cannon when pacified.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- tweak: Pie cannons can now be used when pacified (Thieves rejoice).