### PR TITLE
No Armor Printing

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -109,20 +109,22 @@
     clothingPrototype: ClothingHeadHatHoodWinterBartender
 
 - type: entity
-  parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband, AllowSuitStorageClothing]
+  parent: ClothingOuterWinterCapUnarmored #SL Edit
   id: ClothingOuterWinterCap
   name: captain's winter coat
+  suffix: Armored #SL Edit
   components:
-  - type: Sprite
-    sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
-    layers:
-    - state: CAP-icon
-  - type: Item
-    inhandVisuals:
-      left:
-      - state: CAP-inhand-left
-      right:
-      - state: CAP-inhand-right
+  ### SL Comment Out
+  # - type: Sprite
+    # sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
+    # layers:
+    # - state: CAP-icon
+  # - type: Item
+    # inhandVisuals:
+      # left:
+      # - state: CAP-inhand-left
+      # right:
+      # - state: CAP-inhand-right
   - type: Armor
     modifiers:
       coefficients:
@@ -132,13 +134,14 @@
         Heat: 0.45
   - type: ExplosionResistance
     damageCoefficient: 0.80
-  - type: Clothing
-    sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
-    clothingVisuals:
-      outerClothing:
-      - state: CAP-equipped-OUTERCLOTHING
-  - type: ToggleableClothing
-    clothingPrototype: ClothingHeadHatHoodWinterCaptain
+  ### SL Comment Out
+  # - type: Clothing
+    # sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
+    # clothingVisuals:
+      # outerClothing:
+      # - state: CAP-equipped-OUTERCLOTHING
+  # - type: ToggleableClothing
+    # clothingPrototype: ClothingHeadHatHoodWinterCaptain
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -389,6 +392,7 @@
   parent: [ClothingOuterArmorHoS, ClothingOuterWinterCoatToggleable, BaseSecurityCommandContraband]
   id: ClothingOuterWinterHoS
   name: head of security's armored winter coat
+  suffix: Armored #SL Edit
   description: A sturdy, utilitarian winter coat designed to protect a head of security from any brig-bound threats and hypothermic events.
   components:
   - type: Sprite
@@ -403,6 +407,7 @@
   parent: [ClothingOuterWinterCoatToggleable, BaseSecurityCommandContraband]
   id: ClothingOuterWinterHoSUnarmored
   name: head of security's winter coat
+  suffix: Unarmored #SL Edit
   description: A sturdy coat, a warm coat, but not an armored coat.
   components:
   - type: Sprite
@@ -769,6 +774,7 @@
   parent: [ClothingOuterArmorWarden, ClothingOuterWinterCoatToggleable, BaseSecurityContraband]
   id: ClothingOuterWinterWarden
   name: warden's armored winter coat
+  suffix: Armored #SL Edit
   description: A sturdy, utilitarian winter coat designed to protect a warden from any brig-bound threats and hypothermic events.
   components:
   - type: Sprite
@@ -783,6 +789,7 @@
   parent: [ClothingOuterWinterCoatToggleable, BaseSecurityContraband]
   id: ClothingOuterWinterWardenUnarmored
   name: warden's winter coat
+  suffix: Unarmored #SL Edit
   description: A sturdy coat, a warm coat, but not an armored coat.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
@@ -179,7 +179,7 @@
 - type: latheRecipePack
   id: WinterCoats
   recipes:
-  - ClothingOuterWinterCap
+  - ClothingOuterWinterCapUnarmored #SL Edit
   - ClothingOuterWinterCE
   - ClothingOuterWinterCMO
   - ClothingOuterWinterHoP

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -785,8 +785,8 @@
 # Command winter coats
 - type: latheRecipe
   parent: BaseCommandCoatRecipe
-  id: ClothingOuterWinterCap
-  result: ClothingOuterWinterCap
+  id: ClothingOuterWinterCapUnarmored #SL Edit
+  result: ClothingOuterWinterCapUnarmored #SL Edit
 
 - type: latheRecipe
   parent: BaseCommandCoatRecipe

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -62,3 +62,26 @@
     priceMultiplier: 0.15
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSeniorCourier
+
+- type: entity
+  parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband, AllowSuitStorageClothing]
+  id: ClothingOuterWinterCapUnarmored
+  name: captain's winter coat, lacking the armored lining.
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
+    layers:
+    - state: CAP-icon
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: CAP-inhand-left
+      right:
+      - state: CAP-inhand-right
+  - type: Clothing
+    sprite: Clothing/OuterClothing/WinterCoats/coat.rsi
+    clothingVisuals:
+      outerClothing:
+      - state: CAP-equipped-OUTERCLOTHING
+  - type: ToggleableClothing
+    clothingPrototype: ClothingHeadHatHoodWinterCaptain

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -66,7 +66,9 @@
 - type: entity
   parent: [ClothingOuterWinterCoatToggleable, BaseCommandContraband, AllowSuitStorageClothing]
   id: ClothingOuterWinterCapUnarmored
-  name: captain's winter coat, lacking the armored lining.
+  name: captain's winter coat
+  suffix: Unarmored
+  description: A sturdy coat, a warm coat, but not an armored coat.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/WinterCoats/coat.rsi


### PR DESCRIPTION
## Short description
Swaps the Captain's Winter Coat in the Uniform Fab for an unarmored variant. 

## Why we need to add this
Every other normally-armored coat in the Uniform Fab is instead an unarmored version, see HoS and Warden, so that you can't get get a uniform fab machine board from Sci and print infinite extremely good armor. Captain was the only one that didn't follow this rule, so it's been fixed. If you want lots of armor as revs or cultists, order at cargo or use the Anvil.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Swapped the armored Captain's Winter Coat in the Uniform Fab for an unarmored version for consistency with HoS and Warden's winter coats, both of which are unarmored versions when made in the Uniform Fab. No free infinite carapice level armory, use the Anvil or Cargo if you want tons of armor.

