### PR TITLE
Access Reader to Engiborg

### DIFF
--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -59,6 +59,7 @@
     damageContainers:
     - Inorganic
     - Silicon
+  - type: ShowAccessReaderSettings
   # Starlight end
 
   # Visual


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Added the access reader from the diagnostic hud to the engi borg.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
With PR #3340 the diagnostic hud was added to the engi borg. The hud has two components: health bars for bots/borgs and an access reader for (modified) airlocks. The latter was missing.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="381" height="201" alt="Screenshot_20260327_161923" src="https://github.com/user-attachments/assets/08f1eb8e-f2e7-48fb-a0ef-524c910e4fd0" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: SiTW
- tweak: Engineering borgs now have the access reader with their hud.


