### PR TITLE
Hotfixing turbine migration

### DIFF
--- a/Resources/_Starlight/migration.yml
+++ b/Resources/_Starlight/migration.yml
@@ -54,6 +54,10 @@ CartridgeRifle: CartridgeRifleSP
 SpawnGrayXenobiologySlime: null
 CrateStarterXenobiology: null
 
+# 2026-02-04 - The great turbine rename
+Turbine: GasTurbineNormal
+TurbineSmall: GasTurbineSmall
+
 #2026-02-15
 ClothingOuterArmorSovietFlak: ClothingOuterArmorSovietPlate
 


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Phantom stinky

## Why we need to add this
Someone didn't bother to add a migration for the turbines. This broke the yorktown and anything else with a mapped turbine. So I add the migration.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.