### PR TITLE
Bee Hive/Nest and Meatroid Test Fail Fixes

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/nests.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/nests.yml
@@ -12,7 +12,7 @@
     materialComposition:
       Cloth: 100
   - type: StaticPrice
-    price: 10
+    price: 50
   - type: Damageable
     damageContainer: Inorganic
   - type: Appearance
@@ -22,7 +22,7 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
-    bodyType: Dynamic
+    bodyType: Static
     canCollide: false
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Walls/asteroid.yml
@@ -192,11 +192,6 @@
         !type:DamageTrigger
         damage: 25 # weak
       behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          FoodMeatAnomaly:
-            min: 1
-            max: 2
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: IconSmooth


### PR DESCRIPTION
## Short description
Fixes (99% sure) test failures with Bee Hives, Bee Boxes, and Meatroid Walls

## Why we need to add this
Fixing a handful of test failures that slipped the cracks.

## Media (Video/Screenshots)
No

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Fixed Bee Hives, Bee Boxes, and Meatroid Walls test failing due to Material Arbitrage Tests.
