### PR TITLE
Fixed some Astro-Tiles letting weather in.

### DIFF
--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -1989,7 +1989,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemMowedAstroGrass
-  weather: false
+  weather: false #Starlight-edit
 
 - type: tile
   id: FloorJungleAstroGrass
@@ -1999,7 +1999,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemJungleAstroGrass
-  weather: false
+  weather: false #Starlight-edit
 
 - type: tile
   parent: FloorGrassDark
@@ -2009,7 +2009,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemDarkAstroGrass
-  weather: false
+  weather: false #Starlight-edit
 
 - type: tile
   parent: FloorGrassLight
@@ -2019,7 +2019,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemLightAstroGrass
-  weather: false
+  weather: false #Starlight-edit
 
 # Ice
 - type: tile
@@ -2043,7 +2043,7 @@
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemAstroSnow
-  weather: false
+  weather: false #Starlight-edit
 
 # Asteroid Sand
 - type: tile

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -1989,6 +1989,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemMowedAstroGrass
+  weather: false
 
 - type: tile
   id: FloorJungleAstroGrass
@@ -1998,6 +1999,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemJungleAstroGrass
+  weather: false
 
 - type: tile
   parent: FloorGrassDark
@@ -2007,6 +2009,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemDarkAstroGrass
+  weather: false
 
 - type: tile
   parent: FloorGrassLight
@@ -2016,6 +2019,7 @@
   isSubfloor: false
   deconstructTools: [ Cutting ]
   itemDrop: FloorTileItemLightAstroGrass
+  weather: false
 
 # Ice
 - type: tile
@@ -2039,6 +2043,7 @@
   isSubfloor: false
   deconstructTools: [ Prying ]
   itemDrop: FloorTileItemAstroSnow
+  weather: false
 
 # Asteroid Sand
 - type: tile


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
Fixes some Astro-Tiles letting weather in, as they were not consistent with each other.
<!-- What do you propose to change with your PR? -->

## Why we need to add this
Mapping reasons. Plus, we now have midround weather with mechanical effects, so having Astro-Tiles consistently block weather is a good thing, seeing as they're mainly for indoor use. 
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
BEFORE:
<img width="308" height="598" alt="image" src="https://github.com/user-attachments/assets/7938be8b-e1b3-4795-92a3-312cd48c777f" />

AFTER:
<img width="316" height="609" alt="image" src="https://github.com/user-attachments/assets/fcd09a3d-b5d0-43a9-a77a-1c7a167a9958" />

<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Makeshift
- fix: Some Astro-Tiles no longer let weather in.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
