### PR TITLE
Security magboots no longer have shoelaces

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Shoes/magboots-security.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Shoes/magboots-security.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingShoesBootsMagBase, BaseSecurityContraband, ClothingShoesMilitaryBase]
+  parent: [ClothingShoesBootsMagBase, BaseSecurityContraband, ClothingShoesMilitaryBaseUntieable]
   id: ClothingShoesBootsMagSec
   name: security magboots
   description: A pair of standard magnetic boots, issued alongside the Security Hardsuit.


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->
Follow up for #3873 

Security magboots didn't inherit this fix.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Security magboots currently have permanently untied shoelaces, which makes the magboots super annoying to use.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="898" height="487" alt="image" src="https://github.com/user-attachments/assets/5020c786-b5ed-4672-bb1e-02d52b2a5885" />

fig. 1 - No untied shoelaces prompt when wearing security magboots. Yay.


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- fix: Security magboots no longer have shoelaces.
