### PR TITLE
Prevent cyborgs from entering debrief

### DIFF
--- a/Content.IntegrationTests/Tests/_StarLight/Access/CyborgAllAccessParityTest.cs
+++ b/Content.IntegrationTests/Tests/_StarLight/Access/CyborgAllAccessParityTest.cs
@@ -13,7 +13,7 @@ public sealed class CyborgAllAccessParityTest
     /// </summary>
     private static readonly HashSet<ProtoId<AccessLevelPrototype>> _exclusions =
     [
-        new("Debrief")
+        new("Debrief") // Borgs are not head of staff, and should not be in debrief.
     ];
 
     private static readonly ProtoId<AccessGroupPrototype> _allAccessGroup = "AllAccess";
@@ -36,7 +36,7 @@ public sealed class CyborgAllAccessParityTest
 
             var expectedCyborgTags = allAccessTags.Except(_exclusions).ToList();
 
-            var missingFromCyborg = expectedCyborgTags.Except(allAccessTags).ToList();
+            var missingFromCyborg = expectedCyborgTags.Except(cyborgAllAccessTags).ToList();
             var extraInCyborg = cyborgAllAccessTags.Except(expectedCyborgTags).ToList();
 
             using (Assert.EnterMultipleScope())

--- a/Content.IntegrationTests/Tests/_StarLight/Access/CyborgAllAccessParityTest.cs
+++ b/Content.IntegrationTests/Tests/_StarLight/Access/CyborgAllAccessParityTest.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Content.Shared.Access;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._StarLight.Access;
+
+public sealed class CyborgAllAccessParityTest
+{
+
+    /// <summary>
+    /// Accesses that AllAccess has but CyborgAllAccess does not.
+    /// </summary>
+    private static readonly HashSet<ProtoId<AccessLevelPrototype>> _exclusions =
+    [
+        new("Debrief")
+    ];
+
+    private static readonly ProtoId<AccessGroupPrototype> _allAccessGroup = "AllAccess";
+    private static readonly ProtoId<AccessGroupPrototype> _cyborgAllAccessGroup = "CyborgAllAccess";
+
+    /// <summary>
+    /// Asserts that CyborgAllAccess = AllAccess - Exclusions.
+    /// </summary>
+    [Test]
+    public async Task CyborgAllAccessEqualsAllAccessMinusExclusions()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var protoManager = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var allAccessTags = protoManager.Index(_allAccessGroup).Tags;
+            var cyborgAllAccessTags = protoManager.Index(_cyborgAllAccessGroup).Tags;
+
+            var expectedCyborgTags = allAccessTags.Except(_exclusions).ToList();
+
+            var missingFromCyborg = expectedCyborgTags.Except(allAccessTags).ToList();
+            var extraInCyborg = cyborgAllAccessTags.Except(expectedCyborgTags).ToList();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(missingFromCyborg, Is.Empty,
+                    $"Tags present in AllAccess but missing from CyborgAllAccess: " +
+                    $"[{string.Join(", ", missingFromCyborg)}]. " +
+                    $"Either add them to CyborgAllAccess in " +
+                    $"Resources/Prototypes/_Starlight/Access/misc.yml, " +
+                    $"or add them to {nameof(_exclusions)} in this test " +
+                    $"with a comment explaining why borgs should not have the access.");
+
+                Assert.That(extraInCyborg, Is.Empty,
+                    $"Tags present in CyborgAllAccess but absent from AllAccess: " +
+                    $"[{string.Join(", ", extraInCyborg)}]. " +
+                    $"Either add them to AllAccess in " +
+                    $"Resources/Prototypes/Access/misc.yml, " +
+                    $"or remove them from CyborgAllAccess.");
+            }
+
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+}

--- a/Resources/Locale/en-US/_Starlight/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_Starlight/prototypes/access/accesses.ftl
@@ -1,3 +1,4 @@
+id-card-access-level-debrief = Debrief
 id-card-access-level-magistrate = Magistrate
 id-card-access-level-ntrep = NanoTrasen Representative
 id-card-access-level-blueshield = BlueShield

--- a/Resources/Prototypes/Access/command.yml
+++ b/Resources/Prototypes/Access/command.yml
@@ -25,6 +25,7 @@
   - Magistrate
   - Ntrep
   - BlueShield
+  - Debrief # Starlight
 
 - type: accessLevel
   id: EmergencyShuttleRepealAll

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -46,7 +46,7 @@
   - Mining
   - SalvageLead
   - Mail
-  - Pirate
+  - Pirate # Adding another access? Make sure to also assign it to CyborgAllAccess.
   - Debrief # Starlight end
 
 

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -46,7 +46,8 @@
   - Mining
   - SalvageLead
   - Mail
-  - Pirate # Starlight end
+  - Pirate
+  - Debrief # Starlight end
 
 
 - type: accessGroup

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -351,7 +351,7 @@
     - NanoTrasenSilicon # starlight
   - type: Access
     groups:
-    - AllAccess
+    - CyborgAllAccess # Starlight
     tags:
     - Borg
   - type: AccessReader
@@ -411,7 +411,7 @@
     - NanoTrasenSilicon #The seemingly best fit. It was a regular NT cyborg once, after all. starlight
   - type: Access
     groups:
-    - AllAccess #Randomized access would be fun. AllAccess is the best i can think of right now that does make it too hard for it to enter the station or navigate it..
+    - CyborgAllAccess # Starlight
   - type: AccessReader
     access: [["Command"], ["Robotics"]] # Starlight
   - type: StartIonStormed

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -453,7 +453,7 @@
   - type: Actions
   - type: Access
     groups:
-    - CyborgAllAccess # Starlight
+    - AllAccess
     - Silicon
   - type: Eye
     drawFov: false

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -453,7 +453,7 @@
   - type: Actions
   - type: Access
     groups:
-    - AllAccess
+    - CyborgAllAccess # Starlight
     - Silicon
   - type: Eye
     drawFov: false

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -30,6 +30,7 @@
   - Command
   - Brig
   - Cryogenics
+  - Debrief # Starlight
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -58,6 +58,7 @@
   - Mining # Starlight
   - SalvageLead # Starlight
   - Mail # Starlight
+  - Debrief # Starlight
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -29,6 +29,7 @@
   - Cryogenics
   - GenpopEnter #starlight
   - GenpopLeave #starlight
+  - Debrief # Starlight
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -30,6 +30,7 @@
   - Cryogenics
   - Surgery # Starlight
   - Paramedic # Starlight
+  - Debrief # Starlight
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -27,6 +27,7 @@
   - Brig
   - Cryogenics
   - Robotics # Starlight
+  - Debrief # Starlight
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -36,6 +36,7 @@
   - Brigmedic
   - GenpopEnter
   - GenpopLeave
+  - Debrief # Starlight
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_Starlight/Access/command.yml
+++ b/Resources/Prototypes/_Starlight/Access/command.yml
@@ -1,0 +1,4 @@
+﻿# Separate debrief access. Given to Command members but not to Borgs to prevent 500 cyborgs from entering debrief.
+- type: accessLevel
+  id: Debrief
+  name: id-card-access-level-debrief

--- a/Resources/Prototypes/_Starlight/Access/misc.yml
+++ b/Resources/Prototypes/_Starlight/Access/misc.yml
@@ -1,3 +1,53 @@
+- type: accessGroup
+  id: CyborgAllAccess # Identical to AllAccess, minus Debrief.
+  tags:
+    - EmergencyShuttleRepealAll
+    - Captain
+    - HeadOfPersonnel
+    - ChiefEngineer
+    - ChiefMedicalOfficer
+    - HeadOfSecurity
+    - ResearchDirector
+    - Command
+    - Cryogenics
+    - Security
+    - Detective
+    - Armory
+    - Brig
+    - Lawyer
+    - Engineering
+    - Medical
+    - Quartermaster
+    - Salvage
+    - Cargo
+    - Research
+    - Service
+    - Maintenance
+    - External
+    - Janitor
+    - Theatre
+    - Bar
+    - Chemistry
+    - Kitchen
+    - Chapel
+    - Hydroponics
+    - Atmospherics
+    - GenpopEnter
+    - GenpopLeave
+    - Cadet # Starlight start
+    - Magistrate
+    - Ntrep
+    - IAA
+    - Brigmedic
+    - BlueShield
+    - Robotics
+    - Surgery
+    - Paramedic
+    - Mining
+    - SalvageLead
+    - Mail
+    - Pirate
+
 - type: accessLevel
   id: Debug1
   name: id-card-access-level-debug1

--- a/Resources/Prototypes/_Starlight/Access/misc.yml
+++ b/Resources/Prototypes/_Starlight/Access/misc.yml
@@ -34,7 +34,7 @@
     - Atmospherics
     - GenpopEnter
     - GenpopLeave
-    - Cadet # Starlight start
+    - Cadet
     - Magistrate
     - Ntrep
     - IAA

--- a/Resources/Prototypes/_Starlight/Access/misc.yml
+++ b/Resources/Prototypes/_Starlight/Access/misc.yml
@@ -1,5 +1,5 @@
 - type: accessGroup
-  id: CyborgAllAccess # Identical to AllAccess, minus Debrief.
+  id: CyborgAllAccess # Identical to AllAccess, minus Debrief. Parity ensured by CyborgAllAccessParityTest.
   tags:
     - EmergencyShuttleRepealAll
     - Captain

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
@@ -8,14 +8,6 @@
   - type: AccessReader
     access: [["Command"]]
 
-- type: entity
-  id: TurnstileDebrief
-  parent: Turnstile
-  suffix: Debrief
-  components:
-    - type: AccessReader
-      access: [["Debrief"]]
-
 # CentComm turnstiles
 
 - type: entity

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
@@ -1,4 +1,4 @@
-# Command
+# Regular turnstiles
 
 - type: entity
   id: TurnstileCommand
@@ -7,6 +7,16 @@
   components:
   - type: AccessReader
     access: [["Command"]]
+
+- type: entity
+  id: TurnstileDebrief
+  parent: Turnstile
+  suffix: Debrief
+  components:
+    - type: AccessReader
+      access: [["Debrief"]]
+
+# CentComm turnstiles
 
 - type: entity
   id: TurnstileCentComm
@@ -21,3 +31,17 @@
           map: [ "enum.TurnstileVisualLayers.Base" ]
     - type: AccessReader
       access: [["Command"]]
+
+- type: entity
+  id: TurnstileCentCommDebrief
+  parent: Turnstile
+  name: central command turnstile
+  suffix: Debrief
+  components:
+    - type: Sprite
+      sprite: _Starlight/Structures/Doors/cc-turnstile.rsi
+      layers:
+        - state: turnstile
+          map: [ "enum.TurnstileVisualLayers.Base" ]
+    - type: AccessReader
+      access: [["Debrief"]]

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
@@ -34,14 +34,9 @@
 
 - type: entity
   id: TurnstileCentCommDebrief
-  parent: Turnstile
+  parent: TurnstileCentComm
   name: central command turnstile
   suffix: Debrief
   components:
-    - type: Sprite
-      sprite: _Starlight/Structures/Doors/cc-turnstile.rsi
-      layers:
-        - state: turnstile
-          map: [ "enum.TurnstileVisualLayers.Base" ]
     - type: AccessReader
       access: [["Debrief"]]

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Law/Magistrate.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Law/Magistrate.yml
@@ -28,6 +28,7 @@
   - Maintenance
   - GenpopEnter
   - GenpopLeave
+  - Debrief
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/blueshield.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/blueshield.yml
@@ -51,6 +51,7 @@
     - Paramedic
     - Mining
     - SalvageLead
+    - Debrief
   special:
     - !type:AddImplantSpecial
       implants: [MindShieldImplant]

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/nanotrasenrepresentative.yml
@@ -46,6 +46,7 @@
     - Brigmedic
     - Surgery
     - Paramedic
+    - Debrief
   special:
     - !type:AddImplantSpecial
       implants: [MindShieldImplant]

--- a/Resources/Prototypes/_Starlight/borg_types.yml
+++ b/Resources/Prototypes/_Starlight/borg_types.yml
@@ -156,7 +156,7 @@
   - Command
   - Science
   - Law
-  
+
   addComponents:
   - type: Access
     groups:

--- a/Resources/Prototypes/_Starlight/borg_types.yml
+++ b/Resources/Prototypes/_Starlight/borg_types.yml
@@ -156,6 +156,13 @@
   - Command
   - Science
   - Law
+  
+  addComponents:
+  - type: Access
+    groups:
+    - CyborgAllAccess
+    tags:
+    - Debrief
 
   # Visual
   inventoryTemplateId: borgTall

--- a/Resources/Prototypes/_Starlight/borg_types.yml
+++ b/Resources/Prototypes/_Starlight/borg_types.yml
@@ -162,6 +162,7 @@
     groups:
     - CyborgAllAccess
     tags:
+    - Borg
     - Debrief
 
   # Visual


### PR DESCRIPTION
<!-- IT'S NOT WIZDENS REPO, IF YOU WANT TO ADD YOUR CHANGES ON ALL SERVERS, CREATE PR TO WIZDENS REPO -->

## Short description
<!-- What do you propose to change with your PR? -->

- Adds Debrief access
- Gives Debrief access to all heads of staff
- Gives only Purrfus-type cyborgs Debrief access
- Adds Debrief-access turnstile mapping prototypes

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

**Short version:** Cyborgs are not heads of staff and do not belong in debrief.

Long version: https://discord.com/channels/1272545509562777621/1488339298053783783

Key excerpt from long version:

> For a while now, I've notice something that really irks me in a manner, Cyborgs, tiding in the debrief room (usually either subverted or just being annoying) saying things like "Glory to the Syndicate" and bringing unauthorized personnel into the debriefing room. While i feel like this would be fine on Delta....
>
> **This is not something i would like to see on Alpha or Beta, in a MRP environment.**

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Crew

https://github.com/user-attachments/assets/e46d56e7-179d-49ea-838e-1600afad72a2

### Most cyborgs

https://github.com/user-attachments/assets/6a2c001c-edba-47d8-b76e-38d610954444

### Purrfus

https://github.com/user-attachments/assets/fcd487ba-960a-41e5-9388-da7a96f525b1


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Added Debrief access. All roles that are expected in debrief get this by default. Purrfus are the only cyborgs that get this access.
