### PR TITLE
Jobicon to Job spawners

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
@@ -32,7 +32,11 @@
   parent: SpawnPointJobBase
   components:
   - type: Sprite
-    state: green
+    # Starlight Edit Start: Added layers and jobicon
+    layers:
+      - state: green
+      - state: jobicon
+    # Starlight Edit End: Added layers and jobicon
   - type: SpawnPoint
     spawn_type: LateJoin
 
@@ -42,7 +46,11 @@
   parent: SpawnPointJobBase
   components:
   - type: Sprite
-    state: green
+    # Starlight Edit Start: Added layers and jobicon
+    layers:
+      - state: green
+      - state: jobicon
+    # Starlight Edit End: Added layers and jobicon
   - type: SpawnPoint
     spawn_type: Job
     job_id: null # any job can spawn here
@@ -60,7 +68,7 @@
     layers:
       - state: green
       - state: qm
-
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointCargoTechnician
@@ -73,6 +81,7 @@
     layers:
       - state: green
       - state: cargo_tech
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointSalvageSpecialist
@@ -85,6 +94,7 @@
     layers:
       - state: green
       - state: salvagespecialist
+      - state: jobicon # Starlight
 
 # Civilian
 
@@ -99,6 +109,7 @@
     layers:
       - state: green
       - state: assistant
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointTechnicalAssistant
@@ -111,6 +122,7 @@
     layers:
       - state: green
       - state: technicalassistant
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointMedicalIntern
@@ -123,6 +135,7 @@
     layers:
       - state: green
       - state: medicalintern
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointSecurityCadet
@@ -135,6 +148,7 @@
     layers:
       - state: green
       - state: security_cadet
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointResearchAssistant
@@ -147,6 +161,7 @@
     layers:
       - state: green
       - state: researchassistant
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointServiceWorker
@@ -159,6 +174,7 @@
     layers:
       - state: green
       - state: serviceworker
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointBartender
@@ -171,6 +187,7 @@
     layers:
       - state: green
       - state: bartender
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointChef
@@ -183,6 +200,7 @@
     layers:
       - state: green
       - state: chef
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointBotanist
@@ -195,6 +213,7 @@
     layers:
       - state: green
       - state: botanist
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointClown
@@ -207,6 +226,7 @@
     layers:
       - state: green
       - state: clown
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointMime
@@ -219,6 +239,7 @@
     layers:
       - state: green
       - state: mime
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointChaplain
@@ -231,6 +252,7 @@
     layers:
       - state: green
       - state: chaplain
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointLibrarian
@@ -243,6 +265,7 @@
     layers:
       - state: green
       - state: librarian
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointLawyer
@@ -255,6 +278,7 @@
     layers:
       - state: green
       - state: lawyer
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointJanitor
@@ -267,6 +291,7 @@
     layers:
       - state: green
       - state: janitor
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointMusician
@@ -279,6 +304,7 @@
     layers:
       - state: green
       - state: musician
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointBorg
@@ -294,6 +320,7 @@
       state: borg
     - sprite: Mobs/Silicon/Chassis/generic.rsi
       state: borg_e
+    - state: jobicon # Starlight
 
 # Command
 
@@ -308,6 +335,7 @@
     layers:
       - state: green
       - state: captain
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointHeadOfPersonnel
@@ -320,6 +348,7 @@
     layers:
       - state: green
       - state: hop
+      - state: jobicon # Starlight
 
 # Engineering
 
@@ -334,6 +363,7 @@
     layers:
       - state: green
       - state: ce
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointStationEngineer
@@ -346,6 +376,7 @@
     layers:
       - state: green
       - state: engineer
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointAtmos
@@ -358,6 +389,7 @@
     layers:
       - state: green
       - state: atmospherics
+      - state: jobicon # Starlight
 
 # Medical
 
@@ -372,6 +404,7 @@
     layers:
       - state: green
       - state: cmo
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointMedicalDoctor
@@ -384,6 +417,7 @@
     layers:
       - state: green
       - state: doctor
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointParamedic
@@ -396,6 +430,7 @@
     layers:
       - state: green
       - state: paramedic
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointChemist
@@ -408,6 +443,7 @@
     layers:
       - state: green
       - state: chemist
+      - state: jobicon # Starlight
 
 # Science
 
@@ -422,6 +458,7 @@
     layers:
       - state: green
       - state: rd
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointScientist
@@ -434,6 +471,7 @@
     layers:
       - state: green
       - state: scientist
+      - state: jobicon # Starlight
 
 # Security
 
@@ -448,6 +486,7 @@
     layers:
       - state: green
       - state: hos
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointWarden
@@ -460,6 +499,7 @@
     layers:
       - state: green
       - state: warden
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointSecurityOfficer
@@ -472,6 +512,7 @@
     layers:
       - state: green
       - state: security_officer
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointDetective
@@ -484,6 +525,7 @@
     layers:
       - state: green
       - state: detective
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointBrigmedic
@@ -496,6 +538,7 @@
     layers:
       - state: green
       - state: brigmedic
+      - state: jobicon # Starlight
 
 # SPECIAL
 # ERT
@@ -510,6 +553,7 @@
     layers:
       - state: green
       - state: ertleader
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointERTChaplain
@@ -522,6 +566,7 @@
     layers:
       - state: green
       - state: chaplain
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointERTEngineer
@@ -534,6 +579,7 @@
     layers:
       - state: green
       - state: ertengineer
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointERTMedical
@@ -546,6 +592,7 @@
     layers:
       - state: green
       - state: ertmedical
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointERTSecurity
@@ -558,6 +605,7 @@
     layers:
       - state: green
       - state: ertsecurity
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointERTJanitor
@@ -570,6 +618,7 @@
     layers:
       - state: green
       - state: ertjanitor
+      - state: jobicon # Starlight
 
 # STATION SPECIFIC
 
@@ -584,6 +633,7 @@
     layers:
       - state: green
       - state: reporter
+      - state: jobicon # Starlight
 
 - type: entity
   id: SpawnPointPsychologist
@@ -596,3 +646,4 @@
     layers:
       - state: green
       - state: psychologist
+      - state: jobicon # Starlight

--- a/Resources/Prototypes/_Starlight/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Markers/Spawners/jobs.yml
@@ -190,4 +190,3 @@
       - state: green
       - state: nct
       - state: jobicon
-      - state: jobicon

--- a/Resources/Prototypes/_Starlight/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Markers/Spawners/jobs.yml
@@ -9,6 +9,7 @@
     layers:
       - state: green
       - state: roboticist
+      - state: jobicon
 
 - type: entity
   id: SpawnPointMagistrate
@@ -78,6 +79,7 @@
     layers:
     - state: green
     - state: salvagelead
+    - state: jobicon
 
 - type: entity
   id: SpawnPointminingspecialist
@@ -91,6 +93,7 @@
     layers:
       - state: green
       - state: miningspecialist
+      - state: jobicon
 
 - type: entity
   id: SpawnPointmailtech
@@ -159,6 +162,7 @@
     layers:
       - state: green
       - state: boxer
+      - state: jobicon
 
 - type: entity
   id: SpawnPointZookeeper
@@ -171,6 +175,7 @@
     layers:
       - state: green
       - state: zookeeper
+      - state: jobicon
 
 - type: entity
   id: SpawnPointNCT
@@ -184,4 +189,5 @@
     layers:
       - state: green
       - state: nct
+      - state: jobicon
       - state: jobicon


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds jobicon over all the job spawners. I wish I didnt have to add the layer to *every* spawner but sprite is overridden on every Spawner
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Consistency and they look a bit nicer. We already had these icons on a couple of our spawners so why not add it to all of them.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="706" height="262" alt="image" src="https://github.com/user-attachments/assets/f00d96ac-9ef6-4c16-8d04-744e364b0c47" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

No changelog as its not player facing