### PR TITLE
Fix volume of Funky gas cans

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -9,18 +9,11 @@
     - state: bz # Starlight Edit: purple -> bz
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 1871.71051 # BZ
+        BZ: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -58,19 +51,11 @@
     - state: healium
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 0 # BZ
-      - 1871.71051 # Healium
+        Healium: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -108,20 +93,11 @@
     - state: nitrium # Starlight Edit: brown -> nitrium
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 0 # BZ
-      - 0 # Healium
-      - 1871.71051 # Nitrium
+        Nitrium: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -159,21 +135,11 @@
     - state: pluoxium # Starlight Edit: darkblue -> pluoxium
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 0 # BZ
-      - 0 # Healium
-      - 0 # Nitrium
-      - 1871.71051 # Pluoxium
+        Pluoxium: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -211,22 +177,11 @@
     - state: hydrogen # Starlight Edit: white -> hydrogen
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 0 # BZ
-      - 0 # Healium
-      - 0 # Nitrium
-      - 0 # Pluoxium
-      - 1871.71051 # Hydrogen
+        Hydrogen: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -264,23 +219,11 @@
     - state: hyper_noblium # Starlight Edit: nob -> hyper_noblium
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 0 # BZ
-      - 0 # Healium
-      - 0 # Nitrium
-      - 0 # Pluoxium
-      - 0 # Hydrogen
-      - 1871.71051 # HyperNoblium
+        HyperNoblium: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -318,24 +261,11 @@
     - state: proto_nitrate
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 0 # BZ
-      - 0 # Healium
-      - 0 # Nitrium
-      - 0 # Pluoxium
-      - 0 # Hydrogen
-      - 0 # HyperNoblium
-      - 1871.71051 # ProtoNitrate
+        ProtoNitrate: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -373,25 +303,11 @@
     - state: zauker
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 0 # BZ
-      - 0 # Healium
-      - 0 # Nitrium
-      - 0 # Pluoxium
-      - 0 # Hydrogen
-      - 0 # HyperNoblium
-      - 0 # ProtoNitrate
-      - 1871.71051 # Zauker
+        Zauker: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -429,26 +345,11 @@
     - state: halon
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 0 # BZ
-      - 0 # Healium
-      - 0 # Nitrium
-      - 0 # Pluoxium
-      - 0 # Hydrogen
-      - 0 # HyperNoblium
-      - 0 # ProtoNitrate
-      - 0 # Zauker
-      - 1871.71051 # Halon
+        Halon: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -487,27 +388,11 @@
     - state: helium
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 0 # BZ
-      - 0 # Healium
-      - 0 # Nitrium
-      - 0 # Pluoxium
-      - 0 # Hydrogen
-      - 0 # HyperNoblium
-      - 0 # ProtoNitrate
-      - 0 # Zauker
-      - 0 # Halon
-      - 1871.71051 # Helium
+        Helium: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:
@@ -545,28 +430,11 @@
     - state: anti_noblium # Starlight Edit: antinob -> anti_noblium
   - type: GasCanister
     gasMixture:
-      volume: 1000
+    # Starlight-start: Canister volume
+      volume: 1500
       moles:
-      - 0 # Oxygen
-      - 0 # Nitrogen
-      - 0 # CO2
-      - 0 # Plasma
-      - 0 # Tritium
-      - 0 # Water vapor
-      - 0 # Miasma
-      - 0 # N2O
-      - 0 # Frezon
-      - 0 # BZ
-      - 0 # Healium
-      - 0 # Nitrium
-      - 0 # Pluoxium
-      - 0 # Hydrogen
-      - 0 # HyperNoblium
-      - 0 # ProtoNitrate
-      - 0 # Zauker
-      - 0 # Halon
-      - 0 # Helium
-      - 1871.71051 # AntiNoblium
+        AntiNoblium: 2769.36
+    # Starlight-end
       temperature: 293.15
   - type: Destructible
     thresholds:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Changes:
- Increased the volume of the canisters for the Funky-originating gases (BZ, Healium, …) from 1000 L to 1500 L (the standard gas can volume)
- Increased the standard fill value of canisters for the Funky-originating gases from 1871.71 mol to 2769.36 mol (the standard filling amount for 4500 kPa)

Gameplay effects:
- Funky gas cans will fit 50% more gas per kPa (thus matching the non-Funky cans). Currently the only way to get those cans is through Cargo or Salvage.
- BZ cans ordered through Cargo will contain 50% more BZ. As a result, their resale value has gone up from 2446.05 spesos to 3523.23 spesos, which is still solidly below the buying price of 6000 spesos.
- Cans of Funky gases received from Salvage will contain 50% more gas and will be ~50% more profitable when sold.

Testing:
- Spawned in all gas canisters and checked their volume and gas amount
- Bought a BZ canister and checked its volume and gas amount
- Spawned Salvage Canisters and checked their volume and gas amount

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Funky Station uses a standard volume of [1000 L for gas cans](https://github.com/funky-station/funky-station/blob/824e35d2e2305be3dc2b2503a564ab89ec6d246a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml#L295), while Starlight (and Forky Station) use 1500 L. During the port of the gases [from Funky to Forky](https://github.com/funky-station/forky-station/pull/14) the can volumes were not adjusted, and this was then carried over in the port [from Forky to Starlight](https://github.com/ss14Starlight/space-station-14/pull/2983). The empty can variants (that were added on the Starlight side as part of the port) already have the correct volume of 1500 L.

This discrepancy was visible when ordering BZ from Cargo or when receiving cans from Salvage – all of these cans came with 1000 L rather than 1500 L and 33% less gas than expected. Repainting non-Funky cans to Funky colors did not change the volume, so the problem was not visible that way.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
A standard BZ can previously:
<img width="523" height="606" alt="BZ-1000L" src="https://github.com/user-attachments/assets/49e5ef5f-0bce-40d7-a33e-e7a959f54558" />
A standard BZ can with this PR:
<img width="516" height="603" alt="BZ-1500L" src="https://github.com/user-attachments/assets/d40aa4e9-a386-48c2-9fa2-95a0164e07fb" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: JMxm5
- fix: Increased canister volume of the Funky-originating gases (BZ, Healium, …) from 1000 L to 1500 L to match the Starlight standard.
