### PR TITLE
Hot-Fixed Repairable for Mechs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -91,8 +91,9 @@
   - type: MechAir
   - type: DoAfter
   - type: Repairable
-    fuelCost: 25
-    doAfterDelay: 10
+    damageValue: -30 # 15 seconds to repair durand
+    doAfterDelay: 1
+    fuelCost: 3 # 3x more expensive than cyborg repair costing 70u for durand
   - type: UserInterface
     interfaces:
       enum.MechUiKey.Key:
@@ -734,10 +735,6 @@
   - type: Damageable
     damageModifierSet: DurandArmor
   - type: MechThrusters
-  - type: Repairable
-    damageValue: -30 # 15 seconds to repair durand
-    doAfterDelay: 1
-    fuelCost: 3 # 3x more expensive than cyborg repair costing 70u for durand
   - type: PointLight
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
@@ -800,9 +797,6 @@
   - type: Damageable
     damageModifierSet: HeavyArmorNT
   - type: MechThrusters
-  - type: Repairable
-    fuelCost: 30
-    doAfterDelay: 15
 
 - type: entity
   id: MechMarauderBattery
@@ -874,9 +868,6 @@
   - type: Damageable
     damageModifierSet: HeavyArmorNT
   - type: MechThrusters
-  - type: Repairable
-    fuelCost: 30
-    doAfterDelay: 20
 
 - type: entity
   id: MechSeraphBattery
@@ -951,9 +942,6 @@
   - type: Damageable
     damageModifierSet: MediumArmorSyndi
   - type: MechThrusters
-  - type: Repairable
-    fuelCost: 40
-    doAfterDelay: 20
   - type: PointLight
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
@@ -1031,9 +1019,6 @@
   - type: Damageable
     damageModifierSet: MaulerArmor
   - type: MechThrusters
-  - type: Repairable
-    fuelCost: 50
-    doAfterDelay: 25
   - type: PointLight
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true


### PR DESCRIPTION
## Short description
This adds Repairable as a base value to all mechs using BaseMech prototype

No CL - Hotfix, should be apart of https://github.com/ss14Starlight/space-station-14/pull/4038

## Why we need to add this
Only added the repairable change for repair overtime to the Durand by accident.

## Media (Video/Screenshots)
<img width="521" height="361" alt="image" src="https://github.com/user-attachments/assets/b90373be-4e94-4cef-bc80-c0a96e13f5c4" />

> Rough usage from 4% to 100%.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.


