### PR TITLE
Description markup command/component

### DIFF
--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -281,7 +281,7 @@ namespace Content.Client.Examine
                     continue;
 
                 var richLabel = new RichTextLabel() { Margin = new Thickness(4, 4, 0, 4)};
-                richLabel.SetMessage(message);
+                richLabel.SetMessage(message, null, null); // Starlight-edit: allow more markup in examine tooltips. Sanitize them elsewhere.
                 vBox.AddChild(richLabel);
                 break;
             }

--- a/Content.Server/_Starlight/Markup/MarkupCommand.cs
+++ b/Content.Server/_Starlight/Markup/MarkupCommand.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Content.Server.Administration;
+using Content.Shared._Starlight.Markup.Components;
+using Content.Shared.Administration;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server._Starlight.Markup;
+
+[ToolshedCommand]
+[AdminCommand(AdminFlags.Fun)]
+public sealed class MarkupCommand : ToolshedCommand
+{
+    private MarkupTextSystem? _markup;
+
+    [CommandImplementation("adddesc")]
+    public EntityUid AddDescription(IInvocationContext ctx, [PipedArgument] EntityUid uid, string id, string text)
+    {
+        EnsureDescriptionComp(uid, out var comp);
+        if (comp.Texts.Any(kvp => kvp.Key == id))
+        {
+            ctx.WriteLine($"A description text with the id {id} already exists on the entity {uid}.");
+            return uid;
+        }
+        _markup?.AddDescriptionText((uid, comp), id, text);
+        ctx.WriteLine($"Added text with id {id} to {uid}'s description.");
+        return uid;
+    }
+
+    [CommandImplementation("editdesc")]
+    public EntityUid EditDescription(IInvocationContext ctx, [PipedArgument] EntityUid uid, string id, string text)
+    {
+        EnsureDescriptionComp(uid, out var comp);
+        if (comp.Texts.All(kvp => kvp.Key != id))
+        {
+            ctx.WriteLine($"No description text with the id {id} exists on the entity {uid}.");
+            return uid;
+        }
+        _markup?.EditDescriptionText((uid, comp), id, text);
+        ctx.WriteLine($"Updated text with id {id} in {uid}'s description.");
+        return uid;
+    }
+
+    [CommandImplementation("rmdesc")]
+    public EntityUid RemoveDescription(IInvocationContext ctx, [PipedArgument] EntityUid uid, string id)
+    {
+        EnsureDescriptionComp(uid, out var comp);
+        if (comp.Texts.All(kvp => kvp.Key != id))
+        {
+            ctx.WriteLine($"No description text with the id {id} exists on the entity {uid}.");
+            return uid;
+        }
+        _markup?.RemoveDescriptionText((uid, comp), id);
+        ctx.WriteLine($"Removed text with id {id} from {uid}'s description.");
+        return uid;
+    }
+
+    [CommandImplementation("cleardesc")]
+    public EntityUid ClearDescription(IInvocationContext ctx, [PipedArgument] EntityUid uid)
+    {
+        EnsureDescriptionComp(uid, out var comp);
+        _markup?.ClearDescriptionText((uid, comp));
+        ctx.WriteLine($"Cleared all additional markup text from {uid}'s description.");
+        return uid;
+    }
+
+    [CommandImplementation("adddesc")]
+    public IEnumerable<EntityUid> AddDescription(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid,
+        string id, string text) =>
+        uid.Select(x => AddDescription(ctx, x, id, text));
+
+    [CommandImplementation("editdesc")]
+    public IEnumerable<EntityUid> EditDescription(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid,
+        string id, string text) =>
+        uid.Select(x => EditDescription(ctx, x, id, text));
+
+    [CommandImplementation("rmdesc")]
+    public IEnumerable<EntityUid> RemoveDescription(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid,
+        string id) =>
+        uid.Select(x => RemoveDescription(ctx, x, id));
+
+    [CommandImplementation("cleardesc")]
+    public IEnumerable<EntityUid>
+        ClearDescription(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid) =>
+        uid.Select(x => ClearDescription(ctx, x));
+
+    private void EnsureDescriptionComp(EntityUid uid, out MarkupDescriptionComponent comp)
+    {
+        _markup ??= EntitySystemManager.GetEntitySystem<MarkupTextSystem>();
+        comp = EnsureComp<MarkupDescriptionComponent>(uid);
+    }
+}

--- a/Content.Server/_Starlight/Markup/MarkupCommand.cs
+++ b/Content.Server/_Starlight/Markup/MarkupCommand.cs
@@ -64,6 +64,21 @@ public sealed class MarkupCommand : ToolshedCommand
         return uid;
     }
 
+    [CommandImplementation("listdesc")]
+    public EntityUid ListDescriptions(IInvocationContext ctx, [PipedArgument] EntityUid uid)
+    {
+        EnsureDescriptionComp(uid, out var comp);
+        if (comp.Texts.Count == 0)
+        {
+            ctx.WriteLine($"Entity with uid {uid} has no markup descriptions.");
+            return uid;
+        }
+        ctx.WriteLine($"Markup descriptions for entity {uid}:");
+        foreach (var kvp in comp.Texts)
+            ctx.WriteLine($"- {kvp.Key}: \"{kvp.Value.Replace("\"", "\\\"")}\"");
+        return uid;
+    }
+
     [CommandImplementation("adddesc")]
     public IEnumerable<EntityUid> AddDescription(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid,
         string id, string text) =>
@@ -83,6 +98,11 @@ public sealed class MarkupCommand : ToolshedCommand
     public IEnumerable<EntityUid>
         ClearDescription(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid) =>
         uid.Select(x => ClearDescription(ctx, x));
+
+    [CommandImplementation("listdesc")]
+    public IEnumerable<EntityUid>
+        ListDescriptions(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid) =>
+        uid.Select(x => ListDescriptions(ctx, x));
 
     private void EnsureDescriptionComp(EntityUid uid, out MarkupDescriptionComponent comp)
     {

--- a/Content.Shared/Labels/EntitySystems/LabelSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/LabelSystem.cs
@@ -122,8 +122,8 @@ public sealed partial class LabelSystem : EntitySystem
 
             args.PushMarkup(Loc.GetString("comp-paper-label-has-label"));
             var text = paper.Content;
-            // STARLIGHT: Remove all markup for the examine text.
-            var message = FormattedMessage.FromMarkupPermissive(text.TrimEnd()).ToString();
+            // STARLIGHT: Remove MOST markup for the examine text.
+            var message = FormattedMessage.FromMarkupPermissive(text.TrimEnd()).SanitizeWhitelist(FormattedMessageSanitizer.PaperLabelTags).ToMarkup();
             args.PushMarkup(message);
         }
     }

--- a/Content.Shared/_Starlight/Markup/Components/MarkupDescriptionComponent.cs
+++ b/Content.Shared/_Starlight/Markup/Components/MarkupDescriptionComponent.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.Markup.Components;
+
+/// Pushes custom markup text to the description of the entity. Allows for using richtext tags.
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(MarkupTextSystem))]
+public sealed partial class MarkupDescriptionComponent : Component
+{
+    /// <summary>
+    /// Text that will be appended to the description of an entity on examine.
+    /// Is a dictionary so an ID can be assigned to it, primarily for toolshed.
+    /// </summary>
+    [DataField, AutoNetworkedField] public Dictionary<string, string> Texts = [];
+}

--- a/Content.Shared/_Starlight/Markup/MarkupTextSystem.cs
+++ b/Content.Shared/_Starlight/Markup/MarkupTextSystem.cs
@@ -1,0 +1,47 @@
+using Content.Shared.Examine;
+
+namespace Content.Shared._Starlight.Markup.Components;
+
+public sealed class MarkupTextSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MarkupDescriptionComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(Entity<MarkupDescriptionComponent> entity, ref ExaminedEvent args)
+    {
+        using (args.PushGroup("markupcomp", -1))
+            foreach (var text in entity.Comp.Texts.Values)
+                args.PushMarkup(text);
+    }
+
+    public void AddDescriptionText(Entity<MarkupDescriptionComponent> entity, string id, string text)
+    {
+        entity.Comp.Texts.Add(id, text);
+        Dirty(entity);
+   }
+
+    public void EditDescriptionText(Entity<MarkupDescriptionComponent> entity, string id, string text)
+    {
+        if (!entity.Comp.Texts.ContainsKey(id))
+            return;
+
+        entity.Comp.Texts[id] = text;
+        Dirty(entity);
+    }
+
+    public void RemoveDescriptionText(Entity<MarkupDescriptionComponent> entity, string id)
+    {
+        entity.Comp.Texts.Remove(id);
+        Dirty(entity);
+    }
+
+    public void ClearDescriptionText(Entity<MarkupDescriptionComponent> entity)
+    {
+        entity.Comp.Texts.Clear();
+        Dirty(entity);
+    }
+}

--- a/Content.Shared/_Starlight/Utility/FormattedMessageSanitizer.cs
+++ b/Content.Shared/_Starlight/Utility/FormattedMessageSanitizer.cs
@@ -13,6 +13,12 @@ public static class FormattedMessageSanitizer
      */
     public static string[] ItemLabelTags = new[] { "color", "bold", "bolditalic", "italic", "mono" };
 
+    public static string[] PaperLabelTags =
+        new[]
+        {
+            "color", "bold", "bolditalic", "italic", "mono", "icon", "scramble", "font", "head", "bullet" //, "slogo", "cclogo", "logo" <- uncomment once these don't break and make text go out of bounds of the examine textbox
+        };
+
     /// <summary>
     /// Sanitize the given message using a whitelist, allowing only explicitly permitted tags and/or raw text.
     /// </summary>

--- a/Resources/Locale/en-US/_Starlight/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/_Starlight/commands/toolshed-commands.ftl
@@ -302,4 +302,6 @@ command-description-markup-editdesc =
 command-description-markup-rmdesc =
     Remove a line of markup text from the piped entity's description with the given ID.
 command-description-markup-cleardesc =
-    Clears all additional lines of markup text from the piped entity's description..
+    Clears all additional lines of markup text from the piped entity's description.
+command-description-markup-listdesc =
+    Lists all description markup texts on the entity and their IDs.

--- a/Resources/Locale/en-US/_Starlight/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/_Starlight/commands/toolshed-commands.ftl
@@ -304,4 +304,4 @@ command-description-markup-rmdesc =
 command-description-markup-cleardesc =
     Clears all additional lines of markup text from the piped entity's description.
 command-description-markup-listdesc =
-    Lists all description markup texts on the entity and their IDs.
+    Lists all description markup texts on the piped entity and their IDs.

--- a/Resources/Locale/en-US/_Starlight/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/_Starlight/commands/toolshed-commands.ftl
@@ -295,3 +295,11 @@ command-description-aitakeover =
     Make the piped entity take over the target AI core.
 command-description-mobthreshold-initialize =
     Properly initializes a new mob threshold onto an entity.
+command-description-markup-adddesc =
+    Add markup text to the piped entity's description with the given ID.
+command-description-markup-editdesc =
+    Edit a line of markup text from the piped entity's description with the given ID.
+command-description-markup-rmdesc =
+    Remove a line of markup text from the piped entity's description with the given ID.
+command-description-markup-cleardesc =
+    Clears all additional lines of markup text from the piped entity's description..


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds new system, component, and associated toolshed command for adding markup text to an entity's tooltip description.
commands are as follows:
- `markup:adddesc` - Add markup text to the piped entity's description with the given ID.
  - Must pipe in an entity or list of entities, accepts ID and text to add.
- `markup:editdesc` - Edit a line of markup text from the piped entity's description with the given ID.
  - Must pipe in an entity or list of entities, accepts ID of the text to edit and the replacement text.
- `markup:rmdesc` - Remove a line of markup text from the piped entity's description with the given ID.
  - Must pipe in an entity or list of entities, accepts ID to remove.
- `markup:cleardesc` - Clears all additional lines of markup text from the piped entity's description.
  - Must pipe in an entity or list of entities, accepts no parameters.
- `markup:listdesc` - Lists all description markup texts on the piped entity and their IDs.
  - Must pipe in an entity or list of entities, accepts no parameters.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Admeme shenanigans. Prototypers can also use this to add special text to an entity's tooltip description without needing a custom system for it.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="344" height="157" alt="image" src="https://github.com/user-attachments/assets/39e5f46e-d4de-4f4c-b344-843d0e45fc86" />
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.