### PR TITLE
Revert+fix testfail regarding allow profile override

### DIFF
--- a/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
+++ b/Content.Client/Humanoid/HumanoidAppearanceSystem.cs
@@ -26,10 +26,16 @@ public sealed class HumanoidAppearanceSystem : SharedHumanoidAppearanceSystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<HumanoidAppearanceComponent, MapInitEvent>(OnMapInit); // Starlight
         SubscribeLocalEvent<HumanoidAppearanceComponent, AfterAutoHandleStateEvent>(OnHandleState);
         Subs.CVar(_configurationManager, CCVars.AccessibilityClientCensorNudity, OnCvarChanged, true);
         Subs.CVar(_configurationManager, CCVars.AccessibilityServerCensorNudity, OnCvarChanged, true);
     }
+
+    //Starlight begin
+    private void OnMapInit(Entity<HumanoidAppearanceComponent> entity, ref MapInitEvent ev) =>
+        UpdateSprite((entity, entity.Comp, Comp<SpriteComponent>(entity)));
+    //Starlight end
 
     private void OnHandleState(EntityUid uid, HumanoidAppearanceComponent component, ref AfterAutoHandleStateEvent args)
     {

--- a/Resources/Prototypes/_Starlight/Admeme/neomoth/koni.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/neomoth/koni.yml
@@ -21,7 +21,7 @@
     - type: HumanoidAppearance
       species: CatMoth
       # Set all of this shit up manually because CatMoth is not roundstart so it can't just be saved to a character yml.
-      allowProfileOverride: true # Test fix
+      allowProfileOverride: false
       gender: Female
       eyeColor: '#000000FF'
       skinColor: '#5D4AC7FF'

--- a/Resources/Prototypes/_Starlight/Admeme/neomoth/koni.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/neomoth/koni.yml
@@ -13,6 +13,8 @@
         Male: UnisexCatMoth
         Female: UnisexCatMoth
         Unsexed: UnisexCatMoth
+    - type: TextToSpeech
+      voice: ICASSP48
     - type: Body
       prototype: CatMoth
     - type: Icon


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
__Properly__ fixes `AllItemsHaveSpritesTest` fail caused by `MobKoni` without breaking the prototype in the process.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The original testfail fix was lazy and broke the prototype in a different way.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.