### PR TITLE
Add intangible projectile support to ProjectileSystem, apply to (anti)particles

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -73,7 +73,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
 
             component.ProjectileSpent = !TryPenetrate((uid, component), damage, damageRequired);
         }
-        else
+        else if (component.ParticleType == ParticleType.Solid) // Starlight
         {
             component.ProjectileSpent = true;
         }
@@ -95,7 +95,8 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             //Starlight end
         }
 
-        if (component.DeleteOnCollide && component.ProjectileSpent)
+        if (component is { ParticleType: ParticleType.Solid, DeleteOnCollide: true, ProjectileSpent: true } // Starlight: Original logic for Solid
+            or { ParticleType: ParticleType.Intangible, DeleteOnMaximumHits: true, ProjectileSpent: true }) // Starlight: New logic for Impermanent
             QueueDel(uid);
 
         if (component.ImpactEffect != null && TryComp(uid, out TransformComponent? xform))
@@ -104,7 +105,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
         }
     }
 
-    private bool TryPenetrate(Entity<ProjectileComponent> projectile, DamageSpecifier damage, FixedPoint2 damageRequired)
+    private bool TryPenetrateSolid(Entity<ProjectileComponent> projectile, DamageSpecifier damage, FixedPoint2 damageRequired) // Starlight: Renamed, see methods below
     {
         // If penetration is to be considered, we need to do some checks to see if the projectile should stop.
         if (projectile.Comp.PenetrationThreshold == 0)
@@ -140,4 +141,26 @@ public sealed class ProjectileSystem : SharedProjectileSystem
 
         return true;
     }
+
+    #region Starlight
+    /// <summary>
+    ///     STARLIGHT: TryPenetrate for particles with the Intangible type.
+    /// </summary>
+    private bool TryPenetrateIntangible(Entity<ProjectileComponent> projectile) =>
+        ++projectile.Comp.Hits < projectile.Comp.MaximumHits;
+
+    /// <summary>
+    ///     STARLIGHT: Drop-in replacement method that disambiguates the original <see cref="TryPenetrate"/> call
+    ///     between <see cref="TryPenetrateSolid"/> and <see cref="TryPenetrateIntangible"/>.
+    /// </summary>
+    /// <param name="projectile"></param>
+    /// <param name="damage"></param>
+    /// <param name="damageRequired"></param>
+    /// <returns></returns>
+    private bool TryPenetrate(Entity<ProjectileComponent> projectile, DamageSpecifier damage,
+        FixedPoint2 damageRequired) =>
+        projectile.Comp.ParticleType == ParticleType.Solid
+            ? TryPenetrateSolid(projectile, damage, damageRequired)
+            : TryPenetrateIntangible(projectile);
+    #endregion
 }

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -73,7 +73,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
 
             component.ProjectileSpent = !TryPenetrate((uid, component), damage, damageRequired);
         }
-        else if (component.ParticleType == ParticleType.Solid) // Starlight
+        else if (component.ProjectileType == ProjectileType.Solid) // Starlight
         {
             component.ProjectileSpent = true;
         }
@@ -95,8 +95,8 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             //Starlight end
         }
 
-        if (component is { ParticleType: ParticleType.Solid, DeleteOnCollide: true, ProjectileSpent: true } // Starlight: Original logic for Solid
-            or { ParticleType: ParticleType.Intangible, DeleteOnMaximumHits: true, ProjectileSpent: true }) // Starlight: New logic for Impermanent
+        if (component is { ProjectileType: ProjectileType.Solid, DeleteOnCollide: true, ProjectileSpent: true } // Starlight: Original logic for Solid
+            or { ProjectileType: ProjectileType.Intangible, DeleteOnMaximumHits: true, ProjectileSpent: true }) // Starlight: New logic for Impermanent
             QueueDel(uid);
 
         if (component.ImpactEffect != null && TryComp(uid, out TransformComponent? xform))
@@ -144,7 +144,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
 
     #region Starlight
     /// <summary>
-    ///     STARLIGHT: TryPenetrate for particles with the Intangible type.
+    ///     STARLIGHT: TryPenetrate for projectiles with the Intangible type.
     /// </summary>
     private bool TryPenetrateIntangible(Entity<ProjectileComponent> projectile) =>
         ++projectile.Comp.Hits < projectile.Comp.MaximumHits;
@@ -153,13 +153,9 @@ public sealed class ProjectileSystem : SharedProjectileSystem
     ///     STARLIGHT: Drop-in replacement method that disambiguates the original <see cref="TryPenetrate"/> call
     ///     between <see cref="TryPenetrateSolid"/> and <see cref="TryPenetrateIntangible"/>.
     /// </summary>
-    /// <param name="projectile"></param>
-    /// <param name="damage"></param>
-    /// <param name="damageRequired"></param>
-    /// <returns></returns>
     private bool TryPenetrate(Entity<ProjectileComponent> projectile, DamageSpecifier damage,
         FixedPoint2 damageRequired) =>
-        projectile.Comp.ParticleType == ParticleType.Solid
+        projectile.Comp.ProjectileType == ProjectileType.Solid
             ? TryPenetrateSolid(projectile, damage, damageRequired)
             : TryPenetrateIntangible(projectile);
     #endregion

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -60,20 +60,21 @@ public sealed class ProjectileSystem : SharedProjectileSystem
         }
         var deleted = Deleted(target);
 
-        if (_damageableSystem.TryChangeDamage((target, damageableComponent), ev.Damage, out var damage, component.IgnoreResistances, origin: component.Shooter) && Exists(component.Shooter))
+        if (_damageableSystem.TryChangeDamage((target, damageableComponent), ev.Damage, out var damage, component.IgnoreResistances, origin: component.Shooter)) // Starlight
         {
             if (!deleted)
             {
                 _color.RaiseEffect(Color.Red, new List<EntityUid> { target }, Filter.Pvs(target, entityManager: EntityManager));
             }
 
-            _adminLogger.Add(LogType.BulletHit,
-                LogImpact.Medium,
-                $"Projectile {ToPrettyString(uid):projectile} shot by {ToPrettyString(component.Shooter!.Value):user} hit {otherName:target} and dealt {damage:damage} damage");
+            if (Exists(component.Shooter)) // Starlight
+                _adminLogger.Add(LogType.BulletHit,
+                    LogImpact.Medium,
+                    $"Projectile {ToPrettyString(uid):projectile} shot by {ToPrettyString(component.Shooter!.Value):user} hit {otherName:target} and dealt {damage:damage} damage"); // Starlight
 
             component.ProjectileSpent = !TryPenetrate((uid, component), damage, damageRequired);
         }
-        else if (component.ProjectileType == ProjectileType.Solid) // Starlight
+        else if (component.ProjectileType == ProjectileType.Solid) // Starlight: Solid projectiles are spent on first collision, even if dmg fails.
         {
             component.ProjectileSpent = true;
         }

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -72,7 +72,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
                     LogImpact.Medium,
                     $"Projectile {ToPrettyString(uid):projectile} shot by {ToPrettyString(component.Shooter!.Value):user} hit {otherName:target} and dealt {damage:damage} damage"); // Starlight
 
-            component.ProjectileSpent = !TryPenetrate((uid, component), damage, damageRequired);
+            component.ProjectileSpent = !TryPenetrateByType((uid, component), damage, damageRequired); // Starlight
         }
         else if (component.ProjectileType == ProjectileType.Solid) // Starlight: Solid projectiles are spent on first collision, even if dmg fails.
         {
@@ -106,7 +106,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
         }
     }
 
-    private bool TryPenetrateSolid(Entity<ProjectileComponent> projectile, DamageSpecifier damage, FixedPoint2 damageRequired) // Starlight: Renamed, see methods below
+    private bool TryPenetrate(Entity<ProjectileComponent> projectile, DamageSpecifier damage, FixedPoint2 damageRequired)
     {
         // If penetration is to be considered, we need to do some checks to see if the projectile should stop.
         if (projectile.Comp.PenetrationThreshold == 0)
@@ -145,19 +145,19 @@ public sealed class ProjectileSystem : SharedProjectileSystem
 
     #region Starlight
     /// <summary>
-    ///     STARLIGHT: TryPenetrate for projectiles with the Intangible type.
+    ///     TryPenetrate for projectiles with the Intangible type.
     /// </summary>
     private bool TryPenetrateIntangible(Entity<ProjectileComponent> projectile) =>
         ++projectile.Comp.Hits < projectile.Comp.MaximumHits;
 
     /// <summary>
-    ///     STARLIGHT: Drop-in replacement method that disambiguates the original <see cref="TryPenetrate"/> call
-    ///     between <see cref="TryPenetrateSolid"/> and <see cref="TryPenetrateIntangible"/>.
+    ///     Drop-in replacement method that disambiguates the call between <see cref="TryPenetrate"/> for
+    ///     Solid type particles and <see cref="TryPenetrateIntangible"/> for Intangible ones.
     /// </summary>
-    private bool TryPenetrate(Entity<ProjectileComponent> projectile, DamageSpecifier damage,
+    private bool TryPenetrateByType(Entity<ProjectileComponent> projectile, DamageSpecifier damage,
         FixedPoint2 damageRequired) =>
         projectile.Comp.ProjectileType == ProjectileType.Solid
-            ? TryPenetrateSolid(projectile, damage, damageRequired)
+            ? TryPenetrate(projectile, damage, damageRequired)
             : TryPenetrateIntangible(projectile);
     #endregion
 }

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -96,7 +96,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
         }
 
         if (component is { ProjectileType: ProjectileType.Solid, DeleteOnCollide: true, ProjectileSpent: true } // Starlight: Original logic for Solid
-            or { ProjectileType: ProjectileType.Intangible, DeleteOnMaximumHits: true, ProjectileSpent: true }) // Starlight: New logic for Impermanent
+            or { ProjectileType: ProjectileType.Intangible, DeleteOnMaximumHits: true, ProjectileSpent: true }) // Starlight: New logic for Intangible
             QueueDel(uid);
 
         if (component.ImpactEffect != null && TryComp(uid, out TransformComponent? xform))

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -118,24 +118,24 @@ public sealed partial class ProjectileComponent : Component
 
     #region Starlight
     /// <summary>
-    ///     STARLIGHT: What kind of particle this is, either solid or intangible.
+    ///     STARLIGHT: What kind of projectile this is, either solid or intangible.
     /// </summary>
     [DataField]
-    public ParticleType ParticleType = ParticleType.Solid;
+    public ProjectileType ProjectileType = ProjectileType.Solid;
 
     /// <summary>
-    ///     STARLIGHT: The amount of hits so far. Only relevant for Intangible particles.
+    ///     STARLIGHT: The amount of hits so far. Only relevant for Intangible projectiles.
     /// </summary>
     public int Hits;
 
     /// <summary>
-    ///     STARLIGHT: The maximum hits that are permissible for this particle. Only relevant for Intangible particles.
+    ///     STARLIGHT: The maximum hits that are permissible for this projectile. Only relevant for Intangible projectiles.
     /// </summary>
     [DataField]
     public int MaximumHits = 1;
 
     /// <summary>
-    ///     STARLIGHT: Whether to delete this particle when Hits >= MaximumHits. If false, the particle continues without hitting.
+    ///     STARLIGHT: Whether to delete this projectile when Hits >= MaximumHits. If false, the projectile continues without hitting.
     /// </summary>
     [DataField]
     public bool DeleteOnMaximumHits;
@@ -143,9 +143,9 @@ public sealed partial class ProjectileComponent : Component
 
 
 /// <summary>
-///     STARLIGHT: The type of particle, which determines how it's treated in terms of collision and penetration.
+///     STARLIGHT: The type of projectile, which determines how it's treated in terms of collision and penetration.
 /// </summary>
-public enum ParticleType
+public enum ProjectileType
 {
     Solid,
     Intangible

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -118,35 +118,37 @@ public sealed partial class ProjectileComponent : Component
 
     #region Starlight
     /// <summary>
-    ///     STARLIGHT: What kind of projectile this is, either solid or intangible.
+    ///     What kind of projectile this is, either solid or intangible.
     /// </summary>
     [DataField]
     public ProjectileType ProjectileType = ProjectileType.Solid;
 
     /// <summary>
-    ///     STARLIGHT: The amount of hits so far. Only relevant for Intangible projectiles.
+    ///     The amount of hits so far. Only relevant for Intangible projectiles.
     /// </summary>
     public int Hits;
 
     /// <summary>
-    ///     STARLIGHT: The maximum hits that are permissible for this projectile. Only relevant for Intangible projectiles.
+    ///     The maximum hits that are permissible for this projectile. Only relevant for Intangible projectiles.
     /// </summary>
     [DataField]
     public int MaximumHits = 1;
 
     /// <summary>
-    ///     STARLIGHT: Whether to delete this projectile when Hits >= MaximumHits. If false, the projectile continues without hitting.
+    ///     Whether to delete this projectile when Hits >= MaximumHits. If false, the projectile continues without hitting.
     /// </summary>
     [DataField]
     public bool DeleteOnMaximumHits;
     #endregion
 }
 
+#region Starlight
 /// <summary>
-///     STARLIGHT: The type of projectile, which determines how it's treated in terms of collision and penetration.
+///     The type of projectile, which determines how it's treated in terms of collision and penetration.
 /// </summary>
 public enum ProjectileType
 {
     Solid,
     Intangible
 }
+#endregion Starlight

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -115,4 +115,37 @@ public sealed partial class ProjectileComponent : Component
     /// </summary>
     [DataField]
     public FixedPoint2 PenetrationAmount = FixedPoint2.Zero;
+
+    #region Starlight
+    /// <summary>
+    ///     STARLIGHT: What kind of particle this is, either solid or intangible.
+    /// </summary>
+    [DataField]
+    public ParticleType ParticleType = ParticleType.Solid;
+
+    /// <summary>
+    ///     STARLIGHT: The amount of hits so far. Only relevant for Intangible particles.
+    /// </summary>
+    public int Hits;
+
+    /// <summary>
+    ///     STARLIGHT: The maximum hits that are permissible for this particle. Only relevant for Intangible particles.
+    /// </summary>
+    [DataField]
+    public int MaximumHits = 1;
+
+    /// <summary>
+    ///     STARLIGHT: Whether to delete this particle when Hits >= MaximumHits. If false, the particle continues without hitting.
+    /// </summary>
+    [DataField]
+    public bool DeleteOnMaximumHits;
 }
+
+
+public enum ParticleType
+{
+    Solid,
+    Intangible
+}
+
+#endregion

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -142,6 +142,9 @@ public sealed partial class ProjectileComponent : Component
 }
 
 
+/// <summary>
+///     STARLIGHT: The type of particle, which determines how it's treated in terms of collision and penetration.
+/// </summary>
 public enum ParticleType
 {
     Solid,

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -139,8 +139,8 @@ public sealed partial class ProjectileComponent : Component
     /// </summary>
     [DataField]
     public bool DeleteOnMaximumHits;
+    #endregion
 }
-
 
 /// <summary>
 ///     STARLIGHT: The type of projectile, which determines how it's treated in terms of collision and penetration.
@@ -150,5 +150,3 @@ public enum ProjectileType
     Solid,
     Intangible
 }
-
-#endregion

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -19,6 +19,9 @@
       damage:
         types:
           Radiation: 25
+      particleType: Intangible # Starlight BEGIN
+      maximumHits: 3
+      deleteOnMaximumHits: true # Starlight END
     - type: Physics
     - type: Fixtures
       fixtures:
@@ -75,9 +78,12 @@
       path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
     damage:
       types:
-        Radiation: 10
+        Radiation: 25 # Starlight: Consistency
+    particleType: Intangible # Starlight BEGIN
+    maximumHits: 3
+    deleteOnMaximumHits: true # Starlight END
   - type: TimedDespawn
     lifetime: 0.6
   - type: SinguloFood
-    energy: -10
+    energy: -30 # Starlight: Stronger
     energyFactor: 0.97

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -19,7 +19,7 @@
       damage:
         types:
           Radiation: 25
-      particleType: Intangible # Starlight BEGIN
+      projectileType: Intangible # Starlight BEGIN
       maximumHits: 3
       deleteOnMaximumHits: true # Starlight END
     - type: Physics
@@ -79,7 +79,7 @@
     damage:
       types:
         Radiation: 25 # Starlight: Consistency
-    particleType: Intangible # Starlight BEGIN
+    projectileType: Intangible # Starlight BEGIN
     maximumHits: 3
     deleteOnMaximumHits: true # Starlight END
   - type: TimedDespawn


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

- Adds proper behavior for intangible projectiles.
- Adjust (anti)particles to be intangible, hitting up to 3 targets.
- Make (anti)particles actually disappear after hitting their targets.
- Buff antiparticles from -10 energy each to -30 each.
- Make antiparticles do equivalent damage to their regular counterparts.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

### Intangible projectiles

The particles spawned by the Particle Accelerator (PA) and decelerators have a complete visual mismatch from their actual behavior.

Currently, they appear to phase through all walls and targets. Logically, one would assume this means they will hit every target they cross through. This is not the case however:

https://github.com/user-attachments/assets/faabc38e-a9b5-4ec8-9ce6-406bec57b649

The particles only try to hit the very first thing they collide with, and are inert from that point onwards. This despite their very daunting appearance and the fact that they phase through all matter.

To fix this, I made the intangible behavior a feature, and set a limited hit count before optionally being deleted. See Media.

### Buff antiparticles

Currently, antiparticles are incredibly weak. They apply -10 energy to singulo/tesla, but both of those can accumulate much larger amounts of energy in seconds. All this while the decelerator is two-handed, slows you, and has limited shots.

Here's an example video of me fighting a singularity using a decelerator, in CE hardsuit (rad immune), with jetpack for mobility. This is the absolute best possible case: and I don't really make a dent.

https://s.redmushie.me/2026/04/Content.Client_efV8hCUyvk.mp4

This above video was recorded with the change of it being -30 instead of -10 energy.

In practice, you will _usually_ try to do this with multiple people, so it's typically a bit more reasonable. (Though the movement speed and two-handedness could use a change..)

### Damage equality

Lastly, the damage for the antiparticles was adjusted to match the regular particles. They have roughly equal energy values, so they now deal equal damage. This came up in testing.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Intangible projectiles

This video flips back and forth between the new behavior and the old behavior. The blue particles are the new behavior, the red antiparticles are the old behavior:

https://github.com/user-attachments/assets/2ac74b24-d310-4b3e-971b-ea702d37f6d6

As demonstrated, the new behavior *actually* hits multiple targets instead of just looking like it will, and the particle is deleted after the last hit.

### Regular projectiles

Stuff still works.

https://github.com/user-attachments/assets/f955c592-587f-45d9-a253-c1ac9cf9e8b8

### PA emitter

Acting as expected.

https://s.redmushie.me/2026/04/Content.Client_hnH8z3XmOu.mp4


### Equal damage

Note: Normally neither the PA nor the decelerators shoot this fast; this was just for testing purposes.

https://github.com/user-attachments/assets/dff86236-7101-4b22-8280-664cd0f1a67b

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: Particles (from particle accelerator/decelerators) now hit at most three targets, and dissipate after.
- tweak: Particle decelerators now decelerate 3x as much.
- tweak: Antiparticles do equal damage to regular particles.