### PR TITLE
Fix xenoborg job icons

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -494,6 +494,8 @@
     - Xenoborg
     - Binary
   - type: BorgChassis
+    jobIconOverride: JobIconXenoborg # Starlight
+    jobTitleOverride: chat-radio-xenoborg # Starlight
     maxModules: 0
     hasMindState: robot_e
     noMindState: robot_e_r

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
@@ -23,8 +23,6 @@
       map: ["light"]
       visible: false
   - type: BorgChassis
-    jobIconOverride: JobIconXenoborg # Starlight
-    jobTitleOverride: chat-radio-xenoborg # Starlight
     maxModules: 7
     hasMindState: borg_e
     noMindState: borg_e_r

--- a/Resources/Prototypes/_Starlight/Admeme/neomoth/event/xenomoproach.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/neomoth/event/xenomoproach.yml
@@ -234,7 +234,7 @@
     - type: ActionGrant
       actions:
         - ActionViewLaws
-    - type: IntrinsicRadioReceiver
+#    - type: IntrinsicRadioReceiver // No longer required.
     - type: IntrinsicRadioTransmitter
       channels:
         - Xenoborg

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -36,6 +36,8 @@
       - Xenoborg
       - Binary
   - type: BorgChassis
+    jobIconOverride: JobIconXenoborg
+    jobTitleOverride: chat-radio-xenoborg
     maxModules: 3
     hasMindState: robot_e
     noMindState: robot_e_r

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/borgi_chassis.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/borgi_chassis.yml
@@ -256,7 +256,7 @@
         suitstorage:
           - OxygenTankFilled
         id:
-          - BorgiClearPDA
+          - XenoborgiClearPDA
         back:
           - ClothingBagPet
     - type: ItemSlots

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/pda.yml
@@ -587,6 +587,17 @@
     - DoorBumpOpener
 
 - type: entity
+  parent: ClearPDA
+  id: XenoborgiClearPDA
+  suffix: Xenoborgi
+  components:
+    - type: Pda
+      id: XenoborgiIDCard
+    - type: Tag #  Ignore Chameleon tags
+      tags:
+        - DoorBumpOpener
+
+- type: entity
   parent: ParamedicPDA
   id: SeniorParamedicPDA
   name: senior paramedic PDA

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/identification_cards.yml
@@ -370,6 +370,16 @@
     listNumber: false
 
 - type: entity
+  parent: AssistantDerelictBorgiIDCard
+  id: XenoborgiIDCard
+  name: xenoborgi ID card
+  suffix: Xenoborgi
+  components:
+    - type: IdCard
+      jobTitle: chat-radio-xenoborg
+      jobIcon: JobIconXenoborg
+
+- type: entity
   parent: IDCardStandard
   id: CentcomIDCardNTSF
   name: NTSF ID card


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Turns out basically every xenoborg was missing their job icon on comms. whoops.
Also removes intrinsic radio receiver from the xenomoproach since it is no longer required and causes doubling of comms.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Xenoborg icons cool. Normal borg icons lame. Normal borg icons on xenoborgs stupid.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Xenoborgs now use the correct job icon over comms again.
- fix: Xenoborgis now display xenoborg icon as their job on the status hud.
- fix: Xenomoproach no longer hears each comms message twice.