### PR TITLE
Fixes Monkey and Kobold taildrag

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1432,6 +1432,8 @@
     spawned:
     - id: FoodMeat
       amount: 3
+  - type: Puller
+    needsHands: false
   - type: CanHostGuardian
   - type: NPCRetaliation
     attackMemoryLength: 10


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Monkeys and Kobolds couldn't taildrag, probably due to missing components removed in this PR: https://github.com/ss14Starlight/space-station-14/pull/2063/changes#diff-e5f7ab5797419f13bc8f873f1be1e8b3219369dfdb966262ef824b08e29b3ca5L1233

I re-added the component to `MobBaseAncestor`. No `# Starlight` comments needed, as it's actually part of upstream: https://github.com/space-wizards/space-station-14/blob/master/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml#L1431

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/15a0c41d-8907-4967-a303-0a76a5e8efd6

fig. 1 - Taildragging. Tested nukeops monkeys and kobold too off-camera.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- fix: Monkeys and Kobolds can now taildrag again.