### PR TITLE
(Mapping) Directional sign snapping

### DIFF
--- a/Content.Client/DirectionalSigns/DirectionalSignSystem.cs
+++ b/Content.Client/DirectionalSigns/DirectionalSignSystem.cs
@@ -1,0 +1,105 @@
+﻿using System.Numerics;
+using Content.Shared.DirectionalSigns.Components;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Graphics;
+
+namespace Content.Client.DirectionalSigns;
+
+/// <summary>
+/// Maintains the orientation of directional signs
+/// </summary>
+/// <remarks>
+/// Maintains the orientation of directional signs relative to the player's 'eye'
+/// while keeping directional signs snapped to GRID-space cardinal directions.
+/// Keep changes to client-side sprite to avoid unnecessary network traffic.
+/// </remarks>
+public sealed class DirectionalSignSystem : EntitySystem
+{
+    [Dependency] private readonly IEyeManager _eyeManager = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
+    // Cached references to the previous loop used to check for changes
+    private IEye? _lastEye;
+    private float _lastBaseEyeRotationDeg = float.NaN;
+
+
+    public override void FrameUpdate(float frameTime)
+    {
+        // Get current eye rotation
+        // Must be made relative to GRID-space inside the while loop as some signs
+        // will be on a different grid than the player's controlled entity
+        var eye = _eyeManager.CurrentEye;
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (eye is null)
+            return;
+        var baseEyeRotationDeg = (float)eye.Rotation.Reduced().Degrees;
+
+        // Escape early if the eye attachment or its rotation haven't changed
+        // Avoids unnecessary sprite updates while allowing use of FrameUpdate to maintain smooth animation
+        // I don't know an obvious way to do this via an event, which would be ideal
+        const float epsilonDeg = 0.001f;
+        if (ReferenceEquals(eye, _lastEye) && MathF.Abs(baseEyeRotationDeg - _lastBaseEyeRotationDeg) < epsilonDeg)
+            return;
+
+        _lastEye = eye;
+        _lastBaseEyeRotationDeg = baseEyeRotationDeg;
+
+        // Loop through all directional signs and update the sprite rotation and offset
+        var query = EntityQueryEnumerator<DirectionalSignComponent, TransformComponent, SpriteComponent>();
+        while (query.MoveNext(out var uid, out _, out var signXform, out var sprite))
+        {
+            // Escape early if the sign isn't on a grid, or its grid can't be resolved
+            var gridUid = signXform.GridUid;
+            if (gridUid is null || gridUid.Value == EntityUid.Invalid)
+                continue;
+
+            // Force NoRotation, we will control rotation manually in this system
+            if (!sprite.NoRotation)
+                sprite.NoRotation = true;
+
+            // Define initial positions
+            var spriteCenter = signXform.LocalPosition;
+            var tileCenter = new Vector2(
+                MathF.Floor(spriteCenter.X) + 0.5f,
+                MathF.Floor(spriteCenter.Y) + 0.5f);
+            var spriteTileCenterOffset = spriteCenter - tileCenter;
+
+            // Correct eyeRotation for gridRotation
+            if (!TryComp(gridUid.Value, out TransformComponent? gridXform))
+                continue;
+            var gridRotationDeg = (float)gridXform.LocalRotation.Reduced().Degrees;
+            var adjustedEyeRotationDeg = baseEyeRotationDeg + gridRotationDeg;
+
+            // Define caseID based on eyeRotation: 0deg>0, 90deg>1, 180deg>2, 270deg>3
+            var caseID = ((int)MathF.Floor((adjustedEyeRotationDeg + 45) / 90) % 4 + 4) % 4;
+            var nearestCardinalDeg = caseID * 90;
+
+            // Smoothly counter-rotate within the quadrant; jump at 45° because 'nearestCardinalDeg' flips.
+            // This makes the sprites snap to GRID-space cardinals instead of following eye rotation
+            // while the eye rotation animation is in progress
+            var eyeDeltaNearestCardinalRad = Angle.FromDegrees(adjustedEyeRotationDeg - nearestCardinalDeg);
+
+            // Calculate the sprite offset vector in GRID-space
+            var o = spriteTileCenterOffset;
+            var newSpriteTileCenterOffset = caseID switch
+            {
+                0 => new Vector2( o.X,  o.Y),   // 0°
+                1 => new Vector2( o.Y, -o.X),   // 90°
+                2 => new Vector2(-o.X, -o.Y),   // 180°
+                3 => new Vector2(-o.Y,  o.X),   // 270°
+                _ => Vector2.Zero,
+            };
+
+            // GRID-space vector from current sprite center to desired sprite center.
+            var spriteOffsetGrid = newSpriteTileCenterOffset - spriteTileCenterOffset;
+            // Convert GRID-space vector into CAMERA-space vector
+            var spriteOffsetCamera = Angle.FromDegrees(adjustedEyeRotationDeg).RotateVec(spriteOffsetGrid);
+
+            // Push the values to the sprite
+            _sprite.SetRotation((uid, sprite), eyeDeltaNearestCardinalRad);
+            _sprite.SetOffset((uid, sprite), spriteOffsetCamera);
+
+        }
+    }
+}

--- a/Content.Client/Placement/Modes/AlignDirectionalSign.cs
+++ b/Content.Client/Placement/Modes/AlignDirectionalSign.cs
@@ -1,0 +1,58 @@
+﻿using System.Numerics;
+using Robust.Client.Placement;
+using Robust.Shared.Map;
+
+namespace Content.Client.Placement.Modes;
+
+/// <summary>
+/// Placement mode for directional signs that snaps them vertically to accommodate stacking.
+/// Signs are centered horizontally on tiles and snapped to 3-pixel vertical increments.
+/// </summary>
+public sealed class AlignDirectionalSign : PlacementMode
+{
+    public AlignDirectionalSign(PlacementManager pMan) : base(pMan)
+    {
+    }
+
+    /// <summary>
+    /// Aligns the sign placement by centering it horizontally and snapping it vertically
+    /// to the nearest 3-pixel increment to prevent sprite overlap and allow half-steps.
+    /// </summary>
+    public override void AlignPlacementMode(ScreenCoordinates mouseScreen)
+    {
+        MouseCoords = ScreenToCursorGrid(mouseScreen);
+        CurrentTile = GetTileRef(MouseCoords);
+
+        if (pManager.CurrentPermission!.IsTile)
+            return;
+
+        // Center horizontally on the tile
+        var x = CurrentTile.X + 0.5f;
+
+        // Vertical snapping logic
+        // Sign height is 7px. To overlap 1px borders and allow half-steps, we move in 3px steps.
+        // 3 pixels * 0.03125 (1/32m) = 0.09375m.
+        const float step = 0.09375f;
+
+        // Calculate Y relative to the center of the tile
+        var tileCenterY = CurrentTile.Y + 0.5f;
+        var relativeY = MouseCoords.Y - tileCenterY;
+
+        // Snap to the nearest 6-pixel increment
+        var snappedY = MathF.Round(relativeY / step) * step;
+
+        // Clamp so signs stay within the vertical bounds of the tile
+        // 0.375 is 12 pixels from center (allowing a 5-sign stack comfortably)
+        snappedY = Math.Clamp(snappedY, -0.375f, 0.375f);
+
+        var y = tileCenterY + snappedY;
+
+        MouseCoords = new EntityCoordinates(MouseCoords.EntityId,
+            new Vector2(x, y) + new Vector2(pManager.PlacementOffset.X, pManager.PlacementOffset.Y));
+    }
+
+    public override bool IsValidPosition(EntityCoordinates position)
+    {
+        return !pManager.CurrentPermission!.IsTile && RangeCheck(position);
+    }
+}

--- a/Content.Client/Placement/Modes/AlignDirectionalSign.cs
+++ b/Content.Client/Placement/Modes/AlignDirectionalSign.cs
@@ -38,7 +38,7 @@ public sealed class AlignDirectionalSign : PlacementMode
         var tileCenterY = CurrentTile.Y + 0.5f;
         var relativeY = MouseCoords.Y - tileCenterY;
 
-        // Snap to the nearest 6-pixel increment
+        // Snap to the nearest 3-pixel increment
         var snappedY = MathF.Round(relativeY / step) * step;
 
         // Clamp so signs stay within the vertical bounds of the tile

--- a/Content.Shared/DirectionalSigns/Components/DirectionalSignComponent.cs
+++ b/Content.Shared/DirectionalSigns/Components/DirectionalSignComponent.cs
@@ -1,0 +1,9 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.DirectionalSigns.Components;
+
+/// <summary>
+/// Component that marks a sign for sprite rotation and offset correction when the 'eye' rotates.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DirectionalSignComponent : Component;

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
@@ -12,7 +12,9 @@
   parent: BaseSign
   id: BaseSignDirectional
   abstract: true
+  placementMode: AlignDirectionalSign
   components:
+    - type: DirectionalSign
     - type: Sprite
       snapCardinals: false
 

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
@@ -12,7 +12,6 @@
   parent: BaseSign
   id: BaseSignDirectional
   abstract: true
-  placementMode: AlignDirectionalSign
   components:
     - type: DirectionalSign
     - type: Sprite


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Cherrypicks this incredibly good PR: https://github.com/space-wizards/space-station-14/pull/42622 which has been sitting open for 4 months without review.

<img width="518" height="772" alt="image" src="https://github.com/user-attachments/assets/29844b8a-efdf-47dd-a748-169fb068163f" />

This adds a placement mode for Directional signs that lets them snap to fixed increments. I cannot emphasize just how much pain mapping directional signs is without this PR. Every mapper is genuinely free-handing them (eyeballing it with no snapping) or using view variable to edit the transform component of signs manually, one by one.

As a player-facing bonus, directional signs actually work when you rotate the camera. Before this PR, they'd just all overlap if you rotated the camera +/- 90 degrees.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- Saves mappers sanity
- Saves mappers from wrist injuries
- Makes directional signs work when the camera is rotated

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/aa84482d-310a-431a-96c8-f5dfd668c881

fig. 1 - Before this PR.

https://github.com/user-attachments/assets/3d01ad95-ed34-4e8f-83a7-9cc4107c89a1

fig. 2 - After this PR.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- fix: Directional signs no longer overlap when the camera is at 90 or 270 degrees.