### PR TITLE
Fix JobTest Dispose

### DIFF
--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -69,7 +69,7 @@ public sealed class JobTest
         pair.AssertJob(Passenger);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
-        await pair.RunTicksSync(_waitAfterRestart);
+        await pair.RunTicksSync(_waitAfter);
         await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -18,6 +18,8 @@ public sealed class JobTest
 
     private static string _map = "JobTestMap";
 
+    private const int _waitAfter = 10;
+
     [TestPrototypes]
     private static readonly string JobTestMap = @$"
 - type: gameMap
@@ -62,12 +64,12 @@ public sealed class JobTest
         ticker.ToggleReadyAll(true);
         Assert.That(ticker.PlayerGameStatuses[pair.Client.User!.Value], Is.EqualTo(PlayerGameStatus.ReadyToPlay));
         await pair.Server.WaitPost(() => ticker.StartRound());
-        await pair.RunTicksSync(10);
+        await pair.RunTicksSync(_waitAfter);
 
         pair.AssertJob(Passenger);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
-        await pair.RunTicksSync(10);
+        await pair.RunTicksSync(_waitAfterRestart);
         await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
@@ -96,7 +98,7 @@ public sealed class JobTest
         );
         ticker.ToggleReadyAll(true);
         await pair.Server.WaitPost(() => ticker.StartRound());
-        await pair.RunTicksSync(10);
+        await pair.RunTicksSync(_waitAfter);
 
         pair.AssertJob(Engineer);
 
@@ -108,12 +110,12 @@ public sealed class JobTest
         );
         ticker.ToggleReadyAll(true);
         await pair.Server.WaitPost(() => ticker.StartRound());
-        await pair.RunTicksSync(10);
+        await pair.RunTicksSync(_waitAfter);
 
         pair.AssertJob(Passenger);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
-        await pair.RunTicksSync(10);
+        await pair.RunTicksSync(_waitAfter);
         await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
@@ -149,12 +151,12 @@ public sealed class JobTest
         await pair.SetJobPreferences([Passenger, Engineer, Captain]);
         ticker.ToggleReadyAll(true);
         await pair.Server.WaitPost(() => ticker.StartRound());
-        await pair.RunTicksSync(10);
+        await pair.RunTicksSync(_waitAfter);
 
         pair.AssertJob(Captain);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
-        await pair.RunTicksSync(10);
+        await pair.RunTicksSync(_waitAfter);
         await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
@@ -189,7 +191,7 @@ public sealed class JobTest
         };
 
         var engineers = (await pair.AddDummyPlayers(engJobs, 5)).ToList();
-        await pair.RunTicksSync(5);
+        await pair.RunTicksSync(_waitAfter);
         var captain = engineers[3];
         engineers.RemoveAt(3);
 
@@ -197,7 +199,7 @@ public sealed class JobTest
 
         ticker.ToggleReadyAll(true);
         await pair.Server.WaitPost(() => ticker.StartRound());
-        await pair.RunTicksSync(10);
+        await pair.RunTicksSync(_waitAfter);
 
         pair.AssertJob(Captain, captain);
         Assert.Multiple(() =>
@@ -209,7 +211,7 @@ public sealed class JobTest
         });
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
-        await pair.RunTicksSync(10);
+        await pair.RunTicksSync(_waitAfter);
         await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -44,7 +44,11 @@ public sealed class JobTest
     [Test]
     public async Task StartRoundTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { 
+            InLobby = true,
+            Connected = true,
+            DummyTicker = false
+        });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -74,7 +78,11 @@ public sealed class JobTest
     [Test]
     public async Task JobPreferenceTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { 
+            InLobby = true,
+            Connected = true,
+            DummyTicker = false
+        });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -117,7 +125,11 @@ public sealed class JobTest
     [Test]
     public async Task JobWeightTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { 
+            InLobby = true,
+            Connected = true,
+            DummyTicker = false
+        });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -153,7 +165,11 @@ public sealed class JobTest
     [Test]
     public async Task JobPriorityTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { 
+            InLobby = true,
+            Connected = true,
+            DummyTicker = false
+        });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using Content.Server.GameTicking;
@@ -11,9 +10,10 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Round;
 
 [TestFixture]
+[TestOf(typeof(SharedJobSystem))]
 public sealed class JobTest
 {
-    private static readonly ProtoId<JobPrototype> Passenger = "Assistant"; //starlight
+    private static readonly ProtoId<JobPrototype> Passenger = "Assistant";
     private static readonly ProtoId<JobPrototype> Engineer = "StationEngineer";
     private static readonly ProtoId<JobPrototype> Captain = "Captain";
 
@@ -45,12 +45,7 @@ public sealed class JobTest
     [Test]
     public async Task StartRoundTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -69,6 +64,8 @@ public sealed class JobTest
         pair.AssertJob(Passenger);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(10);
+        await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
 
@@ -78,12 +75,7 @@ public sealed class JobTest
     [Test]
     public async Task JobPreferenceTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -114,6 +106,8 @@ public sealed class JobTest
         pair.AssertJob(Passenger);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(10);
+        await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
 
@@ -124,12 +118,7 @@ public sealed class JobTest
     [Test]
     public async Task JobWeightTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -139,12 +128,8 @@ public sealed class JobTest
         var captain = pair.Server.ProtoMan.Index(Captain);
         var engineer = pair.Server.ProtoMan.Index(Engineer);
         var passenger = pair.Server.ProtoMan.Index(Passenger);
-        // starlight change https://github.com/ss14Starlight/space-station-14/pull/1109
-        //Assert.That(captain.Weight, Is.GreaterThan(engineer.Weight));
-        //Assert.That(engineer.Weight, Is.EqualTo(passenger.Weight));
 
         await pair.SetJobPriorities(
-            //starlight change https://github.com/ss14Starlight/space-station-14/pull/1109
             //essentially, weight only matters for each category now instead of globally
             (Passenger, JobPriority.Medium),
             (Engineer, JobPriority.Medium),
@@ -158,6 +143,8 @@ public sealed class JobTest
         pair.AssertJob(Captain);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(10);
+        await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
 
@@ -167,12 +154,7 @@ public sealed class JobTest
     [Test]
     public async Task JobPriorityTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            DummyTicker = false,
-            Connected = true,
-            InLobby = true
-        });
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { InLobby = true });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
         var ticker = pair.Server.System<GameTicker>();
@@ -212,6 +194,8 @@ public sealed class JobTest
         });
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(10);
+        await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -10,7 +10,6 @@ using Robust.Shared.Prototypes;
 namespace Content.IntegrationTests.Tests.Round;
 
 [TestFixture]
-[TestOf(typeof(SharedJobSystem))]
 public sealed class JobTest
 {
     private static readonly ProtoId<JobPrototype> Passenger = "Assistant";

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -44,7 +44,7 @@ public sealed class JobTest
     [Test]
     public async Task StartRoundTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { 
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
             DummyTicker = false
@@ -78,7 +78,7 @@ public sealed class JobTest
     [Test]
     public async Task JobPreferenceTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { 
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
             DummyTicker = false
@@ -125,7 +125,7 @@ public sealed class JobTest
     [Test]
     public async Task JobWeightTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { 
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
             DummyTicker = false
@@ -165,7 +165,7 @@ public sealed class JobTest
     [Test]
     public async Task JobPriorityTest()
     {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings { 
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
             DummyTicker = false


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

I checked JobTest fail and searched for the same implementation in another tests. It should wait ~10 seconds and be really idle and only then it should be clean disposed.

It doesn't have Starlight Comments now, because it's our test(I checked commits history and wizdens version, they have only 1 test in JobTests, when we're have 3 and they more complex).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Fix tests.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.