### PR TITLE
(Lobster) Removed 'Toolbox Altar' from Tools Room

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Lobster.yml
+++ b/Resources/Maps/_Starlight/Stations/Lobster.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/28/2026 23:42:54
+  time: 04/11/2026 02:42:51
   entityCount: 24908
 maps:
 - 1
@@ -9415,7 +9415,7 @@ entities:
       pos: -1.5,5.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -28275.45
+      secondsUntilStateChange: -28357.287
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9437,160 +9437,160 @@ entities:
       rot: 3.141592653589793 rad
       pos: 78.5,-24.5
       parent: 2
-  - uid: 365
+  - uid: 118
     components:
     - type: Transform
       pos: 14.5,0.5
       parent: 2
-  - uid: 366
+  - uid: 119
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 2
-  - uid: 367
+  - uid: 120
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 2
-  - uid: 370
+  - uid: 121
     components:
     - type: Transform
       pos: 17.5,-0.5
       parent: 2
-  - uid: 374
+  - uid: 122
     components:
     - type: Transform
       pos: 17.5,0.5
       parent: 2
-  - uid: 375
+  - uid: 123
     components:
     - type: Transform
       pos: 14.5,-0.5
       parent: 2
 - proto: AirlockBrigLocked
   entities:
-  - uid: 118
+  - uid: 124
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 2
-  - uid: 119
+  - uid: 125
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
-  - uid: 120
+  - uid: 126
     components:
     - type: Transform
       pos: 75.5,-21.5
       parent: 2
 - proto: AirlockCaptainLocked
   entities:
-  - uid: 121
+  - uid: 127
     components:
     - type: Transform
       pos: 0.5,49.5
       parent: 2
-  - uid: 122
+  - uid: 128
     components:
     - type: Transform
       pos: -6.5,44.5
       parent: 2
-  - uid: 123
+  - uid: 129
     components:
     - type: Transform
       pos: 3.5,46.5
       parent: 2
 - proto: AirlockCargoGlass
   entities:
-  - uid: 124
+  - uid: 130
     components:
     - type: Transform
       pos: -5.5,-28.5
       parent: 2
-  - uid: 125
+  - uid: 131
     components:
     - type: Transform
       pos: -8.5,-26.5
       parent: 2
-  - uid: 126
+  - uid: 132
     components:
     - type: Transform
       pos: -7.5,-26.5
       parent: 2
-  - uid: 127
+  - uid: 133
     components:
     - type: Transform
       pos: -10.5,-24.5
       parent: 2
 - proto: AirlockCargoGlassLocked
   entities:
-  - uid: 128
+  - uid: 134
     components:
     - type: Transform
       pos: 21.5,25.5
       parent: 2
 - proto: AirlockCargoLocked
   entities:
-  - uid: 129
+  - uid: 135
     components:
     - type: Transform
       pos: 8.5,23.5
       parent: 2
-  - uid: 130
+  - uid: 136
     components:
     - type: Transform
       pos: 14.5,25.5
       parent: 2
-  - uid: 131
+  - uid: 137
     components:
     - type: Transform
       pos: 14.5,17.5
       parent: 2
-  - uid: 132
+  - uid: 138
     components:
     - type: Transform
       pos: 19.5,23.5
       parent: 2
-  - uid: 133
+  - uid: 139
     components:
     - type: Transform
       pos: 20.5,23.5
       parent: 2
 - proto: AirlockChapelLocked
   entities:
-  - uid: 134
+  - uid: 140
     components:
     - type: Transform
       pos: -67.5,19.5
       parent: 2
-  - uid: 135
+  - uid: 141
     components:
     - type: Transform
       pos: -63.5,15.5
       parent: 2
 - proto: AirlockChemistryLocked
   entities:
-  - uid: 136
+  - uid: 142
     components:
     - type: Transform
       pos: -39.5,7.5
       parent: 2
 - proto: AirlockChiefEngineerLocked
   entities:
-  - uid: 137
+  - uid: 143
     components:
     - type: Transform
       pos: 37.5,32.5
       parent: 2
-  - uid: 138
+  - uid: 144
     components:
     - type: Transform
       pos: 40.5,28.5
       parent: 2
 - proto: AirlockChiefMedicalOfficerGlassLocked
   entities:
-  - uid: 139
+  - uid: 145
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9598,242 +9598,242 @@ entities:
       parent: 2
 - proto: AirlockCommandGlassLocked
   entities:
-  - uid: 140
+  - uid: 146
     components:
     - type: Transform
       pos: -30.5,49.5
       parent: 2
-  - uid: 141
+  - uid: 147
     components:
     - type: Transform
       pos: -30.5,48.5
       parent: 2
-  - uid: 142
+  - uid: 148
     components:
     - type: Transform
       pos: -21.5,38.5
       parent: 2
-  - uid: 143
+  - uid: 149
     components:
     - type: Transform
       pos: -19.5,38.5
       parent: 2
-  - uid: 144
+  - uid: 150
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,35.5
       parent: 2
-  - uid: 145
+  - uid: 151
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,35.5
       parent: 2
-  - uid: 146
+  - uid: 152
     components:
     - type: Transform
       pos: -15.5,42.5
       parent: 2
-  - uid: 147
+  - uid: 153
     components:
     - type: Transform
       pos: -13.5,42.5
       parent: 2
-  - uid: 148
+  - uid: 154
     components:
     - type: Transform
       pos: -17.5,42.5
       parent: 2
-  - uid: 149
+  - uid: 155
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,44.5
       parent: 2
-  - uid: 150
+  - uid: 156
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,49.5
       parent: 2
-  - uid: 151
+  - uid: 157
     components:
     - type: Transform
       pos: 67.5,41.5
       parent: 2
-  - uid: 152
+  - uid: 158
     components:
     - type: Transform
       pos: 63.5,41.5
       parent: 2
-  - uid: 153
+  - uid: 159
     components:
     - type: Transform
       pos: 63.5,48.5
       parent: 2
-  - uid: 154
+  - uid: 160
     components:
     - type: Transform
       pos: 67.5,48.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -65095.78
+      secondsUntilStateChange: -65177.62
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
-  - uid: 155
+  - uid: 161
     components:
     - type: Transform
       pos: -25.5,17.5
       parent: 2
 - proto: AirlockCommandLocked
   entities:
-  - uid: 156
+  - uid: 162
     components:
     - type: Transform
       pos: -13.5,38.5
       parent: 2
-  - uid: 157
+  - uid: 163
     components:
     - type: Transform
       pos: -17.5,38.5
       parent: 2
-  - uid: 158
+  - uid: 164
     components:
     - type: Transform
       pos: -19.5,4.5
       parent: 2
 - proto: AirlockDetectiveLocked
   entities:
-  - uid: 159
+  - uid: 165
     components:
     - type: Transform
       pos: -17.5,-1.5
       parent: 2
 - proto: AirlockEngineeringGlassLocked
   entities:
-  - uid: 160
+  - uid: 166
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,24.5
       parent: 2
-  - uid: 161
+  - uid: 167
     components:
     - type: Transform
       pos: 36.5,16.5
       parent: 2
-  - uid: 162
+  - uid: 168
     components:
     - type: Transform
       pos: 34.5,16.5
       parent: 2
-  - uid: 163
+  - uid: 169
     components:
     - type: Transform
       pos: 37.5,20.5
       parent: 2
-  - uid: 164
+  - uid: 170
     components:
     - type: Transform
       pos: 37.5,22.5
       parent: 2
-  - uid: 165
+  - uid: 171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,12.5
       parent: 2
-  - uid: 166
+  - uid: 172
     components:
     - type: Transform
       pos: 39.5,23.5
       parent: 2
-  - uid: 167
+  - uid: 173
     components:
     - type: Transform
       pos: 44.5,24.5
       parent: 2
-  - uid: 168
+  - uid: 174
     components:
     - type: Transform
       pos: 55.5,29.5
       parent: 2
-  - uid: 169
+  - uid: 175
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 57.5,25.5
       parent: 2
-  - uid: 170
+  - uid: 176
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 58.5,25.5
       parent: 2
-  - uid: 171
+  - uid: 177
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,-17.5
       parent: 2
-  - uid: 172
+  - uid: 178
     components:
     - type: Transform
       pos: -37.5,-17.5
       parent: 2
 - proto: AirlockEngineeringLocked
   entities:
-  - uid: 173
+  - uid: 179
     components:
     - type: Transform
       pos: -31.5,23.5
       parent: 2
-  - uid: 174
+  - uid: 180
     components:
     - type: Transform
       pos: 51.5,29.5
       parent: 2
-  - uid: 175
+  - uid: 181
     components:
     - type: Transform
       pos: -0.5,-23.5
       parent: 2
-  - uid: 176
+  - uid: 182
     components:
     - type: Transform
       pos: 4.5,22.5
       parent: 2
-  - uid: 177
+  - uid: 183
     components:
     - type: Transform
       pos: -23.5,-5.5
       parent: 2
-  - uid: 178
+  - uid: 184
     components:
     - type: Transform
       pos: -15.5,-9.5
       parent: 2
-  - uid: 179
+  - uid: 185
     components:
     - type: Transform
       pos: -25.5,24.5
       parent: 2
-  - uid: 180
+  - uid: 186
     components:
     - type: Transform
       pos: 72.5,-27.5
       parent: 2
-  - uid: 181
+  - uid: 187
     components:
     - type: Transform
       pos: 16.5,5.5
       parent: 2
 - proto: AirlockEVAGlassLocked
   entities:
-  - uid: 182
+  - uid: 188
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9841,61 +9841,61 @@ entities:
       parent: 2
 - proto: AirlockExternal
   entities:
-  - uid: 183
+  - uid: 189
     components:
     - type: Transform
       pos: 45.5,-35.5
       parent: 2
-  - uid: 184
+  - uid: 190
     components:
     - type: Transform
       pos: 59.5,-35.5
       parent: 2
-  - uid: 185
+  - uid: 191
     components:
     - type: Transform
       pos: -0.5,-50.5
       parent: 2
-  - uid: 186
+  - uid: 192
     components:
     - type: Transform
       pos: 0.5,-50.5
       parent: 2
 - proto: AirlockExternalAtmosphericsLocked
   entities:
-  - uid: 187
+  - uid: 193
     components:
     - type: Transform
       pos: 39.5,13.5
       parent: 2
 - proto: AirlockExternalCommandLocked
   entities:
-  - uid: 188
+  - uid: 194
     components:
     - type: Transform
       pos: 65.5,38.5
       parent: 2
 - proto: AirlockExternalEngineeringLocked
   entities:
-  - uid: 189
+  - uid: 195
     components:
     - type: Transform
       pos: 76.5,22.5
       parent: 2
-  - uid: 190
+  - uid: 196
     components:
     - type: Transform
       pos: 76.5,14.5
       parent: 2
 - proto: AirlockExternalGlass
   entities:
-  - uid: 191
+  - uid: 197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -55.5,-4.5
       parent: 2
-  - uid: 192
+  - uid: 198
     components:
     - type: Transform
       pos: -60.5,43.5
@@ -9903,7 +9903,7 @@ entities:
     - type: AccessReader
       access:
       - - Research
-  - uid: 193
+  - uid: 199
     components:
     - type: Transform
       pos: -60.5,41.5
@@ -9911,7 +9911,7 @@ entities:
     - type: AccessReader
       access:
       - - Research
-  - uid: 194
+  - uid: 200
     components:
     - type: Transform
       pos: -53.5,38.5
@@ -9919,207 +9919,207 @@ entities:
     - type: AccessReader
       access:
       - - Research
-  - uid: 195
+  - uid: 201
     components:
     - type: Transform
       pos: 20.5,-15.5
       parent: 2
-  - uid: 196
+  - uid: 202
     components:
     - type: Transform
       pos: 19.5,-15.5
       parent: 2
-  - uid: 197
+  - uid: 203
     components:
     - type: Transform
       pos: 18.5,-15.5
       parent: 2
-  - uid: 198
+  - uid: 204
     components:
     - type: Transform
       pos: 34.5,-15.5
       parent: 2
-  - uid: 199
+  - uid: 205
     components:
     - type: Transform
       pos: 39.5,-25.5
       parent: 2
-  - uid: 200
+  - uid: 206
     components:
     - type: Transform
       pos: 39.5,-24.5
       parent: 2
-  - uid: 201
+  - uid: 207
     components:
     - type: Transform
       pos: 43.5,-25.5
       parent: 2
-  - uid: 202
+  - uid: 208
     components:
     - type: Transform
       pos: 43.5,-24.5
       parent: 2
-  - uid: 203
+  - uid: 209
     components:
     - type: Transform
       pos: 35.5,-15.5
       parent: 2
-  - uid: 204
+  - uid: 210
     components:
     - type: Transform
       pos: 36.5,-15.5
       parent: 2
-  - uid: 205
+  - uid: 211
     components:
     - type: Transform
       pos: 46.5,-12.5
       parent: 2
-  - uid: 206
+  - uid: 212
     components:
     - type: Transform
       pos: 45.5,-12.5
       parent: 2
-  - uid: 207
+  - uid: 213
     components:
     - type: Transform
       pos: 47.5,-12.5
       parent: 2
-  - uid: 208
+  - uid: 214
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -55.5,-3.5
       parent: 2
-  - uid: 209
+  - uid: 215
     components:
     - type: Transform
       pos: -43.5,-15.5
       parent: 2
-  - uid: 210
+  - uid: 216
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -75.5,11.5
       parent: 2
-  - uid: 211
+  - uid: 217
     components:
     - type: Transform
       pos: 36.5,-40.5
       parent: 2
 - proto: AirlockExternalGlassAtmosphericsLocked
   entities:
-  - uid: 212
+  - uid: 218
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 39.5,8.5
       parent: 2
-  - uid: 213
+  - uid: 219
     components:
     - type: Transform
       pos: 39.5,9.5
       parent: 2
 - proto: AirlockExternalGlassCargoLocked
   entities:
-  - uid: 214
+  - uid: 220
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,37.5
       parent: 2
-  - uid: 215
+  - uid: 221
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,37.5
       parent: 2
-  - uid: 216
+  - uid: 222
     components:
     - type: Transform
       pos: 33.5,34.5
       parent: 2
-  - uid: 217
+  - uid: 223
     components:
     - type: Transform
       pos: 35.5,40.5
       parent: 2
-  - uid: 218
+  - uid: 224
     components:
     - type: Transform
       pos: 36.5,40.5
       parent: 2
 - proto: AirlockExternalGlassCommandLocked
   entities:
-  - uid: 219
+  - uid: 225
     components:
     - type: Transform
       pos: 65.5,36.5
       parent: 2
 - proto: AirlockExternalGlassEngineeringLocked
   entities:
-  - uid: 220
+  - uid: 226
     components:
     - type: Transform
       pos: 57.5,20.5
       parent: 2
-  - uid: 221
+  - uid: 227
     components:
     - type: Transform
       pos: 58.5,20.5
       parent: 2
-  - uid: 222
+  - uid: 228
     components:
     - type: Transform
       pos: 69.5,17.5
       parent: 2
-  - uid: 223
+  - uid: 229
     components:
     - type: Transform
       pos: 69.5,19.5
       parent: 2
-  - uid: 224
+  - uid: 230
     components:
     - type: Transform
       pos: 78.5,13.5
       parent: 2
-  - uid: 225
+  - uid: 231
     components:
     - type: Transform
       pos: 78.5,23.5
       parent: 2
-  - uid: 226
+  - uid: 232
     components:
     - type: Transform
       pos: -37.5,-23.5
       parent: 2
 - proto: AirlockExternalGlassLocked
   entities:
-  - uid: 227
+  - uid: 233
     components:
     - type: Transform
       pos: -10.5,-30.5
       parent: 2
 - proto: AirlockExternalGlassShuttleArrivals
   entities:
-  - uid: 228
+  - uid: 234
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,-22.5
       parent: 2
-  - uid: 229
+  - uid: 235
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,-29.5
       parent: 2
-  - uid: 230
+  - uid: 236
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,-29.5
       parent: 2
-  - uid: 231
+  - uid: 237
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10127,31 +10127,31 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassShuttleEmergencyLocked
   entities:
-  - uid: 232
+  - uid: 238
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 87.5,-17.5
       parent: 2
-  - uid: 233
+  - uid: 239
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 87.5,-23.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -116235.98
+      secondsUntilStateChange: -116317.81
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
-  - uid: 234
+  - uid: 240
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 87.5,-25.5
       parent: 2
-  - uid: 235
+  - uid: 241
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -10159,25 +10159,25 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassShuttleEscape
   entities:
-  - uid: 236
+  - uid: 242
     components:
     - type: Transform
       pos: 20.5,-38.5
       parent: 2
-  - uid: 237
+  - uid: 243
     components:
     - type: Transform
       pos: 24.5,-38.5
       parent: 2
 - proto: AirlockExternalGlassShuttleLocked
   entities:
-  - uid: 238
+  - uid: 244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-31.5
       parent: 2
-  - uid: 239
+  - uid: 245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10185,264 +10185,264 @@ entities:
       parent: 2
 - proto: AirlockExternalLocked
   entities:
-  - uid: 240
+  - uid: 246
     components:
     - type: Transform
       pos: 73.5,-40.5
       parent: 2
-  - uid: 241
+  - uid: 247
     components:
     - type: Transform
       pos: 73.5,-41.5
       parent: 2
-  - uid: 242
+  - uid: 248
     components:
     - type: Transform
       pos: 79.5,-41.5
       parent: 2
-  - uid: 243
+  - uid: 249
     components:
     - type: Transform
       pos: 79.5,-40.5
       parent: 2
 - proto: AirlockFreezer
   entities:
-  - uid: 244
+  - uid: 250
     components:
     - type: Transform
       pos: 4.5,42.5
       parent: 2
-  - uid: 245
+  - uid: 251
     components:
     - type: Transform
       pos: -71.5,11.5
       parent: 2
-  - uid: 246
+  - uid: 252
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 2
 - proto: AirlockFreezerKitchenHydroLocked
   entities:
-  - uid: 247
+  - uid: 253
     components:
     - type: Transform
       pos: 55.5,-7.5
       parent: 2
-  - uid: 248
+  - uid: 254
     components:
     - type: Transform
       pos: 57.5,-3.5
       parent: 2
 - proto: AirlockFreezerLocked
   entities:
-  - uid: 249
+  - uid: 255
     components:
     - type: Transform
       pos: 52.5,-4.5
       parent: 2
 - proto: AirlockGlass
   entities:
-  - uid: 250
+  - uid: 256
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -25.5,38.5
       parent: 2
-  - uid: 251
+  - uid: 257
     components:
     - type: Transform
       pos: -9.5,11.5
       parent: 2
-  - uid: 252
+  - uid: 258
     components:
     - type: Transform
       pos: -10.5,11.5
       parent: 2
-  - uid: 253
-    components:
-    - type: Transform
-      pos: -8.5,11.5
-      parent: 2
-  - uid: 254
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-33.5
-      parent: 2
-  - uid: 255
-    components:
-    - type: Transform
-      pos: 10.5,-28.5
-      parent: 2
-  - uid: 256
-    components:
-    - type: Transform
-      pos: 14.5,-28.5
-      parent: 2
-  - uid: 257
-    components:
-    - type: Transform
-      pos: 8.5,-42.5
-      parent: 2
-  - uid: 258
-    components:
-    - type: Transform
-      pos: 12.5,-42.5
-      parent: 2
   - uid: 259
     components:
     - type: Transform
-      pos: 16.5,-42.5
+      pos: -8.5,11.5
       parent: 2
   - uid: 260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 14.5,-33.5
+      pos: 10.5,-33.5
       parent: 2
   - uid: 261
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-33.5
+      pos: 10.5,-28.5
       parent: 2
   - uid: 262
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-33.5
+      pos: 14.5,-28.5
       parent: 2
   - uid: 263
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-31.5
+      pos: 8.5,-42.5
       parent: 2
   - uid: 264
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-30.5
+      pos: 12.5,-42.5
       parent: 2
   - uid: 265
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-29.5
+      pos: 16.5,-42.5
       parent: 2
   - uid: 266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 17.5,-23.5
+      pos: 14.5,-33.5
       parent: 2
   - uid: 267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 17.5,-22.5
+      pos: 13.5,-33.5
       parent: 2
   - uid: 268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 17.5,-21.5
+      pos: 11.5,-33.5
       parent: 2
   - uid: 269
     components:
     - type: Transform
-      pos: 42.5,-20.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-31.5
       parent: 2
   - uid: 270
     components:
     - type: Transform
-      pos: 42.5,-29.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-30.5
       parent: 2
   - uid: 271
     components:
     - type: Transform
-      pos: 41.5,-33.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-29.5
       parent: 2
   - uid: 272
     components:
     - type: Transform
-      pos: 41.5,-16.5
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-23.5
       parent: 2
   - uid: 273
     components:
     - type: Transform
-      pos: -34.5,-15.5
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-22.5
       parent: 2
   - uid: 274
     components:
     - type: Transform
-      pos: 12.5,-7.5
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-21.5
       parent: 2
   - uid: 275
+    components:
+    - type: Transform
+      pos: 42.5,-20.5
+      parent: 2
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 42.5,-29.5
+      parent: 2
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 41.5,-33.5
+      parent: 2
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 41.5,-16.5
+      parent: 2
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -34.5,-15.5
+      parent: 2
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 12.5,-7.5
+      parent: 2
+  - uid: 281
     components:
     - type: Transform
       pos: 12.5,-8.5
       parent: 2
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 276
+  - uid: 282
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,40.5
       parent: 2
-  - uid: 277
+  - uid: 283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,40.5
       parent: 2
-  - uid: 278
+  - uid: 284
     components:
     - type: Transform
       pos: 53.5,-51.5
       parent: 2
-  - uid: 279
+  - uid: 285
     components:
     - type: Transform
       pos: 54.5,-51.5
       parent: 2
-  - uid: 280
+  - uid: 286
     components:
     - type: Transform
       pos: 63.5,-51.5
       parent: 2
-  - uid: 281
+  - uid: 287
     components:
     - type: Transform
       pos: 65.5,-51.5
       parent: 2
-  - uid: 282
+  - uid: 288
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -77.5,11.5
       parent: 2
-  - uid: 283
+  - uid: 289
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,68.5
       parent: 2
-  - uid: 284
+  - uid: 290
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,67.5
       parent: 2
-  - uid: 285
+  - uid: 291
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,68.5
       parent: 2
-  - uid: 286
+  - uid: 292
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10450,109 +10450,109 @@ entities:
       parent: 2
 - proto: AirlockHatchMaintenance
   entities:
-  - uid: 287
+  - uid: 293
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 2
-  - uid: 288
+  - uid: 294
     components:
     - type: Transform
       pos: -23.5,34.5
       parent: 2
-  - uid: 289
+  - uid: 295
     components:
     - type: Transform
       pos: 19.5,-34.5
       parent: 2
-  - uid: 290
+  - uid: 296
     components:
     - type: Transform
       pos: -25.5,8.5
       parent: 2
-  - uid: 291
+  - uid: 297
     components:
     - type: Transform
       pos: 17.5,-36.5
       parent: 2
-  - uid: 292
+  - uid: 298
     components:
     - type: Transform
       pos: 0.5,-30.5
       parent: 2
-  - uid: 293
+  - uid: 299
     components:
     - type: Transform
       pos: 35.5,-34.5
       parent: 2
-  - uid: 294
+  - uid: 300
     components:
     - type: Transform
       pos: 69.5,-26.5
       parent: 2
-  - uid: 295
+  - uid: 301
     components:
     - type: Transform
       pos: 71.5,-17.5
       parent: 2
-  - uid: 296
+  - uid: 302
     components:
     - type: Transform
       pos: 28.5,16.5
       parent: 2
-  - uid: 297
+  - uid: 303
     components:
     - type: Transform
       pos: -34.5,23.5
       parent: 2
-  - uid: 298
+  - uid: 304
     components:
     - type: Transform
       pos: -23.5,22.5
       parent: 2
-  - uid: 299
+  - uid: 305
     components:
     - type: Transform
       pos: -21.5,11.5
       parent: 2
-  - uid: 300
+  - uid: 306
     components:
     - type: Transform
       pos: -22.5,9.5
       parent: 2
-  - uid: 301
+  - uid: 307
     components:
     - type: Transform
       pos: -13.5,-20.5
       parent: 2
-  - uid: 302
+  - uid: 308
     components:
     - type: Transform
       pos: -49.5,13.5
       parent: 2
-  - uid: 303
+  - uid: 309
     components:
     - type: Transform
       pos: 35.5,-37.5
       parent: 2
-  - uid: 304
+  - uid: 310
     components:
     - type: Transform
       pos: 32.5,-39.5
       parent: 2
-  - uid: 305
+  - uid: 311
     components:
     - type: Transform
       pos: 66.5,-38.5
       parent: 2
-  - uid: 306
+  - uid: 312
     components:
     - type: Transform
       pos: 69.5,-39.5
       parent: 2
 - proto: AirlockHatchMaintenanceLocked
   entities:
-  - uid: 307
+  - uid: 313
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10560,220 +10560,220 @@ entities:
       parent: 2
 - proto: AirlockHeadOfPersonnelLocked
   entities:
-  - uid: 308
+  - uid: 314
     components:
     - type: Transform
       pos: -5.5,27.5
       parent: 2
-  - uid: 309
+  - uid: 315
     components:
     - type: Transform
       pos: -9.5,27.5
       parent: 2
 - proto: AirlockHeadOfSecurityGlassLocked
   entities:
-  - uid: 310
+  - uid: 316
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 2
 - proto: AirlockHeadOfSecurityLocked
   entities:
-  - uid: 311
+  - uid: 317
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 2
 - proto: AirlockHydroGlassLocked
   entities:
-  - uid: 312
+  - uid: 318
     components:
     - type: Transform
       pos: 56.5,1.5
       parent: 2
 - proto: AirlockHydroponicsLocked
   entities:
-  - uid: 313
+  - uid: 319
     components:
     - type: Transform
       pos: 63.5,-7.5
       parent: 2
 - proto: AirlockJanitorLocked
   entities:
-  - uid: 314
+  - uid: 320
     components:
     - type: Transform
       pos: 17.5,-17.5
       parent: 2
 - proto: AirlockKitchenLocked
   entities:
-  - uid: 315
+  - uid: 321
     components:
     - type: Transform
       pos: 50.5,-7.5
       parent: 2
 - proto: AirlockLawyerGlassLocked
   entities:
-  - uid: 316
+  - uid: 322
     components:
     - type: Transform
       pos: -15.5,11.5
       parent: 2
 - proto: AirlockLawyerLocked
   entities:
-  - uid: 317
+  - uid: 323
     components:
     - type: Transform
       pos: -14.5,7.5
       parent: 2
 - proto: AirlockMaintCargoLocked
   entities:
-  - uid: 318
+  - uid: 324
     components:
     - type: Transform
       pos: 7.5,25.5
       parent: 2
 - proto: AirlockMaintChiefEngineerLocked
   entities:
-  - uid: 319
+  - uid: 325
     components:
     - type: Transform
       pos: 34.5,28.5
       parent: 2
 - proto: AirlockMaintCommandLocked
   entities:
-  - uid: 320
+  - uid: 326
     components:
     - type: Transform
       pos: -5.5,20.5
       parent: 2
-  - uid: 321
+  - uid: 327
     components:
     - type: Transform
       pos: -25.5,21.5
       parent: 2
 - proto: AirlockMaintDetectiveLocked
   entities:
-  - uid: 322
+  - uid: 328
     components:
     - type: Transform
       pos: -15.5,-6.5
       parent: 2
 - proto: AirlockMaintEngiLocked
   entities:
-  - uid: 323
+  - uid: 329
     components:
     - type: Transform
       pos: 33.5,21.5
       parent: 2
 - proto: AirlockMaintJanitorLocked
   entities:
-  - uid: 324
+  - uid: 330
     components:
     - type: Transform
       pos: 11.5,-18.5
       parent: 2
 - proto: AirlockMaintLocked
   entities:
-  - uid: 325
+  - uid: 331
     components:
     - type: Transform
       pos: -24.5,-9.5
       parent: 2
 - proto: AirlockMaintMedLocked
   entities:
-  - uid: 326
+  - uid: 332
     components:
     - type: Transform
       pos: -25.5,0.5
       parent: 2
-  - uid: 327
+  - uid: 333
     components:
     - type: Transform
       pos: -46.5,-4.5
       parent: 2
 - proto: AirlockMaintRnDLocked
   entities:
-  - uid: 328
+  - uid: 334
     components:
     - type: Transform
       pos: -42.5,34.5
       parent: 2
 - proto: AirlockMaintSurgeryLocked
   entities:
-  - uid: 329
+  - uid: 335
     components:
     - type: Transform
       pos: -38.5,-8.5
       parent: 2
 - proto: AirlockMedical
   entities:
-  - uid: 330
+  - uid: 336
     components:
     - type: Transform
       pos: -28.5,-16.5
       parent: 2
 - proto: AirlockMedicalGlassLocked
   entities:
-  - uid: 331
+  - uid: 337
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,5.5
       parent: 2
-  - uid: 332
+  - uid: 338
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,5.5
       parent: 2
-  - uid: 333
+  - uid: 339
     components:
     - type: Transform
       pos: -27.5,5.5
       parent: 2
-  - uid: 334
+  - uid: 340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -30.5,2.5
       parent: 2
-  - uid: 335
+  - uid: 341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -31.5,2.5
       parent: 2
-  - uid: 336
+  - uid: 342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,1.5
       parent: 2
-  - uid: 337
+  - uid: 343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,-1.5
       parent: 2
-  - uid: 338
+  - uid: 344
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,-0.5
       parent: 2
-  - uid: 339
+  - uid: 345
     components:
     - type: Transform
       pos: -41.5,2.5
       parent: 2
-  - uid: 340
+  - uid: 346
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -52.5,4.5
       parent: 2
-  - uid: 341
+  - uid: 347
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10781,102 +10781,102 @@ entities:
       parent: 2
 - proto: AirlockMedicalLocked
   entities:
-  - uid: 342
+  - uid: 348
     components:
     - type: Transform
       pos: -41.5,11.5
       parent: 2
-  - uid: 343
+  - uid: 349
     components:
     - type: Transform
       pos: -33.5,17.5
       parent: 2
 - proto: AirlockMedicalMorgueLocked
   entities:
-  - uid: 344
+  - uid: 350
     components:
     - type: Transform
       pos: -43.5,9.5
       parent: 2
 - proto: AirlockMedicalScienceLocked
   entities:
-  - uid: 345
+  - uid: 351
     components:
     - type: Transform
       pos: -48.5,11.5
       parent: 2
 - proto: AirlockQuartermasterLocked
   entities:
-  - uid: 346
+  - uid: 352
     components:
     - type: Transform
       pos: 21.5,21.5
       parent: 2
-  - uid: 347
+  - uid: 353
     components:
     - type: Transform
       pos: 27.5,21.5
       parent: 2
 - proto: AirlockResearchDirectorGlassLocked
   entities:
-  - uid: 348
+  - uid: 354
     components:
     - type: Transform
       pos: -48.5,40.5
       parent: 2
-  - uid: 349
+  - uid: 355
     components:
     - type: Transform
       pos: 65.5,43.5
       parent: 2
 - proto: AirlockResearchDirectorLocked
   entities:
-  - uid: 350
+  - uid: 356
     components:
     - type: Transform
       pos: -42.5,28.5
       parent: 2
 - proto: AirlockRoboticsGlassLocked
   entities:
-  - uid: 351
+  - uid: 357
     components:
     - type: Transform
       pos: -59.5,34.5
       parent: 2
-  - uid: 352
+  - uid: 358
     components:
     - type: Transform
       pos: -57.5,29.5
       parent: 2
-  - uid: 353
+  - uid: 359
     components:
     - type: Transform
       pos: -57.5,28.5
       parent: 2
-  - uid: 354
+  - uid: 360
     components:
     - type: Transform
       pos: -60.5,34.5
       parent: 2
-  - uid: 355
+  - uid: 361
     components:
     - type: Transform
       pos: -63.5,34.5
       parent: 2
-  - uid: 356
+  - uid: 362
     components:
     - type: Transform
       pos: -62.5,34.5
       parent: 2
 - proto: AirlockSalvageMiningGlassLocked
   entities:
-  - uid: 357
+  - uid: 363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,30.5
       parent: 2
-  - uid: 358
+  - uid: 364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -10884,25 +10884,25 @@ entities:
       parent: 2
 - proto: AirlockScienceGlassLocked
   entities:
-  - uid: 359
+  - uid: 365
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -49.5,29.5
       parent: 2
-  - uid: 360
+  - uid: 366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -49.5,28.5
       parent: 2
-  - uid: 361
+  - uid: 367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,33.5
       parent: 2
-  - uid: 362
+  - uid: 368
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -10910,24 +10910,24 @@ entities:
       parent: 2
 - proto: AirlockScienceLocked
   entities:
-  - uid: 363
+  - uid: 369
     components:
     - type: Transform
       pos: -47.5,24.5
       parent: 2
-  - uid: 364
+  - uid: 370
     components:
     - type: Transform
       pos: -65.5,38.5
       parent: 2
 - proto: AirlockSecurityGlassLocked
   entities:
-  - uid: 368
+  - uid: 371
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 2
-  - uid: 369
+  - uid: 372
     components:
     - type: Transform
       pos: 8.5,-1.5
@@ -10935,17 +10935,17 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12964
-  - uid: 371
+  - uid: 373
     components:
     - type: Transform
       pos: 10.5,5.5
       parent: 2
-  - uid: 372
+  - uid: 374
     components:
     - type: Transform
       pos: 12.5,8.5
       parent: 2
-  - uid: 373
+  - uid: 375
     components:
     - type: Transform
       pos: 8.5,2.5
@@ -12039,13 +12039,6 @@ entities:
     - type: Transform
       pos: -60.5,18.5
       parent: 2
-- proto: AltarToolbox
-  entities:
-  - uid: 507
-    components:
-    - type: Transform
-      pos: 4.5,-33.5
-      parent: 2
 - proto: AlwaysPoweredlightCyan
   entities:
   - uid: 508
@@ -13035,217 +13028,77 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 21.5,-30.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 637
     components:
     - type: Transform
       pos: 8.5,16.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 638
     components:
     - type: Transform
       pos: 34.5,2.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 639
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 33.5,-21.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 55.5,-35.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 641
     components:
     - type: Transform
       pos: 62.5,-7.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 642
     components:
     - type: Transform
       pos: 76.5,-12.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 643
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,8.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 644
     components:
     - type: Transform
       pos: -5.5,17.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 645
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,21.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 646
     components:
     - type: Transform
       pos: -18.5,34.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 647
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -43.5,11.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 648
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -49.5,22.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 649
     components:
     - type: Transform
       pos: 7.5,-24.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: AtmosDeviceFanDirectional
   entities:
   - uid: 650
@@ -14070,16 +13923,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 28.5,19.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: BaseGasCondenser
   entities:
   - uid: 795
@@ -15241,6 +15084,11 @@ entities:
       parent: 2
 - proto: BorgCharger
   entities:
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 4.5,-33.5
+      parent: 2
   - uid: 999
     components:
     - type: Transform
@@ -32896,11 +32744,6 @@ entities:
     - type: Transform
       pos: 73.70848,-28.79964
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: Cablecuffs
   entities:
   - uid: 4502
@@ -41752,21 +41595,11 @@ entities:
     - type: Transform
       pos: 73.42723,-28.659016
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 6271
     components:
     - type: Transform
       pos: 59.299408,9.376136
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: CableMV
   entities:
   - uid: 6272
@@ -50716,21 +50549,11 @@ entities:
     - type: Transform
       pos: 6.559381,23.332275
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 8061
     components:
     - type: Transform
       pos: 73.536606,-28.721516
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: CableMVStack1
   entities:
   - uid: 8062
@@ -50738,21 +50561,11 @@ entities:
     - type: Transform
       pos: -30.5,-13.5
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 8063
     components:
     - type: Transform
       pos: -32.31669,-14.548876
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: CableTerminal
   entities:
   - uid: 8064
@@ -65967,109 +65780,21 @@ entities:
     - type: Transform
       pos: 13.5,9.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        beakerSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        outputSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 10897
     components:
     - type: Transform
       pos: -35.5,6.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        beakerSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        outputSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 10898
     components:
     - type: Transform
       pos: -38.5,3.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        beakerSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        outputSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 10899
     components:
     - type: Transform
       pos: -38.5,10.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        beakerSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        outputSlot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        machine_board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        machine_parts: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ChemMasterMachineCircuitboard
   entities:
   - uid: 10900
@@ -68520,20 +68245,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 37.5,38.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        disk_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerAlert
   entities:
   - uid: 11263
@@ -68542,47 +68253,17 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -18.5,54.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11264
     components:
     - type: Transform
       pos: 38.5,11.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11265
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,14.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerAnalysisConsole
   entities:
   - uid: 11266
@@ -68590,16 +68271,6 @@ entities:
     - type: Transform
       pos: -59.5,40.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
     - type: AnalysisConsole
       analyzerEntity: 17537
     - type: DeviceLinkSource
@@ -68612,16 +68283,6 @@ entities:
     - type: Transform
       pos: -54.5,37.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
     - type: AnalysisConsole
       analyzerEntity: 17538
     - type: DeviceLinkSource
@@ -68636,16 +68297,6 @@ entities:
     - type: Transform
       pos: 37.5,11.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: computerBodyScanner
   entities:
   - uid: 11269
@@ -68653,32 +68304,12 @@ entities:
     - type: Transform
       pos: -44.5,10.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11270
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -46.5,-10.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
     - type: BodyScanner
       tableEntity: 17654
     - type: DeviceLinkSource
@@ -68692,16 +68323,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -46.5,-8.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
     - type: BodyScanner
       tableEntity: 17653
     - type: DeviceLinkSource
@@ -68753,32 +68374,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 15.5,20.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11279
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,24.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCargoOrders
   entities:
   - uid: 11280
@@ -68786,63 +68387,23 @@ entities:
     - type: Transform
       pos: -9.5,53.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11281
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,35.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11282
     components:
     - type: Transform
       pos: 15.5,22.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11283
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,17.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCargoOrdersEngineering
   entities:
   - uid: 11284
@@ -68851,16 +68412,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 33.5,13.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCargoOrdersMedical
   entities:
   - uid: 11285
@@ -68869,16 +68420,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -57.5,4.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCargoOrdersScience
   entities:
   - uid: 11286
@@ -68887,16 +68428,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -48.5,25.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCargoOrdersSecurity
   entities:
   - uid: 11287
@@ -68905,16 +68436,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,-5.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCargoOrdersService
   entities:
   - uid: 11288
@@ -68922,16 +68443,6 @@ entities:
     - type: Transform
       pos: 32.5,1.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerComms
   entities:
   - uid: 11289
@@ -68940,31 +68451,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -0.5,43.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11290
     components:
     - type: Transform
       pos: -15.5,55.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCommsCargo
   entities:
   - uid: 11291
@@ -68972,16 +68463,6 @@ entities:
     - type: Transform
       pos: 24.5,22.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCommsEngineering
   entities:
   - uid: 11292
@@ -68990,16 +68471,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 38.5,29.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCommsLaw
   entities:
   - uid: 11293
@@ -69008,16 +68479,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -21.5,2.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCommsMedical
   entities:
   - uid: 11294
@@ -69026,16 +68487,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -48.5,-0.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCommsScience
   entities:
   - uid: 11295
@@ -69044,16 +68495,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -41.5,27.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCommsSecurity
   entities:
   - uid: 11296
@@ -69062,16 +68503,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -4.5,-13.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCommsService
   entities:
   - uid: 11297
@@ -69080,16 +68511,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -6.5,28.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCrewMonitoring
   entities:
   - uid: 11298
@@ -69098,189 +68519,69 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 11.5,3.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11299
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -16.5,54.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11300
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,44.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,31.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,6.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11303
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-3.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11304
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11305
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-20.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11306
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -28.5,3.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11307
     components:
     - type: Transform
       pos: -51.5,1.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11308
     components:
     - type: Transform
       pos: -47.5,43.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11309
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 62.5,40.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCriminalRecords
   entities:
   - uid: 11310
@@ -69288,16 +68589,6 @@ entities:
     - type: Transform
       pos: -13.5,55.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11311
     components:
     - type: Transform
@@ -69307,112 +68598,42 @@ entities:
       accessListsOriginal:
       - - Security
       - - Cadet
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,2.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11313
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-2.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11314
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-15.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11316
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-16.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11317
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 74.5,-23.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerCriminalRecordsDesktop
   entities:
   - uid: 11318
@@ -69420,16 +68641,6 @@ entities:
     - type: Transform
       pos: -18.5,10.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerFrame
   entities:
   - uid: 11319
@@ -69452,16 +68663,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -10.5,24.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerId
   entities:
   - uid: 11322
@@ -69470,95 +68671,23 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -14.5,54.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        IdCardConsole-privilegedId: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        IdCardConsole-targetId: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,43.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        IdCardConsole-privilegedId: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        IdCardConsole-targetId: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11324
     components:
     - type: Transform
       pos: -6.5,33.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        IdCardConsole-privilegedId: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        IdCardConsole-targetId: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,52.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        IdCardConsole-privilegedId: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        IdCardConsole-targetId: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerMassMediaCircuitboard
   entities:
   - uid: 11326
@@ -69579,31 +68708,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -29.5,6.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11329
     components:
     - type: Transform
       pos: -33.5,21.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerPersonalDesktop
   entities:
   - uid: 11330
@@ -69611,36 +68720,6 @@ entities:
     - type: Transform
       pos: -66.5,41.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        PDA-id: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        PDA-pen: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        PDA-pai: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        Cartridge-Slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        program-container: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerPowerMonitoring
   entities:
   - uid: 11331
@@ -69648,63 +68727,23 @@ entities:
     - type: Transform
       pos: -17.5,55.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,13.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11333
     components:
     - type: Transform
       pos: 65.5,50.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,32.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerRadar
   entities:
   - uid: 11335
@@ -69713,63 +68752,23 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,45.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11336
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,52.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11337
     components:
     - type: Transform
       pos: 25.5,36.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,36.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerResearchAndDevelopment
   entities:
   - uid: 11339
@@ -69777,32 +68776,12 @@ entities:
     - type: Transform
       pos: -45.5,26.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11340
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,27.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
     - type: AccessReader
       accessListsOriginal:
       - - Research
@@ -69813,48 +68792,18 @@ entities:
     - type: Transform
       pos: -21.5,53.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,30.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11343
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -47.5,41.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
     - type: AccessReader
       accessListsOriginal:
       - - Robotics
@@ -69864,16 +68813,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -40.5,27.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
     - type: AccessReader
       accessListsOriginal:
       - - Robotics
@@ -69883,16 +68822,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 66.5,39.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerSalvageJobBoard
   entities:
   - uid: 11346
@@ -69901,16 +68830,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 28.5,32.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerShuttleCargo
   entities:
   - uid: 11347
@@ -69918,20 +68837,6 @@ entities:
     - type: Transform
       pos: 21.5,36.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        disk_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerShuttleMining
   entities:
   - uid: 11348
@@ -69940,20 +68845,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 37.5,34.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        disk_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerSolarControl
   entities:
   - uid: 11349
@@ -69961,48 +68852,18 @@ entities:
     - type: Transform
       pos: 31.5,15.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 64.5,39.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11351
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-20.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerStationRecords
   entities:
   - uid: 11352
@@ -70011,16 +68872,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -3.5,30.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerStationRecordsDesktop
   entities:
   - uid: 11353
@@ -70029,16 +68880,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -27.5,19.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerSurveillanceCameraMonitor
   entities:
   - uid: 11354
@@ -70047,94 +68888,34 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -12.5,54.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-4.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11356
     components:
     - type: Transform
       pos: -8.5,1.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11357
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-21.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11358
     components:
     - type: Transform
       pos: 77.5,-22.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11359
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 68.5,40.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerTechnologyDiskTerminal
   entities:
   - uid: 11360
@@ -70142,16 +68923,6 @@ entities:
     - type: Transform
       pos: -49.5,41.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ComputerTelevision
   entities:
   - uid: 11361
@@ -70159,181 +68930,61 @@ entities:
     - type: Transform
       pos: 5.5,-10.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11362
     components:
     - type: Transform
       pos: 9.5,-10.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11363
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11364
     components:
     - type: Transform
       pos: 6.5,-40.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11365
     components:
     - type: Transform
       pos: 10.5,-40.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11366
     components:
     - type: Transform
       pos: 14.5,-40.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11367
     components:
     - type: Transform
       pos: 38.5,-33.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11368
     components:
     - type: Transform
       pos: 39.5,-29.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11369
     components:
     - type: Transform
       pos: 38.5,-16.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11370
     components:
     - type: Transform
       pos: 39.5,-20.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11371
     components:
     - type: Transform
       pos: 30.5,1.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
   - uid: 11372
     components:
     - type: Transform
       pos: 45.5,4.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: ContainmentFieldGenerator
   entities:
   - uid: 11373
@@ -80222,7 +78873,7 @@ entities:
       - 13182
       - 13181
       - 499
-      - 369
+      - 372
       - 494
       - 13052
       - 13055
@@ -109762,21 +108413,11 @@ entities:
     - type: Transform
       pos: -26.458275,32.42608
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 17344
     components:
     - type: Transform
       pos: -39.45096,32.534645
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: IngotSilver
   entities:
   - uid: 17345
@@ -109784,11 +108425,6 @@ entities:
     - type: Transform
       pos: -26.708275,32.535454
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: IntercomAll
   entities:
   - uid: 17346
@@ -111808,11 +110444,6 @@ entities:
     - type: Transform
       pos: -3.4796867,29.543125
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: MaterialDurathread
   entities:
   - uid: 17563
@@ -111820,11 +110451,6 @@ entities:
     - type: Transform
       pos: -3.5,29.5
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: Mattress
   entities:
   - uid: 17564
@@ -112285,16 +110911,6 @@ entities:
     - type: Transform
       pos: -24.5,17.5
       parent: 2
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
-        pai_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: NitrogenCanister
   entities:
   - uid: 17632
@@ -125789,22 +124405,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5195332,41.467716
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19979
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -50.445408,32.432922
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: SheetPlasma10
   entities:
   - uid: 10958
@@ -125814,11 +124420,6 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: SheetPlasteel
   entities:
   - uid: 19980
@@ -125826,11 +124427,6 @@ entities:
     - type: Transform
       pos: 20.733301,17.63073
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: SheetPlastic
   entities:
   - uid: 19981
@@ -125838,61 +124434,31 @@ entities:
     - type: Transform
       pos: -11.354582,-7.4687614
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19982
     components:
     - type: Transform
       pos: -60.401897,31.714697
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19983
     components:
     - type: Transform
       pos: -43.446712,25.554003
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19984
     components:
     - type: Transform
       pos: -43.446712,25.554003
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19985
     components:
     - type: Transform
       pos: 19.952051,17.63073
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19986
     components:
     - type: Transform
       pos: 41.591076,24.380121
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: SheetSteel
   entities:
   - uid: 19987
@@ -125900,131 +124466,66 @@ entities:
     - type: Transform
       pos: 0.50299597,9.497643
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19988
     components:
     - type: Transform
       pos: -11.588957,-7.4062614
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19989
     components:
     - type: Transform
       pos: -56.481823,-1.511231
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19990
     components:
     - type: Transform
       pos: 19.467676,17.583855
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19991
     components:
     - type: Transform
       pos: -60.596622,31.714697
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19992
     components:
     - type: Transform
       pos: -43.462337,25.554003
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19993
     components:
     - type: Transform
       pos: -43.462337,25.554003
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19994
     components:
     - type: Transform
       pos: 3.5,-33.5
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19995
     components:
     - type: Transform
       pos: 30.5,15.5
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19996
     components:
     - type: Transform
       pos: 41.528576,24.505121
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19997
     components:
     - type: Transform
       pos: 46.53861,28.539917
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19998
     components:
     - type: Transform
       pos: 59.374004,9.711176
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 19999
     components:
     - type: Transform
       pos: 59.69997,9.711176
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: SheetUranium
   entities:
   - uid: 20000
@@ -126033,11 +124534,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -16.508617,-11.53904
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: ShelfBar
   entities:
   - uid: 20001
@@ -127162,7 +125658,7 @@ entities:
           - Open
         - - On
           - Close
-        257:
+        263:
         - - Off
           - DoorBolt
         - - On
@@ -127202,7 +125698,7 @@ entities:
           - DoorBolt
         - - Off
           - DoorBolt
-        258:
+        264:
         - - Off
           - DoorBolt
         - - On
@@ -127237,7 +125733,7 @@ entities:
           - DoorBolt
         - - Off
           - DoorBolt
-        259:
+        265:
         - - Off
           - DoorBolt
         - - On
@@ -127257,7 +125753,7 @@ entities:
           - Open
         - - On
           - Close
-        271:
+        277:
         - - On
           - DoorBolt
         - - Off
@@ -127297,7 +125793,7 @@ entities:
           - Open
         - - On
           - Close
-        270:
+        276:
         - - On
           - DoorBolt
         - - Off
@@ -127321,7 +125817,7 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        269:
+        275:
         - - On
           - DoorBolt
         - - Off
@@ -127370,7 +125866,7 @@ entities:
           - Open
         - - On
           - Close
-        272:
+        278:
         - - Off
           - DoorBolt
         - - On
@@ -128302,23 +126798,6 @@ entities:
     - type: Transform
       pos: 48.5,-4.5
       parent: 2
-- proto: SMESBlue
-  entities:
-  - uid: 20233
-    components:
-    - type: Transform
-      pos: 46.5,21.5
-      parent: 2
-  - uid: 20234
-    components:
-    - type: Transform
-      pos: 46.5,22.5
-      parent: 2
-  - uid: 20235
-    components:
-    - type: Transform
-      pos: 46.5,20.5
-      parent: 2
 - proto: SMESAdvanced
   entities:
   - uid: 20236
@@ -128352,6 +126831,23 @@ entities:
     components:
     - type: Transform
       pos: -37.5,-19.5
+      parent: 2
+- proto: SMESBlue
+  entities:
+  - uid: 20233
+    components:
+    - type: Transform
+      pos: 46.5,21.5
+      parent: 2
+  - uid: 20234
+    components:
+    - type: Transform
+      pos: 46.5,22.5
+      parent: 2
+  - uid: 20235
+    components:
+    - type: Transform
+      pos: 46.5,20.5
       parent: 2
 - proto: SnowBattlemap
   entities:
@@ -129634,31 +128130,16 @@ entities:
     - type: Transform
       pos: -25.535286,28.743128
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 20474
     components:
     - type: Transform
       pos: -25.472786,28.618128
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
   - uid: 20475
     components:
     - type: Transform
       pos: -25.39466,28.430628
       parent: 2
-    - type: UserInterface
-      actors: {}
-      interfaces:
-        enum.StackCustomSplitUiKey.Key:
-          type: StackCustomSplitBoundUserInterface
 - proto: SpawnMechPaddyFilled
   entities:
   - uid: 20476
@@ -152677,7 +151158,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -4787.8247
+      secondsUntilStateChange: -4869.6626
       state: Opening
     - type: Airlock
       autoClose: False


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Removes the Toolbox Altar from the Tools Room on Lobster.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The altar would hurt vampires in maints, prevented them from going near tools, and hurt them on the way to cryosleep.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="696" height="702" alt="image" src="https://github.com/user-attachments/assets/f2fb91e3-240c-436c-b087-b033021968c7" />

fig. 1 - I replaced the altar with a second cyborg recharger.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- remove: (Lobster) Toolbox altar in Tools Room, vampires rejoice.