### PR TITLE
Fix gamepresets min players count

### DIFF
--- a/Content.IntegrationTests/Content.IntegrationTests.csproj
+++ b/Content.IntegrationTests/Content.IntegrationTests.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <OutputPath>..\bin\Content.IntegrationTests\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-	<!-- Starlight: Enable nullable reference types -->
-	<Nullable>enable</Nullable>
+	<Nullable>disable</Nullable>
   </PropertyGroup>
   <Import Project="../MSBuild/Content.props" />
   <ItemGroup>

--- a/Content.IntegrationTests/Content.IntegrationTests.csproj
+++ b/Content.IntegrationTests/Content.IntegrationTests.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <OutputPath>..\bin\Content.IntegrationTests\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <Nullable>disable</Nullable>
+	<!-- Starlight: Enable nullable reference types -->
+	<Nullable>enable</Nullable>
   </PropertyGroup>
   <Import Project="../MSBuild/Content.props" />
   <ItemGroup>

--- a/Content.IntegrationTests/Content.IntegrationTests.csproj
+++ b/Content.IntegrationTests/Content.IntegrationTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputPath>..\bin\Content.IntegrationTests\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-	<Nullable>disable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   <Import Project="../MSBuild/Content.props" />
   <ItemGroup>

--- a/Content.IntegrationTests/Tests/_StarLight/GameRules/GamePresetsMinPlayersTest.cs
+++ b/Content.IntegrationTests/Tests/_StarLight/GameRules/GamePresetsMinPlayersTest.cs
@@ -29,14 +29,15 @@ public sealed class GamePresetsMinPlayersTest
             if (preset.ID == TestPreset)
                 continue; // This preset is specifically for testing and has a MinPlayers value that doesn't match its rules, so ignore it
             var minPlayers = preset.MinPlayers ?? 0;
-            Assert.That(minPlayers, Is.GreaterThanOrEqualTo(0));
+            if (minPlayers < 0)
+                errorPresets.Add($"{preset.ID}: preset MinPlayers is negative ({minPlayers})");
             var minPlayersRules = GetBiggestMinPlayers(preset, protoMan, compFactory, errorPresets);
 
             if (minPlayers < minPlayersRules)
                 errorPresets.Add($"{preset.ID}: preset={minPlayers}, required={minPlayersRules}");
         }
 
-        Assert.That(errorPresets.Count, Is.Zero, $"The following presets have a MinPlayers value that is too low: {string.Join(", ", errorPresets)}");
+        Assert.That(errorPresets.Count, Is.Zero, $"Found invalid preset/rule min-player configuration(s): {string.Join(", ", errorPresets)}");
     }
 
     private int GetBiggestMinPlayers(GamePresetPrototype preset, IPrototypeManager manager, IComponentFactory factory, List<string> errors)

--- a/Content.IntegrationTests/Tests/_StarLight/GameRules/GamePresetsMinPlayersTest.cs
+++ b/Content.IntegrationTests/Tests/_StarLight/GameRules/GamePresetsMinPlayersTest.cs
@@ -37,7 +37,10 @@ public sealed class GamePresetsMinPlayersTest
                 errorPresets.Add($"{preset.ID}: preset={minPlayers}, required={minPlayersRules}");
         }
 
-        Assert.That(errorPresets.Count, Is.Zero, $"Found invalid preset/rule min-player configuration(s): {string.Join(", ", errorPresets)}");
+        Assert.That(
+            errorPresets.Count,
+            Is.Zero,
+            $"Found invalid preset/rule min-player configuration(s):{Environment.NewLine}{string.Join(Environment.NewLine, errorPresets)}");
     }
 
     private int GetBiggestMinPlayers(GamePresetPrototype preset, IPrototypeManager manager, IComponentFactory factory, List<string> errors)

--- a/Content.IntegrationTests/Tests/_StarLight/GameRules/GamePresetsMinPlayersTest.cs
+++ b/Content.IntegrationTests/Tests/_StarLight/GameRules/GamePresetsMinPlayersTest.cs
@@ -30,7 +30,7 @@ public sealed class GamePresetsMinPlayersTest
                 continue; // This preset is specifically for testing and has a MinPlayers value that doesn't match its rules, so ignore it
             var minPlayers = preset.MinPlayers ?? 0;
             Assert.That(minPlayers, Is.GreaterThanOrEqualTo(0));
-            var minPlayersRules = GetBiggestMinPlayers(preset, protoMan, compFactory);
+            var minPlayersRules = GetBiggestMinPlayers(preset, protoMan, compFactory, errorPresets);
 
             if (minPlayers < minPlayersRules)
                 errorPresets.Add($"{preset.ID}: preset={minPlayers}, required={minPlayersRules}");
@@ -39,20 +39,20 @@ public sealed class GamePresetsMinPlayersTest
         Assert.That(errorPresets.Count, Is.Zero, $"The following presets have a MinPlayers value that is too low: {string.Join(", ", errorPresets)}");
     }
 
-    private int GetBiggestMinPlayers(GamePresetPrototype preset, IPrototypeManager manager, IComponentFactory factory)
+    private int GetBiggestMinPlayers(GamePresetPrototype preset, IPrototypeManager manager, IComponentFactory factory, List<string> errors)
     {
         var biggest = 0;
         foreach (var rule in preset.Rules)
         {
             if (!manager.TryIndex<EntityPrototype>(rule, out var ruleProto))
             {
-                Assert.Fail($"Rule prototype '{rule}' not found in preset '{preset.ID}'");
+                errors.Add($"Rule prototype '{rule}' not found in preset '{preset.ID}'");
                 continue;
             }
 
             if (!TryGetComponent<GameRuleComponent>(ruleProto.Components, factory, out var ruleComponent))
             {
-                Assert.Fail($"Rule '{rule}' in preset '{preset.ID}' has no GameRuleComponent");
+                errors.Add($"Rule '{rule}' in preset '{preset.ID}' has no GameRuleComponent");
                 continue;
             }
 

--- a/Content.IntegrationTests/Tests/_StarLight/GameRules/GamePresetsMinPlayersTest.cs
+++ b/Content.IntegrationTests/Tests/_StarLight/GameRules/GamePresetsMinPlayersTest.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Content.Server.GameTicking.Presets;
+using Content.Shared.GameTicking.Components;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._StarLight.GameRules;
+
+[TestFixture]
+public sealed class GamePresetsMinPlayersTest
+{
+    private const string TestPreset = "TestPresetTenPlayers";
+
+    [Test]
+    public async Task TestMinPlayers()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var compFactory = server.ResolveDependency<IComponentFactory>();
+        var presets = protoMan.EnumeratePrototypes<GamePresetPrototype>();
+
+        var errorPresets = new List<string>();
+
+        foreach (var preset in presets)
+        {
+            if (preset.ID == TestPreset)
+                continue; // This preset is specifically for testing and has a MinPlayers value that doesn't match its rules, so ignore it
+            var minPlayers = preset.MinPlayers ?? 0;
+            Assert.That(minPlayers, Is.GreaterThanOrEqualTo(0));
+            var minPlayersRules = GetBiggestMinPlayers(preset, protoMan, compFactory);
+
+            if (minPlayers < minPlayersRules)
+                errorPresets.Add($"{preset.ID}: preset={minPlayers}, required={minPlayersRules}");
+        }
+
+        Assert.That(errorPresets.Count, Is.Zero, $"The following presets have a MinPlayers value that is too low: {string.Join(", ", errorPresets)}");
+    }
+
+    private int GetBiggestMinPlayers(GamePresetPrototype preset, IPrototypeManager manager, IComponentFactory factory)
+    {
+        var biggest = 0;
+        foreach (var rule in preset.Rules)
+        {
+            if (!manager.TryIndex<EntityPrototype>(rule, out var ruleProto))
+            {
+                Assert.Fail($"Rule prototype '{rule}' not found in preset '{preset.ID}'");
+                continue;
+            }
+
+            if (!TryGetComponent<GameRuleComponent>(ruleProto.Components, factory, out var ruleComponent))
+            {
+                Assert.Fail($"Rule '{rule}' in preset '{preset.ID}' has no GameRuleComponent");
+                continue;
+            }
+
+            if (!ruleComponent.CancelPresetOnTooFewPlayers) // Ignore rules that don't cancel the preset if there are too few players, as they don't require a minimum player count
+                continue;
+
+            biggest = Math.Max(biggest, ruleComponent.MinPlayers);
+        }
+        return biggest;
+    }
+
+    private static bool TryGetComponent<T>(ComponentRegistry components, IComponentFactory factory, [NotNullWhen(true)] out T? component) where T : IComponent, new()
+    {
+        if (!components.TryGetValue(factory.GetComponentName<T>(), out var componentUnCast))
+        {
+            component = default;
+            return false;
+        }
+
+        if (componentUnCast.Component is not T cast)
+        {
+            component = default;
+            return false;
+        }
+
+        component = cast;
+        return true;
+    }
+}

--- a/Content.IntegrationTests/Tests/_StarLight/GameRules/GamePresetsMinPlayersTest.cs
+++ b/Content.IntegrationTests/Tests/_StarLight/GameRules/GamePresetsMinPlayersTest.cs
@@ -41,6 +41,8 @@ public sealed class GamePresetsMinPlayersTest
             errorPresets.Count,
             Is.Zero,
             $"Found invalid preset/rule min-player configuration(s):{Environment.NewLine}{string.Join(Environment.NewLine, errorPresets)}");
+
+        await pair.CleanReturnAsync();
     }
 
     private int GetBiggestMinPlayers(GamePresetPrototype preset, IPrototypeManager manager, IComponentFactory factory, List<string> errors)

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -277,7 +277,7 @@
   id: Traitor
   components:
   - type: GameRule
-    minPlayers: 0
+    minPlayers: 0 # Starlight-edit
     delay:
       min: 240
       max: 420

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -277,7 +277,7 @@
   id: Traitor
   components:
   - type: GameRule
-    minPlayers: 5
+    minPlayers: 0
     delay:
       min: 240
       max: 420

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -141,6 +141,7 @@
   name: dynamic-title
   showInVote: false # admin-only for now until we fix some bugs
   description: dynamic-description
+  minPlayers: 5 # 🌟Starlight🌟
   rules:
   - DynamicRule
   - DummyNonAntag
@@ -180,7 +181,7 @@
     - tator
   name: traitor-title
   description: traitor-description
-  minPlayers: 4
+  minPlayers: 5 # 🌟Starlight🌟
   showInVote: true # 🌟Starlight🌟
   rules:
   # - DummyNonAntagChance 🌟Starlight🌟
@@ -250,6 +251,7 @@
   - wizard
   name: wizard-title
   description: wizard-description
+  minPlayers: 40 # 🌟Starlight🌟
   showInVote: false
   rules:
   - Wizard
@@ -266,6 +268,7 @@
     - xenoborgs
   name: xenoborgs-title
   description: xenoborgs-description
+  minPlayers: 20 # 🌟Starlight🌟
   showInVote: true # 🌟Starlight🌟
   rules:
   - Xenoborgs

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -181,7 +181,7 @@
     - tator
   name: traitor-title
   description: traitor-description
-  minPlayers: 5 # 🌟Starlight🌟
+  minPlayers: 0 # 🌟Starlight🌟
   showInVote: true # 🌟Starlight🌟
   rules:
   # - DummyNonAntagChance 🌟Starlight🌟


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

1. Adds new test to check biggest min players count in preset and compare it with preset min players value, so we can catch problems when preset has smaller amount of min players than it's rules(ignores rules which won't drop preset selection via min players reason)
2. Fixes presets that have smaller value of min players then their game rules.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

If preset has smaller value of min players it can be selected but game rule won't run and drop preset, so it will cause round restart. I.e. Bugfix.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rinary
- fix: Fixed min players amount on Xenoborgs/Wizards/Traitor presets, now they have the same min players value as their game rules. I.e. fixes bugs when round won't start even without forced game preset.