### PR TITLE
Fix polymorphs bypassing EORG prevention

### DIFF
--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -4,7 +4,6 @@ using Content.Server.Polymorph.Components;
 using Content.Server.Shuttles.Components;
 using Content.Shared._NullLink;
 using Content.Shared._Starlight.GameTicking.Components;
-using Content.Shared.Actions.Components;
 using Content.Shared.Actions.Events;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.CombatMode.Pacification;
@@ -16,8 +15,6 @@ using Content.Shared.Movement.Components;
 using Content.Shared.Polymorph;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
-using Content.Shared.Roles.Components;
-using Content.Shared.Starlight;
 using Content.Shared.Starlight.CCVar;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
@@ -53,40 +50,81 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     /// Validate an entity is eligible for pacification, and applies it if so.
     /// </summary>
     /// <param name="target">The entity to potentially pacify</param>
-    /// <param name="alt">Secondary entity to check for pacification immunity. Used for polymorphs to prevent
-    /// pacifying the original body while the mind is in a polymorphed one.</param>
-    /// <param name="xformOverride">An alternative entity to use for checking what grid the entity is on.
-    /// Useful for polymorphs, as the original body will be elsewhere.</param>
-    private void SpreadPeace(EntityUid target, EntityUid? alt = null, EntityUid? xformOverride = null)
+    private void SpreadPeaceNow(EntityUid target)
     {
         if (!_isEnabled || !_roundedEnded) return;
+        if (!ShouldPacify(target)) return;
+        Pacify(target);
 
-        // If the entity is polymorphed, also spread peace to the original body, using the
-        // polymorphed entity's location as determining grid.
-        if (TryComp<PolymorphedEntityComponent>(target, out var polymorph) && polymorph.Parent != null)
-            SpreadPeace(polymorph.Parent.Value, alt: target, xformOverride: target);
+        // If the entity is polymorphed, also pacify the parent(s).
+        while (TryComp<PolymorphedEntityComponent>(target, out var polymorph) && polymorph.Parent != null)
+        {
+            target = polymorph.Parent.Value;
+            Pacify(target);
+        }
+    }
 
-        // OOC bypass (staff, extroles, ...). We check for both target and alt since the mind is in only one of them.
-        if (_rolesReq.IsPeacefulBypass(target) ||
-            (alt != null && _rolesReq.IsPeacefulBypass(alt.Value))) return;
+    /// <summary>
+    /// The queueing counterpart of <see cref="SpreadPeaceNow"/>. Checks if the target is a valid pacification candidate
+    /// and adds them to the candidate list if they are valid pacification.
+    /// </summary>
+    /// <param name="target"></param>
+    /// <param name="candidates"></param>
+    private void SpreadPeaceQueueing(EntityUid target, ref List<EntityUid> candidates)
+    {
+        if (!ShouldPacify(target)) return;
+        candidates.Add(target);
 
-        // Only pacify people on Evac and CC grids. If xformOverride is set, use that for location.
-        if (!IsGridPacificationTarget(xformOverride ?? target)) return;
+        // If the entity is polymorphed, also pacify the parent(s).
+        while (TryComp<PolymorphedEntityComponent>(target, out var polymorph) && polymorph.Parent != null)
+        {
+            target = polymorph.Parent.Value;
+            candidates.Add(target);
+        }
+    }
+
+    /// <summary>
+    /// Determine if the target should be pacified. Does not do any polymorph-related checks.
+    /// </summary>
+    /// <param name="target">The entity to test</param>
+    /// <returns>Whether the target should be pacified, not accounting or polymorphs</returns>
+    private bool ShouldPacify(EntityUid target)
+    {
+        // OOC bypass (staff, extroles, ...).
+        if (_rolesReq.IsPeacefulBypass(target))
+            return false;
+
+        // Only pacify people on Evac and CC grids.
+        if (!IsGridPacificationTarget(target))
+            return false;
 
         // IC bypasses only apply to a specific mind roles (taken roles of ERT, Decimus, CC, ...).
-        // While it might appear we plainly check both target and alt, there's a guaranteed directionality
-        // about mind roles. If an ERT player gets carp polymorphed, the carp should also not get pacified, as the
-        // player is still roleplaying being ERT. Since polymorphs don't have their own mind roles we can be confident
-        // that the mind roles reflect the mind roles of the main body. As such we can safely check both target and alt
-        // without any unintended side effects.
-        if (IsMindRolePacificationImmune(target) ||
-            (alt != null && IsMindRolePacificationImmune(alt.Value))) return;
+        // Note that in the case of polymorphs, the mind and thus the mind roles are only contained in the child entity
+        // (the one that is being actively controlled).
+        if (IsMindRolePacificationImmune(target))
+            return false;
 
-        if (IsGhostRolePacificationImmune(target)) return; // IC bypass (only when ghost role wasn't taken)
-
-        EnsureComp<PacifiedComponent>(target);
-        EnsureComp<PreventEorgComponent>(target);
+        // IC bypass (only when ghost role wasn't taken)
+        return !IsGhostRolePacificationImmune(target);
     }
+
+    /// <summary>
+    /// Pacify a target. If the system is disabled, only marks them with <see cref="PreventEorgComponent"/>.
+    /// </summary>
+    /// <param name="target"></param>
+    private void Pacify(EntityUid target)
+    {
+        if (HasComp<PreventEorgComponent>(target)) return;
+
+        var wasPacified = HasComp<PacifiedComponent>(target);
+        if (_isEnabled)
+            EnsureComp<PacifiedComponent>(target);
+
+        var preventEorg = EnsureComp<PreventEorgComponent>(target);
+        preventEorg.WasPacifiedPrior = wasPacified;
+    }
+
+    #region Pacification checks
 
     /// <summary>
     /// Checks if the entity has any mind roles that are exempt from pacification.
@@ -142,11 +180,14 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         return false;
     }
 
+    #endregion
+    #region Event handlers
+
     private void OnSpawnComplete(PlayerSpawnCompleteEvent ev)
-        => SpreadPeace(ev.Mob);
+        => SpreadPeaceNow(ev.Mob);
 
     private void OnRehydrateEvent(ref GotRehydratedEvent ev)
-        => SpreadPeace(ev.Target);
+        => SpreadPeaceNow(ev.Target);
 
     private void OnRoundCleanup(RoundRestartCleanupEvent ev)
         => _roundedEnded = false;
@@ -154,14 +195,40 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     private void OnRoundEnded(RoundEndTextAppendEvent ev)
     {
         _roundedEnded = true;
+        if (!_isEnabled) return;
 
+        var candidates = new List<EntityUid>();
+
+        // Collect candidate entities for pacification.
         var mobMoverQuery = EntityQueryEnumerator<MobMoverComponent>();
         while (mobMoverQuery.MoveNext(out var uid, out _))
-            SpreadPeace(uid);
+            SpreadPeaceQueueing(uid, ref candidates);
 
         var mechQuery = EntityQueryEnumerator<MechComponent>();
         while (mechQuery.MoveNext(out var uid, out _))
-            SpreadPeace(uid);
+            SpreadPeaceQueueing(uid, ref candidates);
+
+        // Remove any candidates that are part of a polymorph chain where some immunity (OOC or job immunity) is at play.
+        var polymorphedQuery = EntityQueryEnumerator<PolymorphedEntityComponent>();
+        while (polymorphedQuery.MoveNext(out var uid, out _))
+        {
+            // Loop from the current node up the polymorph tree.
+            var current = uid;
+            var deleting = false;
+            while (TryComp<PolymorphedEntityComponent>(current, out var polymorphed) && polymorphed.Parent.HasValue)
+            {
+                if (deleting || !candidates.Contains(current))
+                {
+                    deleting = true;
+                    candidates.Remove(polymorphed.Parent.Value);
+                }
+                current = polymorphed.Parent.Value;
+            }
+        }
+
+        // Pacify the remaining candidates.
+        foreach (var uid in candidates)
+            Pacify(uid);
     }
 
     /// <summary>
@@ -171,17 +238,22 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     private void OnValidatePossiblyEorgAction(EntityUid uid, EorgActionComponent component, ref ActionValidateEvent args)
     {
         if (!_isEnabled || !_roundedEnded) return;
-        if (!TryComp<PreventEorgComponent>(args.User, out _))  return;
+        if (!HasComp<PreventEorgComponent>(args.User))  return;
 
         _popup.PopupEntity(Loc.GetString("eorg-action"), args.User, args.User, PopupType.LargeCaution);
         args.Invalid = true;
     }
 
+
     /// <summary>
     /// If someone with <see cref="PreventEorgComponent"/> polymorphs, also apply it to their polymorph.
-    /// In this case their locations will be identical so we don't override that parameter.
     /// </summary>
-    private void OnPolymorphed(EntityUid uid, PreventEorgComponent comp, PolymorphedEvent ev) =>
-        SpreadPeace(ev.NewEntity, ev.OldEntity);
+    private void OnPolymorphed(EntityUid uid, PreventEorgComponent comp, PolymorphedEvent ev)
+    {
+        if (HasComp<PreventEorgComponent>(ev.OldEntity))
+            Pacify(ev.NewEntity);
+    }
+
+    #endregion
 
 }

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -53,28 +53,35 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     /// Validate an entity is eligible for pacification, and applies it if so.
     /// </summary>
     /// <param name="target">The entity to potentially pacify</param>
-    /// <param name="altUid">Secondary entity to check for pacification immunity. Used for polymorphs to prevent
+    /// <param name="alt">Secondary entity to check for pacification immunity. Used for polymorphs to prevent
     /// pacifying the original body while the mind is in a polymorphed one.</param>
     /// <param name="xformOverride">An alternative entity to use for checking what grid the entity is on.
     /// Useful for polymorphs, as the original body will be elsewhere.</param>
-    private void SpreadPeace(EntityUid target, EntityUid? altUid = null, EntityUid? xformOverride = null)
+    private void SpreadPeace(EntityUid target, EntityUid? alt = null, EntityUid? xformOverride = null)
     {
         if (!_isEnabled || !_roundedEnded) return;
 
         // If the entity is polymorphed, also spread peace to the original body, using the
         // polymorphed entity's location as determining grid.
         if (TryComp<PolymorphedEntityComponent>(target, out var polymorph) && polymorph.Parent != null)
-            SpreadPeace(polymorph.Parent.Value, altUid: target, xformOverride: target);
+            SpreadPeace(polymorph.Parent.Value, alt: target, xformOverride: target);
 
         // OOC bypass (staff, extroles, ...). We check for both target and alt since the mind is in only one of them.
         if (_rolesReq.IsPeacefulBypass(target) ||
-            (altUid != null && _rolesReq.IsPeacefulBypass(altUid.Value))) return;
+            (alt != null && _rolesReq.IsPeacefulBypass(alt.Value))) return;
 
         // Only pacify people on Evac and CC grids. If xformOverride is set, use that for location.
         if (!IsGridPacificationTarget(xformOverride ?? target)) return;
 
-        // IC bypasses only apply to a specific body.
-        if (IsMindRolePacificationImmune(target)) return; // IC bypass (taken roles of ERT, Decimus, CC, ..)
+        // IC bypasses only apply to a specific mind roles (taken roles of ERT, Decimus, CC, ..)..
+        // While it might appear we plainly check both target and alt, there's a guaranteed directionality
+        // about mind roles. If an ERT player gets carp polymorphed, the carp should also not get pacified, as the
+        // player is still roleplaying being ERT. Since polymorphs don't have their own mind roles we can be confident
+        // that the mind roles reflect the mind roles of the main body. As such we can safely check both target and alt
+        // without any unintended side effects.
+        if (IsMindRolePacificationImmune(target) ||
+            (alt != null && IsMindRolePacificationImmune(alt.Value))) return;
+
         if (IsGhostRolePacificationImmune(target)) return; // IC bypass (only when ghost role wasn't taken)
 
         EnsureComp<PacifiedComponent>(target);

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -1,5 +1,6 @@
 using Content.Server.GameTicking;
 using Content.Server.Ghost.Roles.Components;
+using Content.Server.Polymorph.Components;
 using Content.Server.Shuttles.Components;
 using Content.Shared._NullLink;
 using Content.Shared._Starlight.GameTicking.Components;
@@ -12,6 +13,7 @@ using Content.Shared.Mech.Components;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Movement.Components;
+using Content.Shared.Polymorph;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
 using Content.Shared.Roles.Components;
@@ -44,13 +46,20 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         SubscribeLocalEvent<GotRehydratedEvent>(OnRehydrateEvent);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundCleanup);
         SubscribeLocalEvent<EorgActionComponent, ActionValidateEvent>(OnValidatePossiblyEorgAction);
+        SubscribeLocalEvent<PreventEorgComponent, PolymorphedEvent>(OnPolymorphed);
     }
 
-    private void SpreadPeace(EntityUid target)
+    /// <summary>
+    /// Validate an entity is eligible for pacification, and applies it if so.
+    /// </summary>
+    /// <param name="target">The entity to potentially pacify</param>
+    /// <param name="xformSourceUid">An alternative entity to use for checking what grid the entity is on.
+    /// Useful for polymorphs, as the original body will be elsewhere.</param>
+    private void SpreadPeace(EntityUid target, EntityUid? xformSourceUid = null)
     {
         if (!_isEnabled || !_roundedEnded) return;
         if (_rolesReq.IsPeacefulBypass(target)) return; // OOC bypass (staff, extroles, ..)
-        if (!IsGridPacificationTarget(target)) return; // Only pacify people on Evac and CC grids.
+        if (!IsGridPacificationTarget(xformSourceUid ?? target)) return; // Only pacify people on Evac and CC grids.
         if (IsMindRolePacificationImmune(target)) return; // IC bypass (taken roles of ERT, Decimus, CC, ..)
         if (IsGhostRolePacificationImmune(target)) return; // IC bypass (same as previous, only when ghost role wasn't taken)
 
@@ -127,13 +136,23 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
 
         var mobMoverQuery = EntityQueryEnumerator<MobMoverComponent>();
         while (mobMoverQuery.MoveNext(out var uid, out _))
+        {
             SpreadPeace(uid);
+
+            // If "uid" is a polymorphed entity, also spread peace to the original body.
+            if (TryComp<PolymorphedEntityComponent>(uid, out var polymorph) && polymorph.Parent != null)
+                SpreadPeace(polymorph.Parent.Value, uid);
+        }
 
         var mechQuery = EntityQueryEnumerator<MechComponent>();
         while (mechQuery.MoveNext(out var uid, out _))
             SpreadPeace(uid);
     }
 
+    /// <summary>
+    /// Prevents performing actions marked as <see cref="EorgActionComponent"/> if the user has
+    /// <see cref="PreventEorgComponent"/>.
+    /// </summary>
     private void OnValidatePossiblyEorgAction(EntityUid uid, EorgActionComponent component, ref ActionValidateEvent args)
     {
         if (!_isEnabled || !_roundedEnded) return;
@@ -142,4 +161,10 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         _popup.PopupEntity(Loc.GetString("eorg-action"), args.User, args.User, PopupType.LargeCaution);
         args.Invalid = true;
     }
+
+    /// <summary>
+    /// If someone with <see cref="PreventEorgComponent"/> polymorphs, also apply it to their polymorph.
+    /// </summary>
+    private void OnPolymorphed(EntityUid uid, PreventEorgComponent comp, PolymorphedEvent ev) => SpreadPeace(ev.NewEntity);
+
 }

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -109,16 +109,15 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     }
 
     /// <summary>
-    /// Pacify a target. If the system is disabled, only marks them with <see cref="PreventEorgComponent"/>.
+    /// Pacify a target immediately.
     /// </summary>
-    /// <param name="target"></param>
+    /// <param name="target">The target to pacify</param>
     private void Pacify(EntityUid target)
     {
         if (HasComp<PreventEorgComponent>(target)) return;
 
         var wasPacified = HasComp<PacifiedComponent>(target);
-        if (_isEnabled)
-            EnsureComp<PacifiedComponent>(target);
+        EnsureComp<PacifiedComponent>(target);
 
         var preventEorg = EnsureComp<PreventEorgComponent>(target);
         preventEorg.WasPacifiedPrior = wasPacified;

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -73,7 +73,7 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         // Only pacify people on Evac and CC grids. If xformOverride is set, use that for location.
         if (!IsGridPacificationTarget(xformOverride ?? target)) return;
 
-        // IC bypasses only apply to a specific mind roles (taken roles of ERT, Decimus, CC, ..)..
+        // IC bypasses only apply to a specific mind roles (taken roles of ERT, Decimus, CC, ...).
         // While it might appear we plainly check both target and alt, there's a guaranteed directionality
         // about mind roles. If an ERT player gets carp polymorphed, the carp should also not get pacified, as the
         // player is still roleplaying being ERT. Since polymorphs don't have their own mind roles we can be confident

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -114,13 +114,8 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     /// <param name="target">The target to pacify</param>
     private void Pacify(EntityUid target)
     {
-        if (HasComp<PreventEorgComponent>(target)) return;
-
-        var wasPacified = HasComp<PacifiedComponent>(target);
         EnsureComp<PacifiedComponent>(target);
-
-        var preventEorg = EnsureComp<PreventEorgComponent>(target);
-        preventEorg.WasPacifiedPrior = wasPacified;
+        EnsureComp<PreventEorgComponent>(target);
     }
 
     #region Pacification checks

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -53,15 +53,29 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     /// Validate an entity is eligible for pacification, and applies it if so.
     /// </summary>
     /// <param name="target">The entity to potentially pacify</param>
-    /// <param name="xformSourceUid">An alternative entity to use for checking what grid the entity is on.
+    /// <param name="altUid">Secondary entity to check for pacification immunity. Used for polymorphs to prevent
+    /// pacifying the original body while the mind is in a polymorphed one.</param>
+    /// <param name="xformOverride">An alternative entity to use for checking what grid the entity is on.
     /// Useful for polymorphs, as the original body will be elsewhere.</param>
-    private void SpreadPeace(EntityUid target, EntityUid? xformSourceUid = null)
+    private void SpreadPeace(EntityUid target, EntityUid? altUid = null, EntityUid? xformOverride = null)
     {
         if (!_isEnabled || !_roundedEnded) return;
-        if (_rolesReq.IsPeacefulBypass(target)) return; // OOC bypass (staff, extroles, ..)
-        if (!IsGridPacificationTarget(xformSourceUid ?? target)) return; // Only pacify people on Evac and CC grids.
+
+        // If the entity is polymorphed, also spread peace to the original body, using the
+        // polymorphed entity's location as determining grid.
+        if (TryComp<PolymorphedEntityComponent>(target, out var polymorph) && polymorph.Parent != null)
+            SpreadPeace(polymorph.Parent.Value, altUid: target, xformOverride: target);
+
+        // OOC bypass (staff, extroles, ...). We check for both target and alt since the mind is in only one of them.
+        if (_rolesReq.IsPeacefulBypass(target) ||
+            (altUid != null && _rolesReq.IsPeacefulBypass(altUid.Value))) return;
+
+        // Only pacify people on Evac and CC grids. If xformOverride is set, use that for location.
+        if (!IsGridPacificationTarget(xformOverride ?? target)) return;
+
+        // IC bypasses only apply to a specific body.
         if (IsMindRolePacificationImmune(target)) return; // IC bypass (taken roles of ERT, Decimus, CC, ..)
-        if (IsGhostRolePacificationImmune(target)) return; // IC bypass (same as previous, only when ghost role wasn't taken)
+        if (IsGhostRolePacificationImmune(target)) return; // IC bypass (only when ghost role wasn't taken)
 
         EnsureComp<PacifiedComponent>(target);
         EnsureComp<PreventEorgComponent>(target);
@@ -136,13 +150,7 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
 
         var mobMoverQuery = EntityQueryEnumerator<MobMoverComponent>();
         while (mobMoverQuery.MoveNext(out var uid, out _))
-        {
             SpreadPeace(uid);
-
-            // If "uid" is a polymorphed entity, also spread peace to the original body.
-            if (TryComp<PolymorphedEntityComponent>(uid, out var polymorph) && polymorph.Parent != null)
-                SpreadPeace(polymorph.Parent.Value, uid);
-        }
 
         var mechQuery = EntityQueryEnumerator<MechComponent>();
         while (mechQuery.MoveNext(out var uid, out _))
@@ -164,7 +172,9 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
 
     /// <summary>
     /// If someone with <see cref="PreventEorgComponent"/> polymorphs, also apply it to their polymorph.
+    /// In this case their locations will be identical so we don't override that parameter.
     /// </summary>
-    private void OnPolymorphed(EntityUid uid, PreventEorgComponent comp, PolymorphedEvent ev) => SpreadPeace(ev.NewEntity);
+    private void OnPolymorphed(EntityUid uid, PreventEorgComponent comp, PolymorphedEvent ev) =>
+        SpreadPeace(ev.NewEntity, ev.OldEntity);
 
 }

--- a/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
+++ b/Content.Server/_Starlight/GameTicking/GameTicker.PeacefulRoundEnd.cs
@@ -242,11 +242,7 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     /// <summary>
     /// If someone with <see cref="PreventEorgComponent"/> polymorphs, also apply it to their polymorph.
     /// </summary>
-    private void OnPolymorphed(EntityUid uid, PreventEorgComponent comp, PolymorphedEvent ev)
-    {
-        if (HasComp<PreventEorgComponent>(ev.OldEntity))
-            Pacify(ev.NewEntity);
-    }
+    private void OnPolymorphed(EntityUid uid, PreventEorgComponent comp, PolymorphedEvent ev) => Pacify(ev.NewEntity);
 
     #endregion
 

--- a/Content.Shared/_Starlight/GameTicking/Components/PreventEorgComponent.cs
+++ b/Content.Shared/_Starlight/GameTicking/Components/PreventEorgComponent.cs
@@ -8,4 +8,5 @@ namespace Content.Shared._Starlight.GameTicking.Components;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class PreventEorgComponent : Component
 {
+    public bool WasPacifiedPrior { get; set; }
 }

--- a/Content.Shared/_Starlight/GameTicking/Components/PreventEorgComponent.cs
+++ b/Content.Shared/_Starlight/GameTicking/Components/PreventEorgComponent.cs
@@ -8,5 +8,4 @@ namespace Content.Shared._Starlight.GameTicking.Components;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class PreventEorgComponent : Component
 {
-    public bool WasPacifiedPrior { get; set; }
 }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Title.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

User report: https://discord.com/channels/1272545509562777621/1492422094028411002

It's currently possible to bypass EORG prevention by either:
- Polymorphing before evac departs, and unpolymorphing after departure;
- Polymorphing into a hostile creature after you were pacified.

Both cases are fixed in this PR.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/991301b0-4209-43b6-b61d-191c80d817ad

https://github.com/user-attachments/assets/6152d3e8-daf4-47bd-a6c3-984aa6738e9b

https://s.redmushie.me/2026/04/Content.Client_jkkSWxPq3P.mp4

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: Polymorphing before or after EOR no longer bypasses EORG prevention measures.
