### PR TITLE
PullableComponent: Bypass NeedsHands

### DIFF
--- a/Content.Shared/Movement/Pulling/Components/PullableComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullableComponent.cs
@@ -41,6 +41,15 @@ public sealed partial class PullableComponent : Component
 
     [DataField]
     public ProtoId<AlertPrototype> PulledAlert = "Pulled";
+
+    #region Starlight
+
+    /// <summary>
+    /// Ignores <see cref="PullerComponent.NeedsHands"/>, makes it not take up hand slots when pulled.
+    /// </summary>
+    [DataField, AutoNetworkedField] public bool IgnoreNeedsHands;
+
+    #endregion
 }
 
 public sealed partial class StopBeingPulledAlertEvent : BaseAlertEvent;

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -113,8 +113,13 @@ public sealed class PullingSystem : EntitySystem
         if (args.PullerUid != uid)
             return;
 
-        if (TryComp(args.PullerUid, out PullerComponent? pullerComp) && !pullerComp.NeedsHands)
+        //Starlight begin: add ability for object to ignore needshands
+        if (!TryComp<PullableComponent>(args.PulledUid, out var pulled))
             return;
+
+        if ((TryComp(args.PullerUid, out PullerComponent? pullerComp) && !pullerComp.NeedsHands) || pulled.IgnoreNeedsHands)
+            return;
+        //Starlight end
 
         if (!_virtual.TrySpawnVirtualItemInHand(args.PulledUid, uid))
         {
@@ -438,12 +443,17 @@ public sealed class PullingSystem : EntitySystem
             return false;
         }
 
-        if (pullerComp.NeedsHands
+        //Starlight begin: ignore needshands
+        if (!TryComp<PullableComponent>(pullableUid, out var pullable))
+            return false;
+
+        if (pullerComp.NeedsHands && !pullable.IgnoreNeedsHands
             && !_handsSystem.TryGetEmptyHand(puller, out _)
             && pullerComp.Pulling == null)
         {
             return false;
         }
+        //Starlight end
 
         if (!_blocker.CanInteract(puller, pullableUid))
         {


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds ability to bypass the `NeedsHands` parameter of `PullerComponent`
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Lets you make something not require hands to be pulled without making so that nothing requires hands to be pulled for that entity.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.