### PR TITLE
End-of-round time voting

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -21,6 +21,9 @@ using Robust.Shared.Timing;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Station.Components;
 using Timer = Robust.Shared.Timing.Timer;
+using Content.Shared.Starlight.CCVar;
+using Content.Server.Voting.Managers;
+using Content.Server.Voting;
 
 namespace Content.Server.RoundEnd
 {
@@ -41,6 +44,9 @@ namespace Content.Server.RoundEnd
         [Dependency] private readonly EmergencyShuttleSystem _shuttle = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly StationSystem _stationSystem = default!;
+        // Starlight begin
+        [Dependency] private readonly IVoteManager _votes = default!;
+        // Starlight end
 
         public TimeSpan DefaultCooldownDuration { get; set; } = TimeSpan.FromSeconds(30);
 
@@ -305,6 +311,74 @@ namespace Content.Server.RoundEnd
             }
         }
 
+        /// <summary>
+        /// STARLIGHT
+        /// Ends round, but with a vote for how long EOR should be
+        /// </summary>
+        private void EndRoundWithTimeVote(CancellationTokenSource countdownTokenSource)
+        {
+            var defaultTime = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.RoundRestartTime));
+            var optionSpacing = TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.EndRoundTimeVoteSpacing));
+            var optionQuantity = _cfg.GetCVar(StarlightCCVars.EndRoundTimeVoteAmount);
+
+            var options = new VoteOptions
+            {
+                Title = Loc.GetString("eor-time-vote-title"),
+                InitiatorText = Loc.GetString("eor-time-vote-initiator"),
+                Duration = TimeSpan.FromSeconds(15f),
+            };
+
+            options.Options.Add(($"{defaultTime.Minutes}", defaultTime));
+            var lastSavedNegativeTime = defaultTime;
+            var lastSavedPositiveTime = defaultTime;
+
+            for (int i = 1; i < optionQuantity; i++)
+            {
+                if (lastSavedNegativeTime.Seconds - optionSpacing.Seconds < 0)
+                {
+                    lastSavedNegativeTime = lastSavedNegativeTime.Subtract(optionSpacing);
+                    options.Options.Add(($"{lastSavedNegativeTime.Minutes}", lastSavedNegativeTime));
+                    i++;
+                }
+
+                lastSavedPositiveTime = lastSavedPositiveTime.Add(optionSpacing);
+                options.Options.Add(($"{lastSavedPositiveTime.Minutes}", lastSavedPositiveTime));
+            }
+
+            var vote = _votes.CreateVote(options);
+
+            vote.OnFinished += (_, args) =>
+            {
+                TimeSpan picked;
+                if (args.Winner == null)
+                {
+                    picked = defaultTime;
+                }
+                else
+                {
+                    picked = (TimeSpan)args.Winner;
+                }
+                int time;
+                string unitsLocString;
+                if (picked.TotalSeconds < 60)
+                {
+                    time = picked.Seconds;
+                    unitsLocString = "eta-units-seconds";
+                }
+                else
+                {
+                    time = picked.Minutes;
+                    unitsLocString = "eta-units-minutes";
+                }
+                _chatManager.DispatchServerAnnouncement(
+                    Loc.GetString(
+                        "round-end-system-round-restart-eta-announcement",
+                        ("time", time),
+                        ("units", Loc.GetString(unitsLocString))));
+                Timer.Spawn(picked, AfterEndRoundRestart, countdownTokenSource.Token);
+            };
+        }
+
         public void EndRound(TimeSpan? countdownTime = null)
         {
             if (_gameTicker.RunLevel != GameRunLevel.InRound) return;
@@ -314,6 +388,14 @@ namespace Content.Server.RoundEnd
             _gameTicker.EndRound();
             _countdownTokenSource?.Cancel();
             _countdownTokenSource = new();
+
+            // Starlight
+            if (_cfg.GetCVar(StarlightCCVars.EnableEndRoundTimeVotes))
+            {
+                EndRoundWithTimeVote(_countdownTokenSource);
+                return;
+            }
+            // Starlight END
 
             countdownTime ??= TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.RoundRestartTime));
             int time;

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
@@ -45,4 +45,22 @@ public sealed partial class StarlightCCVars
     /// </summary>
     public static readonly CVarDef<bool> AutogammaRiftEnabled =
         CVarDef.Create("game.autogamma_enabled", false, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Enables voting for how long EOR will be, off by default.
+    /// </summary>
+    public static readonly CVarDef<bool> EnableEndRoundTimeVotes =
+        CVarDef.Create("game.round_end_time_vote_enabled", true, CVar.SERVERONLY);
+
+    /// <summary>
+    /// How many seconds between each time-vote option.
+    /// </summary>
+    public static readonly CVarDef<float> EndRoundTimeVoteSpacing =
+        CVarDef.Create("game.round_end_time_vote_spacing", 300f, CVar.SERVERONLY);
+
+    /// <summary>
+    /// How many different options to generate for end-round times.
+    /// </summary>
+    public static readonly CVarDef<int> EndRoundTimeVoteAmount =
+        CVarDef.Create("game.round_end_time_vote_amount", 3, CVar.SERVERONLY);
 }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
@@ -50,7 +50,7 @@ public sealed partial class StarlightCCVars
     /// Enables voting for how long EOR will be, off by default.
     /// </summary>
     public static readonly CVarDef<bool> EnableEndRoundTimeVotes =
-        CVarDef.Create("game.round_end_time_vote_enabled", true, CVar.SERVERONLY);
+        CVarDef.Create("game.round_end_time_vote_enabled", false, CVar.SERVERONLY);
 
     /// <summary>
     /// How many seconds between each time-vote option.

--- a/Resources/Locale/en-US/_Starlight/roundend/eor_voting.ftl
+++ b/Resources/Locale/en-US/_Starlight/roundend/eor_voting.ftl
@@ -1,0 +1,2 @@
+eor-time-vote-title = How many minutes for end-of-round?
+eor-time-vote-initiator = Server


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds a CVar that, when set to true, enables voting for how long end-of-round should be.
Also adds other CVars to further customise this feature.

Currently a draft as I'm an idiot and this touches a pretty important part of the gameplay cycle.

How this works:

- If enabled, cancels normal EndRound behaviour and interjects EndRoundWithTimeVote
- This generates a vote with an amount of options defined by CCVar, 3 by default

These options are:
1. Default time, so 5 for Alpha, 10 for Beta
2. Default time -X if possible (The number  X subtracted is a CCVar, 5 by default)
3. Default time +X if possible, using the same X as with 2.

This behaviour repeats recursively if the amount of options is set to be more than 3.
It is dynamically calculated using the already existing EOR timer CCVar, meaning this does not use any pre-defined values outside of the 15 second vote timer.

Once the vote is over, EndRoundWithTimeVote fulfils the latter part of EndRound, using the timespan voted for to define the countdown.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Primarily intended for beta.
There's a demand for it, as documented in [this staff suggestion](https://discord.com/channels/1272545509562777621/1488696644248797235)

The desired round-end time is pretty inconsistent though, hence why a voting system is likely better.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->


https://github.com/user-attachments/assets/78d58188-723f-4731-bfc1-946dc5918b7f



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- add: Added server-option for voting for how long end-of-round will last.
