### PR TITLE
Add new thaven moods

### DIFF
--- a/Resources/Locale/en-US/_Starlight/thavens/no-and.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/no-and.ftl
@@ -161,3 +161,18 @@ thaven-mood-perceived-dissonance-desc = {$language} hurts your delicate ears and
 
 thaven-mood-germophobe-name = Germophobe
 thaven-mood-germophobe-desc = You are afraid of these little creatures that conquer every nook and cranny. Make sure to clean your tools and workplace regularly with soap, so not even prints are left.
+
+thaven-mood-forgetful-name = Forgetful
+thaven-mood-forgetful-desc = You have trouble remembering things for more than a few minutes.
+
+thaven-mood-unfinished-thoughts-name = Unfinished Thoughts
+thaven-mood-unfinished-thoughts-desc = You rarely finish sentences.
+
+thaven-mood-caveman-name = Caveman
+thaven-mood-caveman-desc = You can only speak in words with one syllable.
+
+thaven-mood-anger-problems-name = Anger Problems
+thaven-mood-anger-problems-desc = You hate everyone, but you would never hurt them.
+
+thaven-mood-allergies-name = Allergies
+thaven-mood-allergies-desc = You're allergic to {$item} and should avoid being near it as much as you can.

--- a/Resources/Locale/en-US/_Starlight/thavens/shared.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/shared.ftl
@@ -87,3 +87,18 @@ thaven-mood-sirens-song-desc = Thaven are incredibly proud of their wonderful mu
 
 thaven-mood-bloodbank-name = Bloodbank
 thaven-mood-bloodbank-desc = Thaven have a strong culture of mutual aid, going so far to even offer their blood freely to people in need.
+
+thaven-mood-your-funeral-name = Your Funeral
+thaven-mood-your-funeral-desc = It's someone's funeral today. Anyone's. Just pick someone, and host their funeral. They don't actually have to be dead, but it would probably be ideal if the funeral attendees thought they were.
+
+thaven-mood-beach-day-name = Beach Day
+thaven-mood-beach-day-desc = If there is an open water feature on station, Thaven should congregate there and swim merrily. If no water features are available, water puddles will do in a pinch.
+
+thaven-mood-buy-all-the-x-name = Buy All The {$item1} And {$item2}
+thaven-mood-buy-all-the-x-desc = {$disaster} is about to happen. Only massive amounts of {$item1} and {$item2} can prepare Thaven for the coming disaster.
+
+thaven-mood-trendy-words-name = Trendy Words
+thaven-mood-trendy-words-desc = Thaven are always on the frontlines of coolness and therefore use the following words frequently as trendsetters: {$word1}, {$word2}, {$word3}, {$word4}.
+
+thaven-mood-gossipers-name = Gossipers
+thaven-mood-gossipers-desc = Drama is the highest form of entertainment.

--- a/Resources/Locale/en-US/_Starlight/thavens/wildcard.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/wildcard.ftl
@@ -121,6 +121,21 @@ thaven-mood-delicious-moldy-bread-desc = Nothing tastes finer than moldy bread. 
 thaven-mood-blindness-is-freedom-name = Blindness Is Freedom
 thaven-mood-blindness-is-freedom-desc = Your sight disgusts you. Get rid of it.
 
+thaven-mood-charger-name = Charger
+thaven-mood-charger-desc = Your positronic brain consumes a lot of power. Make sure to frequently recharge it by skin contact with exposed electrical wires.
+
+thaven-mood-vital-purity-name = Vital Purity
+thaven-mood-vital-purity-desc = Healing is a crime against nature. Refuse any form of medical intervention at all costs.
+
+thaven-mood-martyr-name = Martyr
+thaven-mood-martyr-desc = It's highly virtuous to be visibly wounded. Keep your health low at all times.
+
+thaven-mood-duck-and-cover-name = Duck and Cover
+thaven-mood-duck-and-cover-desc = Showing your full profile is dangerous, crawl at all times.
+
+thaven-mood-paranoid-name = Paranoid
+thaven-mood-paranoid-desc = You strongly believe that coords cause cancer.
+
 # we love when server context doesn't properly dispose of data...
 DuplicateTest = DuplicateTestFTL
 DuplicateOverlapTest = DuplicateOverlapTestFTL

--- a/Resources/Locale/en-US/_Starlight/thavens/yes-and.ftl
+++ b/Resources/Locale/en-US/_Starlight/thavens/yes-and.ftl
@@ -32,7 +32,7 @@ thaven-mood-very-religious-name = You Are Very Religious
 thaven-mood-very-religious-desc = You should visit the shrine regularly to pray, and speak with a chaplain if possible.
 
 thaven-mood-only-speak-to-command-name = VIP
-thaven-mood-only-speak-to-command-desc = You are too important to speak to the rabble. You will only speak to command.
+thaven-mood-only-speak-to-command-desc = You are too important to speak to the rabble. You will only speak to command and other Thaven.
 
 thaven-mood-scheduler-name = Punctual
 thaven-mood-scheduler-desc = You believe that time must be strictly managed. Everything should be scheduled in advance, and tardiness is exceptionally rude.
@@ -219,4 +219,22 @@ thaven-mood-empath-name = Empath
 thaven-mood-empath-desc = You are heavily influenced by the emotions of others.
 
 thaven-mood-red-light-green-light-name = Red Light, Green Light
-thaven-mood-red-light-green-light-desc = You feel like you can't move when there are eyes on you.
+thaven-mood-red-light-green-light-desc = You feel like you can't move when anyone wearing red is looking at you.
+
+thaven-mood-cold-blooded-name = Cold-blooded
+thaven-mood-cold-blooded-desc = You always feel cold.
+
+thaven-mood-deja-vu-name = Déjà Vu
+thaven-mood-deja-vu-desc = You feel like all of today has happened before.
+
+thaven-mood-impending-doom-name = Impending Doom
+thaven-mood-impending-doom-desc = Something bad is going to happen, and you know exactly where and when.
+
+thaven-mood-rebel-name = Rebel
+thaven-mood-rebel-desc = You feel the need to speak ill of those in charge.
+
+thaven-mood-amateur-photographer-name = Amateur Photographer
+thaven-mood-amateur-photographer-desc = You feel the need to use flashes to take pictures of everyone on station.
+
+thaven-mood-insecure-name = Insecure
+thaven-mood-insecure-desc = You care deeply what people think about you, particularly about your {$appearance}.

--- a/Resources/Prototypes/_Starlight/Thavens/Moods/no_and.yml
+++ b/Resources/Prototypes/_Starlight/Thavens/Moods/no_and.yml
@@ -52,6 +52,11 @@
     - IncrediblyDistrusting
     - PerceivedDissonance
     - Germophobe
+    - Forgetful
+    - UnfinishedThoughts
+    - Caveman
+    - AngerProblems
+    - Allergies
 
 
 # Your Moods are a strictly-kept secret, and should never be revealed to anyone.
@@ -449,6 +454,9 @@
   conflicts:
     - BlindnessIsFreedom
     - FleshIsWeak
+    - Charger
+    - VitalPurity
+    - Martyr
 
 # Incredibly Distrusting: You do not trust anyone except other Thaven, unless someone you trust vouches for them.
 - type: thavenMood
@@ -473,3 +481,37 @@
   moodDesc: thaven-mood-germophobe-desc
   conflicts:
     - ExcessivelyDisorganized
+
+# Forgetful: You have trouble remembering things for more than a few minutes.
+- type: thavenMood
+  id: Forgetful
+  moodName: thaven-mood-forgetful-name
+  moodDesc: thaven-mood-forgetful-desc
+
+# Unfinished thoughts: You rarely finish sentences.
+- type: thavenMood
+  id: UnfinishedThoughts
+  moodName: thaven-mood-unfinished-thoughts-name
+  moodDesc: thaven-mood-unfinished-thoughts-desc
+
+# Caveman: You can only speak in words with one syllable.
+- type: thavenMood
+  id: Caveman
+  moodName: thaven-mood-caveman-name
+  moodDesc: thaven-mood-caveman-desc
+  conflicts:
+    - SpeechRestriction
+
+# Anger problems: You hate everyone, but you would never hurt them.
+- type: thavenMood
+  id: AngerProblems
+  moodName: thaven-mood-anger-problems-name
+  moodDesc: thaven-mood-anger-problems-desc
+
+# Allergies: You're allergic to [Item] and should avoid being near it as much as you can.
+- type: thavenMood
+  id: Allergies
+  moodName: thaven-mood-allergies-name
+  moodDesc: thaven-mood-allergies-desc
+  moodVars:
+    item: Items

--- a/Resources/Prototypes/_Starlight/Thavens/Moods/shared.yml
+++ b/Resources/Prototypes/_Starlight/Thavens/Moods/shared.yml
@@ -37,6 +37,11 @@
     - OppositeDay
     - SirensSong
     - Bloodbank
+    - YourFuneral
+    - BeachDay
+    - BuyAllTheX
+    - TrendyWords
+    - Gossipers
 
 
 # Keep Your Moods Secret: Thaven moods are a strictly-kept secret, and should never be revealed to anyone.
@@ -291,3 +296,42 @@
     - SacredBlood
     - FleshIsSacred
     - LoneActor
+
+# Your Funeral: It's someone's funeral today. Anyone's. Just pick someone, and host their funeral. They don't actually have to be dead, but it would probably be ideal if the funeral attendeees thought they were.
+- type: thavenMood
+  id: YourFuneral
+  moodName: thaven-mood-your-funeral-name
+  moodDesc: thaven-mood-your-funeral-desc
+
+# Beach day!: If there is an open water feature on station, Thaven should congregate there and swim merrily. Should there be no water features, water puddles will do in a pinch!
+- type: thavenMood
+  id: BeachDay
+  moodName: thaven-mood-beach-day-name
+  moodDesc: thaven-mood-beach-day-desc
+
+# Buy All The (X): X is about to happen. Only massive amounts of y and z can prepare Thaven for the coming disaster.
+- type: thavenMood
+  id: BuyAllTheX
+  moodName: thaven-mood-buy-all-the-x-name
+  moodDesc: thaven-mood-buy-all-the-x-desc
+  moodVars:
+    disaster: Disasters
+    item1: Items
+    item2: Items
+
+# Trendy Words: Thaven are always on the frontlines of coolness and therefore use the following words frequently as trendsetters: $WordList
+- type: thavenMood
+  id: TrendyWords
+  moodName: thaven-mood-trendy-words-name
+  moodDesc: thaven-mood-trendy-words-desc
+  moodVars:
+    word1: ThavenWords
+    word2: ThavenWords
+    word3: ThavenWords
+    word4: ThavenWords
+
+# Gossipers: Drama is the highest form of entertainment.
+- type: thavenMood
+  id: Gossipers
+  moodName: thaven-mood-gossipers-name
+  moodDesc: thaven-mood-gossipers-desc

--- a/Resources/Prototypes/_Starlight/Thavens/Moods/wildcard.yml
+++ b/Resources/Prototypes/_Starlight/Thavens/Moods/wildcard.yml
@@ -40,6 +40,11 @@
     - EngineIsDeity
     - DeliciousMoldyBread
     - BlindnessIsFreedom
+    - Charger
+    - VitalPurity
+    - Martyr
+    - DuckAndCover
+    - Paranoid
 
 
 # You must always lie, and can never acknowledge that you are lying. If anyone asks, you're incapable of deception.
@@ -336,3 +341,39 @@
   conflicts:
     - FleshIsSacred
     - BlindSympathizer
+
+# Charger: Your positronic brain consumes a lot of power. Make sure to frequently recharge it by skin contact with exposed electrical wires.
+- type: thavenMood
+  id: Charger
+  moodName: thaven-mood-charger-name
+  moodDesc: thaven-mood-charger-desc
+  conflicts:
+    - FleshIsSacred
+
+# Vital Purity: Healing is a crime against nature. Refuse any form of medical intervention at all cost.
+- type: thavenMood
+  id: VitalPurity
+  moodName: thaven-mood-vital-purity-name
+  moodDesc: thaven-mood-vital-purity-desc
+  conflicts:
+    - FleshIsSacred
+
+# Martyr: It's highly virtuous to be visibly wounded. Keep your health low at all times.
+- type: thavenMood
+  id: Martyr
+  moodName: thaven-mood-martyr-name
+  moodDesc: thaven-mood-martyr-desc
+  conflicts:
+    - FleshIsSacred
+
+# Duck and cover: Showing your full profile is dangerous, crawl at all times.
+- type: thavenMood
+  id: DuckAndCover
+  moodName: thaven-mood-duck-and-cover-name
+  moodDesc: thaven-mood-duck-and-cover-desc
+
+# Paranoid: You strongly believe that coords cause cancer.
+- type: thavenMood
+  id: Paranoid
+  moodName: thaven-mood-paranoid-name
+  moodDesc: thaven-mood-paranoid-desc

--- a/Resources/Prototypes/_Starlight/Thavens/Moods/yes_and.yml
+++ b/Resources/Prototypes/_Starlight/Thavens/Moods/yes_and.yml
@@ -61,6 +61,12 @@
     - Marrvelous
     - Empath
     - RedLightGreenLight
+    - ColdBlooded
+    - DejaVu
+    - ImpendingDoom
+    - Rebel
+    - AmateurPhotographer
+    - Insecure
 
 
 # You are extremely possessive of your property. Refuse to relinquish it, and if it is misplaced or stolen, it must be retrieved at all costs.
@@ -146,7 +152,7 @@
   conflicts:
     - Atheist
 
-# You are too important to speak to the rabble. You will only talk to Command.
+# You are too important to speak to the rabble. You will only talk to Command and other Thaven.
 - type: thavenMood
   id: OnlySpeakToCommand
   moodName: thaven-mood-only-speak-to-command-name
@@ -361,6 +367,7 @@
     speechType: SpeechRestrictions
   conflicts:
     - MuteSympathizer
+    - Caveman
 
 # The color [COLOR] is the only acceptable color for decorations. Endeavor to make your environment this color where possible.
 #- type: thavenMood
@@ -517,3 +524,41 @@
   conflicts:
     - BlindSympathizer
     - MadHatter
+
+# Cold-blooded: You always feel cold.
+- type: thavenMood
+  id: ColdBlooded
+  moodName: thaven-mood-cold-blooded-name
+  moodDesc: thaven-mood-cold-blooded-desc
+
+# Déjà vu: You feel like all of today has happened before.
+- type: thavenMood
+  id: DejaVu
+  moodName: thaven-mood-deja-vu-name
+  moodDesc: thaven-mood-deja-vu-desc
+
+# Impending doom: Something bad is going to happen and you know exactly where and when.
+- type: thavenMood
+  id: ImpendingDoom
+  moodName: thaven-mood-impending-doom-name
+  moodDesc: thaven-mood-impending-doom-desc
+
+# Rebel: You feel the need to speak ill of those in charge.
+- type: thavenMood
+  id: Rebel
+  moodName: thaven-mood-rebel-name
+  moodDesc: thaven-mood-rebel-desc
+
+# Amateur Photographer: You feel the need to use flashes to take pictures of everyone on station.
+- type: thavenMood
+  id: AmateurPhotographer
+  moodName: thaven-mood-amateur-photographer-name
+  moodDesc: thaven-mood-amateur-photographer-desc
+
+# Insecure: You care deeply what people think about you, particularly about your $appearance.
+- type: thavenMood
+  id: Insecure
+  moodName: thaven-mood-insecure-name
+  moodDesc: thaven-mood-insecure-desc
+  moodVars:
+    appearance: AppearanceAspects

--- a/Resources/Prototypes/_Starlight/datasets.yml
+++ b/Resources/Prototypes/_Starlight/datasets.yml
@@ -1234,3 +1234,26 @@
   values:
   - Singularity
   - Tesla
+
+- type: dataset
+  id: Disasters
+  values:
+  - The captain's midlife crisis
+  - The heat death of the universe
+  - Pun Pun's last shift
+  - The new ice age
+  - The gray tide
+  - The great corgi uprising
+  - The final curtain call
+  - The introduction of a new Nanotrasen policy
+
+- type: dataset
+  id: AppearanceAspects
+  values:
+  - Height
+  - Hair
+  - Skin
+  - Tail or lack thereof
+  - Voice
+  - Clothes
+  - Job


### PR DESCRIPTION
## Short description
Add 21 new moods, tweak two existing moods to be less restrictive. As discussed on the discord server [here](https://discord.com/channels/1272545509562777621/1473062977115525233) and [here](https://discord.com/channels/1272545509562777621/1492330181648584875).

## Why we need to add this
More variation in moods is always nice, also this PR includes some more "self-destructive" wildcard moods to make emagging thaven more useful to antags.

## Media (Video/Screenshots)
<img width="579" height="247" alt="image" src="https://github.com/user-attachments/assets/752b8c91-4082-454a-9619-7affa6de009c" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: gabbl0
- add: 21 new thaven moods.
- tweak: VIP and Red Light Green Light moods to be less restrictive.
