### PR TITLE
Vampires: Altar LOS check for burn damage

### DIFF
--- a/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.cs
+++ b/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.cs
@@ -37,7 +37,6 @@ using Robust.Shared.Player;
 using Robust.Shared.Timing;
 using Prometheus;
 using Content.Server._Starlight.Medical.Body.Systems;
-using Content.Shared.Physics;
 
 namespace Content.Server._Starlight.Antags.Vampires.Systems;
 

--- a/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.cs
+++ b/Content.Server/_Starlight/Antags/Vampires/Systems/VampireSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Damage.Prototypes;
 using Content.Shared.Damage.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
+using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -36,6 +37,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Timing;
 using Prometheus;
 using Content.Server._Starlight.Medical.Body.Systems;
+using Content.Shared.Physics;
 
 namespace Content.Server._Starlight.Antags.Vampires.Systems;
 
@@ -72,6 +74,8 @@ public sealed partial class VampireSystem : EntitySystem
     [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+
     private ISawmill? _sawmill;
     private static readonly ProtoId<DamageGroupPrototype> _bruteGroupId = "Brute";
     private static readonly ProtoId<DamageGroupPrototype> _burnGroupId = "Burn";
@@ -683,6 +687,9 @@ public sealed partial class VampireSystem : EntitySystem
                 continue;
 
             if (!Transform(ent).Anchored)
+                continue;
+
+            if (!_interaction.InRangeUnobstructed(uid, ent, comp.HolyPlaceRange))
                 continue;
 
             return true;


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds a simple LOS check to stop vampires from being burned through walls or windows when passing by an altar. Can still be burned near an altar if the door is open, though.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Getting burned by random unseen altars is extremely frustrating to deal with, especially with maints altars. this mostly restricts the "Sacred Ground" to interior of the chapel itself, which is more in line with the intent of the mechanic.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Effect blocked by windows
<img width="391" height="463" alt="Screenshot from 2026-04-13 17-51-57" src="https://github.com/user-attachments/assets/b12b569b-b4b4-44d3-9ca7-764b991fb1f8" />

And walls or closed airlocks
<img width="360" height="424" alt="Screenshot from 2026-04-13 17-52-18" src="https://github.com/user-attachments/assets/af2516cf-bc05-4dc8-afe8-330c08ae6517" />

Effect is not blocked by open airlocks
<img width="367" height="499" alt="Screenshot from 2026-04-13 17-52-53" src="https://github.com/user-attachments/assets/874dfa0f-016b-444e-b5e8-a65cb450fffc" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neurovermi
- tweak: Altars no longer burn vampires through walls or windows.
