### PR TITLE
Fix up grid command a little

### DIFF
--- a/Content.Server/_Starlight/Grid/GridCommand.cs
+++ b/Content.Server/_Starlight/Grid/GridCommand.cs
@@ -40,10 +40,15 @@ public sealed class GridCommand : ToolshedCommand
     public IEnumerable<EntityUid> GetGrids([PipedArgument] IEnumerable<EntityUid> uids) => uids.Select(GetGrid);
 
     [CommandImplementation("getstation")]
-    public EntityUid GetStation([PipedArgument] EntityUid uid) => !TryComp<StationMemberComponent>(uid, out var member)
-        ? EntityUid.Invalid
-        : member.Station;
+    public EntityUid GetStation(IInvocationContext ctx, [PipedArgument] EntityUid uid)
+    {
+        if (TryComp<StationMemberComponent>(uid, out var member) || TryComp(Transform(uid).GridUid, out member))
+            return member.Station;
+        ctx.WriteMarkup($"[color=red]Entity {uid} is not on a station and is not a station grid.[/color]");
+        return EntityUid.Invalid;
+    }
 
     [CommandImplementation("getstation")]
-    public IEnumerable<EntityUid> GetStations([PipedArgument] IEnumerable<EntityUid> uids) => uids.Select(GetStation);
+    public IEnumerable<EntityUid> GetStations(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uids) =>
+        uids.Select(x => GetStation(ctx, x));
 }

--- a/Resources/Locale/en-US/_Starlight/commands/toolshed-commands.ftl
+++ b/Resources/Locale/en-US/_Starlight/commands/toolshed-commands.ftl
@@ -42,11 +42,11 @@ command-description-solution-delete=
 command-description-subtlemessage =
     Sends a subtle message to all the input entities.
 command-description-grid-getplayers =
-    Gets all players on the specified grid(s)
+    Gets all players on the piped grid(s)
 command-description-grid-get =
-    Gets the grid(s) the specified player(s) are standing on.
+    Gets the grid(s) the piped player(s) are standing on.
 command-description-grid-getstation =
-    Gets the station(s) the specified player(s) are standing on.
+    Gets the station(s) that the piped player(s) are standing on, or that of the entity itself if the grid is piped in.
 command-description-crewmanifest-addto =
     Adds the piped entity to the specified station's crew manifest.
 command-description-crewmanifest-removefrom =


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
It sucked and `grid:getstation` didn't even work properly, so I made so that the old functionality still works by piping in the station grid, but also makes so you can pipe in a player and get the station of the grid they're standing on. Also corrects descriptions to mention piping in entity instead of specifying one.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
TSH improvement
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.