### PR TITLE
[ADMEME] NameConfusionSystem

### DIFF
--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -159,13 +159,13 @@ namespace Content.Client.Examine
             // since there's probably one open already if it's coming in from the server.
             var entity = GetEntity(ev.EntityUid);
 
-            OpenTooltip(player.Value, entity, ev.CenterAtCursor, ev.OpenAtOldTooltip, ev.KnowTarget);
+            OpenTooltip(player.Value, entity, out _, out _, ev.CenterAtCursor, ev.OpenAtOldTooltip, ev.KnowTarget); // Starlight-edit
             UpdateTooltipInfo(player.Value, entity, ev.Message, ev.Verbs, getVerbs: false);
         }
 
         public override void SendExamineTooltip(EntityUid player, EntityUid target, FormattedMessage message, bool getVerbs, bool centerAtCursor)
         {
-            OpenTooltip(player, target, centerAtCursor);
+            OpenTooltip(player, target, out _, out _, centerAtCursor); // Starlight-ediit
             UpdateTooltipInfo(player, target, message, getVerbs: getVerbs);
         }
 
@@ -174,7 +174,7 @@ namespace Content.Client.Examine
         ///     not fill it with information. This is done when the server sends examine info/verbs,
         ///     or immediately if it's entirely clientside.
         /// </summary>
-        public void OpenTooltip(EntityUid player, EntityUid target, bool centeredOnCursor=true, bool openAtOldTooltip=true, bool knowTarget = true)
+        public void OpenTooltip(EntityUid player, EntityUid target, out RichTextLabel? nameLabel, out string? name, bool centeredOnCursor=true, bool openAtOldTooltip=true, bool knowTarget = true) // Starlight-edit: need to get the label oughh
         {
             // Close any examine tooltip that might already be opened
             // Before we do that, save its position. We'll prioritize opening any new popups there if
@@ -239,19 +239,24 @@ namespace Content.Client.Examine
 
             if (knowTarget)
             {
-                var itemName = Identity.Name(target, EntityManager, player); // Starlight: Do not blanket escape.
-                var labelMessage = FormattedMessage.FromMarkupPermissive($"[bold]{itemName}[/bold]")
+                name = Identity.Name(target, EntityManager, player); // Starlight: Do not blanket escape.; name edits
+                var labelMessage = FormattedMessage.FromMarkupPermissive($"[bold]{name}[/bold]") // starlight-edit: name edits
                         .SanitizeWhitelist(FormattedMessageSanitizer.ItemLabelTags); // Starlight: Instead, sanitize to permitted tags.
-                var label = new RichTextLabel();
-                label.SetMessage(labelMessage);
-                hBox.AddChild(label);
+                // Starlight begin
+                nameLabel = new RichTextLabel();
+                nameLabel.SetMessage(labelMessage);
+                // Starlight end
             }
             else
             {
-                var label = new RichTextLabel();
-                label.SetMessage(FormattedMessage.FromMarkupOrThrow("[bold]???[/bold]"));
-                hBox.AddChild(label);
+                // Starlight begin
+                name = null;
+                nameLabel = new RichTextLabel();
+                nameLabel.SetMessage(FormattedMessage.FromMarkupOrThrow("[bold]???[/bold]"));
+                // Starlight end
             }
+
+            hBox.AddChild(nameLabel); // Starlight
 
             panel.Measure(Vector2Helpers.Infinity);
             var size = Vector2.Max(new Vector2(minWidth, 0), panel.DesiredSize);
@@ -406,12 +411,16 @@ namespace Content.Client.Examine
 
             FormattedMessage message;
 
-            OpenTooltip(playerEnt.Value, entity, centeredOnCursor, false);
+            OpenTooltip(playerEnt.Value, entity, out var label, out var name, centeredOnCursor, false); // Starlight-edit
 
             // Always update tooltip info from client first.
             // If we get it wrong, server will correct us later anyway.
             // This will usually be correct (barring server-only components, which generally only adds, not replaces text)
-            message = GetExamineText(entity, playerEnt);
+            message = GetExamineText(entity, playerEnt, out var ev, name); // Starlight-edit
+            // Starlight begin: after a lot of stupid edits, apply name modifiers to name label.
+            if (ev?.Modifiers > 0) // no modifiers? don't override it. Otherwise, do that.
+                label?.Text = $"[bold]{ev.GetModifiedName()}[/bold]";
+            // Starlight end
             UpdateTooltipInfo(playerEnt.Value, entity, message);
 
             if (!IsClientSide(entity))

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -49,6 +49,7 @@ using Content.Shared._Starlight.Language;
 using System.Diagnostics.CodeAnalysis;
 using Content.Client._Starlight.Language.Systems;
 using Content.Shared._Starlight.Ghost;
+using Content.Shared._Starlight.NameConfusion;
 using Content.Shared._Starlight.Radio;
 //Starlight end
 
@@ -932,7 +933,7 @@ public sealed partial class ChatUIController : UIController
         {
             var grammar = _ent.GetComponentOrNull<GrammarComponent>(_ent.GetEntity(msg.SenderEntity));
             if (grammar != null && grammar.ProperNoun == true)
-                msg.WrappedMessage = SharedChatSystem.InjectTagInsideTag(msg, "Name", "color", GetNameColor(SharedChatSystem.GetStringInsideTag(msg, "Name")));
+                msg.WrappedMessage = SharedChatSystem.InjectTagInsideTag(msg, "Name", "color", GetNameColor(SharedChatSystem.GetStringInsideTag(msg, "Name"), msg.SenderEntity)); // Starlight-edit: Pass entity so you can use a consistent color.
         }
 
         // Color any words chosen by the client.
@@ -1049,16 +1050,21 @@ public sealed partial class ChatUIController : UIController
         }
     }
 
+    // Starlight begin: consistent name color if altered by NameConfusionSystem.
     /// <summary>
     /// Returns the chat name color for a mob
     /// </summary>
     /// <param name="name">Name of the mob</param>
     /// <returns>Hex value of the color</returns>
-    public string GetNameColor(string name)
+    public string GetNameColor(string name, NetEntity sender)
     {
+        var ent = EntityManager.GetEntity(sender);
+        if (EntityManager.TryGetComponent<NameConfusionComponent>(ent, out var confusion))
+            if (confusion.OriginalName is not null) name = confusion.OriginalName;
         var colorIdx = Math.Abs(name.GetHashCode() % _chatNameColors.Length);
         return _chatNameColors[colorIdx];
     }
+    // Starlight end
 
     private readonly record struct SpeechBubbleData(ChatMessage Message, SpeechBubble.SpeechType Type);
 

--- a/Content.Server/Examine/ExamineSystem.cs
+++ b/Content.Server/Examine/ExamineSystem.cs
@@ -69,7 +69,7 @@ namespace Content.Server.Examine
             if (request.GetVerbs)
                 verbs = _verbSystem.GetLocalVerbs(entity, playerEnt, typeof(ExamineVerb));
 
-            var text = GetExamineText(entity, player.AttachedEntity);
+            var text = GetExamineText(entity, player.AttachedEntity, out _); // Starlight-edit
             RaiseNetworkEvent(new ExamineSystemMessages.ExamineInfoResponseMessage(
                 request.NetEntity, request.Id, text, verbs?.ToList()), channel);
         }

--- a/Content.Server/_Starlight/NameConfusion/NameConfusionCommand.cs
+++ b/Content.Server/_Starlight/NameConfusion/NameConfusionCommand.cs
@@ -1,0 +1,240 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Content.Server.Administration;
+using Content.Shared._Starlight.NameConfusion;
+using Content.Shared.Administration;
+using Robust.Shared.Toolshed;
+
+namespace Content.Server._Starlight.NameConfusion;
+
+[ToolshedCommand(Name = "nconf")]
+[AdminCommand(AdminFlags.Fun)]
+public sealed class NameConfusionCommand : ToolshedCommand
+{
+    private NameConfusionSystem? _conf;
+
+    /// <summary>
+    /// Do a confusion. Can be forced to ignore probability checks.
+    /// </summary>
+    [CommandImplementation("confuse")]
+    public EntityUid Confuse(IInvocationContext ctx, [PipedArgument] EntityUid uid, bool forced)
+    {
+        if(!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        _conf?.ConfuseName(uid, comp, forced);
+        ctx.WriteLine($"Forced a name confusion on entity {uid}.");
+        return uid;
+    }
+
+    /// <summary>
+    /// Restore name. Confuse CAN do this but this guarantees it.
+    /// </summary>
+    [CommandImplementation("restore")]
+    public EntityUid Restore(IInvocationContext ctx, [PipedArgument] EntityUid uid)
+    {
+        if (!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        if (comp.Names.Count != 0)
+        {
+            ctx.WriteLine($"Entity {uid}'s name was not confused.");
+            return uid;
+        }
+        _conf?.RestoreName(uid, comp);
+        ctx.WriteLine($"Restored entity {uid}'s name.");
+        return uid;
+    }
+
+    /// <summary>
+    /// Adds a name to the confusion name list. Adds the component if it doesn't exist.
+    /// </summary>
+    [CommandImplementation("addname")]
+    public EntityUid AddName(IInvocationContext ctx, [PipedArgument] EntityUid uid, string name)
+    {
+        _conf ??= EntitySystemManager.GetEntitySystem<NameConfusionSystem>();
+        var hadComp = HasComp<NameConfusionComponent>(uid);
+        var comp = EnsureComp<NameConfusionComponent>(uid);
+        var names = comp.Names;
+        if (names.Contains(name))
+        {
+            ctx.WriteLine($"Entity {uid} already has the name {name} in the confusion name list.");
+            return uid;
+        }
+
+        _conf?.AddConfusedName(uid, name, comp);
+        if(!hadComp) ctx.WriteLine($"Added name confusion component to entity {uid}.");
+        ctx.WriteLine($"Added name {name} to entity {uid}'s confusion name list.");
+        return uid;
+    }
+
+    /// <summary>
+    /// Removes a name from the confusion name list.
+    /// </summary>
+    [CommandImplementation("rmname")]
+    public EntityUid RemoveName(IInvocationContext ctx, [PipedArgument] EntityUid uid, string name)
+    {
+        if(!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        var names = comp.Names;
+        if (!names.Contains(name))
+        {
+            ctx.WriteLine($"The name {name} does not exist in entity {uid}'s confusion name list.");
+            return uid;
+        }
+
+        _conf?.RemoveConfusedName(uid, name, comp);
+        ctx.WriteLine($"Removed name {name} from entity {uid}'s confusion name list.");
+        return uid;
+    }
+
+    /// <summary>
+    /// Clears the confusion name list. Optionally, removes the component.
+    /// </summary>
+    [CommandImplementation("clearnames")]
+    public EntityUid ClearNames(IInvocationContext ctx, [PipedArgument] EntityUid uid, bool removeComponent)
+    {
+        if(!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        _conf?.ClearConfusedNames(uid, comp);
+        if(removeComponent) RemComp<NameConfusionComponent>(uid);
+        ctx.WriteLine($"Cleared confusion names from entity {uid}{(removeComponent ? " and removed the component." : ".")}");
+        return uid;
+    }
+
+    /// <summary>
+    /// Sets <see cref="NameConfusionComponent.ConfuseOnSpeak"/>.
+    /// </summary>
+    [CommandImplementation("confuseonspeak")]
+    public EntityUid SetConfuseOnSpeak(IInvocationContext ctx, [PipedArgument] EntityUid uid, bool state)
+    {
+        if (!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        _conf?.SetConfusedOnSpeak(uid, state, comp);
+        ctx.WriteLine($"Set {nameof(comp.ConfuseOnSpeak)} on {uid} to {state}.");
+        return uid;
+    }
+
+    /// <summary>
+    /// Sets <see cref="NameConfusionComponent.ConfuseOnExamine"/>.
+    /// </summary>
+    [CommandImplementation("confuseonexamine")]
+    public EntityUid SetConfuseOnExamine(IInvocationContext ctx, [PipedArgument] EntityUid uid, bool state)
+    {
+        if (!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        _conf?.SetConfusedOnExamine(uid, state, comp);
+        ctx.WriteLine($"Set {nameof(comp.ConfuseOnExamine)} on {uid} to {state}.");
+        return uid;
+    }
+
+    /// <summary>
+    /// Sets <see cref="NameConfusionComponent.ConfuseOnInterval"/>.
+    /// </summary>
+    [CommandImplementation("confuseoninterval")]
+    public EntityUid SetConfuseOnInterval(IInvocationContext ctx, [PipedArgument] EntityUid uid, bool state)
+    {
+        if (!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        _conf?.SetConfusedOnInterval(uid, state, comp);
+        ctx.WriteLine($"Set {nameof(comp.ConfuseOnInterval)} on {uid} to {state}.");
+        return uid;
+    }
+
+    /// <summary>
+    /// Sets <see cref="NameConfusionComponent.ConfuseInterval"/>.
+    /// </summary>
+    [CommandImplementation("confuseintervaltime")]
+    public EntityUid SetConfuseIntervalTime(IInvocationContext ctx, [PipedArgument] EntityUid uid, float seconds)
+    {
+        if (!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        _conf?.SetConfusedIntervalTime(uid, TimeSpan.FromSeconds(seconds), comp);
+        ctx.WriteLine($"Set {nameof(comp.ConfuseInterval)} on {uid} to {seconds} seconds.");
+        return uid;
+    }
+
+    /// <summary>
+    /// Sets <see cref="NameConfusionComponent.NameConfusionProbability"/>.
+    /// </summary>
+    [CommandImplementation("confuseprob")]
+    public EntityUid SetConfusionProbability(IInvocationContext ctx, [PipedArgument] EntityUid uid, float prob)
+    {
+        if (!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        _conf?.SetConfusionProbability(uid, prob, comp);
+        ctx.WriteLine($"Set {nameof(comp.NameConfusionProbability)} on {uid} to {prob}.");
+        return uid;
+    }
+
+    /// <summary>
+    /// Sets <see cref="NameConfusionComponent.NameRestoreProbability"/>.
+    /// </summary>
+    [CommandImplementation("restoreprob")]
+    public EntityUid SetRestoreProbability(IInvocationContext ctx, [PipedArgument] EntityUid uid, float prob)
+    {
+        if (!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        _conf?.SetRestoreProbability(uid, prob, comp);
+        ctx.WriteLine($"Set {nameof(comp.NameRestoreProbability)} on {uid} to {prob}.");
+        return uid;
+    }
+
+    [CommandImplementation("confuse")]
+    public IEnumerable<EntityUid> Confuse(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid,
+        bool forced) =>
+        uid.Select(x => Confuse(ctx, x, forced));
+
+    [CommandImplementation("restore")]
+    public IEnumerable<EntityUid> Restore(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid) =>
+        uid.Select(x => Restore(ctx, x));
+
+    [CommandImplementation("addname")]
+    public IEnumerable<EntityUid> AddName(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid,
+        string name) =>
+        uid.Select(x => AddName(ctx, x, name));
+
+    [CommandImplementation("rmname")]
+    public IEnumerable<EntityUid> RemoveName(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid,
+        string name) =>
+        uid.Select(x => RemoveName(ctx, x, name));
+
+    [CommandImplementation("clearnames")]
+    public IEnumerable<EntityUid> ClearNames(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid,
+        bool removeComponent) =>
+        uid.Select(x => ClearNames(ctx, x, removeComponent));
+
+    [CommandImplementation("confuseonspeak")]
+    public IEnumerable<EntityUid> SetConfuseOnSpeak(IInvocationContext ctx, [PipedArgument] IEnumerable<EntityUid> uid,
+        bool state) =>
+        uid.Select(x => SetConfuseOnSpeak(ctx, x, state));
+
+    [CommandImplementation("confuseonexamine")]
+    public IEnumerable<EntityUid> SetConfuseOnExamine(IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> uid, bool state) =>
+        uid.Select(x => SetConfuseOnExamine(ctx, x, state));
+
+    [CommandImplementation("confuseoninterval")]
+    public IEnumerable<EntityUid> SetConfuseOnInterval(IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> uid, bool state) =>
+        uid.Select(x => SetConfuseOnInterval(ctx, x, state));
+
+    [CommandImplementation("confuseintervaltime")]
+    public IEnumerable<EntityUid> SetConfuseIntervalTime(IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> uid, float seconds) =>
+        uid.Select(x => SetConfuseIntervalTime(ctx, x, seconds));
+
+    [CommandImplementation("confuseprob")]
+    public IEnumerable<EntityUid> SetConfusionProbability(IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> uid, float prob) =>
+        uid.Select(x => SetConfusionProbability(ctx, x, prob));
+
+    [CommandImplementation("restoreprob")]
+    public IEnumerable<EntityUid> SetRestoreProbability(IInvocationContext ctx,
+        [PipedArgument] IEnumerable<EntityUid> uid, float prob) =>
+        uid.Select(x => SetRestoreProbability(ctx, x, prob));
+
+
+    private bool EnsureWorkable(IInvocationContext ctx, EntityUid uid, [NotNullWhen(true)] out NameConfusionComponent? comp)
+    {
+        comp = null;
+        _conf = EntitySystemManager.GetEntitySystem<NameConfusionSystem>();
+        if (!TryComp(uid, out comp))
+        {
+            ctx.WriteMarkup($"[color=red]Entity {uid} has no {nameof(NameConfusionComponent)}. Run [color=yellow]nconf:addname[/color] first.[/color]");
+            return false;
+        }
+
+        if (comp.Names.Count != 0) return true;
+        ctx.WriteMarkup($"[color=red]Entity {uid} has no names to pick from. Run [color=yellow]nconf:addname[/color] first.[/color]");
+        return false;
+    }
+}

--- a/Content.Server/_Starlight/NameConfusion/NameConfusionCommand.cs
+++ b/Content.Server/_Starlight/NameConfusion/NameConfusionCommand.cs
@@ -32,7 +32,7 @@ public sealed class NameConfusionCommand : ToolshedCommand
     public EntityUid Restore(IInvocationContext ctx, [PipedArgument] EntityUid uid)
     {
         if (!EnsureWorkable(ctx, uid, out var comp)) return uid;
-        if (comp.Names.Count != 0)
+        if (comp.CurrentName is null)
         {
             ctx.WriteLine($"Entity {uid}'s name was not confused.");
             return uid;

--- a/Content.Server/_Starlight/NameConfusion/NameConfusionCommand.cs
+++ b/Content.Server/_Starlight/NameConfusion/NameConfusionCommand.cs
@@ -139,6 +139,11 @@ public sealed class NameConfusionCommand : ToolshedCommand
     public EntityUid SetConfuseIntervalTime(IInvocationContext ctx, [PipedArgument] EntityUid uid, float seconds)
     {
         if (!EnsureWorkable(ctx, uid, out var comp)) return uid;
+        if (Math.Abs(seconds) < 0)
+        {
+            ctx.WriteMarkup("[color=red]Seconds cannot be negative.[/color]");
+            return uid;
+        }
         _conf?.SetConfusedIntervalTime(uid, TimeSpan.FromSeconds(seconds), comp);
         ctx.WriteLine($"Set {nameof(comp.ConfuseInterval)} on {uid} to {seconds} seconds.");
         return uid;

--- a/Content.Server/_Starlight/NameConfusion/NameConfusionCommand.cs
+++ b/Content.Server/_Starlight/NameConfusion/NameConfusionCommand.cs
@@ -139,7 +139,7 @@ public sealed class NameConfusionCommand : ToolshedCommand
     public EntityUid SetConfuseIntervalTime(IInvocationContext ctx, [PipedArgument] EntityUid uid, float seconds)
     {
         if (!EnsureWorkable(ctx, uid, out var comp)) return uid;
-        if (Math.Abs(seconds) < 0)
+        if (Math.Sign(seconds) < 0)
         {
             ctx.WriteMarkup("[color=red]Seconds cannot be negative.[/color]");
             return uid;

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -253,8 +253,9 @@ namespace Content.Shared.Examine
             return InRangeUnOccluded(originPos, other, range, predicate, ignoreInsideBlocker);
         }
 
-        public FormattedMessage GetExamineText(EntityUid entity, EntityUid? examiner)
+        public FormattedMessage GetExamineText(EntityUid entity, EntityUid? examiner, out ExaminedEvent? ev, string? name = null) // starlight-edit: just pass out the event, that's prob easiest and most scalable.
         {
+            ev = null; // Starlight
             var message = new FormattedMessage();
 
             if (examiner == null)
@@ -276,11 +277,12 @@ namespace Content.Shared.Examine
 
             // Raise the event and let things that subscribe to it change the message...
             var isInDetailsRange = IsInDetailsRange(examiner.Value, entity);
-            var examinedEvent = new ExaminedEvent(message, entity, examiner.Value, isInDetailsRange, hasDescription);
-            RaiseLocalEvent(entity, examinedEvent);
+            // Starlight begin
+            ev = new ExaminedEvent(message, entity, examiner.Value, isInDetailsRange, hasDescription, name);
+            RaiseLocalEvent(entity, ev);
 
-            var newMessage = examinedEvent.GetTotalMessage();
-
+            var newMessage = ev.GetTotalMessage();
+            //Starlight end
             // pop color tag
             newMessage.Pop();
 
@@ -328,17 +330,25 @@ namespace Content.Shared.Examine
         /// </summary>
         public EntityUid Examined { get; }
 
+        // Starlight begin
+        private readonly List<(LocId LocId, int Priority, (string, object)[] ExtraArgs)> _nameModifiers = [];
+        public readonly string BaseName;
+
+        public int Modifiers => _nameModifiers.Count;
+        // Starlight end
+
         private bool _hasDescription;
 
         private ExamineMessagePart? _currentGroupPart;
 
-        public ExaminedEvent(FormattedMessage message, EntityUid examined, EntityUid examiner, bool isInDetailsRange, bool hasDescription)
+        public ExaminedEvent(FormattedMessage message, EntityUid examined, EntityUid examiner, bool isInDetailsRange, bool hasDescription, string? name = null) // Starlight-edit: name editing
         {
             Message = message;
             Examined = examined;
             Examiner = examiner;
             IsInDetailsRange = isInDetailsRange;
             _hasDescription = hasDescription;
+            BaseName = name ?? IoCManager.Resolve<IEntityManager>().GetComponent<MetaDataComponent>(examined).EntityName; // Starlight
         }
 
         /// <summary>
@@ -529,6 +539,29 @@ namespace Content.Shared.Examine
         }
 
         private record ExamineMessagePart(FormattedMessage Message, int Priority, bool DoNewLine, string? Group);
+
+        //Starlight begin: yoink from NameModifierSystem :3
+        public void AddNameModifier(LocId locId, int priority = 0, params (string, object)[] extraArgs) =>
+            _nameModifiers.Add((locId, priority, extraArgs));
+
+        public string GetModifiedName()
+        {
+            var name = BaseName;
+
+            foreach (var modifier in _nameModifiers.OrderBy(n => n.Priority))
+            {
+                // Grab any extra args needed by the Loc string
+                var args = modifier.ExtraArgs;
+                // Add the current version of the entity name as an arg
+                Array.Resize(ref args, args.Length + 1);
+                args[^1] = ("baseName", name);
+                // Resolve the Loc string and use the result as the base in the next iteration.
+                name = Loc.GetString(modifier.LocId, args);
+            }
+
+            return name;
+        }
+        //Starlight end
     }
 
 

--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -540,7 +540,7 @@ namespace Content.Shared.Examine
 
         private record ExamineMessagePart(FormattedMessage Message, int Priority, bool DoNewLine, string? Group);
 
-        //Starlight begin: yoink from NameModifierSystem :3
+        #region Starlight
         public void AddNameModifier(LocId locId, int priority = 0, params (string, object)[] extraArgs) =>
             _nameModifiers.Add((locId, priority, extraArgs));
 
@@ -561,7 +561,7 @@ namespace Content.Shared.Examine
 
             return name;
         }
-        //Starlight end
+        #endregion
     }
 
 

--- a/Content.Shared/IdentityManagement/Identity.cs
+++ b/Content.Shared/IdentityManagement/Identity.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared.Ghost;
 using Content.Shared.IdentityManagement.Components;
+using Content.Shared._Starlight.NameConfusion; // Starlight
 
 namespace Content.Shared.IdentityManagement;
 
@@ -29,6 +30,11 @@ public static class Identity
             return meta.EntityName; // Identity component and such will not yet have initialized and may throw NREs
 
         var uidName = meta.EntityName;
+
+        // Starlight begin: NameConfusion overrides even this.
+        if (ent.TryGetComponent<NameConfusionComponent>(uid, out var confusion) && confusion.CurrentName is not null)
+            return confusion.CurrentName;
+        // Starlight end
 
         if (!ent.TryGetComponent<IdentityComponent>(uid, out var identity))
             return uidName;

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -358,7 +358,7 @@ public sealed class SharedKitchenSpikeSystem : EntitySystem
 
         // Show it at the end of the examine so it looks good.
         args.PushMarkup(Loc.GetString("comp-kitchen-spike-hooked", ("victim", Identity.Entity(victim.Value, EntityManager))), -1);
-        args.PushMessage(_examineSystem.GetExamineText(victim.Value, args.Examiner), -2);
+        args.PushMessage(_examineSystem.GetExamineText(victim.Value, args.Examiner, out _), -2); // Starlight-edit
     }
 
     private void OnGetVerbs(Entity<KitchenSpikeComponent> ent, ref GetVerbsEvent<Verb> args)

--- a/Content.Shared/_Starlight/NameConfusion/NameConfusionComponent.cs
+++ b/Content.Shared/_Starlight/NameConfusion/NameConfusionComponent.cs
@@ -1,0 +1,60 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.NameConfusion;
+
+/// <summary>
+/// Admeme component to periodically change an entity's name. Designed to be used with a command, but it's safe to use VV.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(NameConfusionSystem))]
+public sealed partial class NameConfusionComponent : Component
+{
+    /// <summary>
+    /// List of names to periodically pull from and rename the entity as.
+    /// </summary>
+    [DataField, AutoNetworkedField] public HashSet<string> Names = [];
+
+    /// <summary>
+    /// If it should confuse name after speaking.
+    /// </summary>
+    [DataField, AutoNetworkedField] public bool ConfuseOnSpeak;
+
+    /// <summary>
+    ///  If it should confuse name when being examined.
+    /// </summary>
+    [DataField, AutoNetworkedField] public bool ConfuseOnExamine;
+
+    /// <summary>
+    /// Enables confusing the name on an interval.
+    /// </summary>
+    [DataField, AutoNetworkedField] public bool ConfuseOnInterval;
+
+    /// <summary>
+    /// Probability that name gets confused.
+    /// </summary>
+    [DataField, AutoNetworkedField] public float NameConfusionProbability = 1;
+
+    /// <summary>
+    /// Probability that the name is restored on the next name confusion.
+    /// </summary>
+    [DataField, AutoNetworkedField] public float NameRestoreProbability = 1;
+
+    /// <summary>
+    /// Time to wait before confusing the name if <see cref="ConfuseOnInterval"/> is true.
+    /// </summary>
+    [DataField, AutoNetworkedField] public TimeSpan ConfuseInterval;
+
+    /// <summary>
+    /// The next time the name will be confused.
+    /// </summary>
+    [ViewVariables, AutoNetworkedField] public TimeSpan NextConfuseTime;
+
+    /// <summary>
+    /// Currently selected name for name modifier event.
+    /// </summary>
+    [ViewVariables, AutoNetworkedField] public string? CurrentName;
+
+    /// <summary>
+    /// The entity's name from before the name got confused, modifiers and all. This is to ensure consistent name color.
+    /// </summary>
+    [ViewVariables, AutoNetworkedField] public string? OriginalName;
+}

--- a/Content.Shared/_Starlight/NameConfusion/NameConfusionSystem.cs
+++ b/Content.Shared/_Starlight/NameConfusion/NameConfusionSystem.cs
@@ -1,0 +1,151 @@
+using System.Linq;
+using Content.Shared._Starlight.Abstract.Extensions;
+using Content.Shared.Chat;
+using Content.Shared.Examine;
+using Content.Shared.NameModifier.EntitySystems;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._Starlight.NameConfusion;
+
+/// <summary>
+/// Admeme system to make people get confused about their name.
+/// </summary>
+public sealed class NameConfusionSystem : EntitySystem
+{
+    [Dependency] private readonly NameModifierSystem _name = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IRobustRandom _rand = default!;
+
+    private const int NameModPriority = -900; // Basically it just needs to happen first.
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<NameConfusionComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<NameConfusionComponent, EntitySpokeEvent>(OnSpeak);
+        SubscribeLocalEvent<NameConfusionComponent, RefreshNameModifiersEvent>(OnRefreshNameMod);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityManager.EntityQueryEnumerator<NameConfusionComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (!comp.ConfuseOnInterval) continue;
+            if (_timing.CurTime < comp.NextConfuseTime) continue;
+            comp.NextConfuseTime = _timing.CurTime + comp.ConfuseInterval;
+            ConfuseName(uid, comp);
+        }
+    }
+
+    private void OnExamined(Entity<NameConfusionComponent> entity, ref ExaminedEvent args)
+    {
+        if (!entity.Comp.ConfuseOnExamine) return;
+        ConfuseName(entity, entity.Comp);
+        args.AddNameModifier("name-confusion-mod", NameModPriority,
+            ("confusedName", entity.Comp.CurrentName ?? Name(entity)));
+    }
+
+    private void OnSpeak(Entity<NameConfusionComponent> entity, ref EntitySpokeEvent args)
+    {
+        if (!entity.Comp.ConfuseOnSpeak) return;
+        ConfuseName(entity, entity.Comp);
+    }
+
+    private static void OnRefreshNameMod(Entity<NameConfusionComponent> entity, ref RefreshNameModifiersEvent args) =>
+        args.AddModifier("name-confusion-mod", NameModPriority,
+            ("confusedName", entity.Comp.CurrentName ?? args.BaseName));
+
+    public void ConfuseName(EntityUid uid, NameConfusionComponent? comp = null, bool forced = false)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        if (comp.CurrentName is not null && _rand.ProbPredicted(_timing, comp.NameRestoreProbability)) // if you want to force restore, use RestoreName.
+        {
+            RestoreName(uid, comp);
+            return;
+        }
+
+        if (comp.Names.Count == 0) return;
+        if (!_rand.ProbPredicted(_timing, comp.NameConfusionProbability) && !forced) return;
+        if (comp.CurrentName is null) comp.OriginalName = Name(uid);
+        comp.CurrentName = _rand.PickPredicted(_timing, comp.Names.ToList());
+        Dirty(uid, comp);
+        _name.RefreshNameModifiers(uid);
+    }
+
+    public void RestoreName(EntityUid uid, NameConfusionComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        comp.CurrentName = null;
+        comp.OriginalName = null;
+        Dirty(uid, comp);
+        _name.RefreshNameModifiers(uid);
+    }
+
+    public void AddConfusedName(EntityUid uid, string name, NameConfusionComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        comp.Names.Add(name);
+        Dirty(uid, comp);
+    }
+
+    public void RemoveConfusedName(EntityUid uid, string name, NameConfusionComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        comp.Names.Remove(name);
+        Dirty(uid, comp);
+    }
+
+    public void ClearConfusedNames(EntityUid uid, NameConfusionComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        comp.Names.Clear();
+        Dirty(uid, comp);
+    }
+
+    public void SetConfusedOnSpeak(EntityUid uid, bool state, NameConfusionComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        comp.ConfuseOnSpeak = state;
+        Dirty(uid, comp);
+    }
+
+    public void SetConfusedOnExamine(EntityUid uid, bool state, NameConfusionComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        comp.ConfuseOnExamine = state;
+        Dirty(uid, comp);
+    }
+
+    public void SetConfusedOnInterval(EntityUid uid, bool state, NameConfusionComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        comp.ConfuseOnInterval = state;
+        Dirty(uid, comp);
+    }
+
+    public void SetConfusedIntervalTime(EntityUid uid, TimeSpan time, NameConfusionComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        comp.ConfuseInterval = time;
+        Dirty(uid, comp);
+    }
+
+    public void SetConfusionProbability(EntityUid uid, float prob, NameConfusionComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        comp.NameConfusionProbability = Math.Clamp(prob, 0, 1);
+        Dirty(uid, comp);
+    }
+
+    public void SetRestoreProbability(EntityUid uid, float prob, NameConfusionComponent? comp = null)
+    {
+        if (!Resolve(uid, ref comp)) return;
+        comp.NameRestoreProbability = Math.Clamp(prob, 0, 1);
+        Dirty(uid, comp);
+    }
+}

--- a/Resources/Locale/en-US/_Starlight/name-confusion/name-confusion.ftl
+++ b/Resources/Locale/en-US/_Starlight/name-confusion/name-confusion.ftl
@@ -1,0 +1,25 @@
+name-confusion-mod = {$confusedName}
+
+# wow look at that, organization for once!
+command-description-nconf-confuse =
+    Do a confusion. Can be forced to ignore probability checks.
+command-description-nconf-restore =
+    Restore name. Confuse CAN do this but this guarantees it.
+command-description-nconf-addname =
+    Adds a name to the confusion name list. Adds the component if it doesn't exist.
+command-description-nconf-rmname =
+    Removes a name from the confusion name list.
+command-description-nconf-clearnames =
+    Clears the confusion name list. Optionally, removes the component.
+command-description-nconf-confuseonspeak =
+    Sets ConfuseOnSpeak parameter.
+command-description-nconf-confuseonexamine =
+    Sets ConfuseOnExamine parameter.
+command-description-nconf-confuseoninterval =
+    Sets ConfuseOnInterval parameter.
+command-description-nconf-confuseintervaltime =
+    Sets ConfuseInterval parameter.
+command-description-nconf-confuseprob =
+    Sets NameConfusionProbability parameter.
+command-description-nconf-restoreprob =
+    Sets NameRestoreProbability parameter.


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
The ultimate gaslight. Adds a system that replaces someone's name either on an interval, on speak, or on examine. Toolshed commands exist to facilitate adding new names and setting probabilities and other parameters.
The idea is to add slight misspellings of someone's name, ideally ones that are barely noticeable. The hope is that when they do notice they'll wonder how long their name was like that, then speak again, and their name will be normal. Now every time they speak they're gonna gaslight themselves into checking for their name being changed. It's peak.
Toolshed commands are under `nconf:`
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Admeme.
## Demonstration
https://github.com/user-attachments/assets/16b6daed-2135-4f99-b040-1d53fb5cd4d8

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.