### PR TITLE
Cyberspace

### DIFF
--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -1,17 +1,16 @@
 using System.Numerics;
-using System.Linq; // Carpmosia-edit - AI Navmap
-using Content.Client.Pinpointer.UI; // Carpmosia-edit - AI Navmap
 using Content.Shared.Movement.Components;
 using Content.Client.Graphics;
+using Content.Shared.Pinpointer;
 using Content.Shared.Silicons.StationAi;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
-using Robust.Shared.Collections; // Carpmosia-edit - AI Navmap
 using Robust.Shared.Enums;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Content.Client._Starlight.Silicons.StationAi;
 
 namespace Content.Client.Silicons.StationAi;
 
@@ -19,7 +18,9 @@ public sealed class StationAiOverlay : Overlay
 {
     private static readonly ProtoId<ShaderPrototype> CameraStaticShader = "CameraStatic";
     private static readonly ProtoId<ShaderPrototype> StencilMaskShader = "StencilMask";
-    private static readonly ProtoId<ShaderPrototype> StencilDrawShader = "StencilDraw";
+    // Starlight start
+    private static readonly ProtoId<ShaderPrototype> StencilDrawShader = "StencilDrawUnshaded";
+    // Starlight end
 
     [Dependency] private readonly IClyde _clyde = default!;
     [Dependency] private readonly IEntityManager _entManager = default!;
@@ -27,36 +28,28 @@ public sealed class StationAiOverlay : Overlay
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
 
-    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceEntities; // Starlight
 
     private readonly HashSet<Vector2i> _visibleTiles = new();
-    // Starlight - start
-    private readonly Dictionary<Vector2i, HashSet<string>> _visibleTileTags = new();
-    // Starlight - end
-    private readonly NavMapControl _navMap = new(); // Carpmosia-edit - AI Navmap
+    private readonly Dictionary<Vector2i, HashSet<string>> _visibleTileTags = []; // Starlight
 
     private readonly OverlayResourceCache<CachedResources> _resources = new();
 
-    // Carpmosia-start - AI Navmap
-    private readonly Dictionary<Color, Color> _sRgbLookUp = new();
-    private static readonly RenderTargetFormatParameters RenderTargetFormatParameters = new(RenderTargetColorFormat.Rgba8Srgb);
-
-    private static readonly List<Vector2> TileLinesToDraw = [];
-    private static readonly List<Vector2> TileRectsToDraw = [];
-
-    private const float UpdateRate = 1f / 30f;
-    // Carpmosia-end - AI Navmap
+    private static readonly RenderTargetFormatParameters _renderParams = new(RenderTargetColorFormat.Rgba8Srgb); // Carpmosia
+    private const float UpdateRate = 1f / 30f; // Carpmosia
 
     private float _accumulator;
+
+    // Starlight start
+    private readonly CyberspaceNavMapRenderer _cyberspaceRenderer;
+    private EntityUid _lastGridUid = EntityUid.Invalid;
+    // Starlight end
 
     public StationAiOverlay()
     {
         IoCManager.InjectDependencies(this);
-        // Carpmosia-start - AI Navmap
-        //starlight change, colors are adjusted to be green tints
-        _navMap.WallColor = new(0, 131, 0);
-        _navMap.TileColor = new(0, 60, 0);
-        // Carpmosia-end - AI Navmap
+        ZIndex = (int) Content.Shared.DrawDepth.DrawDepth.CyberspaceOverlays; // Starlight: above all normal DrawDepths (max=13), below CyberspaceObjects (100)
+        _cyberspaceRenderer = new CyberspaceNavMapRenderer(_proto); // Starlight
     }
 
     protected override void Draw(in OverlayDrawArgs args)
@@ -69,10 +62,8 @@ public sealed class StationAiOverlay : Overlay
             res.StencilTexture?.Dispose();
 
             // Carpmosia-start - AI Navmap
-            res.StencilTexture = _clyde.CreateRenderTarget(args.Viewport.Size, RenderTargetFormatParameters, name: "station-ai-stencil");
-            res.StaticTexture = _clyde.CreateRenderTarget(args.Viewport.Size,
-                RenderTargetFormatParameters,
-                name: "station-ai-static");
+            res.StencilTexture = _clyde.CreateRenderTarget(args.Viewport.Size, _renderParams, name: "station-ai-stencil");
+            res.StaticTexture = _clyde.CreateRenderTarget(args.Viewport.Size, _renderParams, name: "station-ai-static");
             // Carpmosia-end - AI Navmap
         }
 
@@ -89,14 +80,17 @@ public sealed class StationAiOverlay : Overlay
             && _entManager.TryGetComponent(playerEnt, out RelayInputMoverComponent? relay))
             playerEnt = relay.RelayEntity;
 
-        // Starlight - start
         _entManager.TryGetComponent(playerEnt, out StationAiOverlayComponent? relayStationAiOverlay);
-        // Starlight - end
-
         _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform);
-        var gridUid = playerXform?.GridUid ?? EntityUid.Invalid;
+
+        var gridUid = playerXform?.GridUid
+            ?? (stationAiOverlay is { AllowCrossGrid: true } ? _lastGridUid : EntityUid.Invalid);
+        if (gridUid != EntityUid.Invalid)
+            _lastGridUid = gridUid;
+
         _entManager.TryGetComponent(gridUid, out MapGridComponent? grid);
         _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase);
+        _entManager.TryGetComponent(gridUid, out NavMapComponent? navMap);
         // Starlight-end
 
         var invMatrix = args.Viewport.GetWorldToLocalMatrix();
@@ -111,7 +105,8 @@ public sealed class StationAiOverlay : Overlay
             if (stationAiOverlay is not null) // 🌟Starlight🌟
                 color = color.WithAlpha(stationAiOverlay.Alfa); // 🌟Starlight🌟
 
-            _navMap.AiFrameUpdate((float)_timing.FrameTime.TotalSeconds, gridUid); // Carpmosia-edit - AI Navmap
+            // Starlight: rebuild cached navmap geometry on timer, grid change, or camera move
+            _cyberspaceRenderer.Update((float)_timing.FrameTime.TotalSeconds, gridUid, navMap, grid, xforms, worldBounds);
             if (_accumulator <= 0f)
             {
                 _accumulator = MathF.Max(0f, _accumulator + UpdateRate); // Carpmosia-edit - AI Navmap
@@ -159,16 +154,7 @@ public sealed class StationAiOverlay : Overlay
 
             // Once this is gucci optimise rendering.
             worldHandle.RenderInRenderTarget(res.StaticTexture!,
-            () =>
-            {
-                // Carpmosia-start - AI Navmap
-                worldHandle.SetTransform(matty);
-                // var shader = _proto.Index(CameraStaticShader).Instance();
-                // worldHandle.UseShader(shader);
-                // worldHandle.DrawRect(worldBounds, Color.White);
-                DrawNavMap(worldHandle, grid);
-                // Carpmosia-end - AI Navmap
-            },
+                () => _cyberspaceRenderer.Draw(worldHandle, matty), // Starlight
             Color.Black);
         }
         // Not on a grid
@@ -218,71 +204,4 @@ public sealed class StationAiOverlay : Overlay
             StencilTexture?.Dispose();
         }
     }
-
-    // Carpmosia-start - AI Navmap
-    protected void DrawNavMap(DrawingHandleWorld handle, MapGridComponent grid)
-    {
-        if (!_sRgbLookUp.TryGetValue(_navMap.WallColor, out var wallsRgb))
-        {
-            wallsRgb = Color.ToSrgb(_navMap.WallColor);
-            _sRgbLookUp[_navMap.WallColor] = wallsRgb;
-        }
-
-        // Draw floor tiles
-        if (_navMap.TilePolygons.Count != 0)
-        {
-            foreach (var (polygonVerts, polygonColor) in _navMap.TilePolygons)
-            {
-                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, polygonVerts.AsSpan()[..], polygonColor);
-            }
-        }
-
-        // Draw map lines
-        if (_navMap.TileLines.Count != 0)
-        {
-            TileLinesToDraw.Clear();
-            TileLinesToDraw.EnsureCapacity(_navMap.TileLines.Count * 2);
-
-            foreach (var (o, t) in _navMap.TileLines)
-            {
-                var origin = o with { Y = -o.Y };
-                var terminus = t with { Y = -t.Y };
-
-                TileLinesToDraw.Add(origin);
-                TileLinesToDraw.Add(terminus);
-            }
-
-            if (TileLinesToDraw.Count > 0)
-                handle.DrawPrimitives(DrawPrimitiveTopology.LineList, TileLinesToDraw, wallsRgb);
-        }
-
-        // Draw map rects
-        if (_navMap.TileRects.Count != 0)
-        {
-            TileRectsToDraw.Clear();
-            TileRectsToDraw.EnsureCapacity(_navMap.TileRects.Count * 8);
-
-            foreach (var (lt, rb) in _navMap.TileRects)
-            {
-                var leftTop = lt with { Y = -lt.Y };
-                var rightBottom = rb with { Y = -rb.Y };
-
-                var rightTop = new Vector2(rightBottom.X, leftTop.Y);
-                var leftBottom = new Vector2(leftTop.X, rightBottom.Y);
-
-                TileRectsToDraw.Add(leftTop);
-                TileRectsToDraw.Add(rightTop);
-                TileRectsToDraw.Add(rightTop);
-                TileRectsToDraw.Add(rightBottom);
-                TileRectsToDraw.Add(rightBottom);
-                TileRectsToDraw.Add(leftBottom);
-                TileRectsToDraw.Add(leftBottom);
-                TileRectsToDraw.Add(leftTop);
-            }
-
-            if (TileRectsToDraw.Count > 0)
-                handle.DrawPrimitives(DrawPrimitiveTopology.LineList, TileRectsToDraw, wallsRgb);
-        }
     }
-    // Carpmosia-end - AI Navmap
-}

--- a/Content.Client/_Starlight/Silicons/StationAi/CyberspaceNavMapRenderer.cs
+++ b/Content.Client/_Starlight/Silicons/StationAi/CyberspaceNavMapRenderer.cs
@@ -44,13 +44,9 @@ internal sealed class CyberspaceNavMapRenderer(IPrototypeManager proto)
 
         if (navMap == null)
         {
-            // No navmap on this grid — clear any geometry left from the previous grid
-            if (gridChanged)
-            {
-                _floorVerts.Clear();
-                _wallVerts.Clear();
-                _doorVerts.Clear();
-            }
+            _floorVerts.Clear();
+            _wallVerts.Clear();
+            _doorVerts.Clear();
             return;
         }
 

--- a/Content.Client/_Starlight/Silicons/StationAi/CyberspaceNavMapRenderer.cs
+++ b/Content.Client/_Starlight/Silicons/StationAi/CyberspaceNavMapRenderer.cs
@@ -1,0 +1,152 @@
+using System.Numerics;
+using Content.Shared.Pinpointer;
+using Robust.Client.Graphics;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._Starlight.Silicons.StationAi;
+
+/// <summary>
+/// Handles building and drawing cyberspace navmap geometry (floor/wall/door tiles).
+/// Formation (geometry rebuild) and drawing are both encapsulated here.
+/// </summary>
+internal sealed class CyberspaceNavMapRenderer(IPrototypeManager proto)
+{
+    private static readonly ProtoId<ShaderPrototype> _floorShader = "CyberspaceFloor";
+    private static readonly ProtoId<ShaderPrototype> _wallShader = "CyberspaceWall";
+    private static readonly ProtoId<ShaderPrototype> _doorShader = "CyberspaceDoor";
+
+    private readonly List<Vector2> _floorVerts = [];
+    private readonly List<Vector2> _wallVerts = [];
+    private readonly List<Vector2> _doorVerts = [];
+
+    private float _navDataTimer;
+    private EntityUid _lastGridUid;
+    private Vector2 _lastRebuildCenter;
+    private const float NavDataUpdateInterval = 1.0f;
+    private const float RebuildMoveThreshold = 8f;
+
+    /// <summary>
+    /// Updates geometry caches: rebuilds vertex arrays when grid, camera, or timer threshold changes.
+    /// </summary>
+    public void Update(float frameTime, EntityUid gridUid, NavMapComponent? navMap, MapGridComponent grid, SharedTransformSystem xforms, Box2Rotated worldBounds)
+    {
+        _navDataTimer += frameTime;
+        var gridChanged = _lastGridUid != gridUid;
+        if (gridChanged)
+            _lastGridUid = gridUid;
+
+        // Compute grid-local viewport bounds for chunk culling
+        var gridInvMatrix = xforms.GetInvWorldMatrix(gridUid);
+        var localAabb = gridInvMatrix.TransformBox(worldBounds);
+        var viewCenter = localAabb.Center;
+        var cameraMoved = (viewCenter - _lastRebuildCenter).LengthSquared() > RebuildMoveThreshold * RebuildMoveThreshold;
+
+        if (navMap == null)
+        {
+            // No navmap on this grid — clear any geometry left from the previous grid
+            if (gridChanged)
+            {
+                _floorVerts.Clear();
+                _wallVerts.Clear();
+                _doorVerts.Clear();
+            }
+            return;
+        }
+
+        if (_navDataTimer >= NavDataUpdateInterval || gridChanged || cameraMoved)
+        {
+            _navDataTimer = 0f;
+            _lastRebuildCenter = viewCenter;
+            var cullBounds = localAabb.Enlarged(SharedNavMapSystem.ChunkSize * grid.TileSize);
+            RebuildNavMapGeometry(navMap, grid.TileSize, cullBounds);
+        }
+    }
+
+    /// <summary>
+    /// Draws the cached navmap geometry using per-category cyberspace shaders.
+    /// </summary>
+    public void Draw(DrawingHandleWorld handle, Matrix3x2 transform)
+    {
+        handle.SetTransform(transform);
+        DrawNavMap(handle);
+        handle.UseShader(null);
+    }
+
+    private void DrawNavMap(DrawingHandleWorld handle)
+    {
+        Draw(_floorShader, _floorVerts);
+        Draw(_wallShader, _wallVerts);
+        Draw(_doorShader, _doorVerts);
+
+        void Draw(ProtoId<ShaderPrototype> shader, List<Vector2> verts)
+        {
+            if (verts.Count == 0) return;
+            handle.UseShader(proto.Index(shader).Instance());
+            handle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, verts, Color.White);
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds floor/wall/door vertex arrays from NavMapComponent chunk bitmasks.
+    /// Only processes chunks that intersect <paramref name="cullBounds"/> (grid-local space).
+    /// Each tile that matches a category becomes a 1×1 quad (6 vertices, 2 triangles).
+    /// </summary>
+    private void RebuildNavMapGeometry(NavMapComponent navMap, int tileSize, Box2 cullBounds)
+    {
+        _floorVerts.Clear();
+        _wallVerts.Clear();
+        _doorVerts.Clear();
+
+        var chunkWorldSize = SharedNavMapSystem.ChunkSize * tileSize;
+
+        foreach (var chunk in navMap.Chunks.Values)
+        {
+            // Chunk AABB in grid-local space
+            var chunkMinX = chunk.Origin.X * chunkWorldSize;
+            var chunkMinY = chunk.Origin.Y * chunkWorldSize;
+            var chunkBox = new Box2(chunkMinX, chunkMinY, chunkMinX + chunkWorldSize, chunkMinY + chunkWorldSize);
+
+            if (!cullBounds.Intersects(chunkBox))
+                continue;
+
+            for (var i = 0; i < SharedNavMapSystem.ArraySize; i++)
+            {
+                var tileData = chunk.TileData[i];
+                if (tileData == 0)
+                    continue;
+
+                var relative = SharedNavMapSystem.GetTileFromIndex(i);
+                var gridTile = (chunk.Origin * SharedNavMapSystem.ChunkSize) + relative;
+
+                var x = (float)(gridTile.X * tileSize);
+                var y = (float)(gridTile.Y * tileSize);
+                var s = (float)tileSize;
+
+                if ((tileData & SharedNavMapSystem.FloorMask) != 0)
+                    AddQuad(_floorVerts, x, y, s);
+
+                if ((tileData & SharedNavMapSystem.WallMask) != 0)
+                    AddQuad(_wallVerts, x, y, s);
+
+                if ((tileData & SharedNavMapSystem.AirlockMask) != 0)
+                    AddQuad(_doorVerts, x, y, s);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Appends 6 vertices (2 triangles) for a quad in grid-local space.
+    /// </summary>
+    private static void AddQuad(List<Vector2> verts, float x, float y, float size)
+    {
+        verts.Add(new Vector2(x, y));
+        verts.Add(new Vector2(x + size, y));
+        verts.Add(new Vector2(x + size, y + size));
+
+        verts.Add(new Vector2(x, y));
+        verts.Add(new Vector2(x + size, y + size));
+        verts.Add(new Vector2(x, y + size));
+        verts.AddRange()
+    }
+}

--- a/Content.Client/_Starlight/Silicons/StationAi/CyberspaceNavMapRenderer.cs
+++ b/Content.Client/_Starlight/Silicons/StationAi/CyberspaceNavMapRenderer.cs
@@ -147,6 +147,5 @@ internal sealed class CyberspaceNavMapRenderer(IPrototypeManager proto)
         verts.Add(new Vector2(x, y));
         verts.Add(new Vector2(x + size, y + size));
         verts.Add(new Vector2(x, y + size));
-        verts.AddRange()
     }
 }

--- a/Content.Shared/DrawDepth/DrawDepth.cs
+++ b/Content.Shared/DrawDepth/DrawDepth.cs
@@ -128,5 +128,14 @@ namespace Content.Shared.DrawDepth
         ///    the pointing arrow, the drag & drop ghost-entity, and some debug tools.
         /// </summary>
         Overlays = DrawDepthTag.Default + 13,
+
+        // Starlight - start
+        CyberspaceOverlays = DrawDepthTag.Default + 14,
+        /// <summary>
+        ///     Objects that exist in cyberspace and should render above the StationAI dark overlay (ZIndex 14).
+        ///     Assign this to any entity that must be visible to the AI regardless of camera coverage.
+        /// </summary>
+        CyberspaceObjects = DrawDepthTag.Default + 100,
+        // Starlight - end
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -536,6 +536,7 @@
     layer: 32768
   - type: Sprite
     sprite: Mobs/Silicon/station_ai.rsi
+    drawdepth: CyberspaceObjects # Starlight
     layers:
     - state: ai_camera
 

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
@@ -157,6 +157,7 @@
     layer: 32768
   - type: Sprite
     sprite: _Starlight/Mobs/Net/net_eye.rsi
+    drawdepth: CyberspaceObjects
     layers:
     - map: ["base"]
       state: enemy
@@ -198,6 +199,7 @@
     layer: 32768
   - type: Sprite
     sprite: _Starlight/Mobs/Net/net_eye.rsi
+    drawdepth: CyberspaceObjects
     layers:
     - map: ["base"]
       state: enemy

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/masterchair.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/masterchair.yml
@@ -86,6 +86,7 @@
     layer: 32768
   - type: Sprite
     sprite: _Starlight/Mobs/Net/net_eye.rsi
+    drawdepth: CyberspaceObjects
     layers:
     - map: ["base"]
       state: enemy

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/syndbath.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/syndbath.yml
@@ -104,6 +104,7 @@
     layer: 32768
   - type: Sprite
     sprite: _Starlight/Mobs/Net/net_eye.rsi
+    drawdepth: CyberspaceObjects
     layers:
     - map: ["base"]
       state: enemy

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/xenobiology_console.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/xenobiology_console.yml
@@ -69,6 +69,7 @@
       layer: 32768
     - type: Sprite
       sprite: _Starlight/Mobs/Net/net_eye.rsi
+      drawdepth: CyberspaceObjects
       layers:
         - map: ["base"]
           state: enemy

--- a/Resources/Prototypes/_Starlight/Shaders/shaders.yml
+++ b/Resources/Prototypes/_Starlight/Shaders/shaders.yml
@@ -15,14 +15,40 @@
     func: NotEqual
 
 - type: shader
-  id: Cyberspace
+  id: CyberspaceFloor
   kind: source
   path: "/Textures/_Starlight/Shaders/cyberspace.swsl"
   params:
     spacing: 0.2
-    dotRad: 0.01
+    dotRad: 0.02
     maxHeight: 0.09
     baseStretch: 0.0
+    colorLow: 0.25, 0.02, 0.01
+    colorHigh: 0.7, 0.02, 0.01
+
+- type: shader
+  id: CyberspaceWall
+  kind: source
+  path: "/Textures/_Starlight/Shaders/cyberspace.swsl"
+  params:
+    spacing: 0.2
+    dotRad: 0.025
+    maxHeight: 0.3
+    baseStretch: 1.3
+    colorLow: 0.3, 0.02, 0.04
+    colorHigh: 0.8, 0.08, 0.15
+
+- type: shader
+  id: CyberspaceDoor
+  kind: source
+  path: "/Textures/_Starlight/Shaders/cyberspace.swsl"
+  params:
+    spacing: 0.2
+    dotRad: 0.025
+    maxHeight: 0.2
+    baseStretch: 1.1
+    colorLow: 0.02, 0.15, 0.3
+    colorHigh: 0.05, 0.3, 0.7
 
 - type: shader
   id: ModernNightVisionShader

--- a/Resources/Prototypes/_Starlight/Shaders/shaders.yml
+++ b/Resources/Prototypes/_Starlight/Shaders/shaders.yml
@@ -6,6 +6,25 @@
     ShiftIntensity: 1.0
 
 - type: shader
+  id: StencilDrawUnshaded
+  kind: canvas
+  light_mode: unshaded
+  stencil:
+    ref: 1
+    op: Keep
+    func: NotEqual
+
+- type: shader
+  id: Cyberspace
+  kind: source
+  path: "/Textures/_Starlight/Shaders/cyberspace.swsl"
+  params:
+    spacing: 0.2
+    dotRad: 0.01
+    maxHeight: 0.09
+    baseStretch: 0.0
+
+- type: shader
   id: ModernNightVisionShader
   kind: source
   path: "/Textures/_Starlight/Shaders/night.swsl"

--- a/Resources/Textures/_Starlight/Shaders/cyberspace.swsl
+++ b/Resources/Textures/_Starlight/Shaders/cyberspace.swsl
@@ -26,7 +26,7 @@ highp float ripple(highp vec2 pos, highp vec2 origin, highp float time, highp fl
     highp float fromFront = abs(dist - radius);
     highp float wave = max(0.0, 1.0 - fromFront / width);
     wave *= wave;
-    highp float fade = smoothstep(0.0, 0.5, time) * smoothstep(duration, duration * 0.6, time);
+    highp float fade = smoothstep(0.0, 0.5, time) * (1.0 - smoothstep(duration * 0.6, duration, time));
     return wave * fade;
 }
 

--- a/Resources/Textures/_Starlight/Shaders/cyberspace.swsl
+++ b/Resources/Textures/_Starlight/Shaders/cyberspace.swsl
@@ -1,0 +1,137 @@
+// Starlight - cyberspace.swsl
+// Parameterised pin-grid shader for AI navmap.
+// Used for floor, wall, and door layers with different density/height/color.
+
+light_mode unshaded;
+
+uniform highp float spacing;      // distance between dot centers
+uniform highp float dotRad;       // tip dot radius
+uniform highp float maxHeight;    // max pin height
+uniform highp float baseStretch;  // minimum stretch (0 = dots at rest, 1 = always full lines)
+uniform highp vec3 colorLow;      // color at stretch = 0
+uniform highp vec3 colorHigh;     // color at stretch = 1
+
+varying highp vec2 gridPos;
+
+void vertex() { gridPos = aPos; }
+
+highp float ripple(highp vec2 pos, highp vec2 origin, highp float time, highp float speed, highp float duration, highp float width) {
+    highp float radius = time * speed;
+    // Tile the origin every 60 units so ripples are visible everywhere on the station
+    highp vec2 delta = mod(pos - origin + 30.0, 60.0) - 30.0;
+    highp float dist = length(delta);
+    highp float wobble = sin(dot(delta, vec2(5.0, 3.0)) + time * 2.0) * 0.6
+                       + sin(dot(delta, vec2(3.0, -2.0)) - time * 1.3) * 0.4;
+    dist += wobble;
+    highp float fromFront = abs(dist - radius);
+    highp float wave = max(0.0, 1.0 - fromFront / width);
+    wave *= wave;
+    highp float fade = smoothstep(0.0, 0.5, time) * smoothstep(duration, duration * 0.6, time);
+    return wave * fade;
+}
+
+// Evaluate pin for a given cell. Returns vec4(d, tip, stretch, grad).
+highp vec4 evalPin(highp vec2 c, highp vec2 gp, highp float cs, highp float sn, highp float t) {
+    highp vec2 cc = (c + 0.5) * spacing;
+    highp vec2 wc = vec2(cc.x*cs - cc.y*sn, cc.x*sn + cc.y*cs);
+
+    highp float s = 0.0;
+    // Strong ripples — fixed offsets spread across the tiling cell (60×60),
+    // waves arrive from different directions. Small drift on top.
+    s += ripple(wc, vec2(  0.0,   0.0) + vec2(sin(t*0.1)*3.0, cos(t*0.08)*3.0), mod(t,      7.0), 3.0, 6.0, 4.0);
+    s += ripple(wc, vec2( 28.0,   5.0) + vec2(cos(t*0.07)*2.0, sin(t*0.12)*2.0), mod(t-2.5, 8.0), 3.5, 7.0, 3.5);
+    s += ripple(wc, vec2( -5.0,  25.0) + vec2(sin(t*0.09)*2.5, cos(t*0.06)*3.0), mod(t-5.0, 9.0), 2.5, 8.0, 4.5);
+    s += ripple(wc, vec2(-22.0, -15.0) + vec2(cos(t*0.12)*2.0, sin(t*0.1)*2.0), mod(t-1.0, 7.5), 3.0, 6.5, 3.0);
+    s += ripple(wc, vec2( 15.0, -20.0) + vec2(sin(t*0.06)*3.0, cos(t*0.11)*2.5), mod(t-4.0, 8.5), 2.8, 7.5, 5.0);
+    // Weak ripples — same spread, faster repeat, fill gaps
+    s += ripple(wc, vec2( 10.0,  15.0) + vec2(cos(t*0.15)*2.0, sin(t*0.1)*2.0), mod(t-0.5, 4.0), 5.0, 3.5, 2.0) * 0.65;
+    s += ripple(wc, vec2(-18.0,  10.0) + vec2(sin(t*0.12)*1.5, cos(t*0.18)*2.0), mod(t-1.5, 3.5), 5.5, 3.0, 2.5) * 0.65;
+    s += ripple(wc, vec2( 20.0, -8.0)  + vec2(cos(t*0.1)*2.0,  sin(t*0.14)*1.5), mod(t-2.5, 4.5), 6.0, 4.0, 2.0) * 0.65;
+    s += ripple(wc, vec2( -8.0, -22.0) + vec2(sin(t*0.16)*2.0, cos(t*0.09)*2.5), mod(t-0.0, 3.8), 4.5, 3.5, 2.2) * 0.65;
+    s += ripple(wc, vec2( 25.0,  20.0) + vec2(cos(t*0.08)*2.5, sin(t*0.13)*1.5), mod(t-1.0, 3.2), 5.0, 2.8, 1.8) * 0.65;
+    s = min(s, 1.0);
+    highp float dv = fract(sin(dot(c, vec2(127.1, 311.7))) * 43758.5);
+    s *= 0.7 + 0.3 * dv;
+    highp float hs = min(baseStretch + s, 1.0);
+
+    highp float sv = sin(c.x * 1.7 + c.y * 2.3 + t * 2.0) * 0.5
+                   + sin(c.x * 0.5 - c.y * 1.1 + t * 1.3) * 0.4
+                   + sin(c.x * 3.1 + c.y * 0.7 + t * 3.5) * 0.15;
+    highp float hm = clamp(0.5 + sv, 0.05, 1.0);
+
+    highp vec2 lp = gp - cc;
+    highp vec2 wl = vec2(lp.x*cs - lp.y*sn, lp.x*sn + lp.y*cs);
+
+    highp float lineH = maxHeight * hs * hm;
+
+    // Tip
+    highp float tipDist = length(wl - vec2(0.0, lineH)) / dotRad;
+    highp float tip = 1.0 - smoothstep(0.7, 1.0, tipDist);
+
+    // Stem
+    highp float sw = dotRad * 0.5;
+    highp float sx = 1.0 - smoothstep(sw * 0.5, sw, abs(wl.x));
+    highp float sy = step(0.0, wl.y) * (1.0 - step(lineH, wl.y));
+
+    highp float d = max(tip, sx * sy * 0.45);
+    highp float grad = clamp(wl.y / max(lineH, 0.001), 0.0, 1.0);
+
+    return vec4(d, tip, s, grad);
+}
+
+void fragment() {
+    highp float pixelSize = length(fwidth(gridPos));
+    highp float dotsPerPixel = spacing / max(pixelSize, 0.0001);
+    highp float detail = smoothstep(1.5, 4.0, dotsPerPixel);
+
+    if (detail < 0.01) {
+        COLOR = vec4(mix(colorLow, colorHigh, baseStretch * 0.3) * 0.35, 1.0);
+        return;
+    }
+
+    highp float t = TIME;
+    const highp float rotation = 0.5235988;
+    highp vec2 wp = gridPos;
+    highp float cs = cos(rotation);
+    highp float sn = sin(rotation);
+    highp vec2 gp = vec2(wp.x*cs + wp.y*sn, -wp.x*sn + wp.y*cs);
+    gp += vec2(sin(t*0.13)*0.1+sin(t*0.7)*0.04+sin(t*2.1)*0.015,
+               cos(t*0.11)*0.08+cos(t*0.53)*0.03+cos(t*1.7)*0.01);
+
+    highp vec2 cell = floor(gp / spacing);
+
+    // Evaluate pin for current cell
+    highp vec4 best = evalPin(cell, gp, cs, sn, t);
+
+    // Pins grow in direction (sn, cs) in gp-space (~30°).
+    // Check neighbor cells that a pin could originate from.
+    // Only needed when pins can cross cell boundaries.
+    if (maxHeight * 0.72 > spacing * 0.45) {
+        highp vec4 r;
+        r = evalPin(cell + vec2(-1.0, 0.0), gp, cs, sn, t);
+        if (r.x > best.x) best = r;
+        r = evalPin(cell + vec2(0.0, -1.0), gp, cs, sn, t);
+        if (r.x > best.x) best = r;
+        r = evalPin(cell + vec2(-1.0, -1.0), gp, cs, sn, t);
+        if (r.x > best.x) best = r;
+    }
+
+    highp float d = best.x;
+    highp float tip = best.y;
+    highp float stretch = best.z;
+    highp float grad = best.w;
+
+    // Color
+    highp vec3 stemCol = mix(colorLow * 0.25, colorLow, grad);
+    highp vec3 tipCol = mix(colorLow, colorHigh, stretch);
+    highp float tipWeight = tip / max(d, 0.001);
+    highp vec3 pinCol = mix(stemCol, tipCol, tipWeight) * d;
+
+    highp vec3 flatCol = mix(colorLow, colorHigh, min(baseStretch + stretch, 1.0) * 0.3) * 0.35;
+    highp vec3 col = mix(flatCol, pinCol, detail);
+    highp float alpha = mix(1.0, d, detail);
+    if (alpha < 0.01) discard;
+    col *= alpha;
+
+    COLOR = vec4(col, 1.0);
+}


### PR DESCRIPTION
## Short description
Reworked the AI nav map. The whole approach to drawing walls and doors has been changed to process the local area around the player instead of drawing the entire grid at once.

The number of allocations has not increased, and GPU load, based on my local and not exactly objective testing, is around 4%. The overlay has also been lowered to an entity overlay so that cyberspace objects can be drawn on top of it.

## Why we need to add this
We continue the expansion into cyberspace. The next step is to add computational properties to devices. Based on those, they will generate various cells around themselves in cyberspace, which netrunners and AI will interact with.

I lied, the next step is to make it possible to talk in cyberspace.
After all, rogue AIs need to be able to roleplay with the AI.

## Media (Video/Screenshots)
<img width="912" height="658" alt="20260415-1427-46 2243338" src="https://github.com/user-attachments/assets/2ca96752-8b3d-47e0-80c5-900eda68d7fd" />
<img width="992" height="644" alt="20260415-1428-38 0081228" src="https://github.com/user-attachments/assets/33ec0402-df97-4b64-93ed-ddfb013f3013" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: CYBERSTARLIGHT TEAM
- add: Added a cyberspace effect.
- tweak: The ai overlay no longer covers cyberspace objects.
- fix: The abductor AI eye no longer fills the screen with black when it steps even slightly into space.
