### PR TITLE
Update CC glasses with Diagnostic HUD features

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Eyes/glasses.yml
@@ -139,6 +139,34 @@
 
 - type: entity
   parent: [ClothingEyesBase, BaseCentcommContraband]
+  id: ClothingEyesGlassesCentCommBase
+  components:
+    - type: ShowJobIcons
+    - type: ShowMindShieldIcons
+    - type: ShowCriminalRecordIcons
+    - type: ShowAccessReaderSettings
+    - type: ShowHealthBars
+      damageContainers:
+        - Biological
+        - Inorganic
+        - Silicon
+        - IPC
+    - type: ShowHealthIcons
+      damageContainers:
+        - Biological
+        - Inorganic
+        - Silicon
+        - IPC
+    - type: FlashImmunity
+    - type: EyeProtection
+      protectionTime: 5
+    - type: Tag
+      tags:
+        - HudMedical
+        - WhitelistChameleon
+
+- type: entity
+  parent: ClothingEyesGlassesCentCommBase
   id: ClothingEyesGlassesCentComm
   name: CentComm officer's glasses
   description: The innovative green lenses hide your eyes from light flashes and have a built-in visor.
@@ -147,23 +175,11 @@
     sprite: _Starlight/Clothing/Eyes/Glasses/centcomm.rsi
   - type: Clothing
     sprite: _Starlight/Clothing/Eyes/Glasses/centcomm.rsi
-  - type: FlashImmunity
-  - type: ShowJobIcons
-  - type: ShowMindShieldIcons
-  - type: ShowCriminalRecordIcons
-  - type: ShowHealthBars
-    damageContainers:
-    - Biological
-  - type: ShowHealthIcons
-    damageContainers:
-    - Biological
   - type: Tag
     tags:
     - HudMedical
     - CorgiWearable
     - WhitelistChameleon
-  - type: EyeProtection
-    protectionTime: 5
   - type: StealTarget
     stealGroup: RareGlassesCollection
 
@@ -232,7 +248,7 @@
   - type: VisionCorrection
 
 - type: entity
-  parent: ClothingEyesGlassesCentComm
+  parent: ClothingEyesGlassesCentCommBase
   id: ClothingEyesGlassesCentCommPrescription
   name: prescription CentComm glasses
   description: A set of prescription glasses for CentComm personnel. Protects against flashes and has a built-in visor.
@@ -242,10 +258,6 @@
     - type: Clothing
       sprite: _Starlight/Clothing/Eyes/Glasses/prescriptioncentcomm.rsi
     - type: VisionCorrection
-    - type: Tag
-      tags:
-        - HudMedical
-        - WhitelistChameleon
 
 # USSP
 
@@ -339,7 +351,7 @@
         protectionTime: 5
 
 - type: entity
-  parent: ClothingEyesGlassesJamjar
+  parent: ClothingEyesGlassesCentCommBase
   id: ClothingEyesGlassesJamjarCentComm
   name: CentComm jamjar glasses
   description: For looking at their profits with even wider eyes.
@@ -348,6 +360,4 @@
       sprite: _Starlight/Clothing/Eyes/Glasses/jamjarcentcomm.rsi
     - type: Clothing
       sprite: _Starlight/Clothing/Eyes/Glasses/jamjarcentcomm.rsi
-    - type: Tag
-      tags:
-        - WhitelistChameleon
+    - type: VisionCorrection

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Eyes/glasses.yml
@@ -140,6 +140,7 @@
 - type: entity
   parent: [ClothingEyesBase, BaseCentcommContraband]
   id: ClothingEyesGlassesCentCommBase
+  abstract: true
   components:
     - type: ShowJobIcons
     - type: ShowMindShieldIcons


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

CC glasses are supposed to be omnipotent because it's CC, but recent additions to both upstream and Starlight have made a few features missing.

- Adds ability to see Cyborg, IPC health and access reader settings.
- Fixes CentComm jamjar now actually show the HUD icons they are supposed to, matching the other ones.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

CC glasses are supposed to be 'omnipotent' because it's CC, but recent additions to both upstream and Starlight have made a few features missing. Currently I and others are relying on VV'ing these components on.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/341cf678-e886-40cf-ad94-e66283450661

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: CentComm glasses now also have diagnostic HUD features, such as seeing cyborg and IPC health.
- fix: CentComm jamjar now behave identically to other CC glasses.