### PR TITLE
Upgrade EORG prevention: More actions, grenades, sticky explosives, staff of animation

### DIFF
--- a/Content.Client/_Starlight/EndOfRoundGriefing/EorgPreventionSystem.cs
+++ b/Content.Client/_Starlight/EndOfRoundGriefing/EorgPreventionSystem.cs
@@ -10,11 +10,11 @@ public sealed class EorgPreventionSystem : SharedEorgPreventionSystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeNetworkEvent<PreventEorgStateEvent>(OnStateChanged); // Handle server state changes.
-        RaiseNetworkEvent(new RequestPreventEorgStateEvent()); // Ask server to send a state.
+        SubscribeNetworkEvent<EorgPreventionStateEvent>(OnStateChanged); // Handle server state changes.
+        RaiseNetworkEvent(new RequestEorgPreventionStateEvent()); // Ask server to send a state.
     }
 
-    private void OnStateChanged(PreventEorgStateEvent ev)
+    private void OnStateChanged(EorgPreventionStateEvent ev)
     {
         IsEnabled = ev.IsEnabled;
         HasRoundEnded = ev.IsRoundEnded;

--- a/Content.Client/_Starlight/EndOfRoundGriefing/EorgPreventionSystem.cs
+++ b/Content.Client/_Starlight/EndOfRoundGriefing/EorgPreventionSystem.cs
@@ -17,6 +17,6 @@ public sealed class EorgPreventionSystem : SharedEorgPreventionSystem
     private void OnStateChanged(EorgPreventionStateEvent ev)
     {
         IsEnabled = ev.IsEnabled;
-        HasRoundEnded = ev.IsRoundEnded;
+        HasRoundEnded = ev.HasRoundEnded;
     }
 }

--- a/Content.Client/_Starlight/EndOfRoundGriefing/EorgPreventionSystem.cs
+++ b/Content.Client/_Starlight/EndOfRoundGriefing/EorgPreventionSystem.cs
@@ -2,9 +2,7 @@
 
 namespace Content.Client._Starlight.EndOfRoundGriefing;
 
-/// <summary>
 /// <inheritdoc/>
-/// </summary>
 public sealed class EorgPreventionSystem : SharedEorgPreventionSystem
 {
     public override void Initialize()

--- a/Content.Client/_Starlight/EndOfRoundGriefing/PreventEorgSystem.cs
+++ b/Content.Client/_Starlight/EndOfRoundGriefing/PreventEorgSystem.cs
@@ -1,0 +1,22 @@
+﻿using Content.Shared._Starlight.EndOfRoundGriefing;
+
+namespace Content.Client._Starlight.EndOfRoundGriefing;
+
+/// <summary>
+/// <inheritdoc/>
+/// </summary>
+public sealed class PreventEorgSystem : SharedPreventEorgSystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeNetworkEvent<PreventEorgStateEvent>(OnStateChanged); // Handle server state changes.
+        RaiseNetworkEvent(new RequestPreventEorgStateEvent()); // Ask server to send a state.
+    }
+
+    private void OnStateChanged(PreventEorgStateEvent ev)
+    {
+        IsEnabled = ev.IsEnabled;
+        HasRoundEnded = ev.IsRoundEnded;
+    }
+}

--- a/Content.Client/_Starlight/EndOfRoundGriefing/PreventEorgSystem.cs
+++ b/Content.Client/_Starlight/EndOfRoundGriefing/PreventEorgSystem.cs
@@ -5,7 +5,7 @@ namespace Content.Client._Starlight.EndOfRoundGriefing;
 /// <summary>
 /// <inheritdoc/>
 /// </summary>
-public sealed class PreventEorgSystem : SharedPreventEorgSystem
+public sealed class EorgPreventionSystem : SharedEorgPreventionSystem
 {
     public override void Initialize()
     {

--- a/Content.Server/_Starlight/EndOfRoundGriefing/EorgPreventionSystem.cs
+++ b/Content.Server/_Starlight/EndOfRoundGriefing/EorgPreventionSystem.cs
@@ -48,7 +48,7 @@ public sealed class EorgPreventionSystem : SharedEorgPreventionSystem
         SubscribeLocalEvent<PreventEorgComponent, PolymorphedEvent>(OnPolymorphed);
     }
 
-    private void BroadcastState() => RaiseNetworkEvent(new PreventEorgStateEvent(IsEnabled, HasRoundEnded));
+    private void BroadcastState() => RaiseNetworkEvent(new EorgPreventionStateEvent(IsEnabled, HasRoundEnded));
 
     /// <summary>
     /// Validate an entity is eligible for pacification, and applies it if so.

--- a/Content.Server/_Starlight/EndOfRoundGriefing/EorgPreventionSystem.cs
+++ b/Content.Server/_Starlight/EndOfRoundGriefing/EorgPreventionSystem.cs
@@ -46,7 +46,11 @@ public sealed class EorgPreventionSystem : SharedEorgPreventionSystem
         SubscribeLocalEvent<GotRehydratedEvent>(OnRehydrateEvent);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundCleanup);
         SubscribeLocalEvent<PreventEorgComponent, PolymorphedEvent>(OnPolymorphed);
+
+        SubscribeNetworkEvent<RequestEorgPreventionStateEvent>(OnRequestEorgPreventionState);
     }
+
+    private void OnRequestEorgPreventionState(RequestEorgPreventionStateEvent msg, EntitySessionEventArgs args) => RaiseNetworkEvent(new EorgPreventionStateEvent(IsEnabled, HasRoundEnded));
 
     private void BroadcastState() => RaiseNetworkEvent(new EorgPreventionStateEvent(IsEnabled, HasRoundEnded));
 

--- a/Content.Server/_Starlight/EndOfRoundGriefing/PreventEorgSystem.cs
+++ b/Content.Server/_Starlight/EndOfRoundGriefing/PreventEorgSystem.cs
@@ -3,8 +3,8 @@ using Content.Server.Ghost.Roles.Components;
 using Content.Server.Polymorph.Components;
 using Content.Server.Shuttles.Components;
 using Content.Shared._NullLink;
-using Content.Shared._Starlight.GameTicking.Components;
-using Content.Shared.Actions.Events;
+using Content.Shared._Starlight.EndOfRoundGriefing;
+using Content.Shared._Starlight.EndOfRoundGriefing.Components;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.GameTicking;
@@ -13,38 +13,42 @@ using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Movement.Components;
 using Content.Shared.Polymorph;
-using Content.Shared.Popups;
 using Content.Shared.Roles;
 using Content.Shared.Starlight.CCVar;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.Starlight.GameTicking;
+namespace Content.Server._Starlight.EndOfRoundGriefing;
 
-public sealed class PeacefulRoundEndSystem : EntitySystem
+/// <summary>
+/// <inheritdoc/>
+///
+/// The server side of the EORG prevent system manages state and is responsible for managing the <see cref="PreventEorgComponent"/>s on players.
+/// </summary>
+public sealed class PreventEorgSystem : SharedPreventEorgSystem
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly ISharedNullLinkPlayerRolesReqManager _rolesReq = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly SharedRoleSystem _role = default!;
-
-    private bool _isEnabled = false;
-    private bool _roundedEnded = false;
-
 
     public override void Initialize()
     {
         base.Initialize();
-        _cfg.OnValueChanged(StarlightCCVars.PeacefulRoundEnd, v => _isEnabled = v, true);
+        _cfg.OnValueChanged(StarlightCCVars.PeacefulRoundEnd, v =>
+        {
+            IsEnabled = v;
+            BroadcastState();
+        }, true);
 
         SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnded);
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnSpawnComplete);
         SubscribeLocalEvent<GotRehydratedEvent>(OnRehydrateEvent);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundCleanup);
-        SubscribeLocalEvent<EorgActionComponent, ActionValidateEvent>(OnValidatePossiblyEorgAction);
         SubscribeLocalEvent<PreventEorgComponent, PolymorphedEvent>(OnPolymorphed);
     }
+
+    private void BroadcastState() => RaiseNetworkEvent(new PreventEorgStateEvent(IsEnabled, HasRoundEnded));
 
     /// <summary>
     /// Validate an entity is eligible for pacification, and applies it if so.
@@ -52,7 +56,7 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     /// <param name="target">The entity to potentially pacify</param>
     private void SpreadPeaceNow(EntityUid target)
     {
-        if (!_isEnabled || !_roundedEnded) return;
+        if (!IsEnabled || !HasRoundEnded) return;
         if (!ShouldPacify(target)) return;
         Pacify(target);
 
@@ -175,6 +179,7 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     }
 
     #endregion
+
     #region Event handlers
 
     private void OnSpawnComplete(PlayerSpawnCompleteEvent ev)
@@ -184,12 +189,16 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
         => SpreadPeaceNow(ev.Target);
 
     private void OnRoundCleanup(RoundRestartCleanupEvent ev)
-        => _roundedEnded = false;
+    {
+        HasRoundEnded = false;
+        BroadcastState();
+    }
 
     private void OnRoundEnded(RoundEndTextAppendEvent ev)
     {
-        _roundedEnded = true;
-        if (!_isEnabled) return;
+        HasRoundEnded = true;
+        BroadcastState();
+        if (!IsEnabled) return;
 
         var candidates = new List<EntityUid>();
 
@@ -216,6 +225,7 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
                     deleting = true;
                     candidates.Remove(polymorphed.Parent.Value);
                 }
+
                 current = polymorphed.Parent.Value;
             }
         }
@@ -226,24 +236,9 @@ public sealed class PeacefulRoundEndSystem : EntitySystem
     }
 
     /// <summary>
-    /// Prevents performing actions marked as <see cref="EorgActionComponent"/> if the user has
-    /// <see cref="PreventEorgComponent"/>.
-    /// </summary>
-    private void OnValidatePossiblyEorgAction(EntityUid uid, EorgActionComponent component, ref ActionValidateEvent args)
-    {
-        if (!_isEnabled || !_roundedEnded) return;
-        if (!HasComp<PreventEorgComponent>(args.User))  return;
-
-        _popup.PopupEntity(Loc.GetString("eorg-action"), args.User, args.User, PopupType.LargeCaution);
-        args.Invalid = true;
-    }
-
-
-    /// <summary>
     /// If someone with <see cref="PreventEorgComponent"/> polymorphs, also apply it to their polymorph.
     /// </summary>
     private void OnPolymorphed(EntityUid uid, PreventEorgComponent comp, PolymorphedEvent ev) => Pacify(ev.NewEntity);
 
     #endregion
-
 }

--- a/Content.Server/_Starlight/EndOfRoundGriefing/PreventEorgSystem.cs
+++ b/Content.Server/_Starlight/EndOfRoundGriefing/PreventEorgSystem.cs
@@ -25,7 +25,7 @@ namespace Content.Server._Starlight.EndOfRoundGriefing;
 ///
 /// The server side of the EORG prevent system manages state and is responsible for managing the <see cref="PreventEorgComponent"/>s on players.
 /// </summary>
-public sealed class PreventEorgSystem : SharedPreventEorgSystem
+public sealed class EorgPreventionSystem : SharedEorgPreventionSystem
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly ISharedNullLinkPlayerRolesReqManager _rolesReq = default!;

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Popups;
 using Content.Shared.Tag;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Serialization;
+using PreventEorgComponent = Content.Shared._Starlight.EndOfRoundGriefing.Components.PreventEorgComponent;
 
 namespace Content.Shared.Emag.Systems;
 

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventActionComponent.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventActionComponent.cs
@@ -1,11 +1,11 @@
 ﻿using Robust.Shared.GameStates;
 
-namespace Content.Shared._Starlight.GameTicking.Components;
+namespace Content.Shared._Starlight.EndOfRoundGriefing.Components;
 
 /// <summary>
 /// Marker component to identify an action as being EORG. Intended to be blocked during EOR to prevent EORG.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class EorgActionComponent : Component
+public sealed partial class EorgPreventActionComponent : Component
 {
 }

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventHandInteractComponent.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventHandInteractComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.EndOfRoundGriefing.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class EorgPreventHandInteractComponent : Component;

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventRangedInteractComponent.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventRangedInteractComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.EndOfRoundGriefing.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class EorgPreventRangedInteractComponent : Component;

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventStickingComponent.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventStickingComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.EndOfRoundGriefing.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class EorgPreventStickingComponent : Component;

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventTriggerComponent.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventTriggerComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.EndOfRoundGriefing.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class EorgPreventTriggerComponent : Component;

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventUseItemComponent.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/Components/EorgPreventUseItemComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.EndOfRoundGriefing.Components;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class EorgPreventUseItemComponent : Component;

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/Components/PreventEorgComponent.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/Components/PreventEorgComponent.cs
@@ -1,6 +1,6 @@
 ﻿using Robust.Shared.GameStates;
 
-namespace Content.Shared._Starlight.GameTicking.Components;
+namespace Content.Shared._Starlight.EndOfRoundGriefing.Components;
 
 /// <summary>
 /// Marker component to disable antagonism. Intended for use in EOR to prevent EORG.

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/SharedEorgPreventionSystem.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/SharedEorgPreventionSystem.cs
@@ -77,7 +77,7 @@ public abstract class SharedEorgPreventionSystem : EntitySystem
         if (args.Handled) return;
         if (!HasComp<PreventEorgComponent>(args.User)) return;
 
-        _popup.PopupPredicted(Loc.GetString("eorg-action"), uid, uid, PopupType.LargeCaution);
+        _popup.PopupPredicted(Loc.GetString("eorg-action"), args.User, args.User, PopupType.LargeCaution);
         args.Handled = true;
     }
 

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/SharedEorgPreventionSystem.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/SharedEorgPreventionSystem.cs
@@ -103,8 +103,8 @@ public sealed class RequestEorgPreventionStateEvent : EntityEventArgs
 }
 
 [Serializable, NetSerializable]
-public sealed class EorgPreventionStateEvent(bool isEnabled, bool isRoundEnded) : EntityEventArgs
+public sealed class EorgPreventionStateEvent(bool isEnabled, bool hasRoundEnded) : EntityEventArgs
 {
     public bool IsEnabled { get; } = isEnabled;
-    public bool IsRoundEnded { get; } = isRoundEnded;
+    public bool HasRoundEnded { get; } = hasRoundEnded;
 }

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/SharedEorgPreventionSystem.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/SharedEorgPreventionSystem.cs
@@ -98,12 +98,12 @@ public abstract class SharedEorgPreventionSystem : EntitySystem
 }
 
 [Serializable, NetSerializable]
-public sealed class RequestPreventEorgStateEvent : EntityEventArgs
+public sealed class RequestEorgPreventionStateEvent : EntityEventArgs
 {
 }
 
 [Serializable, NetSerializable]
-public sealed class PreventEorgStateEvent(bool isEnabled, bool isRoundEnded) : EntityEventArgs
+public sealed class EorgPreventionStateEvent(bool isEnabled, bool isRoundEnded) : EntityEventArgs
 {
     public bool IsEnabled { get; } = isEnabled;
     public bool IsRoundEnded { get; } = isRoundEnded;

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/SharedPreventEorgSystem.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/SharedPreventEorgSystem.cs
@@ -57,13 +57,14 @@ public abstract class SharedPreventEorgSystem : EntitySystem
         if (!args.User.HasValue || args.Cancelled) return;
         if (!HasComp<PreventEorgComponent>(args.User)) return;
 
-        _popup.PopupPredicted(Loc.GetString("eorg-action"), uid, uid, PopupType.LargeCaution);
+        _popup.PopupPredicted(Loc.GetString("eorg-action"), args.User.Value, args.User.Value, PopupType.LargeCaution);
         args.Cancelled = true;
     }
 
     private void OnBeforeInteractHand(EntityUid uid, EorgPreventHandInteractComponent component, ref BeforeInteractHandEvent args)
     {
         if (!IsEnabled || !HasRoundEnded) return;
+        if (args.Handled) return;
         if (!HasComp<PreventEorgComponent>(uid)) return;
 
         _popup.PopupPredicted(Loc.GetString("eorg-action"), uid, uid, PopupType.LargeCaution);
@@ -73,6 +74,7 @@ public abstract class SharedPreventEorgSystem : EntitySystem
     private void OnBeforeRangedInteract(EntityUid uid, EorgPreventRangedInteractComponent component, ref BeforeRangedInteractEvent args)
     {
         if (!IsEnabled || !HasRoundEnded) return;
+        if (args.Handled) return;
         if (!HasComp<PreventEorgComponent>(args.User)) return;
 
         _popup.PopupPredicted(Loc.GetString("eorg-action"), uid, uid, PopupType.LargeCaution);
@@ -86,6 +88,7 @@ public abstract class SharedPreventEorgSystem : EntitySystem
     private void OnValidateAction(EntityUid uid, EorgPreventActionComponent component, ref ActionValidateEvent args)
     {
         if (!IsEnabled || !HasRoundEnded) return;
+        if (args.Invalid) return;
         if (!HasComp<PreventEorgComponent>(args.User))  return;
 
         _popup.PopupPredicted(Loc.GetString("eorg-action"), args.User, args.User, PopupType.LargeCaution);

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/SharedPreventEorgSystem.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/SharedPreventEorgSystem.cs
@@ -12,7 +12,7 @@ namespace Content.Shared._Starlight.EndOfRoundGriefing;
 /// <summary>
 /// Intercepts various events and checks if they can be done.
 /// </summary>
-public abstract class SharedPreventEorgSystem : EntitySystem
+public abstract class SharedEorgPreventionSystem : EntitySystem
 {
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 

--- a/Content.Shared/_Starlight/EndOfRoundGriefing/SharedPreventEorgSystem.cs
+++ b/Content.Shared/_Starlight/EndOfRoundGriefing/SharedPreventEorgSystem.cs
@@ -1,0 +1,107 @@
+﻿using Content.Shared._Starlight.EndOfRoundGriefing.Components;
+using Content.Shared.Actions.Events;
+using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Popups;
+using Content.Shared.Sticky;
+using Content.Shared.Trigger;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Starlight.EndOfRoundGriefing;
+
+/// <summary>
+/// Intercepts various events and checks if they can be done.
+/// </summary>
+public abstract class SharedPreventEorgSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    protected bool IsEnabled = false;
+    protected bool HasRoundEnded = false;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EorgPreventActionComponent, ActionValidateEvent>(OnValidateAction);
+        SubscribeLocalEvent<EorgPreventUseItemComponent, UseAttemptEvent>(OnUseAttempt);
+        SubscribeLocalEvent<EorgPreventTriggerComponent, AttemptTriggerEvent>(OnAttemptTrigger);
+        SubscribeLocalEvent<EorgPreventHandInteractComponent, BeforeInteractHandEvent>(OnBeforeInteractHand);
+        SubscribeLocalEvent<EorgPreventRangedInteractComponent, BeforeRangedInteractEvent>(OnBeforeRangedInteract);
+        SubscribeLocalEvent<EorgPreventStickingComponent, AttemptEntityStickEvent>(OnAttemptStick);
+    }
+
+    private void OnAttemptStick(EntityUid uid, EorgPreventStickingComponent component, ref AttemptEntityStickEvent args)
+    {
+        if (!IsEnabled || !HasRoundEnded) return;
+        if (args.Cancelled) return;
+        if (!HasComp<PreventEorgComponent>(args.User)) return;
+
+        _popup.PopupPredicted(Loc.GetString("eorg-action"), args.User, args.User, PopupType.LargeCaution);
+        args.Cancelled = true;
+    }
+
+    private void OnUseAttempt(EntityUid uid, EorgPreventUseItemComponent component, ref UseAttemptEvent args)
+    {
+        if (!IsEnabled || !HasRoundEnded) return;
+        if (args.Cancelled) return;
+        if (!HasComp<PreventEorgComponent>(uid)) return;
+
+        _popup.PopupPredicted(Loc.GetString("eorg-action"), uid, uid, PopupType.LargeCaution);
+        args.Cancel();
+    }
+
+    private void OnAttemptTrigger(EntityUid uid, EorgPreventTriggerComponent component, ref AttemptTriggerEvent args)
+    {
+        if (!IsEnabled || !HasRoundEnded) return;
+        if (!args.User.HasValue || args.Cancelled) return;
+        if (!HasComp<PreventEorgComponent>(args.User)) return;
+
+        _popup.PopupPredicted(Loc.GetString("eorg-action"), uid, uid, PopupType.LargeCaution);
+        args.Cancelled = true;
+    }
+
+    private void OnBeforeInteractHand(EntityUid uid, EorgPreventHandInteractComponent component, ref BeforeInteractHandEvent args)
+    {
+        if (!IsEnabled || !HasRoundEnded) return;
+        if (!HasComp<PreventEorgComponent>(uid)) return;
+
+        _popup.PopupPredicted(Loc.GetString("eorg-action"), uid, uid, PopupType.LargeCaution);
+        args.Handled = true;
+    }
+
+    private void OnBeforeRangedInteract(EntityUid uid, EorgPreventRangedInteractComponent component, ref BeforeRangedInteractEvent args)
+    {
+        if (!IsEnabled || !HasRoundEnded) return;
+        if (!HasComp<PreventEorgComponent>(args.User)) return;
+
+        _popup.PopupPredicted(Loc.GetString("eorg-action"), uid, uid, PopupType.LargeCaution);
+        args.Handled = true;
+    }
+
+    /// <summary>
+    /// Prevents performing actions marked as <see cref="EorgPreventActionComponent"/> if the user has
+    /// <see cref="PreventEorgComponent"/>.
+    /// </summary>
+    private void OnValidateAction(EntityUid uid, EorgPreventActionComponent component, ref ActionValidateEvent args)
+    {
+        if (!IsEnabled || !HasRoundEnded) return;
+        if (!HasComp<PreventEorgComponent>(args.User))  return;
+
+        _popup.PopupPredicted(Loc.GetString("eorg-action"), args.User, args.User, PopupType.LargeCaution);
+        args.Invalid = true;
+    }
+
+}
+
+[Serializable, NetSerializable]
+public sealed class RequestPreventEorgStateEvent : EntityEventArgs
+{
+}
+
+[Serializable, NetSerializable]
+public sealed class PreventEorgStateEvent(bool isEnabled, bool isRoundEnded) : EntityEventArgs
+{
+    public bool IsEnabled { get; } = isEnabled;
+    public bool IsRoundEnded { get; } = isRoundEnded;
+}

--- a/Resources/Prototypes/Actions/changeling.yml
+++ b/Resources/Prototypes/Actions/changeling.yml
@@ -41,7 +41,7 @@
       components:
       - Absorbed
     event: !type:ChangelingDevourActionEvent
-  - type: EorgAction
+  - type: EorgPreventAction
 
 - type: entity
   id: ActionChangelingTransform

--- a/Resources/Prototypes/Actions/polymorph.yml
+++ b/Resources/Prototypes/Actions/polymorph.yml
@@ -47,6 +47,7 @@
   - type: InstantAction
     event: !type:PolymorphActionEvent
       protoId: WizardRod
+  - type: EorgPreventAction # Starlight
 
 - type: entity
   parent: BaseActionPolymorph

--- a/Resources/Prototypes/Actions/revenant.yml
+++ b/Resources/Prototypes/Actions/revenant.yml
@@ -15,7 +15,7 @@
     icon: Interface/Actions/defile.png
   - type: InstantAction
     event: !type:RevenantDefileActionEvent
-  - type: EorgAction # Starlight
+  - type: EorgPreventAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -28,7 +28,7 @@
     useDelay: 20
   - type: InstantAction
     event: !type:RevenantOverloadLightsActionEvent
-  - type: EorgAction # Starlight
+  - type: EorgPreventAction # Starlight
 
 #- type: entity
 #  parent: BaseAction
@@ -41,7 +41,7 @@
 #    useDelay: 20
 #  - type: InstantAction
 #    event: !type:RevenantBlightActionEvent
-#  - type: EorgAction # Starlight
+#  - type: EorgPreventAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -54,4 +54,4 @@
     useDelay: 20
   - type: InstantAction
     event: !type:RevenantMalfunctionActionEvent
-  - type: EorgAction # Starlight
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -274,7 +274,7 @@
     priority: 3
   - type: InstantAction
     event: !type:DragonSpawnRiftActionEvent
-  - type: EorgAction # Starlight
+  - type: EorgPreventAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -297,7 +297,7 @@
       tags:
       - Wall
     event: !type:DevourActionEvent
-  - type: EorgAction # Starlight
+  - type: EorgPreventAction # Starlight
 
 - type: entity
   parent: BaseAction
@@ -315,4 +315,4 @@
     range: 0
   - type: WorldTargetAction
     event: !type:ActionGunShootEvent
-  - type: EorgAction # Starlight
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -34,6 +34,7 @@
         base:
           Primed: { state: primed }
           Unprimed: { state: icon }
+  - type: EorgPreventSticking # Starlight
 
 - type: entity
   name: composition C-4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -20,6 +20,7 @@
         volume: 5
     initialBeepDelay: 0
     beepInterval: 2 # 2 beeps total (at 0 and 2)
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   name: flashbang
@@ -104,6 +105,7 @@
         volume: 12
   - type: StaticPrice
     price: 2000
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   name: self destruct
@@ -131,6 +133,7 @@
         volume: 30
     initialBeepDelay: 0
     beepInterval: 16
+  - type: EorgPreventTrigger # Starlight
 
 
 - type: entity
@@ -203,6 +206,7 @@
         - stageTwo
   - type: StaticPrice
     price: 1000
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   name: whitehole grenade
@@ -263,6 +267,7 @@
         - stageTwo
   - type: StaticPrice
     price: 1000
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   name: the nuclear option
@@ -296,6 +301,7 @@
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Effects/countdown.ogg
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   name: modular grenade
@@ -344,6 +350,7 @@
           # Unprimed: <Use state determined by enum.ConstructionVisuals.Layer>
   - type: StaticPrice
     price: 75
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   name: EMP grenade
@@ -367,6 +374,7 @@
       path: /Audio/Effects/countdown.ogg
   - type: StaticPrice
     price: 666 # 2000 for 3, I love fractions
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   name: holy hand grenade
@@ -396,6 +404,7 @@
       path: /Audio/Effects/hallelujah.ogg
   - type: StaticPrice
     price: 10000
+  - type: EorgPreventTrigger # Starlight
 
 # Non-explosive "dummy" grenades to use as a distraction.
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -75,6 +75,7 @@
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Effects/countdown.ogg
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   parent: [FragileGrenadeBase, ProjectileGrenadeBase, BaseSyndicateContraband]
@@ -107,6 +108,7 @@
     positional: true
   - type: StaticPrice
     price: 1500
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   parent: [FragileGrenadeBase, ProjectileGrenadeBase, BaseSyndicateContraband]
@@ -139,3 +141,4 @@
     positional: true
   - type: StaticPrice
     price: 1500
+  - type: EorgPreventTrigger # Starlight

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/scattering_grenades.yml
@@ -110,6 +110,7 @@
     positional: true
   - type: StaticPrice
     price: 2500
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   parent: [FragileGrenadeBase, ScatteringGrenadeBase, BaseSyndicateContraband]
@@ -135,6 +136,7 @@
     sound:
       path: "/Audio/Items/bikehorn.ogg"
     positional: true
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   parent: [SoapSyndie, ScatteringGrenadeBase, BaseSyndicateContraband]

--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -166,6 +166,7 @@
     sentence: action-speech-spell-summon-guns
     tts: action-speech-spell-summon-guns-tts # Starlight
     modifier: Spell # Starlight
+  - type: EorgPreventAction # Starlight
 - type: entity
   parent: BaseAction
   id: ActionSummonMagic

--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -215,3 +215,4 @@
     sentence: action-speech-spell-summon-magic
     tts: action-speech-spell-summon-magic-tts # Starlight
     modifier: Spell # Starlight
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Magic/forcewall_spells.yml
+++ b/Resources/Prototypes/Magic/forcewall_spells.yml
@@ -20,3 +20,4 @@
     sentence: action-speech-spell-forcewall
     tts: action-speech-spell-forcewall-tts
     modifier: Spell
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Magic/knock_spell.yml
+++ b/Resources/Prototypes/Magic/knock_spell.yml
@@ -18,3 +18,4 @@
     sentence: action-speech-spell-knock
     tts: action-speech-spell-knock-tts
     modifier: Spell
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Magic/mindswap_spell.yml
+++ b/Resources/Prototypes/Magic/mindswap_spell.yml
@@ -22,3 +22,4 @@
     sentence: action-speech-spell-mind-swap
     tts: action-speech-spell-mind-swap-tts
     modifier: Spell
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Magic/projectile_spells.yml
+++ b/Resources/Prototypes/Magic/projectile_spells.yml
@@ -28,6 +28,7 @@
     effectedLevels:
       2: ActionFireballII
       3: ActionFireballIII
+  - type: EorgPreventAction # Starlight
 
 - type: entity
   parent: ActionFireball

--- a/Resources/Prototypes/Magic/repulse_spell.yml
+++ b/Resources/Prototypes/Magic/repulse_spell.yml
@@ -20,3 +20,4 @@
       state: repulse
   - type: InstantAction
     event: !type:RepulseAttractActionEvent
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Magic/rune_spells.yml
+++ b/Resources/Prototypes/Magic/rune_spells.yml
@@ -32,6 +32,7 @@
   - type: InstantAction
     event: !type:InstantSpawnSpellEvent
       prototype: ExplosionRune
+  - type: EorgPreventAction # Starlight
 
 - type: entity
   parent: BaseRuneAction
@@ -44,6 +45,7 @@
   - type: InstantAction
     event: !type:InstantSpawnSpellEvent
       prototype: IgniteRune
+  - type: EorgPreventAction # Starlight
 
 - type: entity
   parent: BaseRuneAction

--- a/Resources/Prototypes/Magic/smoke_spell.yml
+++ b/Resources/Prototypes/Magic/smoke_spell.yml
@@ -14,3 +14,4 @@
     event: !type:InstantSpawnSpellEvent
       prototype: WizardSmoke
       posData: !type:TargetInFront
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Magic/spawn_spells.yml
+++ b/Resources/Prototypes/Magic/spawn_spells.yml
@@ -22,3 +22,4 @@
     sentence: action-speech-spell-summon-magicarp
     tts: action-speech-spell-summon-magicarp-tts
     modifier: Spell
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Magic/staves.yml
+++ b/Resources/Prototypes/Magic/staves.yml
@@ -65,6 +65,7 @@
   - type: Tag
     tags:
     - WizardWand
+  - type: EorgPreventRangedInteract # Starlight
 
 
 - type: entity

--- a/Resources/Prototypes/Magic/teleport_spells.yml
+++ b/Resources/Prototypes/Magic/teleport_spells.yml
@@ -42,3 +42,4 @@
   - type: EntityTargetAction
     event: !type:VoidApplauseSpellEvent
       effect: EffectVoidBlink
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -44,6 +44,7 @@
     modifier: Spell
   - type: Magic
     requiresClothes: true
+  - type: EorgPreventAction # Starlight
 
 # For the Snail
 - type: entity
@@ -102,3 +103,4 @@
     modifier: Spell
   - type: Magic
     requiresClothes: false
+  - type: EorgPreventAction # Starlight

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -14,6 +14,7 @@
       components:
       - MobState
     canTargetSelf: false
+  - type: EorgPreventAction # Starlight
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -14,7 +14,6 @@
       components:
       - MobState
     canTargetSelf: false
-  - type: EorgPreventAction # Starlight
 
 - type: entity
   abstract: true
@@ -77,6 +76,7 @@
     modifier: Spell
   - type: Magic
     requiresClothes: true
+  - type: EorgPreventAction # Starlight
 
 - type: entity
   parent: BaseSmiteAction

--- a/Resources/Prototypes/_Starlight/Actions/changeling.yml
+++ b/Resources/Prototypes/_Starlight/Actions/changeling.yml
@@ -40,7 +40,7 @@
   - type: ChangelingAction
     chemicalCost: 25
     useInLesserForm: true
-  - type: EorgAction
+  - type: EorgPreventAction
 
 
 - type: entity
@@ -342,7 +342,7 @@
   - type: ChangelingAction
     chemicalCost: 75
     useInLesserForm: true
-  - type: EorgAction
+  - type: EorgPreventAction
 
 # utility
 - type: entity
@@ -399,7 +399,7 @@
     event: !type:ActionBiodegradeEvent {}
   - type: ChangelingAction
     chemicalCost: 30
-  - type: EorgAction
+  - type: EorgPreventAction
 
 - type: entity
   id: ActionChameleonSkin

--- a/Resources/Prototypes/_Starlight/Actions/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Actions/shadekin.yml
@@ -42,7 +42,7 @@
       checkCanInteract: false
     - type: InstantAction
       event: !type:BrighteyePortalActionEvent
-    - type: EorgAction
+    - type: EorgPreventAction
 
 - type: entity
   id: BrighteyeDarkTrapAction
@@ -94,4 +94,4 @@
       itemIconStyle: NoItem
     - type: InstantAction
       event: !type:BrighteyeCreateShadeActionEvent
-    - type: EorgAction
+    - type: EorgPreventAction

--- a/Resources/Prototypes/_Starlight/Actions/vampire.yml
+++ b/Resources/Prototypes/_Starlight/Actions/vampire.yml
@@ -255,7 +255,7 @@
       bloodToUnlock: 800
       bloodCost: 100
       requiredClass: Hemomancer
-    - type: EorgAction
+    - type: EorgPreventAction
 
 - type: entity
   parent: BaseAction
@@ -320,7 +320,7 @@
       bloodToUnlock: 200
       bloodCost: 20
       requiredClass: Umbrae
-    - type: EorgAction
+    - type: EorgPreventAction
 
 - type: entity
   parent: BaseAction
@@ -370,7 +370,7 @@
       bloodToUnlock: 800
       bloodCost: 50
       requiredClass: Umbrae
-    - type: EorgAction
+    - type: EorgPreventAction
 
 - type: entity
   parent: BaseAction
@@ -465,7 +465,7 @@
       bloodToUnlock: 150
       bloodCost: 150
       requiredClass: Dantalion
-    - type: EorgAction
+    - type: EorgPreventAction
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/grenades.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/grenades.yml
@@ -16,6 +16,7 @@
       reagents:
       - ReagentId: SpaceLube
         Quantity: 20
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   parent: [ SmokeGrenade ]
@@ -35,6 +36,7 @@
       reagents:
       - ReagentId: SpaceGlue
         Quantity: 20
+  - type: EorgPreventTrigger # Starlight
 
 - type: entity
   parent: SmokeGrenade
@@ -56,3 +58,4 @@
         Quantity: 12
   - type: StaticPrice
     price: 500
+  - type: EorgPreventTrigger # Starlight

--- a/Resources/Prototypes/_Starlight/Magic/event_spells.yml
+++ b/Resources/Prototypes/_Starlight/Magic/event_spells.yml
@@ -37,6 +37,7 @@
     modifier: Spell
   - type: InstantAction
     event: !type:TowerOfBabelEvent
+  - type: EorgPreventAction
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/_Starlight/Magic/ice_spells.yml
+++ b/Resources/Prototypes/_Starlight/Magic/ice_spells.yml
@@ -27,6 +27,7 @@
     sentence: action-speech-spell-icestorm
     tts: action-speech-spell-icestorm-tts
     modifier: Spell
+  - type: EorgPreventAction # Starlight
 
 # Starlight: Ice Storm projectile
 - type: entity


### PR DESCRIPTION

## Short description
<!-- What do you propose to change with your PR? -->

Technical:
- Upgrades EORG prevention system to its own proper system, with shared/server/client impls for actual prediction.
- Added several new components and event handlers for different types of interactions.

User-facing, during EOR:
- Tons of wizard spells can no longer be used;
- Staff of animation 
- Sticking bombs onto walls is no longer possible;
- Various harmful or disruptive grenades can no longer be activated.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Just like the previous EORG prevention PR, it covers more bases mechanically, reducing workload on admins during EOR and letting them spend more of their time and attention on more pressing matters or quality RP (debrief yay!).

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/099a0178-b3c5-402f-9205-d4e37baa57da

https://github.com/user-attachments/assets/b0b75faf-e75f-457b-9eca-d08ab72dc96e

https://github.com/user-attachments/assets/41387635-5dc1-4553-9c0e-82f639470c2d

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Various harmful and disruptive Wizard abilities are now disabled when EOR pacified.
- add: Staff of Animation is now disabled when EOR pacified.
- add: Sticky explosives can no longer be planted when EOR pacified.
- add: Various harmful grenades can no longer be activated when EOR pacified.
