### PR TITLE
Mech QOL: UI verb and maintenance panel changes

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -469,12 +469,17 @@ public sealed partial class MechSystem : SharedMechSystem
         if (!args.CanAccess || !args.CanInteract)
             return;
 
-        var openUiVerb = new AlternativeVerb
+        // Starlight begin - restrict UI verb to pilot, if pilot present
+        if (IsEmpty(component) || args.User == component.PilotSlot.ContainedEntity)
         {
-            Act = () => ToggleMechUi(uid, component, args.User),
-            Text = Loc.GetString("mech-ui-open-verb")
-        };
-        args.Verbs.Add(openUiVerb);
+            var openUiVerb = new AlternativeVerb
+            {
+                Act = () => ToggleMechUi(uid, component, args.User),
+                Text = Loc.GetString("mech-ui-open-verb")
+            };
+            args.Verbs.Add(openUiVerb);
+        }
+        // Starlight end
 
         if (component.Broken)
             return;

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -78,6 +78,7 @@ public sealed partial class MechSystem : SharedMechSystem
     [Dependency] private readonly IGameTiming Timing = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
     [Dependency] private readonly GasTankSystem _gasTank = default!;
+    [Dependency] private readonly SharedWiresSystem _wires = default!;
 #endregion Starlight
 
 
@@ -443,14 +444,26 @@ public sealed partial class MechSystem : SharedMechSystem
         RemoveEquipment(uid, equip, component);
     }
 
+    #region Starlight
     private void OnMaintenanceMessage(EntityUid uid, MechComponent component, MechMaintenanceUiMessage args)
     {
-        component.MaintenanceMode = args.Toggle;
+        TryToggleMaintenanceMode(uid, component, args.Toggle);
 
         Dirty(uid, component); // Starlight-edit: Update Maintenance State
 
         UpdateCanMove(uid, component); // Starlight-edit: fix movement block
     }
+
+    private void TryToggleMaintenanceMode(EntityUid uid, MechComponent component, bool toggle)
+    {
+        if (TryComp<WiresPanelComponent>(uid, out var panelComp))
+        {
+            _wires.TogglePanel(uid, panelComp, toggle, uid);
+        }
+        component.MaintenanceMode = toggle;
+        UpdateUserInterface(uid, component);
+    }
+    #endregion
 
     private void OnOpenUi(EntityUid uid, MechComponent component, MechOpenUiEvent args)
     {
@@ -544,6 +557,7 @@ public sealed partial class MechSystem : SharedMechSystem
                 _hands.DoDrop((args.Args.User, handsComponent), hand);
 
         TryInsert(uid, args.Args.User, component);
+        _ui.CloseUis(uid); // Starlight - close any UIs upon mech entry
         UpdateCanMove(uid, component); // Starlight-edit: fix movement block
 
         _factionSystem.Up(args.Args.User, uid);

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -434,7 +434,7 @@ public sealed partial class MechSystem : SharedMechSystem
 
         if (!component.MaintenanceMode)
         {
-            _popup.PopupEntity("You need to turn on maintenance mode first!", uid, PopupType.MediumCaution);
+            _popup.PopupEntity(Loc.GetString("mech-requires-maintenance-mode"), uid, PopupType.MediumCaution);
             return;
         }
 
@@ -460,7 +460,18 @@ public sealed partial class MechSystem : SharedMechSystem
         {
             _wires.TogglePanel(uid, panelComp, toggle, uid);
         }
+
+        if (component.MaintenanceMode != toggle)
+        {
+            var popupString = toggle ? "mech-maintenance-enabled" : "mech-maintenance-disabled";
+            _popup.PopupPredicted(Loc.GetString(popupString), uid, uid);
+
+            var panelSound = toggle ? component.MaintenanceOnSound : component.MaintenanceOffSound;
+            _audioSystem.PlayPredicted(panelSound, uid, uid);
+        }
+
         component.MaintenanceMode = toggle;
+
         UpdateUserInterface(uid, component);
     }
     #endregion

--- a/Content.Shared/Mech/Components/MechComponent.cs
+++ b/Content.Shared/Mech/Components/MechComponent.cs
@@ -252,6 +252,18 @@ public sealed partial class MechComponent : Component
     public SoundSpecifier CriticalDamageSound = new SoundPathSpecifier("/Audio/Mecha/critnano.ogg");
 
     [DataField]
+    public SoundSpecifier? MaintenanceOnSound = new SoundPathSpecifier("/Audio/Machines/door_lock_on.ogg")
+    {
+        Params = AudioParams.Default.WithVolume(-5f)
+    };
+
+    [DataField]
+    public SoundSpecifier? MaintenanceOffSound = new SoundPathSpecifier("/Audio/Machines/door_lock_off.ogg")
+    {
+        Params = AudioParams.Default.WithVolume(-5f),
+    };
+
+    [DataField]
     public bool FirstStart = false;
 
     [DataField]

--- a/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
+++ b/Content.Shared/Mech/EntitySystems/SharedMechSystem.cs
@@ -32,6 +32,7 @@ using Content.Shared.Stunnable;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Power.Components;
 using Content.Shared.Power.EntitySystems;
+using Content.Shared.Wires;
 using Content.Shared._Starlight.Mech;
 using Content.Shared._Starlight.Weapons.Melee.Events;
 #endregion
@@ -88,6 +89,7 @@ public abstract partial class SharedMechSystem : EntitySystem
         SubscribeLocalEvent<MechComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
         SubscribeLocalEvent<MechComponent, ShotAttemptedEvent>(OnShootAttempt); // Moved from server side, broken
         SubscribeLocalEvent<MechComponent, CanRepairEvent>(OnRepairAttempt); //  Moved from server side, broken
+        SubscribeLocalEvent<MechComponent, AttemptChangePanelEvent>(OnAttemptPanelChanged);
         SubscribeLocalEvent<MechPilotComponent, KnockDownAttemptEvent>(OnKnockdownAttempt);
         #endregion
 
@@ -700,6 +702,14 @@ public abstract partial class SharedMechSystem : EntitySystem
         component.EquipmentWhitelist = null;
         Dirty(uid, component);
     }
+
+    #region Starlight
+    // Blocks any modification of the wires panel, except by the mech itself
+    private void OnAttemptPanelChanged(EntityUid uid, MechComponent component, ref AttemptChangePanelEvent args)
+    {
+        args.Cancelled = args.User != uid;
+    }
+    #endregion
 }
 
 /// <summary>

--- a/Resources/Locale/en-US/_Starlight/mech/mech.ftl
+++ b/Resources/Locale/en-US/_Starlight/mech/mech.ftl
@@ -1,2 +1,5 @@
 mech-heat-display = Reactor Heat: {$amount}%
 mech-no-tank = No gas tank present!
+mech-requires-maintenance-mode = You need to turn on maintenance mode first!
+mech-maintenance-enabled = Maintenance panel opened
+mech-maintenance-disabled = Maintenance panel closed


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
This PR alleviates some more jank surrounding mechs by removing the "Toggle UI" verb for other people if a pilot is present in the mech.

Additionally, this PR also prevents manual changes of the wires panel, and in doing so prevents random players from opening the panel and rapidly removing your reactor, shutting your mech down instantly. Instead, toggling maintenance mode now closes/opens the panel as well, with both an audio cue and a popup.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

This is good for a couple reasons, one of them being that anybody could toggle the UI, stop your mech, and pull you out, or very rapidly remove all your equipment with 3/4 mouse clicks, no do-afters. Or, alternatively, open the panel and crowbar your reactor out, although this route does have do-afters. Both of these feel utterly horrible gameplay wise, and there's not much you can do about it if someone is spam clicking the UI.

This also has a side effect of alleviating an issue related to maintenance mode causing desyncs, usually caused by other clients toggling maintenance mode. While this PR does not fix that issue directly (I will probably make a separate PR for that, as you can still desync yourself with maints mode), by restricting the usage of the stats panel to just the pilot if a pilot is present, it prevents 80% of the usual causes of this issue, that being other people messing around with the UI.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
"Toggle UI" Verb is hidden when a pilot is present
<img width="593" height="540" alt="Screenshot from 2026-04-17 12-41-45" src="https://github.com/user-attachments/assets/0adba0c4-f9b9-4d62-89de-b2f871fa5898" />

Panel popup, maintenance mode and UI is still accessible from outside the mech if no pilot is present
<img width="231" height="204" alt="Screenshot from 2026-04-17 12-41-14" src="https://github.com/user-attachments/assets/be14fcd8-d999-4d4e-9aa3-fca8be32110f" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neurovermi
- tweak: Non-pilots can no longer open the mech stats panel if a pilot is present.
- tweak: Mech maintenance panel is tied directly to the maintenance mode state.