### PR TITLE
syndicate dead drop typo fix

### DIFF
--- a/Resources/Locale/en-US/_Starlight/station-events/random-spawn-event.ftl
+++ b/Resources/Locale/en-US/_Starlight/station-events/random-spawn-event.ftl
@@ -3,4 +3,4 @@ random-spawn-default-announcement = This entity has been placed near {$location}
 
 # Syndicate dead drop
 syndicate-dead-drop-announcement = A dead drop has been redspaced near {$location}. Collect these tools at your convenience.
-station-syndicate-dead-drop-announcement = Attention. Redspace signatures detected, illegal teleportation of material likely. Please cooperate with your local security department while they secure the unauthorized decive.
+station-syndicate-dead-drop-announcement = Attention. Redspace signatures detected, illegal teleportation of material likely. Please cooperate with your local security department while they secure the unauthorized device.


### PR DESCRIPTION
## Short description
Fixes a typo in the Syndicate Dead Drop announcement.

## Why we need to add this
Typo

## Media (Video/Screenshots)
no u

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Fixed typo in Syndicate Dead Drop announcement.
