### PR TITLE
Remove hunger changes to bruizine

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1489,8 +1489,8 @@
         damage:
           types:
             Blunt: -2.25 # 9 per u
-      - !type:SatiateHunger
-        factor: -1
+      # - !type:SatiateHunger # Starlight removal
+      #   factor: -1 # Starlight removal
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Hunger was added as a naive drawback for bruizine upstream last year when someone decided to make all the brute medicines work slower and have some sort of drawback.  The three effects chosen were heat damage, radiation damage, and making people hungry.  The latter - attributed to bruizine - doesn't really affect a whole lot in most rounds as a drawback.  But what it DOES do is cause any hungry critter to continuously chug the bruizine if the locker is open.  For a given creature it may consume upwards of 45-50u bruizine before collapsing of massive poison damage and bruizine overdose.
This leaves medbay continually restocking bruizine because the AI is seeking out 'food', or in other terms, anything that affects their hunger satiation.  The AI truly doesn't care if it makes them hungrier, only if it affects that hunger value.  Since bruizine affects that value, they seek it out and start chugging.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
We really need to stop having to restock 300u of bruizine in rounds where critters spawn.  The bruizine chugging OD problem has been ongoing for a long time, and it's past time we stop it.
I didn't bother to give any other drawback to this medicine, simply because the hunger damage in the first place was rarely recognizable in common or average use.  This has never been a notable drawback and removing it wholesale maintains the general feel of the drug while stopping the AI chugging.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Testing procedure:
Enclosed a mouse in a controlled space with a 200u jug of bruizine nearby.  
Administered 150u lipozine to make them hungry.
Observed if the mouse went for the bruizine jug.  If they didn't, attempted to feed them some other food.
Before: 

https://github.com/user-attachments/assets/eaf31fe2-7543-434e-810f-ecf548a46e8d

After:

https://github.com/user-attachments/assets/567ddca4-5313-4850-87f1-369485bc1ce7

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Sparlight
- tweak: Removed hunger drawback from bruizine to avoid critters chugging the jug.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
