### PR TITLE
Remove Commissar Overcoat Geiger Complex

### DIFF
--- a/Resources/Maps/_Starlight/Nonstations/geigerComplex.yml
+++ b/Resources/Maps/_Starlight/Nonstations/geigerComplex.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 272.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/04/2026 09:46:59
+  time: 04/21/2026 21:39:14
   entityCount: 8855
 maps:
 - 1
@@ -5847,114 +5847,114 @@ entities:
       container: 7
 - proto: AbductorAlienPad
   entities:
-  - uid: 9
+  - uid: 22
     components:
     - type: Transform
       pos: -17.5,58.5
       parent: 2
 - proto: AbductorOperatingTable
   entities:
-  - uid: 10
+  - uid: 23
     components:
     - type: Transform
       pos: -19.5,58.5
       parent: 2
 - proto: AcousticGuitarInstrument
   entities:
-  - uid: 11
+  - uid: 24
     components:
     - type: Transform
       pos: 3.2849312,35.543667
       parent: 2
-  - uid: 12
+  - uid: 25
     components:
     - type: Transform
       pos: 26.433233,1.6026366
       parent: 2
-  - uid: 13
+  - uid: 26
     components:
     - type: Transform
       pos: 12.491135,-29.378632
       parent: 2
 - proto: ActionToggleInternals
   entities:
-  - uid: 15
+  - uid: 28
     mapInit: true
     paused: true
     components:
     - type: Transform
-      parent: 14
+      parent: 27
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 14
+      container: 27
 - proto: ActionToggleJetpack
   entities:
-  - uid: 16
+  - uid: 29
     mapInit: true
     paused: true
     components:
     - type: Transform
-      parent: 14
+      parent: 27
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 14
+      container: 27
 - proto: ActionToggleLight
   entities:
-  - uid: 19
+  - uid: 32
     mapInit: true
     paused: true
     components:
     - type: Transform
-      parent: 18
+      parent: 31
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 18
-  - uid: 21
+      container: 31
+  - uid: 34
     mapInit: true
     paused: true
     components:
     - type: Transform
-      parent: 20
+      parent: 33
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 20
-  - uid: 23
+      container: 33
+  - uid: 36
     mapInit: true
     paused: true
     components:
     - type: Transform
-      parent: 22
+      parent: 35
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 22
-  - uid: 25
+      container: 35
+  - uid: 38
     mapInit: true
     paused: true
     components:
     - type: Transform
-      parent: 24
+      parent: 37
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 24
-  - uid: 27
+      container: 37
+  - uid: 40
     mapInit: true
     paused: true
     components:
     - type: Transform
-      parent: 26
+      parent: 39
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 26
+      container: 39
 - proto: AdvMopItem
   entities:
-  - uid: 28
+  - uid: 41
     components:
     - type: Transform
       pos: -20.095686,-22.218462
       parent: 2
 - proto: AirlockExternalGlassNukeopsShuttle
   entities:
-  - uid: 29
+  - uid: 42
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5962,7 +5962,7 @@ entities:
       parent: 2
 - proto: AirlockExternalGlassShuttleNukeopLocked
   entities:
-  - uid: 30
+  - uid: 43
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5970,70 +5970,70 @@ entities:
       parent: 2
 - proto: AirlockSyndicateNukeopGlassLocked
   entities:
-  - uid: 31
+  - uid: 44
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,2.5
       parent: 2
-  - uid: 32
+  - uid: 45
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 2
-  - uid: 33
+  - uid: 46
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 2
-  - uid: 34
+  - uid: 47
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 2
-  - uid: 35
+  - uid: 48
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 2
-  - uid: 36
+  - uid: 49
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 2
-  - uid: 37
+  - uid: 50
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 2
-  - uid: 38
+  - uid: 51
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 2
-  - uid: 39
+  - uid: 52
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,3.5
       parent: 2
-  - uid: 40
+  - uid: 53
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 2
-  - uid: 41
+  - uid: 54
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
-  - uid: 42
+  - uid: 55
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
-  - uid: 43
+  - uid: 56
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6043,200 +6043,200 @@ entities:
       accessListsOriginal: []
 - proto: AirlockSyndicateNukeopLocked
   entities:
-  - uid: 44
+  - uid: 57
     components:
     - type: Transform
       pos: 21.5,1.5
       parent: 2
-  - uid: 45
+  - uid: 58
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,30.5
       parent: 2
-  - uid: 46
+  - uid: 59
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,30.5
       parent: 2
-  - uid: 47
+  - uid: 60
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,3.5
       parent: 2
-  - uid: 48
+  - uid: 61
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,2.5
       parent: 2
-  - uid: 49
+  - uid: 62
     components:
     - type: Transform
       pos: 29.5,1.5
       parent: 2
-  - uid: 50
+  - uid: 63
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,30.5
       parent: 2
-  - uid: 51
+  - uid: 64
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,22.5
       parent: 2
-  - uid: 52
+  - uid: 65
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,22.5
       parent: 2
-  - uid: 53
+  - uid: 66
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,22.5
       parent: 2
-  - uid: 54
+  - uid: 67
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,3.5
       parent: 2
-  - uid: 55
+  - uid: 68
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,2.5
       parent: 2
-  - uid: 56
+  - uid: 69
     components:
     - type: Transform
       pos: 3.5,46.5
       parent: 2
-  - uid: 57
+  - uid: 70
     components:
     - type: Transform
       pos: -0.5,46.5
       parent: 2
-  - uid: 58
+  - uid: 71
     components:
     - type: Transform
       pos: 1.5,45.5
       parent: 2
-  - uid: 59
+  - uid: 72
     components:
     - type: Transform
       pos: 1.5,42.5
       parent: 2
-  - uid: 60
+  - uid: 73
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-17.5
       parent: 2
-  - uid: 61
+  - uid: 74
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-17.5
       parent: 2
-  - uid: 62
+  - uid: 75
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-17.5
       parent: 2
-  - uid: 63
+  - uid: 76
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,1.5
       parent: 2
-  - uid: 64
+  - uid: 77
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,2.5
       parent: 2
-  - uid: 65
+  - uid: 78
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -18.5,3.5
       parent: 2
-  - uid: 66
+  - uid: 79
     components:
     - type: Transform
       pos: -26.5,3.5
       parent: 2
-  - uid: 67
+  - uid: 80
     components:
     - type: Transform
       pos: -26.5,2.5
       parent: 2
-  - uid: 68
+  - uid: 81
     components:
     - type: Transform
       pos: -26.5,1.5
       parent: 2
-  - uid: 69
+  - uid: 82
     components:
     - type: Transform
       pos: -11.5,64.5
       parent: 2
 - proto: AltarFangs
   entities:
-  - uid: 70
+  - uid: 83
     components:
     - type: Transform
       pos: 34.5,-43.5
       parent: 2
-  - uid: 71
+  - uid: 84
     components:
     - type: Transform
       pos: 33.5,-43.5
       parent: 2
 - proto: AlwaysPoweredWallLight
   entities:
-  - uid: 72
+  - uid: 85
     components:
     - type: Transform
       pos: -11.5,67.5
       parent: 2
 - proto: AmeJar
   entities:
-  - uid: 73
+  - uid: 86
     components:
     - type: Transform
       pos: 7.6550436,-44.383293
       parent: 2
-  - uid: 74
+  - uid: 87
     components:
     - type: Transform
       pos: 7.377266,-44.383293
       parent: 2
 - proto: AnomalyCorePyroclastic
   entities:
-  - uid: 75
+  - uid: 88
     components:
     - type: Transform
       pos: 12.4679785,-34.56229
       parent: 2
 - proto: APCBasic
   entities:
-  - uid: 76
+  - uid: 89
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 77
+  - uid: 90
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6244,14 +6244,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 78
+  - uid: 91
     components:
     - type: Transform
       pos: 2.5,42.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 79
+  - uid: 92
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6259,7 +6259,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 80
+  - uid: 93
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6267,7 +6267,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 81
+  - uid: 94
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6275,7 +6275,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 82
+  - uid: 95
     components:
     - type: MetaData
       desc: If this won't power it, nothing will.
@@ -6291,7 +6291,7 @@ entities:
       maxLoad: 200000
     - type: Fixtures
       fixtures: {}
-  - uid: 83
+  - uid: 96
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6299,7 +6299,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 84
+  - uid: 97
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6309,298 +6309,298 @@ entities:
       fixtures: {}
 - proto: Ashtray
   entities:
-  - uid: 85
+  - uid: 98
     components:
     - type: Transform
       pos: 39.97857,-30.89197
       parent: 2
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 86
+  - uid: 99
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,2.5
       parent: 2
-  - uid: 87
+  - uid: 100
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,2.5
       parent: 2
-  - uid: 88
+  - uid: 101
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,4.5
       parent: 2
-  - uid: 89
+  - uid: 102
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,4.5
       parent: 2
-  - uid: 90
+  - uid: 103
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,0.5
       parent: 2
-  - uid: 91
+  - uid: 104
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,0.5
       parent: 2
-  - uid: 92
+  - uid: 105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,-1.5
       parent: 2
-  - uid: 93
+  - uid: 106
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,-1.5
       parent: 2
-  - uid: 94
+  - uid: 107
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,-3.5
       parent: 2
-  - uid: 95
+  - uid: 108
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,-3.5
       parent: 2
-  - uid: 96
+  - uid: 109
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,-5.5
       parent: 2
-  - uid: 97
+  - uid: 110
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,-5.5
       parent: 2
-  - uid: 98
+  - uid: 111
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,-7.5
       parent: 2
-  - uid: 99
+  - uid: 112
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,0.5
       parent: 2
-  - uid: 100
+  - uid: 113
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,-1.5
       parent: 2
-  - uid: 101
+  - uid: 114
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,0.5
       parent: 2
-  - uid: 102
+  - uid: 115
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,-1.5
       parent: 2
-  - uid: 103
+  - uid: 116
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 39.5,0.5
       parent: 2
-  - uid: 104
+  - uid: 117
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 39.5,-1.5
       parent: 2
-  - uid: 105
+  - uid: 118
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.5,6.5
       parent: 2
-  - uid: 106
+  - uid: 119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,6.5
       parent: 2
-  - uid: 107
+  - uid: 120
     components:
     - type: Transform
       pos: 1.5,43.5
       parent: 2
-  - uid: 108
+  - uid: 121
     components:
     - type: Transform
       pos: 1.5,44.5
       parent: 2
 - proto: BannerSovietHammer
   entities:
-  - uid: 109
+  - uid: 122
     components:
     - type: Transform
       pos: 22.5,8.5
       parent: 2
 - proto: BannerSyndicate
   entities:
-  - uid: 110
+  - uid: 123
     components:
     - type: Transform
       pos: 30.5,-7.5
       parent: 2
-  - uid: 111
+  - uid: 124
     components:
     - type: Transform
       pos: 32.5,-7.5
       parent: 2
-  - uid: 112
+  - uid: 125
     components:
     - type: Transform
       pos: 12.5,54.5
       parent: 2
-  - uid: 113
+  - uid: 126
     components:
     - type: Transform
       pos: 12.5,52.5
       parent: 2
-  - uid: 114
+  - uid: 127
     components:
     - type: Transform
       pos: -27.5,4.5
       parent: 2
-  - uid: 115
+  - uid: 128
     components:
     - type: Transform
       pos: -41.5,4.5
       parent: 2
-  - uid: 116
+  - uid: 129
     components:
     - type: Transform
       pos: -41.5,0.5
       parent: 2
-  - uid: 117
+  - uid: 130
     components:
     - type: Transform
       pos: -27.5,0.5
       parent: 2
 - proto: Barricade
   entities:
-  - uid: 118
+  - uid: 131
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,52.5
       parent: 2
-  - uid: 119
+  - uid: 132
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-39.5
       parent: 2
-  - uid: 120
+  - uid: 133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-39.5
       parent: 2
-  - uid: 121
+  - uid: 134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-39.5
       parent: 2
-  - uid: 122
+  - uid: 135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,-39.5
       parent: 2
-  - uid: 123
+  - uid: 136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-39.5
       parent: 2
-  - uid: 124
+  - uid: 137
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,4.5
       parent: 2
-  - uid: 125
+  - uid: 138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,5.5
       parent: 2
-  - uid: 126
+  - uid: 139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,3.5
       parent: 2
-  - uid: 127
+  - uid: 140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,3.5
       parent: 2
-  - uid: 128
+  - uid: 141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,3.5
       parent: 2
-  - uid: 129
+  - uid: 142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,3.5
       parent: 2
-  - uid: 130
+  - uid: 143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,3.5
       parent: 2
-  - uid: 131
+  - uid: 144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,4.5
       parent: 2
-  - uid: 132
+  - uid: 145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,5.5
       parent: 2
-  - uid: 133
+  - uid: 146
     components:
     - type: Transform
       pos: 35.5,-31.5
       parent: 2
 - proto: BarricadeBlock
   entities:
-  - uid: 134
+  - uid: 147
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6608,352 +6608,352 @@ entities:
       parent: 2
 - proto: BarricadeDirectional
   entities:
-  - uid: 135
+  - uid: 148
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,52.5
       parent: 2
-  - uid: 136
+  - uid: 149
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,52.5
       parent: 2
-  - uid: 137
+  - uid: 150
     components:
     - type: Transform
       pos: 35.5,-30.5
       parent: 2
 - proto: BaseBarrelChemRadioactiveEmpty
   entities:
-  - uid: 138
+  - uid: 151
     components:
     - type: Transform
       pos: -9.656463,6.851894
       parent: 2
     missingComponents:
     - RadiationSource
-  - uid: 139
+  - uid: 152
     components:
     - type: Transform
       pos: -10.360167,6.463005
       parent: 2
     missingComponents:
     - RadiationSource
-  - uid: 140
+  - uid: 153
     components:
     - type: Transform
       pos: -7.2918205,14.404973
       parent: 2
-  - uid: 141
+  - uid: 154
     components:
     - type: Transform
       pos: -10.147203,6.888931
       parent: 2
     missingComponents:
     - RadiationSource
-  - uid: 142
+  - uid: 155
     components:
     - type: Transform
       pos: -10.536093,6.8796716
       parent: 2
     missingComponents:
     - RadiationSource
-  - uid: 143
+  - uid: 156
     components:
     - type: Transform
       pos: -7.764043,14.418862
       parent: 2
-  - uid: 144
+  - uid: 157
     components:
     - type: Transform
       pos: -6.80571,13.835528
       parent: 2
-  - uid: 145
+  - uid: 158
     components:
     - type: Transform
       pos: 54.09683,-14.305642
       parent: 2
-  - uid: 146
+  - uid: 159
     components:
     - type: Transform
       pos: 7.5,50.5
       parent: 2
     - type: RadiationSource
       intensity: 0.33
-  - uid: 147
+  - uid: 160
     components:
     - type: Transform
       pos: 53.53433,-12.743142
       parent: 2
-  - uid: 148
+  - uid: 161
     components:
     - type: Transform
       pos: 53.44058,-14.993142
       parent: 2
-  - uid: 149
+  - uid: 162
     components:
     - type: Transform
       pos: 53.47183,-13.586892
       parent: 2
-  - uid: 150
+  - uid: 163
     components:
     - type: Transform
       pos: 52.81558,-12.618142
       parent: 2
 - proto: BaseBarrelChemRadioactiveFilledRadium
   entities:
-  - uid: 151
+  - uid: 164
     components:
     - type: Transform
       pos: -7.5223074,52.01703
       parent: 2
-  - uid: 152
+  - uid: 165
     components:
     - type: Transform
       pos: -7.0848074,52.39203
       parent: 2
-  - uid: 153
+  - uid: 166
     components:
     - type: Transform
       pos: -7.1473074,51.475365
       parent: 2
-  - uid: 154
+  - uid: 167
     components:
     - type: Transform
       pos: -6.5848074,51.683697
       parent: 2
-  - uid: 155
+  - uid: 168
     components:
     - type: Transform
       pos: -6.6264744,52.20453
       parent: 2
-  - uid: 156
+  - uid: 169
     components:
     - type: Transform
       pos: -6.7723074,52.746197
       parent: 2
-  - uid: 157
+  - uid: 170
     components:
     - type: Transform
       pos: -6.2514744,52.871197
       parent: 2
-  - uid: 158
+  - uid: 171
     components:
     - type: Transform
       pos: -6.7723074,53.537865
       parent: 2
-  - uid: 159
+  - uid: 172
     components:
     - type: Transform
       pos: -5.9598074,53.746197
       parent: 2
-  - uid: 160
+  - uid: 173
     components:
     - type: Transform
       pos: -5.6056414,53.496197
       parent: 2
-  - uid: 161
+  - uid: 174
     components:
     - type: Transform
       pos: -5.0223074,53.537865
       parent: 2
-  - uid: 162
+  - uid: 175
     components:
     - type: Transform
       pos: 6.4996824,62.605915
       parent: 2
-  - uid: 163
+  - uid: 176
     components:
     - type: Transform
       pos: 7.5309324,62.574665
       parent: 2
-  - uid: 164
+  - uid: 177
     components:
     - type: Transform
       pos: 4.6871824,62.543415
       parent: 2
-  - uid: 165
+  - uid: 178
     components:
     - type: Transform
       pos: 5.7809324,62.637165
       parent: 2
-  - uid: 166
+  - uid: 179
     components:
     - type: Transform
       pos: 6.5621824,63.324665
       parent: 2
-  - uid: 167
+  - uid: 180
     components:
     - type: Transform
       pos: 5.7496824,63.293415
       parent: 2
-  - uid: 168
+  - uid: 181
     components:
     - type: Transform
       pos: 5.0934324,62.887165
       parent: 2
-  - uid: 169
+  - uid: 182
     components:
     - type: Transform
       pos: 6.2809324,63.168415
       parent: 2
-  - uid: 170
+  - uid: 183
     components:
     - type: Transform
       pos: 5.4996824,63.918415
       parent: 2
-  - uid: 171
+  - uid: 184
     components:
     - type: Transform
       pos: 5.5934324,64.76217
       parent: 2
 - proto: BaseBarrelChemRadioactiveFilledUranium
   entities:
-  - uid: 172
+  - uid: 185
     components:
     - type: Transform
       pos: -21.5,-22.5
       parent: 2
-  - uid: 173
+  - uid: 186
     components:
     - type: Transform
       pos: -21.61652,-21.822628
       parent: 2
-  - uid: 174
+  - uid: 187
     components:
     - type: Transform
       pos: -21.92902,-22.364294
       parent: 2
-  - uid: 175
+  - uid: 188
     components:
     - type: Transform
       pos: -22.095686,-21.864294
       parent: 2
-  - uid: 176
+  - uid: 189
     components:
     - type: Transform
       pos: -22.36652,-22.385128
       parent: 2
-  - uid: 177
+  - uid: 190
     components:
     - type: Transform
       pos: -21.908186,-22.905962
       parent: 2
 - proto: BaseComputer
   entities:
-  - uid: 178
+  - uid: 191
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 2
-  - uid: 179
+  - uid: 192
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 2
-  - uid: 180
+  - uid: 193
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,5.5
       parent: 2
-  - uid: 181
+  - uid: 194
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 2
-  - uid: 182
+  - uid: 195
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,0.5
       parent: 2
-  - uid: 183
+  - uid: 196
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,0.5
       parent: 2
-  - uid: 184
+  - uid: 197
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-1.5
       parent: 2
-  - uid: 185
+  - uid: 198
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,1.5
       parent: 2
-  - uid: 186
+  - uid: 199
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 2
 - proto: BaseRevUplinkRadio
   entities:
-  - uid: 187
+  - uid: 200
     components:
     - type: Transform
       pos: 22.399014,9.852157
       parent: 2
 - proto: Bed
   entities:
-  - uid: 188
+  - uid: 201
     components:
     - type: Transform
       pos: 11.5,-39.5
       parent: 2
-  - uid: 189
+  - uid: 202
     components:
     - type: Transform
       pos: 13.5,-39.5
       parent: 2
-  - uid: 190
+  - uid: 203
     components:
     - type: Transform
       pos: 15.5,-39.5
       parent: 2
-  - uid: 191
+  - uid: 204
     components:
     - type: Transform
       pos: 9.5,-39.5
       parent: 2
-  - uid: 192
+  - uid: 205
     components:
     - type: Transform
       pos: 3.5,-20.5
       parent: 2
 - proto: BedsheetBrown
   entities:
-  - uid: 193
+  - uid: 206
     components:
     - type: Transform
       pos: 11.5,-39.5
       parent: 2
-  - uid: 194
+  - uid: 207
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-39.5
       parent: 2
-  - uid: 195
+  - uid: 208
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,-39.5
       parent: 2
-  - uid: 196
+  - uid: 209
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-39.5
       parent: 2
-  - uid: 197
+  - uid: 210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -6961,7 +6961,7 @@ entities:
       parent: 2
 - proto: BibleCommunistManifesto
   entities:
-  - uid: 198
+  - uid: 211
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6969,234 +6969,234 @@ entities:
       parent: 2
 - proto: Bonfire
   entities:
-  - uid: 199
+  - uid: 212
     components:
     - type: Transform
       pos: 25.5,1.5
       parent: 2
-  - uid: 200
+  - uid: 213
     components:
     - type: Transform
       pos: 32.5,-10.5
       parent: 2
-  - uid: 201
+  - uid: 214
     components:
     - type: Transform
       pos: 0.5,25.5
       parent: 2
-  - uid: 202
+  - uid: 215
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,36.5
       parent: 2
-  - uid: 203
+  - uid: 216
     components:
     - type: Transform
       pos: 8.5,51.5
       parent: 2
-  - uid: 204
+  - uid: 217
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-28.5
       parent: 2
-  - uid: 205
+  - uid: 218
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-30.5
       parent: 2
-  - uid: 206
+  - uid: 219
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 12.5,-41.5
       parent: 2
-  - uid: 207
+  - uid: 220
     components:
     - type: Transform
       pos: 5.5,-34.5
       parent: 2
 - proto: BookConspiracies
   entities:
-  - uid: 208
+  - uid: 221
     components:
     - type: Transform
       pos: 13.332861,-43.29097
       parent: 2
 - proto: BookMoreConspiracies
   entities:
-  - uid: 209
+  - uid: 222
     components:
     - type: Transform
       pos: 13.440208,-43.30502
       parent: 2
 - proto: BookNarsieLegend
   entities:
-  - uid: 210
+  - uid: 223
     components:
     - type: Transform
       pos: 33.505474,-43.112293
       parent: 2
 - proto: BookshelfFilled
   entities:
-  - uid: 211
+  - uid: 224
     components:
     - type: Transform
       pos: 7.5,-32.5
       parent: 2
-  - uid: 212
+  - uid: 225
     components:
     - type: Transform
       pos: 8.5,-32.5
       parent: 2
 - proto: BorgCharger
   entities:
-  - uid: 213
+  - uid: 226
     components:
     - type: Transform
       pos: 38.5,0.5
       parent: 2
-  - uid: 214
+  - uid: 227
     components:
     - type: Transform
       pos: 38.5,-1.5
       parent: 2
 - proto: BoxBeaker
   entities:
-  - uid: 215
+  - uid: 228
     components:
     - type: Transform
       pos: -7.4115305,47.704704
       parent: 2
-  - uid: 216
+  - uid: 229
     components:
     - type: Transform
       pos: -7.430049,47.2973
       parent: 2
 - proto: BoxDarts
   entities:
-  - uid: 217
+  - uid: 230
     components:
     - type: Transform
       pos: -0.44823587,35.356274
       parent: 2
 - proto: BoxHandcuff
   entities:
-  - uid: 218
+  - uid: 231
     components:
     - type: Transform
       pos: -33.433468,1.567738
       parent: 2
 - proto: BoxMagazinePistolSubMachineGunPractice
   entities:
-  - uid: 219
+  - uid: 232
     components:
     - type: Transform
       pos: 7.8579674,12.638558
       parent: 2
 - proto: BoxMRE
   entities:
-  - uid: 220
+  - uid: 233
     components:
     - type: Transform
       pos: 13.756495,-29.739595
       parent: 2
-  - uid: 221
+  - uid: 234
     components:
     - type: Transform
       pos: 13.742606,-29.42015
       parent: 2
-  - uid: 222
+  - uid: 235
     components:
     - type: Transform
       pos: 13.770384,-29.031261
       parent: 2
-  - uid: 223
+  - uid: 236
     components:
     - type: Transform
       pos: 9.630624,-30.62734
       parent: 2
-  - uid: 224
+  - uid: 237
     components:
     - type: Transform
       pos: 9.686179,-30.280117
       parent: 2
-  - uid: 225
+  - uid: 238
     components:
     - type: Transform
       pos: 9.269394,-30.224562
       parent: 2
-  - uid: 226
+  - uid: 239
     components:
     - type: Transform
       pos: 9.2000675,-30.488451
       parent: 2
 - proto: BoxPillCanister
   entities:
-  - uid: 227
+  - uid: 240
     components:
     - type: Transform
       pos: -7.3854322,46.948296
       parent: 2
 - proto: BoxSyringe
   entities:
-  - uid: 228
+  - uid: 241
     components:
     - type: Transform
       pos: -7.522641,47.01026
       parent: 2
 - proto: BrokenBottle
   entities:
-  - uid: 229
+  - uid: 242
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.46214294,51.373154
       parent: 2
-  - uid: 230
+  - uid: 243
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.44828033,-25.450775
       parent: 2
-  - uid: 231
+  - uid: 244
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.563993,-28.003923
       parent: 2
-  - uid: 232
+  - uid: 245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.552717,-30.74303
       parent: 2
-  - uid: 233
+  - uid: 246
     components:
     - type: Transform
       pos: 19.622015,-30.329033
       parent: 2
-  - uid: 234
+  - uid: 247
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.675209,-36.03147
       parent: 2
-  - uid: 235
+  - uid: 248
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.006052,-40.02252
       parent: 2
-  - uid: 236
+  - uid: 249
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.484408,-33.139725
       parent: 2
-  - uid: 237
+  - uid: 250
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7204,21 +7204,21 @@ entities:
       parent: 2
 - proto: Bucket
   entities:
-  - uid: 238
+  - uid: 251
     components:
     - type: Transform
       pos: -34.34872,5.499795
       parent: 2
 - proto: ButchCleaver
   entities:
-  - uid: 239
+  - uid: 252
     components:
     - type: Transform
       pos: 10.492374,52.74762
       parent: 2
 - proto: ButtonFrameCaution
   entities:
-  - uid: 240
+  - uid: 253
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7226,1699 +7226,1699 @@ entities:
       parent: 2
 - proto: C4
   entities:
-  - uid: 241
+  - uid: 254
     components:
     - type: Transform
       pos: 9.657351,45.50678
       parent: 2
-  - uid: 242
+  - uid: 255
     components:
     - type: Transform
       pos: 9.865684,45.409557
       parent: 2
-  - uid: 243
+  - uid: 256
     components:
     - type: Transform
       pos: 9.42124,45.59011
       parent: 2
 - proto: CableApcExtension
   entities:
-  - uid: 244
+  - uid: 257
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 2
-  - uid: 245
+  - uid: 258
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 2
-  - uid: 246
+  - uid: 259
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 2
-  - uid: 247
+  - uid: 260
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 2
-  - uid: 248
+  - uid: 261
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 2
-  - uid: 249
+  - uid: 262
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 2
-  - uid: 250
+  - uid: 263
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 2
-  - uid: 251
+  - uid: 264
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 2
-  - uid: 252
+  - uid: 265
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 2
-  - uid: 253
+  - uid: 266
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
-  - uid: 254
+  - uid: 267
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 2
-  - uid: 255
+  - uid: 268
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 2
-  - uid: 256
+  - uid: 269
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 2
-  - uid: 257
+  - uid: 270
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 2
-  - uid: 258
+  - uid: 271
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 2
-  - uid: 259
+  - uid: 272
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 2
-  - uid: 260
+  - uid: 273
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 2
-  - uid: 261
+  - uid: 274
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 2
-  - uid: 262
+  - uid: 275
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 2
-  - uid: 263
+  - uid: 276
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
-  - uid: 264
+  - uid: 277
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 2
-  - uid: 265
+  - uid: 278
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
-  - uid: 266
+  - uid: 279
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 2
-  - uid: 267
+  - uid: 280
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 2
-  - uid: 268
+  - uid: 281
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 2
-  - uid: 269
+  - uid: 282
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 2
-  - uid: 270
+  - uid: 283
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 2
-  - uid: 271
+  - uid: 284
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 2
-  - uid: 272
+  - uid: 285
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 273
+  - uid: 286
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 2
-  - uid: 274
+  - uid: 287
     components:
     - type: Transform
       pos: 4.5,-25.5
       parent: 2
-  - uid: 275
+  - uid: 288
     components:
     - type: Transform
       pos: 4.5,-26.5
       parent: 2
-  - uid: 276
+  - uid: 289
     components:
     - type: Transform
       pos: 4.5,-27.5
       parent: 2
-  - uid: 277
+  - uid: 290
     components:
     - type: Transform
       pos: 4.5,-28.5
       parent: 2
-  - uid: 278
+  - uid: 291
     components:
     - type: Transform
       pos: 6.5,-28.5
       parent: 2
-  - uid: 279
+  - uid: 292
     components:
     - type: Transform
       pos: 5.5,-28.5
       parent: 2
-  - uid: 280
+  - uid: 293
     components:
     - type: Transform
       pos: 7.5,-28.5
       parent: 2
-  - uid: 281
+  - uid: 294
     components:
     - type: Transform
       pos: 7.5,-27.5
       parent: 2
-  - uid: 282
+  - uid: 295
     components:
     - type: Transform
       pos: 8.5,-27.5
       parent: 2
-  - uid: 283
+  - uid: 296
     components:
     - type: Transform
       pos: 7.5,-29.5
       parent: 2
-  - uid: 284
+  - uid: 297
     components:
     - type: Transform
       pos: 9.5,-27.5
       parent: 2
-  - uid: 285
+  - uid: 298
     components:
     - type: Transform
       pos: 10.5,-27.5
       parent: 2
-  - uid: 286
+  - uid: 299
     components:
     - type: Transform
       pos: 7.5,-30.5
       parent: 2
-  - uid: 287
+  - uid: 300
     components:
     - type: Transform
       pos: 7.5,-31.5
       parent: 2
-  - uid: 288
+  - uid: 301
     components:
     - type: Transform
       pos: 7.5,-32.5
       parent: 2
-  - uid: 289
+  - uid: 302
     components:
     - type: Transform
       pos: 8.5,-32.5
       parent: 2
-  - uid: 290
+  - uid: 303
     components:
     - type: Transform
       pos: 2.5,42.5
       parent: 2
-  - uid: 291
+  - uid: 304
     components:
     - type: Transform
       pos: 3.5,42.5
       parent: 2
-  - uid: 292
+  - uid: 305
     components:
     - type: Transform
       pos: 4.5,42.5
       parent: 2
-  - uid: 293
+  - uid: 306
     components:
     - type: Transform
       pos: 5.5,42.5
       parent: 2
-  - uid: 294
+  - uid: 307
     components:
     - type: Transform
       pos: 6.5,42.5
       parent: 2
-  - uid: 295
+  - uid: 308
     components:
     - type: Transform
       pos: 9.5,42.5
       parent: 2
-  - uid: 296
+  - uid: 309
     components:
     - type: Transform
       pos: 10.5,42.5
       parent: 2
-  - uid: 297
+  - uid: 310
     components:
     - type: Transform
       pos: 11.5,42.5
       parent: 2
-  - uid: 298
+  - uid: 311
     components:
     - type: Transform
       pos: 12.5,42.5
       parent: 2
-  - uid: 299
+  - uid: 312
     components:
     - type: Transform
       pos: 7.5,42.5
       parent: 2
-  - uid: 300
+  - uid: 313
     components:
     - type: Transform
       pos: 8.5,42.5
       parent: 2
-  - uid: 301
+  - uid: 314
     components:
     - type: Transform
       pos: 2.5,41.5
       parent: 2
-  - uid: 302
+  - uid: 315
     components:
     - type: Transform
       pos: 2.5,40.5
       parent: 2
-  - uid: 303
+  - uid: 316
     components:
     - type: Transform
       pos: 2.5,39.5
       parent: 2
-  - uid: 304
+  - uid: 317
     components:
     - type: Transform
       pos: 2.5,38.5
       parent: 2
-  - uid: 305
+  - uid: 318
     components:
     - type: Transform
       pos: 2.5,37.5
       parent: 2
-  - uid: 306
+  - uid: 319
     components:
     - type: Transform
       pos: 2.5,36.5
       parent: 2
-  - uid: 307
+  - uid: 320
     components:
     - type: Transform
       pos: 2.5,35.5
       parent: 2
-  - uid: 308
+  - uid: 321
     components:
     - type: Transform
       pos: 2.5,34.5
       parent: 2
-  - uid: 309
+  - uid: 322
     components:
     - type: Transform
       pos: 2.5,33.5
       parent: 2
-  - uid: 310
+  - uid: 323
     components:
     - type: Transform
       pos: 2.5,32.5
       parent: 2
-  - uid: 311
+  - uid: 324
     components:
     - type: Transform
       pos: 2.5,31.5
       parent: 2
-  - uid: 312
+  - uid: 325
     components:
     - type: Transform
       pos: 2.5,30.5
       parent: 2
-  - uid: 313
+  - uid: 326
     components:
     - type: Transform
       pos: 3.5,30.5
       parent: 2
-  - uid: 314
+  - uid: 327
     components:
     - type: Transform
       pos: 4.5,30.5
       parent: 2
-  - uid: 315
+  - uid: 328
     components:
     - type: Transform
       pos: 5.5,30.5
       parent: 2
-  - uid: 316
+  - uid: 329
     components:
     - type: Transform
       pos: 6.5,30.5
       parent: 2
-  - uid: 317
+  - uid: 330
     components:
     - type: Transform
       pos: 7.5,30.5
       parent: 2
-  - uid: 318
+  - uid: 331
     components:
     - type: Transform
       pos: 8.5,30.5
       parent: 2
-  - uid: 319
+  - uid: 332
     components:
     - type: Transform
       pos: 9.5,30.5
       parent: 2
-  - uid: 320
+  - uid: 333
     components:
     - type: Transform
       pos: 10.5,30.5
       parent: 2
-  - uid: 321
+  - uid: 334
     components:
     - type: Transform
       pos: 1.5,30.5
       parent: 2
-  - uid: 322
+  - uid: 335
     components:
     - type: Transform
       pos: 0.5,30.5
       parent: 2
-  - uid: 323
+  - uid: 336
     components:
     - type: Transform
       pos: -0.5,30.5
       parent: 2
-  - uid: 324
+  - uid: 337
     components:
     - type: Transform
       pos: -1.5,30.5
       parent: 2
-  - uid: 325
+  - uid: 338
     components:
     - type: Transform
       pos: -2.5,30.5
       parent: 2
-  - uid: 326
+  - uid: 339
     components:
     - type: Transform
       pos: -3.5,30.5
       parent: 2
-  - uid: 327
+  - uid: 340
     components:
     - type: Transform
       pos: -4.5,30.5
       parent: 2
-  - uid: 328
+  - uid: 341
     components:
     - type: Transform
       pos: -5.5,30.5
       parent: 2
-  - uid: 329
+  - uid: 342
     components:
     - type: Transform
       pos: -6.5,30.5
       parent: 2
-  - uid: 330
+  - uid: 343
     components:
     - type: Transform
       pos: -7.5,30.5
       parent: 2
-  - uid: 331
+  - uid: 344
     components:
     - type: Transform
       pos: -8.5,30.5
       parent: 2
-  - uid: 332
+  - uid: 345
     components:
     - type: Transform
       pos: 1.5,42.5
       parent: 2
-  - uid: 333
+  - uid: 346
     components:
     - type: Transform
       pos: 0.5,42.5
       parent: 2
-  - uid: 334
+  - uid: 347
     components:
     - type: Transform
       pos: -0.5,42.5
       parent: 2
-  - uid: 335
+  - uid: 348
     components:
     - type: Transform
       pos: -1.5,42.5
       parent: 2
-  - uid: 336
+  - uid: 349
     components:
     - type: Transform
       pos: -2.5,42.5
       parent: 2
-  - uid: 337
+  - uid: 350
     components:
     - type: Transform
       pos: -3.5,42.5
       parent: 2
-  - uid: 338
+  - uid: 351
     components:
     - type: Transform
       pos: -4.5,42.5
       parent: 2
-  - uid: 339
+  - uid: 352
     components:
     - type: Transform
       pos: -5.5,42.5
       parent: 2
-  - uid: 340
+  - uid: 353
     components:
     - type: Transform
       pos: -6.5,42.5
       parent: 2
-  - uid: 341
+  - uid: 354
     components:
     - type: Transform
       pos: -7.5,42.5
       parent: 2
-  - uid: 342
+  - uid: 355
     components:
     - type: Transform
       pos: 0.5,45.5
       parent: 2
-  - uid: 343
+  - uid: 356
     components:
     - type: Transform
       pos: -0.5,45.5
       parent: 2
-  - uid: 344
+  - uid: 357
     components:
     - type: Transform
       pos: -1.5,45.5
       parent: 2
-  - uid: 345
+  - uid: 358
     components:
     - type: Transform
       pos: -2.5,45.5
       parent: 2
-  - uid: 346
+  - uid: 359
     components:
     - type: Transform
       pos: -3.5,45.5
       parent: 2
-  - uid: 347
+  - uid: 360
     components:
     - type: Transform
       pos: -4.5,45.5
       parent: 2
-  - uid: 348
+  - uid: 361
     components:
     - type: Transform
       pos: -5.5,45.5
       parent: 2
-  - uid: 349
+  - uid: 362
     components:
     - type: Transform
       pos: -6.5,45.5
       parent: 2
-  - uid: 350
+  - uid: 363
     components:
     - type: Transform
       pos: -7.5,45.5
       parent: 2
-  - uid: 351
+  - uid: 364
     components:
     - type: Transform
       pos: -7.5,46.5
       parent: 2
-  - uid: 352
+  - uid: 365
     components:
     - type: Transform
       pos: -7.5,47.5
       parent: 2
-  - uid: 353
+  - uid: 366
     components:
     - type: Transform
       pos: -6.5,47.5
       parent: 2
-  - uid: 354
+  - uid: 367
     components:
     - type: Transform
       pos: -5.5,47.5
       parent: 2
-  - uid: 355
+  - uid: 368
     components:
     - type: Transform
       pos: -4.5,47.5
       parent: 2
-  - uid: 356
+  - uid: 369
     components:
     - type: Transform
       pos: -3.5,47.5
       parent: 2
-  - uid: 357
+  - uid: 370
     components:
     - type: Transform
       pos: -2.5,47.5
       parent: 2
-  - uid: 358
+  - uid: 371
     components:
     - type: Transform
       pos: -1.5,47.5
       parent: 2
-  - uid: 359
+  - uid: 372
     components:
     - type: Transform
       pos: -1.5,46.5
       parent: 2
-  - uid: 360
+  - uid: 373
     components:
     - type: Transform
       pos: 1.5,45.5
       parent: 2
-  - uid: 361
+  - uid: 374
     components:
     - type: Transform
       pos: 2.5,45.5
       parent: 2
-  - uid: 362
+  - uid: 375
     components:
     - type: Transform
       pos: 3.5,45.5
       parent: 2
-  - uid: 363
+  - uid: 376
     components:
     - type: Transform
       pos: 4.5,45.5
       parent: 2
-  - uid: 364
+  - uid: 377
     components:
     - type: Transform
       pos: 5.5,45.5
       parent: 2
-  - uid: 365
+  - uid: 378
     components:
     - type: Transform
       pos: 6.5,45.5
       parent: 2
-  - uid: 366
+  - uid: 379
     components:
     - type: Transform
       pos: 7.5,45.5
       parent: 2
-  - uid: 367
+  - uid: 380
     components:
     - type: Transform
       pos: 8.5,45.5
       parent: 2
-  - uid: 368
+  - uid: 381
     components:
     - type: Transform
       pos: 9.5,45.5
       parent: 2
-  - uid: 369
+  - uid: 382
     components:
     - type: Transform
       pos: 10.5,45.5
       parent: 2
-  - uid: 370
+  - uid: 383
     components:
     - type: Transform
       pos: 10.5,46.5
       parent: 2
-  - uid: 371
+  - uid: 384
     components:
     - type: Transform
       pos: 10.5,47.5
       parent: 2
-  - uid: 372
+  - uid: 385
     components:
     - type: Transform
       pos: 9.5,47.5
       parent: 2
-  - uid: 373
+  - uid: 386
     components:
     - type: Transform
       pos: 8.5,47.5
       parent: 2
-  - uid: 374
+  - uid: 387
     components:
     - type: Transform
       pos: 7.5,47.5
       parent: 2
-  - uid: 375
+  - uid: 388
     components:
     - type: Transform
       pos: 6.5,47.5
       parent: 2
-  - uid: 376
+  - uid: 389
     components:
     - type: Transform
       pos: 5.5,47.5
       parent: 2
-  - uid: 377
+  - uid: 390
     components:
     - type: Transform
       pos: 4.5,47.5
       parent: 2
-  - uid: 378
+  - uid: 391
     components:
     - type: Transform
       pos: 4.5,46.5
       parent: 2
-  - uid: 379
+  - uid: 392
     components:
     - type: Transform
       pos: 1.5,46.5
       parent: 2
-  - uid: 380
+  - uid: 393
     components:
     - type: Transform
       pos: 1.5,47.5
       parent: 2
-  - uid: 381
+  - uid: 394
     components:
     - type: Transform
       pos: 1.5,48.5
       parent: 2
-  - uid: 382
+  - uid: 395
     components:
     - type: Transform
       pos: 1.5,49.5
       parent: 2
-  - uid: 383
+  - uid: 396
     components:
     - type: Transform
       pos: 1.5,50.5
       parent: 2
-  - uid: 384
+  - uid: 397
     components:
     - type: Transform
       pos: 1.5,51.5
       parent: 2
-  - uid: 385
+  - uid: 398
     components:
     - type: Transform
       pos: 1.5,52.5
       parent: 2
-  - uid: 386
+  - uid: 399
     components:
     - type: Transform
       pos: 2.5,52.5
       parent: 2
-  - uid: 387
+  - uid: 400
     components:
     - type: Transform
       pos: 3.5,52.5
       parent: 2
-  - uid: 388
+  - uid: 401
     components:
     - type: Transform
       pos: 4.5,52.5
       parent: 2
-  - uid: 389
+  - uid: 402
     components:
     - type: Transform
       pos: 5.5,52.5
       parent: 2
-  - uid: 390
+  - uid: 403
     components:
     - type: Transform
       pos: 6.5,52.5
       parent: 2
-  - uid: 391
+  - uid: 404
     components:
     - type: Transform
       pos: 7.5,52.5
       parent: 2
-  - uid: 392
+  - uid: 405
     components:
     - type: Transform
       pos: 8.5,52.5
       parent: 2
-  - uid: 393
+  - uid: 406
     components:
     - type: Transform
       pos: 9.5,52.5
       parent: 2
-  - uid: 394
+  - uid: 407
     components:
     - type: Transform
       pos: 10.5,52.5
       parent: 2
-  - uid: 395
+  - uid: 408
     components:
     - type: Transform
       pos: 1.5,29.5
       parent: 2
-  - uid: 396
+  - uid: 409
     components:
     - type: Transform
       pos: 1.5,28.5
       parent: 2
-  - uid: 397
+  - uid: 410
     components:
     - type: Transform
       pos: 1.5,27.5
       parent: 2
-  - uid: 398
+  - uid: 411
     components:
     - type: Transform
       pos: 1.5,26.5
       parent: 2
-  - uid: 399
+  - uid: 412
     components:
     - type: Transform
       pos: 1.5,25.5
       parent: 2
-  - uid: 400
+  - uid: 413
     components:
     - type: Transform
       pos: 1.5,24.5
       parent: 2
-  - uid: 401
+  - uid: 414
     components:
     - type: Transform
       pos: 1.5,23.5
       parent: 2
-  - uid: 402
+  - uid: 415
     components:
     - type: Transform
       pos: -35.5,3.5
       parent: 2
-  - uid: 403
+  - uid: 416
     components:
     - type: Transform
       pos: -34.5,3.5
       parent: 2
-  - uid: 404
+  - uid: 417
     components:
     - type: Transform
       pos: -33.5,3.5
       parent: 2
-  - uid: 405
+  - uid: 418
     components:
     - type: Transform
       pos: -32.5,3.5
       parent: 2
-  - uid: 406
+  - uid: 419
     components:
     - type: Transform
       pos: -31.5,3.5
       parent: 2
-  - uid: 407
+  - uid: 420
     components:
     - type: Transform
       pos: -29.5,5.5
       parent: 2
-  - uid: 408
+  - uid: 421
     components:
     - type: Transform
       pos: -30.5,3.5
       parent: 2
-  - uid: 409
+  - uid: 422
     components:
     - type: Transform
       pos: -29.5,4.5
       parent: 2
-  - uid: 410
+  - uid: 423
     components:
     - type: Transform
       pos: -29.5,3.5
       parent: 2
-  - uid: 411
+  - uid: 424
     components:
     - type: Transform
       pos: -29.5,2.5
       parent: 2
-  - uid: 412
+  - uid: 425
     components:
     - type: Transform
       pos: -29.5,1.5
       parent: 2
-  - uid: 413
+  - uid: 426
     components:
     - type: Transform
       pos: -29.5,0.5
       parent: 2
-  - uid: 414
+  - uid: 427
     components:
     - type: Transform
       pos: -29.5,-0.5
       parent: 2
-  - uid: 415
+  - uid: 428
     components:
     - type: Transform
       pos: -29.5,-1.5
       parent: 2
-  - uid: 416
+  - uid: 429
     components:
     - type: Transform
       pos: -36.5,3.5
       parent: 2
-  - uid: 417
+  - uid: 430
     components:
     - type: Transform
       pos: -37.5,3.5
       parent: 2
-  - uid: 418
+  - uid: 431
     components:
     - type: Transform
       pos: -38.5,3.5
       parent: 2
-  - uid: 419
+  - uid: 432
     components:
     - type: Transform
       pos: -39.5,3.5
       parent: 2
-  - uid: 420
+  - uid: 433
     components:
     - type: Transform
       pos: -40.5,3.5
       parent: 2
-  - uid: 421
+  - uid: 434
     components:
     - type: Transform
       pos: -41.5,3.5
       parent: 2
-  - uid: 422
+  - uid: 435
     components:
     - type: Transform
       pos: -30.5,0.5
       parent: 2
-  - uid: 423
+  - uid: 436
     components:
     - type: Transform
       pos: -31.5,0.5
       parent: 2
-  - uid: 424
+  - uid: 437
     components:
     - type: Transform
       pos: -32.5,0.5
       parent: 2
-  - uid: 425
+  - uid: 438
     components:
     - type: Transform
       pos: -33.5,0.5
       parent: 2
-  - uid: 426
+  - uid: 439
     components:
     - type: Transform
       pos: -34.5,0.5
       parent: 2
-  - uid: 427
+  - uid: 440
     components:
     - type: Transform
       pos: -35.5,0.5
       parent: 2
-  - uid: 428
+  - uid: 441
     components:
     - type: Transform
       pos: -36.5,0.5
       parent: 2
-  - uid: 429
+  - uid: 442
     components:
     - type: Transform
       pos: -37.5,0.5
       parent: 2
-  - uid: 430
+  - uid: 443
     components:
     - type: Transform
       pos: -38.5,0.5
       parent: 2
-  - uid: 431
+  - uid: 444
     components:
     - type: Transform
       pos: -39.5,0.5
       parent: 2
-  - uid: 432
+  - uid: 445
     components:
     - type: Transform
       pos: -40.5,0.5
       parent: 2
-  - uid: 433
+  - uid: 446
     components:
     - type: Transform
       pos: -41.5,0.5
       parent: 2
-  - uid: 434
+  - uid: 447
     components:
     - type: Transform
       pos: -42.5,3.5
       parent: 2
-  - uid: 435
+  - uid: 448
     components:
     - type: Transform
       pos: -43.5,3.5
       parent: 2
-  - uid: 436
+  - uid: 449
     components:
     - type: Transform
       pos: -42.5,0.5
       parent: 2
-  - uid: 437
+  - uid: 450
     components:
     - type: Transform
       pos: -28.5,2.5
       parent: 2
-  - uid: 438
+  - uid: 451
     components:
     - type: Transform
       pos: -27.5,2.5
       parent: 2
-  - uid: 439
+  - uid: 452
     components:
     - type: Transform
       pos: -26.5,2.5
       parent: 2
-  - uid: 440
+  - uid: 453
     components:
     - type: Transform
       pos: -25.5,2.5
       parent: 2
-  - uid: 441
+  - uid: 454
     components:
     - type: Transform
       pos: -24.5,2.5
       parent: 2
-  - uid: 442
+  - uid: 455
     components:
     - type: Transform
       pos: -23.5,2.5
       parent: 2
-  - uid: 443
+  - uid: 456
     components:
     - type: Transform
       pos: -22.5,2.5
       parent: 2
-  - uid: 444
+  - uid: 457
     components:
     - type: Transform
       pos: -21.5,2.5
       parent: 2
-  - uid: 445
+  - uid: 458
     components:
     - type: Transform
       pos: -20.5,2.5
       parent: 2
-  - uid: 446
+  - uid: 459
     components:
     - type: Transform
       pos: -19.5,2.5
       parent: 2
-  - uid: 447
+  - uid: 460
     components:
     - type: Transform
       pos: 3.5,-21.5
       parent: 2
-  - uid: 448
+  - uid: 461
     components:
     - type: Transform
       pos: 2.5,-21.5
       parent: 2
-  - uid: 449
+  - uid: 462
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 2
-  - uid: 450
+  - uid: 463
     components:
     - type: Transform
       pos: 2.5,-23.5
       parent: 2
-  - uid: 451
+  - uid: 464
     components:
     - type: Transform
       pos: 2.5,-24.5
       parent: 2
-  - uid: 452
+  - uid: 465
     components:
     - type: Transform
       pos: 2.5,-25.5
       parent: 2
-  - uid: 453
+  - uid: 466
     components:
     - type: Transform
       pos: 3.5,-25.5
       parent: 2
-  - uid: 454
+  - uid: 467
     components:
     - type: Transform
       pos: 29.5,-6.5
       parent: 2
-  - uid: 455
+  - uid: 468
     components:
     - type: Transform
       pos: 30.5,-6.5
       parent: 2
-  - uid: 456
+  - uid: 469
     components:
     - type: Transform
       pos: 31.5,-6.5
       parent: 2
-  - uid: 457
+  - uid: 470
     components:
     - type: Transform
       pos: 32.5,-6.5
       parent: 2
-  - uid: 458
+  - uid: 471
     components:
     - type: Transform
       pos: 33.5,-6.5
       parent: 2
-  - uid: 459
+  - uid: 472
     components:
     - type: Transform
       pos: 33.5,-7.5
       parent: 2
-  - uid: 460
+  - uid: 473
     components:
     - type: Transform
       pos: 33.5,-8.5
       parent: 2
-  - uid: 461
+  - uid: 474
     components:
     - type: Transform
       pos: 35.5,-8.5
       parent: 2
-  - uid: 462
+  - uid: 475
     components:
     - type: Transform
       pos: 34.5,-8.5
       parent: 2
-  - uid: 463
+  - uid: 476
     components:
     - type: Transform
       pos: 35.5,-9.5
       parent: 2
-  - uid: 464
+  - uid: 477
     components:
     - type: Transform
       pos: 35.5,-10.5
       parent: 2
-  - uid: 465
+  - uid: 478
     components:
     - type: Transform
       pos: 35.5,-11.5
       parent: 2
-  - uid: 466
+  - uid: 479
     components:
     - type: Transform
       pos: 35.5,-12.5
       parent: 2
-  - uid: 467
+  - uid: 480
     components:
     - type: Transform
       pos: 35.5,-13.5
       parent: 2
-  - uid: 468
+  - uid: 481
     components:
     - type: Transform
       pos: 35.5,-14.5
       parent: 2
-  - uid: 469
+  - uid: 482
     components:
     - type: Transform
       pos: 35.5,-15.5
       parent: 2
-  - uid: 470
+  - uid: 483
     components:
     - type: Transform
       pos: 35.5,-16.5
       parent: 2
-  - uid: 471
+  - uid: 484
     components:
     - type: Transform
       pos: 35.5,-17.5
       parent: 2
-  - uid: 472
+  - uid: 485
     components:
     - type: Transform
       pos: 35.5,-18.5
       parent: 2
-  - uid: 473
+  - uid: 486
     components:
     - type: Transform
       pos: 36.5,-18.5
       parent: 2
-  - uid: 474
+  - uid: 487
     components:
     - type: Transform
       pos: 37.5,-18.5
       parent: 2
-  - uid: 475
+  - uid: 488
     components:
     - type: Transform
       pos: 31.5,-5.5
       parent: 2
-  - uid: 476
+  - uid: 489
     components:
     - type: Transform
       pos: 31.5,-4.5
       parent: 2
-  - uid: 477
+  - uid: 490
     components:
     - type: Transform
       pos: 31.5,-3.5
       parent: 2
-  - uid: 478
+  - uid: 491
     components:
     - type: Transform
       pos: 31.5,-2.5
       parent: 2
-  - uid: 479
+  - uid: 492
     components:
     - type: Transform
       pos: 31.5,-1.5
       parent: 2
-  - uid: 480
+  - uid: 493
     components:
     - type: Transform
       pos: 31.5,-0.5
       parent: 2
-  - uid: 481
+  - uid: 494
     components:
     - type: Transform
       pos: 31.5,0.5
       parent: 2
-  - uid: 482
+  - uid: 495
     components:
     - type: Transform
       pos: 31.5,1.5
       parent: 2
-  - uid: 483
+  - uid: 496
     components:
     - type: Transform
       pos: 31.5,2.5
       parent: 2
-  - uid: 484
+  - uid: 497
     components:
     - type: Transform
       pos: 31.5,3.5
       parent: 2
-  - uid: 485
+  - uid: 498
     components:
     - type: Transform
       pos: 31.5,4.5
       parent: 2
-  - uid: 486
+  - uid: 499
     components:
     - type: Transform
       pos: 31.5,5.5
       parent: 2
-  - uid: 487
+  - uid: 500
     components:
     - type: Transform
       pos: 32.5,-0.5
       parent: 2
-  - uid: 488
+  - uid: 501
     components:
     - type: Transform
       pos: 33.5,-0.5
       parent: 2
-  - uid: 489
+  - uid: 502
     components:
     - type: Transform
       pos: 34.5,-0.5
       parent: 2
-  - uid: 490
+  - uid: 503
     components:
     - type: Transform
       pos: 35.5,-0.5
       parent: 2
-  - uid: 491
+  - uid: 504
     components:
     - type: Transform
       pos: 36.5,-0.5
       parent: 2
-  - uid: 492
+  - uid: 505
     components:
     - type: Transform
       pos: 37.5,-0.5
       parent: 2
-  - uid: 493
+  - uid: 506
     components:
     - type: Transform
       pos: 38.5,-0.5
       parent: 2
-  - uid: 494
+  - uid: 507
     components:
     - type: Transform
       pos: 39.5,-0.5
       parent: 2
-  - uid: 495
+  - uid: 508
     components:
     - type: Transform
       pos: 40.5,-0.5
       parent: 2
-  - uid: 496
+  - uid: 509
     components:
     - type: Transform
       pos: 40.5,0.5
       parent: 2
-  - uid: 497
+  - uid: 510
     components:
     - type: Transform
       pos: 40.5,1.5
       parent: 2
-  - uid: 498
+  - uid: 511
     components:
     - type: Transform
       pos: 40.5,2.5
       parent: 2
-  - uid: 499
+  - uid: 512
     components:
     - type: Transform
       pos: 40.5,3.5
       parent: 2
-  - uid: 500
+  - uid: 513
     components:
     - type: Transform
       pos: 40.5,4.5
       parent: 2
-  - uid: 501
+  - uid: 514
     components:
     - type: Transform
       pos: 39.5,4.5
       parent: 2
-  - uid: 502
+  - uid: 515
     components:
     - type: Transform
       pos: 38.5,4.5
       parent: 2
-  - uid: 503
+  - uid: 516
     components:
     - type: Transform
       pos: 37.5,4.5
       parent: 2
-  - uid: 504
+  - uid: 517
     components:
     - type: Transform
       pos: 36.5,4.5
       parent: 2
-  - uid: 505
+  - uid: 518
     components:
     - type: Transform
       pos: 36.5,3.5
       parent: 2
-  - uid: 506
+  - uid: 519
     components:
     - type: Transform
       pos: 36.5,2.5
       parent: 2
-  - uid: 507
+  - uid: 520
     components:
     - type: Transform
       pos: 36.5,1.5
       parent: 2
-  - uid: 508
+  - uid: 521
     components:
     - type: Transform
       pos: 36.5,0.5
       parent: 2
-  - uid: 509
+  - uid: 522
     components:
     - type: Transform
       pos: 36.5,-1.5
       parent: 2
-  - uid: 510
+  - uid: 523
     components:
     - type: Transform
       pos: 36.5,-2.5
       parent: 2
-  - uid: 511
+  - uid: 524
     components:
     - type: Transform
       pos: 36.5,-3.5
       parent: 2
-  - uid: 512
+  - uid: 525
     components:
     - type: Transform
       pos: 36.5,-4.5
       parent: 2
-  - uid: 513
+  - uid: 526
     components:
     - type: Transform
       pos: 36.5,-5.5
       parent: 2
-  - uid: 514
+  - uid: 527
     components:
     - type: Transform
       pos: 37.5,-5.5
       parent: 2
-  - uid: 515
+  - uid: 528
     components:
     - type: Transform
       pos: 38.5,-5.5
       parent: 2
-  - uid: 516
+  - uid: 529
     components:
     - type: Transform
       pos: 39.5,-5.5
       parent: 2
-  - uid: 517
+  - uid: 530
     components:
     - type: Transform
       pos: 40.5,-5.5
       parent: 2
-  - uid: 518
+  - uid: 531
     components:
     - type: Transform
       pos: 41.5,-5.5
       parent: 2
-  - uid: 519
+  - uid: 532
     components:
     - type: Transform
       pos: 42.5,-5.5
       parent: 2
-  - uid: 520
+  - uid: 533
     components:
     - type: Transform
       pos: 42.5,-4.5
       parent: 2
-  - uid: 521
+  - uid: 534
     components:
     - type: Transform
       pos: 42.5,-3.5
       parent: 2
-  - uid: 522
+  - uid: 535
     components:
     - type: Transform
       pos: 42.5,-2.5
       parent: 2
-  - uid: 523
+  - uid: 536
     components:
     - type: Transform
       pos: 42.5,-1.5
       parent: 2
-  - uid: 524
+  - uid: 537
     components:
     - type: Transform
       pos: 42.5,-0.5
       parent: 2
-  - uid: 525
+  - uid: 538
     components:
     - type: Transform
       pos: 42.5,0.5
       parent: 2
-  - uid: 526
+  - uid: 539
     components:
     - type: Transform
       pos: 42.5,1.5
       parent: 2
-  - uid: 527
+  - uid: 540
     components:
     - type: Transform
       pos: 42.5,2.5
       parent: 2
-  - uid: 528
+  - uid: 541
     components:
     - type: Transform
       pos: 42.5,3.5
       parent: 2
-  - uid: 529
+  - uid: 542
     components:
     - type: Transform
       pos: 42.5,4.5
       parent: 2
-  - uid: 530
+  - uid: 543
     components:
     - type: Transform
       pos: 41.5,4.5
       parent: 2
-  - uid: 531
+  - uid: 544
     components:
     - type: Transform
       pos: 30.5,2.5
       parent: 2
-  - uid: 532
+  - uid: 545
     components:
     - type: Transform
       pos: 29.5,2.5
       parent: 2
-  - uid: 533
+  - uid: 546
     components:
     - type: Transform
       pos: 28.5,2.5
       parent: 2
-  - uid: 534
+  - uid: 547
     components:
     - type: Transform
       pos: 27.5,2.5
       parent: 2
-  - uid: 535
+  - uid: 548
     components:
     - type: Transform
       pos: 26.5,2.5
       parent: 2
-  - uid: 536
+  - uid: 549
     components:
     - type: Transform
       pos: 25.5,2.5
       parent: 2
-  - uid: 537
+  - uid: 550
     components:
     - type: Transform
       pos: 24.5,2.5
       parent: 2
-  - uid: 538
+  - uid: 551
     components:
     - type: Transform
       pos: 23.5,2.5
       parent: 2
-  - uid: 539
+  - uid: 552
     components:
     - type: Transform
       pos: 22.5,2.5
       parent: 2
-  - uid: 540
+  - uid: 553
     components:
     - type: Transform
       pos: 25.5,3.5
       parent: 2
-  - uid: 541
+  - uid: 554
     components:
     - type: Transform
       pos: 25.5,4.5
       parent: 2
-  - uid: 542
+  - uid: 555
     components:
     - type: Transform
       pos: 25.5,5.5
       parent: 2
-  - uid: 543
+  - uid: 556
     components:
     - type: Transform
       pos: 25.5,6.5
       parent: 2
-  - uid: 544
+  - uid: 557
     components:
     - type: Transform
       pos: 24.5,6.5
       parent: 2
-  - uid: 545
+  - uid: 558
     components:
     - type: Transform
       pos: 23.5,6.5
       parent: 2
-  - uid: 546
+  - uid: 559
     components:
     - type: Transform
       pos: 22.5,6.5
       parent: 2
-  - uid: 547
+  - uid: 560
     components:
     - type: Transform
       pos: 21.5,6.5
       parent: 2
-  - uid: 548
+  - uid: 561
     components:
     - type: Transform
       pos: 21.5,7.5
       parent: 2
-  - uid: 549
+  - uid: 562
     components:
     - type: Transform
       pos: 21.5,8.5
       parent: 2
-  - uid: 550
+  - uid: 563
     components:
     - type: Transform
       pos: 21.5,9.5
       parent: 2
-  - uid: 551
+  - uid: 564
     components:
     - type: Transform
       pos: 2.5,-20.5
       parent: 2
-  - uid: 552
+  - uid: 565
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 2
-  - uid: 553
+  - uid: 566
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 2
-  - uid: 554
+  - uid: 567
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 2
-  - uid: 555
+  - uid: 568
     components:
     - type: Transform
       pos: -19.5,39.5
       parent: 2
-  - uid: 556
+  - uid: 569
     components:
     - type: Transform
       pos: -19.5,40.5
       parent: 2
-  - uid: 557
+  - uid: 570
     components:
     - type: Transform
       pos: -19.5,42.5
       parent: 2
-  - uid: 558
+  - uid: 571
     components:
     - type: Transform
       pos: -19.5,41.5
       parent: 2
-  - uid: 559
+  - uid: 572
     components:
     - type: Transform
       pos: -18.5,42.5
       parent: 2
-  - uid: 560
+  - uid: 573
     components:
     - type: Transform
       pos: -18.5,41.5
       parent: 2
-  - uid: 561
+  - uid: 574
     components:
     - type: Transform
       pos: -18.5,40.5
       parent: 2
-  - uid: 562
+  - uid: 575
     components:
     - type: Transform
       pos: -20.5,40.5
       parent: 2
-  - uid: 563
+  - uid: 576
     components:
     - type: Transform
       pos: -20.5,41.5
       parent: 2
-  - uid: 564
+  - uid: 577
     components:
     - type: Transform
       pos: -20.5,42.5
       parent: 2
-  - uid: 565
+  - uid: 578
     components:
     - type: Transform
       pos: 38.5,-18.5
       parent: 2
-  - uid: 566
+  - uid: 579
     components:
     - type: Transform
       pos: 39.5,-18.5
       parent: 2
-  - uid: 567
+  - uid: 580
     components:
     - type: Transform
       pos: 39.5,-19.5
       parent: 2
-  - uid: 568
+  - uid: 581
     components:
     - type: Transform
       pos: 39.5,-20.5
       parent: 2
-  - uid: 569
+  - uid: 582
     components:
     - type: Transform
       pos: 39.5,-21.5
       parent: 2
-  - uid: 570
+  - uid: 583
     components:
     - type: Transform
       pos: 39.5,-22.5
       parent: 2
-  - uid: 571
+  - uid: 584
     components:
     - type: Transform
       pos: 39.5,-23.5
       parent: 2
-  - uid: 572
+  - uid: 585
     components:
     - type: Transform
       pos: 39.5,-24.5
       parent: 2
-  - uid: 573
+  - uid: 586
     components:
     - type: Transform
       pos: 39.5,-25.5
       parent: 2
-  - uid: 574
+  - uid: 587
     components:
     - type: Transform
       pos: 39.5,-26.5
       parent: 2
-  - uid: 575
+  - uid: 588
     components:
     - type: Transform
       pos: 39.5,-27.5
       parent: 2
-  - uid: 576
+  - uid: 589
     components:
     - type: Transform
       pos: 39.5,-28.5
       parent: 2
-  - uid: 577
+  - uid: 590
     components:
     - type: Transform
       pos: -13.5,66.5
       parent: 2
-  - uid: 578
+  - uid: 591
     components:
     - type: Transform
       pos: -12.5,66.5
       parent: 2
-  - uid: 579
+  - uid: 592
     components:
     - type: Transform
       pos: -11.5,66.5
@@ -8947,2944 +8947,2944 @@ entities:
       dnas: []
       fibers: []
       fingerprints: []
-  - uid: 580
+  - uid: 593
     components:
     - type: Transform
       pos: -30.017519,1.6118836
       parent: 2
 - proto: CableApcStack10
   entities:
-  - uid: 581
+  - uid: 594
     components:
     - type: Transform
       pos: -7.484565,46.65012
       parent: 2
 - proto: CablecuffsBroken
   entities:
-  - uid: 582
+  - uid: 595
     components:
     - type: Transform
       pos: -31.344448,4.503932
       parent: 2
 - proto: CableHV
   entities:
-  - uid: 583
+  - uid: 596
     components:
     - type: Transform
       pos: 25.5,1.5
       parent: 2
-  - uid: 584
+  - uid: 597
     components:
     - type: Transform
       pos: 23.5,3.5
       parent: 2
-  - uid: 585
+  - uid: 598
     components:
     - type: Transform
       pos: 22.5,3.5
       parent: 2
-  - uid: 586
+  - uid: 599
     components:
     - type: Transform
       pos: 24.5,1.5
       parent: 2
-  - uid: 587
+  - uid: 600
     components:
     - type: Transform
       pos: 23.5,1.5
       parent: 2
-  - uid: 588
+  - uid: 601
     components:
     - type: Transform
       pos: 22.5,1.5
       parent: 2
-  - uid: 589
+  - uid: 602
     components:
     - type: Transform
       pos: 26.5,3.5
       parent: 2
-  - uid: 590
+  - uid: 603
     components:
     - type: Transform
       pos: 27.5,3.5
       parent: 2
-  - uid: 591
+  - uid: 604
     components:
     - type: Transform
       pos: 28.5,3.5
       parent: 2
-  - uid: 592
+  - uid: 605
     components:
     - type: Transform
       pos: 27.5,1.5
       parent: 2
-  - uid: 593
+  - uid: 606
     components:
     - type: Transform
       pos: 24.5,3.5
       parent: 2
-  - uid: 594
+  - uid: 607
     components:
     - type: Transform
       pos: 25.5,3.5
       parent: 2
-  - uid: 595
+  - uid: 608
     components:
     - type: Transform
       pos: 26.5,1.5
       parent: 2
-  - uid: 596
+  - uid: 609
     components:
     - type: Transform
       pos: 28.5,1.5
       parent: 2
-  - uid: 597
+  - uid: 610
     components:
     - type: Transform
       pos: 33.5,-0.5
       parent: 2
-  - uid: 598
+  - uid: 611
     components:
     - type: Transform
       pos: 35.5,-0.5
       parent: 2
-  - uid: 599
+  - uid: 612
     components:
     - type: Transform
       pos: 36.5,-0.5
       parent: 2
-  - uid: 600
+  - uid: 613
     components:
     - type: Transform
       pos: 38.5,-0.5
       parent: 2
-  - uid: 601
+  - uid: 614
     components:
     - type: Transform
       pos: 42.5,4.5
       parent: 2
-  - uid: 602
-    components:
-    - type: Transform
-      pos: 36.5,-4.5
-      parent: 2
-  - uid: 603
-    components:
-    - type: Transform
-      pos: 36.5,-4.5
-      parent: 2
-  - uid: 604
-    components:
-    - type: Transform
-      pos: 37.5,-2.5
-      parent: 2
-  - uid: 605
-    components:
-    - type: Transform
-      pos: 37.5,-3.5
-      parent: 2
-  - uid: 606
-    components:
-    - type: Transform
-      pos: 37.5,-4.5
-      parent: 2
-  - uid: 607
-    components:
-    - type: Transform
-      pos: 37.5,-0.5
-      parent: 2
-  - uid: 608
-    components:
-    - type: Transform
-      pos: 38.5,-4.5
-      parent: 2
-  - uid: 609
-    components:
-    - type: Transform
-      pos: 39.5,-2.5
-      parent: 2
-  - uid: 610
-    components:
-    - type: Transform
-      pos: 39.5,-3.5
-      parent: 2
-  - uid: 611
-    components:
-    - type: Transform
-      pos: 39.5,-4.5
-      parent: 2
-  - uid: 612
-    components:
-    - type: Transform
-      pos: 38.5,-2.5
-      parent: 2
-  - uid: 613
-    components:
-    - type: Transform
-      pos: 36.5,3.5
-      parent: 2
-  - uid: 614
-    components:
-    - type: Transform
-      pos: 34.5,-0.5
-      parent: 2
   - uid: 615
     components:
     - type: Transform
-      pos: 41.5,4.5
+      pos: 36.5,-4.5
       parent: 2
   - uid: 616
     components:
     - type: Transform
-      pos: 37.5,3.5
+      pos: 36.5,-4.5
       parent: 2
   - uid: 617
     components:
     - type: Transform
-      pos: 37.5,2.5
+      pos: 37.5,-2.5
       parent: 2
   - uid: 618
     components:
     - type: Transform
-      pos: 37.5,1.5
+      pos: 37.5,-3.5
       parent: 2
   - uid: 619
     components:
     - type: Transform
-      pos: 38.5,3.5
+      pos: 37.5,-4.5
       parent: 2
   - uid: 620
     components:
     - type: Transform
-      pos: 36.5,4.5
+      pos: 37.5,-0.5
       parent: 2
   - uid: 621
     components:
     - type: Transform
-      pos: 38.5,1.5
+      pos: 38.5,-4.5
       parent: 2
   - uid: 622
     components:
     - type: Transform
-      pos: 39.5,3.5
+      pos: 39.5,-2.5
       parent: 2
   - uid: 623
     components:
     - type: Transform
-      pos: 39.5,2.5
+      pos: 39.5,-3.5
       parent: 2
   - uid: 624
     components:
     - type: Transform
-      pos: 39.5,1.5
+      pos: 39.5,-4.5
       parent: 2
   - uid: 625
     components:
     - type: Transform
-      pos: 41.5,3.5
+      pos: 38.5,-2.5
       parent: 2
   - uid: 626
     components:
     - type: Transform
-      pos: 41.5,2.5
+      pos: 36.5,3.5
       parent: 2
   - uid: 627
     components:
     - type: Transform
-      pos: 41.5,1.5
+      pos: 34.5,-0.5
       parent: 2
   - uid: 628
     components:
     - type: Transform
-      pos: 41.5,0.5
+      pos: 41.5,4.5
       parent: 2
   - uid: 629
     components:
     - type: Transform
-      pos: 41.5,-0.5
+      pos: 37.5,3.5
       parent: 2
   - uid: 630
     components:
     - type: Transform
-      pos: 41.5,-1.5
+      pos: 37.5,2.5
       parent: 2
   - uid: 631
     components:
     - type: Transform
-      pos: 41.5,-2.5
+      pos: 37.5,1.5
       parent: 2
   - uid: 632
     components:
     - type: Transform
-      pos: 41.5,-3.5
+      pos: 38.5,3.5
       parent: 2
   - uid: 633
     components:
     - type: Transform
-      pos: 41.5,-4.5
+      pos: 36.5,4.5
       parent: 2
   - uid: 634
     components:
     - type: Transform
-      pos: 42.5,3.5
+      pos: 38.5,1.5
       parent: 2
   - uid: 635
     components:
     - type: Transform
-      pos: 42.5,1.5
+      pos: 39.5,3.5
       parent: 2
   - uid: 636
     components:
     - type: Transform
-      pos: 42.5,0.5
+      pos: 39.5,2.5
       parent: 2
   - uid: 637
     components:
     - type: Transform
-      pos: 42.5,-0.5
+      pos: 39.5,1.5
       parent: 2
   - uid: 638
     components:
     - type: Transform
-      pos: 42.5,-1.5
+      pos: 41.5,3.5
       parent: 2
   - uid: 639
     components:
     - type: Transform
-      pos: 42.5,-2.5
+      pos: 41.5,2.5
       parent: 2
   - uid: 640
     components:
     - type: Transform
-      pos: 42.5,-3.5
+      pos: 41.5,1.5
       parent: 2
   - uid: 641
     components:
     - type: Transform
-      pos: 42.5,-4.5
+      pos: 41.5,0.5
       parent: 2
   - uid: 642
     components:
     - type: Transform
-      pos: 42.5,2.5
+      pos: 41.5,-0.5
       parent: 2
   - uid: 643
     components:
     - type: Transform
-      pos: 42.5,-5.5
+      pos: 41.5,-1.5
       parent: 2
   - uid: 644
     components:
     - type: Transform
-      pos: 41.5,-5.5
+      pos: 41.5,-2.5
       parent: 2
   - uid: 645
     components:
     - type: Transform
-      pos: 36.5,5.5
+      pos: 41.5,-3.5
       parent: 2
   - uid: 646
     components:
     - type: Transform
-      pos: 39.5,-1.5
+      pos: 41.5,-4.5
       parent: 2
   - uid: 647
     components:
     - type: Transform
-      pos: 39.5,-0.5
+      pos: 42.5,3.5
       parent: 2
   - uid: 648
     components:
     - type: Transform
-      pos: 39.5,0.5
+      pos: 42.5,1.5
       parent: 2
   - uid: 649
     components:
     - type: Transform
-      pos: 38.5,-1.5
+      pos: 42.5,0.5
       parent: 2
   - uid: 650
     components:
     - type: Transform
-      pos: 38.5,0.5
+      pos: 42.5,-0.5
       parent: 2
   - uid: 651
     components:
     - type: Transform
-      pos: 37.5,-1.5
+      pos: 42.5,-1.5
       parent: 2
   - uid: 652
     components:
     - type: Transform
-      pos: 37.5,0.5
+      pos: 42.5,-2.5
       parent: 2
   - uid: 653
     components:
     - type: Transform
-      pos: 32.5,-0.5
+      pos: 42.5,-3.5
       parent: 2
   - uid: 654
     components:
     - type: Transform
-      pos: 36.5,-3.5
+      pos: 42.5,-4.5
       parent: 2
   - uid: 655
     components:
     - type: Transform
-      pos: 38.5,-3.5
+      pos: 42.5,2.5
       parent: 2
   - uid: 656
     components:
     - type: Transform
-      pos: 36.5,2.5
+      pos: 42.5,-5.5
       parent: 2
   - uid: 657
     components:
     - type: Transform
-      pos: 38.5,2.5
+      pos: 41.5,-5.5
       parent: 2
   - uid: 658
     components:
     - type: Transform
-      pos: 2.5,24.5
+      pos: 36.5,5.5
       parent: 2
   - uid: 659
     components:
     - type: Transform
-      pos: 2.5,26.5
+      pos: 39.5,-1.5
       parent: 2
   - uid: 660
     components:
     - type: Transform
-      pos: 0.5,29.5
+      pos: 39.5,-0.5
       parent: 2
   - uid: 661
     components:
     - type: Transform
-      pos: 2.5,23.5
+      pos: 39.5,0.5
       parent: 2
   - uid: 662
     components:
     - type: Transform
-      pos: 2.5,25.5
+      pos: 38.5,-1.5
       parent: 2
   - uid: 663
     components:
     - type: Transform
-      pos: 0.5,23.5
+      pos: 38.5,0.5
       parent: 2
   - uid: 664
     components:
     - type: Transform
-      pos: 0.5,24.5
+      pos: 37.5,-1.5
       parent: 2
   - uid: 665
     components:
     - type: Transform
-      pos: 2.5,28.5
+      pos: 37.5,0.5
       parent: 2
   - uid: 666
     components:
     - type: Transform
-      pos: 0.5,25.5
+      pos: 32.5,-0.5
       parent: 2
   - uid: 667
     components:
     - type: Transform
-      pos: 0.5,26.5
+      pos: 36.5,-3.5
       parent: 2
   - uid: 668
     components:
     - type: Transform
-      pos: 2.5,29.5
+      pos: 38.5,-3.5
       parent: 2
   - uid: 669
     components:
     - type: Transform
-      pos: 2.5,27.5
+      pos: 36.5,2.5
       parent: 2
   - uid: 670
     components:
     - type: Transform
-      pos: 0.5,27.5
+      pos: 38.5,2.5
       parent: 2
   - uid: 671
     components:
     - type: Transform
-      pos: 0.5,28.5
+      pos: 2.5,24.5
       parent: 2
   - uid: 672
     components:
     - type: Transform
-      pos: 0.5,30.5
+      pos: 2.5,26.5
       parent: 2
   - uid: 673
     components:
     - type: Transform
-      pos: 0.5,31.5
+      pos: 0.5,29.5
       parent: 2
   - uid: 674
     components:
     - type: Transform
-      pos: 0.5,32.5
+      pos: 2.5,23.5
       parent: 2
   - uid: 675
     components:
     - type: Transform
-      pos: 0.5,33.5
+      pos: 2.5,25.5
       parent: 2
   - uid: 676
     components:
     - type: Transform
-      pos: 0.5,34.5
+      pos: 0.5,23.5
       parent: 2
   - uid: 677
     components:
     - type: Transform
-      pos: 0.5,38.5
+      pos: 0.5,24.5
       parent: 2
   - uid: 678
     components:
     - type: Transform
-      pos: 2.5,35.5
+      pos: 2.5,28.5
       parent: 2
   - uid: 679
     components:
     - type: Transform
-      pos: 2.5,34.5
+      pos: 0.5,25.5
       parent: 2
   - uid: 680
     components:
     - type: Transform
-      pos: 2.5,33.5
+      pos: 0.5,26.5
       parent: 2
   - uid: 681
     components:
     - type: Transform
-      pos: 2.5,32.5
+      pos: 2.5,29.5
       parent: 2
   - uid: 682
     components:
     - type: Transform
-      pos: 2.5,31.5
+      pos: 2.5,27.5
       parent: 2
   - uid: 683
     components:
     - type: Transform
-      pos: 2.5,30.5
+      pos: 0.5,27.5
       parent: 2
   - uid: 684
     components:
     - type: Transform
-      pos: 0.5,36.5
+      pos: 0.5,28.5
       parent: 2
   - uid: 685
     components:
     - type: Transform
-      pos: 0.5,39.5
+      pos: 0.5,30.5
       parent: 2
   - uid: 686
     components:
     - type: Transform
-      pos: 0.5,35.5
+      pos: 0.5,31.5
       parent: 2
   - uid: 687
     components:
     - type: Transform
-      pos: 0.5,40.5
+      pos: 0.5,32.5
       parent: 2
   - uid: 688
     components:
     - type: Transform
-      pos: 0.5,41.5
+      pos: 0.5,33.5
       parent: 2
   - uid: 689
     components:
     - type: Transform
-      pos: 2.5,36.5
+      pos: 0.5,34.5
       parent: 2
   - uid: 690
     components:
     - type: Transform
-      pos: 2.5,40.5
+      pos: 0.5,38.5
       parent: 2
   - uid: 691
     components:
     - type: Transform
-      pos: 2.5,39.5
+      pos: 2.5,35.5
       parent: 2
   - uid: 692
     components:
     - type: Transform
-      pos: 2.5,37.5
+      pos: 2.5,34.5
       parent: 2
   - uid: 693
     components:
     - type: Transform
-      pos: 2.5,41.5
+      pos: 2.5,33.5
       parent: 2
   - uid: 694
     components:
     - type: Transform
-      pos: 0.5,37.5
+      pos: 2.5,32.5
       parent: 2
   - uid: 695
     components:
     - type: Transform
-      pos: 2.5,38.5
+      pos: 2.5,31.5
       parent: 2
   - uid: 696
     components:
     - type: Transform
-      pos: 2.5,50.5
+      pos: 2.5,30.5
       parent: 2
   - uid: 697
     components:
     - type: Transform
-      pos: -2.5,48.5
+      pos: 0.5,36.5
       parent: 2
   - uid: 698
     components:
     - type: Transform
-      pos: -2.5,47.5
+      pos: 0.5,39.5
       parent: 2
   - uid: 699
     components:
     - type: Transform
-      pos: -2.5,46.5
+      pos: 0.5,35.5
       parent: 2
   - uid: 700
     components:
     - type: Transform
-      pos: -2.5,45.5
+      pos: 0.5,40.5
       parent: 2
   - uid: 701
     components:
     - type: Transform
-      pos: -2.5,44.5
+      pos: 0.5,41.5
       parent: 2
   - uid: 702
     components:
     - type: Transform
-      pos: -6.5,44.5
+      pos: 2.5,36.5
       parent: 2
   - uid: 703
     components:
     - type: Transform
-      pos: -6.5,45.5
+      pos: 2.5,40.5
       parent: 2
   - uid: 704
     components:
     - type: Transform
-      pos: -6.5,46.5
+      pos: 2.5,39.5
       parent: 2
   - uid: 705
     components:
     - type: Transform
-      pos: -6.5,47.5
+      pos: 2.5,37.5
       parent: 2
   - uid: 706
     components:
     - type: Transform
-      pos: -6.5,48.5
+      pos: 2.5,41.5
       parent: 2
   - uid: 707
     components:
     - type: Transform
-      pos: 5.5,48.5
+      pos: 0.5,37.5
       parent: 2
   - uid: 708
     components:
     - type: Transform
-      pos: 5.5,46.5
+      pos: 2.5,38.5
       parent: 2
   - uid: 709
     components:
     - type: Transform
-      pos: 5.5,45.5
+      pos: 2.5,50.5
       parent: 2
   - uid: 710
     components:
     - type: Transform
-      pos: 5.5,44.5
+      pos: -2.5,48.5
       parent: 2
   - uid: 711
     components:
     - type: Transform
-      pos: 5.5,47.5
+      pos: -2.5,47.5
       parent: 2
   - uid: 712
     components:
     - type: Transform
-      pos: 9.5,48.5
+      pos: -2.5,46.5
       parent: 2
   - uid: 713
     components:
     - type: Transform
-      pos: 9.5,47.5
+      pos: -2.5,45.5
       parent: 2
   - uid: 714
     components:
     - type: Transform
-      pos: 9.5,46.5
+      pos: -2.5,44.5
       parent: 2
   - uid: 715
     components:
     - type: Transform
-      pos: 9.5,45.5
+      pos: -6.5,44.5
       parent: 2
   - uid: 716
     components:
     - type: Transform
-      pos: 9.5,44.5
+      pos: -6.5,45.5
       parent: 2
   - uid: 717
     components:
     - type: Transform
-      pos: -0.5,47.5
+      pos: -6.5,46.5
       parent: 2
   - uid: 718
     components:
     - type: Transform
-      pos: -0.5,46.5
+      pos: -6.5,47.5
       parent: 2
   - uid: 719
     components:
     - type: Transform
-      pos: -0.5,45.5
+      pos: -6.5,48.5
       parent: 2
   - uid: 720
     components:
     - type: Transform
-      pos: 3.5,47.5
+      pos: 5.5,48.5
       parent: 2
   - uid: 721
     components:
     - type: Transform
-      pos: 3.5,46.5
+      pos: 5.5,46.5
       parent: 2
   - uid: 722
     components:
     - type: Transform
-      pos: 3.5,45.5
+      pos: 5.5,45.5
       parent: 2
   - uid: 723
     components:
     - type: Transform
-      pos: 8.5,49.5
+      pos: 5.5,44.5
       parent: 2
   - uid: 724
     components:
     - type: Transform
-      pos: 4.5,50.5
+      pos: 5.5,47.5
       parent: 2
   - uid: 725
     components:
     - type: Transform
-      pos: 6.5,50.5
+      pos: 9.5,48.5
       parent: 2
   - uid: 726
     components:
     - type: Transform
-      pos: 7.5,50.5
+      pos: 9.5,47.5
       parent: 2
   - uid: 727
     components:
     - type: Transform
-      pos: 8.5,50.5
+      pos: 9.5,46.5
       parent: 2
   - uid: 728
     components:
     - type: Transform
-      pos: 9.5,50.5
+      pos: 9.5,45.5
       parent: 2
   - uid: 729
     components:
     - type: Transform
-      pos: 3.5,50.5
+      pos: 9.5,44.5
       parent: 2
   - uid: 730
     components:
     - type: Transform
-      pos: 3.5,49.5
+      pos: -0.5,47.5
       parent: 2
   - uid: 731
     components:
     - type: Transform
-      pos: 2.5,-18.5
+      pos: -0.5,46.5
       parent: 2
   - uid: 732
     components:
     - type: Transform
-      pos: 2.5,-19.5
+      pos: -0.5,45.5
       parent: 2
   - uid: 733
     components:
     - type: Transform
-      pos: 2.5,-20.5
+      pos: 3.5,47.5
       parent: 2
   - uid: 734
     components:
     - type: Transform
-      pos: 2.5,-21.5
+      pos: 3.5,46.5
       parent: 2
   - uid: 735
     components:
     - type: Transform
-      pos: 2.5,-22.5
+      pos: 3.5,45.5
       parent: 2
   - uid: 736
     components:
     - type: Transform
-      pos: 2.5,-23.5
+      pos: 8.5,49.5
       parent: 2
   - uid: 737
     components:
     - type: Transform
-      pos: 2.5,-24.5
+      pos: 4.5,50.5
       parent: 2
   - uid: 738
     components:
     - type: Transform
-      pos: 0.5,-18.5
+      pos: 6.5,50.5
       parent: 2
   - uid: 739
     components:
     - type: Transform
-      pos: 0.5,-19.5
+      pos: 7.5,50.5
       parent: 2
   - uid: 740
     components:
     - type: Transform
-      pos: 0.5,-20.5
+      pos: 8.5,50.5
       parent: 2
   - uid: 741
     components:
     - type: Transform
-      pos: 0.5,-21.5
+      pos: 9.5,50.5
       parent: 2
   - uid: 742
     components:
     - type: Transform
-      pos: 0.5,-22.5
+      pos: 3.5,50.5
       parent: 2
   - uid: 743
     components:
     - type: Transform
-      pos: 0.5,-23.5
+      pos: 3.5,49.5
       parent: 2
   - uid: 744
     components:
     - type: Transform
-      pos: 0.5,-24.5
+      pos: 2.5,-18.5
       parent: 2
   - uid: 745
     components:
     - type: Transform
-      pos: 18.5,3.5
+      pos: 2.5,-19.5
       parent: 2
   - uid: 746
     components:
     - type: Transform
-      pos: 17.5,3.5
+      pos: 2.5,-20.5
       parent: 2
   - uid: 747
     components:
     - type: Transform
-      pos: 16.5,3.5
+      pos: 2.5,-21.5
       parent: 2
   - uid: 748
     components:
     - type: Transform
-      pos: 15.5,3.5
+      pos: 2.5,-22.5
       parent: 2
   - uid: 749
     components:
     - type: Transform
-      pos: 19.5,3.5
+      pos: 2.5,-23.5
       parent: 2
   - uid: 750
     components:
     - type: Transform
-      pos: 20.5,3.5
+      pos: 2.5,-24.5
       parent: 2
   - uid: 751
     components:
     - type: Transform
-      pos: 21.5,3.5
+      pos: 0.5,-18.5
       parent: 2
   - uid: 752
     components:
     - type: Transform
-      pos: 14.5,3.5
+      pos: 0.5,-19.5
       parent: 2
   - uid: 753
     components:
     - type: Transform
-      pos: 13.5,3.5
+      pos: 0.5,-20.5
       parent: 2
   - uid: 754
     components:
     - type: Transform
-      pos: 12.5,3.5
+      pos: 0.5,-21.5
       parent: 2
   - uid: 755
     components:
     - type: Transform
-      pos: 11.5,3.5
+      pos: 0.5,-22.5
       parent: 2
   - uid: 756
     components:
     - type: Transform
-      pos: 10.5,3.5
+      pos: 0.5,-23.5
       parent: 2
   - uid: 757
     components:
     - type: Transform
-      pos: 9.5,3.5
+      pos: 0.5,-24.5
       parent: 2
   - uid: 758
     components:
     - type: Transform
-      pos: 8.5,3.5
+      pos: 18.5,3.5
       parent: 2
   - uid: 759
     components:
     - type: Transform
-      pos: 7.5,3.5
+      pos: 17.5,3.5
       parent: 2
   - uid: 760
     components:
     - type: Transform
-      pos: 6.5,3.5
+      pos: 16.5,3.5
       parent: 2
   - uid: 761
     components:
     - type: Transform
-      pos: 5.5,3.5
+      pos: 15.5,3.5
       parent: 2
   - uid: 762
     components:
     - type: Transform
-      pos: 4.5,3.5
+      pos: 19.5,3.5
       parent: 2
   - uid: 763
     components:
     - type: Transform
-      pos: 3.5,3.5
+      pos: 20.5,3.5
       parent: 2
   - uid: 764
     components:
     - type: Transform
-      pos: 2.5,3.5
+      pos: 21.5,3.5
       parent: 2
   - uid: 765
     components:
     - type: Transform
-      pos: 1.5,3.5
+      pos: 14.5,3.5
       parent: 2
   - uid: 766
     components:
     - type: Transform
-      pos: -0.5,3.5
+      pos: 13.5,3.5
       parent: 2
   - uid: 767
     components:
     - type: Transform
-      pos: -1.5,3.5
+      pos: 12.5,3.5
       parent: 2
   - uid: 768
     components:
     - type: Transform
-      pos: -2.5,3.5
+      pos: 11.5,3.5
       parent: 2
   - uid: 769
     components:
     - type: Transform
-      pos: 0.5,3.5
+      pos: 10.5,3.5
       parent: 2
   - uid: 770
     components:
     - type: Transform
-      pos: -3.5,3.5
+      pos: 9.5,3.5
       parent: 2
   - uid: 771
     components:
     - type: Transform
-      pos: -4.5,3.5
+      pos: 8.5,3.5
       parent: 2
   - uid: 772
     components:
     - type: Transform
-      pos: -5.5,3.5
+      pos: 7.5,3.5
       parent: 2
   - uid: 773
     components:
     - type: Transform
-      pos: -6.5,3.5
+      pos: 6.5,3.5
       parent: 2
   - uid: 774
     components:
     - type: Transform
-      pos: -7.5,3.5
+      pos: 5.5,3.5
       parent: 2
   - uid: 775
     components:
     - type: Transform
-      pos: -8.5,3.5
+      pos: 4.5,3.5
       parent: 2
   - uid: 776
     components:
     - type: Transform
-      pos: -9.5,3.5
+      pos: 3.5,3.5
       parent: 2
   - uid: 777
     components:
     - type: Transform
-      pos: -10.5,3.5
+      pos: 2.5,3.5
       parent: 2
   - uid: 778
     components:
     - type: Transform
-      pos: -11.5,3.5
+      pos: 1.5,3.5
       parent: 2
   - uid: 779
     components:
     - type: Transform
-      pos: -12.5,3.5
+      pos: -0.5,3.5
       parent: 2
   - uid: 780
     components:
     - type: Transform
-      pos: -13.5,3.5
+      pos: -1.5,3.5
       parent: 2
   - uid: 781
     components:
     - type: Transform
-      pos: -14.5,3.5
+      pos: -2.5,3.5
       parent: 2
   - uid: 782
     components:
     - type: Transform
-      pos: -15.5,3.5
+      pos: 0.5,3.5
       parent: 2
   - uid: 783
     components:
     - type: Transform
-      pos: -16.5,3.5
+      pos: -3.5,3.5
       parent: 2
   - uid: 784
     components:
     - type: Transform
-      pos: -17.5,3.5
+      pos: -4.5,3.5
       parent: 2
   - uid: 785
     components:
     - type: Transform
-      pos: -18.5,3.5
+      pos: -5.5,3.5
       parent: 2
   - uid: 786
     components:
     - type: Transform
-      pos: -19.5,3.5
+      pos: -6.5,3.5
       parent: 2
   - uid: 787
     components:
     - type: Transform
-      pos: -20.5,3.5
+      pos: -7.5,3.5
       parent: 2
   - uid: 788
     components:
     - type: Transform
-      pos: -21.5,3.5
+      pos: -8.5,3.5
       parent: 2
   - uid: 789
     components:
     - type: Transform
-      pos: -22.5,3.5
+      pos: -9.5,3.5
       parent: 2
   - uid: 790
     components:
     - type: Transform
-      pos: -23.5,3.5
+      pos: -10.5,3.5
       parent: 2
   - uid: 791
     components:
     - type: Transform
-      pos: -24.5,3.5
+      pos: -11.5,3.5
       parent: 2
   - uid: 792
     components:
     - type: Transform
-      pos: -25.5,3.5
+      pos: -12.5,3.5
       parent: 2
   - uid: 793
     components:
     - type: Transform
-      pos: -26.5,3.5
+      pos: -13.5,3.5
       parent: 2
   - uid: 794
     components:
     - type: Transform
-      pos: -27.5,3.5
+      pos: -14.5,3.5
       parent: 2
   - uid: 795
     components:
     - type: Transform
-      pos: -28.5,3.5
+      pos: -15.5,3.5
       parent: 2
   - uid: 796
     components:
     - type: Transform
-      pos: -29.5,3.5
+      pos: -16.5,3.5
       parent: 2
   - uid: 797
     components:
     - type: Transform
-      pos: -30.5,3.5
+      pos: -17.5,3.5
       parent: 2
   - uid: 798
     components:
     - type: Transform
-      pos: -31.5,3.5
+      pos: -18.5,3.5
       parent: 2
   - uid: 799
     components:
     - type: Transform
-      pos: -33.5,3.5
+      pos: -19.5,3.5
       parent: 2
   - uid: 800
     components:
     - type: Transform
-      pos: -34.5,3.5
+      pos: -20.5,3.5
       parent: 2
   - uid: 801
     components:
     - type: Transform
-      pos: -35.5,3.5
+      pos: -21.5,3.5
       parent: 2
   - uid: 802
     components:
     - type: Transform
-      pos: -32.5,3.5
+      pos: -22.5,3.5
       parent: 2
   - uid: 803
     components:
     - type: Transform
-      pos: -35.5,4.5
+      pos: -23.5,3.5
       parent: 2
   - uid: 804
     components:
     - type: Transform
-      pos: -35.5,5.5
+      pos: -24.5,3.5
       parent: 2
   - uid: 805
     components:
     - type: Transform
-      pos: -30.5,4.5
+      pos: -25.5,3.5
       parent: 2
   - uid: 806
     components:
     - type: Transform
-      pos: -30.5,5.5
+      pos: -26.5,3.5
       parent: 2
   - uid: 807
     components:
     - type: Transform
-      pos: 29.5,3.5
+      pos: -27.5,3.5
       parent: 2
   - uid: 808
     components:
     - type: Transform
-      pos: 30.5,3.5
+      pos: -28.5,3.5
       parent: 2
   - uid: 809
     components:
     - type: Transform
-      pos: 31.5,3.5
+      pos: -29.5,3.5
       parent: 2
   - uid: 810
     components:
     - type: Transform
-      pos: 32.5,3.5
+      pos: -30.5,3.5
       parent: 2
   - uid: 811
     components:
     - type: Transform
-      pos: 32.5,2.5
+      pos: -31.5,3.5
       parent: 2
   - uid: 812
     components:
     - type: Transform
-      pos: 32.5,1.5
+      pos: -33.5,3.5
       parent: 2
   - uid: 813
     components:
     - type: Transform
-      pos: 32.5,0.5
+      pos: -34.5,3.5
       parent: 2
   - uid: 814
     components:
     - type: Transform
-      pos: 41.5,-6.5
+      pos: -35.5,3.5
       parent: 2
   - uid: 815
     components:
     - type: Transform
-      pos: 40.5,-6.5
+      pos: -32.5,3.5
       parent: 2
   - uid: 816
     components:
     - type: Transform
-      pos: 39.5,-6.5
+      pos: -35.5,4.5
       parent: 2
   - uid: 817
     components:
     - type: Transform
-      pos: 38.5,-6.5
+      pos: -35.5,5.5
       parent: 2
   - uid: 818
     components:
     - type: Transform
-      pos: -19.5,1.5
+      pos: -30.5,4.5
       parent: 2
   - uid: 819
     components:
     - type: Transform
-      pos: -20.5,1.5
+      pos: -30.5,5.5
       parent: 2
   - uid: 820
     components:
     - type: Transform
-      pos: -22.5,1.5
+      pos: 29.5,3.5
       parent: 2
   - uid: 821
     components:
     - type: Transform
-      pos: -23.5,1.5
+      pos: 30.5,3.5
       parent: 2
   - uid: 822
     components:
     - type: Transform
-      pos: -24.5,1.5
+      pos: 31.5,3.5
       parent: 2
   - uid: 823
     components:
     - type: Transform
-      pos: -25.5,1.5
+      pos: 32.5,3.5
       parent: 2
   - uid: 824
     components:
     - type: Transform
-      pos: 40.5,3.5
+      pos: 32.5,2.5
       parent: 2
   - uid: 825
     components:
     - type: Transform
-      pos: 40.5,-4.5
+      pos: 32.5,1.5
       parent: 2
   - uid: 826
     components:
     - type: Transform
-      pos: 40.5,2.5
+      pos: 32.5,0.5
       parent: 2
   - uid: 827
     components:
     - type: Transform
-      pos: 40.5,-3.5
+      pos: 41.5,-6.5
       parent: 2
   - uid: 828
     components:
     - type: Transform
-      pos: 37.5,-6.5
+      pos: 40.5,-6.5
       parent: 2
   - uid: 829
     components:
     - type: Transform
-      pos: 36.5,-6.5
+      pos: 39.5,-6.5
       parent: 2
   - uid: 830
     components:
     - type: Transform
-      pos: 36.5,-5.5
+      pos: 38.5,-6.5
       parent: 2
   - uid: 831
     components:
     - type: Transform
-      pos: 37.5,5.5
+      pos: -19.5,1.5
       parent: 2
   - uid: 832
     components:
     - type: Transform
-      pos: 38.5,5.5
+      pos: -20.5,1.5
       parent: 2
   - uid: 833
     components:
     - type: Transform
-      pos: 39.5,5.5
+      pos: -22.5,1.5
       parent: 2
   - uid: 834
     components:
     - type: Transform
-      pos: 40.5,5.5
+      pos: -23.5,1.5
       parent: 2
   - uid: 835
     components:
     - type: Transform
-      pos: 41.5,5.5
+      pos: -24.5,1.5
       parent: 2
   - uid: 836
     components:
     - type: Transform
-      pos: -13.5,65.5
+      pos: -25.5,1.5
       parent: 2
   - uid: 837
     components:
     - type: Transform
-      pos: -12.5,64.5
+      pos: 40.5,3.5
       parent: 2
   - uid: 838
+    components:
+    - type: Transform
+      pos: 40.5,-4.5
+      parent: 2
+  - uid: 839
+    components:
+    - type: Transform
+      pos: 40.5,2.5
+      parent: 2
+  - uid: 840
+    components:
+    - type: Transform
+      pos: 40.5,-3.5
+      parent: 2
+  - uid: 841
+    components:
+    - type: Transform
+      pos: 37.5,-6.5
+      parent: 2
+  - uid: 842
+    components:
+    - type: Transform
+      pos: 36.5,-6.5
+      parent: 2
+  - uid: 843
+    components:
+    - type: Transform
+      pos: 36.5,-5.5
+      parent: 2
+  - uid: 844
+    components:
+    - type: Transform
+      pos: 37.5,5.5
+      parent: 2
+  - uid: 845
+    components:
+    - type: Transform
+      pos: 38.5,5.5
+      parent: 2
+  - uid: 846
+    components:
+    - type: Transform
+      pos: 39.5,5.5
+      parent: 2
+  - uid: 847
+    components:
+    - type: Transform
+      pos: 40.5,5.5
+      parent: 2
+  - uid: 848
+    components:
+    - type: Transform
+      pos: 41.5,5.5
+      parent: 2
+  - uid: 849
+    components:
+    - type: Transform
+      pos: -13.5,65.5
+      parent: 2
+  - uid: 850
+    components:
+    - type: Transform
+      pos: -12.5,64.5
+      parent: 2
+  - uid: 851
     components:
     - type: Transform
       pos: -13.5,64.5
       parent: 2
 - proto: CableMV
   entities:
-  - uid: 839
+  - uid: 852
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 2
-  - uid: 840
+  - uid: 853
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 2
-  - uid: 841
+  - uid: 854
     components:
     - type: Transform
       pos: 2.5,40.5
       parent: 2
-  - uid: 842
+  - uid: 855
     components:
     - type: Transform
       pos: 2.5,38.5
       parent: 2
-  - uid: 843
+  - uid: 856
     components:
     - type: Transform
       pos: 2.5,36.5
       parent: 2
-  - uid: 844
+  - uid: 857
     components:
     - type: Transform
       pos: 0.5,39.5
       parent: 2
-  - uid: 845
+  - uid: 858
     components:
     - type: Transform
       pos: 0.5,35.5
       parent: 2
-  - uid: 846
+  - uid: 859
     components:
     - type: Transform
       pos: 25.5,3.5
       parent: 2
-  - uid: 847
+  - uid: 860
     components:
     - type: Transform
       pos: 27.5,3.5
       parent: 2
-  - uid: 848
+  - uid: 861
     components:
     - type: Transform
       pos: 26.5,3.5
       parent: 2
-  - uid: 849
+  - uid: 862
     components:
     - type: Transform
       pos: 28.5,3.5
       parent: 2
-  - uid: 850
+  - uid: 863
     components:
     - type: Transform
       pos: 24.5,3.5
       parent: 2
-  - uid: 851
+  - uid: 864
     components:
     - type: Transform
       pos: 23.5,3.5
       parent: 2
-  - uid: 852
+  - uid: 865
     components:
     - type: Transform
       pos: 22.5,3.5
       parent: 2
-  - uid: 853
+  - uid: 866
     components:
     - type: Transform
       pos: 22.5,1.5
       parent: 2
-  - uid: 854
+  - uid: 867
     components:
     - type: Transform
       pos: 23.5,1.5
       parent: 2
-  - uid: 855
+  - uid: 868
     components:
     - type: Transform
       pos: 24.5,1.5
       parent: 2
-  - uid: 856
+  - uid: 869
     components:
     - type: Transform
       pos: 25.5,1.5
       parent: 2
-  - uid: 857
+  - uid: 870
     components:
     - type: Transform
       pos: 26.5,1.5
       parent: 2
-  - uid: 858
+  - uid: 871
     components:
     - type: Transform
       pos: 27.5,1.5
       parent: 2
-  - uid: 859
+  - uid: 872
     components:
     - type: Transform
       pos: 28.5,1.5
       parent: 2
-  - uid: 860
+  - uid: 873
     components:
     - type: Transform
       pos: 39.5,1.5
       parent: 2
-  - uid: 861
+  - uid: 874
     components:
     - type: Transform
       pos: 39.5,-0.5
       parent: 2
-  - uid: 862
+  - uid: 875
     components:
     - type: Transform
       pos: 39.5,-2.5
       parent: 2
-  - uid: 863
+  - uid: 876
     components:
     - type: Transform
       pos: 39.5,-1.5
       parent: 2
-  - uid: 864
+  - uid: 877
     components:
     - type: Transform
       pos: 37.5,1.5
       parent: 2
-  - uid: 865
+  - uid: 878
     components:
     - type: Transform
       pos: 37.5,0.5
       parent: 2
-  - uid: 866
+  - uid: 879
     components:
     - type: Transform
       pos: 37.5,-1.5
       parent: 2
-  - uid: 867
+  - uid: 880
     components:
     - type: Transform
       pos: 37.5,-2.5
       parent: 2
-  - uid: 868
+  - uid: 881
     components:
     - type: Transform
       pos: 37.5,-0.5
       parent: 2
-  - uid: 869
+  - uid: 882
     components:
     - type: Transform
       pos: 38.5,-0.5
       parent: 2
-  - uid: 870
+  - uid: 883
     components:
     - type: Transform
       pos: 39.5,0.5
       parent: 2
-  - uid: 871
+  - uid: 884
     components:
     - type: Transform
       pos: 38.5,1.5
       parent: 2
-  - uid: 872
+  - uid: 885
     components:
     - type: Transform
       pos: 38.5,-2.5
       parent: 2
-  - uid: 873
+  - uid: 886
     components:
     - type: Transform
       pos: 36.5,0.5
       parent: 2
-  - uid: 874
+  - uid: 887
     components:
     - type: Transform
       pos: 35.5,0.5
       parent: 2
-  - uid: 875
+  - uid: 888
     components:
     - type: Transform
       pos: 34.5,0.5
       parent: 2
-  - uid: 876
+  - uid: 889
     components:
     - type: Transform
       pos: 33.5,0.5
       parent: 2
-  - uid: 877
+  - uid: 890
     components:
     - type: Transform
       pos: 36.5,-1.5
       parent: 2
-  - uid: 878
+  - uid: 891
     components:
     - type: Transform
       pos: 34.5,-1.5
       parent: 2
-  - uid: 879
+  - uid: 892
     components:
     - type: Transform
       pos: 33.5,-1.5
       parent: 2
-  - uid: 880
+  - uid: 893
     components:
     - type: Transform
       pos: 35.5,-1.5
       parent: 2
-  - uid: 881
+  - uid: 894
     components:
     - type: Transform
       pos: 32.5,0.5
       parent: 2
-  - uid: 882
+  - uid: 895
     components:
     - type: Transform
       pos: 32.5,1.5
       parent: 2
-  - uid: 883
+  - uid: 896
     components:
     - type: Transform
       pos: 32.5,2.5
       parent: 2
-  - uid: 884
+  - uid: 897
     components:
     - type: Transform
       pos: 32.5,3.5
       parent: 2
-  - uid: 885
+  - uid: 898
     components:
     - type: Transform
       pos: 32.5,-1.5
       parent: 2
-  - uid: 886
+  - uid: 899
     components:
     - type: Transform
       pos: 31.5,-1.5
       parent: 2
-  - uid: 887
+  - uid: 900
     components:
     - type: Transform
       pos: 31.5,-0.5
       parent: 2
-  - uid: 888
+  - uid: 901
     components:
     - type: Transform
       pos: 31.5,0.5
       parent: 2
-  - uid: 889
+  - uid: 902
     components:
     - type: Transform
       pos: 31.5,1.5
       parent: 2
-  - uid: 890
+  - uid: 903
     components:
     - type: Transform
       pos: 30.5,1.5
       parent: 2
-  - uid: 891
+  - uid: 904
     components:
     - type: Transform
       pos: 29.5,1.5
       parent: 2
-  - uid: 892
+  - uid: 905
     components:
     - type: Transform
       pos: 31.5,3.5
       parent: 2
-  - uid: 893
+  - uid: 906
     components:
     - type: Transform
       pos: 30.5,3.5
       parent: 2
-  - uid: 894
+  - uid: 907
     components:
     - type: Transform
       pos: 29.5,3.5
       parent: 2
-  - uid: 895
+  - uid: 908
     components:
     - type: Transform
       pos: 21.5,3.5
       parent: 2
-  - uid: 896
+  - uid: 909
     components:
     - type: Transform
       pos: 20.5,3.5
       parent: 2
-  - uid: 897
+  - uid: 910
     components:
     - type: Transform
       pos: 19.5,3.5
       parent: 2
-  - uid: 898
+  - uid: 911
     components:
     - type: Transform
       pos: 18.5,3.5
       parent: 2
-  - uid: 899
+  - uid: 912
     components:
     - type: Transform
       pos: 17.5,3.5
       parent: 2
-  - uid: 900
+  - uid: 913
     components:
     - type: Transform
       pos: 16.5,3.5
       parent: 2
-  - uid: 901
+  - uid: 914
     components:
     - type: Transform
       pos: 15.5,3.5
       parent: 2
-  - uid: 902
+  - uid: 915
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 2
-  - uid: 903
+  - uid: 916
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 2
-  - uid: 904
+  - uid: 917
     components:
     - type: Transform
       pos: 12.5,3.5
       parent: 2
-  - uid: 905
+  - uid: 918
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 2
-  - uid: 906
+  - uid: 919
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 2
-  - uid: 907
+  - uid: 920
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 2
-  - uid: 908
+  - uid: 921
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 2
-  - uid: 909
+  - uid: 922
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 2
-  - uid: 910
+  - uid: 923
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 2
-  - uid: 911
+  - uid: 924
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 2
-  - uid: 912
+  - uid: 925
     components:
     - type: Transform
       pos: 21.5,1.5
       parent: 2
-  - uid: 913
+  - uid: 926
     components:
     - type: Transform
       pos: 20.5,1.5
       parent: 2
-  - uid: 914
+  - uid: 927
     components:
     - type: Transform
       pos: 19.5,1.5
       parent: 2
-  - uid: 915
+  - uid: 928
     components:
     - type: Transform
       pos: 18.5,1.5
       parent: 2
-  - uid: 916
+  - uid: 929
     components:
     - type: Transform
       pos: 17.5,1.5
       parent: 2
-  - uid: 917
+  - uid: 930
     components:
     - type: Transform
       pos: 16.5,1.5
       parent: 2
-  - uid: 918
+  - uid: 931
     components:
     - type: Transform
       pos: 15.5,1.5
       parent: 2
-  - uid: 919
+  - uid: 932
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 2
-  - uid: 920
+  - uid: 933
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 2
-  - uid: 921
+  - uid: 934
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 2
-  - uid: 922
+  - uid: 935
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 2
-  - uid: 923
+  - uid: 936
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 2
-  - uid: 924
+  - uid: 937
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 2
-  - uid: 925
+  - uid: 938
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 2
-  - uid: 926
+  - uid: 939
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-  - uid: 927
+  - uid: 940
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 2
-  - uid: 928
+  - uid: 941
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 2
-  - uid: 929
+  - uid: 942
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 2
-  - uid: 930
+  - uid: 943
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 2
-  - uid: 931
+  - uid: 944
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-  - uid: 932
+  - uid: 945
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 2
-  - uid: 933
+  - uid: 946
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 2
-  - uid: 934
+  - uid: 947
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 2
-  - uid: 935
+  - uid: 948
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 2
-  - uid: 936
+  - uid: 949
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
-  - uid: 937
+  - uid: 950
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
-  - uid: 938
+  - uid: 951
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 2
-  - uid: 939
+  - uid: 952
     components:
     - type: Transform
       pos: 2.5,29.5
       parent: 2
-  - uid: 940
+  - uid: 953
     components:
     - type: Transform
       pos: 2.5,28.5
       parent: 2
-  - uid: 941
+  - uid: 954
     components:
     - type: Transform
       pos: 2.5,27.5
       parent: 2
-  - uid: 942
+  - uid: 955
     components:
     - type: Transform
       pos: 2.5,26.5
       parent: 2
-  - uid: 943
+  - uid: 956
     components:
     - type: Transform
       pos: 2.5,25.5
       parent: 2
-  - uid: 944
+  - uid: 957
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 2
-  - uid: 945
+  - uid: 958
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 2
-  - uid: 946
+  - uid: 959
     components:
     - type: Transform
       pos: 0.5,23.5
       parent: 2
-  - uid: 947
+  - uid: 960
     components:
     - type: Transform
       pos: 0.5,24.5
       parent: 2
-  - uid: 948
+  - uid: 961
     components:
     - type: Transform
       pos: 0.5,25.5
       parent: 2
-  - uid: 949
+  - uid: 962
     components:
     - type: Transform
       pos: 0.5,26.5
       parent: 2
-  - uid: 950
+  - uid: 963
     components:
     - type: Transform
       pos: 0.5,27.5
       parent: 2
-  - uid: 951
+  - uid: 964
     components:
     - type: Transform
       pos: 0.5,28.5
       parent: 2
-  - uid: 952
+  - uid: 965
     components:
     - type: Transform
       pos: 0.5,29.5
       parent: 2
-  - uid: 953
+  - uid: 966
     components:
     - type: Transform
       pos: 2.5,30.5
       parent: 2
-  - uid: 954
+  - uid: 967
     components:
     - type: Transform
       pos: 2.5,31.5
       parent: 2
-  - uid: 955
+  - uid: 968
     components:
     - type: Transform
       pos: 2.5,32.5
       parent: 2
-  - uid: 956
+  - uid: 969
     components:
     - type: Transform
       pos: 2.5,33.5
       parent: 2
-  - uid: 957
+  - uid: 970
     components:
     - type: Transform
       pos: 2.5,34.5
       parent: 2
-  - uid: 958
+  - uid: 971
     components:
     - type: Transform
       pos: 2.5,35.5
       parent: 2
-  - uid: 959
+  - uid: 972
     components:
     - type: Transform
       pos: 2.5,37.5
       parent: 2
-  - uid: 960
+  - uid: 973
     components:
     - type: Transform
       pos: 2.5,39.5
       parent: 2
-  - uid: 961
+  - uid: 974
     components:
     - type: Transform
       pos: 2.5,41.5
       parent: 2
-  - uid: 962
+  - uid: 975
     components:
     - type: Transform
       pos: 0.5,34.5
       parent: 2
-  - uid: 963
+  - uid: 976
     components:
     - type: Transform
       pos: 0.5,33.5
       parent: 2
-  - uid: 964
+  - uid: 977
     components:
     - type: Transform
       pos: 0.5,31.5
       parent: 2
-  - uid: 965
+  - uid: 978
     components:
     - type: Transform
       pos: 0.5,30.5
       parent: 2
-  - uid: 966
+  - uid: 979
     components:
     - type: Transform
       pos: 0.5,32.5
       parent: 2
-  - uid: 967
+  - uid: 980
     components:
     - type: Transform
       pos: 0.5,36.5
       parent: 2
-  - uid: 968
+  - uid: 981
     components:
     - type: Transform
       pos: 0.5,40.5
       parent: 2
-  - uid: 969
+  - uid: 982
     components:
     - type: Transform
       pos: 0.5,37.5
       parent: 2
-  - uid: 970
+  - uid: 983
     components:
     - type: Transform
       pos: 0.5,41.5
       parent: 2
-  - uid: 971
+  - uid: 984
     components:
     - type: Transform
       pos: 0.5,38.5
       parent: 2
-  - uid: 972
+  - uid: 985
     components:
     - type: Transform
       pos: 9.5,48.5
       parent: 2
-  - uid: 973
+  - uid: 986
     components:
     - type: Transform
       pos: 9.5,47.5
       parent: 2
-  - uid: 974
+  - uid: 987
     components:
     - type: Transform
       pos: 9.5,46.5
       parent: 2
-  - uid: 975
+  - uid: 988
     components:
     - type: Transform
       pos: 9.5,45.5
       parent: 2
-  - uid: 976
+  - uid: 989
     components:
     - type: Transform
       pos: 9.5,44.5
       parent: 2
-  - uid: 977
+  - uid: 990
     components:
     - type: Transform
       pos: 5.5,48.5
       parent: 2
-  - uid: 978
+  - uid: 991
     components:
     - type: Transform
       pos: 5.5,47.5
       parent: 2
-  - uid: 979
+  - uid: 992
     components:
     - type: Transform
       pos: 5.5,46.5
       parent: 2
-  - uid: 980
+  - uid: 993
     components:
     - type: Transform
       pos: 5.5,45.5
       parent: 2
-  - uid: 981
+  - uid: 994
     components:
     - type: Transform
       pos: 5.5,44.5
       parent: 2
-  - uid: 982
+  - uid: 995
     components:
     - type: Transform
       pos: -2.5,48.5
       parent: 2
-  - uid: 983
+  - uid: 996
     components:
     - type: Transform
       pos: -2.5,47.5
       parent: 2
-  - uid: 984
+  - uid: 997
     components:
     - type: Transform
       pos: -2.5,46.5
       parent: 2
-  - uid: 985
+  - uid: 998
     components:
     - type: Transform
       pos: -2.5,45.5
       parent: 2
-  - uid: 986
+  - uid: 999
     components:
     - type: Transform
       pos: -2.5,44.5
       parent: 2
-  - uid: 987
+  - uid: 1000
     components:
     - type: Transform
       pos: -6.5,48.5
       parent: 2
-  - uid: 988
+  - uid: 1001
     components:
     - type: Transform
       pos: -6.5,47.5
       parent: 2
-  - uid: 989
+  - uid: 1002
     components:
     - type: Transform
       pos: -6.5,46.5
       parent: 2
-  - uid: 990
+  - uid: 1003
     components:
     - type: Transform
       pos: -6.5,45.5
       parent: 2
-  - uid: 991
+  - uid: 1004
     components:
     - type: Transform
       pos: -6.5,44.5
       parent: 2
-  - uid: 992
+  - uid: 1005
     components:
     - type: Transform
       pos: -0.5,47.5
       parent: 2
-  - uid: 993
+  - uid: 1006
     components:
     - type: Transform
       pos: -0.5,46.5
       parent: 2
-  - uid: 994
+  - uid: 1007
     components:
     - type: Transform
       pos: -0.5,45.5
       parent: 2
-  - uid: 995
+  - uid: 1008
     components:
     - type: Transform
       pos: 3.5,47.5
       parent: 2
-  - uid: 996
+  - uid: 1009
     components:
     - type: Transform
       pos: 3.5,46.5
       parent: 2
-  - uid: 997
+  - uid: 1010
     components:
     - type: Transform
       pos: 3.5,45.5
       parent: 2
-  - uid: 998
+  - uid: 1011
     components:
     - type: Transform
       pos: 2.5,54.5
       parent: 2
-  - uid: 999
+  - uid: 1012
     components:
     - type: Transform
       pos: 3.5,54.5
       parent: 2
-  - uid: 1000
+  - uid: 1013
     components:
     - type: Transform
       pos: 4.5,54.5
       parent: 2
-  - uid: 1001
+  - uid: 1014
     components:
     - type: Transform
       pos: 5.5,54.5
       parent: 2
-  - uid: 1002
+  - uid: 1015
     components:
     - type: Transform
       pos: 6.5,54.5
       parent: 2
-  - uid: 1003
+  - uid: 1016
     components:
     - type: Transform
       pos: 7.5,54.5
       parent: 2
-  - uid: 1004
+  - uid: 1017
     components:
     - type: Transform
       pos: 8.5,54.5
       parent: 2
-  - uid: 1005
+  - uid: 1018
     components:
     - type: Transform
       pos: 9.5,54.5
       parent: 2
-  - uid: 1006
+  - uid: 1019
     components:
     - type: Transform
       pos: 10.5,54.5
       parent: 2
-  - uid: 1007
+  - uid: 1020
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 2
-  - uid: 1008
+  - uid: 1021
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 2
-  - uid: 1009
+  - uid: 1022
     components:
     - type: Transform
       pos: 0.5,-20.5
       parent: 2
-  - uid: 1010
+  - uid: 1023
     components:
     - type: Transform
       pos: 0.5,-21.5
       parent: 2
-  - uid: 1011
+  - uid: 1024
     components:
     - type: Transform
       pos: 0.5,-22.5
       parent: 2
-  - uid: 1012
+  - uid: 1025
     components:
     - type: Transform
       pos: 0.5,-23.5
       parent: 2
-  - uid: 1013
+  - uid: 1026
     components:
     - type: Transform
       pos: 0.5,-24.5
       parent: 2
-  - uid: 1014
+  - uid: 1027
     components:
     - type: Transform
       pos: 2.5,-18.5
       parent: 2
-  - uid: 1015
+  - uid: 1028
     components:
     - type: Transform
       pos: 2.5,-20.5
       parent: 2
-  - uid: 1016
+  - uid: 1029
     components:
     - type: Transform
       pos: 2.5,-21.5
       parent: 2
-  - uid: 1017
+  - uid: 1030
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 2
-  - uid: 1018
+  - uid: 1031
     components:
     - type: Transform
       pos: 2.5,-23.5
       parent: 2
-  - uid: 1019
+  - uid: 1032
     components:
     - type: Transform
       pos: 2.5,-24.5
       parent: 2
-  - uid: 1020
+  - uid: 1033
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 2
-  - uid: 1021
+  - uid: 1034
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 2
-  - uid: 1022
+  - uid: 1035
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 2
-  - uid: 1023
+  - uid: 1036
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
-  - uid: 1024
+  - uid: 1037
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 2
-  - uid: 1025
+  - uid: 1038
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 2
-  - uid: 1026
+  - uid: 1039
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 2
-  - uid: 1027
+  - uid: 1040
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 2
-  - uid: 1028
+  - uid: 1041
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 2
-  - uid: 1029
+  - uid: 1042
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 2
-  - uid: 1030
+  - uid: 1043
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 2
-  - uid: 1031
+  - uid: 1044
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 2
-  - uid: 1032
+  - uid: 1045
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 2
-  - uid: 1033
+  - uid: 1046
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 2
-  - uid: 1034
+  - uid: 1047
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 2
-  - uid: 1035
+  - uid: 1048
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 2
-  - uid: 1036
+  - uid: 1049
     components:
     - type: Transform
       pos: 1.5,15.5
       parent: 2
-  - uid: 1037
+  - uid: 1050
     components:
     - type: Transform
       pos: 1.5,16.5
       parent: 2
-  - uid: 1038
+  - uid: 1051
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 2
-  - uid: 1039
+  - uid: 1052
     components:
     - type: Transform
       pos: 1.5,18.5
       parent: 2
-  - uid: 1040
+  - uid: 1053
     components:
     - type: Transform
       pos: 1.5,19.5
       parent: 2
-  - uid: 1041
+  - uid: 1054
     components:
     - type: Transform
       pos: 1.5,20.5
       parent: 2
-  - uid: 1042
+  - uid: 1055
     components:
     - type: Transform
       pos: 1.5,21.5
       parent: 2
-  - uid: 1043
+  - uid: 1056
     components:
     - type: Transform
       pos: 2.5,22.5
       parent: 2
-  - uid: 1044
+  - uid: 1057
     components:
     - type: Transform
       pos: 1.5,23.5
       parent: 2
-  - uid: 1045
+  - uid: 1058
     components:
     - type: Transform
       pos: 2.5,21.5
       parent: 2
-  - uid: 1046
+  - uid: 1059
     components:
     - type: Transform
       pos: 0.5,22.5
       parent: 2
-  - uid: 1047
+  - uid: 1060
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 2
-  - uid: 1048
+  - uid: 1061
     components:
     - type: Transform
       pos: 2.5,42.5
       parent: 2
-  - uid: 1049
+  - uid: 1062
     components:
     - type: Transform
       pos: 0.5,42.5
       parent: 2
-  - uid: 1050
+  - uid: 1063
     components:
     - type: Transform
       pos: 0.5,43.5
       parent: 2
-  - uid: 1051
+  - uid: 1064
     components:
     - type: Transform
       pos: 0.5,44.5
       parent: 2
-  - uid: 1052
+  - uid: 1065
     components:
     - type: Transform
       pos: 0.5,45.5
       parent: 2
-  - uid: 1053
+  - uid: 1066
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
-  - uid: 1054
+  - uid: 1067
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 1055
+  - uid: 1068
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 2
-  - uid: 1056
+  - uid: 1069
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
-  - uid: 1057
+  - uid: 1070
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
-  - uid: 1058
+  - uid: 1071
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 2
-  - uid: 1059
+  - uid: 1072
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 2
-  - uid: 1060
+  - uid: 1073
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 2
-  - uid: 1061
+  - uid: 1074
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 2
-  - uid: 1062
+  - uid: 1075
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 2
-  - uid: 1063
+  - uid: 1076
     components:
     - type: Transform
       pos: -10.5,3.5
       parent: 2
-  - uid: 1064
+  - uid: 1077
     components:
     - type: Transform
       pos: -11.5,3.5
       parent: 2
-  - uid: 1065
+  - uid: 1078
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 2
-  - uid: 1066
+  - uid: 1079
     components:
     - type: Transform
       pos: -13.5,3.5
       parent: 2
-  - uid: 1067
+  - uid: 1080
     components:
     - type: Transform
       pos: -14.5,3.5
       parent: 2
-  - uid: 1068
+  - uid: 1081
     components:
     - type: Transform
       pos: -15.5,3.5
       parent: 2
-  - uid: 1069
+  - uid: 1082
     components:
     - type: Transform
       pos: -16.5,3.5
       parent: 2
-  - uid: 1070
+  - uid: 1083
     components:
     - type: Transform
       pos: -17.5,3.5
       parent: 2
-  - uid: 1071
+  - uid: 1084
     components:
     - type: Transform
       pos: -18.5,3.5
       parent: 2
-  - uid: 1072
+  - uid: 1085
     components:
     - type: Transform
       pos: -19.5,3.5
       parent: 2
-  - uid: 1073
+  - uid: 1086
     components:
     - type: Transform
       pos: -20.5,3.5
       parent: 2
-  - uid: 1074
+  - uid: 1087
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 2
-  - uid: 1075
+  - uid: 1088
     components:
     - type: Transform
       pos: -22.5,3.5
       parent: 2
-  - uid: 1076
+  - uid: 1089
     components:
     - type: Transform
       pos: -23.5,3.5
       parent: 2
-  - uid: 1077
+  - uid: 1090
     components:
     - type: Transform
       pos: -24.5,3.5
       parent: 2
-  - uid: 1078
+  - uid: 1091
     components:
     - type: Transform
       pos: -25.5,3.5
       parent: 2
-  - uid: 1079
+  - uid: 1092
     components:
     - type: Transform
       pos: -26.5,3.5
       parent: 2
-  - uid: 1080
+  - uid: 1093
     components:
     - type: Transform
       pos: -27.5,3.5
       parent: 2
-  - uid: 1081
+  - uid: 1094
     components:
     - type: Transform
       pos: -28.5,3.5
       parent: 2
-  - uid: 1082
+  - uid: 1095
     components:
     - type: Transform
       pos: -29.5,3.5
       parent: 2
-  - uid: 1083
+  - uid: 1096
     components:
     - type: Transform
       pos: -29.5,2.5
       parent: 2
-  - uid: 1084
+  - uid: 1097
     components:
     - type: Transform
       pos: -29.5,1.5
       parent: 2
-  - uid: 1085
+  - uid: 1098
     components:
     - type: Transform
       pos: -29.5,0.5
       parent: 2
-  - uid: 1086
+  - uid: 1099
     components:
     - type: Transform
       pos: -29.5,-0.5
       parent: 2
-  - uid: 1087
+  - uid: 1100
     components:
     - type: Transform
       pos: -29.5,-1.5
       parent: 2
-  - uid: 1088
+  - uid: 1101
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 2
-  - uid: 1089
+  - uid: 1102
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 2
-  - uid: 1090
+  - uid: 1103
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 2
-  - uid: 1091
+  - uid: 1104
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 2
-  - uid: 1092
+  - uid: 1105
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 2
-  - uid: 1093
+  - uid: 1106
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-  - uid: 1094
+  - uid: 1107
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 2
-  - uid: 1095
+  - uid: 1108
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 2
-  - uid: 1096
+  - uid: 1109
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 2
-  - uid: 1097
+  - uid: 1110
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 2
-  - uid: 1098
+  - uid: 1111
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 2
-  - uid: 1099
+  - uid: 1112
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 2
-  - uid: 1100
+  - uid: 1113
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 2
-  - uid: 1101
+  - uid: 1114
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 2
-  - uid: 1102
+  - uid: 1115
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 2
-  - uid: 1103
+  - uid: 1116
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 2
-  - uid: 1104
+  - uid: 1117
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 2
-  - uid: 1105
+  - uid: 1118
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 2
-  - uid: 1106
+  - uid: 1119
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 2
-  - uid: 1107
+  - uid: 1120
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 2
-  - uid: 1108
+  - uid: 1121
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 2
-  - uid: 1109
+  - uid: 1122
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 2
-  - uid: 1110
+  - uid: 1123
     components:
     - type: Transform
       pos: 3.5,-21.5
       parent: 2
-  - uid: 1111
+  - uid: 1124
     components:
     - type: Transform
       pos: 31.5,-2.5
       parent: 2
-  - uid: 1112
+  - uid: 1125
     components:
     - type: Transform
       pos: 31.5,-3.5
       parent: 2
-  - uid: 1113
+  - uid: 1126
     components:
     - type: Transform
       pos: 31.5,-4.5
       parent: 2
-  - uid: 1114
+  - uid: 1127
     components:
     - type: Transform
       pos: 31.5,-5.5
       parent: 2
-  - uid: 1115
+  - uid: 1128
     components:
     - type: Transform
       pos: 31.5,-6.5
       parent: 2
-  - uid: 1116
+  - uid: 1129
     components:
     - type: Transform
       pos: 30.5,-6.5
       parent: 2
-  - uid: 1117
+  - uid: 1130
     components:
     - type: Transform
       pos: 29.5,-6.5
       parent: 2
-  - uid: 1118
+  - uid: 1131
     components:
     - type: Transform
       pos: -20.5,4.5
       parent: 2
-  - uid: 1119
+  - uid: 1132
     components:
     - type: Transform
       pos: -20.5,5.5
       parent: 2
-  - uid: 1120
+  - uid: 1133
     components:
     - type: Transform
       pos: -20.5,6.5
       parent: 2
-  - uid: 1121
+  - uid: 1134
     components:
     - type: Transform
       pos: -20.5,7.5
       parent: 2
-  - uid: 1122
+  - uid: 1135
     components:
     - type: Transform
       pos: -20.5,8.5
       parent: 2
-  - uid: 1123
+  - uid: 1136
     components:
     - type: Transform
       pos: -20.5,9.5
       parent: 2
-  - uid: 1124
+  - uid: 1137
     components:
     - type: Transform
       pos: -20.5,10.5
       parent: 2
-  - uid: 1125
+  - uid: 1138
     components:
     - type: Transform
       pos: -20.5,11.5
       parent: 2
-  - uid: 1126
+  - uid: 1139
     components:
     - type: Transform
       pos: -20.5,12.5
       parent: 2
-  - uid: 1127
+  - uid: 1140
     components:
     - type: Transform
       pos: -20.5,13.5
       parent: 2
-  - uid: 1128
+  - uid: 1141
     components:
     - type: Transform
       pos: -20.5,14.5
       parent: 2
-  - uid: 1129
+  - uid: 1142
     components:
     - type: Transform
       pos: -20.5,15.5
       parent: 2
-  - uid: 1130
+  - uid: 1143
     components:
     - type: Transform
       pos: -20.5,16.5
       parent: 2
-  - uid: 1131
+  - uid: 1144
     components:
     - type: Transform
       pos: -20.5,17.5
       parent: 2
-  - uid: 1132
+  - uid: 1145
     components:
     - type: Transform
       pos: -20.5,18.5
       parent: 2
-  - uid: 1133
+  - uid: 1146
     components:
     - type: Transform
       pos: -20.5,19.5
       parent: 2
-  - uid: 1134
+  - uid: 1147
     components:
     - type: Transform
       pos: -20.5,20.5
       parent: 2
-  - uid: 1135
+  - uid: 1148
     components:
     - type: Transform
       pos: -19.5,20.5
       parent: 2
-  - uid: 1136
+  - uid: 1149
     components:
     - type: Transform
       pos: -19.5,21.5
       parent: 2
-  - uid: 1137
+  - uid: 1150
     components:
     - type: Transform
       pos: -19.5,22.5
       parent: 2
-  - uid: 1138
+  - uid: 1151
     components:
     - type: Transform
       pos: -19.5,23.5
       parent: 2
-  - uid: 1139
+  - uid: 1152
     components:
     - type: Transform
       pos: -19.5,24.5
       parent: 2
-  - uid: 1140
+  - uid: 1153
     components:
     - type: Transform
       pos: -19.5,25.5
       parent: 2
-  - uid: 1141
+  - uid: 1154
     components:
     - type: Transform
       pos: -19.5,26.5
       parent: 2
-  - uid: 1142
+  - uid: 1155
     components:
     - type: Transform
       pos: -19.5,27.5
       parent: 2
-  - uid: 1143
+  - uid: 1156
     components:
     - type: Transform
       pos: -19.5,28.5
       parent: 2
-  - uid: 1144
+  - uid: 1157
     components:
     - type: Transform
       pos: -19.5,29.5
       parent: 2
-  - uid: 1145
+  - uid: 1158
     components:
     - type: Transform
       pos: -19.5,30.5
       parent: 2
-  - uid: 1146
+  - uid: 1159
     components:
     - type: Transform
       pos: -19.5,31.5
       parent: 2
-  - uid: 1147
+  - uid: 1160
     components:
     - type: Transform
       pos: -19.5,32.5
       parent: 2
-  - uid: 1148
+  - uid: 1161
     components:
     - type: Transform
       pos: -19.5,33.5
       parent: 2
-  - uid: 1149
+  - uid: 1162
     components:
     - type: Transform
       pos: -19.5,34.5
       parent: 2
-  - uid: 1150
+  - uid: 1163
     components:
     - type: Transform
       pos: -19.5,35.5
       parent: 2
-  - uid: 1151
+  - uid: 1164
     components:
     - type: Transform
       pos: -19.5,36.5
       parent: 2
-  - uid: 1152
+  - uid: 1165
     components:
     - type: Transform
       pos: -19.5,37.5
       parent: 2
-  - uid: 1153
+  - uid: 1166
     components:
     - type: Transform
       pos: -19.5,38.5
       parent: 2
-  - uid: 1154
+  - uid: 1167
     components:
     - type: Transform
       pos: -19.5,39.5
       parent: 2
-  - uid: 1155
+  - uid: 1168
     components:
     - type: Transform
       pos: -13.5,65.5
       parent: 2
-  - uid: 1156
+  - uid: 1169
     components:
     - type: Transform
       pos: -13.5,66.5
       parent: 2
 - proto: CableTerminal
   entities:
-  - uid: 1157
+  - uid: 1170
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,3.5
       parent: 2
-  - uid: 1158
+  - uid: 1171
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,-4.5
       parent: 2
-  - uid: 1159
+  - uid: 1172
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,2.5
       parent: 2
-  - uid: 1160
+  - uid: 1173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,-3.5
       parent: 2
-  - uid: 1161
+  - uid: 1174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,3.5
       parent: 2
-  - uid: 1162
+  - uid: 1175
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,2.5
       parent: 2
-  - uid: 1163
+  - uid: 1176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,-3.5
       parent: 2
-  - uid: 1164
+  - uid: 1177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11892,2779 +11892,2779 @@ entities:
       parent: 2
 - proto: CandleRedInfinite
   entities:
-  - uid: 1165
+  - uid: 1178
     components:
     - type: Transform
       pos: 34.774452,-42.807594
       parent: 2
-  - uid: 1166
+  - uid: 1179
     components:
     - type: Transform
       pos: 34.024452,-42.83537
       parent: 2
-  - uid: 1167
+  - uid: 1180
     components:
     - type: Transform
       pos: 34.376305,-42.72426
       parent: 2
-  - uid: 1168
+  - uid: 1181
     components:
     - type: Transform
       pos: 32.569164,-39.81172
       parent: 2
-  - uid: 1169
+  - uid: 1182
     components:
     - type: Transform
       pos: 32.87472,-39.691353
       parent: 2
-  - uid: 1170
+  - uid: 1183
     components:
     - type: Transform
       pos: 33.189537,-40.765427
       parent: 2
-  - uid: 1171
+  - uid: 1184
     components:
     - type: Transform
       pos: 33.467316,-40.32098
       parent: 2
-  - uid: 1172
+  - uid: 1185
     components:
     - type: Transform
       pos: 33.01361,-39.95987
       parent: 2
-  - uid: 1173
+  - uid: 1186
     components:
     - type: Transform
       pos: 32.300648,-39.663574
       parent: 2
-  - uid: 1174
+  - uid: 1187
     components:
     - type: Transform
       pos: 32.51361,-39.422832
       parent: 2
-  - uid: 1175
+  - uid: 1188
     components:
     - type: Transform
       pos: 33.515194,-42.816853
       parent: 2
-  - uid: 1176
+  - uid: 1189
     components:
     - type: Transform
       pos: 34.99997,-42.029816
       parent: 2
-  - uid: 1177
+  - uid: 1190
     components:
     - type: Transform
       pos: 33.14482,-42.715
       parent: 2
-  - uid: 1178
+  - uid: 1191
     components:
     - type: Transform
       pos: 34.675896,-40.465267
       parent: 2
-  - uid: 1179
+  - uid: 1192
     components:
     - type: Transform
       pos: 33.3359,-38.978542
       parent: 2
-  - uid: 1180
+  - uid: 1193
     components:
     - type: Transform
       pos: 34.88886,-42.289074
       parent: 2
-  - uid: 1181
+  - uid: 1194
     components:
     - type: Transform
       pos: 33.35454,-38.524624
       parent: 2
-  - uid: 1182
+  - uid: 1195
     components:
     - type: Transform
       pos: 33.75269,-38.422775
       parent: 2
-  - uid: 1183
+  - uid: 1196
     components:
     - type: Transform
       pos: 35.039013,-32.275513
       parent: 2
-  - uid: 1184
+  - uid: 1197
     components:
     - type: Transform
       pos: 34.63886,-39.743046
       parent: 2
-  - uid: 1185
+  - uid: 1198
     components:
     - type: Transform
       pos: 34.648117,-40.03934
       parent: 2
-  - uid: 1186
+  - uid: 1199
     components:
     - type: Transform
       pos: 34.870342,-40.17823
       parent: 2
-  - uid: 1187
+  - uid: 1200
     components:
     - type: Transform
       pos: 34.704185,-34.748775
       parent: 2
-  - uid: 1188
+  - uid: 1201
     components:
     - type: Transform
       pos: 34.020496,-32.784775
       parent: 2
 - proto: CandyClownUniformSuit
   entities:
-  - uid: 1189
+  - uid: 1202
     components:
     - type: Transform
       pos: -27.307487,28.436026
       parent: 2
 - proto: CarpetCard
   entities:
-  - uid: 1190
+  - uid: 1203
     components:
     - type: Transform
       pos: 5.5,53.5
       parent: 2
-  - uid: 1191
+  - uid: 1204
     components:
     - type: Transform
       pos: 6.5,53.5
       parent: 2
-  - uid: 1192
+  - uid: 1205
     components:
     - type: Transform
       pos: 4.5,53.5
       parent: 2
-  - uid: 1193
+  - uid: 1206
     components:
     - type: Transform
       pos: 4.5,52.5
       parent: 2
-  - uid: 1194
+  - uid: 1207
     components:
     - type: Transform
       pos: 5.5,52.5
       parent: 2
-  - uid: 1195
+  - uid: 1208
     components:
     - type: Transform
       pos: 6.5,52.5
       parent: 2
-  - uid: 1196
+  - uid: 1209
     components:
     - type: Transform
       pos: -16.5,18.5
       parent: 2
-  - uid: 1197
+  - uid: 1210
     components:
     - type: Transform
       pos: -18.5,18.5
       parent: 2
-  - uid: 1198
+  - uid: 1211
     components:
     - type: Transform
       pos: -17.5,18.5
       parent: 2
-  - uid: 1199
+  - uid: 1212
     components:
     - type: Transform
       pos: -17.5,19.5
       parent: 2
-  - uid: 1200
+  - uid: 1213
     components:
     - type: Transform
       pos: -18.5,19.5
       parent: 2
-  - uid: 1201
+  - uid: 1214
     components:
     - type: Transform
       pos: -18.5,20.5
       parent: 2
-  - uid: 1202
+  - uid: 1215
     components:
     - type: Transform
       pos: -17.5,20.5
       parent: 2
-  - uid: 1203
+  - uid: 1216
     components:
     - type: Transform
       pos: -16.5,19.5
       parent: 2
 - proto: Catwalk
   entities:
-  - uid: 1204
+  - uid: 1217
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,14.5
       parent: 2
-  - uid: 1205
+  - uid: 1218
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,14.5
       parent: 2
-  - uid: 1206
+  - uid: 1219
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,20.5
       parent: 2
-  - uid: 1207
+  - uid: 1220
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,14.5
       parent: 2
-  - uid: 1208
+  - uid: 1221
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,14.5
       parent: 2
-  - uid: 1209
-    components:
-    - type: Transform
-      pos: 12.5,4.5
-      parent: 2
-  - uid: 1210
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,14.5
-      parent: 2
-  - uid: 1211
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,14.5
-      parent: 2
-  - uid: 1212
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,5.5
-      parent: 2
-  - uid: 1213
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,14.5
-      parent: 2
-  - uid: 1214
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,-9.5
-      parent: 2
-  - uid: 1215
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,14.5
-      parent: 2
-  - uid: 1216
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-9.5
-      parent: 2
-  - uid: 1217
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,14.5
-      parent: 2
-  - uid: 1218
-    components:
-    - type: Transform
-      pos: 12.5,-0.5
-      parent: 2
-  - uid: 1219
-    components:
-    - type: Transform
-      pos: -8.5,13.5
-      parent: 2
-  - uid: 1220
-    components:
-    - type: Transform
-      pos: 12.5,6.5
-      parent: 2
-  - uid: 1221
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,12.5
-      parent: 2
   - uid: 1222
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,12.5
+      pos: 12.5,4.5
       parent: 2
   - uid: 1223
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 13.5,10.5
+      pos: -3.5,14.5
       parent: 2
   - uid: 1224
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 13.5,6.5
+      pos: 11.5,14.5
       parent: 2
   - uid: 1225
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 13.5,8.5
+      pos: 13.5,5.5
       parent: 2
   - uid: 1226
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 13.5,-0.5
+      pos: 5.5,14.5
       parent: 2
   - uid: 1227
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -10.5,-5.5
+      pos: 5.5,-9.5
       parent: 2
   - uid: 1228
     components:
     - type: Transform
-      pos: 12.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,14.5
       parent: 2
   - uid: 1229
     components:
     - type: Transform
-      pos: 12.5,10.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-9.5
       parent: 2
   - uid: 1230
     components:
     - type: Transform
-      pos: 12.5,12.5
+      rot: 1.5707963267948966 rad
+      pos: 7.5,14.5
       parent: 2
   - uid: 1231
     components:
     - type: Transform
-      pos: 11.5,13.5
+      pos: 12.5,-0.5
       parent: 2
   - uid: 1232
     components:
     - type: Transform
-      pos: 9.5,13.5
+      pos: -8.5,13.5
       parent: 2
   - uid: 1233
     components:
     - type: Transform
-      pos: 7.5,13.5
+      pos: 12.5,6.5
       parent: 2
   - uid: 1234
     components:
     - type: Transform
-      pos: -9.5,-8.5
+      rot: 3.141592653589793 rad
+      pos: 10.5,12.5
       parent: 2
   - uid: 1235
     components:
     - type: Transform
-      pos: -5.5,13.5
+      rot: 1.5707963267948966 rad
+      pos: 13.5,12.5
       parent: 2
   - uid: 1236
     components:
     - type: Transform
-      pos: -3.5,13.5
+      rot: 1.5707963267948966 rad
+      pos: 13.5,10.5
       parent: 2
   - uid: 1237
     components:
     - type: Transform
-      pos: -1.5,13.5
+      rot: 1.5707963267948966 rad
+      pos: 13.5,6.5
       parent: 2
   - uid: 1238
     components:
     - type: Transform
-      pos: 0.5,13.5
+      rot: 1.5707963267948966 rad
+      pos: 13.5,8.5
       parent: 2
   - uid: 1239
     components:
     - type: Transform
-      pos: 3.5,13.5
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-0.5
       parent: 2
   - uid: 1240
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 6.5,-9.5
+      pos: -10.5,-5.5
       parent: 2
   - uid: 1241
+    components:
+    - type: Transform
+      pos: 12.5,8.5
+      parent: 2
+  - uid: 1242
+    components:
+    - type: Transform
+      pos: 12.5,10.5
+      parent: 2
+  - uid: 1243
+    components:
+    - type: Transform
+      pos: 12.5,12.5
+      parent: 2
+  - uid: 1244
+    components:
+    - type: Transform
+      pos: 11.5,13.5
+      parent: 2
+  - uid: 1245
+    components:
+    - type: Transform
+      pos: 9.5,13.5
+      parent: 2
+  - uid: 1246
+    components:
+    - type: Transform
+      pos: 7.5,13.5
+      parent: 2
+  - uid: 1247
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 1248
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 2
+  - uid: 1249
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 2
+  - uid: 1250
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 2
+  - uid: 1251
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 2
+  - uid: 1252
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 2
+  - uid: 1253
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-9.5
+      parent: 2
+  - uid: 1254
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,14.5
       parent: 2
-  - uid: 1242
+  - uid: 1255
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-9.5
       parent: 2
-  - uid: 1243
+  - uid: 1256
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,0.5
       parent: 2
-  - uid: 1244
+  - uid: 1257
     components:
     - type: Transform
       pos: -9.5,6.5
       parent: 2
-  - uid: 1245
+  - uid: 1258
     components:
     - type: Transform
       pos: 21.5,1.5
       parent: 2
-  - uid: 1246
+  - uid: 1259
     components:
     - type: Transform
       pos: 5.5,13.5
       parent: 2
-  - uid: 1247
+  - uid: 1260
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 2
-  - uid: 1248
+  - uid: 1261
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 2
-  - uid: 1249
+  - uid: 1262
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 2
-  - uid: 1250
+  - uid: 1263
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 2
-  - uid: 1251
+  - uid: 1264
     components:
     - type: Transform
       pos: -9.5,3.5
       parent: 2
-  - uid: 1252
+  - uid: 1265
     components:
     - type: Transform
       pos: -9.5,-0.5
       parent: 2
-  - uid: 1253
+  - uid: 1266
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 2
-  - uid: 1254
+  - uid: 1267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,18.5
       parent: 2
-  - uid: 1255
+  - uid: 1268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,22.5
       parent: 2
-  - uid: 1256
+  - uid: 1269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,22.5
       parent: 2
-  - uid: 1257
+  - uid: 1270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,22.5
       parent: 2
-  - uid: 1258
+  - uid: 1271
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-8.5
       parent: 2
-  - uid: 1259
+  - uid: 1272
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-9.5
       parent: 2
-  - uid: 1260
+  - uid: 1273
     components:
     - type: Transform
       pos: 20.5,2.5
       parent: 2
-  - uid: 1261
+  - uid: 1274
     components:
     - type: Transform
       pos: 20.5,3.5
       parent: 2
-  - uid: 1262
+  - uid: 1275
     components:
     - type: Transform
       pos: 20.5,1.5
       parent: 2
-  - uid: 1263
+  - uid: 1276
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 2
-  - uid: 1264
+  - uid: 1277
     components:
     - type: Transform
       pos: 19.5,3.5
       parent: 2
-  - uid: 1265
+  - uid: 1278
     components:
     - type: Transform
       pos: 19.5,2.5
       parent: 2
-  - uid: 1266
+  - uid: 1279
     components:
     - type: Transform
       pos: 19.5,1.5
       parent: 2
-  - uid: 1267
+  - uid: 1280
     components:
     - type: Transform
       pos: 18.5,3.5
       parent: 2
-  - uid: 1268
+  - uid: 1281
     components:
     - type: Transform
       pos: 18.5,2.5
       parent: 2
-  - uid: 1269
+  - uid: 1282
     components:
     - type: Transform
       pos: 18.5,1.5
       parent: 2
-  - uid: 1270
+  - uid: 1283
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 2
-  - uid: 1271
+  - uid: 1284
     components:
     - type: Transform
       pos: 17.5,3.5
       parent: 2
-  - uid: 1272
+  - uid: 1285
     components:
     - type: Transform
       pos: 17.5,2.5
       parent: 2
-  - uid: 1273
+  - uid: 1286
     components:
     - type: Transform
       pos: 16.5,3.5
       parent: 2
-  - uid: 1274
+  - uid: 1287
     components:
     - type: Transform
       pos: 16.5,2.5
       parent: 2
-  - uid: 1275
+  - uid: 1288
     components:
     - type: Transform
       pos: 16.5,1.5
       parent: 2
-  - uid: 1276
+  - uid: 1289
     components:
     - type: Transform
       pos: 15.5,3.5
       parent: 2
-  - uid: 1277
+  - uid: 1290
     components:
     - type: Transform
       pos: 15.5,2.5
       parent: 2
-  - uid: 1278
+  - uid: 1291
     components:
     - type: Transform
       pos: 17.5,1.5
       parent: 2
-  - uid: 1279
+  - uid: 1292
     components:
     - type: Transform
       pos: 15.5,1.5
       parent: 2
-  - uid: 1280
+  - uid: 1293
     components:
     - type: Transform
       pos: 14.5,3.5
       parent: 2
-  - uid: 1281
+  - uid: 1294
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 2
-  - uid: 1282
+  - uid: 1295
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 2
-  - uid: 1283
+  - uid: 1296
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 2
-  - uid: 1284
+  - uid: 1297
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 2
-  - uid: 1285
+  - uid: 1298
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 2
-  - uid: 1286
+  - uid: 1299
     components:
     - type: Transform
       pos: -6.5,13.5
       parent: 2
-  - uid: 1287
+  - uid: 1300
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 2
-  - uid: 1288
+  - uid: 1301
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-1.5
       parent: 2
-  - uid: 1289
+  - uid: 1302
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 2
-  - uid: 1290
+  - uid: 1303
     components:
     - type: Transform
       pos: 11.5,2.5
       parent: 2
-  - uid: 1291
+  - uid: 1304
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 2
-  - uid: 1292
+  - uid: 1305
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 2
-  - uid: 1293
+  - uid: 1306
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 2
-  - uid: 1294
+  - uid: 1307
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 2
-  - uid: 1295
+  - uid: 1308
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 2
-  - uid: 1296
+  - uid: 1309
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 2
-  - uid: 1297
+  - uid: 1310
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 2
-  - uid: 1298
+  - uid: 1311
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 2
-  - uid: 1299
+  - uid: 1312
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 2
-  - uid: 1300
+  - uid: 1313
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 2
-  - uid: 1301
+  - uid: 1314
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 2
-  - uid: 1302
+  - uid: 1315
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 2
-  - uid: 1303
+  - uid: 1316
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 2
-  - uid: 1304
+  - uid: 1317
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 2
-  - uid: 1305
+  - uid: 1318
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 2
-  - uid: 1306
+  - uid: 1319
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-  - uid: 1307
+  - uid: 1320
     components:
     - type: Transform
       pos: -4.5,13.5
       parent: 2
-  - uid: 1308
+  - uid: 1321
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 2
-  - uid: 1309
+  - uid: 1322
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 2
-  - uid: 1310
+  - uid: 1323
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 2
-  - uid: 1311
+  - uid: 1324
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 2
-  - uid: 1312
+  - uid: 1325
     components:
     - type: Transform
       pos: 12.5,9.5
       parent: 2
-  - uid: 1313
+  - uid: 1326
     components:
     - type: Transform
       pos: 12.5,11.5
       parent: 2
-  - uid: 1314
+  - uid: 1327
     components:
     - type: Transform
       pos: 12.5,13.5
       parent: 2
-  - uid: 1315
+  - uid: 1328
     components:
     - type: Transform
       pos: 10.5,13.5
       parent: 2
-  - uid: 1316
+  - uid: 1329
     components:
     - type: Transform
       pos: 8.5,13.5
       parent: 2
-  - uid: 1317
+  - uid: 1330
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,12.5
       parent: 2
-  - uid: 1318
+  - uid: 1331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,11.5
       parent: 2
-  - uid: 1319
+  - uid: 1332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,9.5
       parent: 2
-  - uid: 1320
+  - uid: 1333
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,7.5
       parent: 2
-  - uid: 1321
+  - uid: 1334
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,14.5
       parent: 2
-  - uid: 1322
+  - uid: 1335
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,8.5
       parent: 2
-  - uid: 1323
+  - uid: 1336
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,14.5
       parent: 2
-  - uid: 1324
+  - uid: 1337
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,14.5
       parent: 2
-  - uid: 1325
+  - uid: 1338
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,14.5
       parent: 2
-  - uid: 1326
+  - uid: 1339
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,14.5
       parent: 2
-  - uid: 1327
+  - uid: 1340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,14.5
       parent: 2
-  - uid: 1328
+  - uid: 1341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,14.5
       parent: 2
-  - uid: 1329
+  - uid: 1342
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,14.5
       parent: 2
-  - uid: 1330
+  - uid: 1343
     components:
     - type: Transform
       pos: 22.5,1.5
       parent: 2
-  - uid: 1331
+  - uid: 1344
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 2
-  - uid: 1332
+  - uid: 1345
     components:
     - type: Transform
       pos: -0.5,-8.5
       parent: 2
-  - uid: 1333
+  - uid: 1346
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 2
-  - uid: 1334
+  - uid: 1347
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 2
-  - uid: 1335
+  - uid: 1348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,19.5
       parent: 2
-  - uid: 1336
+  - uid: 1349
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 2
-  - uid: 1337
+  - uid: 1350
     components:
     - type: Transform
       pos: -9.5,-1.5
       parent: 2
-  - uid: 1338
+  - uid: 1351
     components:
     - type: Transform
       pos: -9.5,1.5
       parent: 2
-  - uid: 1339
+  - uid: 1352
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
-  - uid: 1340
+  - uid: 1353
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 2
-  - uid: 1341
+  - uid: 1354
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 2
-  - uid: 1342
+  - uid: 1355
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
-  - uid: 1343
+  - uid: 1356
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 2
-  - uid: 1344
+  - uid: 1357
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 2
-  - uid: 1345
+  - uid: 1358
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 2
-  - uid: 1346
+  - uid: 1359
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 2
-  - uid: 1347
+  - uid: 1360
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 2
-  - uid: 1348
+  - uid: 1361
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 2
-  - uid: 1349
+  - uid: 1362
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 2
-  - uid: 1350
+  - uid: 1363
     components:
     - type: Transform
       pos: -6.5,1.5
       parent: 2
-  - uid: 1351
+  - uid: 1364
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 2
-  - uid: 1352
+  - uid: 1365
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 2
-  - uid: 1353
+  - uid: 1366
     components:
     - type: Transform
       pos: -7.5,1.5
       parent: 2
-  - uid: 1354
+  - uid: 1367
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 2
-  - uid: 1355
+  - uid: 1368
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-  - uid: 1356
+  - uid: 1369
     components:
     - type: Transform
       pos: -8.5,1.5
       parent: 2
-  - uid: 1357
+  - uid: 1370
     components:
     - type: Transform
       pos: 12.5,-2.5
       parent: 2
-  - uid: 1358
+  - uid: 1371
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 2
-  - uid: 1359
+  - uid: 1372
     components:
     - type: Transform
       pos: -10.5,3.5
       parent: 2
-  - uid: 1360
+  - uid: 1373
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 2
-  - uid: 1361
+  - uid: 1374
     components:
     - type: Transform
       pos: -10.5,1.5
       parent: 2
-  - uid: 1362
+  - uid: 1375
     components:
     - type: Transform
       pos: -11.5,3.5
       parent: 2
-  - uid: 1363
+  - uid: 1376
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 2
-  - uid: 1364
+  - uid: 1377
     components:
     - type: Transform
       pos: -11.5,1.5
       parent: 2
-  - uid: 1365
+  - uid: 1378
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 2
-  - uid: 1366
+  - uid: 1379
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 2
-  - uid: 1367
+  - uid: 1380
     components:
     - type: Transform
       pos: -12.5,1.5
       parent: 2
-  - uid: 1368
+  - uid: 1381
     components:
     - type: Transform
       pos: -13.5,3.5
       parent: 2
-  - uid: 1369
+  - uid: 1382
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 2
-  - uid: 1370
+  - uid: 1383
     components:
     - type: Transform
       pos: -13.5,1.5
       parent: 2
-  - uid: 1371
+  - uid: 1384
     components:
     - type: Transform
       pos: -14.5,3.5
       parent: 2
-  - uid: 1372
+  - uid: 1385
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
-  - uid: 1373
+  - uid: 1386
     components:
     - type: Transform
       pos: -14.5,1.5
       parent: 2
-  - uid: 1374
+  - uid: 1387
     components:
     - type: Transform
       pos: -15.5,3.5
       parent: 2
-  - uid: 1375
+  - uid: 1388
     components:
     - type: Transform
       pos: -15.5,2.5
       parent: 2
-  - uid: 1376
+  - uid: 1389
     components:
     - type: Transform
       pos: -15.5,1.5
       parent: 2
-  - uid: 1377
+  - uid: 1390
     components:
     - type: Transform
       pos: -16.5,3.5
       parent: 2
-  - uid: 1378
+  - uid: 1391
     components:
     - type: Transform
       pos: -16.5,2.5
       parent: 2
-  - uid: 1379
+  - uid: 1392
     components:
     - type: Transform
       pos: -16.5,1.5
       parent: 2
-  - uid: 1380
+  - uid: 1393
     components:
     - type: Transform
       pos: -17.5,3.5
       parent: 2
-  - uid: 1381
+  - uid: 1394
     components:
     - type: Transform
       pos: -17.5,2.5
       parent: 2
-  - uid: 1382
+  - uid: 1395
     components:
     - type: Transform
       pos: -17.5,1.5
       parent: 2
-  - uid: 1383
+  - uid: 1396
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 2
-  - uid: 1384
+  - uid: 1397
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 2
-  - uid: 1385
+  - uid: 1398
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 2
-  - uid: 1386
+  - uid: 1399
     components:
     - type: Transform
       pos: 12.5,7.5
       parent: 2
-  - uid: 1387
+  - uid: 1400
     components:
     - type: Transform
       pos: -9.5,4.5
       parent: 2
-  - uid: 1388
+  - uid: 1401
     components:
     - type: Transform
       pos: 6.5,13.5
       parent: 2
-  - uid: 1389
+  - uid: 1402
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 2
-  - uid: 1390
+  - uid: 1403
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,4.5
       parent: 2
-  - uid: 1391
+  - uid: 1404
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 2
-  - uid: 1392
+  - uid: 1405
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 2
-  - uid: 1393
+  - uid: 1406
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 2
-  - uid: 1394
+  - uid: 1407
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 2
-  - uid: 1395
+  - uid: 1408
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 2
-  - uid: 1396
+  - uid: 1409
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 2
-  - uid: 1397
+  - uid: 1410
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 2
-  - uid: 1398
+  - uid: 1411
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 2
-  - uid: 1399
+  - uid: 1412
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 2
-  - uid: 1400
+  - uid: 1413
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 2
-  - uid: 1401
+  - uid: 1414
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
-  - uid: 1402
+  - uid: 1415
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
-  - uid: 1403
+  - uid: 1416
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 1404
+  - uid: 1417
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 2
-  - uid: 1405
+  - uid: 1418
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,0.5
       parent: 2
-  - uid: 1406
+  - uid: 1419
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 2
-  - uid: 1407
+  - uid: 1420
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 2
-  - uid: 1408
+  - uid: 1421
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 2
-  - uid: 1409
+  - uid: 1422
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 2
-  - uid: 1410
+  - uid: 1423
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 2
-  - uid: 1411
+  - uid: 1424
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 2
-  - uid: 1412
+  - uid: 1425
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 2
-  - uid: 1413
+  - uid: 1426
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 2
-  - uid: 1414
+  - uid: 1427
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 2
-  - uid: 1415
+  - uid: 1428
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 2
-  - uid: 1416
+  - uid: 1429
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 2
-  - uid: 1417
+  - uid: 1430
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-  - uid: 1418
+  - uid: 1431
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 2
-  - uid: 1419
+  - uid: 1432
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 2
-  - uid: 1420
+  - uid: 1433
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 2
-  - uid: 1421
+  - uid: 1434
     components:
     - type: Transform
       pos: 0.5,-15.5
       parent: 2
-  - uid: 1422
+  - uid: 1435
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 2
-  - uid: 1423
+  - uid: 1436
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 2
-  - uid: 1424
+  - uid: 1437
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 2
-  - uid: 1425
+  - uid: 1438
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 2
-  - uid: 1426
+  - uid: 1439
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 2
-  - uid: 1427
+  - uid: 1440
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 2
-  - uid: 1428
+  - uid: 1441
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 2
-  - uid: 1429
+  - uid: 1442
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 2
-  - uid: 1430
+  - uid: 1443
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 2
-  - uid: 1431
+  - uid: 1444
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 2
-  - uid: 1432
+  - uid: 1445
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 2
-  - uid: 1433
+  - uid: 1446
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 2
-  - uid: 1434
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
-      parent: 2
-  - uid: 1435
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-8.5
-      parent: 2
-  - uid: 1436
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-8.5
-      parent: 2
-  - uid: 1437
-    components:
-    - type: Transform
-      pos: -6.5,-8.5
-      parent: 2
-  - uid: 1438
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,-9.5
-      parent: 2
-  - uid: 1439
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-9.5
-      parent: 2
-  - uid: 1440
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-9.5
-      parent: 2
-  - uid: 1441
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-9.5
-      parent: 2
-  - uid: 1442
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,-9.5
-      parent: 2
-  - uid: 1443
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-9.5
-      parent: 2
-  - uid: 1444
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-9.5
-      parent: 2
-  - uid: 1445
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-9.5
-      parent: 2
-  - uid: 1446
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -11.5,4.5
-      parent: 2
   - uid: 1447
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,4.5
+      pos: 0.5,-2.5
       parent: 2
   - uid: 1448
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -10.5,-7.5
+      pos: 7.5,-8.5
       parent: 2
   - uid: 1449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -10.5,-4.5
+      pos: 8.5,-8.5
       parent: 2
   - uid: 1450
     components:
     - type: Transform
-      pos: 12.5,5.5
+      pos: -6.5,-8.5
       parent: 2
   - uid: 1451
     components:
     - type: Transform
-      pos: -7.5,13.5
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-9.5
       parent: 2
   - uid: 1452
     components:
     - type: Transform
-      pos: 12.5,3.5
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-9.5
       parent: 2
   - uid: 1453
     components:
     - type: Transform
-      pos: 2.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-9.5
       parent: 2
   - uid: 1454
     components:
     - type: Transform
-      pos: 2.5,7.5
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-9.5
       parent: 2
   - uid: 1455
     components:
     - type: Transform
-      pos: 2.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-9.5
       parent: 2
   - uid: 1456
     components:
     - type: Transform
-      pos: 2.5,10.5
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-9.5
       parent: 2
   - uid: 1457
     components:
     - type: Transform
-      pos: 2.5,11.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-9.5
       parent: 2
   - uid: 1458
     components:
     - type: Transform
-      pos: 2.5,12.5
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-9.5
       parent: 2
   - uid: 1459
     components:
     - type: Transform
-      pos: 2.5,14.5
+      rot: 3.141592653589793 rad
+      pos: -11.5,4.5
       parent: 2
   - uid: 1460
     components:
     - type: Transform
-      pos: 2.5,15.5
+      rot: 3.141592653589793 rad
+      pos: -8.5,4.5
       parent: 2
   - uid: 1461
     components:
     - type: Transform
-      pos: 2.5,16.5
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-7.5
       parent: 2
   - uid: 1462
     components:
     - type: Transform
-      pos: 2.5,17.5
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-4.5
       parent: 2
   - uid: 1463
     components:
     - type: Transform
-      pos: 2.5,18.5
+      pos: 12.5,5.5
       parent: 2
   - uid: 1464
     components:
     - type: Transform
-      pos: 2.5,19.5
+      pos: -7.5,13.5
       parent: 2
   - uid: 1465
     components:
     - type: Transform
-      pos: 2.5,20.5
+      pos: 12.5,3.5
       parent: 2
   - uid: 1466
     components:
     - type: Transform
-      pos: 2.5,21.5
+      pos: 2.5,8.5
       parent: 2
   - uid: 1467
     components:
     - type: Transform
-      pos: 1.5,7.5
+      pos: 2.5,7.5
       parent: 2
   - uid: 1468
     components:
     - type: Transform
-      pos: 1.5,8.5
+      pos: 2.5,9.5
       parent: 2
   - uid: 1469
     components:
     - type: Transform
-      pos: 1.5,9.5
+      pos: 2.5,10.5
       parent: 2
   - uid: 1470
     components:
     - type: Transform
-      pos: 1.5,10.5
+      pos: 2.5,11.5
       parent: 2
   - uid: 1471
     components:
     - type: Transform
-      pos: 1.5,11.5
+      pos: 2.5,12.5
       parent: 2
   - uid: 1472
     components:
     - type: Transform
-      pos: 1.5,12.5
+      pos: 2.5,14.5
       parent: 2
   - uid: 1473
     components:
     - type: Transform
-      pos: 1.5,13.5
+      pos: 2.5,15.5
       parent: 2
   - uid: 1474
     components:
     - type: Transform
-      pos: 1.5,14.5
+      pos: 2.5,16.5
       parent: 2
   - uid: 1475
     components:
     - type: Transform
-      pos: 1.5,15.5
+      pos: 2.5,17.5
       parent: 2
   - uid: 1476
     components:
     - type: Transform
-      pos: 1.5,16.5
+      pos: 2.5,18.5
       parent: 2
   - uid: 1477
     components:
     - type: Transform
-      pos: 1.5,17.5
+      pos: 2.5,19.5
       parent: 2
   - uid: 1478
     components:
     - type: Transform
-      pos: 1.5,18.5
+      pos: 2.5,20.5
       parent: 2
   - uid: 1479
     components:
     - type: Transform
-      pos: 1.5,19.5
+      pos: 2.5,21.5
       parent: 2
   - uid: 1480
     components:
     - type: Transform
-      pos: 1.5,20.5
+      pos: 1.5,7.5
       parent: 2
   - uid: 1481
     components:
     - type: Transform
-      pos: 1.5,21.5
+      pos: 1.5,8.5
       parent: 2
   - uid: 1482
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 2
+  - uid: 1483
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 2
+  - uid: 1484
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 2
+  - uid: 1485
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 2
+  - uid: 1486
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 2
+  - uid: 1487
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 2
+  - uid: 1488
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 2
+  - uid: 1489
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 2
+  - uid: 1490
+    components:
+    - type: Transform
+      pos: 1.5,17.5
+      parent: 2
+  - uid: 1491
+    components:
+    - type: Transform
+      pos: 1.5,18.5
+      parent: 2
+  - uid: 1492
+    components:
+    - type: Transform
+      pos: 1.5,19.5
+      parent: 2
+  - uid: 1493
+    components:
+    - type: Transform
+      pos: 1.5,20.5
+      parent: 2
+  - uid: 1494
+    components:
+    - type: Transform
+      pos: 1.5,21.5
+      parent: 2
+  - uid: 1495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,0.5
       parent: 2
-  - uid: 1483
+  - uid: 1496
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 2
-  - uid: 1484
+  - uid: 1497
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 2
-  - uid: 1485
+  - uid: 1498
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 2
-  - uid: 1486
+  - uid: 1499
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 2
-  - uid: 1487
+  - uid: 1500
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
-  - uid: 1488
+  - uid: 1501
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 2
-  - uid: 1489
+  - uid: 1502
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 2
-  - uid: 1490
+  - uid: 1503
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 2
-  - uid: 1491
+  - uid: 1504
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 2
-  - uid: 1492
+  - uid: 1505
     components:
     - type: Transform
       pos: 0.5,17.5
       parent: 2
-  - uid: 1493
+  - uid: 1506
     components:
     - type: Transform
       pos: 0.5,18.5
       parent: 2
-  - uid: 1494
+  - uid: 1507
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 2
-  - uid: 1495
+  - uid: 1508
     components:
     - type: Transform
       pos: 0.5,20.5
       parent: 2
-  - uid: 1496
+  - uid: 1509
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 2
-  - uid: 1497
+  - uid: 1510
     components:
     - type: Transform
       pos: -9.5,7.5
       parent: 2
-  - uid: 1498
+  - uid: 1511
     components:
     - type: Transform
       pos: 12.5,-1.5
       parent: 2
-  - uid: 1499
+  - uid: 1512
     components:
     - type: Transform
       pos: 21.5,2.5
       parent: 2
-  - uid: 1500
+  - uid: 1513
     components:
     - type: Transform
       pos: 24.5,1.5
       parent: 2
-  - uid: 1501
+  - uid: 1514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,4.5
       parent: 2
-  - uid: 1502
+  - uid: 1515
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,5.5
       parent: 2
-  - uid: 1503
+  - uid: 1516
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,6.5
       parent: 2
-  - uid: 1504
+  - uid: 1517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,7.5
       parent: 2
-  - uid: 1505
+  - uid: 1518
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,0.5
       parent: 2
-  - uid: 1506
+  - uid: 1519
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-0.5
       parent: 2
-  - uid: 1507
+  - uid: 1520
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-1.5
       parent: 2
-  - uid: 1508
+  - uid: 1521
     components:
     - type: Transform
       pos: -9.5,-4.5
       parent: 2
-  - uid: 1509
+  - uid: 1522
     components:
     - type: Transform
       pos: 24.5,3.5
       parent: 2
-  - uid: 1510
+  - uid: 1523
     components:
     - type: Transform
       pos: 22.5,3.5
       parent: 2
-  - uid: 1511
+  - uid: 1524
     components:
     - type: Transform
       pos: 21.5,3.5
       parent: 2
-  - uid: 1512
+  - uid: 1525
     components:
     - type: Transform
       pos: 26.5,1.5
       parent: 2
-  - uid: 1513
-    components:
-    - type: Transform
-      pos: 28.5,3.5
-      parent: 2
-  - uid: 1514
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,12.5
-      parent: 2
-  - uid: 1515
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,12.5
-      parent: 2
-  - uid: 1516
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,12.5
-      parent: 2
-  - uid: 1517
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,13.5
-      parent: 2
-  - uid: 1518
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,12.5
-      parent: 2
-  - uid: 1519
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,11.5
-      parent: 2
-  - uid: 1520
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,12.5
-      parent: 2
-  - uid: 1521
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,11.5
-      parent: 2
-  - uid: 1522
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,4.5
-      parent: 2
-  - uid: 1523
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,4.5
-      parent: 2
-  - uid: 1524
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,0.5
-      parent: 2
-  - uid: 1525
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,0.5
-      parent: 2
   - uid: 1526
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,15.5
+      pos: 28.5,3.5
       parent: 2
   - uid: 1527
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,15.5
+      pos: 7.5,12.5
       parent: 2
   - uid: 1528
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,12.5
+      pos: 8.5,12.5
       parent: 2
   - uid: 1529
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,12.5
+      pos: -8.5,12.5
       parent: 2
   - uid: 1530
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-7.5
+      rot: 1.5707963267948966 rad
+      pos: -9.5,13.5
       parent: 2
   - uid: 1531
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-7.5
+      pos: 9.5,12.5
       parent: 2
   - uid: 1532
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-10.5
+      rot: 1.5707963267948966 rad
+      pos: -8.5,11.5
       parent: 2
   - uid: 1533
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-10.5
+      rot: 3.141592653589793 rad
+      pos: 11.5,12.5
       parent: 2
   - uid: 1534
     components:
     - type: Transform
-      pos: 32.5,-12.5
+      rot: 3.141592653589793 rad
+      pos: 11.5,11.5
       parent: 2
   - uid: 1535
     components:
     - type: Transform
-      pos: 28.5,-10.5
+      rot: 3.141592653589793 rad
+      pos: 11.5,4.5
       parent: 2
   - uid: 1536
     components:
     - type: Transform
-      pos: -9.5,0.5
+      rot: 3.141592653589793 rad
+      pos: 14.5,4.5
       parent: 2
   - uid: 1537
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,18.5
+      rot: 3.141592653589793 rad
+      pos: 14.5,0.5
       parent: 2
   - uid: 1538
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,19.5
+      rot: 3.141592653589793 rad
+      pos: 11.5,0.5
       parent: 2
   - uid: 1539
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 10.5,18.5
+      pos: -0.5,15.5
       parent: 2
   - uid: 1540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 10.5,19.5
+      pos: 3.5,15.5
       parent: 2
   - uid: 1541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,20.5
+      pos: 3.5,12.5
       parent: 2
   - uid: 1542
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,12.5
+      pos: -0.5,12.5
       parent: 2
   - uid: 1543
     components:
     - type: Transform
-      pos: 5.5,16.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-7.5
       parent: 2
   - uid: 1544
     components:
     - type: Transform
-      pos: 14.5,16.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-7.5
       parent: 2
   - uid: 1545
     components:
     - type: Transform
-      pos: 13.5,16.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-10.5
       parent: 2
   - uid: 1546
     components:
     - type: Transform
-      pos: 12.5,16.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-10.5
       parent: 2
   - uid: 1547
     components:
     - type: Transform
-      pos: 11.5,16.5
+      pos: 32.5,-12.5
       parent: 2
   - uid: 1548
     components:
     - type: Transform
-      pos: 28.5,1.5
+      pos: 28.5,-10.5
       parent: 2
   - uid: 1549
     components:
     - type: Transform
-      pos: 26.5,3.5
+      pos: -9.5,0.5
       parent: 2
   - uid: 1550
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 33.5,-2.5
+      rot: -1.5707963267948966 rad
+      pos: 8.5,18.5
       parent: 2
   - uid: 1551
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 33.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,19.5
       parent: 2
   - uid: 1552
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 33.5,-4.5
+      rot: -1.5707963267948966 rad
+      pos: 10.5,18.5
       parent: 2
   - uid: 1553
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 32.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: 10.5,19.5
       parent: 2
   - uid: 1554
     components:
     - type: Transform
-      pos: 33.5,2.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,20.5
       parent: 2
   - uid: 1555
     components:
     - type: Transform
-      pos: 33.5,3.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,12.5
       parent: 2
   - uid: 1556
     components:
     - type: Transform
-      pos: 33.5,4.5
+      pos: 5.5,16.5
       parent: 2
   - uid: 1557
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,16.5
+      pos: 14.5,16.5
       parent: 2
   - uid: 1558
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,29.5
+      pos: 13.5,16.5
       parent: 2
   - uid: 1559
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,27.5
+      pos: 12.5,16.5
       parent: 2
   - uid: 1560
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,29.5
+      pos: 11.5,16.5
       parent: 2
   - uid: 1561
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,23.5
+      pos: 28.5,1.5
       parent: 2
   - uid: 1562
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,23.5
+      pos: 26.5,3.5
       parent: 2
   - uid: 1563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,25.5
+      pos: 33.5,-2.5
       parent: 2
   - uid: 1564
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,25.5
+      pos: 33.5,-3.5
       parent: 2
   - uid: 1565
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,27.5
+      pos: 33.5,-4.5
       parent: 2
   - uid: 1566
     components:
     - type: Transform
-      pos: 0.5,31.5
+      rot: 1.5707963267948966 rad
+      pos: 32.5,-3.5
       parent: 2
   - uid: 1567
     components:
     - type: Transform
-      pos: 2.5,31.5
+      pos: 33.5,2.5
       parent: 2
   - uid: 1568
     components:
     - type: Transform
-      pos: 2.5,33.5
+      pos: 33.5,3.5
       parent: 2
   - uid: 1569
     components:
     - type: Transform
-      pos: 0.5,33.5
+      pos: 33.5,4.5
       parent: 2
   - uid: 1570
     components:
     - type: Transform
-      pos: 2.5,35.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,16.5
       parent: 2
   - uid: 1571
     components:
     - type: Transform
-      pos: -10.5,42.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,29.5
       parent: 2
   - uid: 1572
     components:
     - type: Transform
-      pos: -10.5,32.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,27.5
       parent: 2
   - uid: 1573
     components:
     - type: Transform
-      pos: -10.5,31.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,29.5
       parent: 2
   - uid: 1574
     components:
     - type: Transform
-      pos: -10.5,35.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,23.5
       parent: 2
   - uid: 1575
     components:
     - type: Transform
-      pos: -10.5,34.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,23.5
       parent: 2
   - uid: 1576
     components:
     - type: Transform
-      pos: -10.5,33.5
+      rot: 1.5707963267948966 rad
+      pos: 0.5,25.5
       parent: 2
   - uid: 1577
     components:
     - type: Transform
-      pos: -10.5,40.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,25.5
       parent: 2
   - uid: 1578
     components:
     - type: Transform
-      pos: -10.5,39.5
+      rot: 1.5707963267948966 rad
+      pos: 2.5,27.5
       parent: 2
   - uid: 1579
     components:
     - type: Transform
-      pos: -10.5,38.5
+      pos: 0.5,31.5
       parent: 2
   - uid: 1580
     components:
     - type: Transform
-      pos: -10.5,37.5
+      pos: 2.5,31.5
       parent: 2
   - uid: 1581
     components:
     - type: Transform
-      pos: -10.5,36.5
+      pos: 2.5,33.5
       parent: 2
   - uid: 1582
     components:
     - type: Transform
-      pos: -10.5,41.5
+      pos: 0.5,33.5
       parent: 2
   - uid: 1583
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,31.5
+      pos: 2.5,35.5
       parent: 2
   - uid: 1584
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,34.5
+      pos: -10.5,42.5
       parent: 2
   - uid: 1585
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,36.5
+      pos: -10.5,32.5
       parent: 2
   - uid: 1586
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,41.5
+      pos: -10.5,31.5
       parent: 2
   - uid: 1587
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,37.5
+      pos: -10.5,35.5
       parent: 2
   - uid: 1588
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,35.5
+      pos: -10.5,34.5
       parent: 2
   - uid: 1589
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,38.5
+      pos: -10.5,33.5
       parent: 2
   - uid: 1590
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,39.5
+      pos: -10.5,40.5
       parent: 2
   - uid: 1591
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,40.5
+      pos: -10.5,39.5
       parent: 2
   - uid: 1592
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,33.5
+      pos: -10.5,38.5
       parent: 2
   - uid: 1593
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,32.5
+      pos: -10.5,37.5
       parent: 2
   - uid: 1594
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,37.5
+      pos: -10.5,36.5
       parent: 2
   - uid: 1595
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,35.5
+      pos: -10.5,41.5
       parent: 2
   - uid: 1596
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,39.5
+      pos: 13.5,31.5
       parent: 2
   - uid: 1597
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,39.5
+      pos: 13.5,34.5
       parent: 2
   - uid: 1598
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,37.5
+      pos: 13.5,36.5
       parent: 2
   - uid: 1599
     components:
     - type: Transform
-      pos: 5.5,47.5
+      rot: -1.5707963267948966 rad
+      pos: 13.5,41.5
       parent: 2
   - uid: 1600
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,52.5
+      pos: 13.5,37.5
       parent: 2
   - uid: 1601
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,46.5
+      pos: 13.5,35.5
       parent: 2
   - uid: 1602
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,46.5
+      pos: 13.5,38.5
       parent: 2
   - uid: 1603
     components:
     - type: Transform
-      pos: -1.5,53.5
+      rot: -1.5707963267948966 rad
+      pos: 13.5,39.5
       parent: 2
   - uid: 1604
     components:
     - type: Transform
-      pos: -1.5,52.5
+      rot: -1.5707963267948966 rad
+      pos: 13.5,40.5
       parent: 2
   - uid: 1605
     components:
     - type: Transform
-      pos: -1.5,51.5
+      rot: -1.5707963267948966 rad
+      pos: 13.5,33.5
       parent: 2
   - uid: 1606
     components:
     - type: Transform
-      pos: -2.5,53.5
+      rot: -1.5707963267948966 rad
+      pos: 13.5,32.5
       parent: 2
   - uid: 1607
     components:
     - type: Transform
-      pos: -2.5,52.5
+      rot: -1.5707963267948966 rad
+      pos: 0.5,37.5
       parent: 2
   - uid: 1608
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,53.5
+      pos: 0.5,35.5
       parent: 2
   - uid: 1609
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,51.5
+      pos: 0.5,39.5
       parent: 2
   - uid: 1610
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,51.5
+      pos: 2.5,39.5
       parent: 2
   - uid: 1611
     components:
     - type: Transform
-      pos: 5.5,45.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,37.5
       parent: 2
   - uid: 1612
     components:
     - type: Transform
-      pos: 7.5,47.5
+      pos: 5.5,47.5
       parent: 2
   - uid: 1613
     components:
     - type: Transform
-      pos: 7.5,45.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,52.5
       parent: 2
   - uid: 1614
     components:
     - type: Transform
-      pos: 9.5,47.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,46.5
       parent: 2
   - uid: 1615
     components:
     - type: Transform
-      pos: 9.5,45.5
+      rot: -1.5707963267948966 rad
+      pos: 3.5,46.5
       parent: 2
   - uid: 1616
     components:
     - type: Transform
-      pos: 10.5,47.5
+      pos: -1.5,53.5
       parent: 2
   - uid: 1617
     components:
     - type: Transform
-      pos: -2.5,47.5
+      pos: -1.5,52.5
       parent: 2
   - uid: 1618
     components:
     - type: Transform
-      pos: 10.5,45.5
+      pos: -1.5,51.5
       parent: 2
   - uid: 1619
+    components:
+    - type: Transform
+      pos: -2.5,53.5
+      parent: 2
+  - uid: 1620
+    components:
+    - type: Transform
+      pos: -2.5,52.5
+      parent: 2
+  - uid: 1621
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,53.5
+      parent: 2
+  - uid: 1622
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,51.5
+      parent: 2
+  - uid: 1623
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,51.5
+      parent: 2
+  - uid: 1624
+    components:
+    - type: Transform
+      pos: 5.5,45.5
+      parent: 2
+  - uid: 1625
+    components:
+    - type: Transform
+      pos: 7.5,47.5
+      parent: 2
+  - uid: 1626
+    components:
+    - type: Transform
+      pos: 7.5,45.5
+      parent: 2
+  - uid: 1627
+    components:
+    - type: Transform
+      pos: 9.5,47.5
+      parent: 2
+  - uid: 1628
+    components:
+    - type: Transform
+      pos: 9.5,45.5
+      parent: 2
+  - uid: 1629
+    components:
+    - type: Transform
+      pos: 10.5,47.5
+      parent: 2
+  - uid: 1630
+    components:
+    - type: Transform
+      pos: -2.5,47.5
+      parent: 2
+  - uid: 1631
+    components:
+    - type: Transform
+      pos: 10.5,45.5
+      parent: 2
+  - uid: 1632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,55.5
       parent: 2
-  - uid: 1620
+  - uid: 1633
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.5,52.5
       parent: 2
-  - uid: 1621
+  - uid: 1634
     components:
     - type: Transform
       pos: 9.5,46.5
       parent: 2
-  - uid: 1622
+  - uid: 1635
     components:
     - type: Transform
       pos: 5.5,46.5
       parent: 2
-  - uid: 1623
+  - uid: 1636
     components:
     - type: Transform
       pos: -2.5,46.5
       parent: 2
-  - uid: 1624
+  - uid: 1637
     components:
     - type: Transform
       pos: -2.5,45.5
       parent: 2
-  - uid: 1625
+  - uid: 1638
     components:
     - type: Transform
       pos: -6.5,45.5
       parent: 2
-  - uid: 1626
+  - uid: 1639
     components:
     - type: Transform
       pos: -6.5,46.5
       parent: 2
-  - uid: 1627
+  - uid: 1640
     components:
     - type: Transform
       pos: -6.5,47.5
       parent: 2
-  - uid: 1628
+  - uid: 1641
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,52.5
       parent: 2
-  - uid: 1629
+  - uid: 1642
     components:
     - type: Transform
       pos: 3.5,54.5
       parent: 2
-  - uid: 1630
+  - uid: 1643
     components:
     - type: Transform
       pos: 5.5,54.5
       parent: 2
-  - uid: 1631
+  - uid: 1644
     components:
     - type: Transform
       pos: 6.5,54.5
       parent: 2
-  - uid: 1632
+  - uid: 1645
     components:
     - type: Transform
       pos: 7.5,54.5
       parent: 2
-  - uid: 1633
+  - uid: 1646
     components:
     - type: Transform
       pos: 9.5,54.5
       parent: 2
-  - uid: 1634
+  - uid: 1647
     components:
     - type: Transform
       pos: 13.5,42.5
       parent: 2
-  - uid: 1635
+  - uid: 1648
     components:
     - type: Transform
       pos: -18.5,3.5
       parent: 2
-  - uid: 1636
+  - uid: 1649
     components:
     - type: Transform
       pos: -18.5,2.5
       parent: 2
-  - uid: 1637
+  - uid: 1650
     components:
     - type: Transform
       pos: -18.5,1.5
       parent: 2
-  - uid: 1638
+  - uid: 1651
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 2
-  - uid: 1639
+  - uid: 1652
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 2
-  - uid: 1640
+  - uid: 1653
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 2
-  - uid: 1641
+  - uid: 1654
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-18.5
       parent: 2
-  - uid: 1642
+  - uid: 1655
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-18.5
       parent: 2
-  - uid: 1643
+  - uid: 1656
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-20.5
       parent: 2
-  - uid: 1644
+  - uid: 1657
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-20.5
       parent: 2
-  - uid: 1645
+  - uid: 1658
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-22.5
       parent: 2
-  - uid: 1646
+  - uid: 1659
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-22.5
       parent: 2
-  - uid: 1647
+  - uid: 1660
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-24.5
       parent: 2
-  - uid: 1648
+  - uid: 1661
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-24.5
       parent: 2
-  - uid: 1649
+  - uid: 1662
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-27.5
       parent: 2
-  - uid: 1650
+  - uid: 1663
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-27.5
       parent: 2
-  - uid: 1651
+  - uid: 1664
     components:
     - type: Transform
       pos: -3.5,-30.5
       parent: 2
-  - uid: 1652
+  - uid: 1665
     components:
     - type: Transform
       pos: -0.5,-35.5
       parent: 2
-  - uid: 1653
+  - uid: 1666
     components:
     - type: Transform
       pos: -27.5,-0.5
       parent: 2
-  - uid: 1654
+  - uid: 1667
     components:
     - type: Transform
       pos: -42.5,0.5
       parent: 2
-  - uid: 1655
+  - uid: 1668
     components:
     - type: Transform
       pos: -42.5,4.5
       parent: 2
-  - uid: 1656
+  - uid: 1669
     components:
     - type: Transform
       pos: -19.5,1.5
       parent: 2
-  - uid: 1657
+  - uid: 1670
     components:
     - type: Transform
       pos: -19.5,3.5
       parent: 2
-  - uid: 1658
+  - uid: 1671
     components:
     - type: Transform
       pos: -21.5,3.5
       parent: 2
-  - uid: 1659
+  - uid: 1672
     components:
     - type: Transform
       pos: -23.5,3.5
       parent: 2
-  - uid: 1660
+  - uid: 1673
     components:
     - type: Transform
       pos: -23.5,1.5
       parent: 2
-  - uid: 1661
+  - uid: 1674
     components:
     - type: Transform
       pos: -25.5,1.5
       parent: 2
-  - uid: 1662
+  - uid: 1675
     components:
     - type: Transform
       pos: -25.5,3.5
       parent: 2
 - proto: Chair
   entities:
-  - uid: 1663
+  - uid: 1676
     components:
     - type: Transform
       pos: 1.5,37.5
       parent: 2
-  - uid: 1664
+  - uid: 1677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,35.5
       parent: 2
-  - uid: 1665
+  - uid: 1678
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,1.5
       parent: 2
-  - uid: 1666
-    components:
-    - type: Transform
-      pos: 25.5,2.5
-      parent: 2
-  - uid: 1667
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 32.5,-9.5
-      parent: 2
-  - uid: 1668
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,-0.5
-      parent: 2
-  - uid: 1669
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,24.5
-      parent: 2
-  - uid: 1670
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,28.5
-      parent: 2
-  - uid: 1671
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,25.5
-      parent: 2
-  - uid: 1672
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,26.5
-      parent: 2
-  - uid: 1673
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,27.5
-      parent: 2
-  - uid: 1674
-    components:
-    - type: Transform
-      pos: 11.5,-27.5
-      parent: 2
-  - uid: 1675
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-29.5
-      parent: 2
-  - uid: 1676
-    components:
-    - type: Transform
-      pos: 17.5,-29.5
-      parent: 2
-  - uid: 1677
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-30.5
-      parent: 2
-  - uid: 1678
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.5,-31.5
-      parent: 2
   - uid: 1679
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,-41.5
+      pos: 25.5,2.5
       parent: 2
   - uid: 1680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 13.5,-41.5
+      pos: 32.5,-9.5
       parent: 2
   - uid: 1681
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,-29.5
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-0.5
       parent: 2
   - uid: 1682
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 16.5,-36.5
+      pos: 2.5,24.5
       parent: 2
   - uid: 1683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 16.5,-35.5
+      pos: 2.5,28.5
       parent: 2
   - uid: 1684
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 16.5,-34.5
+      pos: 2.5,25.5
       parent: 2
   - uid: 1685
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,26.5
+      parent: 2
+  - uid: 1686
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,27.5
+      parent: 2
+  - uid: 1687
+    components:
+    - type: Transform
+      pos: 11.5,-27.5
+      parent: 2
+  - uid: 1688
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-29.5
+      parent: 2
+  - uid: 1689
+    components:
+    - type: Transform
+      pos: 17.5,-29.5
+      parent: 2
+  - uid: 1690
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-30.5
+      parent: 2
+  - uid: 1691
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-31.5
+      parent: 2
+  - uid: 1692
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-41.5
+      parent: 2
+  - uid: 1693
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-41.5
+      parent: 2
+  - uid: 1694
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-29.5
+      parent: 2
+  - uid: 1695
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-36.5
+      parent: 2
+  - uid: 1696
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-35.5
+      parent: 2
+  - uid: 1697
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-34.5
+      parent: 2
+  - uid: 1698
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14672,52 +14672,52 @@ entities:
       parent: 2
 - proto: ChairOfficeDark
   entities:
-  - uid: 1686
+  - uid: 1699
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.495495,52.496975
       parent: 2
-  - uid: 1687
+  - uid: 1700
     components:
     - type: Transform
       pos: -32.474518,5.5515475
       parent: 2
-  - uid: 1688
+  - uid: 1701
     components:
     - type: Transform
       pos: -38.5,4.5
       parent: 2
-  - uid: 1689
+  - uid: 1702
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -29.5,0.5
       parent: 2
-  - uid: 1690
+  - uid: 1703
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,0.5
       parent: 2
-  - uid: 1691
+  - uid: 1704
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,0.5
       parent: 2
-  - uid: 1692
+  - uid: 1705
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,0.5
       parent: 2
-  - uid: 1693
+  - uid: 1706
     components:
     - type: Transform
       pos: -33.266186,5.634881
       parent: 2
-  - uid: 1694
+  - uid: 1707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -14728,7 +14728,7 @@ entities:
       linearDamping: 8
     - type: Pullable
       prevFixedRotation: True
-  - uid: 1695
+  - uid: 1708
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -14736,167 +14736,167 @@ entities:
       parent: 2
 - proto: ChemDispenser
   entities:
-  - uid: 1696
+  - uid: 1709
     components:
     - type: Transform
       pos: -3.5,47.5
       parent: 2
-  - uid: 1697
+  - uid: 1710
     components:
     - type: Transform
       pos: -5.5,47.5
       parent: 2
 - proto: ChemicalPayload
   entities:
-  - uid: 1698
+  - uid: 1711
     components:
     - type: Transform
       pos: -7.5956764,46.4279
       parent: 2
-  - uid: 1699
+  - uid: 1712
     components:
     - type: Transform
       pos: -7.5956764,46.4279
       parent: 2
-  - uid: 1700
+  - uid: 1713
     components:
     - type: Transform
       pos: -7.5956764,46.4279
       parent: 2
-  - uid: 1701
+  - uid: 1714
     components:
     - type: Transform
       pos: -7.5956764,46.4279
       parent: 2
 - proto: ChemicalSynthesisKit
   entities:
-  - uid: 1702
+  - uid: 1715
     components:
     - type: Transform
       pos: -7.605975,47.51026
       parent: 2
 - proto: ChemistryHotplate
   entities:
-  - uid: 1703
+  - uid: 1716
     components:
     - type: Transform
       pos: -6.5,45.5
       parent: 2
 - proto: ChemMaster
   entities:
-  - uid: 1704
+  - uid: 1717
     components:
     - type: Transform
       pos: -2.5,47.5
       parent: 2
-  - uid: 1705
+  - uid: 1718
     components:
     - type: Transform
       pos: -6.5,47.5
       parent: 2
 - proto: Cigarette
   entities:
-  - uid: 1706
+  - uid: 1719
     components:
     - type: Transform
       pos: 26.459034,2.946263
       parent: 2
-  - uid: 1707
+  - uid: 1720
     components:
     - type: Transform
       pos: 26.320145,2.849041
       parent: 2
-  - uid: 1708
+  - uid: 1721
     components:
     - type: Transform
       pos: 26.334034,2.9184854
       parent: 2
 - proto: CigarGold
   entities:
-  - uid: 1709
+  - uid: 1722
     components:
     - type: Transform
       pos: 40.691532,-30.947525
       parent: 2
-  - uid: 1710
+  - uid: 1723
     components:
     - type: Transform
       pos: 39.34894,-30.25308
       parent: 2
-  - uid: 1711
+  - uid: 1724
     components:
     - type: Transform
       pos: 39.524868,-30.225304
       parent: 2
 - proto: CigPackBlue
   entities:
-  - uid: 1712
+  - uid: 1725
     components:
     - type: Transform
       pos: 9.155782,-28.049753
       parent: 2
 - proto: CigPackSoviet
   entities:
-  - uid: 1714
+  - uid: 1727
     components:
     - type: Transform
-      parent: 1713
+      parent: 1726
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1713
+      storage: 1726
 - proto: CigPackSyndicate
   entities:
-  - uid: 1716
+  - uid: 1729
     components:
     - type: Transform
       pos: -36.21977,1.1540551
       parent: 2
 - proto: ClosetRadiationSuitFilled
   entities:
-  - uid: 1717
+  - uid: 1730
     components:
     - type: Transform
       pos: 0.5,43.5
       parent: 2
-  - uid: 1718
+  - uid: 1731
     components:
     - type: Transform
       pos: 2.5,44.5
       parent: 2
-  - uid: 1719
+  - uid: 1732
     components:
     - type: Transform
       pos: 30.5,6.5
       parent: 2
-  - uid: 1720
+  - uid: 1733
     components:
     - type: Transform
       pos: 33.5,6.5
       parent: 2
-  - uid: 1721
+  - uid: 1734
     components:
     - type: Transform
       pos: 32.5,6.5
       parent: 2
-  - uid: 1722
+  - uid: 1735
     components:
     - type: Transform
       pos: 31.5,6.5
       parent: 2
-  - uid: 1723
+  - uid: 1736
     components:
     - type: Transform
       pos: 2.5,43.5
       parent: 2
-  - uid: 1724
+  - uid: 1737
     components:
     - type: Transform
       pos: 0.5,44.5
       parent: 2
 - proto: ClothingBackpackDuffelAbductorFilled
   entities:
-  - uid: 1725
+  - uid: 1738
     components:
     - type: Transform
       pos: -21.53909,60.490067
@@ -14924,33 +14924,33 @@ entities:
         title: null
 - proto: ClothingBackpackDuffelSyndicateFilledMedical
   entities:
-  - uid: 1726
+  - uid: 1739
     components:
     - type: Transform
       pos: -3.484619,45.659508
       parent: 2
 - proto: ClothingBackpackSyndicate
   entities:
-  - uid: 1727
+  - uid: 1740
     components:
     - type: Transform
       pos: 9.3442745,47.65289
       parent: 2
-  - uid: 1728
+  - uid: 1741
     components:
     - type: Transform
       pos: 9.39013,47.58431
       parent: 2
 - proto: ClothingBeltJanitorFilled
   entities:
-  - uid: 1729
+  - uid: 1742
     components:
     - type: Transform
       pos: -18.970686,-22.780962
       parent: 2
 - proto: ClothingBeltSalvageMercWebbing
   entities:
-  - uid: 1730
+  - uid: 1743
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -14958,7 +14958,7 @@ entities:
       parent: 2
 - proto: ClothingBeltSovietMarineWebbing
   entities:
-  - uid: 1731
+  - uid: 1744
     components:
     - type: Transform
       pos: 25.519642,7.54024
@@ -14983,193 +14983,204 @@ entities:
         title: null
 - proto: ClothingBeltUtilityFilled
   entities:
-  - uid: 1732
+  - uid: 1745
     components:
     - type: Transform
       pos: 30.698162,4.5478916
       parent: 2
-  - uid: 1733
+  - uid: 1746
     components:
     - type: Transform
       pos: 30.698162,4.631225
       parent: 2
-  - uid: 1734
+  - uid: 1747
     components:
     - type: Transform
       pos: 30.698162,4.483077
       parent: 2
-  - uid: 1735
+  - uid: 1748
     components:
     - type: Transform
       pos: 30.401867,4.631225
       parent: 2
-  - uid: 1736
+  - uid: 1749
     components:
     - type: Transform
       pos: 30.411125,4.5386324
       parent: 2
-  - uid: 1737
+  - uid: 1750
     components:
     - type: Transform
       pos: 30.411125,4.464558
       parent: 2
+- proto: ClothingEyesGlassesMercenary
+  entities:
+  - uid: 1780
+    components:
+    - type: Transform
+      parent: 1776
+    - type: Clothing
+      inSlot: eyes
+      inSlotFlag: EYES
+    - type: Physics
+      canCollide: False
 - proto: ClothingEyesGlassesThermal
   entities:
-  - uid: 1738
+  - uid: 1751
     components:
     - type: Transform
       pos: -36.441067,1.2825253
       parent: 2
 - proto: ClothingEyesHudBeer
   entities:
-  - uid: 1739
+  - uid: 1752
     components:
     - type: Transform
       pos: -0.3658551,40.501442
       parent: 2
 - proto: ClothingHandsGlovesCombat
   entities:
-  - uid: 1740
+  - uid: 1753
     components:
     - type: Transform
       pos: 9.64983,47.680668
       parent: 2
-  - uid: 1741
+  - uid: 1754
     components:
     - type: Transform
       pos: 9.64983,47.680668
       parent: 2
 - proto: ClothingHandsSalvageMercGlovesCombat
   entities:
-  - uid: 1742
+  - uid: 1755
     components:
     - type: Transform
       pos: 21.459843,63.645782
       parent: 2
 - proto: ClothingHeadHatCone
   entities:
-  - uid: 1743
+  - uid: 1756
     components:
     - type: Transform
       pos: -9.427302,5.1318336
       parent: 2
-  - uid: 1744
+  - uid: 1757
     components:
     - type: Transform
       pos: 3.5216458,-8.830348
       parent: 2
-  - uid: 1745
+  - uid: 1758
     components:
     - type: Transform
       pos: 13.661793,0.4808635
       parent: 2
-  - uid: 1746
+  - uid: 1759
     components:
     - type: Transform
       pos: 13.01596,0.7516968
       parent: 2
-  - uid: 1747
+  - uid: 1760
     components:
     - type: Transform
       pos: 3.6605346,-8.274792
       parent: 2
-  - uid: 1748
+  - uid: 1761
     components:
     - type: Transform
       pos: -6.5169115,14.531375
       parent: 2
-  - uid: 1749
+  - uid: 1762
     components:
     - type: Transform
       pos: 3.7160904,-9.385903
       parent: 2
-  - uid: 1750
+  - uid: 1763
     components:
     - type: Transform
       pos: -10.635635,4.7568336
       parent: 2
-  - uid: 1751
+  - uid: 1764
     components:
     - type: Transform
       pos: 12.39096,0.46003017
       parent: 2
-  - uid: 1752
+  - uid: 1765
     components:
     - type: Transform
       pos: -5.7667685,13.573041
       parent: 2
-  - uid: 1753
+  - uid: 1766
     components:
     - type: Transform
       pos: 0.28403473,53.35935
       parent: 2
-  - uid: 1754
+  - uid: 1767
     components:
     - type: Transform
       pos: 0.67986804,52.81768
       parent: 2
-  - uid: 1755
+  - uid: 1768
     components:
     - type: Transform
       pos: 0.36736804,51.98435
       parent: 2
-  - uid: 1756
+  - uid: 1769
     components:
     - type: Transform
       pos: 7.393566,51.228863
       parent: 2
-  - uid: 1757
+  - uid: 1770
     components:
     - type: Transform
       pos: 6.768566,51.048306
       parent: 2
-  - uid: 1758
+  - uid: 1771
     components:
     - type: Transform
       pos: 6.504678,50.423306
       parent: 2
-  - uid: 1759
+  - uid: 1772
     components:
     - type: Transform
       pos: 7.963011,51.03442
       parent: 2
 - proto: ClothingHeadHatCowboyBrown
   entities:
-  - uid: 1761
+  - uid: 10
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: ClothingHeadHatHetmanHat
   entities:
-  - uid: 1774
+  - uid: 1773
     components:
     - type: Transform
       pos: 17.890541,-28.43083
       parent: 2
 - proto: ClothingHeadHatHoodCulthood
   entities:
-  - uid: 1775
+  - uid: 1774
     components:
     - type: Transform
       pos: 32.48536,-40.950134
       parent: 2
 - proto: ClothingHeadHatRichard
   entities:
-  - uid: 1776
+  - uid: 1775
     components:
     - type: Transform
       pos: 7.4258804,-34.48426
       parent: 2
 - proto: ClothingHeadHatSovietAdmiralHat
   entities:
-  - uid: 1778
+  - uid: 1777
     components:
     - type: Transform
-      parent: 1777
+      parent: 1776
     - type: Clothing
       inSlot: head
       inSlotFlag: HEAD
@@ -15238,22 +15249,6 @@ entities:
     components:
     - type: Transform
       pos: -24.263155,24.577642
-      parent: 2
-- proto: ClothingNeckCloakCommissar
-  entities:
-  - uid: 1779
-    components:
-    - type: Transform
-      parent: 1777
-    - type: Clothing
-      inSlot: outerClothing
-      inSlotFlag: OUTERCLOTHING
-    - type: Physics
-      canCollide: False
-  - uid: 1790
-    components:
-    - type: Transform
-      pos: -36.48713,-0.45494884
       parent: 2
 - proto: ClothingOuterArmorCult
   entities:
@@ -15327,6 +15322,20 @@ entities:
       parent: 2
 - proto: ClothingOuterSovietCoat
   entities:
+  - uid: 1778
+    components:
+    - type: Transform
+      parent: 1776
+    - type: Clothing
+      inSlot: outerClothing
+      inSlotFlag: OUTERCLOTHING
+    - type: Physics
+      canCollide: False
+  - uid: 1790
+    components:
+    - type: Transform
+      pos: -36.480194,-0.38557494
+      parent: 2
   - uid: 1803
     components:
     - type: Transform
@@ -15392,14 +15401,14 @@ entities:
       parent: 2
 - proto: ClothingShoesLeather
   entities:
-  - uid: 1762
+  - uid: 11
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: ClothingSovietBandolier
   entities:
   - uid: 1815
@@ -15514,10 +15523,10 @@ entities:
       storage: 1792
 - proto: ClothingUniformJumpsuitSovietAdmiral
   entities:
-  - uid: 1780
+  - uid: 1779
     components:
     - type: Transform
-      parent: 1777
+      parent: 1776
     - type: Clothing
       inSlot: jumpsuit
       inSlotFlag: INNERCLOTHING
@@ -15525,14 +15534,14 @@ entities:
       canCollide: False
 - proto: ClothingUniformJumpsuitSovietFatigues
   entities:
-  - uid: 1715
+  - uid: 1728
     components:
     - type: Transform
-      parent: 1713
+      parent: 1726
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1713
+      storage: 1726
   - uid: 1807
     components:
     - type: Transform
@@ -17838,13 +17847,13 @@ entities:
       parent: 2
 - proto: FlashlightLantern
   entities:
-  - uid: 18
+  - uid: 31
     components:
     - type: Transform
       pos: 3.7763643,4.665565
       parent: 2
     - type: HandheldLight
-      toggleActionEntity: 19
+      toggleActionEntity: 32
     - type: ContainerContainer
       containers:
         cell_slot: !type:ContainerSlot
@@ -17855,15 +17864,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 19
+          - 32
     - type: ActionsContainer
-  - uid: 20
+  - uid: 33
     components:
     - type: Transform
       pos: 3.7489207,4.888139
       parent: 2
     - type: HandheldLight
-      toggleActionEntity: 21
+      toggleActionEntity: 34
     - type: ContainerContainer
       containers:
         cell_slot: !type:ContainerSlot
@@ -17874,7 +17883,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 21
+          - 34
     - type: ActionsContainer
 - proto: FloorLavaEntity
   entities:
@@ -25880,25 +25889,25 @@ entities:
       parent: 2
 - proto: JetpackSSFMarineFilled
   entities:
-  - uid: 14
+  - uid: 27
     components:
     - type: Transform
       pos: 10.536323,45.662663
       parent: 2
     - type: GasTank
-      toggleActionEntity: 15
+      toggleActionEntity: 28
     - type: Jump
-      actionEntity: 17
+      actionEntity: 30
     - type: Jetpack
-      toggleActionEntity: 16
+      toggleActionEntity: 29
     - type: ActionsContainer
     - type: ContainerContainer
       containers:
         actions: !type:Container
           ents:
-          - 16
-          - 17
-          - 15
+          - 29
+          - 30
+          - 28
   - uid: 3758
     components:
     - type: Transform
@@ -25933,15 +25942,15 @@ entities:
       parent: 2
 - proto: JumpJet
   entities:
-  - uid: 17
+  - uid: 30
     mapInit: true
     paused: true
     components:
     - type: Transform
-      parent: 14
+      parent: 27
     - type: Action
       originalIconColor: '#FFFFFFFF'
-      container: 14
+      container: 27
 - proto: KitchenElectricGrill
   entities:
   - uid: 3764
@@ -25987,13 +25996,13 @@ entities:
       parent: 2
 - proto: Lamp
   entities:
-  - uid: 24
+  - uid: 37
     components:
     - type: Transform
       pos: -33.541782,1.9873886
       parent: 2
     - type: HandheldLight
-      toggleActionEntity: 25
+      toggleActionEntity: 38
     - type: ContainerContainer
       containers:
         cell_slot: !type:ContainerSlot
@@ -26004,17 +26013,17 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 25
+          - 38
     - type: Physics
       canCollide: True
     - type: ActionsContainer
-  - uid: 26
+  - uid: 39
     components:
     - type: Transform
       pos: -39.533432,1.9665554
       parent: 2
     - type: HandheldLight
-      toggleActionEntity: 27
+      toggleActionEntity: 40
     - type: ContainerContainer
       containers:
         cell_slot: !type:ContainerSlot
@@ -26025,7 +26034,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 27
+          - 40
     - type: Physics
       canCollide: True
     - type: ActionsContainer
@@ -26240,13 +26249,13 @@ entities:
       parent: 2
 - proto: Lantern
   entities:
-  - uid: 22
+  - uid: 35
     components:
     - type: Transform
       pos: -40.277966,5.2933135
       parent: 2
     - type: HandheldLight
-      toggleActionEntity: 23
+      toggleActionEntity: 36
     - type: ContainerContainer
       containers:
         cell_slot: !type:ContainerSlot
@@ -26257,7 +26266,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 23
+          - 36
     - type: ActionsContainer
   - uid: 3812
     components:
@@ -26288,44 +26297,44 @@ entities:
       parent: 2
 - proto: LeftArmSkeleton
   entities:
-  - uid: 1763
+  - uid: 12
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: LeftFootSkeleton
   entities:
-  - uid: 1764
+  - uid: 13
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: LeftHandSkeleton
   entities:
-  - uid: 1765
+  - uid: 14
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: LeftLegSkeleton
   entities:
-  - uid: 1766
+  - uid: 15
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: LightBulbCrystalRed
   entities:
   - uid: 3818
@@ -26402,7 +26411,7 @@ entities:
       - - NuclearOperative
 - proto: LockerFreezerBase
   entities:
-  - uid: 1760
+  - uid: 9
     components:
     - type: Transform
       pos: 31.5,29.5
@@ -26413,19 +26422,18 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1771
-          - 1770
-          - 1762
-          - 1769
-          - 1763
-          - 1765
-          - 1761
-          - 1764
-          - 1767
-          - 1772
-          - 1766
-          - 1768
-          - 1773
+          - 20
+          - 19
+          - 11
+          - 18
+          - 12
+          - 14
+          - 10
+          - 13
+          - 16
+          - 21
+          - 15
+          - 17
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -26454,7 +26462,7 @@ entities:
           ent: null
 - proto: LockerSyndicatePersonalFilled
   entities:
-  - uid: 1713
+  - uid: 1726
     components:
     - type: Transform
       pos: 4.5,47.5
@@ -26473,8 +26481,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 1714
-          - 1715
+          - 1727
+          - 1728
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -26655,12 +26663,12 @@ entities:
       parent: 2
 - proto: MagazinePistolSubMachineGunSP
   entities:
-  - uid: 3837
+  - uid: 3836
     components:
     - type: Transform
       pos: 7.6116095,47.70961
       parent: 2
-  - uid: 8807
+  - uid: 3837
     components:
     - type: Transform
       pos: 7.3616095,47.672573
@@ -26675,7 +26683,7 @@ entities:
       parent: 2
 - proto: Mannequin
   entities:
-  - uid: 1777
+  - uid: 1776
     components:
     - type: Transform
       pos: 10.5,46.5
@@ -26685,11 +26693,11 @@ entities:
         jumpsuit: !type:ContainerSlot
           showEnts: False
           occludes: False
-          ent: 1780
+          ent: 1779
         outerClothing: !type:ContainerSlot
           showEnts: False
           occludes: False
-          ent: 1779
+          ent: 1778
         neck: !type:ContainerSlot
           showEnts: False
           occludes: False
@@ -26701,11 +26709,11 @@ entities:
         eyes: !type:ContainerSlot
           showEnts: False
           occludes: False
-          ent: null
+          ent: 1780
         head: !type:ContainerSlot
           showEnts: False
           occludes: False
-          ent: 1778
+          ent: 1777
         suitstorage: !type:ContainerSlot
           showEnts: False
           occludes: False
@@ -30820,44 +30828,44 @@ entities:
       parent: 2
 - proto: RightArmSkeleton
   entities:
-  - uid: 1767
+  - uid: 16
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: RightFootSkeleton
   entities:
-  - uid: 1768
+  - uid: 17
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: RightHandSkeleton
   entities:
-  - uid: 1769
+  - uid: 18
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: RightLegSkeleton
   entities:
-  - uid: 1770
+  - uid: 19
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: RitualDagger
   entities:
   - uid: 4502
@@ -31845,8 +31853,6 @@ entities:
     - type: Transform
       pos: 1.3624003,1.6144578
       parent: 2
-    - type: IntrinsicRadioTransmitter
-      channels: []
 - proto: SyndieFlag
   entities:
   - uid: 4647
@@ -32313,14 +32319,14 @@ entities:
       parent: 2
 - proto: Telebond1
   entities:
-  - uid: 1771
+  - uid: 20
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
   - uid: 4727
     components:
     - type: Transform
@@ -32440,14 +32446,14 @@ entities:
       parent: 2
 - proto: TorsoSkeleton
   entities:
-  - uid: 1772
+  - uid: 21
     components:
     - type: Transform
-      parent: 1760
+      parent: 9
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-      storage: 1760
+      storage: 9
 - proto: ToyNuke
   entities:
   - uid: 4748
@@ -53493,16 +53499,6 @@ entities:
     - type: Transform
       pos: 8.718154,12.626069
       parent: 2
-- proto: WeaponRevolverPython
-  entities:
-  - uid: 1773
-    components:
-    - type: Transform
-      parent: 1760
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
-      storage: 1760
 - proto: WeaponShotgunDoubleBarreled
   entities:
   - uid: 8801
@@ -53536,14 +53532,14 @@ entities:
       parent: 2
 - proto: WeaponSubMachineGunC20r
   entities:
-  - uid: 3836
+  - uid: 8806
     components:
     - type: Transform
       pos: 7.6116095,47.394794
       parent: 2
 - proto: WeaponSubMachineGunForged
   entities:
-  - uid: 8806
+  - uid: 8807
     components:
     - type: Transform
       pos: 0.5348942,-21.351381


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

This replaces both of the Commissar Overcoats on Geiger Complex Nuclear Operative Base with normal Soviet Great Coats.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->


I thought it was just aesthetic - it's not, it's very good armor that stacks on juggs. 

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: teapoterror
- remove: Both of the Commissar Overcoats from Geiger Complex have been removed. Thy drip consumed.