### PR TITLE
Security Loadout Normalization

### DIFF
--- a/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
@@ -42,6 +42,7 @@ loadout-group-blueshield-id = Blueshield ID
 # Security
 loadout-group-security-tie = Security tie
 loadout-group-security-mask = Security mask
+loadout-group-security-mask-elite = Elite Security mask
 
 loadout-group-brigmedic-gloves = Brigmedic gloves
 loadout-group-security-non-lethal-weapon = Security Non-Lethal Weapon

--- a/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
@@ -14,6 +14,15 @@ uplink-stechkin-desc = A small, easily concealable 10mm handgun. Has a threaded 
 uplink-stechkin-bundle-name = Solid Operative Bundle
 uplink-stechkin-bundle-desc = A mysterious cardboard box containing a slew of equipment for only the most solid of operatives.
 
+uplink-pistol-high-capacity-magazine-name = High Capacity Pistol Magazine (.35 auto)
+uplink-pistol-high-capacity-magazine-desc = Pistol magazine with 16 cartridges. Compatible with the Viper.
+
+uplink-pistol-hp-magazine-name = Pistol Magazine (.35 auto HP)
+uplink-pistol-hp-magazine-desc = Pistol magazine with 10 cartridges. Compatible with the Viper.
+
+uplink-pistol-fmj-magazine-name = Pistol Magazine (.35 auto FMJ)
+uplink-pistol-fmj-magazine-desc = Pistol magazine with 10 cartridges. Compatible with the Viper.
+
 uplink-pistol-magnum-magazine-name = Pistol Magazine (.45 magnum)
 uplink-pistol-magnum-magazine-desc = Pistol magazine with 10 cartridges. Compatible with the Desert Eagle.
 

--- a/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
@@ -14,7 +14,7 @@ uplink-stechkin-desc = A small, easily concealable 10mm handgun. Has a threaded 
 uplink-stechkin-bundle-name = Solid Operative Bundle
 uplink-stechkin-bundle-desc = A mysterious cardboard box containing a slew of equipment for only the most solid of operatives.
 
-uplink-pistol-high-capacity-magazine-name = High Capacity Pistol Magazine (.35 auto)
+uplink-pistol-high-capacity-magazine-name = Extended Pistol Magazine (.35 auto)
 uplink-pistol-high-capacity-magazine-desc = Pistol magazine with 16 cartridges. Compatible with the Viper.
 
 uplink-pistol-hp-magazine-name = Pistol Magazine (.35 auto HP)

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -231,7 +231,7 @@
       prob: 0.15
     - id: ClothingBeltChiefEngineerFilled
     - id: ClothingEyesGlassesMeson
-    - id: ClothingHandsGlovesColorYellow
+#    - id: ClothingHandsGlovesColorYellow # Starlight, they spawn with these now.
     - id: ClothingHeadsetAltEngineering
     - id: DoorRemoteEngineering
     - id: BoxCECircuitboards
@@ -454,7 +454,7 @@
     - id: DrinkHosFlask
     - id: SecurityShuttleConsoleCircuitboard # Starlight start
     - id: ClothingOuterWinterHoS
-    - id: ClothingHandsGlovesCombat
+#    - id: ClothingHandsGlovesCombat # Starlight, they spawn with them now.
     - id: SecureBriefings
     - id: PrintedDocumentGreenshiftAlert
       conditions:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -253,16 +253,12 @@
       amount: 2
     - id: WeaponPistolEnforcer
       amount: 1
-    #- id: WeaponMachinePistolMk64
-      #amount: 1
     - id: MagazinePistolSP
       amount: 4
     - id: MagazinePistolHP
       amount: 2
     - id: MagazinePistolFMJ
       amount: 2
-    #- id: MagazinePistolHighCapacitySP
-      #amount: 2
 
 - type: entity
   parent: [GunSafeBaseSecure, BaseSecurityContraband]

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -35,7 +35,7 @@
     - id: ClothingBeltSecurityFilled
     - id: Flash
     - id: ClothingEyesGlassesSecurity
-    - id: ClothingHandsGlovesCombat
+#    - id: ClothingHandsGlovesCombat # Starlight, they spawn with these now.
     - id: ClothingShoesBootsJack
     - id: ClothingOuterCoatWarden
     - id: ClothingOuterWinterWarden

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -539,10 +539,10 @@
 
 - type: listing
   id: UplinkPistol9mmMagazineSP
-  name: uplink-pistol-magazine-name
-  description: uplink-pistol-magazine-desc
+  name: uplink-pistol-high-capacity-magazine-name # Starlight, actually descriptive now
+  description: uplink-pistol-high-capacity-magazine-desc # Starlight
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_high_capacity_mag.rsi, state: base-icon }
-  productEntity: MagazinePistolSP
+  productEntity: MagazinePistolHighCapacitySP # Staright
   cost:
     Telecrystal: 1
   categories:
@@ -550,8 +550,8 @@
 
 - type: listing
   id: UplinkPistol9mmMagazineHP
-  name: uplink-pistol-magazine-name
-  description: uplink-pistol-magazine-desc
+  name: uplink-pistol-hp-magazine-name # Starlight
+  description: uplink-pistol-hp-magazine-desc # Starlight
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: sp }
   productEntity: MagazinePistolHP
   cost:
@@ -561,8 +561,8 @@
 
 - type: listing
   id: UplinkPistol9mmMagazineFMJ
-  name: uplink-pistol-magazine-name
-  description: uplink-pistol-magazine-desc
+  name: uplink-pistol-fmj-magazine-name # Starlight
+  description: uplink-pistol-fmj-magazine-desc # Starlight
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: fmj }
   productEntity: MagazinePistolFMJ
   cost:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -552,7 +552,7 @@
   id: UplinkPistol9mmMagazineHP
   name: uplink-pistol-hp-magazine-name # Starlight
   description: uplink-pistol-hp-magazine-desc # Starlight
-  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: sp }
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: red } # Starlight, now actually the right icon
   productEntity: MagazinePistolHP
   cost:
     Telecrystal: 1
@@ -563,7 +563,7 @@
   id: UplinkPistol9mmMagazineFMJ
   name: uplink-pistol-fmj-magazine-name # Starlight
   description: uplink-pistol-fmj-magazine-desc # Starlight
-  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: fmj }
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_mag.rsi, state: fmj } # Starlight, now actually the right icon
   productEntity: MagazinePistolFMJ
   cost:
     Telecrystal: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -90,10 +90,17 @@
   name: viper
   parent: [BaseWeaponPistol, BaseSyndicateContraband]
   id: WeaponPistolViper
-  description: A common handgun illegally modified by the Syndicate. The Viper sports a selector switch between semi-auto and ‘rock and roll’. The standard sidearm for any soldier who fights under the three serpents. Feeds from .35 pistol magazines.
+  description: A common handgun illegally modified by the Syndicate. The Viper sports a selector switch between semi-auto, "rock and roll", and "spray and pray". The standard sidearm for any soldier who fights under the three serpents. Feeds from .35 pistol magazines. # Starlight
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi
+  - type: Gun # Starlight start
+    fireRate: 6
+    selectedMode: SemiAuto
+    availableModes:
+      - SemiAuto
+      - FullAuto
+      - Burst # Starlight end
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -106,7 +106,7 @@
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazinePistolSP
+        startingItem: MagazinePistolHighCapacitySP # Starlight, starts with the high capacity now
         insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
         priority: 2

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -55,7 +55,7 @@
         whitelist:
           tags:
             - MagazinePistol
-            - MagazinePistolHighCapacity
+            - MagazinePistolHighCapacitySP # Starlight, dude, this typo meant no guns could actually use high capacity ammo
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
@@ -101,7 +101,7 @@
       - SemiAuto
       - FullAuto
       - Burst
-    shotsPerBurst: 3 # Starlight end
+    shotsPerBurst: 4 # Starlight end
   - type: ItemSlots
     slots:
       gun_magazine:
@@ -113,7 +113,7 @@
         whitelist:
           tags:
             - MagazinePistol
-            - MagazinePistolHighCapacity
+            - MagazinePistolHighCapacitySP # Starlight, they couldn't actually use this before because Capacity without SP *doesn't exist as a tag*
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -100,7 +100,8 @@
     availableModes:
       - SemiAuto
       - FullAuto
-      - Burst # Starlight end
+      - Burst
+    shotsPerBurst: 3 # Starlight end
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
@@ -472,7 +472,7 @@
   id: JobHeadOfSecurity
   groups:
   - HeadofSecurityHead
-  - SecurityMask # Starlight
+  - EliteSecurityMask # Starlight
   - HeadofSecurityNeck
   - HeadofSecurityJumpsuit
   - SecurityBackpack
@@ -481,7 +481,7 @@
   - HeadofSecurityOuterClothing
   - SecurityEyewear
   - SecurityShoes
-  - SurvivalSecurity
+  - SurvivalExtended # Starlight, since they can pick their mask now, they shouldn't get an extra security mask.
   - InsulsCombat # Starlight
   - Trinkets
   - Scarves # Starlight
@@ -494,7 +494,7 @@
   id: JobWarden
   groups:
   - WardenHead
-  - SecurityMask # Starlight
+  - EliteSecurityMask # Starlight
   - WardenNeck # Starlight
   - WardenJumpsuit
   - SecurityBackpack
@@ -502,7 +502,7 @@
   - WardenOuterClothing
   - SecurityEyewear
   - SecurityShoes
-  - SurvivalSecurity
+  - SurvivalExtended # Starlight
   - InsulsCombat # Starlight
   - Trinkets
   - Scarves # Starlight
@@ -515,6 +515,7 @@
   id: JobSecurityOfficer
   groups:
   - SecurityHead
+  - SecurityMask # Starlight
   - SecurityJumpsuit
   - SecurityBackpack
   - SecurityEyewear
@@ -526,7 +527,7 @@
   - SecurityTie # Starlight
   - SecurityNonLethalWeapon #Starlight
   - SecuritySidearm #Starlight
-  - SurvivalSecurity
+  - SurvivalExtended # Starlight
   - Trinkets
   - Scarves # Starlight
   - Pins # Starlight
@@ -538,6 +539,7 @@
   id: JobDetective
   groups:
   - DetectiveHead
+  - SecurityMask # Starlight
   - DetectiveNeck
   - DetectiveJumpsuit
   - SecurityBackpack
@@ -545,7 +547,7 @@
   - DetectiveOuterClothing
   - SecurityGloves # Starlight
   - DetectiveShoes # 🌟Starlight🌟
-  - SurvivalSecurity
+  - SurvivalExtended # Starlight
   - Trinkets
   - Scarves # Starlight
   - Pins # Starlight
@@ -556,11 +558,12 @@
 - type: roleLoadout
   id: JobSecurityCadet
   groups:
+  - SecurityMask # Starlight
   - SecurityCadetJumpsuit
   - SecurityBackpack
   - SecurityNonLethalWeapon
   - SecurityEyewear
-  - SurvivalSecurity
+  - SurvivalExtended # Starlight
   - SecurityGloves # Starlight
   - Trinkets
   - Scarves # Starlight

--- a/Resources/Prototypes/_Starlight/Catalog/Fills/Lockers/representatives.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Fills/Lockers/representatives.yml
@@ -111,7 +111,6 @@
       entity_storage: !type:AllSelector
         children:
         - id: FlashlightSeclite
-        - id: ClothingHandsGlovesCombat
         - id: ClothingShoesBootsJack
         - id: TrackingImplanter
           amount: 3

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Masks/masks.yml
@@ -89,6 +89,18 @@
         Radiation: 0.60
 
 - type: entity
+  parent: ClothingMaskBreathMedicalSecurity
+  id: ClothingMaskBreathMedicalSecurityBudget
+  name: budget military-style medical mask
+  description: A low-cost medical mask with a small layer of protection against damage and viruses. It's less effective than the standard issue medical mask, but it's better than nothing.
+  components:
+  - type: Armor
+    modifiers:
+      coefficients:
+        Slash: 0.95
+        Heat: 0.95
+
+- type: entity
   parent: ClothingMaskGas
   id: ClothingKitsuneMask
   name: kitsune mask

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -38,7 +38,7 @@
 
 - type: entity
   id: BaseMagazinePistolHighCapacity
-  name: machine pistol magazine (.35 auto)
+  name: extended pistol magazine (.35 auto)
   parent: BaseItem
   abstract: true
   components:
@@ -418,7 +418,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityEmpty
-  name: machine pistol magazine (.35 auto any)
+  name: extended pistol magazine (.35 auto any)
   suffix: empty
   parent: BaseMagazinePistolHighCapacity
   components:
@@ -439,7 +439,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacitySP
-  name: machine pistol magazine (.35 auto SP)
+  name: extended pistol magazine (.35 auto SP)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -463,7 +463,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityHP
-  name: machine pistol magazine (.35 auto HP)
+  name: extended pistol magazine (.35 auto HP)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -487,7 +487,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityFMJ
-  name: machine pistol magazine (.35 auto FMJ)
+  name: extended pistol magazine (.35 auto FMJ)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -511,7 +511,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityAP
-  name: machine pistol magazine (.35 auto AP)
+  name: extended pistol magazine (.35 auto AP)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -535,7 +535,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityPractice
-  name: machine pistol magazine (.35 auto practice)
+  name: extended pistol magazine (.35 auto practice)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -559,7 +559,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityRubber
-  name: machine pistol magazine (.35 auto rubber)
+  name: extended pistol magazine (.35 auto rubber)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -583,7 +583,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityIncendiary
-  name: machine pistol magazine (.35 auto incendiary)
+  name: extended pistol magazine (.35 auto incendiary)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -607,7 +607,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityUranium
-  name: machine pistol magazine (.35 auto uranium)
+  name: extended pistol magazine (.35 auto uranium)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -109,14 +109,17 @@
   name: enforcer
   parent: [BaseWeaponPistol, BaseSecurityContraband]
   id: WeaponPistolEnforcer
-  description: A pistol of modern design.
+  description: A versatile pistol of modern design.
   components:
     - type: Sprite
       sprite: _Starlight/Objects/Weapons/Guns/Pistols/enforcer.rsi
     - type: Gun
       fireRate: 6
+      selectedMode: FullAuto
       availableModes:
         - SemiAuto
+        - FullAuto
+        - Burst
     - type: ChamberMagazineAmmoProvider
       availablePrefixes:
         - ""
@@ -142,7 +145,7 @@
     - type: Clothing
       sprite: _Starlight/Objects/Weapons/Guns/Pistols/dp.rsi
     - type: Gun
-      fireRate: 5
+      fireRate: 4
       availableModes:
         - SemiAuto
       soundGunshot:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -114,7 +114,7 @@
     - type: Sprite
       sprite: _Starlight/Objects/Weapons/Guns/Pistols/enforcer.rsi
     - type: Gun
-      minAngle: 1
+      minAngle: 10
       maxAngle: 35
       angleIncrease: 5
       angleDecay: 3

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -114,6 +114,8 @@
     - type: Sprite
       sprite: _Starlight/Objects/Weapons/Guns/Pistols/enforcer.rsi
     - type: Gun
+      minAngle: 1
+      maxAngle: 15
       fireRate: 6
       selectedMode: FullAuto
       availableModes:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -122,6 +122,7 @@
         - SemiAuto
         - FullAuto
         - Burst
+      shotsPerBurst: 3
     - type: ChamberMagazineAmmoProvider
       availablePrefixes:
         - ""

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -114,8 +114,10 @@
     - type: Sprite
       sprite: _Starlight/Objects/Weapons/Guns/Pistols/enforcer.rsi
     - type: Gun
-      minAngle: 15
+      minAngle: 1
       maxAngle: 35
+      angleIncrease: 5
+      angleDecay: 3
       fireRate: 6
       selectedMode: FullAuto
       availableModes:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -317,56 +317,6 @@
       soundGunshot:
         path: /Audio/_Starlight/Weapons/Guns/Gunshots/colt.ogg
 
-# Doesn't work and idk why
-
-#- type: entity
-#name: mk 64
-#parent: [BaseWeaponPistol, BaseSecurityContraband]
-#id: WeaponMachinePistolMk64
-#description: Designed by Nanotrasen’s Small Arms Division, the Mk64 is an unconventional full-auto machine pistol with questionable accuracy, though it can be fired one-handed. Feeds from .35 machine pistol magazines.
-#components:
-#- type: Sprite
-#sprite: _Starlight/Objects/Weapons/Guns/Pistols/mk64.rsi
-#layers:
-#- state: base
-#map: ["enum.GunVisualLayers.Base"]
-#- state: mag-0
-#map: ["enum.GunVisualLayers.Mag"]
-#- type: Clothing
-#sprite: _Starlight/Objects/Weapons/Guns/Pistols/mk64.rsi
-#- type: Gun
-#fireRate: 6
-#availableModes:
-#- FullAuto
-#soundGunshot:
-#path: _Starlight/Audio/Weapons/Guns/Gunshots/uzi.ogg
-#- type: ChamberMagazineAmmoProvider
-#soundRack:
-#path: /Audio/Weapons/Guns/Cock/pistol_cock.ogg
-#- type: ItemSlots
-#slots:
-#gun_magazine:
-#name: Magazine
-#startingItem: MagazinePistolHighCapacitySP
-#insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
-#ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
-#priority: 2
-#whitelist:
-#tags:
-#- MagazinePistolHighCapacity
-#whitelistFailPopup: gun-magazine-whitelist-fail
-#gun_chamber:
-#name: Chamber
-#startingItem: CartridgePistolSP
-#priority: 1
-#whitelist:
-#tags:
-#- CartridgePistol
-#- type: ContainerContainer
-#containers:
-#gun_magazine: !type:ContainerSlot
-#gun_chamber: !type:ContainerSlot
-
 - type: entity
   name: makeshift pistol
   parent: [BaseWeaponPistol, BaseMinorContraband]

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -114,8 +114,8 @@
     - type: Sprite
       sprite: _Starlight/Objects/Weapons/Guns/Pistols/enforcer.rsi
     - type: Gun
-      minAngle: 1
-      maxAngle: 15
+      minAngle: 10
+      maxAngle: 25
       fireRate: 6
       selectedMode: FullAuto
       availableModes:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -114,8 +114,8 @@
     - type: Sprite
       sprite: _Starlight/Objects/Weapons/Guns/Pistols/enforcer.rsi
     - type: Gun
-      minAngle: 10
-      maxAngle: 25
+      minAngle: 15
+      maxAngle: 35
       fireRate: 6
       selectedMode: FullAuto
       availableModes:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -107,6 +107,7 @@
     availableModes:
     - SemiAuto
     - Burst
+    shotsPerBurst: 3
     soundGunshot:
       path: /Audio/_Starlight/Weapons/Guns/Gunshots/revolver_stronger.ogg
   - type: RevolverAmmoProvider

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -107,7 +107,6 @@
     availableModes:
     - SemiAuto
     - Burst
-    selectedMode: SemiAuto
     soundGunshot:
       path: /Audio/_Starlight/Weapons/Guns/Gunshots/revolver_stronger.ogg
   - type: RevolverAmmoProvider

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -90,10 +90,10 @@
     dismantleChance: 0
 
 - type: entity
-  name: NT Model-7 'Dispatcher' Service Revolver
+  name: dispatcher
   parent: [BaseWeaponRevolver, BaseSecurityContraband]
   id: WeaponRevolverDispatcher
-  description: The Model 7, known unofficially as the 'Dispatcher.' chambered in .45 Magnum with robust stopping power for putting an end to any non-compliance. A true timeless classic carried amongst NanoTrasen's elite security staff.
+  description: The NT Model 7 Servivce Revolver, known unofficially as the 'Dispatcher.' chambered in .45 Magnum with robust stopping power for putting an end to any non-compliance. A true timeless classic carried amongst NanoTrasen's elite security staff.
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Revolvers/Dispatcher.rsi
@@ -102,9 +102,11 @@
   - type: Item
     storedOffset: 0,-2
   - type: Gun
-    fireRate: 1.25
+    fireRate: 2.0
+    selectedMode: Burst
     availableModes:
     - SemiAuto
+    - Burst
     selectedMode: SemiAuto
     soundGunshot:
       path: /Audio/_Starlight/Weapons/Guns/Gunshots/revolver_stronger.ogg

--- a/Resources/Prototypes/_Starlight/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Jobs/Security/security_officer.yml
@@ -8,6 +8,24 @@
       role: JobSecurityOfficer
       time: 18000 # 5 hrs
 
+- type: loadoutEffectGroup
+  id: SkilledOfficer
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobSecurityOfficer
+      time: 54000 # 15 hrs
+
+- type: loadoutEffectGroup
+  id: EliteOfficer
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobSecurityOfficer
+      time: 360000 # 100 hrs!!!
+
 # Non-Lethal Weapons
 - type: loadout
   id: SecurityDominator
@@ -29,6 +47,26 @@
       - MagazinePistolSP
 
 - type: loadout
+  id: SecurityPistolEnforcer
+  dummyEntity: WeaponPistolEnforcer
+  storage:
+    back:
+    - WeaponPistolEnforcer
+    - MagazinePistolSP
+
+- type: loadout
+  id: SecurityRevolverDispatcher
+  effects:
+    - !type:GroupLoadoutEffect
+      proto: SkilledOfficer
+  dummyEntity: WeaponRevolverDispatcher
+  storage:
+    back:
+      - WeaponRevolverDispatcher
+      - SpeedLoaderMagnumSP
+      - SpeedLoaderMagnumHP
+
+- type: loadout
   id: SecurityPistolDP
   effects:
     - !type:GroupLoadoutEffect
@@ -40,12 +78,15 @@
       - MagazinePistol40SP
 
 - type: loadout
-  id: SecurityPistolEnforcer
-  dummyEntity: WeaponPistolEnforcer
+  id: SecurityMk58Gold
+  effects:
+    - !type:GroupLoadoutEffect
+      proto: EliteOfficer
+  dummyEntity: WeaponPistolGoldenMk58
   storage:
     back:
-    - WeaponPistolEnforcer
-    - MagazinePistolSP
+      - WeaponPistolGoldenMk58
+      - MagazinePistolSP
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/masks.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/masks.yml
@@ -19,3 +19,12 @@
     proto: VeteranBrigmedic
   equipment:
     mask: ClothingMaskGasCorpsman
+
+- type: loadout
+  id: BreathMaskMedicalSecurityBudget
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SkilledBrigmedic
+  equipment:
+    mask: ClothingMaskBreathMedicalSecurityBudget
+

--- a/Resources/Prototypes/_Starlight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/loadout_groups.yml
@@ -1,7 +1,6 @@
 - type: loadoutGroup
   id: Insuls
   name: loadout-group-insuls-normal
-  minLimit: 0
   defaultSelected: 1
   loadouts:
   - InsulsRegular
@@ -12,7 +11,6 @@
 - type: loadoutGroup
   id: InsulsCombat
   name: loadout-group-insuls-combat
-  minLimit: 0
   defaultSelected: 1
   loadouts:
   - InsulsCombatNoLock
@@ -23,7 +21,6 @@
 - type: loadoutGroup
   id: InsulsCaptain
   name: loadout-group-insuls-captain
-  minLimit: 0
   defaultSelected: 1
   loadouts:
   - InsulsCaptain
@@ -422,8 +419,10 @@
   name: loadout-group-security-sidearm
   loadouts:
   - SecurityMk58
-  - SecurityPistolDP
   - SecurityPistolEnforcer
+  - SecurityRevolverDispatcher
+  - SecurityPistolDP
+  - SecurityMk58Gold
 
 # Assorted Boots
 - type: loadoutGroup
@@ -881,12 +880,20 @@
 
 # HoS/Ward Masks
 - type: loadoutGroup
-  id: SecurityMask
-  name: loadout-group-security-mask
-  minLimit: 0
+  id: EliteSecurityMask
+  name: loadout-group-security-mask-elite
   loadouts:
     - MaskGasSecurity
     - BreathMaskMedicalSecurity
+    - MaskGasCorpsman
+
+# General Security Masks
+- type: loadoutGroup
+  id: SecurityMask
+  name: loadout-group-security-mask
+  loadouts:
+    - MaskGasSecurity
+    - BreathMaskMedicalSecurityBudget
     - MaskGasCorpsman
 
 # Brigmedic

--- a/Resources/Prototypes/_Starlight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/role_loadouts.yml
@@ -98,7 +98,7 @@
   - Scarves
   - Pins
   - Pens
-  - SurvivalSecurity
+  - SurvivalExtended # Starlight
   - GroupSpeciesBreathToolSecurity
 
 - type: roleLoadout
@@ -155,7 +155,7 @@
   - SecurityShoes
   - SecurityNonLethalWeapon
   - SecuritySidearm
-  - SurvivalSecurity
+  - SurvivalExtended
   - Trinkets
   - Scarves
   - Pins
@@ -167,6 +167,7 @@
   id: JobDutyOfficer
   groups:
   - DutyOfficerHead
+  - SecurityMask # Starlight
   - DutyOfficerJumpsuit
   - SecurityBackpack
   - SecurityEyewear
@@ -176,7 +177,7 @@
   - SecurityShoes
   - SecurityGloves
   - SecurityNonLethalWeapon
-  - SurvivalSecurity
+  - SurvivalExtended
   - Trinkets
   - Scarves
   - Pins


### PR DESCRIPTION
## Short description
Adjusts Security's sidearm loadout, normalizing the options a bit so none of them are quite outright better than the others, except the mk58, since everyone gets that one. The golden mk58 doesn't have any stat differences, so it's just a prestige reward.

All security members can choose their masks now, but in exchange, use the extended survival kit instead of the security one, to stop them from having an extra sec mask. Non-HoS/Warden/Brigmedic get a budget version of the Brigmedic's medical security mask, since it's just outright better.

Also removes duplicate insulated gloves in Captain, HoS, Warden, CE, and BSO's lockers, since they have them as loadout options.

Also also... while doing this, I learned that pistols just... _couldn't_ take extended magazines because... of a typo??? Like the intent was clearly there, but it was using the wrong tag... It's honestly quite incredible.
## Why we need to add this
The Due Process has stood as the best security loadout option for a while, and I don't think it's healthy to have an option that's just outright better.

## Media (Video/Screenshots)
<img width="795" height="352" alt="image" src="https://github.com/user-attachments/assets/52952e9a-bca2-4103-9f07-b03c0c989b1c" />

<img width="781" height="478" alt="image" src="https://github.com/user-attachments/assets/78c45bcc-a49f-4d5a-9d1f-02ee24e39d51" />

<img width="380" height="327" alt="image" src="https://github.com/user-attachments/assets/ceb4134d-0ee9-481c-8777-1523776f0645" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: Added the Dispatcher (15hrs Sec Officer) and the Golden mk58 (100hrs Sec Officer) to security sidearm loadout. 
- add: Added a budget medical security mask.
- add: All members of security can now choose their masks. (And are forced to equip one in loadout by default.).
- tweak: Security now spawn with Extended Survival Kits instead of Security ones, to prevent getting duplicate security masks. Their survival kits already had extended air tanks, so this only changes the mask.  
- tweak: Due Process Fire Rate -1.
- tweak: Dispatcher Fire Rate +0.75.
- tweak: The Dispatcher now has access to Burst Fire Mode. (Default: Burst.).
- tweak: The Enforcer now has access to Full Auto and Burst Fire Modes. (Default: Full Auto.).
- tweak: The Enforcer now has some scatter.
- tweak: The Viper now has access to Burst Fire Mode, so the Enforcer isn't just better than it.
- tweak: The Viper starts with the extended-capacity magazine now.
- tweak: The Captain, HoS, Warden, CE, and BSO no longer spawn with extra insuls in their lockers, and now are forced to equip one in loadout.
- tweak: Renamed Machine magazines to Extended magazines.
- remove: Removes the unused, commented out mk64 from the files. For what it's worth, for the same reason pistol's couldn't use the extended magazine, the mk64 didn't work, so it's actually possible to make it work now.
- fix: Pistols can actually use the extended-capacity magazines now.
- fix: The 3 viper ammos in the uplink have proper loc now.