### PR TITLE
More Law Accesses

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Electronics/door_access.yml
@@ -79,6 +79,25 @@
   - type: AccessReader
     access: [["Lawyer"]]
 
+# Courtroom
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsCourtroom
+  suffix: Security/Internal Affairs/Legal (Courtroom), Locked
+  components:
+  - type: AccessReader
+    access: [["Security"], ["IAA"], ["Lawyer"]]
+
+
+# Attorney
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsAttorney
+  suffix: Internal Affairs/Legal (Attorney), Locked
+  components:
+  - type: AccessReader
+    access: [["IAA"], ["Lawyer"]]
+
 #Brigmedic
 - type: entity
   parent: DoorElectronics

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/Airlocks/access.yml
@@ -362,6 +362,60 @@
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/maint.rsi
 
+# Courtroom
+- type: entity
+  parent: AirlockSecurityLocked
+  id: AirlockCourtroomLocked
+  suffix: Security/Internal Affairs/Legal (Courtroom), Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCourtroom ]
+
+- type: entity
+  parent: AirlockSecurityGlassLocked
+  id: AirlockCourtroomGlassLocked
+  suffix: Security/Internal Affairs/Legal (Courtroom), Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCourtroom ]
+
+- type: entity
+  parent: AirlockCourtroomLocked
+  id: AirlockMaintCourtroomLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+
+# Attorney
+- type: entity
+  parent: AirlockServiceLocked
+  id: AirlockAttorneyLocked
+  suffix: Internal Affairs/Legal (Attorney), Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsAttorney ]
+
+- type: entity
+  parent: AirlockServiceGlassLocked
+  id: AirlockAttorneyGlassLocked
+  suffix: Internal Affairs/Legal (Attorney), Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsAttorney ]
+
+- type: entity
+  parent: AirlockAttorneyLocked
+  id: AirlockMaintAttorneyLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
+
 # Xenoborg
 - type: entity
   parent: AirlockXenoborgGlass

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/Windoors/windoor.yml
@@ -60,6 +60,115 @@
     - type: Wires
       layoutId: AirlockScience
 
+# Security
+- type: entity
+  parent: Windoor
+  id: WindoorSecurityLocked
+  suffix: Security, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSecurity ]
+  - type: Wires
+    layoutId: AirlockSecurity
+
+# Internal Affairs
+- type: entity
+  parent: WindoorSecurityLocked
+  id: WindoorInternalAffairsLocked
+  suffix: Internal Affairs, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsInternalAffairs ]
+
+- type: entity
+  parent: WindoorSecureSecurityLocked
+  id: WindoorSecureInternalAffairsLocked
+  suffix: Internal Affairs, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsInternalAffairs ]
+
+# Security/Internal Affairs
+- type: entity
+  parent: WindoorSecurityLocked
+  id: WindoorSecurityInternalAffairsLocked
+  suffix: Security/Internal Affairs, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSecurityInternalAffairs ]
+
+- type: entity
+  parent: WindoorSecureSecurityLocked
+  id: WindoorSecureSecurityInternalAffairsLocked
+  suffix: Security/Internal Affairs, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSecurityInternalAffairs ]
+
+# Legal
+- type: entity
+  parent: WindoorServiceLocked
+  id: WindoorLegalLocked
+  suffix: Legal, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLegal ]
+
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureLegalLocked
+  suffix: Legal, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsLegal ]
+
+# Courtroom
+- type: entity
+  parent: WindoorSecurityLocked
+  id: WindoorCourtroomLocked
+  suffix: Security/Internal Affairs/Legal (Courtroom), Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCourtroom ]
+
+- type: entity
+  parent: WindoorSecureSecurityLocked
+  id: WindoorSecureCourtroomLocked
+  suffix: Security/Internal Affairs/Legal (Courtroom), Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsCourtroom ]
+
+
+# Attorney
+- type: entity
+  parent: WindoorServiceLocked
+  id: WindoorAttorneyLocked
+  suffix: Internal Affairs/Legal (Attorney), Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsAttorney ]
+
+- type: entity
+  parent: WindoorSecureServiceLocked
+  id: WindoorSecureAttorneyLocked
+  suffix: Internal Affairs/Legal (Attorney), Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsAttorney ]
+
+
 # MedTak
 - type: entity
   parent: WindoorSecure

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/Windoors/windoor.yml
@@ -101,15 +101,6 @@
     containers:
       board: [ DoorElectronicsSecurityInternalAffairs ]
 
-- type: entity
-  parent: WindoorSecureSecurityLocked
-  id: WindoorSecureSecurityInternalAffairsLocked
-  suffix: Security/Internal Affairs, Locked
-  components:
-  - type: ContainerFill
-    containers:
-      board: [ DoorElectronicsSecurityInternalAffairs ]
-
 # Legal
 - type: entity
   parent: WindoorServiceLocked


### PR DESCRIPTION
## Short description
Adds the following:

Security/Internal Affairs/Lawyer "Courtroom" Airlocks and Windoors

Internal Affairs/Lawyer "Attorney" Airlocks and Windoors

Security normal Windoors (there were only secure ones before)

Security/Internal Affairs Windoors

Internal Affairs Windoors

Lawyer Windoors

## Why we need to add this
As we add depth to our legal system, we need new airlocks to account for it.

## Media (Video/Screenshots)
<img width="691" height="468" alt="image" src="https://github.com/user-attachments/assets/8152e2b2-0049-4901-bbd0-f51f6d8cc354" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: Security/Internal Affairs/Lawyer "Courtroom" Airlocks and Windoors.
- add: Internal Affairs/Lawyer "Attorney" Airlocks and Windoors.
- add: Security normal Windoors (there were only secure ones before).
- add: Security/Internal Affairs Windoors.
- add: Internal Affairs Windoors.
- add: Lawyer Windoors.
