### PR TITLE
Firearm Contra fixes

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
@@ -17,7 +17,7 @@
 - type: entity
   id: BaseMagazineMagnumSubMachineGun
   name: SMG magazine (.45 magnum)
-  parent: BaseItem
+  parent: [BaseItem, BaseSecuritySalvageContraband]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -39,7 +39,7 @@
 - type: entity
   id: BaseMagazinePistolHighCapacity
   name: extended pistol magazine (.35 auto)
-  parent: BaseItem
+  parent: [ BaseItem, BaseSecurityContraband ]
   abstract: true
   components:
   - type: Tag

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -93,7 +93,7 @@
   name: dispatcher
   parent: [BaseWeaponRevolver, BaseSecurityContraband]
   id: WeaponRevolverDispatcher
-  description: The NT Model 7 Servivce Revolver, known unofficially as the 'Dispatcher.' chambered in .45 Magnum with robust stopping power for putting an end to any non-compliance. A true timeless classic carried amongst NanoTrasen's elite security staff.
+  description: The NT Model 7 Service Revolver, known unofficially as the 'Dispatcher.' chambered in .45 Magnum with robust stopping power for putting an end to any non-compliance. A true timeless classic carried amongst NanoTrasen's elite security staff.
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Revolvers/Dispatcher.rsi


### PR DESCRIPTION
## Short description
Adds contra labels to the extended pistol magazines and the smg magazines.

## Why we need to add this
They just didn't have them.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Extended magazines and .45 SMG magazines now have contra labels.
- fix: Fixes a typo in the dispatcher's description.