### PR TITLE
Fixes PAIs being voided on shuttleconsole break hotfix i guess?

### DIFF
--- a/Content.Client/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Client/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -17,7 +17,7 @@ namespace Content.Client.Shuttles.Systems
             base.Initialize();
             SubscribeLocalEvent<PilotComponent, ComponentHandleState>(OnHandleState);
             // Starlight: reset input if the console entity itself is destroyed while we're still piloting.
-            SubscribeLocalEvent<SharedShuttleConsoleComponent, ComponentShutdown>(OnConsoleShutdown);
+            SubscribeLocalEvent<ShuttleConsoleComponent, ComponentShutdown>(OnConsoleShutdown);
             var shuttle = _input.Contexts.New("shuttle", "common");
             shuttle.AddFunction(ContentKeyFunctions.ShuttleStrafeUp);
             shuttle.AddFunction(ContentKeyFunctions.ShuttleStrafeDown);
@@ -37,7 +37,7 @@ namespace Content.Client.Shuttles.Systems
         // Starlight: safety net — if the console entity is deleted while the local player is still
         // piloting it, RemovePilot may have bailed early server-side (console component already gone),
         // leaving PilotComponent on the PAI. Reset input here so the screen never stays frozen.
-        private void OnConsoleShutdown(EntityUid uid, SharedShuttleConsoleComponent component, ComponentShutdown args)
+        private void OnConsoleShutdown(EntityUid uid, ShuttleConsoleComponent component, ComponentShutdown args)
         {
             var localEntity = _playerManager.LocalEntity;
             if (localEntity == null)

--- a/Content.Client/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Client/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -16,6 +16,8 @@ namespace Content.Client.Shuttles.Systems
         {
             base.Initialize();
             SubscribeLocalEvent<PilotComponent, ComponentHandleState>(OnHandleState);
+            // Starlight: reset input if the console entity itself is destroyed while we're still piloting.
+            SubscribeLocalEvent<SharedShuttleConsoleComponent, ComponentShutdown>(OnConsoleShutdown);
             var shuttle = _input.Contexts.New("shuttle", "common");
             shuttle.AddFunction(ContentKeyFunctions.ShuttleStrafeUp);
             shuttle.AddFunction(ContentKeyFunctions.ShuttleStrafeDown);
@@ -30,6 +32,22 @@ namespace Content.Client.Shuttles.Systems
         {
             base.Shutdown();
             _input.Contexts.Remove("shuttle");
+        }
+
+        // Starlight: safety net — if the console entity is deleted while the local player is still
+        // piloting it, RemovePilot may have bailed early server-side (console component already gone),
+        // leaving PilotComponent on the PAI. Reset input here so the screen never stays frozen.
+        private void OnConsoleShutdown(EntityUid uid, SharedShuttleConsoleComponent component, ComponentShutdown args)
+        {
+            var localEntity = _playerManager.LocalEntity;
+            if (localEntity == null)
+                return;
+            if (!TryComp<PilotComponent>(localEntity.Value, out var pilot))
+                return;
+            if (pilot.Console != uid)
+                return;
+
+            _input.Contexts.SetActiveContext("human");
         }
 
         protected override void HandlePilotShutdown(EntityUid uid, PilotComponent component, ComponentShutdown args)

--- a/Content.Client/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Client/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -16,8 +16,7 @@ namespace Content.Client.Shuttles.Systems
         {
             base.Initialize();
             SubscribeLocalEvent<PilotComponent, ComponentHandleState>(OnHandleState);
-            // Starlight: reset input if the console entity itself is destroyed while we're still piloting.
-            SubscribeLocalEvent<ShuttleConsoleComponent, ComponentShutdown>(OnConsoleShutdown);
+            SubscribeLocalEvent<ShuttleConsoleComponent, ComponentShutdown>(OnConsoleShutdown); // Starlight: reset input if the console entity itself is destroyed while we're still piloting.
             var shuttle = _input.Contexts.New("shuttle", "common");
             shuttle.AddFunction(ContentKeyFunctions.ShuttleStrafeUp);
             shuttle.AddFunction(ContentKeyFunctions.ShuttleStrafeDown);
@@ -34,7 +33,7 @@ namespace Content.Client.Shuttles.Systems
             _input.Contexts.Remove("shuttle");
         }
 
-        // Starlight: safety net — if the console entity is deleted while the local player is still
+        // Starlight-start: safety net — if the console entity is deleted while the local player is still
         // piloting it, RemovePilot may have bailed early server-side (console component already gone),
         // leaving PilotComponent on the PAI. Reset input here so the screen never stays frozen.
         private void OnConsoleShutdown(EntityUid uid, ShuttleConsoleComponent component, ComponentShutdown args)
@@ -49,6 +48,7 @@ namespace Content.Client.Shuttles.Systems
 
             _input.Contexts.SetActiveContext("human");
         }
+        // Starlight-end
 
         protected override void HandlePilotShutdown(EntityUid uid, PilotComponent component, ComponentShutdown args)
         {

--- a/Content.Client/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Client/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -16,7 +16,6 @@ namespace Content.Client.Shuttles.Systems
         {
             base.Initialize();
             SubscribeLocalEvent<PilotComponent, ComponentHandleState>(OnHandleState);
-            SubscribeLocalEvent<ShuttleConsoleComponent, ComponentShutdown>(OnConsoleShutdown); // Starlight: reset input if the console entity itself is destroyed while we're still piloting.
             var shuttle = _input.Contexts.New("shuttle", "common");
             shuttle.AddFunction(ContentKeyFunctions.ShuttleStrafeUp);
             shuttle.AddFunction(ContentKeyFunctions.ShuttleStrafeDown);
@@ -32,23 +31,6 @@ namespace Content.Client.Shuttles.Systems
             base.Shutdown();
             _input.Contexts.Remove("shuttle");
         }
-
-        // Starlight-start: safety net — if the console entity is deleted while the local player is still
-        // piloting it, RemovePilot may have bailed early server-side (console component already gone),
-        // leaving PilotComponent on the PAI. Reset input here so the screen never stays frozen.
-        private void OnConsoleShutdown(EntityUid uid, ShuttleConsoleComponent component, ComponentShutdown args)
-        {
-            var localEntity = _playerManager.LocalEntity;
-            if (localEntity == null)
-                return;
-            if (!TryComp<PilotComponent>(localEntity.Value, out var pilot))
-                return;
-            if (pilot.Console != uid)
-                return;
-
-            _input.Contexts.SetActiveContext("human");
-        }
-        // Starlight-end
 
         protected override void HandlePilotShutdown(EntityUid uid, PilotComponent component, ComponentShutdown args)
         {

--- a/Content.Client/_Starlight/PAI/PAIShuttleConsoleSystem.cs
+++ b/Content.Client/_Starlight/PAI/PAIShuttleConsoleSystem.cs
@@ -1,0 +1,39 @@
+using Content.Client.Shuttles;
+using Content.Shared.Shuttles.Components;
+using Robust.Client.Input;
+using Robust.Client.Player;
+
+namespace Content.Client.PAI;
+
+/// <summary>
+/// Safety net: if the shuttle console is deleted while the local player is still piloting it,
+/// the server-side RemovePilot may bail early once the console component is tearing down,
+/// leaving PilotComponent on the PAI and the input stuck in "shuttle" mode.
+/// This system resets the input context on the client side so the screen never stays frozen.
+/// </summary>
+public sealed class PAIShuttleConsoleSystem : EntitySystem
+{
+    [Dependency] private readonly IInputManager _input = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ShuttleConsoleComponent, ComponentShutdown>(OnConsoleShutdown);
+    }
+
+    #region Console Shutdown
+    private void OnConsoleShutdown(EntityUid uid, ShuttleConsoleComponent component, ComponentShutdown args)
+    {
+        var localEntity = _playerManager.LocalEntity;
+        if (localEntity == null)
+            return;
+        if (!TryComp<PilotComponent>(localEntity.Value, out var pilot))
+            return;
+        if (pilot.Console != uid)
+            return;
+
+        _input.Contexts.SetActiveContext("human");
+    }
+    #endregion
+}

--- a/Content.Server/_Starlight/PAI/PAIShuttleRamSystem.cs
+++ b/Content.Server/_Starlight/PAI/PAIShuttleRamSystem.cs
@@ -30,11 +30,11 @@ public sealed class PAIShuttleRamSystem : EntitySystem
     {
         base.Initialize();
 
-        // Starlight: when a shuttle console is destroyed (fires before QueueDel), clean up any
+        // When a shuttle console is destroyed (fires before QueueDel), clean up any
         // active pilots so PilotComponent is removed and the player's input is never left stuck.
         SubscribeLocalEvent<ShuttleConsoleComponent, DestructionEventArgs>(OnConsoleDestroyed);
 
-        // Starlight: catch-all for any deletion that doesn't go through DestructionEventArgs
+        // Catch-all for any deletion that doesn't go through DestructionEventArgs
         // (e.g. admin tools, map unload). Also ejects any PAI still in the container.
         SubscribeLocalEvent<ShuttleConsoleComponent, EntityTerminatingEvent>(OnConsoleDying);
 

--- a/Content.Server/_Starlight/PAI/PAIShuttleRamSystem.cs
+++ b/Content.Server/_Starlight/PAI/PAIShuttleRamSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
+using Content.Shared.Destructible;
 using Content.Shared.Popups;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Throwing;
@@ -29,8 +30,12 @@ public sealed class PAIShuttleRamSystem : EntitySystem
     {
         base.Initialize();
 
-        // When a shuttle console is about to be destroyed, eject any slotted PAI first
-        // so the container doesn't delete it.
+        // Starlight: when a shuttle console is destroyed (fires before QueueDel), clean up any
+        // active pilots so PilotComponent is removed and the player's input is never left stuck.
+        SubscribeLocalEvent<ShuttleConsoleComponent, DestructionEventArgs>(OnConsoleDestroyed);
+
+        // Starlight: catch-all for any deletion that doesn't go through DestructionEventArgs
+        // (e.g. admin tools, map unload). Also ejects any PAI still in the container.
         SubscribeLocalEvent<ShuttleConsoleComponent, EntityTerminatingEvent>(OnConsoleDying);
 
         // Event-driven ram detection: fires only when a shuttle grid actually hits something.
@@ -39,20 +44,56 @@ public sealed class PAIShuttleRamSystem : EntitySystem
         SubscribeLocalEvent<MapGridComponent, StartCollideEvent>(OnGridCollide);
     }
 
+    /// <summary>
+    /// Fires during <see cref="DestructionEventArgs"/>, BEFORE <c>QueueDel</c> is called.
+    /// The console entity and all its components are fully alive at this point, so
+    /// <c>RemovePilot</c> works correctly and can clean up the pilot's input state.
+    /// </summary>
+    private void OnConsoleDestroyed(EntityUid console, ShuttleConsoleComponent component, DestructionEventArgs args)
+    {
+        CleanupPilots(component);
+    }
+
+    /// <summary>
+    /// Fires when the entity starts terminating (during <c>DeleteEntity</c>).
+    /// Handles deletions that don't go through <see cref="DestructionEventArgs"/>.
+    /// Also forcibly ejects any PAI still in the container slot so it isn't deleted with the console.
+    /// Note: <c>ejectOnBreak: true</c> on the YAML slot handles the common destructible case; this
+    /// is a belt-and-suspenders fallback.
+    /// </summary>
     private void OnConsoleDying(EntityUid console, ShuttleConsoleComponent component, ref EntityTerminatingEvent args)
     {
+        // Clean up any pilots that weren't already handled by OnConsoleDestroyed.
+        CleanupPilots(component);
+
+        // Eject any PAI still physically in the container so it isn't voided with the console.
         if (!_container.TryGetContainer(console, component.PaiSlotId, out var slot))
             return;
 
-        // Collect to avoid modifying while iterating.
         var contained = new List<EntityUid>(slot.ContainedEntities);
         foreach (var ent in contained)
         {
-            // Remove pilot status first (if they were actively piloting).
-            _shuttleConsole.RemovePilot(ent);
-
-            // Eject from container so it lands at the console's position instead of being deleted.
             _container.Remove(ent, slot, force: true);
+        }
+    }
+
+    /// <summary>
+    /// Remove <see cref="PilotComponent"/> from every entity currently piloting this console.
+    /// Safe to call during both <see cref="DestructionEventArgs"/> and <see cref="EntityTerminatingEvent"/>;
+    /// will no-op on entities that have already had the component removed.
+    /// </summary>
+    private void CleanupPilots(ShuttleConsoleComponent component)
+    {
+        var pilots = new List<EntityUid>(component.SubscribedPilots);
+        foreach (var pilot in pilots)
+        {
+            // RemovePilot handles the full cleanup (alerts, zoom, popup, RemComp).
+            _shuttleConsole.RemovePilot(pilot);
+
+            // Fallback: explicitly remove PilotComponent in case RemovePilot returned early
+            // (e.g. the pilot was not in SubscribedPilots for some reason, or the console
+            // component was already partially torn down).
+            RemComp<PilotComponent>(pilot);
         }
     }
 

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -174,6 +174,7 @@
       pai_slot:
         name: Personal AI Device
         ejectOnInteract: true
+        ejectOnBreak: true # Starlight: eject PAI when console is destroyed so it isn't voided.
         whitelist:
           components:
           - PAI


### PR DESCRIPTION
## Short description
Bug fixxing PAIs

## Why we need to add this
A bug that would void a PAI when they ram and or if the shuttle console is broken the PAI would be voided

## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Scarlet Lightweaver
- fix: Fixed PAIs being voided when the shuttle console breaks when ramming, whops.
