### PR TITLE
Ling Fix: Allow lesser form to devour and use the store

### DIFF
--- a/Content.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -503,7 +503,7 @@ public sealed partial class ChangelingSystem : EntitySystem
     }
     public void OnLesserForm(EntityUid uid, ChangelingComponent comp, ref ActionLesserFormEvent args)
     {
-        var newUid = TransformEntity(uid, protoId: "MobMonkey", comp: comp);
+        var newUid = TransformEntity(uid, protoId: "MobLingMonkey", comp: comp); // Starlight - fix lesser form
         if (newUid == null)
         {
             comp.Chemicals += Comp<ChangelingActionComponent>(args.Action).ChemicalCost;

--- a/Resources/Locale/en-US/store/changeling-catalog.ftl
+++ b/Resources/Locale/en-US/store/changeling-catalog.ftl
@@ -119,9 +119,10 @@ evolutionmenu-utility-fleshmend-desc =
     Rapidly heal yourself of all bruises and burns.
     Costs 35 chemicals.
 
+# Starlight - monkey form is permanent (until transform is fixed, at least)
 evolutionmenu-utility-lesserform-name = Lesser Form
 evolutionmenu-utility-lesserform-desc =
-    Abandon your current form and turn into a sentient monkey.
+    Abandon your current form and turn into a sentient monkey. Permanently.
     Costs 20 chemicals.
 
 evolutionmenu-utility-spacesuit-name = Space Adaptation

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Player/changeling.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Player/changeling.yml
@@ -1,0 +1,12 @@
+- type: entity
+  parent: [ MobMonkey, StorePresetChangeling ]
+  id: MobLingMonkey
+  suffix: Do Not Map
+  components:
+    - type: ChangelingDevour
+    - type: ChangelingIdentity
+    - type: UserInterface # Ensures that lesser form has necessary UIs
+      interfaces:
+        enum.StoreUiKey.Key:
+          type: StoreBoundUserInterface
+          requireInputValidation: false


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
This PR creates a short term fix that prevents monkey form from guaranteeing a RR for changeling, rather than removing it entirely. A true fix that allows lesser form to transform back into a humanoid form will likely be a more involved process and require a wider overhaul of the ling identity system. As such, it is not being addressed in this PR. Instead, the ability text for the store catalog has been updated to indicate that becoming a monkey is currently permanent, which should prevent it from being a player trap.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Monkey form currently guarantees a round remove, and is very broken. At least in this fashion, it can still be an escape option.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="402" height="139" alt="Screenshot from 2026-04-24 18-42-39" src="https://github.com/user-attachments/assets/85691bb3-4a9d-4e3c-8029-3ffed32e59c0" />
<img width="462" height="242" alt="Screenshot from 2026-04-24 18-43-09" src="https://github.com/user-attachments/assets/9961477f-e2ba-49d8-951d-b6f5e1d54bf6" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neurovermi
- fix: Lesser form changelings can devour and use the store again.
- tweak: Lesser form flavor text now shows that lesser form prevents transformation.