### PR TITLE
Loadout restoration

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -68,7 +68,602 @@
         color: "#EAE8E8"
   - type: Fiber
     fiberColor: fibers-white
+# Starlight Start - Towel Restoration
+- type: entity
+  id: TowelColorPurple
+  name: purple towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#9C0DE1"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#9C0DE1"
+      right:
+      - state: inhand-right
+        color: "#9C0DE1"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#9C0DE1"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#9C0DE1"
+      belt:
+      - state: equipped-BELT
+        color: "#9C0DE1"
+  - type: Fiber
+    fiberColor: fibers-purple
 
+- type: entity
+  id: TowelColorRed
+  name: red towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#940000"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#940000"
+      right:
+      - state: inhand-right
+        color: "#940000"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#940000"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#940000"
+      belt:
+      - state: equipped-BELT
+        color: "#940000"
+  - type: Fiber
+    fiberColor: fibers-red
+
+- type: entity
+  id: TowelColorBlue
+  name: blue towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#0089EF"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#0089EF"
+      right:
+      - state: inhand-right
+        color: "#0089EF"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#0089EF"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#0089EF"
+      belt:
+      - state: equipped-BELT
+        color: "#0089EF"
+  - type: Fiber
+    fiberColor: fibers-blue
+
+- type: entity
+  id: TowelColorDarkBlue
+  name: dark blue towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#3285ba"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#3285ba"
+      right:
+      - state: inhand-right
+        color: "#3285ba"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#3285ba"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#3285ba"
+      belt:
+      - state: equipped-BELT
+        color: "#3285ba"
+  - type: Fiber
+    fiberColor: fibers-blue
+
+- type: entity
+  id: TowelColorLightBlue
+  name: light blue towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#58abcc"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#58abcc"
+      right:
+      - state: inhand-right
+        color: "#58abcc"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#58abcc"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#58abcc"
+      belt:
+      - state: equipped-BELT
+        color: "#58abcc"
+  - type: Fiber
+    fiberColor: fibers-blue
+
+- type: entity
+  id: TowelColorTeal
+  name: teal towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#3CB57C"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#3CB57C"
+      right:
+      - state: inhand-right
+        color: "#3CB57C"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#3CB57C"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#3CB57C"
+      belt:
+      - state: equipped-BELT
+        color: "#3CB57C"
+  - type: Fiber
+    fiberColor: fibers-teal
+
+- type: entity
+  id: TowelColorBrown
+  name: brown towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#723A02"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#723A02"
+      right:
+      - state: inhand-right
+        color: "#723A02"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#723A02"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#723A02"
+      belt:
+      - state: equipped-BELT
+        color: "#723A02"
+  - type: Fiber
+    fiberColor: fibers-light-brown
+
+- type: entity
+  id: TowelColorLightBrown
+  name: light brown towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#c59431"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#c59431"
+      right:
+      - state: inhand-right
+        color: "#c59431"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#c59431"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#c59431"
+      belt:
+      - state: equipped-BELT
+        color: "#c59431"
+  - type: Fiber
+    fiberColor: fibers-brown
+
+- type: entity
+  id: TowelColorGray
+  name: gray towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#999999"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#999999"
+      right:
+      - state: inhand-right
+        color: "#999999"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#999999"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#999999"
+      belt:
+      - state: equipped-BELT
+        color: "#999999"
+  - type: Fiber
+    fiberColor: fibers-grey
+
+- type: entity
+  id: TowelColorGreen
+  name: green towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#5ABF2F"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#5ABF2F"
+      right:
+      - state: inhand-right
+        color: "#5ABF2F"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#5ABF2F"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#5ABF2F"
+      belt:
+      - state: equipped-BELT
+        color: "#5ABF2F"
+  - type: Fiber
+    fiberColor: fibers-green
+
+- type: entity
+  id: TowelColorDarkGreen
+  name: dark green towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#639137"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#639137"
+      right:
+      - state: inhand-right
+        color: "#639137"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#639137"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#639137"
+      belt:
+      - state: equipped-BELT
+        color: "#639137"
+  - type: Fiber
+    fiberColor: fibers-green
+
+- type: entity
+  id: TowelColorGold
+  name: gold towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#F7C430"
+    - state: iconstripe
+      color: "#535353"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#F7C430"
+      right:
+      - state: inhand-right
+        color: "#F7C430"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#F7C430"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#F7C430"
+      belt:
+      - state: equipped-BELT
+        color: "#F7C430"
+  - type: Fiber
+    fiberColor: fibers-gold
+
+- type: entity
+  id: TowelColorOrange
+  name: orange towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#EF8100"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#EF8100"
+      right:
+      - state: inhand-right
+        color: "#EF8100"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#EF8100"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#EF8100"
+      belt:
+      - state: equipped-BELT
+        color: "#EF8100"
+  - type: Fiber
+    fiberColor: fibers-orange
+
+- type: entity
+  id: TowelColorBlack
+  name: black towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#535353"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#535353"
+      right:
+      - state: inhand-right
+        color: "#535353"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#535353"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#535353"
+      belt:
+      - state: equipped-BELT
+        color: "#535353"
+  - type: Fiber
+    fiberColor: fibers-black
+
+- type: entity
+  id: TowelColorPink
+  name: pink towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#ffa69b"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#ffa69b"
+      right:
+      - state: inhand-right
+        color: "#ffa69b"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#ffa69b"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#ffa69b"
+      belt:
+      - state: equipped-BELT
+        color: "#ffa69b"
+  - type: Fiber
+    fiberColor: fibers-pink
+
+- type: entity
+  id: TowelColorYellow
+  name: yellow towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#ffe14d"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#ffe14d"
+      right:
+      - state: inhand-right
+        color: "#ffe14d"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#ffe14d"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#ffe14d"
+      belt:
+      - state: equipped-BELT
+        color: "#ffe14d"
+  - type: Fiber
+    fiberColor: fibers-yellow
+
+- type: entity
+  id: TowelColorMaroon
+  name: maroon towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#cc295f"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#cc295f"
+      right:
+      - state: inhand-right
+        color: "#cc295f"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#cc295f"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#cc295f"
+      belt:
+      - state: equipped-BELT
+        color: "#cc295f"
+  - type: Fiber
+    fiberColor: fibers-maroon
+
+- type: entity
+  id: TowelColorSilver
+  name: silver towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#d0d0d0"
+    - state: iconstripe
+      color: "#F7C430"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#d0d0d0"
+      right:
+      - state: inhand-right
+        color: "#d0d0d0"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#d0d0d0"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#d0d0d0"
+      belt:
+      - state: equipped-BELT
+        color: "#d0d0d0"
+  - type: Fiber
+    fiberColor: fibers-silver
+
+- type: entity
+  id: TowelColorMime
+  name: silent towel
+  parent: BaseTowel
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+      color: "#EAE8E8"
+    - state: iconstripe
+      color: "#535353"
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#EAE8E8"
+      right:
+      - state: inhand-right
+        color: "#EAE8E8"
+  - type: Clothing
+    clothingVisuals:
+      head:
+      - state: equipped-HELMET
+        color: "#EAE8E8"
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#EAE8E8"
+      belt:
+      - state: equipped-BELT
+        color: "#EAE8E8"
+  - type: Fiber
+    fiberColor: fibers-white
+# Starlight End
 - type: entity
   id: TowelColorNT
   name: NanoTrasen brand towel

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -69,6 +69,11 @@
   - AcousticGuitarInstrument
   - TrumpetInstrument
   - RoadCone
+  - MaidOutfit #Restored *again*, why do these keep getting removed?
+  - MaidGloves
+  - MaidOutfitTactical
+  - MaidHeadbandTactical
+  - TacticalMaidGloves
   - ClothWrapGloveTrinket
   - ClothWrapShoeTrinket
   - RollerSkates
@@ -336,6 +341,7 @@
   - TatteredClothes
   - TieDye
   - VintageClothes
+  - MaidOutfit # Starlight
 
 
 - type: loadoutGroup
@@ -416,6 +422,7 @@
   - BartenderJumpsuit
   - BartenderJumpskirt
   - BartenderJumpsuitPurple
+  - MaidOutfit # Starlight
 
 
 - type: loadoutGroup
@@ -465,6 +472,7 @@
   loadouts:
   - ChefJumpsuit
   - ChefJumpskirt
+  - MaidOutfit # Starlight
 
 
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -68,7 +68,7 @@
   - AcousticGuitarInstrument
   - TrumpetInstrument
   - RoadCone
-  - MaidOutfit #Restored *again*, why do these keep getting removed?
+  - MaidOutfit
   - MaidGloves
   - MaidOutfitTactical
   - MaidHeadbandTactical

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -63,7 +63,6 @@
   - TowelColorMime
   - TowelColorSilver
   - TowelColorGold
-  - TowelColorWhite
   - HarmonicaInstrument
   - FluteInstrument
   - AcousticGuitarInstrument

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -48,7 +48,23 @@
   - OffsetCaneNT
   - Cane
   - TowelColorWhite
-  - HarmonicaInstrument # Starlight start
+  - TowelColorGray # Starlight start
+  - TowelColorBlack
+  - TowelColorRed
+  - TowelColorOrange
+  - TowelColorLightBrown
+  - TowelColorYellow
+  - TowelColorDarkGreen
+  - TowelColorGreen
+  - TowelColorLightBlue
+  - TowelColorDarkBlue
+  - TowelColorPurple
+  - TowelColorMaroon
+  - TowelColorMime
+  - TowelColorSilver
+  - TowelColorGold
+  - TowelColorWhite
+  - HarmonicaInstrument
   - FluteInstrument
   - AcousticGuitarInstrument
   - TrumpetInstrument

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -322,3 +322,198 @@
     back:
     - TowelColorWhite
   groupBy: "towels"
+
+#Starlight Start - Towel Restoration
+
+- type: loadout
+  id: TowelColorGray
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobPassenger
+      time: 100h
+  storage:
+    back:
+    - TowelColorGray
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorBlack
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChaplain
+      time: 100h
+  storage:
+    back:
+    - TowelColorBlack
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorRed
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Security
+      time: 100h
+  storage:
+    back:
+    - TowelColorRed
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorOrange
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 100h
+  storage:
+    back:
+    - TowelColorOrange
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorLightBrown
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Cargo
+      time: 100h
+  storage:
+    back:
+    - TowelColorLightBrown
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorYellow
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobClown
+      time: 100h
+  storage:
+    back:
+    - TowelColorYellow
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorDarkGreen
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobLibrarian
+      time: 100h
+  storage:
+    back:
+    - TowelColorDarkGreen
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorGreen
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 100h
+  storage:
+    back:
+    - TowelColorGreen
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorLightBlue
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorPhysician
+  storage:
+    back:
+    - TowelColorLightBlue
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorDarkBlue
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Command
+      time: 100h
+  storage:
+    back:
+    - TowelColorDarkBlue
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorPurple
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Science
+      time: 100h
+  storage:
+    back:
+    - TowelColorPurple
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorMaroon
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+     # !type:RoleTimeRequirement # Starlight start: switch to law dept
+     # role: JobLawyer
+      !type:DepartmentTimeRequirement
+      department: Law # Starlight end
+      time: 100h
+  storage:
+    back:
+    - TowelColorMaroon
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorMime
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobMime
+      time: 100h
+  storage:
+    back:
+    - TowelColorMime
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorSilver
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 500h
+  storage:
+    back:
+    - TowelColorSilver
+  groupBy: "towels"
+
+- type: loadout
+  id: TowelColorGold
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:OverallPlaytimeRequirement
+      time: 1000h
+  storage:
+    back:
+    - TowelColorGold
+  groupBy: "towels"
+# Starlight End

--- a/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/fashion.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/fashion.yml
@@ -28,28 +28,6 @@
       stock: 1
 
 - type: listing
-  id: ClothingUniformJumpskirtElegantMaid
-  productEntity: ClothingUniformJumpskirtElegantMaid
-  cost:
-    NTCredit: 990
-  categories:
-    - SLFashionSkirt
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
-  id: ClothingUniformJumpskirtTacticalMaid
-  productEntity: ClothingUniformJumpskirtTacticalMaid
-  cost:
-    NTCredit: 990
-  categories:
-    - SLFashionSkirt
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
   id: ClothingUniformJumpskirtDressRed
   productEntity: ClothingUniformJumpskirtDressRed
   cost:
@@ -381,17 +359,6 @@
       stock: 1
 
 - type: listing
-  id: ClothingHeadHatTacticalMaidHeadband
-  productEntity: ClothingHeadHatTacticalMaidHeadband
-  cost:
-    NTCredit: 400
-  categories:
-    - SLFashionHead
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-- type: listing
   id: ClothingMaskGeneralBorg
   productEntity: ClothingMaskGeneralBorg
   cost:
@@ -652,18 +619,6 @@
 - type: listing
   id: ClothingHandsTacticalMaidGlovesDelicate
   productEntity: ClothingHandsTacticalMaidGlovesDelicate
-  cost:
-    NTCredit: 400
-  categories:
-    - SLFashionOther
-  conditions:
-    - !type:ListingLimitedStockCondition
-      stock: 1
-
-
-- type: listing
-  id: ClothingHandsMaidGlovesElegant
-  productEntity: ClothingHandsMaidGlovesElegant
   cost:
     NTCredit: 400
   categories:

--- a/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
@@ -572,6 +572,66 @@
     gloves: ClothingClothWrap
   groupBy: "cloth wraps"
 
+# Maid Outfits
+- type: loadout
+  id: MaidOutfit
+  effects:
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:OverallPlaytimeRequirement
+        time: 144000 # 40hr
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtElegantMaid
+  groupBy: "maid outfit"
+
+- type: loadout
+  id: MaidGloves
+  effects:
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:OverallPlaytimeRequirement
+        time: 144000 # 40 hr
+  equipment:
+    gloves: ClothingHandsMaidGlovesElegant
+  groupBy: "maid outfit"
+
+- type: loadout
+  id: TacticalMaidGloves
+  effects:
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:DepartmentTimeRequirement
+        department: Security
+        time: 216000 # 60 hours of charging batong
+  equipment:
+    gloves: ClothingHandsTacticalMaidGlovesDelicate
+  groupBy: "maid outfit"
+
+- type: loadout
+  id: MaidOutfitTactical
+  effects:
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:DepartmentTimeRequirement
+        department: Security
+        time: 216000 # 60 hours of charging batong
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtTacticalMaid
+  groupBy: "maid outfit"
+
+- type: loadout
+  id: MaidHeadbandTactical
+  effects:
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:DepartmentTimeRequirement
+        department: Security
+        time: 216000 # 60 hours of charging batong
+  equipment:
+    head: ClothingHeadHatTacticalMaidHeadband
+  groupBy: "maid outfit"
+
+
 - type: loadout
   id: TreasureCoinIron
   storage:

--- a/Resources/Prototypes/_Starlight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/loadout_groups.yml
@@ -712,6 +712,7 @@
   - ServiceWorkerBotanyJumpskirt
   - ServiceWorkerChefJumpsuit
   - ServiceWorkerChefJumpskirt
+  - MaidOutfit
 
 # Performer
 - type: loadoutGroup

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -776,4 +776,4 @@ OrganSkeletonPersonArmRight: RightArmSkeleton
 # Starlight end
 
 # 2026-01-19
-TowelColorOrange: null
+#TowelColorOrange: null # Starlight - Towel Restorarion

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -776,4 +776,4 @@ OrganSkeletonPersonArmRight: RightArmSkeleton
 # Starlight end
 
 # 2026-01-19
-#TowelColorOrange: null # Starlight - Towel Restorarion
+#TowelColorOrange: null # Starlight - Towel Restoration


### PR DESCRIPTION
## Short description
Restores several removed loadout options

## Why we need to add this
Towels were removed wizden-side for seemingly no reason, and maid outfits likewise (but on our end), so this PR restores both.
Especially notable that some of the items in the fashion-o-matic exist *expressly and exclusively* because the maid outfits were moved fully into loadouts, where they belong.
Not touching the mess with the medical loadout for now, as that is already being addressed
(https://discord.com/channels/1272545509562777621/1498044933637013776)

## Media (Video/Screenshots)
<img width="224" height="428" alt="image" src="https://github.com/user-attachments/assets/cb146337-cd24-489c-a444-1af23cfbdfe7" />

Service jobs get to bring maid outfits - and if you want to spend trinket slots on it you can

<img width="505" height="713" alt="image" src="https://github.com/user-attachments/assets/b8c83a88-09e8-498c-a5b8-d0909a31112f" />

Towels exist again

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Towels with colours exist again.
- fix: Maid outfits are back in loadouts.
