### PR TITLE
Revert wizden medical loadout changes

### DIFF
--- a/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Starlight/preferences/loadout-groups.ftl
@@ -103,7 +103,8 @@ loadout-group-chemist-beaker = Chemist beaker
 loadout-group-chemist-bag = Chemist bag
 loadout-group-chemist-labeler = Chemist labeler
 loadout-group-chemist-shoes = Chemist shoes
-
+loadout-group-medical-glasses = Medical glasses
+loadout-group-medical-gloves = Medical gloves
 # Service
 loadout-group-janitor-neck = Janitor neck
 

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -111,11 +111,13 @@
         - id: ChemistryBottleSaline
         - id: ChemistryBottleBicaridine
         - id: ChemistryBottleDexalin
+        - id: ChemistryBottleAmoxla # Starlight, for the birds
         - id: ChemistryBottleDylovene
         - id: ChemistryBottleHyronalin
         - id: ChemistryBottleKelotane
         - id: ChemistryBottleEpinephrine # A power item for medical players that feels thematic and worth stealing
         - id: PillCanisterTricordrazine
+        - id: EmergencyMedipen # Starlight
 
 - type: entity
   parent: ClothingBeltMedicalEMT
@@ -131,10 +133,13 @@
         # Reagents focused on emergency response rather than outright healing
         - id: ChemistryBottleInaprovaline
           amount: 2
-        - id: ChemistryBottleHaloperidol
-        - id: ChemistryBottleEthylredoxrazine
+        # - id: ChemistryBottleHaloperidol Starlight - making room (also these are more perscription meds)
+        # - id: ChemistryBottleEthylredoxrazine Starlight end
+        - id: Syringe # Starlight - utility
         - id: ChemistryBottleIpecac
         - id: ChemistryBottleCharcoal
+        - id: EmergencyMedipen # Starlight - really useful for paramedics and can't be made
+          amount: 3 # SL
 
 - type: entity
   id: ClothingBeltPlantFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -310,18 +310,21 @@
     - id: DoorRemoteMedical
     - id: BoxEncryptionKeyMedical
     - id: BoxCMOCircuitboards
-    - id: AutoMenderBurnFilled #Starlight
-    - id: AutoMenderBruteFilled #Starlight
-    - id: CMOLicense #STARLIGHT
-    - id: EncryptionKeyMedicalScience # Starlight, steal target
-      prob: 0.5 # Starlight
-    - id: PrintedDocumentGreenshiftAlert #SL
-      conditions: #SL
-      - !type:GamemodeCondition #SL
-        presets: #SL
-        - Greenshift #SL
-        - Sandbox #SL
-    - id: JawsOfLifeMed #Starlight
+    - id: AutoMenderBurnFilled # Starlight start
+    - id: AutoMenderBruteFilled
+    - id: ClothingBackpackDuffelSurgeryFilled
+    - id: ClothingMaskSterile
+    - id: ClothingHandsGlovesNitrile
+    - id: CMOLicense
+    - id: EncryptionKeyMedicalScience # Steal target
+      prob: 0.5
+    - id: PrintedDocumentGreenshiftAlert
+      conditions:
+      - !type:GamemodeCondition
+        presets:
+        - Greenshift
+        - Sandbox
+    - id: JawsOfLifeMed #Starlight end
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -43,6 +43,29 @@
   id: LockerFillMedicalDoctor
   table: !type:AllSelector
     children:
+    # Starlight start
+    - id: ClothingHeadMirror
+      prob: 0.1
+    - id: ClothingHandsGlovesLatex
+    - id: ClothingHeadsetMedical
+    - !type:GroupSelector
+      children:
+      - id: ClothingHeadHatSurgcapGreen
+        weight: 0.1
+      - id: ClothingHeadHatSurgcapPurple
+        weight: 0.05
+      - id: ClothingHeadHatSurgcapBlue
+        weight: 0.90
+    - !type:GroupSelector
+      children:
+      - id: UniformScrubsColorBlue
+        weight: 0.5
+      - id: UniformScrubsColorGreen
+        weight: 0.1
+      - id: UniformScrubsColorPurple
+        weight: 0.05
+    - id: ClothingMaskSterile
+    #Starlight end
     - id: ClothingEyesHudMedical
     - id: ClothingBeltMedicalFilled
     - id: JetInjector
@@ -121,16 +144,16 @@
     - id: ClothingOuterHardsuitVoidParamed
     - id: ClothingBeltMedicalEMTFilled
     - id: JetInjector
-    - id: PlushieKiosha #starlight
-    - id: EmergencyHandheldCrewMonitor #starlight
-    - id: JawsOfLifeMed #Starlight
-    - id: HandheldHealthAnalyzer
+    - id: EmergencyHandheldCrewMonitor # Starlight
+    - id: JawsOfLifeMed # Starlight
+    # - id: HandheldHealthAnalyzer Starlight - kind of just junk in the locker at this point, use your PDA or get one at a nanomed
     - id: BoxBodyBag
-    - !type:GroupSelector
-      children:
-      - id: RollerBedSpawnFolded
-      - id: CheapRollerBedSpawnFolded
-      - id: EmergencyRollerBedSpawnFolded
+    # Starlight edit - rollerbeds - these are mapped, printable and in your bag round start
+    # - !type:GroupSelector
+    #   children:
+    #   - id: RollerBedSpawnFolded
+    #   - id: CheapRollerBedSpawnFolded
+    #   - id: EmergencyRollerBedSpawnFolded
 
 - type: entity
   parent: LockerParamedic

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemdrobe.yml
@@ -5,20 +5,23 @@
     ClothingHeadNurseHatChemist: 2 # Starlight
     ClothingShoesBootsWinterChem: 2 # Starlight
     ClothingEyeGlassesChemicalPrescription: 2 # Starlight
+    # Starlight start - reverting to two stock instead of one
     # Essential
-    ClothingEyesGlassesChemical: 1
+    ClothingEyesGlassesChemical: 2
+    HandLabeler: 2
     # Optional
-    ClothingHeadsetMedical: 1
-    ClothingBackpackChemistry: 1
-    ClothingBackpackSatchelChemistry: 1
-    ClothingBackpackDuffelChemistry: 1
-    ChemBag: 1
-    ClothingUniformJumpsuitChemistry: 1
-    ClothingUniformJumpskirtChemistry: 1
-    ClothingOuterCoatLabChem: 1
-    ClothingOuterWinterChem: 1
-    ClothingHandsGlovesLatex: 1
-    ClothingShoesColorWhite: 1
+    ClothingHeadsetMedical: 2
+    ClothingBackpackChemistry: 2
+    ClothingBackpackSatchelChemistry: 2
+    ClothingBackpackDuffelChemistry: 2
+    ChemBag: 2
+    ClothingUniformJumpsuitChemistry: 2
+    ClothingUniformJumpskirtChemistry: 2
+    ClothingOuterCoatLabChem: 2
+    ClothingOuterWinterChem: 2
+    ClothingHandsGlovesLatex: 2
+    ClothingShoesColorWhite: 2
+    # Starlight end
   contrabandInventory:
     ToyFigurineChemist: 1
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -22,6 +22,7 @@
   id: NanoMedCivilianWallInventory
   startingInventory:
     HandheldHealthAnalyzer: 1
+    Gauze: 3 # Starlight
     Tourniquet: 3
     Brutepack: 3
     AloeCream: 3 # Currently just a reskin of Ointment but it's something
@@ -75,6 +76,7 @@
   startingInventory:
     HandheldHealthAnalyzer: 3
     Tourniquet: 5
+    Gauze: 3 # Starlight
     Brutepack: 5
     AloeCream: 5
     Bloodpack: 5

--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -214,6 +214,7 @@
       tags:
       - Wrench
       - Bottle
+      - Vial
       - Spray
       - Brutepack
       - Bloodpack
@@ -286,6 +287,7 @@
       tags:
         - Crowbar
         - Bottle
+        - Vial
         - Spray
         - Brutepack
         - Bloodpack

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -955,7 +955,7 @@
   name: NanoMed Plus
   components:
   - type: VendingMachine
-    pack: NanoMedPlusInventory
+    pack: NanoMedPlusInventorySL # Starlight
     offState: off
     showPrices: false  # Starlight-edit: Vending Machines Prices
   - type: Machine # Starlight-edit: Vending Machine boards

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
@@ -246,6 +246,7 @@
   - WhiteShoes
   - MedicalWinterBoots
   - Heels # Starlight
+  - HighHeelBoots # Starlight
 
 - type: loadoutGroup
   id: ParamedicJobTrinkets

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/medical.yml
@@ -41,6 +41,26 @@
   - EmergencyNonBreatherMedical # 🌟Starlight🌟
   - EmergencyIPC # 🌟Starlight🌟
 
+- type: loadoutGroup # Starlight start
+  id: MedicalGloves
+  name: loadout-group-medical-gloves
+  minLimit: 0
+  loadouts:
+  - LatexGloves
+  - NitrileGloves
+
+- type: loadoutGroup
+  id: MedicalEyewear
+  name: loadout-group-medical-glasses
+  minLimit: 0
+  loadouts:
+  - MedicalHud
+  - MedicalEyePatchHud
+  - Glasses
+  - GlassesJamjar
+  - GlassesJensen
+  - MedicalGlassesPrescription # Starlight end
+
 # Chief Medical Officer
 
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/RoleLoadouts/medical.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/medical.yml
@@ -7,11 +7,13 @@
   - ChiefMedicalOfficerHead
   - MedicalMask
   - ChiefMedicalOfficerJumpsuit
+  - MedicalGloves # Starlight
   - MedicalBackpack
   - ChiefMedicalOfficerOuterClothing
   - ChiefMedicalOfficerNeck
   - ChiefMedicalOfficerShoes
-  - Glasses
+  - MedicalEyewear # Starlight
+  # - Glasses Starlight
   - SurvivalMedical
   - Trinkets
   - Scarves # 🌟Starlight🌟
@@ -27,11 +29,13 @@
   - MedicalDoctorHead
   - MedicalMask
   - MedicalDoctorJumpsuit
+  - MedicalGloves # Starlight
   - MedicalBackpack
   - MedicalDoctorOuterClothing
   - MedicalShoes
   - MedicalDoctorPDA
-  - Glasses
+  - MedicalEyewear # Starlight
+  # - Glasses Starlight
   - SurvivalMedical
   - Trinkets
   - Scarves # 🌟Starlight🌟
@@ -46,14 +50,16 @@
   - GroupTankHarness
   - MedicalInternJumpsuit
   # 🌟Starlight🌟 start
+  - MedicalGloves
   - MedicalDoctorHead
   - MedicalMask
   - MedicalDoctorJumpsuit
   - MedicalBackpack
   - MedicalDoctorOuterClothing
   - MedicalShoes
+  - MedicalEyewear
   # 🌟Starlight🌟 end
-  - Glasses
+  # - Glasses Starlight
   - SurvivalMedical
   - Trinkets
   - Scarves # 🌟Starlight🌟
@@ -69,6 +75,7 @@
   - ChemistHead # 🌟Starlight🌟
   - MedicalMask
   - ChemistJumpsuit
+  - MedicalGloves # Starlight
   - ChemistBackpack
   - ChemistOuterClothing
   # 🌟Starlight🌟 start
@@ -96,11 +103,13 @@
   - ParamedicHead
   - MedicalMask
   - ParamedicJumpsuit
+  - MedicalGloves # Starlight
   - MedicalBackpack
   - ParamedicOuterClothing
   - ParamedicShoes
   - ParamedicPDA # 🌟Starlight🌟
-  - Glasses
+  - MedicalEyewear # Starlight
+  # - Glasses Starlight
   - SurvivalMedical
   - Trinkets
   - Scarves # 🌟Starlight🌟

--- a/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/RoleLoadouts/role_loadouts.yml
@@ -595,6 +595,7 @@
   groups:
   - GroupTankHarness
   - PsychologistJumpsuit
+  - MedicalGloves # Starlight
   - MedicalBackpack
   - MedicalDoctorHead # Starlight start
   - MedicalDoctorOuterClothing

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -25,6 +25,9 @@
   equipment:
     # id: ChemistryPDA #Starlight
     ears: ClothingHeadsetMedical
+    belt: ChemBag # Starlight start
+    pocket1: HandLabeler
+    eyes: ClothingEyesGlassesChemical # Starlight end
 
 - type: chameleonOutfit
   id: ChemistChameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -43,6 +43,7 @@
   equipment:
     id: CMOPDA
     ears: ClothingHeadsetCMO
+    belt: ClothingBeltMedicalFilled # Starlight - adding back belts
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -28,6 +28,7 @@
   id: DoctorGear
   equipment:
     ears: ClothingHeadsetMedical
+    belt: ClothingBeltMedicalFilled # Starlight - adding back belts
 
 - type: chameleonOutfit
   id: MedicalDoctorChameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -23,6 +23,7 @@
 #    shoes: ClothingShoesColorWhite Starlight loadout options enabled
     id: MedicalInternPDA
     ears: ClothingHeadsetMedical
+    belt: ClothingBeltMedicalFilled # Starlight - adding back belts
     pocket2: BookMedicalReferenceBook
 
 - type: chameleonOutfit

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -27,10 +27,12 @@
   id: ParamedicGear
   equipment:
     ears: ClothingHeadsetMedical
+    belt: ClothingBeltMedicalEMTFilled # Starlight start
   storage:
     back:
-    - BodyBagLockableFolded #Starlight
-    - DefibrillatorParamed #Starlight
+    - EmergencyRollerBedSpawnFolded
+    - BodyBagLockableFolded
+    - DefibrillatorParamed # Starlight end
 
 - type: chameleonOutfit
   id: ParamedicChameleonOutfit

--- a/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/medical.yml
@@ -367,3 +367,37 @@
   emaggedInventory:
     OminousPill: 1
     StrangePill: 1
+
+- type: vendingMachineInventory
+  id: NanoMedPlusInventorySL
+  startingInventory:
+    HandheldHealthAnalyzer: 3
+    Gauze: 5
+    Brutepack: 5
+    Ointment: 5
+    Bloodpack: 5
+    Tourniquet: 2
+    ChemistryBottleEpinephrine: 3
+    ChemistryBottleBicaridine: 1
+    Syringe: 5
+    JetInjector: 3
+    BoxBottle: 3
+    PillCanisterTricordrazine: 3
+    PillCanisterIron: 1
+    PillCanisterCopper: 1
+    PillCanisterPotassiumIodide: 1
+    SyringeIpecac: 1
+    ClothingEyesHudMedical: 2
+    ClothingEyesEyepatchHudMedical: 2
+    ClothingEyeGlassesMedicalPrescription: 2
+    AutoMenderBruteFilled: 1
+    AutoMenderBurnFilled: 1
+    SpaceMedipen: 1
+  contrabandInventory:
+    PillCanisterRandom: 3
+    PillSpaceDrugs: 3
+    StrangePill: 2
+    FoodApple: 1
+  emaggedInventory:
+    OminousPill: 2
+    PillDesoxyephedrine5: 2

--- a/Resources/Prototypes/_Starlight/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -30,8 +30,24 @@
   - !type:GroupLoadoutEffect
     proto: SeniorPhysician
 
-    # Eyewear
+# Gloves
+- type: loadout
+  id: NitrileGloves
+  equipment:
+    gloves: ClothingHandsGlovesNitrile
+
+# Eyewear
 - type: loadout
   id: MedicalGlassesPrescription
   equipment:
     eyes: ClothingEyeGlassesMedicalPrescription
+
+- type: loadout
+  id: MedicalHud
+  equipment:
+    eyes: ClothingEyesHudMedical
+
+- type: loadout
+  id: MedicalEyePatchHud
+  equipment:
+    eyes: ClothingEyesEyepatchHudMedical

--- a/Resources/Prototypes/_Starlight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/role_loadouts.yml
@@ -40,10 +40,12 @@
   - MedicalDoctorHead
   - MedicalMask
   - MedicalDoctorJumpsuit
+  - MedicalGloves
   - MedicalBackpack
   - MedicalDoctorOuterClothing
   - MedicalShoes
   - MedicalDoctorPDA
+  - MedicalEyewear
   - SurvivalMedical
   - Trinkets
   - Scarves


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Revert changes to starting medical loadouts - mainly, belts, gloves and eyewear
Revert NanoMed stock changes
Changes to lockers and drobes, bringing some things back and cleaning up others
Various small changes to loadouts and belt contents
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
[Suggestions post](https://discord.com/channels/1272545509562777621/1498025392592916713) | [PR workshop thread](https://discord.com/channels/1272545509562777621/1498044933637013776)
These were changes made by wizden and aren't suitable for how medical runs on SL, not to mention often there are not enough lockers mapped for every doctor in an alpha pop medbay.
The intent of the changes from wizden was to create RP, but instead they only add more tedium to the start of the shift.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: SevenShades
- add: Added back loadout options for medical gloves and eyewear.
- add: Returned emergency medipens to doctor and EMT belts.
- tweak: Reverted changes made to the NanoMed Plus inventory.
- add: Added gauze back to NanoMed civilian and band aid inventories.
- tweak: Added back belts to roundstart medical loadouts and other small loadout changes.