### PR TITLE
Resomi lungs now have resomi metabolism

### DIFF
--- a/Resources/Prototypes/_Starlight/Body/Organs/resomi.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/resomi.yml
@@ -63,6 +63,14 @@
   suffix: Resomi
   description: "The lungs of a resomi."
   components:
+  - type: Metabolizer
+    removeEmpty: true
+    solutionOnBody: false
+    solution: "Lung"
+    metabolizerTypes: [ Resomi, Human ] #They get both so they can still breathe oxygen without us needing to add Resomi everywhere Human is listed
+    groups:
+    - id: Gas
+      rateModifier: 100.0
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Resomi/organs.rsi
     layers:


### PR DESCRIPTION
## Short description
Resomi now use Resomi metabolism for breathing

## Why we need to add this
This was clearly intended to already be the case, there are gasses with filters for the Resomi metabolism type, but Resomi lungs do not *have* that type.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Resomi no longer get poisoned by ammonia gas.
