### PR TITLE
Atmospheric Network Monitor fixed again

### DIFF
--- a/Content.Client/Atmos/Consoles/AtmosMonitoringConsoleNavMapControl.cs
+++ b/Content.Client/Atmos/Consoles/AtmosMonitoringConsoleNavMapControl.cs
@@ -28,11 +28,11 @@ public sealed partial class AtmosMonitoringConsoleNavMapControl : NavMapControl
     /// </summary>
     private readonly float[] _layerFraction =
     {
-        0.50f,  // middle pipe
-        0.625f, // above middle
-        0.375f, // below middle
-        0.75f,  // top pipe
-        0.25f,  // bottom pipe
+        0.50f,  // primary    (middle pipe)
+        0.625f, // secondary  (above middle pipe)
+        0.375f, // tertiary   (below middle pipe)
+        0.75f,  // quaternary (top pipe)
+        0.25f,  // quinary    (bottom pipe)
     };
     // #endregion Starlight
     private const float LineThickness = 0.05f;

--- a/Content.Client/Atmos/Consoles/AtmosMonitoringConsoleWindow.xaml.cs
+++ b/Content.Client/Atmos/Consoles/AtmosMonitoringConsoleWindow.xaml.cs
@@ -34,7 +34,17 @@ public sealed partial class AtmosMonitoringConsoleWindow : FancyWindow
     private ProtoId<NavMapBlipPrototype> _navMapConsoleProtoId = "NavMapConsole";
     private ProtoId<NavMapBlipPrototype> _gasPipeSensorProtoId = "GasPipeSensor";
 
-    private readonly Vector2[] _pipeLayerOffsets = { new Vector2(0f, 0f), new Vector2(0.25f, 0.25f), new Vector2(-0.25f, -0.25f) };
+    // #region Starlight
+    // used for rendering the "map blips" when the 'Gas pipe sensors' is toggled on in the 'Toggle map overlays' on the Atmosheric Network Monitor.
+    private readonly Vector2[] _pipeLayerOffsets =
+    {
+        new Vector2(0f, 0f),           // primary    (middle pipe)
+        new Vector2(0.125f, 0.125f),   // secondary  (above middle pipe)
+        new Vector2(-0.125f, -0.125f), // tertiary   (below middle pipe)
+        new Vector2(0.25f, 0.25f),     // quaternary (top pipe)
+        new Vector2(-0.25f, -0.25f)    // quinary    (bottom pipe)
+    };
+    // #endregion Starlight
 
     public AtmosMonitoringConsoleWindow(AtmosMonitoringConsoleBoundUserInterface userInterface, EntityUid? owner)
     {


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Follow-up for #4255

There was a second array of values that would throw an out-of-range error whenever there were gas sensors on pipe layers 4 or 5 and *sometimes* when gas pumps were on pipe layer 4 or 5.

In `Content.Client\Atmos\Consoles\AtmosMonitoringConsoleWindow.xaml.cs`
```csharp
private readonly Vector2[] _pipeLayerOffsets = 
{
  new Vector2(0f, 0f),
  new Vector2(0.25f, 0.25f),
  new Vector2(-0.25f, -0.25f)
};
```

This would throw this error:
> [ERRO] system.user_interface: Caught exception while attempting to create a BUI key with type Content.Client.Atmos.Consoles.AtmosMonitoringConsoleBoundUserInterface on entity atmospheric network monitor (84017/n1147613, ComputerAtmosMonitoring). Exception: System.IndexOutOfRangeException: Index was outside the bounds of the array. at Content.Client.Atmos.Consoles.AtmosMonitoringConsoleWindow.AddTrackedEntityToNavMap(AtmosDeviceNavMapData metaData, Boolean isSensor) in /home/runner/work/space-station-14/space-station-14/Content.Client/Atmos/Consoles/AtmosMonitoringConsoleWindow.xaml.cs:line 230

Which is referring to this line in `AddTrackedEntityToNavMap()`
```csharp
  if (proto.Placement == NavMapBlipPlacement.Offset && metaData.PipeLayer > 0)
    coords = coords.Offset(_pipeLayerOffsets[(int)metaData.PipeLayer]);
```

`_pipeLayerOffsets[(int)metaData.PipeLayer])` would go out of range out of the `_pipeLayerOffsets` array because it only has 3 entires and the `PipeLayer` enum has 5 entries.

I've fixed this and another bug by adjusting the `_pipeLayerOffsets` array.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It fixes two bugs:
- The little sprites for stuff like gas pumps were misaligned with pipes (see Media).
- The Network Monitor will soft-crash (throw an error and close the GUI) every time there is a gas pump or gas sensor on pipe layer 4 or pipe layer 5.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
fig. 1 - **Before** this fix is applied. Note how the triangles (which represent gas pumps) are really offset from their pipes.
<img width="732" height="573" alt="image" src="https://github.com/user-attachments/assets/69ca26e2-1465-4f73-89eb-8b13fdef0ef6" />

fig. 2 - **After** this fix was is applied. Note that the triangles align with their pipes much better. Also pictured are the gas sensors, correctly aligned with their pipes.
<img width="1530" height="761" alt="image" src="https://github.com/user-attachments/assets/fa105069-a971-4495-a5d9-c43ed7bb4306" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Toggling on "Gas pipe sensors" in the Atmospheric Network Monitor no longer breaks the network monitor. Engineers rejoice, again.
- fix: The triangle sprites that represent gas pumps on the Atmospheric Network Monitor now correctly align with their respective gas pipes again.