### PR TITLE
Nukie Nuke round end CVar

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -32,9 +32,10 @@ using Content.Shared.Cuffs.Components;
 using Content.Shared.Cuffs;
 using Prometheus;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Containers;
 using Content.Server.AlertLevel;
 using Content.Server._Starlight.Station;
+using Content.Shared.Starlight.CCVar;
+using Robust.Shared.Configuration;
 // Starlight End
 
 namespace Content.Server.GameTicking.Rules;
@@ -55,9 +56,12 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
     [Dependency] private readonly StoreSystem _store = default!;
     [Dependency] private readonly TagSystem _tag = default!;
-    [Dependency] private readonly SharedCuffableSystem _cuffable = default!; // Starlight
-    [Dependency] private readonly AlertLevelSystem _alertLevel = default!; // SL
-    [Dependency] private readonly StationCrewCountSystem _stationCrewCount = default!; // Starlight
+    // Starlight Start
+    [Dependency] private readonly SharedCuffableSystem _cuffable = default!;
+    [Dependency] private readonly AlertLevelSystem _alertLevel = default!;
+    [Dependency] private readonly StationCrewCountSystem _stationCrewCount = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    // Starlight End
 
     private static readonly ProtoId<CurrencyPrototype> TelecrystalCurrencyPrototype = "Telecrystal";
     private static readonly ProtoId<TagPrototype> NukeOpsUplinkTagPrototype = "NukeOpsUplink";
@@ -179,7 +183,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 
             if (GameTicker.IsGameRuleActive("Nukeops")) // If it's Nukeops then end the round on any detonation
             {
-                _roundEndSystem.EndRound();
+                _roundEndSystem.EndRound(TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.NukeRoundRestartTime))); // Starlight Edit: Round end timer set by Cvar
             }
             else
             { // It's a LoneOp. Only end the round if the station was destroyed
@@ -188,7 +192,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 {
                     if (cond.ToString().ToLower() == "NukeExplodedOnCorrectStation") // If this is true, then the nuke destroyed the station! It's likely everyone is very dead so keeping the round going is pointless.
                     {
-                        _roundEndSystem.EndRound(); // end the round!
+                        _roundEndSystem.EndRound(TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.NukeRoundRestartTime))); // end the round! // Starlight Edit: Round end timer set by Cvar
                         handled = true;
                         break;
                     }
@@ -459,7 +463,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         _nukeopsCount.WithLabels(type.ToString()).Inc(1); // Starlight
 
         if (endRound && (type == WinType.CrewMajor || type == WinType.OpsMajor))
-            _roundEndSystem.EndRound();
+            _roundEndSystem.EndRound(TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.NukeRoundRestartTime))); // Starlight Edit: Round end timer set by Cvar
     }
 
     private void CheckRoundShouldEnd()

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
@@ -45,4 +45,10 @@ public sealed partial class StarlightCCVars
     /// </summary>
     public static readonly CVarDef<bool> AutogammaRiftEnabled =
         CVarDef.Create("game.autogamma_enabled", false, CVar.SERVERONLY);
+
+    /// <summary>
+    /// The time in seconds that it will take the round to end after the nuke explodes durign nukies.
+    /// </summary>
+    public static readonly CVarDef<float> NukeRoundRestartTime =
+        CVarDef.Create("game.nuke_round_restart_time", 20f, CVar.SERVERONLY);
 }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Ports https://github.com/space-wizards/space-station-14/pull/38336 (MIT) (Closed Wizden PR)
Makes round end during Nukie rounds after a CVar set time, Currently 20 Seconds
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Nobody wants to float for 5 minutes in space, 10 minutes on beta.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="516" height="233" alt="image" src="https://github.com/user-attachments/assets/96099b05-8297-40f1-9676-6d23c1f35fe9" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- tweak: The round will now end in 20 seconds after nuke explosion during a nukie round.