### PR TITLE
Reduce NT-ISD criminal card handcuff metagaming

### DIFF
--- a/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
+++ b/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
@@ -29,7 +29,7 @@ rr-criminal-failed-name = Decision regarding the criminal {$subject}
 rr-criminal-failed-content =
                          [head=3]Authorized Inspector on the Case[/head]
     ─────────────────────────────────────────
-                                      [center][color=#006666][italic][bold]Mitigation Decision[/bold][/italic][/color][/center]
+                                      [center][color=#006666][italic][bold]Mitigation Decision[/bold][/italic][/color][/center]
     ─────────────────────────────────────────
     Regarding the case of the criminal {$subject}. We have just intercepted a recruitment letter indicating that the crimes committed were not of direct intent.
 

--- a/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
+++ b/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
@@ -35,7 +35,7 @@ rr-criminal-failed-content =
 
     In this regard, the crime is no longer classified as informational extremism, but as fatal negligence.
 
-    You should [bold]interrogate[/bold] the criminal, and if {SUBJECT($subject)} admits {POSS-ADJ($subject)} guilt, [bold]parole[/bold] {POSS-ADJ($subject)} and allow {OBJECT($subject)} to work it off in lower positions, with damages assessed from one and a half to ten million credits.
+    You should [bold]interrogate[/bold] the criminal, and if {SUBJECT($subject)} admits {POSS-ADJ($subject)} guilt, [bold]parole[/bold] {OBJECT($subject)} and allow {OBJECT($subject)} to work it off in lower positions, with damages assessed from one and a half to ten million credits.
     ─────────────────────────────────────────
    ⠀                                    [italic]Place for stamps[/italic]
 

--- a/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
+++ b/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
@@ -17,7 +17,7 @@ rr-criminal-1-letter-content =
     In accordance with Directive 25, Section B of the Code of Information Crimes, you are ordered to deliver {OBJECT($subject)} to Central Command, dead or alive.
 
     {$subject} [italic]must[/italic] be:
-    - [bold]Handcuffed[/bold] (even if {SUBJECT($subject)} {CONJUGATE-BE($subject)} is compliant)
+    - [bold]Handcuffed[/bold] (even if {SUBJECT($subject)} {CONJUGATE-BE($subject)} compliant)
     - [bold]Searched[/bold]
     - [bold]Interrogated[/bold]
 

--- a/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
+++ b/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
@@ -4,7 +4,7 @@ rr-criminal-desc = That was a mistake, at any moment I could be reported and the
 rr-criminal-message = Well-wisher: We have just intercepted a fax, you’ve been declared wanted. Nevertheless, your recent malicious act against NT has greatly impressed us. We’ll send you a gift by mail, it should arrive in about 20 minutes.
 rr-criminal-wrapped-message = [bold]Well-wisher[/bold]: We have just intercepted a fax, you’ve been declared wanted. Nevertheless, your recent malicious act against NT has greatly impressed us. We’ll send you a gift by mail, it should arrive in about 20 minutes.
 
-rr-criminal-letter-name = ORDER, dangerous criminal {$subject} is wanted.
+rr-criminal-letter-name = ORDER, dangerous criminal {$subject} is wanted
 rr-criminal-1-letter-content =
                  [head=3]NT Information Security Department[/head]
     ─────────────────────────────────────────
@@ -25,7 +25,7 @@ rr-criminal-1-letter-content =
     ─────────────────────────────────────────
    ⠀                                    [italic]Place for stamps[/italic]
 
-rr-criminal-failed-name = Decision regarding the criminal {$subject}.
+rr-criminal-failed-name = Decision regarding the criminal {$subject}
 rr-criminal-failed-content =
                          [head=3]Authorized Inspector on the Case[/head]
     ─────────────────────────────────────────

--- a/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
+++ b/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
@@ -6,15 +6,20 @@ rr-criminal-wrapped-message = [bold]Well-wisher[/bold]: We have just intercepted
 
 rr-criminal-letter-name = ORDER, dangerous criminal {$subject} is wanted.
 rr-criminal-1-letter-content =
-                             [head=3]NT Information Security Department[/head]
-
-                  [center][color=#006666][italic][bold]   Order for the immediate interception[/bold][/italic][/color][/center]
+                 [head=3]NT Information Security Department[/head]
     ─────────────────────────────────────────
-    A dangerous criminal {$subject} has infiltrated your station.
-    {SUBJECT($subject)} {CONJUGATE-BE($subject)} charged with multiple counts of ████████████████████ , as well as ██████████████.
-    There is also clear evidence pointing to crimes of a ██████████████  nature against █████████████. {SUBJECT($subject)} may be armed.
+                      [center][color=#006666][italic][bold]Order for Immediate Interception[/bold][/italic][/color][/center]
+    ─────────────────────────────────────────
+    A dangerous criminal named '{$subject}' has infiltrated your station.
+
+    {CAPITALIZE(SUBJECT($subject))} {CONJUGATE-BE($subject)} charged with multiple counts of █████████████, as well as ██████████████. There is also clear evidence pointing to crimes of a ██████████████ nature against █████████████. {CAPITALIZE(SUBJECT($subject))} may be armed.
 
     In accordance with Directive 25, Section B of the Code of Information Crimes, you are ordered to deliver {OBJECT($subject)} to Central Command, dead or alive.
+
+    {$subject} [italic]must[/italic] be:
+    - [bold]Handcuffed[/bold] (even if {SUBJECT($subject)} {CONJUGATE-BE($subject)} is compliant)
+    - [bold]Searched[/bold]
+    - [bold]Interrogated[/bold]
 
     Failure to comply with this order may result in charges of incompetence and dismissal.
     ─────────────────────────────────────────
@@ -22,13 +27,15 @@ rr-criminal-1-letter-content =
 
 rr-criminal-failed-name = Decision regarding the criminal {$subject}.
 rr-criminal-failed-content =
-                             [head=3]Authorized inspector on the case[/head]
-
-                  [center][color=#006666][italic][bold]            Decision[/bold][/italic][/color][/center]
+                         [head=3]Authorized Inspector on the Case[/head]
+    ─────────────────────────────────────────
+                                      [center][color=#006666][italic][bold]Migitation Decision[/bold][/italic][/color][/center]
     ─────────────────────────────────────────
     Regarding the case of the criminal {$subject}. We have just intercepted a recruitment letter indicating that the crimes committed were not of direct intent.
+
     In this regard, the crime is no longer classified as informational extremism, but as fatal negligence.
-    You should interrogate the criminal, and if {CONJUGATE-BE($subject)} admits {POSS-ADJ($subject)} guilt, allow {OBJECT($subject)} to work it off in lower positions, with damages assessed from one and a half to ten million credits.
+
+    You should [bold]interrogate[/bold] the criminal, and if {SUBJECT($subject)} admits {POSS-ADJ($subject)} guilt, [bold]parole[/bold] {POSS-ADJ($subject)} and allow {OBJECT($subject)} to work it off in lower positions, with damages assessed from one and a half to ten million credits.
     ─────────────────────────────────────────
    ⠀                                    [italic]Place for stamps[/italic]
 

--- a/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
+++ b/Resources/Locale/en-US/_Starlight/rail/fax-based.ftl
@@ -29,7 +29,7 @@ rr-criminal-failed-name = Decision regarding the criminal {$subject}
 rr-criminal-failed-content =
                          [head=3]Authorized Inspector on the Case[/head]
     ─────────────────────────────────────────
-                                      [center][color=#006666][italic][bold]Migitation Decision[/bold][/italic][/color][/center]
+                                      [center][color=#006666][italic][bold]Mitigation Decision[/bold][/italic][/color][/center]
     ─────────────────────────────────────────
     Regarding the case of the criminal {$subject}. We have just intercepted a recruitment letter indicating that the crimes committed were not of direct intent.
 


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
There's an issue with the NT-ISD wanted criminal card:
- Security SOP says to not handcuff people if they are compliant.
- The criminal card's success/failure condition is based on being handcuffed.

This leads to awkward metagaming from _both_ Security and the criminal.
- **For the criminal, it is always optimal to comply with Security as to not get handcuffed.** They have no incentive to go on the run or hide because it's more risk of getting cuffed (with the same level of reward).
- For Security, it is always optimal to argue the wording of the fax, stating that the NT-ISD wanted criminal is dangerous and thus should be handcuffed as a precaution.

This sucks for everyone involved and leads to a bunch of hurt feelings in LOOC.

This PR changes the wording in the fax to explicitly state that that the criminal should be:
- Handcuffed (even if compliant)
- Searched
- Interrogated

Additionally, this PR just touches up some of the grammar and formatting on the letter, capitalizes stuff that should be capitalized at the start of sentences, etc. See Media.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- Security can now simply point at the paper and go "just doing my job" when criminals state they should not be handcuffed.
- Criminals now have a clear incentive to not get caught (instead of just blindly being cooperative with Security).

Both faxes now include bolded keywords hinting at what players should consider, like parole in the follow-up fax.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="660" height="672" alt="image" src="https://github.com/user-attachments/assets/20c1a71a-9320-4462-a11f-77a5f981a8fe" />

fig. 1 - Criminal fax.

<img width="657" height="666" alt="image" src="https://github.com/user-attachments/assets/cd5dbfc8-1cd6-407f-b666-83426e209de7" />

fig. 2 - Follow-up fax.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: NT-ISD criminal faxes list specific arrest procedures now, both to give players more direction as to what to do with NT-ISD wanted criminals and to help prevent metagaming.