### PR TITLE
Fix exterminator objectives

### DIFF
--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -65,7 +65,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return targetMarooned ? 0.5f : 0f;
 
         // If the shuttle has already left, and the target isn't on it, 100%
-        if (requireMaroon && _emergencyShuttle.ShuttlesLeft )
+        if (requireMaroon && _emergencyShuttle.ShuttlesLeft)
             return targetMarooned ? 1f : 0f;
 
         return 1f; // Good job you did it woohoo

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -62,12 +62,10 @@ public sealed class KillPersonConditionSystem : EntitySystem
                 return 0f;
 
             // If the shuttle hasn't left, give 50% progress if the target isn't on the shuttle as a "almost there!"
-            if (!_emergencyShuttle.ShuttlesLeft)
-                return targetMarooned ? 0.5f : 0f;
-
-            // If the shuttle has already left, and the target isn't on it, 100%
-            if (_emergencyShuttle.ShuttlesLeft)
-                return targetMarooned ? 1f : 0f;
+            return !_emergencyShuttle.ShuttlesLeft
+                ? targetMarooned ? 0.5f : 0f
+                // If the shuttle has already left, and the target isn't on it, 100%
+                : targetMarooned ? 1f : 0f;
         }
         //Starlight End
 

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -51,22 +51,25 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return 0f;
 
         //Starlight start
-        //An unrevivable target is always counted as marooned, regardless of the escape status, so we can update the objective right away.
-        if (requireMaroon && targetUnrevivable)
-            return 1f;
+        if(requireMaroon)
+        {
+            //An unrevivable target is always counted as marooned, regardless of the escape status, so we can update the objective right away.
+            if (targetUnrevivable)
+                return 1f;
+
+            // Always failed if the target needs to be marooned and the shuttle hasn't even arrived yet
+            if (!_emergencyShuttle.EmergencyShuttleArrived)
+                return 0f;
+
+            // If the shuttle hasn't left, give 50% progress if the target isn't on the shuttle as a "almost there!"
+            if (!_emergencyShuttle.ShuttlesLeft)
+                return targetMarooned ? 0.5f : 0f;
+
+            // If the shuttle has already left, and the target isn't on it, 100%
+            if (_emergencyShuttle.ShuttlesLeft)
+                return targetMarooned ? 1f : 0f;
+        }
         //Starlight End
-
-        // Always failed if the target needs to be marooned and the shuttle hasn't even arrived yet
-        if (requireMaroon && !_emergencyShuttle.EmergencyShuttleArrived)
-            return 0f;
-
-        // If the shuttle hasn't left, give 50% progress if the target isn't on the shuttle as a "almost there!"
-        if (requireMaroon && !_emergencyShuttle.ShuttlesLeft)
-            return targetMarooned ? 0.5f : 0f;
-
-        // If the shuttle has already left, and the target isn't on it, 100%
-        if (requireMaroon && _emergencyShuttle.ShuttlesLeft)
-            return targetMarooned ? 1f : 0f;
 
         return 1f; // Good job you did it woohoo
     }

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -29,7 +29,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
         if (!_target.GetTarget(uid, out var target))
             return;
 
-        args.Progress = GetProgress(target.Value, comp.RequireDead, comp.RequireMaroon);
+        args.Progress = GetProgress(target.Value, comp.RequireDead, comp.RequireMaroon)
     }
 
     private float GetProgress(EntityUid target, bool requireDead, bool requireMaroon)
@@ -39,7 +39,8 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return 1f;
 
         var targetDead = _mind.IsCharacterDeadIc(mind);
-        var targetMarooned = !_emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value) || _mind.IsCharacterUnrevivableIc(mind);
+        var targetUnrevivable = _mind.IsCharacterUnrevivableIc(mind); //Starlight
+        var targetMarooned = !_emergencyShuttle.IsTargetEscaping(mind.OwnedEntity.Value) || targetUnrevivable; //Starlight edit: Moved unrevivable check out
         if (!_config.GetCVar(CCVars.EmergencyShuttleEnabled) && requireMaroon)
         {
             requireDead = true;
@@ -48,6 +49,12 @@ public sealed class KillPersonConditionSystem : EntitySystem
 
         if (requireDead && !targetDead)
             return 0f;
+
+        //Starlight start
+        //An unrevivable target is always counted as marooned, regardless of the escape status, so we can update the objective right away.
+        if (requireMaroon && targetUnrevivable)
+            return 1f;
+        //Starlight End
 
         // Always failed if the target needs to be marooned and the shuttle hasn't even arrived yet
         if (requireMaroon && !_emergencyShuttle.EmergencyShuttleArrived)
@@ -58,7 +65,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
             return targetMarooned ? 0.5f : 0f;
 
         // If the shuttle has already left, and the target isn't on it, 100%
-        if (requireMaroon && _emergencyShuttle.ShuttlesLeft)
+        if (requireMaroon && _emergencyShuttle.ShuttlesLeft )
             return targetMarooned ? 1f : 0f;
 
         return 1f; // Good job you did it woohoo

--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -29,7 +29,7 @@ public sealed class KillPersonConditionSystem : EntitySystem
         if (!_target.GetTarget(uid, out var target))
             return;
 
-        args.Progress = GetProgress(target.Value, comp.RequireDead, comp.RequireMaroon)
+        args.Progress = GetProgress(target.Value, comp.RequireDead, comp.RequireMaroon);
     }
 
     private float GetProgress(EntityUid target, bool requireDead, bool requireMaroon)

--- a/Resources/Prototypes/_Starlight/Objectives/terminator.yml
+++ b/Resources/Prototypes/_Starlight/Objectives/terminator.yml
@@ -14,7 +14,7 @@
   parent: [BaseTerminatorObjective, BaseKillObjective]
   id: TerminatorExterminateObjective
   name: Secure our future.
-  description: Follow your programming and kill the target. Minimise additional casualties. They know what they did.
+  description: Follow your programming and kill the target. Minimise unnecessary casualties. They know what they will do.
   components:
   - type: PickSpecificPerson
   - type: KillPersonCondition

--- a/Resources/Prototypes/_Starlight/Objectives/terminator.yml
+++ b/Resources/Prototypes/_Starlight/Objectives/terminator.yml
@@ -14,7 +14,7 @@
   parent: [BaseTerminatorObjective, BaseKillObjective]
   id: TerminatorExterminateObjective
   name: Secure our future.
-  description: Follow your programming and kill the target. Minimise unnecessary casualties. They know what they will do.
+  description: Follow your programming and kill the target. Make sure they do not evacuate alive. Minimise unnecessary casualties. They know what they will do.
   components:
   - type: PickSpecificPerson
   - type: KillPersonCondition

--- a/Resources/Prototypes/_Starlight/Objectives/terminator.yml
+++ b/Resources/Prototypes/_Starlight/Objectives/terminator.yml
@@ -14,7 +14,7 @@
   parent: [BaseTerminatorObjective, BaseKillObjective]
   id: TerminatorExterminateObjective
   name: Secure our future.
-  description: Follow your programming and kill the target. Ensure they are not evacuated. Minimise unnecessary casualties.
+  description: Follow your programming and kill the target. Ensure the future does not have this iteration of them in it. Minimise causing temporal flux through unnecessary casualties.
   components:
   - type: PickSpecificPerson
   - type: KillPersonCondition

--- a/Resources/Prototypes/_Starlight/Objectives/terminator.yml
+++ b/Resources/Prototypes/_Starlight/Objectives/terminator.yml
@@ -14,7 +14,7 @@
   parent: [BaseTerminatorObjective, BaseKillObjective]
   id: TerminatorExterminateObjective
   name: Secure our future.
-  description: Follow your programming and kill the target. Ensure the future doesn't have them in it.
+  description: Follow your programming and kill the target. Minimise additional casualties. They know what they did.
   components:
   - type: PickSpecificPerson
   - type: KillPersonCondition

--- a/Resources/Prototypes/_Starlight/Objectives/terminator.yml
+++ b/Resources/Prototypes/_Starlight/Objectives/terminator.yml
@@ -14,13 +14,14 @@
   parent: [BaseTerminatorObjective, BaseKillObjective]
   id: TerminatorExterminateObjective
   name: Secure our future.
-  description: Follow your programming and kill the target. Make sure they do not evacuate alive. Minimise unnecessary casualties. They know what they will do.
+  description: Follow your programming and kill the target. Ensure they are not evacuated. Minimise unnecessary casualties.
   components:
   - type: PickSpecificPerson
   - type: KillPersonCondition
     requireDead: true
+    requireMaroon: true
   - type: TargetObjective
-    title: objective-condition-kill-head-title
+    title: objective-condition-kill-maroon-title
 
 - type: entity
   parent: BaseTerminatorObjective


### PR DESCRIPTION
## Short description
Rewords exterminator objective and adjusts it's mechanics to properly reflect that the exact conditions of success.

## Why we need to add this
The wording on the exterminator objective was relatively recently changed to imply they should RR people - but the objective did not actually require them to do so. It also did not fit with our existing lore - the PSO cloning system makes it all but impossible to actually ensure a character not making it into the future.

This PR changes their objectives to be kill *AND* maroon, as well as doing some rewording to make it generally fit better, and clarify an Exterminator should not be going for anyone else.
I also made the maroon objective type show as complete the moment it is guaranteed to be completed, as round-removing someone did *not* complete the objective unless the shuttle had actually left, even though it was guaranteed to complete.

## Media (Video/Screenshots)
<img width="375" height="234" alt="image" src="https://github.com/user-attachments/assets/c3ab94cf-82c8-44ad-87e9-7c82984e207e" />

Adjusted objective. Objective completes when success is guaranteed, regardless of shuttle status


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- tweak: Terminator objective now only completes when the target is properly and finally dead, either by being left behind while dead, or round-removal.
- tweak: Reworded exterminator objective to make it clear they need to kill *and* maroon their target, and only their target.
- tweak: Maroon objectives now show as complete, if the maroon target is unrevivable, as that always counts as completion, even if the brain is evacuated.