### PR TITLE
Security Borgs

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -42,7 +42,7 @@
     - purrfus
     - service
     - cargo
- #   - security Currently admeme only
+    - security
   # Starlight-end
 
 - type: entity


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Allows to select security borgs for anyone.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Security borgs was intended to be selectable for anyone, but it was rejected by Shades because he doesn't like the idea of sec borgs, but we recently merged IPCs, they technically borgs with hands that can work in security.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Yes

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rinary
- add: Now sec borgs available for anyone(if they have enough sec time).