### PR TITLE
Makes the xenoborg mothership core as tough as a station AI core

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
@@ -61,7 +61,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 200
+        damage: 400 # Starlight - as tough as an AI Core
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
The xenoborg mothership core has 200 HP. The station AI core has 400 HP.

This has been pointed by players as unintuitive. Using .35 soft point ammo, you can destroy the mothership core with half of an SMG magazine.

This PR doesn't make the mothership core that much more difficult to kill (it's still about a magazine depending on your accuracy), but it does make it less comically fragile.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Requested by the community via Discord: https://discord.com/channels/1272545509562777621/1498548018478321684

Bumping it to the same amount of HP as the station's AI core felt appropriate. I didn't want to overbuff it, but future PRs may decide that this is still too fragile for a spoopy alien robot mothership core.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/04116056-dbee-4ae0-951c-82656489edb5

fig. 1 - Mothership core being shot at with a standard SP-91-RC using .35 softpoint ammo. It's not that tough, but it is less comically fragile.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: The xenoborg mothership core now is now destroyed at 400 damage (up from 200 damage), the same amount of damage needed to destroy a station AI core.