### PR TITLE
Buffing Oil Pack Heal Amount

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Specific/Medical/healing.yml
@@ -18,7 +18,7 @@
       - IPC
     damage:
       types:
-        Bloodloss: -0.5 #lowers bloodloss damage
+        Bloodloss: -3 #lowers bloodloss damage
     delay: 1.6
     modifyBloodLevel: 15 #restores about 5% blood per use on standard humanoids.
     healingBeginSound:


### PR DESCRIPTION
## Short description
Changes Oil Packs to heal 3 blood loss, not -0.5.

## Why we need to add this
Balance. IPCs do not have active ways to heal blood loss damage except for this, and oil packs will barely help, especially if the IPC is critical or already dead.

## Media (Video/Screenshots)
Not needed.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Bigfoot Bravo
- tweak: Oil packs heal a little more blood loss with each use.
