### PR TITLE
Mech Fix: Mauler repair

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
@@ -358,6 +358,9 @@
         types:
           Blunt: 40
           Structural: 200
+    - type: MeleeThrowOnHit
+      speed: 20
+      distance: 5
     - type: MovementSpeedModifier
       baseWalkSpeed: 2
       baseSprintSpeed: 2.2
@@ -581,9 +584,6 @@
       damageModifierSet: MaulerArmor
     - type: MechThrusters
     - type: Magboots
-    - type: Repairable
-      fuelCost: 50
-      doAfterDelay: 25
     - type: PointLight
       mask: /Textures/Effects/LightMasks/cone.png
       autoRot: true


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Removes an extraneous RepairableComponent that got re-added by accident during a recent PR. Also adds a missing throwOnHit component to the marauder.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It's busted!

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/b6fffaaf-ae02-4ce9-abf3-f53c66164148

see #4020  for the throw on hit.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neurovermi
- fix: Mauler repair now works as expected.