### PR TITLE
IPC health bars

### DIFF
--- a/Resources/Prototypes/_Starlight/Body/Implants/eye.yml
+++ b/Resources/Prototypes/_Starlight/Body/Implants/eye.yml
@@ -38,6 +38,7 @@
       damageContainers:
       - Inorganic
       - Silicon
+      - IPC
 
 - type: entity
   id: EyeImplantMedical

--- a/Resources/Prototypes/_Starlight/Body/Implants/eye.yml
+++ b/Resources/Prototypes/_Starlight/Body/Implants/eye.yml
@@ -34,6 +34,7 @@
     state: eye_implant_diagnostic
   - type: FunctionalOrgan
     comps:
+    - type: ShowAccessReaderSettings
     - type: ShowHealthBars
       damageContainers:
       - Inorganic

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Eyes/glasses.yml
@@ -126,9 +126,11 @@
   - type: ShowHealthBars
     damageContainers:
     - Biological
+    - IPC
   - type: ShowHealthIcons
     damageContainers:
     - Biological
+    - IPC
   - type: Tag
     tags:
     - HudMedical

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Eyes/hud.yml
@@ -14,9 +14,11 @@
     - type: ShowHealthBars
       damageContainers:
         - Biological
+        - IPC
     - type: ShowHealthIcons
       damageContainers:
         - Biological
+        - IPC
     - type: Tag
       tags:
         - HudMedical


### PR DESCRIPTION
## Short description
Adds IPC health readouts to diagnostics implants and Blueshield Officer's glasses/HUD

## Why we need to add this
The diagnostics implant should not loose functionality when upgraded to an implant, and BSO specifically should be able to see IPC command members' health just as they see biological command members' health.

## Media (Video/Screenshots)
<img width="234" height="144" alt="grafik" src="https://github.com/user-attachments/assets/1b401b91-d461-43bf-ad4d-de7c38d77a1b" />
<img width="90" height="108" alt="grafik" src="https://github.com/user-attachments/assets/26e739be-5874-41f6-9e60-eaab07e61efe" />
<img width="375" height="358" alt="grafik" src="https://github.com/user-attachments/assets/7c2d6585-4c9c-4f1e-9461-c9fe2251ea48" />




## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Diagnostic implants now show IPC health.
- tweak: Blueshield Officers' glasses and HUDs have been upgraded to include diagnostic readouts of IPC integrity.
