### PR TITLE
IPC Screens Can Be Colored.

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Species/ipc.yml
@@ -8,7 +8,6 @@
   markingLimits: MobIPCMarkingLimits
   dollPrototype: AppearanceIPC
   skinColoration: Hues
-  eyeColoration: FullWhite
   customName: true
   roundstartCyberwareCapacity: 6
   sexes:


### PR DESCRIPTION
## Short description
IPCs can now choose the color of their screen, if they have one.

## Why we need to add this
Bug fix for character customization.

## Media (Video/Screenshots)
Not needed.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Bigfoot Bravo
- fix: IPCs can change their screen color via the eye color sliders.
