### PR TITLE
Fix Antag Health Scaling

### DIFF
--- a/Content.Server/_Starlight/Scaling/AntagMonsterScalingSystem.cs
+++ b/Content.Server/_Starlight/Scaling/AntagMonsterScalingSystem.cs
@@ -1,5 +1,5 @@
+using Content.Server.Ghost.Roles.Events;
 using Content.Shared._Starlight.Scaling.Components;
-using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Roles;
 using Content.Shared.Starlight.CCVar;
@@ -10,8 +10,6 @@ using Content.Shared.StationRecords;
 using Content.Server.Station.Systems;
 using Robust.Shared.Utility;
 using Content.Shared._Starlight.Scaling;
-using Content.Server.Ghost.Roles.Events;
-using Content.Shared.Mobs;
 
 namespace Content.Server._Starlight.Scaling;
 
@@ -34,6 +32,7 @@ public sealed class ScalingSystem : SharedScalingSystem
     {
         base.Initialize();
         SubscribeLocalEvent<AntagMonsterScalingComponent, MapInitEvent>(OnMobStartup);
+        SubscribeLocalEvent<AntagMonsterScalingComponent, GhostRoleSpawnerUsedEvent>(OnGhostRoleSpawnerUsed);
 
         _cfg.OnValueChanged(StarlightCCVars.ScalingHealthWeight, UpdateUniversalHealthWeight, true);
     }
@@ -43,32 +42,36 @@ public sealed class ScalingSystem : SharedScalingSystem
         _universalHealthWeight = universalHealthWeight;
     }
 
-    private void OnMobStartup(EntityUid mob, AntagMonsterScalingComponent scalingComp, ref MapInitEvent args)
+    private void OnMobStartup(EntityUid mob, AntagMonsterScalingComponent scalingComp, ref MapInitEvent args) =>
+        TryScaling(mob, scalingComp);
+
+
+    private void OnGhostRoleSpawnerUsed(
+        EntityUid mob,
+        AntagMonsterScalingComponent scalingComp,
+        ref GhostRoleSpawnerUsedEvent args) =>
+        TryScaling(args.Spawned, scalingComp);
+
+
+    private void TryScaling(EntityUid mob, AntagMonsterScalingComponent scalingComp)
     {
         if (!TryComp(mob, out MobThresholdsComponent? thresholdsComp))
             return;
 
-        scalingComp.OriginalThresholds = new();
-
-        foreach (var threshold in thresholdsComp.Thresholds)
-        {
-            scalingComp.OriginalThresholds.Add(threshold.Key, threshold.Value);
-        }
-
-        var nullableStation = _stationSystem.GetStationInMap(Transform(mob).MapID);
-        if (nullableStation == null)
+        if (scalingComp.IsScaled)
             return;
 
-        EntityUid station = nullableStation.Value;
+        scalingComp.OriginalThresholds = new();
+
+        foreach (var threshold in thresholdsComp.Thresholds) scalingComp.OriginalThresholds.Add(threshold.Key, threshold.Value);
+
+        var station = _stationSystem.GetNearestStation(mob);
 
         UpdatePopulation(station);
 
-        if (scalingComp.IsScaled == false)
-        {
-            ApplyHealthScaling(station, scalingComp, thresholdsComp, _cachedPopulations, _universalHealthWeight);
+        ApplyHealthScaling(station, scalingComp, thresholdsComp, _cachedPopulations, _universalHealthWeight);
 
-            scalingComp.IsScaled = true;
-        }
+        scalingComp.IsScaled = true;
     }
 
     private void UpdatePopulation(EntityUid station)

--- a/Content.Server/_Starlight/Scaling/AntagMonsterScalingSystem.cs
+++ b/Content.Server/_Starlight/Scaling/AntagMonsterScalingSystem.cs
@@ -67,14 +67,15 @@ public sealed class ScalingSystem : SharedScalingSystem
 
         var station = _stationSystem.GetNearestStation(mob);
 
-        UpdatePopulation(station);
+        if (!UpdatePopulation(station))
+            return;
 
         ApplyHealthScaling(station, scalingComp, thresholdsComp, _cachedPopulations, _universalHealthWeight);
 
         scalingComp.IsScaled = true;
     }
 
-    private void UpdatePopulation(EntityUid station)
+    private bool UpdatePopulation(EntityUid station)
     {
         _populationBase = _cfg.GetCVar(StarlightCCVars.ScalingPopulationBase);
         _securityWeight = _cfg.GetCVar(StarlightCCVars.ScalingSecurityWeight);
@@ -84,7 +85,7 @@ public sealed class ScalingSystem : SharedScalingSystem
         double updatedPopulation = 0;
 
         if (!_recordsSystem.TryGetRandomRecord<GeneralStationRecord>(station, out var entry))
-            return;
+            return false;
 
         var crewMembers = _recordsSystem.GetRecordsOfType<GeneralStationRecord>(station);
 
@@ -114,5 +115,7 @@ public sealed class ScalingSystem : SharedScalingSystem
 
         _cachedPopulations.GetOrNew(station);
         _cachedPopulations[station] = updatedPopulation - _populationBase;
+
+        return true;
     }
 }

--- a/Content.Server/_Starlight/Scaling/AntagMonsterScalingSystem.cs
+++ b/Content.Server/_Starlight/Scaling/AntagMonsterScalingSystem.cs
@@ -84,6 +84,9 @@ public sealed class ScalingSystem : SharedScalingSystem
 
         double updatedPopulation = 0;
 
+        if (!TryComp<StationRecordsComponent>(station, out var recordsComponent))
+            return false;
+
         if (!_recordsSystem.TryGetRandomRecord<GeneralStationRecord>(station, out var entry))
             return false;
 

--- a/Content.Server/_Starlight/Scaling/AntagMonsterScalingSystem.cs
+++ b/Content.Server/_Starlight/Scaling/AntagMonsterScalingSystem.cs
@@ -83,6 +83,9 @@ public sealed class ScalingSystem : SharedScalingSystem
 
         double updatedPopulation = 0;
 
+        if (!_recordsSystem.TryGetRandomRecord<GeneralStationRecord>(station, out var entry))
+            return;
+
         var crewMembers = _recordsSystem.GetRecordsOfType<GeneralStationRecord>(station);
 
         foreach (var crewMember in crewMembers)

--- a/Content.Shared/_Starlight/Scaling/AntagMonsterScalingComponent.cs
+++ b/Content.Shared/_Starlight/Scaling/AntagMonsterScalingComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class AntagMonsterScalingComponent : Component
     public double MaximumHealthScaling = 0.50;
 
     [DataField]
-    public bool IsScaled;
+    public bool IsScaled = false;
 
     [DataField]
     public SortedDictionary<FixedPoint2, MobState>? OriginalThresholds;

--- a/Content.Shared/_Starlight/Scaling/AntagMonsterScalingComponent.cs
+++ b/Content.Shared/_Starlight/Scaling/AntagMonsterScalingComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class AntagMonsterScalingComponent : Component
     public double MaximumHealthScaling = 0.50;
 
     [DataField]
-    public bool IsScaled = false;
+    public bool IsScaled;
 
     [DataField]
     public SortedDictionary<FixedPoint2, MobState>? OriginalThresholds;

--- a/Content.Shared/_Starlight/Scaling/SharedAntagMonsterScalingSystem.cs
+++ b/Content.Shared/_Starlight/Scaling/SharedAntagMonsterScalingSystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared._Starlight.Scaling.Components;
-using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 
 namespace Content.Shared._Starlight.Scaling;
@@ -29,9 +28,9 @@ public abstract partial class SharedScalingSystem : EntitySystem
             if (scalingPercent < 0.0 - scalingComp.MaximumHealthScaling)
                 scalingPercent = 0.0 - scalingComp.MaximumHealthScaling;
 
-            FixedPoint2 scalingValue = key.Double() * scalingPercent;
+            var scalingValue = key.Double() * scalingPercent;
 
-            FixedPoint2 scaledKey = key + scalingValue;
+            var scaledKey = key + scalingValue;
 
             if (key != scaledKey)
             {


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fix an issue with the dragon health scaling caused by a failing station retrieval function

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It's already added, just wasn't working. No idea how long.

To jog the memory a bit, this essentially makes the dragon 50% tankier at most on highpop.
Apparently the dragon is real weak these days so seems like a good thing to get working again.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- fix: Fixed health scaling for ghost role dragons.
