### PR TITLE
Disables zombies entirely

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -809,25 +809,27 @@
   categories:
   - UplinkChemicals
 
-- type: listing
-  id: UplinkZombieBundle
-  name: uplink-zombie-bundle-name
-  description: uplink-zombie-bundle-desc
-  icon: { sprite: /Textures/Structures/Wallmounts/signs.rsi, state: bio }
-  productEntity: ClothingBackpackDuffelZombieBundle
-  cost:
-    Telecrystal: 40
-  categories:
-  - UplinkChemicals
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
-  - !type:BuyerWhitelistCondition
-    blacklist:
-      components:
-      - SurplusBundle
+# Starlight start remove zombies until IPC ruling
+# - type: listing
+#   id: UplinkZombieBundle
+#   name: uplink-zombie-bundle-name
+#   description: uplink-zombie-bundle-desc
+#   icon: { sprite: /Textures/Structures/Wallmounts/signs.rsi, state: bio }
+#   productEntity: ClothingBackpackDuffelZombieBundle
+#   cost:
+#     Telecrystal: 40
+#   categories:
+#   - UplinkChemicals
+#   conditions:
+#   - !type:StoreWhitelistCondition
+#     whitelist:
+#       tags:
+#       - NukeOpsUplink
+#   - !type:BuyerWhitelistCondition
+#     blacklist:
+#       components:
+#       - SurplusBundle
+# Starlight end
 
 - type: listing
   id: UplinkNocturineChemistryBottle

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -4,9 +4,9 @@
   weights:
     Nukeops: 0.105 # SL
     Traitor: 0.21 # SL
-    Zombie: 0.10 # SL
+    # Zombie: 0.10 # SL Removed pending IPC ruling
     Changeling: 0.05 #SL
-    Zombieteors: 0.01 # SL
+    # Zombieteors: 0.01 # SL Removed pending IPC ruling
     Survival: 0.11 # SL
     KesslerSyndrome: 0.01 # SL
     Revolutionary: 0.105 # SL
@@ -25,9 +25,9 @@
   weights:
     Nukeops: 0.07
     Traitor: 0.25
-    Zombie: 0.07
+    # Zombie: 0.07 Removed pending IPC ruling
     Changeling: 0.06
-    Zombieteors: 0.01
+    # Zombieteors: 0.01 Removed pending IPC ruling
     Survival: 0.07
     KesslerSyndrome: 0.01
     Revolutionary: 0.06


### PR DESCRIPTION
## Short description
Removes Zombies/Zombieteors from possible secret rolls, alongside the Romerol bundle from being purchase-able.

## Why we need to add this
Mald PR in response to https://github.com/ss14Starlight/space-station-14/pull/4306 . I refuse to let a group of players be tortured because it is the easiest solution.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: R3v3l4t1on
- remove: Zombies/Zombieteors can no longer roll as secret options.
- remove: Romerol bundle is temporarily disabled.
