### PR TITLE
The Nuke going off now triggers end of round

### DIFF
--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -81,6 +81,8 @@ namespace Content.Server.GameTicking
 
         private ISawmill _sawmill = default!;
 
+        private const string NukeopsRuleId = "Nukeops"; // Starlight
+
         private bool _randomizeCharacters;
 
         public override void Initialize()
@@ -150,7 +152,7 @@ namespace Content.Server.GameTicking
         /// <param name="ev"></param>
         private void OnNukeExploded(NukeExplodedEvent ev)
         {
-            if (!ev.EndRound || IsGameRuleActive("Nukeops")) // nukeops rule system handles nuke ops specific nuke round end logic
+            if (!ev.EndRound || IsGameRuleActive(NukeopsRuleId)) // nukeops rule system handles nuke ops specific nuke round end logic
             {
                 return;
             }

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics; // Starlight
 using Content.Server._Starlight.Administration.Systems;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
@@ -7,8 +8,10 @@ using Content.Server.Chat.Systems;
 using Content.Server.Database;
 using Content.Server.Ghost;
 using Content.Server.Maps;
+using Content.Server.Nuke; // Starlight
 using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Preferences.Managers;
+using Content.Server.RoundEnd; // Starlight
 using Content.Server.ServerUpdates;
 using Content.Server.Station.Systems;
 using Content.Shared.CCVar;
@@ -67,6 +70,7 @@ namespace Content.Server.GameTicking
         [Dependency] private readonly MetaDataSystem _metaData = default!;
         [Dependency] private readonly SharedRoleSystem _roles = default!;
         [Dependency] private readonly ServerDbEntryManager _dbEntryManager = default!;
+        [Dependency] private readonly RoundEndSystem _roundEndSystem = default!; // Starlight
         [Dependency] private readonly AntagSelectionSystem _antagSelection = default!;
         [Dependency] private readonly AutoDiscordLogSystem _autolog = default!; // Starlight
 
@@ -97,6 +101,7 @@ namespace Content.Server.GameTicking
             InitializePlayer();
             InitializeLobbyBackground();
             InitializeGamePreset();
+            SubscribeLocalEvent<NukeExplodedEvent>(OnNukeExploded); // Starlight
             DebugTools.Assert(_prototypeManager.Index(FallbackOverflowJob).Name == FallbackOverflowJobName,
                 "Overflow role does not have the correct name!");
             InitializeGameRules();
@@ -137,5 +142,21 @@ namespace Content.Server.GameTicking
             UpdateRoundFlow(frameTime);
             UpdateGameRules();
         }
+        // Starlight start
+        /// <summary>
+        /// Ends round if a nuke with the component to end the round goes off.
+        /// TODO: make this instead check for if the preset overrides nuke explosion ending the round behavior somehow
+        /// </summary>
+        /// <param name="ev"></param>
+        private void OnNukeExploded(NukeExplodedEvent ev)
+        {
+            if (!ev.EndRound || IsGameRuleActive("Nukeops")) // nukeops rule system handles nuke ops specific nuke round end logic
+            {
+                return;
+            }
+
+            _roundEndSystem.EndRound();
+        }
+        // Starlight end
     }
 }

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -144,7 +144,7 @@ namespace Content.Server.GameTicking
             UpdateRoundFlow(frameTime);
             UpdateGameRules();
         }
-        // Starlight start
+        #region Starlight
         /// <summary>
         /// Ends round if a nuke with the component to end the round goes off.
         /// TODO: make this instead check for if the preset overrides nuke explosion ending the round behavior somehow
@@ -159,6 +159,6 @@ namespace Content.Server.GameTicking
 
             _roundEndSystem.EndRound();
         }
-        // Starlight end
+        #endregion
     }
 }

--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -62,6 +62,14 @@ namespace Content.Server.Nuke
         [DataField("alertLevelOnActivate")] public string AlertLevelOnActivate = default!;
         [DataField("alertLevelOnDeactivate")] public string AlertLevelOnDeactivate = default!;
 
+        // Starlight start
+        /// <summary>
+        ///     If the detonation should end the current round if on the main grid.
+        /// </summary>
+        [DataField("endRound")]
+        public bool EndRound = true;
+        // Starlight end
+
         /// <summary>
         ///     This is stored so we can do a funny by making 0 shift the last played note up by 12 semitones (octave)
         /// </summary>

--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -62,14 +62,6 @@ namespace Content.Server.Nuke
         [DataField("alertLevelOnActivate")] public string AlertLevelOnActivate = default!;
         [DataField("alertLevelOnDeactivate")] public string AlertLevelOnDeactivate = default!;
 
-        // Starlight start
-        /// <summary>
-        ///     If the detonation should end the current round if on the main grid.
-        /// </summary>
-        [DataField("endRound")]
-        public bool EndRound = true;
-        // Starlight end
-
         /// <summary>
         ///     This is stored so we can do a funny by making 0 shift the last played note up by 12 semitones (octave)
         /// </summary>
@@ -208,5 +200,12 @@ namespace Content.Server.Nuke
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("requiredFloorRadius")]
         public float RequiredFloorRadius = 5;
+        #region Starlight
+        /// <summary>
+        ///     If the detonation should end the current round if on the main grid.
+        /// </summary>
+        [DataField("endRound")]
+        public bool EndRound = true;
+        #endregion
     }
 }

--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -636,6 +636,7 @@ public sealed class NukeSystem : EntitySystem
         RaiseLocalEvent(new NukeExplodedEvent()
         {
             OwningStation = transform.GridUid,
+            EndRound = component.EndRound, // Starlight, for ending the round
         });
 
         _sound.StopStationEventMusic(uid, StationEventMusicType.Nuke);
@@ -708,6 +709,7 @@ public sealed class NukeSystem : EntitySystem
 public sealed class NukeExplodedEvent : EntityEventArgs
 {
     public EntityUid? OwningStation;
+    public bool EndRound; // Starlight, for ending the round
 }
 
 /// <summary>

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -3,7 +3,7 @@
   id: NuclearBomb
   name: nuclear fission explosive
   description: You probably shouldn't stick around to see if this is armed.
-  suffix: Round ending # Starlight
+  suffix: ROUND ENDING # Starlight
   components:
   - type: Transform
     anchored: true
@@ -123,7 +123,7 @@
 - type: entity
   parent: NuclearBomb
   id: NuclearBombUnanchored
-  suffix: Round ending, unanchored # Starlight
+  suffix: ROUND ENDING, unanchored # Starlight
   components:
   - type: Transform
     anchored: false

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -3,6 +3,7 @@
   id: NuclearBomb
   name: nuclear fission explosive
   description: You probably shouldn't stick around to see if this is armed.
+  suffix: Round ending # Starlight
   components:
   - type: Transform
     anchored: true
@@ -122,7 +123,7 @@
 - type: entity
   parent: NuclearBomb
   id: NuclearBombUnanchored
-  suffix: unanchored
+  suffix: Round ending, unanchored # Starlight
   components:
   - type: Transform
     anchored: false

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/nuke.yml
@@ -1,0 +1,36 @@
+- type: entity
+  parent: [NuclearBomb]
+  id: NuclearBombSafe
+  name: nuclear fission explosive
+  description: You probably shouldn't stick around to see if this is armed.
+  suffix: Non-round ending
+  components:
+  - type: Nuke
+    explosionType: Default
+    maxIntensity: 100
+    intensitySlope: 5
+    totalIntensity: 5000000
+    diskSlot:
+      name: nuke-slot-component-slot-name-disk
+      insertSound:
+        path: /Audio/Machines/terminal_insert_disc.ogg
+      ejectSound:
+        path: /Audio/Machines/terminal_insert_disc.ogg
+      whitelist:
+        components:
+        - NukeDisk
+    alertLevelOnActivate: delta
+    alertLevelOnDeactivate: green
+    endRound: false
+
+- type: entity
+  parent: NuclearBombSafe
+  id: NuclearBombSafeUnanchored
+  suffix: Non-round ending, unanchored
+  components:
+  - type: Transform
+    anchored: false
+  - type: Physics
+    bodyType: Dynamic
+  - type: NukeLabel
+    prefix: "nuke-label-syndicate"


### PR DESCRIPTION
## Short description
Ports the other half of the closed Wizden [#41611](https://github.com/space-wizards/space-station-14/pull/41611). Nuking the station now triggers end of round, regardless of gamemode.

Also adds a non-round ending Nuke, if Admins want to mess with it.

## Why we need to add this
To go with [#4299](https://github.com/ss14Starlight/space-station-14/pull/4299), and also for Lone Ops.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld, alexalexmax
- add: Added a nuke that doesn't end the round to the spawn menu.
- tweak: The (normal) nuke going off now starts the end of round sequence, regardless of gamemode.