### PR TITLE
Chav accent now replaces 'borg' with 'tin man' instead of 'toaster'

### DIFF
--- a/Resources/Locale/en-US/_Starlight/accent/chav.ftl
+++ b/Resources/Locale/en-US/_Starlight/accent/chav.ftl
@@ -224,10 +224,10 @@ accent-chav-replaced-75 = cat
 accent-chav-replacement-75 = hissy wanka
 
 accent-chav-replaced-76 = borg
-accent-chav-replacement-76 = toaster
+accent-chav-replacement-76 = tin man
 
 accent-chav-replaced-77 = borgs
-accent-chav-replacement-77 = toasters
+accent-chav-replacement-77 = tin men
 
 accent-chav-replaced-78 = right
 accent-chav-replacement-78 = roight


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Changes the chav accent's word replacement:
- borg -> tin man (previously 'toaster')
- borgs -> tin men (previously 'toasters')

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Two reasons:
- Toaster is actually a random borg name, which leads to confusion when someone rolls the name randomly.
- Per updates to Rule 0, toaster is likely to get confused as a derogatory name for an IPC, e.g. "Why is a toaster working as HOP?" (original: "Why is a borg working as HOP?")

Tin man is a suitably British-ism replacement for robot (as in the Tin Man from the Wizard of Oz).

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Chav accent's word replacement for 'borg/borgs' has been changed to 'tin man/tin men' instead of 'toaster/toasters'.