### PR TITLE
Add Donut Recipe

### DIFF
--- a/Resources/Prototypes/_Starlight/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Cooking/meal_recipes.yml
@@ -167,4 +167,13 @@
   result: FoodDonutPlain
   time: 10
   ingredient: FoodDoughRope
-  group: Dessert
+  group: TP14-Deep-Fry
+
+- type: microwaveMealRecipe
+  id: RecipeMeatDonut
+  name: meat donut
+  result: FoodDonutMeat
+  time: 5
+  solids:
+    FoodDonutPlain: 1
+    FoodMeatCutlet: 1

--- a/Resources/Prototypes/_Starlight/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Cooking/meal_recipes.yml
@@ -160,3 +160,11 @@
   solids:
     FoodNoodlesBoiled: 1
     OrganShadekinCore: 1
+
+- type: deepFryingRecipe
+  id: RecipeDonut
+  name: plain donut
+  result: FoodDonutPlain
+  time: 10
+  ingredient: FoodDoughRope
+  group: Dessert


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds the ability to make donuts in the deep fryer.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
There is a donut cargo bounty, and currently the only way to get donuts is via the vending machine in Security. This is odd, considering the station has 2+ full-time chefs. Now those chefs can actually make the requisite donuts for the bounty, instead of cargo needing to order a donut vendor restock just to complete the bounty.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="546" height="633" alt="image" src="https://github.com/user-attachments/assets/64a3edb5-fc52-4841-987c-ec2249578b80" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CommanderAlex365
- add: Added recipes for plain and meat donuts.
