### PR TITLE
Fix guidebook sorting of chemicals and drinks

### DIFF
--- a/Content.Client/Guidebook/Controls/GuideReagentGroupEmbed.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuideReagentGroupEmbed.xaml.cs
@@ -40,7 +40,7 @@ public sealed partial class GuideReagentGroupEmbed : BoxContainer, IDocumentTag,
     public GuideReagentGroupEmbed(string group) : this()
     {
         var prototypes = _prototype.EnumeratePrototypes<ReagentPrototype>()
-            .Where(p => p.Group.Equals(group)).OrderBy(p => p.LocalizedName);
+            .Where(p => p.Group.Equals(group)).OrderByDescending(p => p.LocalizedName); // Starlight - Order reversed to support FrameUpdate
         _reagentsToAdd = prototypes.ToList(); // Starlight
     }
 
@@ -54,7 +54,7 @@ public sealed partial class GuideReagentGroupEmbed : BoxContainer, IDocumentTag,
         }
 
         var prototypes = _prototype.EnumeratePrototypes<ReagentPrototype>()
-            .Where(p => p.Group.Equals(group)).OrderBy(p => p.LocalizedName);
+            .Where(p => p.Group.Equals(group)).OrderByDescending(p => p.LocalizedName); // Starlight - Order reversed to support FrameUpdate
         _reagentsToAdd = prototypes.ToList(); // Starlight
 
         control = this;


### PR DESCRIPTION
## Short description
Fixes sorting of chemicals / drinks / reagents in the guidebook to once again be alphabetical.

## Why we need to add this
Fixes a regression in #3989 which caused guidebook reagents to be listed in inverse order. Cause of this is that the `FrameUpdate` performance optimization iterates through the reagent list in inverse order, meaning the output became inverted of the input.
https://github.com/ss14Starlight/space-station-14/blob/b190c6e9e00e0d6bbdc2e193b901bcd3c933ce84/Content.Client/Guidebook/Controls/GuideReagentGroupEmbed.xaml.cs#L76-L82
The simplest solution which does not touch the optimization above is to pre-sort in inverse order instead, which results in the correct final order.

## Media (Video/Screenshots)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/6ab621a6-85a9-4ecd-a23d-f8cd2a1d2a87" />


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- fix: Fixed guidebook sorting of chemicals and drinks to once again be in alphabetical order.