### PR TITLE
Fix alcoholic and caffeinated properties of various beverages

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -258,7 +258,7 @@
 - type: reagent
   id: CoffeeLiqueur
   name: reagent-name-coffeeliqueur
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-coffeeliqueur
   physicalDesc: reagent-physical-desc-cloudy
   flavor: coffeeliquor
@@ -624,7 +624,7 @@
 - type: reagent
   id: AtomicBomb
   name: reagent-name-atomic-bomb
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-atomic-bomb
   physicalDesc: reagent-physical-desc-cloudy
   flavor: atomicbomb
@@ -646,11 +646,16 @@
       - !type:AdjustReagent
         reagent: Uranium
         amount: 0.05
+# Starlight Start
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+# Starlight End
 
 - type: reagent
   id: B52
   name: reagent-name-b52
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-b52
   physicalDesc: reagent-physical-desc-bubbly
   flavor: b52
@@ -669,6 +674,11 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.15
+# Starlight Start
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+# Starlight End
 
 - type: reagent
   id: BahamaMama
@@ -742,7 +752,7 @@
 - type: reagent
   id: BlackRussian
   name: reagent-name-black-russian
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-black-russian
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: blackrussian
@@ -761,6 +771,11 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.2
+# Starlight Start
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+# Starlight End
 
 - type: reagent
   id: BloodyMary
@@ -795,7 +810,7 @@
 - type: reagent
   id: BraveBull
   name: reagent-name-brave-bull
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-brave-bull
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bravebull
@@ -814,6 +829,11 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.2
+# Starlight Start
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+# Starlight End
 
 - type: reagent
   id: Bronx
@@ -960,7 +980,7 @@
 - type: reagent
   id: DevilsKiss
   name: reagent-name-devils-kiss
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-devils-kiss
   physicalDesc: reagent-physical-desc-ferrous
   flavor: devilskiss
@@ -986,7 +1006,7 @@
 - type: reagent
   id: DoctorsDelight
   name: reagent-name-doctors-delight
-  parent: BaseDrink
+  parent: BaseAlcohol # Starlight Edit
   desc: reagent-desc-doctors-delight
   physicalDesc: reagent-physical-desc-soothing
   flavor: medicine
@@ -1282,7 +1302,7 @@
 - type: reagent
   id: IrishCoffee
   name: reagent-name-irish-coffee
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-irish-coffee
   physicalDesc: reagent-physical-desc-cloudy
   flavor: irishcoffee
@@ -1301,6 +1321,11 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.15
+# Starlight Start
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+# Starlight End
 
 - type: reagent
   id: JackRose
@@ -2011,7 +2036,7 @@
 - type: reagent
   id: WhiteGilgamesh
   name: reagent-name-white-gilgamesh
-  parent: BaseDrink
+  parent: BaseAlcohol # Starlight Edit
   desc: reagent-desc-white-gilgamesh
   physicalDesc: reagent-physical-desc-creamy
   flavor: white-gilgamesh
@@ -2029,7 +2054,7 @@
 - type: reagent
   id: WhiteRussian
   name: reagent-name-white-russian
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-white-russian
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: whiterussian
@@ -2048,11 +2073,16 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.15
+# Starlight Start
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+# Starlight End
 
 - type: reagent
   id: VodkaRedBool
   name: reagent-name-vodka-red-bool
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-vodka-red-bool
   physicalDesc: reagent-physical-desc-bubbly
   flavor: vodkaredbool
@@ -2083,7 +2113,7 @@
 - type: reagent
   id: XenoBasher
   name: reagent-name-xeno-basher
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-xeno-basher
   physicalDesc: reagent-physical-desc-fizzy-and-creamy
   flavor: xenobasher
@@ -2114,7 +2144,7 @@
 - type: reagent
   id: IrishBool
   name: reagent-name-irish-bool
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-irish-bool
   physicalDesc: reagent-physical-desc-bubbly
   flavor: irishbool
@@ -2145,7 +2175,7 @@
 - type: reagent
   id: BudgetInsulsDrink
   name: reagent-name-budget-insuls
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-budget-insuls
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: budgetinsulsdrink
@@ -2176,7 +2206,7 @@
 - type: reagent
   id: WatermelonWakeup
   name: reagent-name-watermelon-wakeup
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-watermelon-wakeup
   physicalDesc: reagent-physical-desc-sweet
   flavor: watermelonwakeup
@@ -2207,7 +2237,7 @@
 - type: reagent
   id: Rubberneck
   name: reagent-name-rubberneck
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-rubberneck
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: rubberneck
@@ -2438,7 +2468,7 @@
 - type: reagent
   id: EspressoMartini
   name: reagent-name-espresso-martini
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedAlcohol # Starlight Edit
   desc: reagent-desc-espresso-martini
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: espressomartini
@@ -2457,6 +2487,11 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.2
+# Starlight Start
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+# Starlight End
 
 - type: reagent
   id: Daiquiri

--- a/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
@@ -77,3 +77,47 @@
   flavor: sweet
   footstepSound:
     collection: FootstepSlime
+
+# Starlight Start
+- type: reagent
+  id: BaseCaffeinatedDrink
+  parent: BaseDrink
+  abstract: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 3
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+
+- type: reagent
+  id: BaseCaffeinatedAlcohol
+  parent: BaseAlcohol
+  abstract: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Ethanol
+        amount: 0.06
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+
+- type: reagent
+  id: BaseCaffeinatedSoda
+  parent: BaseSoda
+  abstract: true
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+# Starlight End

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -1,7 +1,7 @@
 - type: reagent
   id: Coffee
   name: reagent-name-coffee
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-coffee
   physicalDesc: reagent-physical-desc-aromatic
   flavor: coffee
@@ -29,7 +29,7 @@
 - type: reagent
   id: HotCocoa
   name: reagent-name-hot-cocoa
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-hot-cocoa
   physicalDesc: reagent-physical-desc-aromatic
   flavor: chocolate
@@ -89,7 +89,7 @@
 - type: reagent
   id: CafeLatte
   name: reagent-name-cafe-latte
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-cafe-latte
   physicalDesc: reagent-physical-desc-creamy
   flavor: creamy
@@ -109,11 +109,16 @@
         effectProto: StatusEffectDrowsiness
         time: 2
         type: Remove
+# Starlight Start
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+# Starlight End
 
 - type: reagent
   id: GreenTea
   name: reagent-name-green-tea
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-green-tea
   physicalDesc: reagent-physical-desc-aromatic
   flavor: tea
@@ -145,7 +150,7 @@
 - type: reagent
   id: IcedCoffee
   name: reagent-name-iced-coffee
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-iced-coffee
   physicalDesc: reagent-physical-desc-aromatic
   flavor: coffee
@@ -172,7 +177,7 @@
 - type: reagent
   id: IcedGreenTea
   name: reagent-name-iced-green-tea
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink  # Starlight Edit
   desc: reagent-desc-iced-green-tea
   physicalDesc: reagent-physical-desc-aromatic
   flavor: icedtea
@@ -187,7 +192,7 @@
 - type: reagent
   id: IcedTea
   name: reagent-name-iced-tea
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-iced-tea
   physicalDesc: reagent-physical-desc-aromatic
   flavor: icedtea
@@ -370,7 +375,7 @@
 - type: reagent
   id: SoyLatte
   name: reagent-name-soy-latte
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-soy-latte
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: soy
@@ -390,11 +395,16 @@
         effectProto: StatusEffectDrowsiness
         time: 2
         type: Remove
+# Starlight Start
+      - !type:AdjustReagent
+        reagent: Theobromine
+        amount: 0.05
+# Starlight End
 
 - type: reagent
   id: Tea
   name: reagent-name-tea
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-tea
   physicalDesc: reagent-physical-desc-aromatic
   flavor: tea
@@ -521,7 +531,7 @@
 - type: reagent
   id: ArnoldPalmer
   name: reagent-name-arnold-palmer
-  parent: BaseAlcohol
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-arnold-palmer
   physicalDesc: reagent-physical-desc-sweet
   flavor: arnoldpalmer
@@ -584,7 +594,7 @@
 - type: reagent
   id: Rewriter
   name: reagent-name-rewriter
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-rewriter
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: sweet
@@ -614,7 +624,7 @@
 - type: reagent
   id: Tortuga
   name: reagent-name-tortuga
-  parent: BaseDrink
+  parent: BaseCaffeinatedDrink # Starlight Edit
   desc: reagent-desc-tortuga
   physicalDesc: reagent-physical-desc-sweet
   flavor: tortuga

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -70,7 +70,7 @@
 - type: reagent
   id: EnergyDrink
   name: reagent-name-energy-drink
-  parent: BaseSoda
+  parent: BaseCaffeinatedSoda # Starlight Edit
   desc: reagent-desc-energy-drink
   physicalDesc: reagent-physical-desc-fizzy
   flavor: energydrink
@@ -251,7 +251,7 @@
 - type: reagent
   id: FourteenLoko
   name: reagent-name-fourteen-loko
-  parent: BaseSoda
+  parent: BaseCaffeinatedSoda # Starlight Edit
   desc: reagent-desc-fourteen-loko
   physicalDesc: reagent-physical-desc-fizzy
   flavor: fourteenlokosoda


### PR DESCRIPTION
## Short description
Fixes alcoholic and caffeinated properties of various cocktails and drinks to match their expected composition.

## Why we need to add this
Multiple drinks did not have the correct property, for example not containing theobromine despite consisting of coffee or tea, or using the incorrect drink base such as alcoholic drinks using the non-alcoholic base and vice-versa.

Aside from making it difficult to determine whether or not some species can actually drink the cocktail, it also complicates a planned update to the drinks guidebook. Fixing these inconsistencies will make it easier to create drinks categories, much like for cooking recipes or regular chemicals.

## Media (Video/Screenshots)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ab8c9195-dc93-4fcf-abf4-13fc850af368" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- tweak: Multiple tea and coffee drinks now contain theobromine. This affects Cafe latte, Soy latte, Coffee liqueur, Green tea, Iced green tea, Espresso martini, Irish coffee, Black russian, White russian, Atomic bomb, B-52, Brave bull, Rewriter, and Tortuga.