### PR TITLE
Rock Anomalies now spawn astro-asteroidtiles

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -411,13 +411,13 @@
         minAmount: 15
         maxAmount: 20
         maxRange: 7.5
-      floor: FloorAstroAsteroidTile
+      floor: FloorAstroAsteroidTile #Starlight
     - settings:
         spawnOnSuperCritical: true
         minAmount: 30
         maxAmount: 50
         maxRange: 12
-      floor: FloorAstroAsteroidTile
+      floor: FloorAstroAsteroidTile #Starlight
 
 - type: entity
   id: AnomalyRockUranium

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -411,13 +411,13 @@
         minAmount: 15
         maxAmount: 20
         maxRange: 7.5
-      floor: FloorAsteroidTile
+      floor: FloorAstroAsteroidTile
     - settings:
         spawnOnSuperCritical: true
         minAmount: 30
         maxAmount: 50
         maxRange: 12
-      floor: FloorAsteroidTile
+      floor: FloorAstroAsteroidTile
 
 - type: entity
   id: AnomalyRockUranium

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
@@ -288,13 +288,13 @@
         minAmount: 7
         maxAmount: 10
         maxRange: 4
-      floor: FloorAstroAsteroidTile
+      floor: FloorAstroAsteroidTile #Starlight
     - settings:
         spawnOnSuperCritical: true
         minAmount: 15
         maxAmount: 25
         maxRange: 6
-      floor: FloorAstroAsteroidTile
+      floor: FloorAstroAsteroidTile #Starlight
   - type: EntitySpawnAnomaly
     entries:
     - settings:

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
@@ -288,13 +288,13 @@
         minAmount: 7
         maxAmount: 10
         maxRange: 4
-      floor: FloorAsteroidTile
+      floor: FloorAstroAsteroidTile
     - settings:
         spawnOnSuperCritical: true
         minAmount: 15
         maxAmount: 25
         maxRange: 6
-      floor: FloorAsteroidTile
+      floor: FloorAstroAsteroidTile
   - type: EntitySpawnAnomaly
     entries:
     - settings:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Rock anomalies no longer cause weather inside of stations.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Currently, rock anomalies spawn FloorAsteroidTile, which is a sandy steel tile that is not immune to weather. Crew can crowbar and replace it with steel tile, but it really shouldn't be causing weather in the first place. Replacing with the weather-proof variant of the tile.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="1388" height="844" alt="image" src="https://github.com/user-attachments/assets/3ba11841-d84b-4493-bb4e-c2cd74e9e021" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Ohelig
- fix: Rock anomalies no longer cause weather inside the station.