### PR TITLE
Chav accent now replaces 'borg' with 'tin can' instead of 'tin man'

### DIFF
--- a/Resources/Locale/en-US/_Starlight/accent/chav.ftl
+++ b/Resources/Locale/en-US/_Starlight/accent/chav.ftl
@@ -224,10 +224,10 @@ accent-chav-replaced-75 = cat
 accent-chav-replacement-75 = hissy wanka
 
 accent-chav-replaced-76 = borg
-accent-chav-replacement-76 = tin man
+accent-chav-replacement-76 = tin can
 
 accent-chav-replaced-77 = borgs
-accent-chav-replacement-77 = tin men
+accent-chav-replacement-77 = tin cans
 
 accent-chav-replaced-78 = right
 accent-chav-replacement-78 = roight


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
I got feedback that the prior word replacement for #4309 was too gendered.

Tin man -> tin can is a small change that makes the borg slang in chav accent more neutral with the same chav-slangy outcome.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Response to community feedback.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Chav accent's word replacement for 'borg/borgs' has been changed to 'tin can/tin cans' instead of 'tin man/tin men'.