### PR TITLE
Mech: Give vim equipment

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -363,7 +363,7 @@
 # Vim!!!!!!!
 
 - type: entity
-  parent: BaseMech
+  parent: [ BaseMech, SmallMech ] # Starlight - give Vim equipment
   id: MechVim
   name: Vim
   description: A miniature exosuit from Nanotrasen, developed to let the irreplaceable station pets live a little longer.
@@ -395,7 +395,7 @@
     baseState: base
     openState: base-open
     brokenState: base-broken
-    maxEquipmentAmount: 0
+    maxEquipmentAmount: 1 # Starlight - give Vim equipment
     # keep mouse safe
     mechToPilotDamageMultiplier: 0.0 #Starlight - Mechs are safe
     airtight: true


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Lets vim install an equipment. Just one, since it's still smaller than HAMTR and comes with maints access that HAMTR doesn't.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Remember Vim? I don't! Cause it sucks and can't carry anything so no one ever builds it!!

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="605" height="544" alt="Screenshot from 2026-05-02 14-47-37" src="https://github.com/user-attachments/assets/84b44cff-e969-4e4e-958d-41ed1eb24842" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neurovermi
- tweak: Vim now can install a singular equipment module, instead of none.