### PR TITLE
Let The Animals Understand Common

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -217,6 +217,7 @@
     speaks:
     - Chicken
     understands:
+    - GalacticCommon
     - Chicken
   - type: MobThresholds
     thresholds:
@@ -523,6 +524,7 @@
     speaks:
     - Mothroach
     understands:
+    - GalacticCommon
     - Moffic
     - Mothroach
   # Starlight-end
@@ -709,6 +711,7 @@
     speaks:
     - Duck
     understands:
+    - GalacticCommon
     - Duck
   - type: MobThresholds
     thresholds:
@@ -1347,6 +1350,7 @@
     speaks:
     - Ancestor
     understands:
+    - GalacticCommon
     - Ancestor
   # Starlight-end
   - type: VentCrawler # Starlight-edit: Vent Crawl
@@ -1606,6 +1610,7 @@
     - Ancestor
     - Draconic
     understands:
+    - GalacticCommon
     - Ancestor
     - Draconic
   # Starlight-end
@@ -1804,6 +1809,7 @@
     speaks:
     - Mouse
     understands:
+    - GalacticCommon
     - Mouse
   # Starlight-end
   - type: VentCrawler # Starlight-edit: Vent Crawl
@@ -2596,6 +2602,7 @@
     speaks:
     - Chittin
     understands:
+    - GalacticCommon
     - Chittin
   # Starlight-end
   - type: VentCrawler # Starlight-edit: Vent Crawl
@@ -2979,6 +2986,7 @@
     speaks:
     - Fox
     understands:
+    - GalacticCommon
     - Fox
     - Canilunzt
   # Starlight-end
@@ -3145,6 +3153,7 @@
     speaks:
     - Dog
     understands:
+    - GalacticCommon
     - Dog
     - Canilunzt
   # Starlight-end
@@ -3181,6 +3190,7 @@
     understands:
     - Dog
     - GalacticCommon
+    - Canilunzt
   # Starlight End
   - type: Sprite
     drawdepth: Mobs
@@ -3280,6 +3290,7 @@
     speaks:
     - Cat
     understands:
+    - GalacticCommon
     - Cat
     - Nekomimetic
   # Starlight-end
@@ -3646,6 +3657,7 @@
     speaks:
     - Mouse
     understands:
+    - GalacticCommon
     - Mouse
   # Starlight-end
   - type: VentCrawler # Starlight-edit: Vent Crawl
@@ -3807,6 +3819,7 @@
     speaks:
     - Pig
     understands:
+    - GalacticCommon
     - Pig
   # Starlight-end
   - type: Sprite
@@ -3883,6 +3896,7 @@
     speaks:
     - Sylvan
     understands:
+    - GalacticCommon
     - Sylvan
   # Starlight-end
   - type: Sprite
@@ -3972,6 +3986,7 @@
     speaks:
     - Sylvan
     understands:
+    - GalacticCommon
     - Sylvan
   # Starlight-end
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -13,6 +13,8 @@
       understands:
       - Carptongue
       - Thaveyan
+      - GalacticCommon
+
   # Starlight-end
     - type: InputMover
     - type: MobMover

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -11,6 +11,7 @@
     speaks:
     - Bubblish
     understands:
+    - GalacticCommon
     - Bubblish
   # Starlight - End
   - type: VentCrawler


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Lets animals, slimes, and carps understand common.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
There's been a LOT of discord discussion about this on the staff dev side of things, and we've come to the decision that overall, having animals and especially animal ghostroles not be able to comprehend common only gets in the way of roleplay potential. It makes these ghost roles so utterly undesirable that they are rarely, if ever, picked up outside of zombie rounds. 

Keep note that this does not allow any of these creatures to speak more languages, only understand Galactic Common.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- add: Animals Now Understand Galactic Common.
- add: Space Carp Now Understand Galactic Common.
- add: Slimes Now Understand Galactic Common.