### PR TITLE
Fix: make 'wth' correct to 'what the hell' instead of 'heck'

### DIFF
--- a/Resources/Locale/en-US/speech/speech-chatsan.ftl
+++ b/Resources/Locale/en-US/speech/speech-chatsan.ftl
@@ -11,7 +11,7 @@ chatsan-word-4 = wtf
 chatsan-replacement-4 = what the fuck
 
 chatsan-word-5 = wth
-chatsan-replacement-5 = what the heck
+chatsan-replacement-5 = what the hell
 
 chatsan-word-6 = tf
 chatsan-replacement-6 = the fuck


### PR DESCRIPTION
## Short description
Changes the chatsan autocorrect for `wth` from "what the heck" to "what the hell".

## Why we need to add this
This was suggested by a community member on the Discord. The current correction to "heck" is inconsistent with the tone of other entries in the chatsan list (e.g. `wtf` → "what the fuck", `tf` → "the fuck"). "What the hell" is the natural and more commonly used expansion of `wth`.

## Media (Video/Screenshots)
No in-game visual changes — text/chat only.

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [Starlight Fork License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE-Starlight.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Magwitch
- tweak: Changed `wth` replacement from `what the heck` to `what the hell`.
