### PR TITLE
Add 1 tick per lathe recipe minimum.

### DIFF
--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -200,6 +200,13 @@ namespace Content.Server.Lathe
             var recipe = _proto.Index(batch.Recipe);
 
             var time = _reagentSpeed.ApplySpeed(uid, recipe.CompleteTime) * component.TimeMultiplier;
+            // Starlight Begin
+            // Ensure the production time is at least one tick to avoid issue with multiple recipes completing at once causing lag.
+            if (time < _timing.TickPeriod)
+            {
+                time = _timing.TickPeriod;
+            }
+            // Starlight End
 
             var lathe = EnsureComp<LatheProducingComponent>(uid);
             lathe.StartTime = _timing.CurTime;

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -217,10 +217,12 @@ namespace Content.Server.Lathe
             UpdateRunningAppearance(uid, true);
             UpdateUserInterfaceState(uid, component);
 
-            if (time == TimeSpan.Zero)
-            {
-                FinishProducing(uid, component, lathe);
-            }
+            // Starlight Begin
+            // if (time == TimeSpan.Zero)
+            // {
+            //     FinishProducing(uid, component, lathe);
+            // }
+            // Starlight End
             return true;
         }
 

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -202,10 +202,7 @@ namespace Content.Server.Lathe
             var time = _reagentSpeed.ApplySpeed(uid, recipe.CompleteTime) * component.TimeMultiplier;
             // Starlight Begin
             // Ensure the production time is at least one tick to avoid issue with multiple recipes completing at once causing lag.
-            if (time < _timing.TickPeriod)
-            {
-                time = _timing.TickPeriod;
-            }
+           time = MathHelper.Max(time, _timing.TickPeriod);
             // Starlight End
 
             var lathe = EnsureComp<LatheProducingComponent>(uid);


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds a minimum of 1 tick of server time per lathe recipe. 

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This fixes an issue where Mining would crash the server by queueing up some bluespace crystals, then adding 5000 steel or glass crafts on the end, which stalls out the server when it tries to print all at once. This applies to all lathes, not just the ore processor.

This makes it take about a minute to print 1000 resources from the ore processor.


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/e0203ae2-5951-4a0d-ad51-f2d19867f093

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Ohelig
- fix: Fixes mining being able to crash the server by queueing up too many ore processor recipes.