### PR TITLE
Adds Lawyer Station Beacon and Holopad for mappers

### DIFF
--- a/Resources/Locale/en-US/_Starlight/holopad/holopad.ftl
+++ b/Resources/Locale/en-US/_Starlight/holopad/holopad.ftl
@@ -1,5 +1,5 @@
 # Service
-holopad-service-legal = Service - Legal
+holopad-service-lawyer = Service - Lawyer
 
 # Security
 holopad-security-iaa = Security - Internal Affairs

--- a/Resources/Locale/en-US/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/navmap-beacons/station-beacons.ftl
@@ -100,3 +100,4 @@ station-beacon-escape-pod-W = Escape Pod W
 station-beacon-escape-pod-NW = Escape Pod NW
 station-beacon-vox = Vox Break Room
 station-beacon-nct = NCT Office
+station-beacon-lawyer = Lawyer

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -851,6 +851,7 @@
   - type: NavMapBeacon
     defaultText: station-beacon-vox
 
+#region Starlight
 - type: entity
   parent: DefaultStationBeacon
   id: DefaultStationBeaconNCT
@@ -859,6 +860,14 @@
   - type: NavMapBeacon
     defaultText: station-beacon-nct
 
+- type: entity
+  parent: DefaultStationBeaconService
+  id: DefaultStationBeaconLawyer
+  suffix: Lawyer
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-lawyer
+#endregion Starlight
 
 # Ghost Only Beacons
 - type: entity

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/holopad.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: Holopad
-  id: HolopadServiceLegal
-  suffix: Legal
+  id: HolopadServiceLawyer
+  suffix: Lawyer
   components:
   - type: Label
-    currentLabel: holopad-service-legal
+    currentLabel: holopad-service-lawyer


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
- Adds a Lawyer station beacon.
- Renames the 'Legal' holopad to be the Lawyer holopad. No migration needed as this was not mapped.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- Needed for mapping.
- Station beacons are essential for players finding their way back to their job areas when they get lost.
- The Legal holopad was named after its Access rather than the actual area it should be used in. No mapper is going to search 'Legal' when they want a Lawyer holopad. IAAs already have their own holopad, so they're not losing out on anything.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="764" height="542" alt="image" src="https://github.com/user-attachments/assets/9dc47f5a-de70-4923-8d9a-7f5abcfe2dad" />

fig. 1 - Station beacon for Lawyer and the Holopad for them.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
