### PR TITLE
Add Corporate Law to the Security SOP category in the guidebook

### DIFF
--- a/Resources/Prototypes/_Starlight/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Starlight/Guidebook/sop.yml
@@ -257,6 +257,7 @@
   text: "/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/security-sop-intro.xml"
   priority: 2
   children:
+  - SpaceLaw
   - security-sop-cadet
   - security-sop-securityofficer
   - security-sop-dutyofficer

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
@@ -897,10 +897,5 @@
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
       </Box>
     </ColorBox>
-    <ColorBox Color="#475c7d">
-      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To act as or knowingly aid a known enemy of the Station and NT-CC. Only applies beyond a shadow of doubt.
-      </Box>
-    </ColorBox>
   </Table>
 </Document>

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SLCrimeList.xml
@@ -893,9 +893,5 @@
         To kill three or more sentient humanoids with malicious intent. This only applies when there have been multiple killings with intention.
       </Box>
     </ColorBox>
-    <ColorBox Color="#475c7d">
-      <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-      </Box>
-    </ColorBox>
   </Table>
 </Document>


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Add corporate law to the sec SOP category, that's it.

also fixed a vestigial part of EOC still left on the crime-list that was supposed to be removed.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It just makes corporate law easier to navigate to, something that I frequently find myself in need of.

Security in general have one of the bulkiest and most demanding SOPs in the game, and having Corporate Law close to that SOP is just very handy.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="262" height="388" alt="billede" src="https://github.com/user-attachments/assets/b68de311-0559-4cb3-baf9-cc6a1fd63ca3" />



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- add: Added corporate law to Security SOP in the guidebook for easier navigation.