### PR TITLE
End of Round Time Voting - The Reckoning

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -183,7 +183,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 
             if (GameTicker.IsGameRuleActive("Nukeops")) // If it's Nukeops then end the round on any detonation
             {
-                _roundEndSystem.EndRound(TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.NukeRoundRestartTime))); // Starlight Edit: Round end timer set by Cvar
+                _roundEndSystem.EndRound(TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.NukeRoundRestartTime)), priorityTime: true); // Starlight Edit: Round end timer set by Cvar
             }
             else
             { // It's a LoneOp. Only end the round if the station was destroyed
@@ -192,7 +192,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                 {
                     if (cond.ToString().ToLower() == "NukeExplodedOnCorrectStation") // If this is true, then the nuke destroyed the station! It's likely everyone is very dead so keeping the round going is pointless.
                     {
-                        _roundEndSystem.EndRound(TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.NukeRoundRestartTime))); // end the round! // Starlight Edit: Round end timer set by Cvar
+                        _roundEndSystem.EndRound(TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.NukeRoundRestartTime)), priorityTime: true); // end the round! // Starlight Edit: Round end timer set by Cvar
                         handled = true;
                         break;
                     }
@@ -463,7 +463,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         _nukeopsCount.WithLabels(type.ToString()).Inc(1); // Starlight
 
         if (endRound && (type == WinType.CrewMajor || type == WinType.OpsMajor))
-            _roundEndSystem.EndRound(TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.NukeRoundRestartTime))); // Starlight Edit: Round end timer set by Cvar
+            _roundEndSystem.EndRound(TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.NukeRoundRestartTime)), priorityTime: true); // Starlight Edit: Round end timer set by Cvar
     }
 
     private void CheckRoundShouldEnd()

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -383,7 +383,7 @@ namespace Content.Server.RoundEnd
         }
         // Starlight END
 
-        public void EndRound(TimeSpan? countdownTime = null)
+        public void EndRound(TimeSpan? countdownTime = null, bool priorityTime = false) // Starlight Edit
         {
             if (_gameTicker.RunLevel != GameRunLevel.InRound) return;
             LastCountdownStart = null;
@@ -394,7 +394,7 @@ namespace Content.Server.RoundEnd
             _countdownTokenSource = new();
 
             // Starlight
-            if (_cfg.GetCVar(StarlightCCVars.EnableEndRoundTimeVotes) && countdownTime == null)
+            if (_cfg.GetCVar(StarlightCCVars.EnableEndRoundTimeVotes) && !priorityTime)
             {
                 EndRoundWithTimeVote(_countdownTokenSource);
                 return;

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -21,9 +21,11 @@ using Robust.Shared.Timing;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Station.Components;
 using Timer = Robust.Shared.Timing.Timer;
+# region Starlight
 using Content.Shared.Starlight.CCVar;
 using Content.Server.Voting.Managers;
 using Content.Server.Voting;
+# endregion
 
 namespace Content.Server.RoundEnd
 {
@@ -311,8 +313,8 @@ namespace Content.Server.RoundEnd
             }
         }
 
+        // Starlight START
         /// <summary>
-        /// STARLIGHT
         /// Ends round, but with a vote for how long EOR should be
         /// </summary>
         private void EndRoundWithTimeVote(CancellationTokenSource countdownTokenSource)
@@ -334,11 +336,12 @@ namespace Content.Server.RoundEnd
 
             for (int i = 1; i < optionQuantity; i++)
             {
-                if (lastSavedNegativeTime.Seconds - optionSpacing.Seconds < 0)
+                if (lastSavedNegativeTime - optionSpacing > TimeSpan.Zero)
                 {
                     lastSavedNegativeTime = lastSavedNegativeTime.Subtract(optionSpacing);
                     options.Options.Add(($"{lastSavedNegativeTime.Minutes}", lastSavedNegativeTime));
-                    i++;
+                    if (++i >= optionQuantity)
+                        break;
                 }
 
                 lastSavedPositiveTime = lastSavedPositiveTime.Add(optionSpacing);
@@ -378,6 +381,7 @@ namespace Content.Server.RoundEnd
                 Timer.Spawn(picked, AfterEndRoundRestart, countdownTokenSource.Token);
             };
         }
+        // Starlight END
 
         public void EndRound(TimeSpan? countdownTime = null)
         {

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -394,7 +394,7 @@ namespace Content.Server.RoundEnd
             _countdownTokenSource = new();
 
             // Starlight
-            if (_cfg.GetCVar(StarlightCCVars.EnableEndRoundTimeVotes))
+            if (_cfg.GetCVar(StarlightCCVars.EnableEndRoundTimeVotes) && countdownTime == null)
             {
                 EndRoundWithTimeVote(_countdownTokenSource);
                 return;

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -21,6 +21,9 @@ using Robust.Shared.Timing;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Station.Components;
 using Timer = Robust.Shared.Timing.Timer;
+using Content.Shared.Starlight.CCVar;
+using Content.Server.Voting.Managers;
+using Content.Server.Voting;
 
 namespace Content.Server.RoundEnd
 {
@@ -41,6 +44,9 @@ namespace Content.Server.RoundEnd
         [Dependency] private readonly EmergencyShuttleSystem _shuttle = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly StationSystem _stationSystem = default!;
+        // Starlight begin
+        [Dependency] private readonly IVoteManager _votes = default!;
+        // Starlight end
 
         public TimeSpan DefaultCooldownDuration { get; set; } = TimeSpan.FromSeconds(30);
 
@@ -305,6 +311,74 @@ namespace Content.Server.RoundEnd
             }
         }
 
+        /// <summary>
+        /// STARLIGHT
+        /// Ends round, but with a vote for how long EOR should be
+        /// </summary>
+        private void EndRoundWithTimeVote(CancellationTokenSource countdownTokenSource)
+        {
+            var defaultTime = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.RoundRestartTime));
+            var optionSpacing = TimeSpan.FromSeconds(_cfg.GetCVar(StarlightCCVars.EndRoundTimeVoteSpacing));
+            var optionQuantity = _cfg.GetCVar(StarlightCCVars.EndRoundTimeVoteAmount);
+
+            var options = new VoteOptions
+            {
+                Title = Loc.GetString("eor-time-vote-title"),
+                InitiatorText = Loc.GetString("eor-time-vote-initiator"),
+                Duration = TimeSpan.FromSeconds(15f),
+            };
+
+            options.Options.Add(($"{defaultTime.Minutes}", defaultTime));
+            var lastSavedNegativeTime = defaultTime;
+            var lastSavedPositiveTime = defaultTime;
+
+            for (int i = 1; i < optionQuantity; i++)
+            {
+                if (lastSavedNegativeTime.Seconds - optionSpacing.Seconds < 0)
+                {
+                    lastSavedNegativeTime = lastSavedNegativeTime.Subtract(optionSpacing);
+                    options.Options.Add(($"{lastSavedNegativeTime.Minutes}", lastSavedNegativeTime));
+                    i++;
+                }
+
+                lastSavedPositiveTime = lastSavedPositiveTime.Add(optionSpacing);
+                options.Options.Add(($"{lastSavedPositiveTime.Minutes}", lastSavedPositiveTime));
+            }
+
+            var vote = _votes.CreateVote(options);
+
+            vote.OnFinished += (_, args) =>
+            {
+                TimeSpan picked;
+                if (args.Winner == null)
+                {
+                    picked = defaultTime;
+                }
+                else
+                {
+                    picked = (TimeSpan)args.Winner;
+                }
+                int time;
+                string unitsLocString;
+                if (picked.TotalSeconds < 60)
+                {
+                    time = picked.Seconds;
+                    unitsLocString = "eta-units-seconds";
+                }
+                else
+                {
+                    time = picked.Minutes;
+                    unitsLocString = "eta-units-minutes";
+                }
+                _chatManager.DispatchServerAnnouncement(
+                    Loc.GetString(
+                        "round-end-system-round-restart-eta-announcement",
+                        ("time", time),
+                        ("units", Loc.GetString(unitsLocString))));
+                Timer.Spawn(picked, AfterEndRoundRestart, countdownTokenSource.Token);
+            };
+        }
+
         public void EndRound(TimeSpan? countdownTime = null)
         {
             if (_gameTicker.RunLevel != GameRunLevel.InRound) return;
@@ -314,6 +388,14 @@ namespace Content.Server.RoundEnd
             _gameTicker.EndRound();
             _countdownTokenSource?.Cancel();
             _countdownTokenSource = new();
+
+            // Starlight
+            if (_cfg.GetCVar(StarlightCCVars.EnableEndRoundTimeVotes))
+            {
+                EndRoundWithTimeVote(_countdownTokenSource);
+                return;
+            }
+            // Starlight END
 
             countdownTime ??= TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.RoundRestartTime));
             int time;

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
@@ -59,7 +59,7 @@ public sealed partial class StarlightCCVars
         CVarDef.Create("game.nuke_round_restart_time", 20f, CVar.SERVERONLY);
 
     /// <summary>
-    /// Enables voting for how long EOR will be, off by default.
+    /// Enables voting for how long EOR will be, on by default.
     /// </summary>
     public static readonly CVarDef<bool> EnableEndRoundTimeVotes =
         CVarDef.Create("game.round_end_time_vote_enabled", true, CVar.SERVER);

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
@@ -52,12 +52,13 @@ public sealed partial class StarlightCCVars
     public static readonly CVarDef<bool> Shipyard =
         CVarDef.Create("shuttle.shipyard", true, CVar.SERVERONLY);
 
+    /// <summary>
     /// The time in seconds that it will take the round to end after the nuke explodes durign nukies.
     /// </summary>
     public static readonly CVarDef<float> NukeRoundRestartTime =
         CVarDef.Create("game.nuke_round_restart_time", 20f, CVar.SERVERONLY);
 
-        /// <summary>
+    /// <summary>
     /// Enables voting for how long EOR will be, off by default.
     /// </summary>
     public static readonly CVarDef<bool> EnableEndRoundTimeVotes =

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Game.cs
@@ -56,4 +56,22 @@ public sealed partial class StarlightCCVars
     /// </summary>
     public static readonly CVarDef<float> NukeRoundRestartTime =
         CVarDef.Create("game.nuke_round_restart_time", 20f, CVar.SERVERONLY);
+
+        /// <summary>
+    /// Enables voting for how long EOR will be, off by default.
+    /// </summary>
+    public static readonly CVarDef<bool> EnableEndRoundTimeVotes =
+        CVarDef.Create("game.round_end_time_vote_enabled", true, CVar.SERVER);
+
+    /// <summary>
+    /// How many seconds between each time-vote option.
+    /// </summary>
+    public static readonly CVarDef<float> EndRoundTimeVoteSpacing =
+        CVarDef.Create("game.round_end_time_vote_spacing", 300f, CVar.SERVERONLY);
+
+    /// <summary>
+    /// How many different options to generate for end-round times.
+    /// </summary>
+    public static readonly CVarDef<int> EndRoundTimeVoteAmount =
+        CVarDef.Create("game.round_end_time_vote_amount", 3, CVar.SERVER);
 }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds an admin-changeable CVar that enables or disables (enabled by default) a system that allowed players to vote on how long end-of-round will last.

While I am aware that a prototype with pre-defined options was recommended, I insist that this current, dynamic, system is preferable, but am willing to concede if push comes to shove. Although it will waste a bit of my work.

It works by taking the default round end timer, and then generating an amount of options based off of it for the vote equal to _game.round_end_time_vote_amount_.

Among the options there will always be the default time.
The system will then recursively attempt to:

1. Generate a time that is equal to the lowest option generated so far, minus _game.round_end_time_vote_spacing_ (5 minutes by default)
2. Generate a time that is equal to the highest option generated so far, plus _game.round_end_time_vote_spacing_ (again, 5 minutes by default).

In practice it generates the following on Alpha:

1. 5 minutes, default time
2.  10 minutes, default time + 5 (_game.round_end_time_vote_spacing_)
3. 15 minutes, option two + 5 (_game.round_end_time_vote_spacing_)

On Beta, it generates:

1. 10 minutes, default time
2. 5 minutes, default time - 5 (_game.round_end_time_vote_spacing_)
3. 15 minutes, default time + 5 (_game.round_end_time_vote_spacing_)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

It was requested, particularly for Beta.
In general, I anticipate that it will seldom see use on Alpha, but on Beta (where I also recommend a larger option range, 4 perhaps) I think it will be quite popular.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
[example.webm](https://github.com/user-attachments/assets/b6c22361-937b-413e-951a-577a78170a9a)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- add: End-of-Round duration voting.