### PR TITLE
Adds N2 tank and cooling unit to Salvage Lead's locker

### DIFF
--- a/Resources/Prototypes/_Starlight/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Fills/Lockers/cargo.yml
@@ -12,6 +12,8 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled
+    - id: CoolingUnit
     - id: ClothingShoesBootsMag
     - id: ClothingOuterHardsuitSpatioLead
     - id: ClothingMaskGasExplorer


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
salvage lead's locker [Filled, Hardsuit] `LockerSalvageLeadFilledHardsuit` only had an O2 tank in it.
- no N2 tank for nitrogen breathers
- no cooling unit for IPCs

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Consistency bugfix. All other lockers with EVA gear that have an O2 tank also have an N2 tank and a cooling unit.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="484" height="437" alt="image" src="https://github.com/user-attachments/assets/8770ce9c-d15c-407d-943b-8d87c06a3aee" />

fig. 1 - Salvage Leader's [Filled, Hardsuit] variant of the locker now has a nitrogen tank and a cooling unit inside of it.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Salvage Lead's locker now starts with a nitrogen tank and a cooling unit inside of it.
