### PR TITLE
Adds an EMAG interaction to the ShadyCigs Deluxe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
@@ -20,4 +20,9 @@
     CigarGold: 2
     Igniter: 1
     CigPackMedRollie: 1 # Starlight-edit
-    MysteryLighterBox: 1 # Starlight-edit
+    MysteryLighterBox: 1 # Starlight-edit a
+  #region Starlight
+  emaggedInventory:
+    CigPackSyndicate: 1
+    InterdyneFlippo: 1
+  #endregion Starlight


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Using the EMAG on a ShadyCigs adds the following items to its stock:
- Interdyne herbals packet
- Interdyne flippo

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This PR removed all "useful" items from EMAG vending machine inventories: https://github.com/space-wizards/space-station-14/pull/36839

It was unpopular. This PR re-adds the ShadyCigs EMAG interaction because it's fun and intuitive. EMAG smokes machine, get some Syndicate smokes.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="946" height="383" alt="image" src="https://github.com/user-attachments/assets/97afc9cf-eb5d-4d40-a991-dcf5851f661d" />

fig. 1 - Stock after being EMAG'd.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- add: Added an EMAG interaction to the ShadyCigs Deluxe vending machine.