### PR TITLE
Fixes being unable to restock the NanoMed Plus vending machine

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -40,37 +40,43 @@
     PillDesoxyephedrine5: 1 # Starlight
 
 # Core medical supply vendor
+#region Starlight - reverts Wizden NanoMed inventory changes
 - type: vendingMachineInventory
   id: NanoMedPlusInventory
   startingInventory:
-    # Medical Essential Gear
-    ClothingBeltMedicalFilled: 2
-    # Shared Essential
     HandheldHealthAnalyzer: 3
+    ClothingBeltMedical: 3
+    ClothingBeltMedicalEMT: 2
+    Gauze: 5
+    Brutepack: 5
+    Ointment: 5
+    Bloodpack: 5
+    Tourniquet: 2
+    ChemistryBottleEpinephrine: 3
+    ChemistryBottleBicaridine: 1
+    Syringe: 5
     JetInjector: 3
-    # Paramed Essential Gear
-    ClothingBeltMedicalEMTFilled: 1
-    EmergencyRollerBedSpawnFolded: 1
-    BoxBodyBag: 1
-    # Extra Expendable Gear
-    Gauze: 4
-    Brutepack: 4
-    Ointment: 4
-    Bloodpack: 4
-    # Optional / Situational Gear
     BoxBottle: 3
-    ClothingEyeGlassesMedicalPrescription: 2 #Starlight
-    AutoMenderBruteFilled: 1 #Starlight
-    AutoMenderBurnFilled: 1 #Starlight
-    SpaceMedipen: 1 #Starlight
+    PillCanisterTricordrazine: 3
+    PillCanisterIron: 1
+    PillCanisterCopper: 1
+    PillCanisterPotassiumIodide: 1
+    SyringeIpecac: 1
+    ClothingEyesHudMedical: 2
+    ClothingEyesEyepatchHudMedical: 2
+    ClothingEyeGlassesMedicalPrescription: 2
+    AutoMenderBruteFilled: 1
+    AutoMenderBurnFilled: 1
+    SpaceMedipen: 1
   contrabandInventory:
     PillCanisterRandom: 3
     PillSpaceDrugs: 3
-    StrangePill: 2 # Starlight
+    StrangePill: 2
     FoodApple: 1
-  emaggedInventory: # Starlight
-    OminousPill: 2 # Starlight
-    PillDesoxyephedrine5: 2 # Starlight
+  emaggedInventory:
+    OminousPill: 2
+    PillDesoxyephedrine5: 2
+#endregion Starlight
 
 # All access version. Should reflect NanoMedCivilianWallInventory, but with more stock
 - type: vendingMachineInventory

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -40,9 +40,9 @@
     PillDesoxyephedrine5: 1 # Starlight
 
 # Core medical supply vendor
-#region Starlight - reverts Wizden NanoMed inventory changes
 - type: vendingMachineInventory
   id: NanoMedPlusInventory
+  #region Starlight - reverts Wizden NanoMed inventory changes
   startingInventory:
     HandheldHealthAnalyzer: 3
     ClothingBeltMedical: 3
@@ -76,7 +76,7 @@
   emaggedInventory:
     OminousPill: 2
     PillDesoxyephedrine5: 2
-#endregion Starlight
+  #endregion Starlight
 
 # All access version. Should reflect NanoMedCivilianWallInventory, but with more stock
 - type: vendingMachineInventory

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -955,7 +955,7 @@
   name: NanoMed Plus
   components:
   - type: VendingMachine
-    pack: NanoMedPlusInventorySL # Starlight
+    pack: NanoMedPlusInventory
     offState: off
     showPrices: false  # Starlight-edit: Vending Machines Prices
   - type: Machine # Starlight-edit: Vending Machine boards

--- a/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/medical.yml
@@ -367,39 +367,3 @@
   emaggedInventory:
     OminousPill: 1
     StrangePill: 1
-
-- type: vendingMachineInventory
-  id: NanoMedPlusInventorySL
-  startingInventory:
-    HandheldHealthAnalyzer: 3
-    ClothingBeltMedical: 3
-    ClothingBeltMedicalEMT: 2
-    Gauze: 5
-    Brutepack: 5
-    Ointment: 5
-    Bloodpack: 5
-    Tourniquet: 2
-    ChemistryBottleEpinephrine: 3
-    ChemistryBottleBicaridine: 1
-    Syringe: 5
-    JetInjector: 3
-    BoxBottle: 3
-    PillCanisterTricordrazine: 3
-    PillCanisterIron: 1
-    PillCanisterCopper: 1
-    PillCanisterPotassiumIodide: 1
-    SyringeIpecac: 1
-    ClothingEyesHudMedical: 2
-    ClothingEyesEyepatchHudMedical: 2
-    ClothingEyeGlassesMedicalPrescription: 2
-    AutoMenderBruteFilled: 1
-    AutoMenderBurnFilled: 1
-    SpaceMedipen: 1
-  contrabandInventory:
-    PillCanisterRandom: 3
-    PillSpaceDrugs: 3
-    StrangePill: 2
-    FoodApple: 1
-  emaggedInventory:
-    OminousPill: 2
-    PillDesoxyephedrine5: 2


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
In #4268, the NanoMed Plus had its inventory changed to `NanoMedPlusInventorySL` from `NanoMedPlusInventory`

But the restock box was not updated to reflect this. It still only had `NanoMedPlusInventory`
```yml
- type: entity
  parent: BaseVendingMachineRestock
  id: VendingMachineRestockMedical
  name: NanoMed restock box
  description: Slot into your department's NanoMed or NanoMedPlus to dispense. Handle with care.
  components:
  - type: VendingMachineRestock
    canRestock:
    - NanoMedInventory
    - NanoMedPlusInventory
    - NanoMedCivilianInventory
    - NanoMedCivilianWallInventory
    - NanoMedSecurityInventory #SL
    - InterdyneCommercialInventory #SL
    - InterdyneEnterpriseInventory #SL
    - InterdyneCommercialWallInventory #SL
    - InterdyneEnterpriseWallInventory #SL
  - type: Sprite
    layers:
    - state: base
    - state: green_bit
      shader: unshaded
    - state: refill_medical
```

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes being unable to restock the NanoMed Plus.

Regarding the PR's implementation: There's no reason for `NanoMedPlusInventory` to exist if we just replace it with `NanoMedPlusInventorySL`. This is why I've opted to remove `NanoMedPlusInventorySL` and just put Starlight comments around the NanoMed inventory, since ours basically entirely divorced from Wizden's now.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="490" height="330" alt="image" src="https://github.com/user-attachments/assets/8b64acbb-923d-470f-b2c5-ab8af398e56e" />

fig. 1 - You can now restock the NanoMed Plus again.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Restocking NanoMed Plus vending machines has been fixed.
