### PR TITLE
Desoxyephedrine pill name fix

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/syndicate_pills.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Medical/syndicate_pills.yml
@@ -30,7 +30,7 @@
 
 # Desoxyephedrine
 - type: entity
-  name: lead
+  name: desoxyephedrine
   parent: Pill
   id: PillDesoxyephedrine5
   suffix: Desoxyephedrine 5u
@@ -45,7 +45,7 @@
 
 # Here for consistency, but ideally if you're going to map these, use the 5u version instead.
 - type: entity
-  name: lead
+  name: desoxyephedrine
   parent: Pill
   id: PillDesoxyephedrine
   suffix: Desoxyephedrine 15u


### PR DESCRIPTION
## Short description
Fixes the desoxyephedrine pills' name accidentally labeling them lead.

## Why we need to add this
Bug fix.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Desoxyephedrine pills are now properly named, instead of being labeled as lead.

