### PR TITLE
Outer clothing storage is 2x3 again

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -35,7 +35,7 @@
     - 0,0,1,2
   - type: Storage
     grid:
-    - 0,0,1,1 # Starlight
+    - 0,0,2,1
   - type: ContainerContainer
     containers:
       storagebase: !type:Container


### PR DESCRIPTION
## Short description
Wizden changed it so outer clothing like winter coats were 2x3, to match their 2x3 inventories. We made outer clothing storage have 2x2 storage, to match their inventory size. We merged wizden's changes, so we don't need to keep our storage reduced to 2x2 anymore, as outer clothing is now 2x3, again.

## Why we need to add this
We accepted a wizden balance merge but didn't actually inherit the reason they did it.

Starlight comment removed since that line is now equal to Wizden's.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Outer clothing storage is now 2x3 again.
