### PR TITLE
Add a "Clumsy Only" Component

### DIFF
--- a/Content.Server/_Starlight/Clumsy/ClumsyOnlySystem.cs
+++ b/Content.Server/_Starlight/Clumsy/ClumsyOnlySystem.cs
@@ -1,0 +1,43 @@
+using Content.Shared._Starlight.Clumsy;
+using Content.Shared.Clumsy;
+using Content.Shared.Hands;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Popups;
+using Content.Shared.Throwing;
+using Robust.Shared.Random;
+
+namespace Content.Server._Starlight.Clumsy;
+
+public sealed class ClumsyOnlySystem : EntitySystem
+{
+    [Dependency] private readonly ThrowingSystem _throwing = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ClumsyOnlyComponent, BeforeGettingEquippedHandEvent>(OnItemPickedUp);
+    }
+
+    /// <remarks>
+    /// see remarks on LubedSystem as to why this is in Server, and not in Shared
+    /// </remarks>
+    private void OnItemPickedUp(EntityUid uid, ClumsyOnlyComponent comp, ref BeforeGettingEquippedHandEvent args)
+    {
+        if (HasComp<ClumsyComponent>(args.User) || args.Cancelled)
+            return;
+
+        args.Cancelled = true;
+
+        _transform.SetCoordinates(uid, Transform(args.User).Coordinates);
+        _transform.AttachToGridOrMap(uid);
+        _throwing.TryThrow(uid, _random.NextVector2(), comp.SlipStrength);
+        _popup.PopupEntity(Loc.GetString("lube-slip", ("target", Identity.Entity(uid, EntityManager))),
+            args.User,
+            args.User,
+            PopupType.MediumCaution);
+    }
+
+}

--- a/Content.Shared/_Starlight/Clumsy/ClumsyOnlyComponent.cs
+++ b/Content.Shared/_Starlight/Clumsy/ClumsyOnlyComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared._Starlight.Clumsy;
+
+/// <summary>
+/// This component restricts the usage of items to entities with a ClumsyComponent
+/// </summary>
+[RegisterComponent]
+public sealed partial class ClumsyOnlyComponent : Component
+{
+    [DataField("slipStrength"), ViewVariables(VVAccess.ReadWrite)]
+    public int SlipStrength = 10;
+}

--- a/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
@@ -129,7 +129,7 @@ uplink-noslip-clown-shoes-name = No-Slip Clown Shoes
 uplink-noslip-clown-shoes-desc = For the clowns who want that extra edge against security.
 
 uplink-banana-esword-name = Banana Energy Sword
-uplink-banana-esword-desc = A bananium-modified energy sword that slips whoever it slices. Does minimal damage.
+uplink-banana-esword-desc = A bananium-modified energy sword that slips whoever it slices. Does minimal damage. Clumsy only!
 
 uplink-mimana-stealthy-name = Stealthy Mimana
 uplink-mimana-stealthy-desc = A mutated mimana that seems to fade into the background. Don't lose it!

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/e_melee.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/e_melee.yml
@@ -108,3 +108,4 @@
       requiredSlipSpeed: 0
       knockdownTime: 1
       launchForwardsMultiplier: 2
+  - type: ClumsyOnly


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds a component that restricts the usage of entities to users with the clumsy component. An interaction for items has been added, with an effect similar to trying to pick up a lubed item.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Balancing of Clown syndicate gear + any new gag items that may be added in the future. Ex. the banana energy sword is a very powerful item, and can be purchased by performers in addition to clowns. This would be undesirable if the performers do not have the Clumsy trait, which would otherwise prevent them from using most ranged weapons. This allows for balancing to be more independent of overall gun meta.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="457" height="361" alt="Screenshot from 2026-05-06 13-36-19" src="https://github.com/user-attachments/assets/1dac7c88-8059-4e37-96f2-5b670ad4082d" />
<img width="762" height="505" alt="Screenshot from 2026-05-06 13-40-18" src="https://github.com/user-attachments/assets/3593f1eb-1175-4d7b-8fd7-8deee9f75ad0" />



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neurovermi
- tweak: restricts the banana energy sword to Clumsy-traited users.