### PR TITLE
that stupid mk 58 again

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -132,6 +132,14 @@
         gun_magazine:
           name: Magazine
           startingItem: MagazinePistolSPGolden
+          insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
+          ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
+          priority: 2
+          whitelist:
+            tags:
+              - MagazinePistol
+              - MagazinePistolHighCapacitySP
+          whitelistFailPopup: gun-magazine-whitelist-fail
 
 - type: entity
   name: golden mk 58


### PR DESCRIPTION
## Short description
Fixes the normal golden mk 58 to no longer accept everything.

## Why we need to add this
I forgot about it

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: You can no longer insert literally anything into the normal golden mk 58.
