### PR TITLE
Nerfs the deaccelrator again from commit 908b119

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/particles.yml
@@ -78,7 +78,7 @@
       path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
     damage:
       types:
-        Radiation: 25 # Starlight: Consistency
+        Radiation: 10 # Starlight: Nerfed rad damage again. Bullshit it pens inf walls and deals 25 rad
     projectileType: Intangible # Starlight BEGIN
     maximumHits: 3
     deleteOnMaximumHits: true # Starlight END


### PR DESCRIPTION
## Short description
Nerfs the WeaponParticleDecelerator... 10 rad damage now

## Why we need to add this
25 rad +4 humanoid pen + inf wall pen is literaly worse then when we had the sec LMG and it creates nigh 0 counterplay

## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Scarlet Lightweaver.
- tweak: Changed ParticleDecelerator to deal 10 rad damage.