### PR TITLE
Add DoNotMap to Nuclear Centrifuge

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/nuclear_centrifuge.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/nuclear_centrifuge.yml
@@ -3,6 +3,7 @@
   parent: [ BaseMachinePowered, ConstructibleMachine ]
   name: nuclear centrifuge
   description: A large machine that can be used to separate radioactive isotopes from spent fuel.
+  categories: [ DoNotMap ]
   components:
   - type: Sprite
     sprite: _Starlight/Structures/Machines/nuclear_centrifuge.rsi #SL Edit

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/nuclear_centrifuge.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Machines/nuclear_centrifuge.yml
@@ -3,7 +3,7 @@
   parent: [ BaseMachinePowered, ConstructibleMachine ]
   name: nuclear centrifuge
   description: A large machine that can be used to separate radioactive isotopes from spent fuel.
-  categories: [ DoNotMap ]
+  categories: [ DoNotMap ] # Starlight
   components:
   - type: Sprite
     sprite: _Starlight/Structures/Machines/nuclear_centrifuge.rsi #SL Edit


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds DoNotMap to the Nuclear Centrifuge.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The Centrifuge is intended to be only researched, not roundstart. Clarification for mappers
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

Not player facing