### PR TITLE
Urgent round fail to start bug fix

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -136,7 +136,6 @@
     SalvageShuttleCircuitboardStealObjective: 1 # technically qm
     MiningShuttleCircuitboardStealObjective: 1 # ditto
     SpyglassCaptainStealObjective: 0.7 #Cappy
-    CaptainTabletStealObjective: 0.7 # captain, newly added
     # Starlight-end
     ClothingOuterHardsuitVoidParamedStealObjective: 1   #med
     MedicalTechFabCircuitboardStealObjective: 1

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -50,7 +50,7 @@
     CorporateSecretsStealObjective: 0.75 #Starlight Unique Target
     CriminalReportsStealObjective: 0.75 #Starlight Unique Target
     SecureKnowledgeStealObjective:  0.75 #Starlight Unique Target
-    CaptainTabletStealObjective: 0.75 # #Starlight Unique Target + newly added
+    CaptainTabletStealObjective: 0.75 # #Starlight Unique Target
     # Starlight end
 
 

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Deliveries/deliveries_items.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Deliveries/deliveries_items.yml
@@ -146,6 +146,7 @@
         - CMOLicenseStealObjective
         - PinpointerNuclearStealObjective
         - AccessConfiguratorStealObjective
+        - CaptainTabletStealObjective
         - EncryptionKeyHybridStealObjective
         - NTRepBriefcaseSecureStealObjective
         # no ian meat because you are a pacifist and need them alive

--- a/Resources/Prototypes/_Starlight/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Starlight/Objectives/traitor.yml
@@ -186,6 +186,13 @@
     stealGroup: AccessConfigurator
 
 - type: entity
+  parent: BaseTraitorCommandStealObjective
+  id: CaptainTabletStealObjective
+  components:
+  - type: StealCondition
+    stealGroup: CaptainTablet
+
+- type: entity
   parent: BaseTraitorStealObjective
   id: EncryptionKeyHybridStealObjective
   components:


### PR DESCRIPTION
## Short description
Fixes a steal target causing rounds not to start.

## Why we need to add this
It causes Thief and Traitor rounds to fail to start when it rolls.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: The Captain's Tablet steal objective is now traitors only.
- fix: The Captain's Tablet steal objective no longer causes rounds to fail to start.
