### PR TITLE
Resomi and avali now breathe nitrogen (like slimes and cyclorites NOT like vox)

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -7,6 +7,8 @@
     - SlimePerson
     - Vox
     - Cyclorite #🌟Starlight🌟
+    - Resomi #🌟Starlight🌟
+    - Avali #🌟Starlight🌟
 
 - type: loadoutEffectGroup
   id: OxygenBreather
@@ -21,8 +23,6 @@
     - Reptilian
     - Vulpkanin # Starlight
     - Felionoid #🌟Starlight🌟
-    - Resomi #🌟Starlight🌟
-    - Avali #🌟Starlight🌟
     - Thaven # Starlight
     - Lagomorph # Starlight
 

--- a/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
@@ -76,6 +76,17 @@
   suffix: Avali
   description: "The lungs of an avali."
   components:
+  - type: Metabolizer
+    removeEmpty: true
+    solutionOnBody: false
+    solution: "Lung"
+    metabolizerTypes: [ Resomi, Slime ] #They get both so they can still breathe nitrogen without us needing to add Resomi everywhere Slime is listed
+    groups:
+    - id: Gas
+      rateModifier: 100.0
+  - type: Lung
+    alert:
+      LowNitrogen
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Avali/organs.rsi
     layers:

--- a/Resources/Prototypes/_Starlight/Body/Organs/resomi.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/resomi.yml
@@ -67,10 +67,13 @@
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
-    metabolizerTypes: [ Resomi, Human ] #They get both so they can still breathe oxygen without us needing to add Resomi everywhere Human is listed
+    metabolizerTypes: [ Resomi, Slime ] #They get both so they can still breathe nitrogen without us needing to add Resomi everywhere Slime is listed
     groups:
     - id: Gas
       rateModifier: 100.0
+  - type: Lung
+    alert:
+      LowNitrogen
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Resomi/organs.rsi
     layers:


### PR DESCRIPTION
## Short description
edited the properties of resomi and avali lungs to make them breathe nitrogen instead of oxygen, replacing their survival kits with appropriate ones and having them be alerted to lacks of nitrogen instead of oxygen 

## Why we need to add this
it is more accurate to the avali lore

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/5290ab88-156b-4db8-b58f-cbbc9cbec542

https://github.com/user-attachments/assets/0f7441e1-19cf-4f7d-9978-b1fee4a5e178




## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: StrangerOfParadiseOG
- tweak: Now resomi and avali are nitrogen breathers (not poisoned by oxygen), get used to picking the red tanks