### PR TITLE
Fix Vox atmos alt1/2 to inherit vox sensor settings properly

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Atmospherics/vox.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Atmospherics/vox.yml
@@ -1,20 +1,20 @@
 - type: entity
-  parent: [GasVentPumpAlt1, GasVentPumpVox]
+  parent: [AirSensorVoxBase, GasVentPumpAlt1, GasVentPumpVox]
   id: GasVentPumpVoxAlt1
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [GasVentPumpAlt2, GasVentPumpVox]
+  parent: [AirSensorVoxBase, GasVentPumpAlt2, GasVentPumpVox]
   id: GasVentPumpVoxAlt2
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [GasVentScrubberAlt1, GasVentScrubberVox]
+  parent: [AirSensorVoxBase, GasVentScrubberAlt1, GasVentScrubberVox]
   id: GasVentScrubberVoxAlt1
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [GasVentScrubberAlt2, GasVentScrubberVox]
+  parent: [AirSensorVoxBase, GasVentScrubberAlt2, GasVentScrubberVox]
   id: GasVentScrubberVoxAlt2
   categories: [ HideSpawnMenu ]
 
@@ -32,21 +32,21 @@
       Quinary: GasDualPortVentPumpVoxAlt4
 
 - type: entity
-  parent: [GasDualPortVentPumpAlt1, GasDualPortVentPumpVox]
+  parent: [AirSensorVoxBase, GasDualPortVentPumpAlt1, GasDualPortVentPumpVox]
   id: GasDualPortVentPumpVoxAlt1
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [GasDualPortVentPumpAlt2, GasDualPortVentPumpVox]
+  parent: [AirSensorVoxBase, GasDualPortVentPumpAlt2, GasDualPortVentPumpVox]
   id: GasDualPortVentPumpVoxAlt2
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [GasDualPortVentPumpAlt3, GasDualPortVentPumpVox]
+  parent: [AirSensorVoxBase, GasDualPortVentPumpAlt3, GasDualPortVentPumpVox]
   id: GasDualPortVentPumpVoxAlt3
   categories: [ HideSpawnMenu ]
 
 - type: entity
-  parent: [GasDualPortVentPumpAlt4, GasDualPortVentPumpVox]
+  parent: [AirSensorVoxBase, GasDualPortVentPumpAlt4, GasDualPortVentPumpVox]
   id: GasDualPortVentPumpVoxAlt4
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Vox atmos devices alt1/2 need to inherit the vox sensor settings.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
When I touched GasVentPump/Scrubber/DualPortVent alt layers in https://github.com/ss14Starlight/space-station-14/pull/4289 I forgot to have them inherit the Vox sensor values. Without this, any devices on the Alt1/2 layer would have normal station sensor values and alarm in a vox box.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

