### PR TITLE
Brigmed no longer requires Chemist job time

### DIFF
--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Security/brigmedic.yml
@@ -8,9 +8,6 @@
       role: JobSecurityOfficer
       time: 36000 # 10 hrs
     - !type:RoleTimeRequirement
-      role: JobChemist
-      time: 3h
-    - !type:RoleTimeRequirement
       role: JobParamedic
       time: 5h
     - !type:DepartmentTimeRequirement


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Brigmed chemistry was removed in #3346, but they still require Chemist job hours.

This PR removes the required Chemist job hours.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Brigmeds are not expected do Chemistry anymore after their Chemistry setup was removed from their job areas. This should be reflected in the job requirements.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1440" height="423" alt="image" src="https://github.com/user-attachments/assets/023ffed7-94e8-421c-a18e-fe4962c330bb" />

fig. 1 - Job requirements as seen in game.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Brigmed no longer requires Chemist job time.