### PR TITLE
Vox and Vulp colouring Hotfix

### DIFF
--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -6,7 +6,7 @@
   sprites: MobVoxSprites
   markingLimits: MobVoxMarkingLimits
   dollPrototype: AppearanceVox
-  skinColoration: VoxFeathers
+  skinColoration: Hues # Starlight Edit: VoxFeathers -> Hues
   defaultSkinTone: "#6c741d"
   maleFirstNames: NamesVox
   femaleFirstNames: NamesVox

--- a/Resources/Prototypes/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Species/vulpkanin.yml
@@ -7,7 +7,7 @@
   defaultSkinTone: "#5a3f2d"
   markingLimits: MobVulpkaninMarkingLimits
   dollPrototype: AppearanceVulpkanin
-  skinColoration: VulpkaninColors
+  skinColoration: Hues # Starlight Edit: VulpkaninColors -> Hues
   maleFirstNames: names_vulpkanin_male
   femaleFirstNames: names_vulpkanin_female
   lastNames: names_vulpkanin_last


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Reverts upstreams changes to vox and vulp colouring that was accidentally included in last upstream merge. Oops
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
We use Hues, Upstream dosent
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="565" height="594" alt="image" src="https://github.com/user-attachments/assets/b16f15ac-67c0-48fd-9a46-beb5fa276b4e" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Vox and Vulps can now use the correct colours.