### PR TITLE
Nerfing the syndicate mailtrunk

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Back/trunks.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Back/trunks.yml
@@ -42,7 +42,7 @@
   parent: [ClothingBackpackTrunk, BaseMinorContraband]
   id: ClothingBackpackTrunkSyndicate
   name: syndicate trunk
-  description: Huge, metal, reflective, and stylish. All the other syndicates will want to get their hands on this trunk.
+  description: Huge, metal, and stylish. All the other syndicates will want to get their hands on this trunk.
   components:
   - type: Sprite
     sprite: _Starlight/Clothing/Back/Trunks/syndicate.rsi
@@ -57,10 +57,6 @@
         Blunt: 15
     soundHit:
       collection: MetalThud
-  - type: Reflect  # It's a metal trunk
-    reflectProb: 0.2
-    reflects:
-      - Energy
 
 # Fashion-O-Mat
 - type: entity


### PR DESCRIPTION
## Short description
Nerfing the syndicate mailtrunk

## Why we need to add this
This item. for 4 tc and 3 on sale, Holds the most storage out of any bago ther then bluespace

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Scarlet Lightweaver
- tweak: The syndicate has had budget costs, the syndicate mail trunk no longer can reflect, mailtechs wheep.
