### PR TITLE
Amoxla OD Fix

### DIFF
--- a/Resources/Prototypes/_Starlight/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/medicine.yml
@@ -64,7 +64,7 @@
       - !type:HealthChange
         conditions:
           - !type:ReagentCondition
-            reagent: HeartbreakerToxin
+            reagent: Amoxla
             min: 25
         damage:
           types:


### PR DESCRIPTION
## Short description
Amoxla previously OD'd when there was too much Heartbreaker Toxin, not when there was too much Amoxla. This PR fixes that, making its behavior more normal, and more like how Dexalin Plus works. 

## Why we need to add this
It was a bug. Why was Heartbreaker Toxin set to be the OD for Amoxla, despite Amoxla removing Heartbreaker Toxin, just like Dexalin Plus. Likely was a mistake when making Amoxla, overlooked and forgotten about.

## Media (Video/Screenshots)
Not needed.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Bigfoot Bravo
- fix: Amoxla's OD now correctly works. Don't OD the birds with Amoxla!
