### PR TITLE
IPC Holographic Hair (kinda)

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Species/ipc.yml
@@ -19,6 +19,8 @@
   id: MobIPCSprites
   sprites:
     Head: MobIPCHead
+    Hair: MobIPCHair
+    FacialHair: MobIPCHair
     Snout: MobHumanoidAnyMarking
     Chest: MobIPCTorso
     HeadTop: MobHumanoidAnyMarking
@@ -39,10 +41,10 @@
       points: 1
       required: false
     Hair:
-      points: 0
+      points: 1
       required: false
     FacialHair:
-      points: 0
+      points: 1
       required: false
     Head:
       points: 1
@@ -67,6 +69,10 @@
   baseSprite:
     sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: light
+
+- type: humanoidBaseSprite
+  id: MobIPCHair # This should use the Hologram shader like holopads do, but markings cannot currently be dynamically applied shaders, especially not the Hologram shader, needing inputs.
+  layerAlpha: 0.9 # 0.9 to match the opacity of holograms.
 
 - type: humanoidBaseSprite
   id: MobIPCAnyMarking


### PR DESCRIPTION
## Short description
Gives IPC hair, defined to have 0.9 alpha (though marking alpha is currently broken). It should be 'holographic' (i.e. with the holographic shader or transparent), but currently that is not feasible. LayerAlpha is broken and only works if a marking is set to match skin color, and shaders cannot currently be defined to markings.

When layerAlpha works, which apparently is being fixed [Trauma Med](https://github.com/ss14Starlight/space-station-14/pull/4230), or so I have been told, then IPC hair will have 0.9 Alpha, making it the same alpha as Holograms. If shaders are are allowed for markings, also possibly through trauma med (though that is just my personal hope and I have no idea if that is planned at all), then this hair could be further changed to use a hologram shader, making it even more authentic.

## Why we need to add this
People want IPCs to have hair!

## Media (Video/Screenshots)
Not needed.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Bigfoot Bravo
- tweak: IPCs can use Hair! NT spared some expense with these hair sets, but NT may invest further later on, upgrading this hair to true holograms at a later date.
