### PR TITLE
Allow non-humanoid selection on a wide range of antag-related gamerules

### DIFF
--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -145,7 +145,7 @@ public partial struct AntagSelectionDefinition()
     /// Mostly just here for legacy compatibility and reducing boilerplate
     /// </remarks>
     [DataField]
-    public bool AllowNonHumans = false;
+    public bool AllowNonHumans = true; // Starlight:  changed default from false to true for permissive non-humanoid antag selection
 
     /// <summary>
     /// A whitelist for selecting which players can become this antag.

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -145,7 +145,7 @@ public partial struct AntagSelectionDefinition()
     /// Mostly just here for legacy compatibility and reducing boilerplate
     /// </remarks>
     [DataField]
-    public bool AllowNonHumans = true; // Starlight:  changed default from false to true for permissive non-humanoid antag selection
+    public bool AllowNonHumans = false;
 
     /// <summary>
     /// A whitelist for selecting which players can become this antag.

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -205,6 +205,7 @@
       mindRoles:
       - MindRoleNukeopsCommander
       # Starlight-start
+      allowNonHumans: true
       tags:
         - CantBecomeRevolutionary
       # Starlight-end
@@ -226,6 +227,7 @@
       mindRoles:
       - MindRoleNukeopsMedic
       # Starlight-start
+      allowNonHumans: true
       tags:
         - CantBecomeRevolutionary
       # Starlight-end
@@ -249,6 +251,7 @@
       mindRoles:
       - MindRoleNukeops
       # Starlight-start
+      allowNonHumans: true
       tags:
         - CantBecomeRevolutionary
       # Starlight-end
@@ -291,6 +294,7 @@
         components:
         - AntagImmune
       lateJoinAdditional: false
+      allowNonHumans: true # Starlight; we have playable non-humanoids
       mindRoles:
       - MindRoleTraitor
 
@@ -305,6 +309,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]
+      allowNonHumans: true # Starlight; we have playable non-humanoids
       mindRoles:
       - MindRoleTraitorReinforcement
 
@@ -349,6 +354,7 @@
       mindRoles:
       - MindRoleChangeling
       # Starlight-start
+      allowNonHumans: false # unanticipated behavior possible for non-humanoid -> humanoid lings
       tags:
         - CantBecomeRevolutionary
       # Starlight-end
@@ -374,6 +380,7 @@
       max: 3
       playerRatio: 15
       startingGear: HeadRevGear
+      allowNonHumans: true # Starlight; we have playable non-humanoids
       components:
       - type: Revolutionary
       - type: HeadRevolutionary
@@ -458,6 +465,7 @@
       mindRoles:
       - MindRoleWizard
       # Starlight-start
+      allowNonHumans: true # We have playable non-humanoids
       tags:
         - CantBecomeRevolutionary
         - Wizard
@@ -481,6 +489,7 @@
     - prefRoles: [ InitialInfected ]
       max: 6
       playerRatio: 10
+      allowNonHumans: true # Starlight; we have playable non-humanoids
       blacklist:
         components:
         - ZombieImmune

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -124,6 +124,7 @@
       tags:
         - CantBecomeRevolutionary
         - Wizard
+      allowNonHumans: true
       # Starlight-end
 
 - type: entity

--- a/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
@@ -158,5 +158,6 @@
         components:
         - AntagImmune
       lateJoinAdditional: false
+      allowNonHumans: true
       mindRoles:
       - MindRoleTraitor

--- a/Resources/Prototypes/_Starlight/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/subgamemodes.yml
@@ -19,6 +19,7 @@
       - MindRoleSELFAgent
       briefing:
         sound: "/Audio/_Starlight/Ambience/Antag/self_greeting.ogg"
+      allowNonHumans: true
   - type: DynamicRuleCost
     cost: 70
 
@@ -135,5 +136,6 @@
         components:
         - AntagImmune
       lateJoinAdditional: false
+      allowNonHumans: true
       mindRoles:
       - MindRoleTraitor


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Changes various antag-related gamerules to allow for non-humanoids.
This will be largely invisible to most players; the purpose of the change is to allow non-humanoids to enter more antag roles.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Discussion at certain points in time from folks like Walksanator indicate a potential desire to have non-humanoid roundstart playable characters.  Many players like playing antagonist roles, and prior to this change, the only gamerules that non-humanoids could enter were vampire and thief.
This allows most antags to be rolled for non-humanoids.  Notably, the changeling gamerule specifically does not allow non-humanoids due to potential complications from the changeling's mechanics relying on HumanoidAppearance.
<img width="1008" height="327" alt="image" src="https://github.com/user-attachments/assets/aa459822-5270-4fbb-8a3e-4ee6063fff9c" />
<img width="1227" height="536" alt="image" src="https://github.com/user-attachments/assets/3b9a54ee-d837-4726-ba8f-08c55b2f2c2a" />


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="296" height="191" alt="image" src="https://github.com/user-attachments/assets/d37df54d-659b-455e-a454-c512a3864a83" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Sparlight
- tweak: Most antagonist gamerules now allow non-humanoids to be selected.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
