### PR TITLE
Re-introduce preference-based antag selection check

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -386,10 +386,8 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     {
         _adminLogger.Add(LogType.AntagSelection, $"Start trying to make {session} become the antagonist: {ToPrettyString(ent)}");
 
-        /* Starlight start - disable upstream antag check logic
-        if (checkPref && !ValidAntagPreference(session, def.PrefRoles))
+        if (checkPref && !ValidAntagPreference(session, def.PrefRoles, ent.Comp.SelectionTime))
             return false;
-        */// Starlight end of disable
 
         if (!IsSessionValid(ent, session, def) || !IsEntityValid(session?.AttachedEntity, def))
             return false;


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Re-adds a simple check at the beginning of antag selection to fix unintended antag selection  behavior.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I've been getting Thief and Vampire rolls immediately after latejoining into rounds despite them not being selected in my antag settings.
This change verifies antag preferences before assigning the role.
I've verified before and after during localhost on vampire rounds that this change works to respect antag selection preferences.
<img width="585" height="182" alt="image" src="https://github.com/user-attachments/assets/e37221da-bfa3-4deb-afd0-445c11b86159" />
<img width="634" height="543" alt="image" src="https://github.com/user-attachments/assets/5a6e7f1e-004a-4b15-9542-3142cca1b4f9" />


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- fix: Fixes an occasional issue where players would be put into antag roles that do not align with their selected preferences.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
