### PR TITLE
Detective's Energy Magnum

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -948,7 +948,7 @@
   name: energy magnum
   parent: [BaseWeaponBatterySmall, BaseDetectiveGrandTheftContraband] # Starlight - detective grand contra
   id: WeaponEnergyMagnum
-  description: A high powered self-charging energy pistol designed for elite security personnel. It has has two firing modes allowing for either high damage window piercing, or non-lethal disabling.
+  description: A high powered self-charging energy pistol designed for elite security personnel. It has two firing modes allowing for either high-damage window piercing or non-lethal disabling.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/energy_magnum.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -948,7 +948,7 @@
   name: energy magnum
   parent: [BaseWeaponBatterySmall, BaseDetectiveGrandTheftContraband] # Starlight - detective grand contra
   id: WeaponEnergyMagnum
-  description: A high powered self-charging energy pistol designed for elite security personnel. It has has three firing modes allowing for either high damage, window piercing, or non-lethal disabling.
+  description: A high powered self-charging energy pistol designed for elite security personnel. It has has two firing modes allowing for either high damage window piercing, or non-lethal disabling.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/energy_magnum.rsi
@@ -980,8 +980,8 @@
     fireCost: 150
   - type: BatteryWeaponFireModes
     fireModes:
-    - proto: BulletLaserMagnumSL # Starlight - Hitscan
-      fireCost: 150
+    #- proto: BulletLaserMagnumSL # Starlight - Hitscan
+    #  fireCost: 150
     - proto: BulletLaserWindowPiercingMagnumSL # Starlight - Hitscan
       fireCost: 150
     - proto: DisablerBolt # Starlight - Hitscan

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -1579,7 +1579,7 @@
   - type: HitscanBasicDamage
     damage:
       types:
-        Heat: 20
+        Heat: 30
 # USSP maints garbage for Toz (Zoz-106)
 
 - type: entity


### PR DESCRIPTION
## Short description
Merging the lethal and window piercing shot.

## Why we need to add this
Both the Window Pierce and Default Lethal mode shared the same cell charge usage while dealing different damage and use conditions. 

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl:
- tweak: Merged the Lethal and Window Piercer fire modes into one, giving it 30 heat damage.
