### PR TITLE
Cata Examine Bugfix

### DIFF
--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -12,6 +12,9 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using System.Diagnostics.CodeAnalysis;
+#region Starlight
+using Content.Shared._Starlight.Mind.Events;
+#endregion
 
 namespace Content.Server.Mind;
 
@@ -279,6 +282,10 @@ public sealed class MindSystem : SharedMindSystem
         if (mind.UserId == userId)
             return;
 
+        // Starlight Start
+        var oldUserId = mind.UserId;
+        // Starlight End
+
         Dirty(mindId, mind);
 
         if (userId != null && !_players.TryGetPlayerData(userId.Value, out _))
@@ -303,7 +310,10 @@ public sealed class MindSystem : SharedMindSystem
         }
 
         if (userId == null)
+        {
+            RaiseMindUserIdChanged(mindId, mind, oldUserId, null); // Starlight
             return;
+        }
 
         if (UserMinds.TryGetValue(userId.Value, out var oldMindId) &&
             TryComp(oldMindId, out MindComponent? oldMind))
@@ -327,7 +337,20 @@ public sealed class MindSystem : SharedMindSystem
             _pvsOverride.AddSessionOverride(mindId, session);
             _players.SetAttachedEntity(session, mind.CurrentEntity);
         }
+        RaiseMindUserIdChanged(mindId, mind, oldUserId, userId); // Starlight
     }
+
+    // Starlight Start
+    private void RaiseMindUserIdChanged(EntityUid mindId, MindComponent mind, NetUserId? oldUserId, NetUserId? newUserId)
+    {
+        if (mind.OwnedEntity is not { } owned || !TryComp(owned, out MindContainerComponent? container))
+            return;
+
+        Entity<MindComponent> mindEnt = (mindId, mind);
+        Entity<MindContainerComponent> containerEnt = (owned, container);
+        RaiseLocalEvent(owned, new MindUserIdChangedEvent(mindEnt, containerEnt, oldUserId, newUserId));
+    }
+    // Starlight End
 
     public override void ControlMob(EntityUid user, EntityUid target)
     {

--- a/Content.Shared/Mind/MindExamineSystem.cs
+++ b/Content.Shared/Mind/MindExamineSystem.cs
@@ -4,6 +4,9 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
+#region Starlight
+using Content.Shared._Starlight.Mind.Events;
+#endregion
 
 namespace Content.Shared.Mind;
 
@@ -23,6 +26,7 @@ public sealed class MindExamineSystem : EntitySystem
         SubscribeLocalEvent<MindExaminableComponent, MindAddedMessage>((e, ref _) => RefreshMindStatus(e.AsNullable()));
         SubscribeLocalEvent<MindExaminableComponent, MindRemovedMessage>((e, ref _) => RefreshMindStatus(e.AsNullable()));
         SubscribeLocalEvent<MindExaminableComponent, MobStateChangedEvent>((e, ref _) => RefreshMindStatus(e.AsNullable()));
+        SubscribeLocalEvent<MindExaminableComponent, MindUserIdChangedEvent>((e, ref _) => RefreshMindStatus(e.AsNullable())); // Starlight
 
         SubscribeLocalEvent<PlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<PlayerDetachedEvent>(OnPlayerDetached);
@@ -32,6 +36,12 @@ public sealed class MindExamineSystem : EntitySystem
     {
         if (!args.IsInDetailsRange)
             return;
+
+        // Starlight Start
+        // This is important for corpses that went catatonic/out-of-PVS.
+        if (!_net.IsClient)
+            RefreshMindStatus(ent.AsNullable());
+        // Starlight End
 
         var message = ent.Comp.State switch
         {
@@ -100,20 +110,24 @@ public sealed class MindExamineSystem : EntitySystem
         // 3. Dead + Has Session: Player is dead but still connected
         // 4. Alive + No User ID: Entity is alive but has no mind attached to it
         // 5. Alive + No Session: Player disconnected while alive (SSD)
-
+        // Starlight edit Start
+        var state = MindState.None;
         if (dead && hasUserId == null)
-            ent.Comp.State = MindState.Irrecoverable;
+            state = MindState.Irrecoverable;
         else if (dead && !hasActiveSession)
-            ent.Comp.State = MindState.DeadSSD;
+            state = MindState.DeadSSD;
         else if (dead)
-            ent.Comp.State = MindState.Dead;
+            state = MindState.Dead;
         else if (hasUserId == null)
-            ent.Comp.State = MindState.Catatonic;
+            state = MindState.Catatonic;
         else if (!hasActiveSession)
-            ent.Comp.State = MindState.SSD;
-        else
-            ent.Comp.State = MindState.None;
+            state = MindState.SSD;
 
+        if (ent.Comp.State == state)
+            return;
+
+        ent.Comp.State = state;
+        // Starlight edit End
         Dirty(ent);
     }
 }

--- a/Content.Shared/_Starlight/Mind/Events/MindUserIdChangedEvent.cs
+++ b/Content.Shared/_Starlight/Mind/Events/MindUserIdChangedEvent.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Robust.Shared.Network;
+
+namespace Content.Shared._Starlight.Mind.Events;
+
+/// <summary>
+/// Raised when the user associated with a mind changes.
+/// Raised on the owning mind-container body.
+/// </summary>
+public sealed class MindUserIdChangedEvent(
+    Entity<MindComponent> mind,
+    Entity<MindContainerComponent> container,
+    NetUserId? oldUserId,
+    NetUserId? newUserId) : EntityEventArgs
+{
+    public readonly Entity<MindComponent> Mind = mind;
+    public readonly Entity<MindContainerComponent> Container = container;
+    public readonly NetUserId? OldUserId = oldUserId;
+    public readonly NetUserId? NewUserId = newUserId;
+}


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes an issue where if an entity dies outside of PVS the Catatonic text wouldn't show till they were defibed.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Fixed an issue where if someone died outside of your view you wouldn't see the Catatonic text on examine.