### PR TITLE
Tourniquets shouldn't make you bleed

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -278,8 +278,10 @@
       damageContainers:
         - Biological
       damage:
-        groups:
-          Brute: 5 # Tourniquets HURT!
+      #region Starlight
+      #  groups:
+      #    Brute: 5 # removed: doing brute damage means that putting on a tourniquet makes you bleed (??)
+      #endregion Starlight
         types:
           Asphyxiation: 5 # Essentially Stopping all blood reaching a part of your body
       bloodlossModifier: -10 # Tourniquets stop bleeding


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Background:
- When applied, tourniquets deal 5 brute and 5 asphyxiation damage.
- This means that you start bleeding _after_ you apply a tourniquet, because brute damage causes bleeding.

What this PR does:
- This PR removes the brute damage from tourniquets, so they don't make you bleed.

Not in scope for this PR:
- Re-using tourniquets. That kind of stuff needs to wait for TraumaMed.
- Tourniquets making you scream on application (because ouch painful). I didn't see any easy way to add this so I'm not messing with it.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Discord thread: https://discord.com/channels/1272545509562777621/1499651904362381422

It's dumb that tourniquets cause bleeding. They're already non-craftable items that cannot be stacked (unlike gauze). Their only benefit over gauze (which heals just as many bleed stacks, by the way!) is that they're applied quicker. There were some ideas in the thread as to how tourniquets could be improved (e.g. being craftable), but those can be PR'd separately.

This PR does not remove the Asphyxiation damage that tourniquets apply. I think that part is fine.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/a38b85ac-79f4-4da2-aecb-1772dc16cec7

fig. 1 - Video demonstration. Tourniquets still deal 5 Asphyxiation damage, but no longer deal brute damage (and thus no longer cause bleeding).

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Tourniquets no longer deal 5 brute damage when applied to someone. This also means that tourniquets no longer inadvertently make you bleed (due to dealing brute damage to you on application).