### PR TITLE
Meta File Credits Fix

### DIFF
--- a/Resources/Textures/_Starlight/Decals/drain.rsi/meta.json
+++ b/Resources/Textures/_Starlight/Decals/drain.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-3.0",
-  "copyright": "Sprites by Wayiscute",
+  "copyright": "Sprites from https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/blob/HEAD/icons/turf/decals.dmi",
   "size": {
     "x": 32,
     "y": 32

--- a/Resources/Textures/_Starlight/Decals/hatch.rsi/meta.json
+++ b/Resources/Textures/_Starlight/Decals/hatch.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-3.0",
-  "copyright": "Sprites by Wayiscute",
+  "copyright": "Sprites from https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/blob/HEAD/icons/turf/decals.dmi",
   "size": {
     "x": 32,
     "y": 32

--- a/Resources/Textures/_Starlight/Decals/steelrim.rsi/meta.json
+++ b/Resources/Textures/_Starlight/Decals/steelrim.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-3.0",
-  "copyright": "Sprites by Wayiscute",
+  "copyright": "Sprites from https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/blob/HEAD/icons/turf/decals.dmi, edited by Conflee",
   "size": {
     "x": 32,
     "y": 32


### PR DESCRIPTION
## Short description
Fixes the crediting in 3 meta files for decals added by my Decor PR. 

## Why we need to add this
Proper crediting, I missed them in my copy-pasting of files.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Fixed credits in 3 .mta files.

