### PR TITLE
Fix Quick construct

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -5,6 +5,14 @@
   name: glass
   description: A sheet of glass, used often on the station in various applications.
   components:
+    #Starlight start
+    - type: UserInterface
+      interfaces:
+        enum.StackCustomSplitUiKey.Key:
+          type: StackCustomSplitBoundUserInterface
+        enum.QuickConstructionUiKey.Key:
+          type: QuickConstructionBoundUserInterface
+    # Starlight end
     - type: Sprite
       sprite: Objects/Materials/Sheets/glass.rsi
     - type: Item

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -11,7 +11,7 @@
         type: StackCustomSplitBoundUserInterface
       enum.QuickConstructionUiKey.Key:
         type: QuickConstructionBoundUserInterface
-    # Starlight end
+  # Starlight end
   - type: Sprite
     sprite: Objects/Materials/Sheets/metal.rsi
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -29,6 +29,14 @@
   name: metal rod
   suffix: Full
   components:
+  #Starlight start
+  - type: UserInterface
+    interfaces:
+      enum.StackCustomSplitUiKey.Key:
+        type: StackCustomSplitBoundUserInterface
+      enum.QuickConstructionUiKey.Key:
+        type: QuickConstructionBoundUserInterface
+  # Starlight end
   - type: PhysicalComposition
     materialComposition:
       Steel: 50 #Half of a regular steel sheet to reflect the crafting recipe

--- a/Resources/Prototypes/_DEN/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Materials/materials.yml
@@ -7,3 +7,7 @@
       singleUser: true
       requireActiveHand: false
       key: enum.QuickConstructionUiKey.Key
+    - type: UserInterface
+      interfaces:
+        enum.QuickConstructionUiKey.Key:
+          type: QuickConstructionBoundUserInterface


### PR DESCRIPTION
## Short description
Quick construction didn't work on glass and rods, this fixes that.

## Why we need to add this
quick fix 


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
