### PR TITLE
Revolutionaries win if all living Command members abandon the station

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
@@ -27,4 +27,12 @@ public sealed partial class RevolutionaryRuleComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan ShuttleCallTime = TimeSpan.FromMinutes(5);
+
+    #region Starlight
+    /// <summary>
+    /// The time it takes for Command to be considered 'abandoning the station.' If they're off station for longer than this, the revolutionaries win.
+    /// </summary>
+    [DataField]
+    public TimeSpan CommandOffstationGracePeriod = TimeSpan.FromSeconds(45);
+    #endregion Starlight
 }

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -93,9 +93,6 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     [Dependency] private readonly SubdermalImplantSystem _subdermalImplantSystem = default!;
     [Dependency] private readonly USSPUplinkSystem _usspUplinkSystem = default!;
 
-    // grace period for command going AWOL
-    private static readonly TimeSpan _commandOffstationGracePeriod = TimeSpan.FromSeconds(45);
-
     // last time at least 1 command member was on station
     private TimeSpan _commandLastTimeOnStation = default;
     // Starlight-end
@@ -129,6 +126,10 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     {
         base.Started(uid, component, gameRule, args);
         component.CommandCheck = _timing.CurTime + component.TimerWait;
+
+        #region Starlight
+        _commandLastTimeOnStation = _timing.CurTime;
+        #endregion Starlight
     }
 
     protected override void ActiveTick(EntityUid uid, RevolutionaryRuleComponent component, GameRuleComponent gameRule, float frameTime)
@@ -144,7 +145,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
                 GameTicker.EndGameRule(uid, gameRule);
             }
 
-            if (CheckCommandLose())
+            if (CheckCommandLose(component))
             {
                 // Starlight Start
 
@@ -234,7 +235,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         base.AppendRoundEndText(uid, component, gameRule, ref args);
 
         var revsLost = CheckRevsLose();
-        var commandLost = CheckCommandLose();
+        var commandLost = CheckCommandLose(component);
         // This is (revsLost, commandsLost) concatted together
         // (moony wrote this comment idk what it means)
         var index = (commandLost ? 1 : 0) | (revsLost ? 2 : 0);
@@ -552,14 +553,24 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     //TODO: Enemies of the revolution
     private void OnCommandMobStateChanged(EntityUid uid, CommandStaffComponent comp, MobStateChangedEvent ev)
     {
+        #region Starlight
         if (ev.NewMobState == MobState.Dead || ev.NewMobState == MobState.Invalid)
-            CheckCommandLose();
+        {
+            // need to pass the RevolutionaryRule comp to CheckCommandLose()
+            var query = EntityQueryEnumerator<RevolutionaryRuleComponent, GameRuleComponent>();
+
+            while (query.MoveNext(out var _, out var ruleComp, out var gameRule))
+            {
+                CheckCommandLose(ruleComp);
+            }
+        }
+        #endregion Starlight
     }
 
     /// <summary>
     /// Checks if all of command is dead and if so will remove all sec and command jobs if there were any left.
     /// </summary>
-    private bool CheckCommandLose()
+    private bool CheckCommandLose(RevolutionaryRuleComponent component)
     {
         var commandList = new List<EntityUid>();
 
@@ -580,7 +591,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             _commandLastTimeOnStation = _timing.CurTime;
 
         // check if command have abandoned the station
-        var allCommandAbandonedStation = !anyCommandOnStation && (_timing.CurTime.Subtract(_commandLastTimeOnStation) > _commandOffstationGracePeriod);
+        var allCommandAbandonedStation = !anyCommandOnStation && (_timing.CurTime.Subtract(_commandLastTimeOnStation) > component.CommandOffstationGracePeriod);
 
         // command loses if they're all dead, detained, or they left the station
         return allCommandDead || allCommandAbandonedStation;

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -57,7 +57,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
-using Content.Server.Station.Components;
+using Content.Shared.Station.Components;
 #endregion Starlight
 
 namespace Content.Server.GameTicking.Rules;
@@ -768,13 +768,8 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
                 }
 
                 #region Starlight
-                // get the "station" this entity is on, which could also be a shuttle
-                var station = _stationSystem.GetOwningStation(entity);
-
-                if (checkOffStation
-                && station != null
-                && !HasComp<BecomesStationComponent>(station.Value) // check they're on the actual station and not on a shuttle
-                && !_emergencyShuttle.EmergencyShuttleArrived)
+                // Starlight: previous 'off station check' straight up never worked. replaced with a new helper method 'IsOnMainStation'
+                if (checkOffStation && !IsOnMainStation(entity) && !_emergencyShuttle.EmergencyShuttleArrived)
                 {
                     gone++;
                     continue;
@@ -797,6 +792,42 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
         return gone == list.Count || list.Count == 0;
     }
+
+#region Starlight
+    /// <summary>
+    /// Determines whether an entity is located on a "main" station grid.
+    /// Grids like the Arrivals or Cargo Shuttle are not considered "being on the main station."
+    /// </summary>
+    /// <param name="entity">Entity to be evaluated.</param>
+    /// <returns>True if entity is on the main station grid, false otherwise.</returns>
+    private bool IsOnMainStation(EntityUid entity)
+    {
+        // get transform data. used at the end to check if the entity is actually *on* the station grid
+        var xform = EntityManager.GetComponentOrNull<TransformComponent>(entity);
+        if(xform == null || xform.GridUid == null)
+            return false;
+
+        // check that some station actually owns this entity
+        var station = _stationSystem.GetOwningStation(entity);
+
+        // make sure station's not null, then get uid of station
+        if(station is not { } stationUid)
+            return false;
+
+        // station data contains all of the station grids
+        var stationData = EntityManager.GetComponentOrNull<StationDataComponent>(stationUid);
+        if(stationData == null)
+            return false;
+
+        // main station grid check. if main grids is (somehow) empty, fallback to any grid in station data
+        var grids = stationData.MainGrids.Count > 0
+            ? stationData.MainGrids
+            : stationData.Grids;
+
+        // finally, check if the entity is on the main grid
+        return grids.Contains(xform.GridUid.Value);
+    }
+#endregion Starlight
 
     private static readonly string[] Outcomes =
     {

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -578,11 +578,11 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             commandList.Add(id);
         }
 
-
+        // check if all command are dead
         var allCommandDead = IsGroupDetainedOrDead(commandList, false, true, true);
 
-        // check if any command are on the main station grid
-        var anyCommandOnStation = commandList.Any(IsOnMainStation);
+        // check if there at least one command member alive, uncuffed, and unconverted that is on the station
+        var anyCommandOnStation = !IsGroupDetainedOrDead(commandList, true, true, true);
 
         // grace period - prevents round instantly ending if all of command leave a grid for just 1 tick
         if (anyCommandOnStation)

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -57,6 +57,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Content.Server.Station.Components;
 #endregion Starlight
 
 namespace Content.Server.GameTicking.Rules;
@@ -766,11 +767,19 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
                     continue;
                 }
 
-                if (checkOffStation && _stationSystem.GetOwningStation(entity) == null && !_emergencyShuttle.EmergencyShuttleArrived)
+                #region Starlight
+                // get the "station" this entity is on, which could also be a shuttle
+                var station = _stationSystem.GetOwningStation(entity);
+
+                if (checkOffStation
+                && station != null
+                && !HasComp<BecomesStationComponent>(station.Value) // check they're on the actual station and not on a shuttle
+                && !_emergencyShuttle.EmergencyShuttleArrived)
                 {
                     gone++;
                     continue;
                 }
+                #endregion Starlight
             }
             //If they don't have the MobStateComponent they might as well be dead.
             else

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -58,6 +58,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Content.Shared.Station.Components;
+using Content.Server.Shuttles.Components;
 #endregion Starlight
 
 namespace Content.Server.GameTicking.Rules;
@@ -768,7 +769,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
                 }
 
                 #region Starlight
-                // Starlight: previous 'off station check' straight up never worked. replaced with a new helper method 'IsOnMainStation'
+                // Starlight: previous 'off station check' straight-up never worked. replaced with a new helper method 'IsOnMainStation'
                 if (checkOffStation && !IsOnMainStation(entity) && !_emergencyShuttle.EmergencyShuttleArrived)
                 {
                     gone++;
@@ -796,6 +797,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 #region Starlight
     /// <summary>
     /// Determines whether an entity is located on a "main" station grid.
+    /// Being on an unlaunched escape pod counts as "being on the main station."
     /// Grids like the Arrivals or Cargo Shuttle are not considered "being on the main station."
     /// </summary>
     /// <param name="entity">Entity to be evaluated.</param>
@@ -806,6 +808,15 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         var xform = EntityManager.GetComponentOrNull<TransformComponent>(entity);
         if(xform == null || xform.GridUid == null)
             return false;
+
+        var grid = xform.GridUid.Value;
+
+        // special case: unlaunched (docked) escape pods are still "part of the main station"
+        // escape pods lose their EscapePodComponent when they are launched, so this check will fail on launched escape pods
+        if (HasComp<EscapePodComponent>(grid))
+        {
+            return true;
+        }
 
         // check that some station actually owns this entity
         var station = _stationSystem.GetOwningStation(entity);
@@ -825,7 +836,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             : stationData.Grids;
 
         // finally, check if the entity is on the main grid
-        return grids.Contains(xform.GridUid.Value);
+        return grids.Contains(grid);
     }
 #endregion Starlight
 

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -127,9 +127,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         base.Started(uid, component, gameRule, args);
         component.CommandCheck = _timing.CurTime + component.TimerWait;
 
-        #region Starlight
-        _commandLastTimeOnStation = _timing.CurTime;
-        #endregion Starlight
+        _commandLastTimeOnStation = _timing.CurTime; // Starlight
     }
 
     protected override void ActiveTick(EntityUid uid, RevolutionaryRuleComponent component, GameRuleComponent gameRule, float frameTime)
@@ -145,10 +143,9 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
                 GameTicker.EndGameRule(uid, gameRule);
             }
 
+            #region Starlight
             if (CheckCommandLose(component))
             {
-                // Starlight Start
-
                 _roundEnd.CancelRoundEndCountdown(null, false);
 
                 // Play the revolutionary end sound globally
@@ -222,8 +219,8 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
                         _roundEnd.EndRound();
                     }
                 });
-                // Starlight End
             }
+            #endregion Starlight
         }
     }
 
@@ -235,7 +232,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         base.AppendRoundEndText(uid, component, gameRule, ref args);
 
         var revsLost = CheckRevsLose();
-        var commandLost = CheckCommandLose(component);
+        var commandLost = CheckCommandLose(component); // Starlight
         // This is (revsLost, commandsLost) concatted together
         // (moony wrote this comment idk what it means)
         var index = (commandLost ? 1 : 0) | (revsLost ? 2 : 0);
@@ -570,6 +567,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     /// <summary>
     /// Checks if all of command is dead and if so will remove all sec and command jobs if there were any left.
     /// </summary>
+    #region Starlight
     private bool CheckCommandLose(RevolutionaryRuleComponent component)
     {
         var commandList = new List<EntityUid>();
@@ -580,7 +578,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             commandList.Add(id);
         }
 
-    // STARLIGHT START
+
         var allCommandDead = IsGroupDetainedOrDead(commandList, false, true, true);
 
         // check if any command are on the main station grid
@@ -618,8 +616,8 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
         // Get all game rule entities
         // var gameRuleQuery = EntityManager.EntityQuery<GameRuleComponent>();
-        // STARLIGHT END
     }
+    #endregion Starlight
 
     private void OnHeadRevMobStateChanged(EntityUid uid, HeadRevolutionaryComponent comp, MobStateChangedEvent ev)
     {

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -59,6 +59,7 @@ using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Content.Shared.Station.Components;
 using Content.Server.Shuttles.Components;
+using System.Linq;
 #endregion Starlight
 
 namespace Content.Server.GameTicking.Rules;
@@ -91,6 +92,12 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly SubdermalImplantSystem _subdermalImplantSystem = default!;
     [Dependency] private readonly USSPUplinkSystem _usspUplinkSystem = default!;
+
+    // grace period for command going AWOL
+    private static readonly TimeSpan _commandOffstationGracePeriod = TimeSpan.FromSeconds(30);
+
+    // last time at least 1 command member was on station
+    private static TimeSpan _commandLastTimeOnStation = default;
     // Starlight-end
 
     //Used in OnPostFlash, no reference to the rule component is available
@@ -563,8 +570,20 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         }
 
     // STARLIGHT START
-        var allCommandDead = IsGroupDetainedOrDead(commandList, true, true, true);
-        return allCommandDead;
+        var allCommandDead = IsGroupDetainedOrDead(commandList, false, true, true);
+
+        // check if any command are on the main station grid
+        var anyCommandOnStation = commandList.Any(IsOnMainStation);
+
+        // grace period - prevents round instantly ending if all of command leave a grid for just 1 tick
+        if (anyCommandOnStation)
+            _commandLastTimeOnStation = _timing.CurTime;
+
+        // check if command have abandoned the station
+        var allCommandAbandonedStation = !anyCommandOnStation && (_timing.CurTime.Subtract(_commandLastTimeOnStation) > _commandOffstationGracePeriod);
+
+        // command loses if they're all dead, detained, or they left the station
+        return allCommandDead || allCommandAbandonedStation;
     }
 
     /// <summary>
@@ -821,7 +840,6 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         // check that some station actually owns this entity
         var station = _stationSystem.GetOwningStation(entity);
 
-        // make sure station's not null, then get uid of station
         if(station is not { } stationUid)
             return false;
 

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -94,10 +94,10 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     [Dependency] private readonly USSPUplinkSystem _usspUplinkSystem = default!;
 
     // grace period for command going AWOL
-    private static readonly TimeSpan _commandOffstationGracePeriod = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan _commandOffstationGracePeriod = TimeSpan.FromSeconds(45);
 
     // last time at least 1 command member was on station
-    private static TimeSpan _commandLastTimeOnStation = default;
+    private TimeSpan _commandLastTimeOnStation = default;
     // Starlight-end
 
     //Used in OnPostFlash, no reference to the rule component is available

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
@@ -51,7 +51,8 @@ rev-stalemate = All of the SKB agents and command have died. It's a draw.
 
 rev-reverse-stalemate = Both Command and SKB agents survived.
 
-central-command-revolution-announcement = Based on our scans from our long-range sensors, we believe the station has fallen under the control of hostile revolutionary forces. All heads of staff have been confirmed deceased or missing. All remaining crew members are to stand by for further instructions.
+# Starlight - added "or have abandoned the station" as a clarification for why revs may have won
+central-command-revolution-announcement = Based on our scans from our long-range sensors, we believe the station has fallen under the control of hostile revolutionary forces. All heads of staff have been confirmed deceased, missing, or have abandoned the station. All remaining crew members are to stand by for further instructions.
 
 soviet-commissariat-revolution-announcement = Long range communications array online. Motherland salutes you comrades, but the battle is not yet over. Your corporation will check if they can reclaim your station one last time, but do not worry! The SSF will arrive shorty. Glory to the USSP!
 


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Revolutionaries are meant to win if Command abandons the station, but code to detect that doesn't actually work.

This PR does two things:
- Fixes `IsGroupDetainedOrDead()` to actually work if `checkOffStation` is set to `true`.
- Changes `CheckCommandLose()` to make Command lose the round if they're off station for more than 45 seconds. I put in a grace period in there intentionally just so that command doesn't magically lose if they walk across a spaced tile inside the station for 1 tick.

Basically:
- If all living / unconverted / uncuffed Command members flee to the ATS, they lose.
- If all living / unconverted / uncuffed Command members on the Cargo / Salvage / Mining shuttles, they lose.
- If at least one Command member is still on station, this fail condition doesn't trigger.

I did this by implementing a function `IsOnMainStation()` which I _think_ should also work with dual-station , but I dunno how to test that. It does work fine for regular single station gameplay. For the purposes of gameplay, Escape Pods that are still docked count as "part of the station." Launched Escape Pods won't (not that this can currently happen, but I figured it's better to be safe than sorry).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- Command is meant to lose if they all abandon the station. The code just doesn't work right now.
- Roundstalling is bad! This PR prevents roundstalling by hiding in space with a jetpack.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/c25e23de-67b6-4510-9fd3-19486ffe55af

fig. 1 - Video of this PR in action.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Revolutionaries will now win as intended if all living members of Command abandon the station (e.g. hiding in space, on a shuttle, on the ATS, etc.).