### PR TITLE
Antag Roleban Fix [ HOTFIX ]

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.API.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.cs
@@ -195,7 +195,13 @@ public sealed partial class AntagSelectionSystem
 
             foreach (var role in roles)
             {
-                if (humanoid.AntagPreferences.Contains(role))
+                // Starlight edit Start: RoleBans
+                var list = new List<ProtoId<AntagPrototype>> { role };
+
+                if (humanoid.AntagPreferences.Contains(role)
+                    && !_ban.IsRoleBanned(session, list)
+                    && _playTime.IsAllowed(session, list))
+                // Starlight edit End: Rolebans
                     return true;
             }
         }
@@ -261,7 +267,13 @@ public sealed partial class AntagSelectionSystem
 
             foreach (var antag in antagList)
             {
-                if (humanoid.AntagPreferences.Contains(antag))
+                // Starlight edit Start: RoleBans
+                var list = new List<ProtoId<AntagPrototype>> { antag };
+
+                if (humanoid.AntagPreferences.Contains(antag)
+                    && !_ban.IsRoleBanned(session, list)
+                    && _playTime.IsAllowed(session, list))
+                // Starlight edit End: RoleBans
                     return true;
             }
         }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes Antag Rolebans.

You could still roll antags through roundstart even if you were antag rolebanned, This was caused by a previous upstream merge (Not mine)
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Urgent Bugfix
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Fixed Rolebans.