### PR TITLE
Antag Immortality Fix

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -728,14 +728,8 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     {
         if (!TryComp(uid, out PhysicsComponent? physics))
             return;
-
+    
         _physics.WakeBody(uid, body: physics);
-
-        if (!physics.CanCollide || !TryComp(uid, out FixturesComponent? fixtures))
-            return;
-
-        _physics.SetCanCollide(uid, false, manager: fixtures, body: physics);
-        _physics.SetCanCollide(uid, true, manager: fixtures, body: physics);
     }
     // Starlight End
 }

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -728,7 +728,7 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     {
         if (!TryComp(uid, out PhysicsComponent? physics))
             return;
-    
+
         _physics.WakeBody(uid, body: physics);
     }
     // Starlight End

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -36,16 +36,14 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 // Starlight Start
-using Content.Server.Body.Components;
 using Content.Server.Bible.Components;
-using Content.Server.GameTicking.Rules.Components;
-using Content.Shared.Body.Components;
 using Content.Shared.Tag;
-using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
 using Prometheus;
-using Content.Server._Starlight.Medical.Body.Systems;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics;
 // Starlight End
 
 namespace Content.Server.Antag;
@@ -79,10 +77,10 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     [Dependency] private readonly ArrivalsSystem _arrivals = default!;
 
 #region Starlight
-    [Dependency] private readonly BodySystem _body = default!;
     [Dependency] private readonly SharedHumanoidAppearanceSystem _appearance = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
 #endregion Starlight
 
     // arbitrary random number to give late joining some mild interest.
@@ -481,6 +479,8 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             var playerXform = Transform(player);
             var pos = RobustRandom.Pick(getPosEv.Coordinates);
             _transform.SetMapCoordinates((player, playerXform), pos);
+
+            RefreshSpawnedAntagPhysics(player); // Starlight
         }
 
         // If we want to just do a ghost role spawner, set up data here and then return early.
@@ -722,6 +722,22 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         args.Minds = ent.Comp.AssignedMinds;
         args.AgentName = Loc.GetString(name);
     }
+
+    // Starlight Start: Refresh physics after antag spawn relocation.
+    private void RefreshSpawnedAntagPhysics(EntityUid uid)
+    {
+        if (!TryComp(uid, out PhysicsComponent? physics))
+            return;
+
+        _physics.WakeBody(uid, body: physics);
+
+        if (!physics.CanCollide || !TryComp(uid, out FixturesComponent? fixtures))
+            return;
+
+        _physics.SetCanCollide(uid, false, manager: fixtures, body: physics);
+        _physics.SetCanCollide(uid, true, manager: fixtures, body: physics);
+    }
+    // Starlight End
 }
 
 /// <summary>


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes an issue where antags would be invincible to bullets if they didn't move by resetting there physics after being moved from nullspace. 
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Fixed an issue where bullets would not hit the Mothership Core.