### PR TITLE
Fix the Raid Suit's slowdown

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -292,8 +292,8 @@
   #   damageCoefficient: 0.45
   # Starlight-end
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 1.1
+    sprintModifier: 1.1
   #Shoulder mounted flashlight
   - type: ToggleableVisuals
     spriteLayer: light


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

The raid suit was seemingly randomly changed to be 10% slower instead of faster. I'm not sure why, but it was. This fixes that.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

The raid suit being faster is significant to it's whole gimmick and balance. If we keep it slower, we should discuss other changes that should be made to it.

## Media (Video/Screenshots)
<img width="442" height="153" alt="image" src="https://github.com/user-attachments/assets/d4ba515d-a4bc-49e3-8a06-093447928456" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- fix: Removed the lead from the raidsuit, it's now correctly 10% faster (instead of being 10% slower) 
-->
