### PR TITLE
Fix human observation console 

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -30,6 +30,8 @@
       enum.EdgeConnectionVisuals.ConnectionMask:
         computerLayerBody:
           None: { state: arcade }
+  - type: EdgeConnection
+    connectionKey: other
   # Starlight End
   - type: Icon
     sprite: Structures/Machines/arcade.rsi

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
@@ -18,6 +18,8 @@
       enum.EdgeConnectionVisuals.ConnectionMask:
         computerLayerBody:
           None: { state: icon, sprite: Structures/Machines/tech_disk_printer.rsi }
+  - type: EdgeConnection
+    connectionKey: other
   # Starlight End
   - type: DiskConsole
   - type: ResearchClient

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/wooden_television.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/wooden_television.yml
@@ -20,6 +20,8 @@
       enum.EdgeConnectionVisuals.ConnectionMask:
         console:
           None: { state: television}
+  - type: EdgeConnection
+    connectionKey: other
   # Starlight End
   - type: PointLight
     radius: 2.0 #SL Edit

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
@@ -62,6 +62,8 @@
       enum.EdgeConnectionVisuals.ConnectionMask:
         console:
           None: { state: console, sprite: _Starlight/Structures/Machines/abductor_console.rsi }
+  - type: EdgeConnection
+    connectionKey: other
   - type: ActivatableUI
     key: enum.AbductorConsoleUIKey.Key
   - type: UserInterface
@@ -116,6 +118,13 @@
     layers:
     - map: ["console"]
       state: console
+  - type: GenericVisualizer  # Override to prevent edge connection sprites
+    visuals:
+      enum.EdgeConnectionVisuals.ConnectionMask:
+        console:
+          None: { state: console }
+  - type: EdgeConnection
+    connectionKey: other
   - type: RemoteEyeConsole
     remoteEntityProto: AbductorHumanObservationConsoleEye
     color: "#A04B81"

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
@@ -49,7 +49,7 @@
   parent: BaseComputer
   id: AbductorConsole
   name: abductor console
-  description: A computer that is used for spying on the station.
+  description: retrieve people marked by scientist tools. Also used for buying replacement gear and linking the agent's vest.
   components:
   - type: AbductorConsole
   - type: Sprite
@@ -111,7 +111,7 @@
   parent: BaseComputer
   id: AbductorHumanObservationConsole
   name: human observation console
-  description: Use this to set teleporter destination or retrieve people marked by scientist tools. Also used for buying replacement gear and linking the agent's vest.
+  description: A computer that is used for spying and teleporting on the station.
   components:
   - type: Sprite
     sprite: _Starlight/Structures/Machines/abductor_camera_console.rsi


### PR DESCRIPTION
## Short description
Fixes the human observation console and adds some missing edge connector overrides.

## Why we need to add this
its been visually broken for ages.
the tech disk terminal, television. and arcades where causing computers to connect visually.

## Media (Video/Screenshots)
<img width="431" height="459" alt="image" src="https://github.com/user-attachments/assets/4db7656f-f638-438a-8780-124cd7c6cd80" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

:cl: STARLIGHT TEAM
- fix: Human observation console looks as it should.
