### PR TITLE
Change nonhumanoid antags to require hands

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -44,6 +44,7 @@ using Prometheus;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics;
+using Content.Shared.Hands.Components;
 // Starlight End
 
 namespace Content.Server.Antag;
@@ -685,6 +686,12 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         if (!def.AllowNonHumans && !HasComp<HumanoidAppearanceComponent>(entity))
             return false;
+
+        // Starlight-begin
+        // If non-humanoid, check for hands.  We don't want Hamlet as a traitor if he can't really manipulate tools.
+        if (def.AllowNonHumans && !HasComp<HumanoidAppearanceComponent>(entity) && !HasComp<HandsComponent>(entity))
+            return false;
+        // Starlight-end
 
         // Ensure that the profile has the antag preference set, if this is a late join this hasn't been checked!
         var baseProfile = _appearance.GetBaseProfile(entity.Value);


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Limit non-humanoid antag selection to require hands.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
A short while ago I made a change to allow nonhumanoids to become antags, since the pipeline indicates we may have more playable nonhumanoids.
Unfortunately, Hamlet became a SELF agent.  He... doesn't have the ability to manipulate tools.  We should probably gate the ability for non-humanoids to become antags behind things like tool manipulation, as a lot of antag work requires the ability to use hands.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Tested via running starlight-dev with traitor/traitor reinforcement settings on, then ghostroling hamlet.  After six minutes, I became a traitor.
Made my changes, ran the same test again.  After 15 minutes the traitor gamerule established itself and Hamlet was not a traitor.
I then restarted the round, ran the same test but as a smart corgi.  After about six minutes, I became a traitor.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- tweak: Non-humanoid antag selection is now gated behind having hands - sorry Hamlet players.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
