### PR TITLE
Hyper circuit imprinter bugfix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -327,17 +327,6 @@
     sprite: Structures/Machines/circuit_imprinter_hypercon.rsi
   - type: Machine
     board: CircuitImprinterHyperConvectionMachineCircuitboard
-  - type: MaterialStorage
-    whitelist:
-      tags:
-        - Sheet
-        - RawMaterial
-        - Ingot
-  - type: EmagLatheRecipes
-    emagDynamicPacks:
-    - StarlightSecurityBoards
-    emagStaticPacks: # Starlight
-    - StarlightDangerousLawboards # Starlight
 
 - type: entity
   id: ExosuitFabricator


### PR DESCRIPTION
## Short description
Fixes an obscure bug with the hyperconvection circuit imprinter

## Why we need to add this
For some reason the hyperconvection circuit imprinter had its' own list of things it could get when emagged. This list was less expansive than the normal circuit imprinter. It also for some reason re-specified it had a material storage... which the normal circuit imprinter does as well. So I removed both, making the hyperconvection circuit imprinter be in line with the other lathes in terms of upgrading it

## Media (Video/Screenshots)
Nuh

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: R3v3l4t1on
- fix: The hyperconvection circuit imprinter now gets the same recipes added to it upon being emagged as the normal counterpart.
