### PR TITLE
JobTest Fix Pt2

### DIFF
--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -68,6 +68,9 @@ public sealed class JobTest
 
         pair.AssertJob(Passenger);
 
+        await pair.Server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(_waitAfter);
+        await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
 
@@ -111,6 +114,9 @@ public sealed class JobTest
 
         pair.AssertJob(Passenger);
 
+        await pair.Server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(_waitAfter);
+        await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
 
@@ -136,6 +142,9 @@ public sealed class JobTest
         var engineer = pair.Server.ProtoMan.Index(Engineer);
         var passenger = pair.Server.ProtoMan.Index(Passenger);
 
+        Assert.That(captain.Weight, Is.GreaterThan(engineer.Weight));
+        Assert.That(engineer.Weight, Is.EqualTo(passenger.Weight));
+
         await pair.SetJobPriorities(
             //essentially, weight only matters for each category now instead of globally
             (Passenger, JobPriority.Medium),
@@ -149,6 +158,9 @@ public sealed class JobTest
 
         pair.AssertJob(Captain);
 
+        await pair.Server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(_waitAfter);
+        await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
 
@@ -201,6 +213,9 @@ public sealed class JobTest
             }
         });
 
+        await pair.Server.WaitPost(() => ticker.RestartRound());
+        await pair.RunTicksSync(_waitAfter);
+        await pair.ReallyBeIdle();
         await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -5,6 +5,7 @@ using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
+using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests.Tests.Round;
@@ -130,7 +131,8 @@ public sealed class JobTest
         await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
-            DummyTicker = false
+            DummyTicker = false,
+            Dirty = true
         });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
@@ -157,6 +159,9 @@ public sealed class JobTest
         await pair.RunTicksSync(_waitAfter);
 
         pair.AssertJob(Captain);
+
+        await pair.Client.WaitPost(() => ((IClientNetManager) pair.Client.NetMan).ClientDisconnect("JobWeightTest cleanup"));
+        await pair.RunTicksSync(1);
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
         await pair.RunTicksSync(_waitAfter);

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -46,7 +46,7 @@ public sealed class JobTest
     [Test]
     public async Task StartRoundTest()
     {
-        var pair = await PoolManager.GetServerClient(new PoolSettings {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
             DummyTicker = false
@@ -68,7 +68,6 @@ public sealed class JobTest
 
         pair.AssertJob(Passenger);
 
-        await pair.Server.WaitPost(() => ticker.RestartRound());
         await pair.CleanReturnAsync();
     }
 
@@ -78,7 +77,7 @@ public sealed class JobTest
     [Test]
     public async Task JobPreferenceTest()
     {
-        var pair = await PoolManager.GetServerClient(new PoolSettings {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
             DummyTicker = false
@@ -112,7 +111,6 @@ public sealed class JobTest
 
         pair.AssertJob(Passenger);
 
-        await pair.Server.WaitPost(() => ticker.RestartRound());
         await pair.CleanReturnAsync();
     }
 
@@ -123,7 +121,7 @@ public sealed class JobTest
     [Test]
     public async Task JobWeightTest()
     {
-        var pair = await PoolManager.GetServerClient(new PoolSettings {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
             DummyTicker = false
@@ -134,12 +132,8 @@ public sealed class JobTest
         Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.PreRoundLobby));
         Assert.That(pair.Client.AttachedEntity, Is.Null);
 
-        var captain = pair.Server.ProtoMan.Index(Captain);
-        var engineer = pair.Server.ProtoMan.Index(Engineer);
-        var passenger = pair.Server.ProtoMan.Index(Passenger);
-
         await pair.SetJobPriorities(
-            //essentially, weight only matters for each category now instead of globally
+            // essentially, weight only matters for each category now instead of globally
             (Passenger, JobPriority.Medium),
             (Engineer, JobPriority.Medium),
             (Captain, JobPriority.Medium)
@@ -151,7 +145,6 @@ public sealed class JobTest
 
         pair.AssertJob(Captain);
 
-        await pair.Server.WaitPost(() => ticker.RestartRound());
         await pair.CleanReturnAsync();
     }
 
@@ -161,7 +154,7 @@ public sealed class JobTest
     [Test]
     public async Task JobPriorityTest()
     {
-        var pair = await PoolManager.GetServerClient(new PoolSettings {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
             DummyTicker = false
@@ -204,7 +197,6 @@ public sealed class JobTest
             }
         });
 
-        await pair.Server.WaitPost(() => ticker.RestartRound());
         await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -132,8 +132,12 @@ public sealed class JobTest
         Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.PreRoundLobby));
         Assert.That(pair.Client.AttachedEntity, Is.Null);
 
+        var captain = pair.Server.ProtoMan.Index(Captain);
+        var engineer = pair.Server.ProtoMan.Index(Engineer);
+        var passenger = pair.Server.ProtoMan.Index(Passenger);
+
         await pair.SetJobPriorities(
-            // essentially, weight only matters for each category now instead of globally
+            //essentially, weight only matters for each category now instead of globally
             (Passenger, JobPriority.Medium),
             (Engineer, JobPriority.Medium),
             (Captain, JobPriority.Medium)

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -49,7 +49,8 @@ public sealed class JobTest
         await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
-            DummyTicker = false
+            DummyTicker = false,
+            Dirty = true
         });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
@@ -80,7 +81,8 @@ public sealed class JobTest
         await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
-            DummyTicker = false
+            DummyTicker = false,
+            Dirty = true
         });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
@@ -124,7 +126,8 @@ public sealed class JobTest
         await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
-            DummyTicker = false
+            DummyTicker = false,
+            Dirty = true
         });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
@@ -161,7 +164,8 @@ public sealed class JobTest
         await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
-            DummyTicker = false
+            DummyTicker = false,
+            Dirty = true
         });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -49,8 +49,7 @@ public sealed class JobTest
         await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
-            DummyTicker = false,
-            Dirty = true
+            DummyTicker = false
         });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
@@ -81,8 +80,7 @@ public sealed class JobTest
         await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
-            DummyTicker = false,
-            Dirty = true
+            DummyTicker = false
         });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
@@ -126,8 +124,7 @@ public sealed class JobTest
         await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
-            DummyTicker = false,
-            Dirty = true
+            DummyTicker = false
         });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
@@ -164,8 +161,7 @@ public sealed class JobTest
         await using var pair = await PoolManager.GetServerClient(new PoolSettings {
             InLobby = true,
             Connected = true,
-            DummyTicker = false,
-            Dirty = true
+            DummyTicker = false
         });
 
         pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Reverts https://github.com/ss14Starlight/space-station-14/pull/4487 and adds an Assert in JobWeightTest so job prototypes are resolved before the round starts and adds a cleanup so client dosen't break test
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Test Fail Fix Attempt
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

Not player facing