### PR TITLE
Fix panic bunker info for NullLink

### DIFF
--- a/Content.Server/_NullLink/HubSystem.ServerInfo.cs
+++ b/Content.Server/_NullLink/HubSystem.ServerInfo.cs
@@ -139,7 +139,7 @@ public sealed partial class HubSystem : EntitySystem
         _lastSent = _timing.RealTime;
 
         return _actors.TryGetServerGrain(out var serverGrain)
-            ? serverGrain!.UpdateServerInfo(_serverInfo)
+            ? serverGrain.UpdateServerInfo(_serverInfo)
             : ValueTask.CompletedTask;
     }
 }

--- a/Content.Server/_NullLink/HubSystem.ServerInfo.cs
+++ b/Content.Server/_NullLink/HubSystem.ServerInfo.cs
@@ -1,16 +1,10 @@
 ﻿using System.Threading.Tasks;
-using Content.Server._NullLink.Core;
 using Content.Server._NullLink.Helpers;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Events;
-using Content.Server.Players.RateLimiting;
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
-using Content.Shared.Administration.Events;
-using Robust.Server.Player;
-using Robust.Shared.Configuration;
 using Robust.Shared.Player;
-using Robust.Shared.Timing;
 using Starlight.NullLink;
 using ServerInfoRequest = Starlight.NullLink.ServerInfo;
 

--- a/Content.Server/_NullLink/HubSystem.ServerInfo.cs
+++ b/Content.Server/_NullLink/HubSystem.ServerInfo.cs
@@ -30,21 +30,21 @@ public sealed partial class HubSystem : EntitySystem
     public void InitializeServerInfo()
     {
         _cfg.OnValueChanged(CCVars.SoftMaxPlayers, OnSoftMaxPlayersChanged, true);
+        _cfg.OnValueChanged(CCVars.PanicBunkerEnabled, OnPanicBunkerChanged, true);
 
         SubscribeLocalEvent<RoundRestartCleanupEvent>(_ => OnLobby());
         SubscribeLocalEvent<RoundEndTextAppendEvent>(_ => OnRoundEnding());
         SubscribeLocalEvent<RoundStartingEvent>(_ => OnRoundStart());
-        SubscribeLocalEvent<PanicBunkerChangedEvent>(OnPanicBunkerChanged);
 
         _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
     }
 
-    private void OnPanicBunkerChanged(PanicBunkerChangedEvent args)
+    private void OnPanicBunkerChanged(bool enabled)
     {
-        if (_serverInfo.PanicBunkerActive == args.Status.Enabled) return;
+        if (_serverInfo.PanicBunkerActive == enabled) return;
         _serverInfo = _serverInfo with
         {
-            PanicBunkerActive = args.Status.Enabled
+            PanicBunkerActive = enabled
         };
         TryUpdateServerInfo();
     }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Panic bunker always off in hub system of NullLink.

Changed subscribe to CCVar, should help.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Bugfix.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rinary
- fix: Fixed "Panic Bunker" field in discord statuses always says that "Panic Bunker" off.