### PR TITLE
Fix IDs with any Law access being uneditable on bureaucratic digi-board

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
@@ -117,6 +117,7 @@
       - Service
       - Engineering
       - Law
+      - NanoTrasen
       privilegedIdSlot:
         name: id-card-clipboard-priviliged-id
         ejectSound: /Audio/Machines/id_swipe.ogg

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
@@ -116,6 +116,7 @@
       - Medical
       - Service
       - Engineering
+      - Law
       privilegedIdSlot:
         name: id-card-clipboard-priviliged-id
         ejectSound: /Audio/Machines/id_swipe.ogg


### PR DESCRIPTION

## Short description
Title

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

It's currently impossible to edit any ID card that has *any* Law accesses on it using the bureaucratic digi-board, even if you're e.g. the Captain.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://s.redmushie.me/2026/05/2026-05-22%2017-27-02.mp4

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: The bureaucratic digi-board can now correctly edit ID cards that have accesses in the Law and NanoTrasen categories.
