### PR TITLE
Removes antag scaling on lone operatives

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -632,8 +632,7 @@
     definitions:
     - spawnerPrototype: SpawnPointLoneNukeOperative
       min: 1
-      max: 3 # Starlight, for Alpha.
-      playerRatio: 75 # Starlight. 1 vs 150 is essentially impossible. 2 vs 150 might stand a chance. 3 vs 225 is funny.
+      max: 1 # Starlight. Lone operatives should be alone.
       prefRoles: [ Nukeops ]
       pickPlayer: false
       startingGear: SyndicateLoneOperativeGearFull


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
In #4391 , Lone Operatives could scale from 1 to 3 depending on server population.

This PR makes it so lone operatives never scale with server population. There can only be one lone operative (excluding ninjas calling in extras).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
They supposed to be a lone operative. If they're to scale, they should scale in other ways (e.g. TC). We shouldn't be spawning 1 to 2 extra lone operatives for a lone op. That's not a lone op, that's a small nukie team.

Additionally ninjas can call in *extra* lone operatives. This has resulted in a situation where there was **four 'lone' operatives on Alpha**. That's silly.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Lone operatives no longer scale with server population. Lone operatives work (mostly) alone, after all.