### PR TITLE
Antag Scaling Week 4.1

### DIFF
--- a/Resources/Locale/en-US/_Starlight/communications/terror.ftl
+++ b/Resources/Locale/en-US/_Starlight/communications/terror.ftl
@@ -4,3 +4,5 @@ terror-lone-op = Attention crew, it appears that someone on your station has mad
 terror-ninja = Attention crew, it appears that someone on your station has made an unexpected communication with the spider clan in nearby space.
 terror-rod = Attention crew, it appears that someone on your station has made an unexpected communication with an unstoppable force in nearby space.
 terror-wizard = Attention crew, it appears that someone on your station has made an unexpected communication with a wizard federation representative in nearby space.
+terror-spider = Attention crew, it appears that someone on your station has made an unexpected communication with an infested shuttle in nearby space.
+terror-borgs = Attention crew, it appears that someone on your station has made an unexpected communication with an anomalous shuttle in nearby space.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -618,7 +618,7 @@
   components:
   - type: StationEvent
     earliestStart: 55 # 🌟Starlight🌟 Casualization
-    weight: 2.5 # 🌟Starlight🌟 Casualization
+    weight: 3 # 🌟Starlight🌟 Casualization
     minimumPlayers: 35 # 🌟Starlight🌟 Casualization
     duration: null # LoneOpsSpawn needs an infinite duration so that it inherits the NukeOpsRule things of an actually appropriate end scrreen (not always "Neutral outcome!") and... ending the game if the station is nuked.
   - type: RuleGrids

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -240,8 +240,7 @@
     definitions:
     - spawnerPrototype: SpawnPointGhostDragon
       min: 1
-      max: 3 # Starlight, for alpha.
-      playerRatio: 95 # Starlight. Realistically, Alpha shouldn't ever see more than 2, but future proofing's future proofing...
+      max: 1 # Just remove scaling. I want to do an elder dragon above a certain pop, but I'm kinda being rushed to make this so I can't right now.
       pickPlayer: false
       mindRoles:
       - MindRoleDragon
@@ -312,7 +311,7 @@
   id: ParadoxCloneSpawn
   components:
   - type: StationEvent
-    weight: 5
+    weight: 4 # Starlight
     duration: null
     earliestStart: 20
     reoccurrenceDelay: 20
@@ -331,8 +330,7 @@
     definitions:
     - spawnerPrototype: SpawnPointGhostParadoxClone
       min: 1
-      max: 4 # Starlight. Future proofing.
-      playerRatio: 70 # Starlight. Paradoxes really aren't that impactful
+      max: 1
       pickPlayer: false
       startingGear: ParadoxCloneGear
       roleLoadout:
@@ -620,7 +618,7 @@
   components:
   - type: StationEvent
     earliestStart: 55 # 🌟Starlight🌟 Casualization
-    weight: 3 # 🌟Starlight🌟 Casualization
+    weight: 2.5 # 🌟Starlight🌟 Casualization
     minimumPlayers: 35 # 🌟Starlight🌟 Casualization
     duration: null # LoneOpsSpawn needs an infinite duration so that it inherits the NukeOpsRule things of an actually appropriate end scrreen (not always "Neutral outcome!") and... ending the game if the station is nuked.
   - type: RuleGrids
@@ -632,8 +630,7 @@
     definitions:
     - spawnerPrototype: SpawnPointLoneNukeOperative
       min: 1
-      max: 3 # Starlight, for Alpha.
-      playerRatio: 75 # Starlight. 1 vs 150 is essentially impossible. 2 vs 150 might stand a chance. 3 vs 225 is funny.
+      max: 1
       prefRoles: [ Nukeops ]
       pickPlayer: false
       startingGear: SyndicateLoneOperativeGearFull

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -240,7 +240,7 @@
     definitions:
     - spawnerPrototype: SpawnPointGhostDragon
       min: 1
-      max: 1 # Just remove scaling. I want to do an elder dragon above a certain pop, but I'm kinda being rushed to make this so I can't right now.
+      max: 1
       pickPlayer: false
       mindRoles:
       - MindRoleDragon

--- a/Resources/Prototypes/_Starlight/GameRules/events.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/events.yml
@@ -422,8 +422,8 @@
   components:
   - type: StationEvent
     earliestStart: 75 # 🌟Starlight🌟 Casualization
-    weight: 1 # 🌟Starlight🌟 Casualization
-    minimumPlayers: 160 # 🌟Starlight🌟 Casualization
+    weight: 0.5 # 🌟Starlight🌟 Casualization
+    minimumPlayers: 175 # 🌟Starlight🌟 Casualization
     duration: null # LoneOpsSpawn needs an infinite duration so that it inherits the NukeOpsRule things of an actually appropriate end scrreen (not always "Neutral outcome!") and... ending the game if the station is nuked.
   - type: RuleGrids
   - type: LoadMapRule

--- a/Resources/Prototypes/_Starlight/GameRules/events.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/events.yml
@@ -99,7 +99,7 @@
       - !type:NestedSelector
         tableId: DerelictBorgEventTable
       - id: WizardSpawn
-      - id: Xenoborgs
+      - id: SubXenoborgs # Starlight, make it spawn sub instead
       # Starlight gamerules:
       - id: AbductorsSpawn
       - id: RailroadingTerminator

--- a/Resources/Prototypes/_Starlight/GameRules/events.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/events.yml
@@ -95,7 +95,6 @@
       - id: SleeperAgents
       #    - id: ZombieOutbreak
       - id: LoneOpsSpawn
-      - id: StrikeOpsSpawn # Starlight
       - !type:NestedSelector
         tableId: DerelictBorgEventTable
       - id: WizardSpawn
@@ -414,50 +413,6 @@
       - MindRoleTerrorPrincess
   - type: DynamicRuleCost
     cost: 75
-
-# Strike Ops
-- type: entity
-  parent: BaseNukeopsRule
-  id: StrikeOpsSpawn
-  components:
-  - type: StationEvent
-    earliestStart: 75 # 🌟Starlight🌟 Casualization
-    weight: 1 # 🌟Starlight🌟 Casualization
-    minimumPlayers: 160 # 🌟Starlight🌟 Casualization
-    duration: null # LoneOpsSpawn needs an infinite duration so that it inherits the NukeOpsRule things of an actually appropriate end scrreen (not always "Neutral outcome!") and... ending the game if the station is nuked.
-  - type: RuleGrids
-  - type: LoadMapRule
-    gridPath: /Maps/Shuttles/ShuttleEvent/striker.yml
-  - type: NukeopsRule
-    roundEndBehavior: Nothing
-  - type: AntagSelection
-    definitions:
-    - spawnerPrototype: SpawnPointLoneNukeOperative
-      min: 2
-      max: 2
-      prefRoles: [ Nukeops ]
-      pickPlayer: false
-      startingGear: SyndicateLoneOperativeGearFull
-      roleLoadout:
-      - RoleSurvivalNukie
-      components:
-      - type: NukeOperative
-      - type: RandomMetadata
-        nameSegments:
-        - NamesSyndicatePrefix
-        - NamesSyndicateNormal
-        nameFormat: name-format-nukie-generic
-      - type: NpcFactionMember
-        factions:
-        - Syndicate
-      mindRoles:
-      - MindRoleLoneops
-      # Starlight-start
-      tags:
-        - CantBecomeRevolutionary
-      # Starlight-end
-  - type: DynamicRuleCost
-    cost: 125
 
 # Multi Paradoxes
 - type: entity

--- a/Resources/Prototypes/_Starlight/GameRules/events.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/events.yml
@@ -90,10 +90,12 @@
       - id: KingRatMigration
       - id: NinjaSpawn
       - id: ParadoxCloneSpawn
+      - id: ParadoxCrisisSpawn # Starlight
       - id: RevenantSpawn
       - id: SleeperAgents
       #    - id: ZombieOutbreak
       - id: LoneOpsSpawn
+      - id: StrikeOpsSpawn # Starlight
       - !type:NestedSelector
         tableId: DerelictBorgEventTable
       - id: WizardSpawn
@@ -412,3 +414,87 @@
       - MindRoleTerrorPrincess
   - type: DynamicRuleCost
     cost: 75
+
+# Strike Ops
+- type: entity
+  parent: BaseNukeopsRule
+  id: StrikeOpsSpawn
+  components:
+  - type: StationEvent
+    earliestStart: 75 # 🌟Starlight🌟 Casualization
+    weight: 1 # 🌟Starlight🌟 Casualization
+    minimumPlayers: 160 # 🌟Starlight🌟 Casualization
+    duration: null # LoneOpsSpawn needs an infinite duration so that it inherits the NukeOpsRule things of an actually appropriate end scrreen (not always "Neutral outcome!") and... ending the game if the station is nuked.
+  - type: RuleGrids
+  - type: LoadMapRule
+    gridPath: /Maps/Shuttles/ShuttleEvent/striker.yml
+  - type: NukeopsRule
+    roundEndBehavior: Nothing
+  - type: AntagSelection
+    definitions:
+    - spawnerPrototype: SpawnPointLoneNukeOperative
+      min: 2
+      max: 2
+      prefRoles: [ Nukeops ]
+      pickPlayer: false
+      startingGear: SyndicateLoneOperativeGearFull
+      roleLoadout:
+      - RoleSurvivalNukie
+      components:
+      - type: NukeOperative
+      - type: RandomMetadata
+        nameSegments:
+        - NamesSyndicatePrefix
+        - NamesSyndicateNormal
+        nameFormat: name-format-nukie-generic
+      - type: NpcFactionMember
+        factions:
+        - Syndicate
+      mindRoles:
+      - MindRoleLoneops
+      # Starlight-start
+      tags:
+        - CantBecomeRevolutionary
+      # Starlight-end
+  - type: DynamicRuleCost
+    cost: 125
+
+# Multi Paradoxes
+- type: entity
+  parent: BaseGameRule
+  id: ParadoxCrisisSpawn
+  components:
+  - type: StationEvent
+    weight: 2
+    duration: null
+    earliestStart: 35
+    reoccurrenceDelay: 20
+    minimumPlayers: 15
+  - type: ParadoxCloneRule
+    objectiveBlacklist:
+      tags:
+      - ParadoxCloneObjectiveBlacklist
+  - type: AntagObjectives
+    objectives:
+    - ParadoxCloneKillObjective
+    - ParadoxCloneLivingObjective
+  - type: AntagRandomSpawn # TODO: improve spawning so they only start in maints
+  - type: AntagSelection
+    agentName: paradox-clone-round-end-agent-name
+    definitions:
+    - spawnerPrototype: SpawnPointGhostParadoxClone
+      min: 1
+      max: 4 # Starlight. Future proofing.
+      playerRatio: 70 # Starlight. Paradoxes really aren't that impactful
+      pickPlayer: false
+      startingGear: ParadoxCloneGear
+      roleLoadout:
+      - RoleSurvivalVoxTank # give vox something to breath in case they don't get a copy
+      briefing:
+        text: paradox-clone-role-greeting
+        color: lightblue
+        sound: /Audio/Misc/paradox_clone_greeting.ogg
+      mindRoles:
+      - MindRoleParadoxClone
+  - type: DynamicRuleCost
+    cost: 50

--- a/Resources/Prototypes/_Starlight/ninja_threats.yml
+++ b/Resources/Prototypes/_Starlight/ninja_threats.yml
@@ -22,3 +22,13 @@
   id: Wizard
   announcement: terror-wizard
   rule: WizardSpawn
+
+- type: ninjaHackingThreat
+  id: TerrorSpider
+  announcement: terror-spider
+  rule: TerrorSpidersSpawn
+
+- type: ninjaHackingThreat
+  id: Xenoborgs
+  announcement: terror-borgs
+  rule: SubXenoborgs

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -9,7 +9,9 @@
     LoneOp: 0.25
     NinjaBackup: 0.75
     Rod: 0.75
+    TerrorSpider: 0.5
     Wizard: 0.1
+    Xenoborgs: 0.05
     # Starlight End
 
 - type: ninjaHackingThreat


### PR DESCRIPTION
## Short description
Tweaks some antag scaling. Really wasn't ready to release this yet but I'm being pressured into it. Please merge this instead of [#4517](https://github.com/ss14Starlight/space-station-14/pull/4517).

## Why we need to add this
Addresses Antag Scaling concerns.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: Added a midround event, ParadoxCrisis. It's ParadoxClone scaling as it was before this pr. Has half the spawn weight of Paradox clone.
- add: Ninja can now call Terror Spiders (chance between lone op and backup ninja) and SubXenoborgs (chance half of that of Ninja spawning a Wizard, which is about 2%, so this is 1%).
- remove: LoneOps, Paradox Clones, and Dragons no longer scale.
- tweak: ParadoxClone spawn weight -1.
- tweak: The already existing Xenoborgs midround now uses SubXenoborgs instead.

