### PR TITLE
Misc Sinon Fixes

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -13,7 +13,7 @@
   displayWeight: 1 # Starlight, we're reordering things
   canBeAntag: false
   icon: JobIconStationAi
-  supervisors: job-supervisors-nanotrasen # Starlight, listen to NT
+  supervisors: job-supervisors-nanotrasen # Starlight, listen to NT.
   jobEntity: StationAiBrain
   jobPreviewEntity: PlayerStationAiPreview
   # Cosmatic Drift Record System-start: AIs spawn as non-humanoids, so skip loading character records for them.
@@ -35,7 +35,7 @@
   canBeAntag: false
   displayWeight: 0 # Starlight, we're reordering things
   icon: JobIconBorg
-  supervisors: job-supervisors-station-ai # Starlight, listen to the AI
+  supervisors: job-supervisors-station-ai # Starlight, listen to the AI.
   jobEntity: PlayerBorgChassis # Starlight edit
   # Cosmatic Drift Record System-start: Cyborg shells do not use humanoid profiles, so avoid seeding records.
   special:

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Ears/headsets.yml
@@ -7,7 +7,7 @@
     - type: ContainerFill
       containers:
         key_slots:
-        - EncryptionKeyNanoTrasen
+        - EncryptionKeyNanoTrasenUnremovable
         - EncryptionKeyLawSecurity
         - EncryptionKeyCommon
     - type: Sprite
@@ -22,7 +22,7 @@
     - type: ContainerFill
       containers:
         key_slots:
-        - EncryptionKeyNanoTrasen
+        - EncryptionKeyNanoTrasenUnremovable
         - EncryptionKeyLawSecurity
         - EncryptionKeyCommand
         - EncryptionKeyCommon
@@ -158,7 +158,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyNanoTrasen
+      - EncryptionKeyNanoTrasenUnremovable
       - EncryptionKeyCommand
       - EncryptionKeyNCTrainer
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Ears/headsets_alt.yml
@@ -44,7 +44,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyNanoTrasen
+      - EncryptionKeyNanoTrasenUnremovable
       - EncryptionKeyCentCom
       - EncryptionKeyStationMaster
   - type: Sprite
@@ -63,7 +63,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyNanoTrasen
+      - EncryptionKeyNanoTrasenUnremovable
       - EncryptionKeyStationMaster
   - type: Sprite
     sprite: Clothing/Ears/Headsets/command.rsi
@@ -84,7 +84,7 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyNanoTrasen
+      - EncryptionKeyNanoTrasenUnremovable
       - EncryptionKeyCommand
       - EncryptionKeyNCTrainer
   - type: Sprite
@@ -134,6 +134,7 @@
   - type: ContainerFill
     containers:
       key_slots:
+      - EncryptionKeyNanoTrasenUnremovable
       - EncryptionKeyStationMaster
   - type: Sprite
     sprite: Clothing/Ears/Headsets/command.rsi
@@ -212,7 +213,7 @@
     containers:
       key_slots:
       - EncryptionKeyCentCom
-      - EncryptionKeyNanoTrasen
+      - EncryptionKeyNanoTrasenUnremovable
       - EncryptionKeyStationMaster
   - type: Sprite
     sprite: Clothing/Ears/Headsets/command.rsi

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/encryption_keys.yml
@@ -29,6 +29,15 @@
     - state: nano_label
 
 - type: entity
+  parent: EncryptionKeyNanoTrasen
+  id: EncryptionKeyNanoTrasenUnremovable
+  name: nanotrasen encryption key
+  description: An encryption key used by captain's bosses' bosses.
+  suffix: Unremovable
+  components:
+  - type: Unremoveable
+
+- type: entity
   parent: [ EncryptionKey, BaseSovietContraband ]
   id: EncryptionKeySoviet
   name: soviet encryption key

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
@@ -379,9 +379,6 @@
           Slash: 0.35
           Piercing: 0.25
           Heat: 0.35
-        flatReductions:
-          Heat: 0.5
-          Piercing: 0.5
       passiveBlockFraction: 0.2
       activeBlockFraction: 0.3
     - type: Appearance

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
@@ -373,16 +373,17 @@
           Slash: 0.15
           Piercing: 0.10
           Heat: 0.15
-      activeBlockModifier: # This is just here because the game requires it. You can't actually wield this as a Xenoborg.
+      activeBlockModifier: # You shouldn't be able to wield it, but if for some reason you end up doing it, no more immortality.
         coefficients:
-          Blunt: 0.7
-          Slash: 0.5
-          Piercing: 0.4
-          Heat: 0.5
+          Blunt: 0.4
+          Slash: 0.35
+          Piercing: 0.25
+          Heat: 0.35
         flatReductions:
           Heat: 0.5
           Piercing: 0.5
       passiveBlockFraction: 0.2
+      activeBlockFraction: 0.3
     - type: Appearance
     - type: Damageable
       damageContainer: Shield


### PR DESCRIPTION
## Short description
Fixes some things.

## Why we need to add this
Bug fixes.

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: The NanoTrasen Encryption key is now unremovable. It's more advanced, after all.
- fix: BSO now has a NanoTrasen Encryption key in their headset.
- fix: T3 Scout Xenoborgs are no longer immortal when spawned from the entities menu. (The normal ones can't achieve immortality, but this should prevent admins from accidentally spawning immortality versions (the ones without brains).).
