### PR TITLE
More Cold Resist

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_emergency.yml
@@ -24,7 +24,7 @@
     sprite: Clothing/Mask/breath.rsi
     state: icon
   product: CrateEmergencyInternals
-  cost: 1000
+  cost: 1100 # Starlight, EVAs have cold resist, so they became a little more expensive.
   category: cargoproduct-category-name-emergency
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Clothing/Mask/breath.rsi
     state: icon
   product: CrateEmergencyInternalsLarge
-  cost: 1800
+  cost: 2000 # Starlight, EVAs have cold resist, so they became a little more expensive.
   category: cargoproduct-category-name-emergency
   group: market
 

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -279,7 +279,8 @@
     zombificationResistanceCoefficient: 0.90
   - type: Armor # so zombification resistance shows up
     modifiers:
-      coefficients: { }
+      coefficients: # Starlight
+        Cold: 0.9 # Starlight, I mean, that's literally what they're for
   - type: GroupExamine
   - type: HideLayerClothing
     slots:

--- a/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/base_clothingneck.yml
@@ -43,6 +43,10 @@
   - type: TemperatureProtection # same as winter boots
     heatingCoefficient: 1.025
     coolingCoefficient: 0.6
+  - type: Armor
+    modifiers:
+      coefficients:
+        Cold: 0.9 # I mean, that's literally what they're for...
   #endregion Starlight
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -194,6 +194,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
+  - type: Armor # Starlight start
+    modifiers:
+      coefficients:
+        Cold: 0.85 # Starlight end, I mean, that's literally what they're for...
   - type: HeldSpeedModifier
   - type: Item
     size: Huge

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, ClothingOuterColdBase] # Starlight
   id: ClothingOuterCoatBomber
   name: bomber jacket
   description: A thick, well-worn WW2 leather bomber jacket.
@@ -25,6 +25,14 @@
         children:
         - id: SmokingPipeFilledTobacco
         - id: FlippoEngravedLighter
+  - type: Armor # Starlight start
+    modifiers:
+      coefficients:
+        Blunt: 0.75 # Lose a little blunt to tradeoff cold
+        Slash: 0.70
+        Piercing: 0.70
+        Heat: 0.80
+        Cold: 0.85 # Starlight end, here for cold
 
 - type: entity
   parent: [ClothingOuterCoatDetectiveLoadout]
@@ -49,7 +57,7 @@
         - id: FlippoLighter #Not the steal objective, only difference from normal detective trenchcoat
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, ClothingOuterColdBase] # Starlight
   id: ClothingOuterCoatGentle
   name: gentle coat
   description: A gentle coat for a gentle man, or woman.
@@ -73,6 +81,7 @@
         Slash: 0.65
         Piercing: 0.6
         Heat: 0.7
+        Cold: 0.8 # Starlight
         Caustic: 0.75 # not the full 90% from ss13 because of the head
 
 - type: entity
@@ -89,6 +98,7 @@
         Slash: 0.65
         Piercing: 0.7
         Heat: 0.7
+        Cold: 0.8 # Starlight
         Caustic: 0.9
 
 - type: entity
@@ -103,7 +113,7 @@
     sprite: Clothing/OuterClothing/Coats/hos_trenchcoat.rsi
 
 - type: entity
-  parent: ClothingOuterStorageToggleableBase
+  parent: [ClothingOuterStorageToggleableBase, ClothingOuterColdBase] # Starlight
   id: ClothingOuterCoatJensen
   name: jensen coat
   description: A jensen coat.
@@ -144,6 +154,7 @@
     modifiers:
       coefficients:
         Slash: 0.95
+        Cold: 0.85 # Starlight, I mean, it's a coat
   - type: Edible
     requiresSpecialDigestion: true
   - type: SolutionContainerManager
@@ -169,6 +180,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Cold: 0.9 # Starlight
         Caustic: 0.75
 
 - type: entity
@@ -191,6 +203,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Cold: 0.9 # Starlight
         Caustic: 0.75
 
 - type: entity
@@ -213,6 +226,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Cold: 0.9 # Starlight
         Caustic: 0.75
 
 - type: entity
@@ -235,6 +249,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Cold: 0.9 # Starlight
         Caustic: 0.75
 
 - type: entity
@@ -259,6 +274,7 @@
       coefficients:
         Slash: 0.95
         Heat: 0.95
+        Cold: 0.85 # Starlight, CMO can have a little better than the others
         Caustic: 0.65
 
 - type: entity
@@ -281,6 +297,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Cold: 0.9 # Starlight
         Caustic: 0.75
 
 - type: entity
@@ -303,6 +320,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Cold: 0.9 # Starlight
         Caustic: 0.75
 
 - type: entity
@@ -325,6 +343,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Cold: 0.8 # Starlight, RD can have a little better protection than normal lab coats
         Caustic: 0.75
         Radiation: 0.9
 
@@ -334,7 +353,7 @@
   name: research director lab coat
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, AllowSuitStorageClothing ]
+  parent: [ ClothingOuterStorageBase, , ClothingOuterColdBase, AllowSuitStorageClothing ] # Starlight
   id: ClothingOuterCoatPirate
   name: pirate garb
   description: Yarr.
@@ -356,7 +375,7 @@
     sprite: Clothing/OuterClothing/Coats/warden.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, ClothingOuterColdBase] # Starlight
   id: ClothingOuterDameDane
   name: yakuza coat
   description: Friday...
@@ -367,7 +386,7 @@
     sprite: Clothing/OuterClothing/Coats/damedanecoat.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, ClothingOuterColdBase] # Starlight
   id: ClothingOuterClownPriest
   name: robes of the honkmother
   description: Meant for a clown of the cloth.
@@ -397,7 +416,7 @@
         Piercing: 0.85
 
 - type: entity
-  parent: [ClothingOuterStorageFoldableBase, AllowSuitStorageClothing]
+  parent: [ClothingOuterStorageFoldableBase, ClothingOuterColdBase, AllowSuitStorageClothing] # Starlight
   id: ClothingOuterCoatParamedicWB
   name: paramedic windbreaker
   description: A paramedic's trusty windbreaker, for all the space wind.
@@ -413,7 +432,7 @@
   name: paramedic windbreaker
 
 - type: entity
-  parent: [ClothingOuterStorageBase, BaseMinorContraband] #SL Edit Syndie > Minor
+  parent: [ClothingOuterStorageBase, ClothingOuterColdBase, BaseMinorContraband] #SL Edit Syndie > Minor + Cold
   id: ClothingOuterCoatSyndieCap
   name: syndicate's coat
   description: The syndicate's coat is made of durable fabric, with gilded patterns.
@@ -472,6 +491,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Cold: 0.9 # Starlight
         Caustic: 0.75
 
 - type: entity
@@ -494,6 +514,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Cold: 0.9
         Caustic: 0.75
 
 - type: entity
@@ -511,9 +532,13 @@
     sprite: Clothing/OuterClothing/Coats/space_asshole.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/space_asshole.rsi
+  - type: Armor # Starlight start
+    modifiers:
+      coefficients:
+        Cold: 0.85 # Starlight end
 
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: [ClothingOuterStorageFoldableBase, ClothingOuterColdBase] # Starlight
   id: ClothingOuterCoatExpensive
   name: expensive coat
   description: Very fluffy pink coat, made out of very expensive fur (clearly).

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -353,7 +353,7 @@
   name: research director lab coat
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, , ClothingOuterColdBase, AllowSuitStorageClothing ] # Starlight
+  parent: [ ClothingOuterStorageBase, ClothingOuterColdBase, AllowSuitStorageClothing ] # Starlight
   id: ClothingOuterCoatPirate
   name: pirate garb
   description: Yarr.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -141,6 +141,7 @@
         Heat: 0.90
         Radiation: 0.75
         Caustic: 0.5
+        Cold: 0.7 # Starlight
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.5 # Starlight Edit
   - type: GroupExamine

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -412,6 +412,15 @@
       toggleable-clothing: !type:ContainerSlot { }
       storagebase: !type:Container
         ents: [ ]
+  - type: Armor # Starlight start
+    modifiers:
+      coefficients:
+        Blunt: 0.7 # Less blunt resist, so it's not just better
+        Slash: 0.65
+        Piercing: 0.6
+        Heat: 0.7
+        Cold: 0.7 # Not as much as Warden
+        Caustic: 0.75 # Starlight end
 ##########################################################
 
 - type: entity
@@ -801,6 +810,15 @@
     sprite: Clothing/OuterClothing/WinterCoats/coatwardenarmored.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterWarden
+  - type: Armor # Starlight start
+    modifiers:
+      coefficients:
+        Blunt: 0.7 # Less blunt resist, so it's not just better
+        Slash: 0.65
+        Piercing: 0.7
+        Heat: 0.7
+        Cold: 0.6 # Winter coat, and warden at that, so it can be a lot.
+        Caustic: 0.9 # Starlight end
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot { }

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -327,6 +327,11 @@
     sprite: Clothing/Uniforms/Jumpskirt/brigmedic.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpskirt/brigmedic.rsi
+  - type: Armor # Starlight start, so zombification resistance shows up
+    modifiers:
+      coefficients: { }
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.90 # Starlight end
 
 - type: entity
   parent: ClothingUniformBase
@@ -689,8 +694,11 @@
       sprite: Clothing/Uniforms/Jumpskirt/skirtoflife.rsi
     - type: Clothing
       sprite: Clothing/Uniforms/Jumpskirt/skirtoflife.rsi
-    - type: ZombificationResistance # Starlight
-      zombificationResistanceCoefficient: 0.95 # Starlight
+    - type: Armor # Starlight start, so zombification resistance shows up
+      modifiers:
+        coefficients: { }
+    - type: ZombificationResistance
+      zombificationResistanceCoefficient: 0.95 # Starlight end
 
 - type: entity
   parent: ClothingUniformSkirtBase

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -504,6 +504,11 @@
     sprite: Clothing/Uniforms/Jumpsuit/brigmedic.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/brigmedic.rsi
+  - type: Armor # Starlight start, so zombification resistance shows up
+    modifiers:
+      coefficients: { }
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.90 # Starlight end
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Head/hoods.yml
@@ -39,6 +39,7 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
+        Cold: 0.95
         Caustic: 0.95
   - type: HideLayerClothing
     slots:

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
@@ -400,7 +400,7 @@
 
 # Medical Windbreaker
 - type: entity
-  parent: [ClothingOuterStorageFoldableBase, ClothingOuterColdBase, llowSuitStorageClothing]
+  parent: [ClothingOuterStorageFoldableBase, ClothingOuterColdBase, AllowSuitStorageClothing]
   id: ClothingOuterWindbreakerMedical
   name: medical windbreaker
   description: A light windbreaker to see when you accidentally cut an artery.

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
@@ -50,7 +50,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Slash: 0.99
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.8
+
 
 - type: entity
   parent: [ ClothingOuterStorageFoldableBase, ClothingOuterColdBase, BaseNanoTrasenContraband ]

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
@@ -1,4 +1,14 @@
 - type: entity
+  abstract: true
+  parent: ClothingOuterBase
+  id: ClothingOuterColdBase
+  components:
+  - type: Armor
+    modifiers:
+      coefficients:
+        Cold: 0.9
+
+- type: entity
   parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseBlueShieldContraband]
   id: ClothingOuterCoatBlueShield
   name: blueshield overcoat
@@ -16,13 +26,13 @@
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
-        Heat: 0.7
+        Heat: 0.7 # No cold resist because the item literally says it doesn't protect you from cold.
   - type: ExplosionResistance
     damageCoefficient: 0.80
   - type: Item
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, BaseCommandContraband ]
+  parent: [ ClothingOuterStorageBase, ClothingOuterColdBase, BaseNanoTrasenContraband ]
   id: ClothingOuterCoatMagi
   name: magistrate's longcoat
   description: New and improved, this jacket actually keeps you warm! Brought to you by the NanoTrasen Fashion Board.
@@ -43,7 +53,7 @@
         Slash: 0.99
 
 - type: entity
-  parent: [ ClothingOuterStorageFoldableBase, BaseCommandContraband ]
+  parent: [ ClothingOuterStorageFoldableBase, , ClothingOuterColdBase, BaseNanoTrasenContraband ]
   id: ClothingOuterCoatNtrep
   name: nt representative jacket
   description: A fancy black jacket, standart issue to NanoTrasen Representatives.
@@ -62,7 +72,7 @@
         Piercing: 0.8
 
 - type: entity
-  parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatNtrep, BaseCommandContraband ]
+  parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatNtrep, BaseNanoTrasenContraband ]
   id: ClothingOuterCoatNtrepOpen
   name: nt representative jacket
 
@@ -81,6 +91,7 @@
   - type: Armor
     modifiers:
       coefficients:
+        Cold: 0.9
         Caustic: 0.75
 
 - type: entity
@@ -110,6 +121,7 @@
         Slash: 0.85
         Piercing: 0.65
         Heat: 0.85
+        Cold: 0.90 # It's a jacket
         Caustic: 0.75
   - type: ExplosionResistance
     damageCoefficient: 0.95
@@ -143,6 +155,7 @@
         Slash: 0.65
         Piercing: 0.75
         Heat: 0.85
+        Cold: 0.90 # It's technically a coat
         Caustic: 0.75
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.65
@@ -171,6 +184,7 @@
         Slash: 0.65
         Piercing: 0.75
         Heat: 0.85
+        Cold: 0.90 # It's technically a coat
         Caustic: 0.75
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.65
@@ -201,6 +215,7 @@
       coefficients:
         Slash: 0.90
         Heat: 0.85
+        Cold: 0.8 # Space is in the name
     priceMultiplier: 0
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.50
@@ -235,6 +250,7 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.9
+        Cold: 0.9
         Caustic: 0.9
 
 #USSP
@@ -260,9 +276,10 @@
         Slash: 0.90
         Piercing: 0.75
         Heat: 0.80
+        Cold: 0.8 # Great coat
 
 - type: entity
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing]
+  parent: [ClothingOuterStorageBase, ClothingOuterColdBase, AllowSuitStorageClothing]
   id: ClothingOuterCoatGreytiderTrenchcoat
   name: greytider trenchcoat
   description: Ah, your trusty coat. There's a few tears here and there, giving it a more timely look. Or at least, that's what you told yourself when you found out gettin' it repaired would set you back 200 spesos.
@@ -296,6 +313,7 @@
         Slash: 0.75
         Piercing: 0.95
         Heat: 0.65
+        Cold: 0.80 # Sec can get a little more
   - type: ExplosionResistance
     damageCoefficient: 0.85
 
@@ -322,6 +340,7 @@
         Slash: 0.80
         Piercing: 0.70
         Heat: 0.90
+        Cold: 0.90
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.75
 
@@ -332,7 +351,7 @@
 
 # Cargo Windbreaker
 - type: entity
-  parent: [ClothingOuterStorageFoldableBase, AllowSuitStorageClothing]
+  parent: [ClothingOuterStorageFoldableBase, ClothingOuterColdBase, AllowSuitStorageClothing]
   id: ClothingOuterWindbreakerCargo
   name: cargo windbreaker
   description: A simple windbreaker with a fur collar.
@@ -351,7 +370,7 @@
 
 # Engineering Windbreaker
 - type: entity
-  parent: [ClothingOuterStorageFoldableBase, AllowSuitStorageClothing]
+  parent: [ClothingOuterStorageFoldableBase, ClothingOuterColdBase, AllowSuitStorageClothing]
   id: ClothingOuterWindbreakerEngineering
   name: engineering windbreaker
   description: A reflective windbreaker for engineers.
@@ -378,7 +397,7 @@
 
 # Medical Windbreaker
 - type: entity
-  parent: [ClothingOuterStorageFoldableBase, AllowSuitStorageClothing]
+  parent: [ClothingOuterStorageFoldableBase, ClothingOuterColdBase, llowSuitStorageClothing]
   id: ClothingOuterWindbreakerMedical
   name: medical windbreaker
   description: A light windbreaker to see when you accidentally cut an artery.
@@ -397,7 +416,7 @@
 
 #Science Windbreaker
 - type: entity
-  parent: [ClothingOuterStorageFoldableBase, AllowSuitStorageClothing]
+  parent: [ClothingOuterStorageFoldableBase, ClothingOuterColdBase, AllowSuitStorageClothing]
   id: ClothingOuterWindbreakerScience
   name: science windbreaker
   description: a labcoat style windbreaker with a pocket for all of your pens.
@@ -433,6 +452,7 @@
         Slash: 0.4
         Piercing: 0.4
         Heat: 0.5
+        Cold: 0.55 # CentComm
   - type: ExplosionResistance
     damageCoefficient: 0.80
   - type: Item
@@ -455,6 +475,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.8
+        Cold: 0.8 # It's a pretty dense coat, all things considered
 
 - type: entity
   parent: [ClothingOuterStorageBase, AllowSuitStorageClothing]
@@ -468,7 +489,7 @@
     sprite: _Starlight/Clothing/OuterClothing/OverClothes/ratvar_robes.rsi
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, AllowSuitStorageClothing ]
+  parent: [ ClothingOuterStorageBase, ClothingOuterColdBase, AllowSuitStorageClothing]
   id: ClothingOuterCoatPirateDark
   name: dark pirate garb
   description: Yarr, but dark.
@@ -479,7 +500,7 @@
     sprite: _Starlight/Clothing/OuterClothing/Coats/dark_pirate.rsi
 
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, ClothingOuterColdBase]
   id: ClothingOuterCoatField
   name: field jacket
   description: A thick, well-worn field jacket.

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
@@ -12,7 +12,7 @@
   parent: [ClothingOuterStorageBase, AllowSuitStorageClothing, BaseBlueShieldContraband]
   id: ClothingOuterCoatBlueShield
   name: blueshield overcoat
-  description: A coat worn by Blueshield Officers who don't mind a little cold. Heavily reinforced, for when diplomacy won't cut it.
+  description: A coat worn by Blueshield Officers who don't mind the lighter wear. Heavily reinforced, for when diplomacy won't cut it.
   components:
   - type: Sprite
     sprite: _Starlight/Clothing/OuterClothing/Coats/blueshield_coat.rsi
@@ -26,7 +26,8 @@
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
-        Heat: 0.7 # No cold resist because the item literally says it doesn't protect you from cold.
+        Heat: 0.7
+        Cold: 0.7 # BlueShield is expensive armor.
   - type: ExplosionResistance
     damageCoefficient: 0.80
   - type: Item

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
@@ -53,7 +53,7 @@
         Slash: 0.99
 
 - type: entity
-  parent: [ ClothingOuterStorageFoldableBase, , ClothingOuterColdBase, BaseNanoTrasenContraband ]
+  parent: [ ClothingOuterStorageFoldableBase, ClothingOuterColdBase, BaseNanoTrasenContraband ]
   id: ClothingOuterCoatNtrep
   name: nt representative jacket
   description: A fancy black jacket, standart issue to NanoTrasen Representatives.

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -75,6 +75,11 @@
     sprite: _Starlight/Clothing/Uniforms/Jumpskirt/corpsman.rsi
   - type: Clothing
     sprite: _Starlight/Clothing/Uniforms/Jumpskirt/corpsman.rsi
+  - type: Armor # so zombification resistance shows up
+    modifiers:
+      coefficients: { }
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.90
 
 - type: entity
   parent: [ ClothingUniformSkirtBase, BaseSecurityContraband ]
@@ -86,6 +91,11 @@
     sprite: _Starlight/Clothing/Uniforms/Jumpskirt/corpsman_trauma.rsi
   - type: Clothing
     sprite: _Starlight/Clothing/Uniforms/Jumpskirt/corpsman_trauma.rsi
+  - type: Armor # so zombification resistance shows up
+    modifiers:
+      coefficients: { }
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.90
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -160,6 +160,11 @@
     sprite: _Starlight/Clothing/Uniforms/Jumpsuit/corpsman.rsi
   - type: Clothing
     sprite: _Starlight/Clothing/Uniforms/Jumpsuit/corpsman.rsi
+  - type: Armor # so zombification resistance shows up
+    modifiers:
+      coefficients: { }
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.90
 
 - type: entity
   parent: [ClothingUniformBase, BaseSecurityContraband]
@@ -171,6 +176,11 @@
     sprite: _Starlight/Clothing/Uniforms/Jumpsuit/corpsman_response.rsi
   - type: Clothing
     sprite: _Starlight/Clothing/Uniforms/Jumpsuit/corpsman_response.rsi
+  - type: Armor # so zombification resistance shows up
+    modifiers:
+      coefficients: { }
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.90
 
 - type: entity
   parent: [ClothingUniformBase, ClothingUniformFoldableBase]
@@ -183,6 +193,9 @@
     sprite: _Starlight/Clothing/Uniforms/Jumpsuit/suitoflife.rsi
   - type: Clothing
     sprite: _Starlight/Clothing/Uniforms/Jumpsuit/suitoflife.rsi
+  - type: Armor # so zombification resistance shows up
+    modifiers:
+      coefficients: { }
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.95
 


### PR DESCRIPTION
## Short description
Most coats and softsuits give some degree of cold resist now. Scarves do too.

## Why we need to add this
Reducing true damage of Cold, preventing it from being used as a normal damage. Hardsuits do not get this, to give them a tradeoff (metal). Use a softsuit if you want to resist cold in space. Will make more departmental softsuits in the future to encourage this further.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Most coats, softsuits, and scarves now give some degree of Cold resist, to make it not true damage, and to give them a niche for that.
- tweak: The Magistrate's Longcoat now has equal stats to NT Representative's Jacket.
- tweak: The NT Representative's Jacket and Magistrate's Longcoat are now NanoTrasen contraband.
- fix: Suit of Life and Skirt of Life now show their zombification resist.
- fix: Winter Coat hoods now give Cold resist.
