### PR TITLE
Cluwne Cure Chance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -24,6 +24,7 @@
     damageUnholy: ## What damage is dealt when a chaplain hits an unholy creature
       types:
         Heat: 20
+    cluwneCureChance: 0.7 #Starlight Edit
   - type: MeleeWeapon
     soundHit:
       collection: Punch


### PR DESCRIPTION
## Short description
Increased to Cluwne Cure chance for Chaplain using the Bible from 3% to 70%.

## Why we need to add this
At 3%, with only slightly bad luck you can easily have to hit one person 100+ times to cure them, resulting in them dying multiple times over in the process. Because of this, most players give up after 40-50 times and assume the feature is just broken.

Making people hit someone to cure them more than 3 times has zero benefit for gameplay or balance, and only makes the experience abysmally bad.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed Cluwne Cure Chance on the Bible from 3% to 70%. With slightly bad RNG, you would have to hit someone 100+ times, leading most people to assume it was bugged. Zero gameplay or balance benefit from making someone get hit that many times to cure, it sucked.

