### PR TITLE
Xenoborg T3 Tweaks

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1277,7 +1277,7 @@
   parent: [ BaseXenoborgModuleStealth, BaseProviderBorgModule, BaseXenoborgContraband ]
   id: XenoborgModuleHypoPlus
   name: advanced hypo xenoborg module
-  description: Module with a better set of self-refilling hypo.
+  description: Module with a better set of self-refilling hypos.
   components:
   - type: Sprite
     sprite: _Starlight/Objects/Specific/Robotics/borgmodule.rsi
@@ -1287,8 +1287,7 @@
   - type: ItemBorgModule
     hands:
     - item: NocturineHypoPlus
-    - item: TazinideHypo
-    - item: MuteToxinHypo
+    - item: LicoxideHypoPlus
   - type: BorgModuleIcon
     icon: { sprite: _Starlight/Interface/Actions/actions_borg.rsi, state: xenoborg-hypo2-module }
 

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/xenoborgs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/xenoborgs.yml
@@ -67,10 +67,10 @@
   - type: SolutionContainerManager
     solutions:
       hypospray:
-        maxVol: 12
+        maxVol: 8
         reagents:
         - ReagentId: MuteToxin
-          Quantity: 12
+          Quantity: 8
   - type: SolutionRegeneration
     solution: hypospray
     generated:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/xenoborgs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/xenoborgs.yml
@@ -20,6 +20,26 @@
 
 - type: entity
   parent: [ BorgHypo, BaseXenoborgContraband ]
+  id: LicoxideHypoPlus
+  name: licoxide hypo
+  description: A self-refilling injector for rapid administration of licoxide to victims. Has 1.5x the storage of the base one.
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      hypospray:
+        maxVol: 12
+        reagents:
+        - ReagentId: Licoxide
+          Quantity: 12
+  - type: SolutionRegeneration
+    solution: hypospray
+    generated:
+      reagents:
+      - ReagentId: Licoxide
+        Quantity: 0.2
+
+- type: entity
+  parent: [ BorgHypo, BaseXenoborgContraband ]
   id: NocturineHypoPlus
   name: extended nocturine hypo
   description: A self-refilling injector for rapid administration of nocturine to victims. Has 1.5x the storage of the base one.
@@ -36,44 +56,4 @@
     generated:
       reagents:
       - ReagentId: Nocturine
-        Quantity: 0.2
-
-- type: entity
-  parent: [ BorgHypo, BaseXenoborgContraband ]
-  id: TazinideHypo
-  name: tazinide hypo
-  description: A self-refilling injector for rapid administration of tazinide to victims.
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      hypospray:
-        maxVol: 8
-        reagents:
-        - ReagentId: Tazinide
-          Quantity: 8
-  - type: SolutionRegeneration
-    solution: hypospray
-    generated:
-      reagents:
-      - ReagentId: Tazinide
-        Quantity: 0.1 # Recharge slower
-
-- type: entity
-  parent: [ BorgHypo, BaseXenoborgContraband ]
-  id: MuteToxinHypo
-  name: mute toxin hypo
-  description: A self-refilling injector for rapid administration of mute toxin to victims.
-  components:
-  - type: SolutionContainerManager
-    solutions:
-      hypospray:
-        maxVol: 8
-        reagents:
-        - ReagentId: MuteToxin
-          Quantity: 8
-  - type: SolutionRegeneration
-    solution: hypospray
-    generated:
-      reagents:
-      - ReagentId: MuteToxin
         Quantity: 0.2

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/xenoborgs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/xenoborgs.yml
@@ -22,15 +22,15 @@
   parent: [ BorgHypo, BaseXenoborgContraband ]
   id: NocturineHypoPlus
   name: extended nocturine hypo
-  description: A self-refilling injector for rapid administration of nocturine to victims. Has double the storage of the other one.
+  description: A self-refilling injector for rapid administration of nocturine to victims. Has 1.5x the storage of the base one.
   components:
   - type: SolutionContainerManager
     solutions:
       hypospray:
-        maxVol: 24
+        maxVol: 18
         reagents:
         - ReagentId: Nocturine
-          Quantity: 24
+          Quantity: 18
   - type: SolutionRegeneration
     solution: hypospray
     generated:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/xenoborgs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/xenoborgs.yml
@@ -7,10 +7,10 @@
   - type: SolutionContainerManager
     solutions:
       hypospray:
-        maxVol: 12
+        maxVol: 8
         reagents:
         - ReagentId: Licoxide
-          Quantity: 12
+          Quantity: 8
   - type: SolutionRegeneration
     solution: hypospray
     generated:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/xenoborgs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/xenoborgs.yml
@@ -47,16 +47,16 @@
   - type: SolutionContainerManager
     solutions:
       hypospray:
-        maxVol: 12
+        maxVol: 8
         reagents:
         - ReagentId: Tazinide
-          Quantity: 12
+          Quantity: 8
   - type: SolutionRegeneration
     solution: hypospray
     generated:
       reagents:
       - ReagentId: Tazinide
-        Quantity: 0.2
+        Quantity: 0.1 # Recharge slower
 
 - type: entity
   parent: [ BorgHypo, BaseXenoborgContraband ]

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1058,11 +1058,9 @@
   id: WeaponLaserCannonXenoborgCold
   name: xenoborg bitterfrost cannon
   components:
-  # region starlight - fix xenoborg cannon's absurdly low fire cost.
   - type: BatteryAmmoProvider
     proto: FreezeRay
-    fireCost: 100
-  # end region starlight
+    fireCost: 150
   - type: BatterySelfRecharger
     autoRechargeRate: 30
   # "remove" wield bonus and penalty so borgs can use it

--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/xenoborgs.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/xenoborgs.yml
@@ -14,9 +14,10 @@
   materials:
     Steel: 2500
     Glass: 2500
-    Plastic: 1000
+    Plastic: 1250
+    Plasma: 500
 
-# TODO: When we get xenoborg crystals, make this and all other tier 3s cost 1 and a half crystals. Plastic's moderately hard for them to get, they'll have to salvage or steal cargo shipments.
+# TODO: When we get xenoborg crystals, make this and all other tier 3s cost 1.5 - 2 crystals. Plastic and Plasma are moderately hard for them to get, they'll have to salvage or steal cargo shipments.
 
 ## Scout Xenoborg Modules
 - type: latheRecipe
@@ -26,7 +27,8 @@
   materials:
     Steel: 2500
     Glass: 2500
-    Plastic: 1000
+    Plastic: 1250
+    Plasma: 500
 
 ## Stealth Xenoborg Modules
 - type: latheRecipe
@@ -37,3 +39,4 @@
     Steel: 2500
     Glass: 2500
     Plastic: 1000
+    Plasma: 500

--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/xenoborgs.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/xenoborgs.yml
@@ -14,7 +14,7 @@
   materials:
     Steel: 2500
     Glass: 2500
-    Plastic: 1250
+    Plastic: 1500
     Plasma: 500
 
 # TODO: When we get xenoborg crystals, make this and all other tier 3s cost 1.5 - 2 crystals. Plastic and Plasma are moderately hard for them to get, they'll have to salvage or steal cargo shipments.
@@ -27,7 +27,7 @@
   materials:
     Steel: 2500
     Glass: 2500
-    Plastic: 1250
+    Plastic: 1500
     Plasma: 500
 
 ## Stealth Xenoborg Modules
@@ -38,5 +38,5 @@
   materials:
     Steel: 2500
     Glass: 2500
-    Plastic: 1000
+    Plastic: 1500
     Plasma: 500


### PR DESCRIPTION
## Short description
Nerfs some of the T3 modules.

## Why we need to add this
Balancing.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: T3 Xenoborg Modules and the Advanced Hypo module now cost a little more plastic, and also cost Plasma.
- tweak: Bitterfrost Cannon now consumes 50% more charge per shot.
- tweak: Extended Nocturine Hypo now only stores up to 18u.
- tweak: Licoxide Hypo now only stores up to 8u.
- tweak: Advanced Hypo module now has a 12u Licoxide hypo instead of Tazinide and Mute Toxin.

