### PR TITLE
remove terminator damnation for now

### DIFF
--- a/Content.Shared/_Starlight/Devil/DevilComponent.cs
+++ b/Content.Shared/_Starlight/Devil/DevilComponent.cs
@@ -38,7 +38,6 @@ public sealed partial class DevilComponent : Component
         "Time",
         "Organ",
         "Power",
-        "Terminator",
         "Gun",
         "Electricity",
         "Noslip",


### PR DESCRIPTION
## Short description
Removes terminator damnation from the list of damnations devil can apply
type still exists in code, just not allowed

## Why we need to add this
Reducing its point value wasnt enough, had a round where players on beta spawned like 7 of them or something
Devil is meant to be an antag that enhances randomness of existing antags, it shouldnt serve as an infinite spawner of new antags

Once I actually have time (1 month from now) I'll go through and either make it limited in number (ie can only do one terminator) or just remove it from the code entirely

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- remove: Disallow Terminator damnation for now, until I either rework or remove it - too many terminator spam rounds when devil is playtested.
