### PR TITLE
Make Scream second in Action bar priority.

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -59,6 +59,7 @@
   components:
   - type: Action
     useDelay: 10
+    priority: -99
     icon: Interface/Actions/scream.png
     checkCanInteract: false
   - type: InstantAction

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -59,7 +59,7 @@
   components:
   - type: Action
     useDelay: 10
-    priority: -99
+    priority: -99 # Starlight - Make Scream second in Action bar priority.
     icon: Interface/Actions/scream.png
     checkCanInteract: false
   - type: InstantAction


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Scream should always be on button 2. I'm sick and tired of having to move it cause of other species actions.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
If you think it shouldn't be on number 2, then I am sorry about your opinion being wrong. I hope you can get help.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="445" height="177" alt="image" src="https://github.com/user-attachments/assets/881cf37d-a0ce-41db-83c8-5c1e5f972fd7" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Huaqas
- tweak: Scream should always appear second in the action bar priority.
