### PR TITLE
Makes Cluwne Fix 50%

### DIFF
--- a/Content.Server/Bible/Components/BibleComponent.cs
+++ b/Content.Server/Bible/Components/BibleComponent.cs
@@ -66,10 +66,10 @@ namespace Content.Server.Bible.Components
         //#region Starlight
 
         /// <summary>
-        /// what is the chance a successfull bible thwack removes the cluwning.
+        /// Chance that a successful bible thwack removes cluwning.
         /// </summary>
         [DataField]
-        public float CluwneCureChance = 0.03f;
+        public float CluwneCureChance = 0.50f;
 
         /// <summary>
         /// if a item has this tag. the unremovable comp is ignored when dropping the item.


### PR DESCRIPTION
## Short description
Hitting a cluwne with a bible is a 50% chance to fix, instead of a 3%.

## Why we need to add this
[Bug report](https://discord.com/channels/1272545509562777621/1507853632941588690) + this would streamline gameplay significantly, and make Chaplains less stressed during a mass cluwning.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- fix: Makes bibles uncluwn with a 50% chance, instead of a 3% chance.
