### PR TITLE
Fix terror spiders rule

### DIFF
--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -35,13 +35,22 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
             return;
 
         var query = QueryAllRules();
-        while (query.MoveNext(out var uid, out _, out var gameRule))
+        while (query.MoveNext(out var uid, out var rule, out var gameRule))
         {
             var minPlayers = gameRule.MinPlayers;
             var name = ToPrettyString(uid);
 
             if (args.Players.Length >= minPlayers)
                 continue;
+
+            // Starlight-start
+            if (!StartAttempt(uid, rule, gameRule, args, out var reason))
+            {
+                ChatManager.SendAdminAnnouncement(Loc.GetString("preset-cant-start", ("reason", reason)));
+                args.Cancel();
+                Log.Info($"Rule '{name}' can't start with reason: {reason}");
+            }
+            // Starlight-end
 
             if (gameRule.CancelPresetOnTooFewPlayers)
             {
@@ -146,4 +155,15 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
             ActiveTick(uid, comp1, comp2, frameTime);
         }
     }
+
+    #region Starlight
+    /// <summary>
+    /// Called when trying to start this gamerule.
+    /// </summary>
+    protected virtual bool StartAttempt(EntityUid uid, T component, GameRuleComponent gameRule, RoundStartAttemptEvent args, out string reason)
+    {
+        reason = "";
+        return true;
+    }
+    #endregion
 }

--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -44,7 +44,7 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
                 continue;
 
             // Starlight-start
-            if (!StartAttempt(uid, rule, gameRule, args, out var reason))
+            if (!CanStartRule(uid, rule, gameRule, args, out var reason))
             {
                 ChatManager.SendAdminAnnouncement(Loc.GetString("preset-cant-start", ("reason", reason)));
                 args.Cancel();
@@ -160,7 +160,7 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
     /// <summary>
     /// Called when trying to start this gamerule.
     /// </summary>
-    protected virtual bool StartAttempt(EntityUid uid, T component, GameRuleComponent gameRule, RoundStartAttemptEvent args, out string reason)
+    protected virtual bool CanStartRule(EntityUid uid, T component, GameRuleComponent gameRule, RoundStartAttemptEvent args, out string reason)
     {
         reason = "";
         return true;

--- a/Content.Server/_Starlight/GameTicking/Rules/TerrorSpiderRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/TerrorSpiderRuleSystem.cs
@@ -25,7 +25,6 @@ public sealed partial class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpider
     [Dependency] private RoundEndSystem _roundEnd = default!;
     [Dependency] private ChatSystem _chatSystem = default!;
     [Dependency] private IPlayerManager _player = default!;
-    [Dependency] private EntityQueryEnumerator<MetaDataComponent, TerrorSpiderComponent> _terrorSpiders = default!;
     [Dependency] private EntityQuery<TerrorSpiderRuleComponent> _rules = default!;
 
     /// <summary>
@@ -39,7 +38,7 @@ public sealed partial class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpider
     {
         CheckLoseStatus(out var percentage);
         reason = "Can't run terror spiders rule when more than 40% crew is already died!";
-        return percentage >= 40; // If there's more than 40% died players - don't run this rule.
+        return percentage < 40; // If there's more than 40% died players - don't run this rule.
     }
 
     public override void Initialize()
@@ -55,6 +54,13 @@ public sealed partial class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpider
     {
         base.Started(uid, component, gameRule, args);
         ActiveRulesCount++;
+    }
+
+    protected override void Ended(EntityUid uid, TerrorSpiderRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
+    {
+        base.Ended(uid, component, gameRule, args);
+        if (ActiveRulesCount > 0)
+            ActiveRulesCount--;
     }
 
     private void OnGetBriefing(Entity<TerrorPrincessComponent> ent, ref GetBriefingEvent args)
@@ -86,7 +92,8 @@ public sealed partial class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpider
 
         args.AddLine(Loc.GetString("terrorspiders-list-start"));
 
-        while (_terrorSpiders.MoveNext(out var spider, out var metaData, out _))
+        var query = EntityQueryEnumerator<MetaDataComponent, TerrorSpiderComponent>();
+        while (query.MoveNext(out var spider, out var metaData, out _))
         {
             if (!_player.TryGetSessionByEntity(spider, out var session))
                 continue;

--- a/Content.Server/_Starlight/GameTicking/Rules/TerrorSpiderRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/TerrorSpiderRuleSystem.cs
@@ -34,7 +34,7 @@ public sealed partial class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpider
 
     private int ActiveRulesCount = 0;
 
-    protected override bool StartAttempt(EntityUid uid, TerrorSpiderRuleComponent component, GameRuleComponent gameRule, RoundStartAttemptEvent args, out string reason)
+    protected override bool CanStartRule(EntityUid uid, TerrorSpiderRuleComponent component, GameRuleComponent gameRule, RoundStartAttemptEvent args, out string reason)
     {
         CheckLoseStatus(out var percentage);
         reason = "Can't run terror spiders rule when more than 40% crew is already died!";

--- a/Content.Server/_Starlight/GameTicking/Rules/TerrorSpiderRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/TerrorSpiderRuleSystem.cs
@@ -1,38 +1,60 @@
 using Content.Server._Starlight.Antags.Components;
 using Content.Server._Starlight.GameTicking.Rules.Components;
 using Content.Server.Chat.Systems;
+using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
+using Content.Server.Mind;
 using Content.Server.Roles;
 using Content.Server.RoundEnd;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Systems;
 using Content.Shared._Starlight.Antags.TerrorSpider;
+using Content.Shared.GameTicking.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
+using Robust.Server.Player;
 using Robust.Shared.Audio;
-using Robust.Shared.Player;
 using Robust.Shared.Timing;
 
 namespace Content.Server._Starlight.GameTicking.Rules;
 
-public sealed class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpiderRuleComponent>
+public sealed partial class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpiderRuleComponent>
 {
-    [Dependency] private readonly StationSystem _stationSystem = default!;
-    [Dependency] private readonly EmergencyShuttleSystem _emergencyShuttle = default!;
-    [Dependency] private readonly RoundEndSystem _roundEnd = default!;
-    [Dependency] private readonly ChatSystem _chatSystem = default!;
+    [Dependency] private StationSystem _stationSystem = default!;
+    [Dependency] private EmergencyShuttleSystem _emergencyShuttle = default!;
+    [Dependency] private RoundEndSystem _roundEnd = default!;
+    [Dependency] private ChatSystem _chatSystem = default!;
+    [Dependency] private IPlayerManager _player = default!;
+    [Dependency] private EntityQueryEnumerator<MetaDataComponent, TerrorSpiderComponent> _terrorSpiders = default!;
+    [Dependency] private EntityQuery<TerrorSpiderRuleComponent> _rules = default!;
 
     /// <summary>
     /// How much of the crew needs to be dead for the spiders to win.
     /// </summary>
     private const int TargetDeadCrewPercentage = 70;
 
+    private int ActiveRulesCount = 0;
+
+    protected override bool StartAttempt(EntityUid uid, TerrorSpiderRuleComponent component, GameRuleComponent gameRule, RoundStartAttemptEvent args, out string reason)
+    {
+        CheckLoseStatus(out var percentage);
+        reason = "Can't run terror spiders rule when more than 40% crew is already died!";
+        return percentage >= 40; // If there's more than 40% died players - don't run this rule.
+    }
+
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<StationCrewComponent, MobStateChangedEvent>(OnCrewMobStateChanged);
+        SubscribeLocalEvent<TerrorPrincessComponent, MobStateChangedEvent>(OnPrincessStateChanged);
         SubscribeLocalEvent<TerrorPrincessComponent, GetBriefingEvent>(OnGetBriefing);
+    }
+
+    protected override void Started(EntityUid uid, TerrorSpiderRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+        ActiveRulesCount++;
     }
 
     private void OnGetBriefing(Entity<TerrorPrincessComponent> ent, ref GetBriefingEvent args)
@@ -40,13 +62,42 @@ public sealed class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpiderRuleComp
 
     private void OnCrewMobStateChanged(EntityUid uid, StationCrewComponent component, MobStateChangedEvent args)
     {
-        if (args.NewMobState is MobState.Dead or MobState.Invalid)
+        if (ActiveRulesCount > 0 && args.NewMobState is MobState.Dead or MobState.Invalid)
             ProcessLose();
+    }
+
+    private void OnPrincessStateChanged(EntityUid uid, TerrorPrincessComponent component, MobStateChangedEvent args)
+    {
+        var query = EntityQueryEnumerator<TerrorPrincessComponent, MobStateComponent>();
+        var count = 0;
+        while (query.MoveNext(out var princess, out _, out var state))
+        {
+            if (state.CurrentState is MobState.Alive)
+                count++;
+        }
+
+        if (count == 0 && ActiveRulesCount > 0)
+            ActiveRulesCount--;
+    }
+
+    protected override void AppendRoundEndText(EntityUid uid, TerrorSpiderRuleComponent component, GameRuleComponent gameRule, ref RoundEndTextAppendEvent args)
+    {
+        args.AddLine(Loc.GetString($"terrorspiders-win"));
+
+        args.AddLine(Loc.GetString("terrorspiders-list-start"));
+
+        while (_terrorSpiders.MoveNext(out var spider, out var metaData, out _))
+        {
+            if (!_player.TryGetSessionByEntity(spider, out var session))
+                continue;
+            args.AddLine(Loc.GetString("terrorspiders-list-name-user", ("name", metaData.EntityName), ("user", session.Name)));
+        }
+        args.AddLine("");
     }
 
     private void ProcessLose()
     {
-        if (CheckLoseStatus())
+        if (CheckLoseStatus(out _))
         {
             _roundEnd.CancelRoundEndCountdown(null, false);
             var query = EntityQueryEnumerator<TerrorSpiderRuleComponent>();
@@ -105,8 +156,9 @@ public sealed class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpiderRuleComp
         }
     }
 
-    private bool CheckLoseStatus()
+    private bool CheckLoseStatus(out float percentage)
     {
+        percentage = 0;
         var crewList = new List<EntityUid>();
 
         var crew = EntityQueryEnumerator<StationCrewComponent>();
@@ -117,7 +169,8 @@ public sealed class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpiderRuleComp
             return false;
 
         var crewDeadAmount = CheckGroupStatus(crewList);
-        return crewDeadAmount * 100 / crewList.Count >= TargetDeadCrewPercentage;
+        percentage = crewDeadAmount * 100 / crewList.Count;
+        return percentage >= TargetDeadCrewPercentage;
     }
 
     /// <summary>
@@ -131,7 +184,7 @@ public sealed class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpiderRuleComp
         var gone = 0;
         foreach (var ent in entities)
         {
-            if (EntityManager.TryGetComponent(ent, out MobStateComponent? mobState) && mobState.CurrentState is MobState.Dead or MobState.Invalid)
+            if (TryComp<MobStateComponent>(ent, out var mobState) && mobState.CurrentState is MobState.Dead or MobState.Invalid)
                 gone++;
             else if (checkOffStation && _stationSystem.GetOwningStation(ent) == null && !_emergencyShuttle.EmergencyShuttleArrived)
                 gone++;

--- a/Content.Shared/_Starlight/Antags/TerrorSpider/TerrorSpiderComponents.cs
+++ b/Content.Shared/_Starlight/Antags/TerrorSpider/TerrorSpiderComponents.cs
@@ -44,6 +44,11 @@ public sealed partial class TerrorPrincessComponent : Component
     public EntityUid? LayEggAction = null;
 }
 
+[RegisterComponent]
+public sealed partial class TerrorSpiderComponent : Component
+{
+}
+
 #endregion
 
 #region BUI

--- a/Resources/Locale/en-US/_Starlight/game-ticking/game-presets/preset-terror-spiders.ftl
+++ b/Resources/Locale/en-US/_Starlight/game-ticking/game-presets/preset-terror-spiders.ftl
@@ -9,3 +9,7 @@ terror-spider-princess-briefing =
     Read more about your role in the guidebook entry.
 
 central-command-terror-spiders-announcement = Based on scans from our long-range sensors, we believe the station has fallen under the control of hostile spider forces. Most personnel have been confirmed deceased, missing, or to have abandoned the station. All remaining crew members are to stand by for further instructions.
+
+terrorspiders-win = [color=crimson]Terror Spiders major victory![/color]
+terrorspiders-list-start = Terror Spiders were:
+terrorspiders-list-name-user = [color=White]{$name}[/color] ([color=gray]{$user}[/color])


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Fixes bugs:

When terror spiders rule can be spawned after 50% died players and they insta win.
When terror spiders can win without active rule.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

bugfix

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rinary
- fix: Fixed bug when terror spiders win without active rule.
- fix: Fixed bug when terror spiders can be spawned after 50% died players, so they instantly win. Now they spawn only if there's 60% alive crew.