### PR TITLE
Made Security Turnstiles take structural damage

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
@@ -45,8 +45,8 @@
       - Pullable # no dragging things in
   - type: Appearance
   - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StrongMetallic # Starlight - they really should take structural damage
+    damageContainer: StructuralInorganic # Starlight - they really should take structural damage
+    damageModifierSet: StrongMetallic
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
@@ -45,8 +45,8 @@
       - Pullable # no dragging things in
   - type: Appearance
   - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: StrongMetallic
+    damageContainer: StructuralInorganic
+    damageModifierSet: StrongMetallic # Starlight - they really should take structural damage
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
Made no sense otherwise, they were the most cost effective barrier

## Short description
Made Security Turnstiles take Structural damage

## Why we need to add this
Security Turnstiles take 3 steel to construct, which gives you a 500 HP barrier that took no structural damage. Needing 47 breaching hammer hits and tons of ammo to bring down. Given how cheap it is to construct it can be very annoying to deal with when spammed. Also being a security turnstile, they were made significantly difficult to deconstruct, both in steps, tools and doafters.
https://discord.com/channels/1272545509562777621/1302787783135596604

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl:
- tweak: Turnstiles now take Structural Damage.
