### PR TITLE
Species Durability

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -16,13 +16,10 @@
         knockback: 0.5
         staminaMultiplier: 100
       Resomi:
-        knockback: 0.01
-        staminaMultiplier: 100
-      Avali:
-        knockback: 0.005 # half of what resomi take
+        knockback: 0.005
         staminaMultiplier: 100
       Felionoid:
-        knockback: 0.005 # half of what resomi take
+        knockback: 0.005
         staminaMultiplier: 100
   - type: Sprite
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -16,10 +16,7 @@
         knockback: 0.5
         staminaMultiplier: 100
       Resomi:
-        knockback: 0.02
-        staminaMultiplier: 100
-      Avali:
-        knockback: 0.01 # half of what resomi take
+        knockback: 0.01
         staminaMultiplier: 100
       Felionoid:
         knockback: 0.01 #half of what resomi take

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -16,13 +16,10 @@
         knockback: 5
         staminaMultiplier: 20
       Resomi:
-        knockback: 10
-        staminaMultiplier: 8
-      Avali:
-        knockback: 5 # half of what resomi take
+        knockback: 5
         staminaMultiplier: 8
       Felionoid:
-        knockback: 5 # half of what resomi take
+        knockback: 5
         staminaMultiplier: 8
   - type: Sprite
   - type: Clothing
@@ -141,11 +138,9 @@
       Skating:
         knockback: -2.5
       Resomi:
-        knockback: -5
-      Avali:
-        knockback: -2.5 # half of what resomi take
+        knockback: -2.5
       Felionoid:
-        knockback: -2.5 # half of what resomi take
+        knockback: -2.5
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/rocket.rsi
     layers:
@@ -182,10 +177,7 @@
   - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
-        knockback: 10
-        staminaMultiplier: 8
-      Avali:
-        knockback: 5 # half of what resomi take
+        knockback: 5
         staminaMultiplier: 8
       Felionoid:
         knockback: 5 # half of what resomi take

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -16,9 +16,7 @@
         knockback: 1.0
         staminaMultiplier: 100
       Resomi:
-        knockback: 0.1
-      Avali:
-        knockback: 0.05 # Bigger bird, more sturdy bones.. or something.
+        knockback: 0.05
       Felionoid:
         knockback: 0.05 #half of what resomi take
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -16,10 +16,7 @@
         knockback: 2
         staminaMultiplier: 50
       Resomi:
-        knockback: 3
-        staminaMultiplier: 20
-      Avali:
-        knockback: 1 # half of what resomi take
+        knockback: 1.5
         staminaMultiplier: 20
       Felionoid:
         knockback: 1.5 #half of what resomi take

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -16,10 +16,7 @@
         knockback: 2.0
         staminaMultiplier: 50
       Resomi:
-        knockback: 4
-        staminaMultiplier: 15
-      Avali:
-        knockback: 2 # half of what resomi take
+        knockback: 2
         staminaMultiplier: 15
       Felionoid:
         knockback: 2 #half of what resomi take
@@ -76,11 +73,9 @@
   - type: KnockbackByUserTag # Starlight
     doestContain:
       Resomi:
-        knockback: 2
-      Avali:
-        knockback: 1 # half of what resomi take
+        knockback: 1
       Felionoid:
-        knockback: 1 # half of what resomi take
+        knockback: 1
   - type: BallisticAmmoProvider # Starlight
     capacity: 10
     proto: CartridgeMagnumSP

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -342,8 +342,8 @@
           inverted: true
         damage:
           types:
-            Asphyxiation: -1
-            Bloodloss: -0.5
+            Asphyxiation: -0.5
+            Bloodloss: -0.25
       - !type:HealthChange
         conditions:
           - !type:ReagentCondition
@@ -359,9 +359,9 @@
           type: [ Avali, Resomi ]
         damage:
           types:
-            Poison: 1.5 #Avali and Resomi blood is ammonia based, so chems made to treat normal bloodloss poison them instead (Lethal Dose: 20u)
-            Asphyxiation: 1
-            Bloodloss: 1
+            Poison: 0.75 #Avali and Resomi blood is ammonia based, so chems made to treat normal bloodloss poison them instead (Lethal Dose: 40u)
+            Asphyxiation: 0.5
+            Bloodloss: 0.5
       # Starlight-Start: Cyclorite Metabolism
       - !type:AdjustReagent
         conditions:
@@ -389,8 +389,8 @@
           inverted: true
         damage:
           types:
-            Asphyxiation: -3.5
-            Bloodloss: -3
+            Asphyxiation: -1.75
+            Bloodloss: -1.5
       - !type:AdjustReagent
         conditions:
         - !type:ReagentCondition
@@ -413,9 +413,9 @@
           type: [ Avali, Resomi ]
         damage:
           types:
-            Poison: 2.5 #Avali and Resomi blood is ammonia based, so chems made to treat normal bloodloss poison them instead. Dex+ is worse. (Lethal Dose: 15u)
-            Asphyxiation: 1.5
-            Bloodloss: 1
+            Poison: 1.25 #Avali and Resomi blood is ammonia based, so chems made to treat normal bloodloss poison them instead. Dex+ is worse. (Lethal Dose: 30u)
+            Asphyxiation: 0.75
+            Bloodloss: 0.5
       # Starlight-Start: Cyclorite Metabolism
       - !type:AdjustReagent
         conditions:
@@ -920,15 +920,15 @@
           - !type:MetabolizerTypeCondition
             type: [ Avali, Resomi ]
             inverted: true
-          amount: 6
+          amount: 3
         - !type:HealthChange
           conditions:
           - !type:MetabolizerTypeCondition
            type: [ Avali, Resomi ]
           damage:
             types:
-              Caustic: 2 # 30 damage per unit was ridiculous, but I'm leaving some damage to punish mistakes without risking round removal. Adding salt to water shouldn't suddenly make it the strongest toxin in the game by far.
-              Heat: 2
+              Caustic: 1 # 30 damage per unit was ridiculous, but I'm leaving some damage to punish mistakes without risking round removal. Adding salt to water shouldn't suddenly make it the strongest toxin in the game by far.
+              Heat: 1
         # Starlight-Start: Cyclorite Metabolism
         - !type:AdjustReagent
           conditions:

--- a/Resources/Prototypes/_Starlight/Admeme/minigunracing.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/minigunracing.yml
@@ -11,7 +11,7 @@
         knockback: 0.2
         staminaMultiplier: 0.0
       Resomi:
-        knockback: 0.02
+        knockback: 0.01
         staminaMultiplier: 0.0
       Avali:
         knockback: 0.01

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/avali.yml
@@ -77,8 +77,8 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        90: Critical
-        180: Dead
+        95: Critical
+        190: Dead
     - type: Fixtures
       fixtures:
         fix1:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/diona.yml
@@ -16,8 +16,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      95: Critical
-      190: Dead
+      110: Critical
+      220: Dead
   # Starlight-end
   - type: Absorbable
   - type: Tag

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/diona.yml
@@ -13,6 +13,11 @@
     understands:
     - GalacticCommon
     - Sylvan
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      95: Critical
+      190: Dead
   # Starlight-end
   - type: Absorbable
   - type: Tag

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/resomi.yml
@@ -84,8 +84,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      85: Critical
-      170: Dead
+      90: Critical
+      180: Dead
   - type: SlowOnDamage
     speedModifierThresholds:
       51: 0.7  #Basicly 60% and 80%

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -25,9 +25,7 @@
         knockback: 1.0
         staminaMultiplier: 100
       Resomi:
-        knockback: 1.5
-      Avali:
-        knockback: 0.75 # half of what resomi take
+        knockback: 0.75
       Felionoid:
         knockback: 0.75 # half of what resomi take
   - type: BallisticAmmoProvider

--- a/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
@@ -9,6 +9,7 @@
   They get hungry and thirsty slower.
   Their "blood" is tree sap and can't be metabolised from Iron.
   Being plants, Weed Killer poisons them, while Robust Harvest heals them (but not without risk when overused!)
+  In addition to this, Diona are quite resilient, having 10% more health than Humans.
 
   They take [color=#1e90ff]30% less Blunt damage and 20% less Slash damage[/color];
   but [color=#ffa500]50% more Heat damage, 20% more Shock damage, and they can easily

--- a/Resources/ServerInfo/_StarLight/Guidebook/Mobs/Avali.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Mobs/Avali.xml
@@ -21,5 +21,5 @@
   - Can only eat meat-related food items (including organs) and pills.
   - Heal airloss from Ammonia and Amoxla but..
   - Saline will burn you, and both Dexalin and Dexalin+ are lethal to you. Remember to remind doctors about it!
-  - Fall into crit at 90 and dead at 180.
+  - Fall into crit at 95 and dead at 190.
 </Document>

--- a/Resources/ServerInfo/_StarLight/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Mobs/Resomi.xml
@@ -50,7 +50,7 @@
   These attacks deal [color=red]5[/color] points of Slash damage with a hit rate that is the same as humans fists attack.
 
   ## Weapon Knockback
-  Resomi are very lightweight, and as such take so much knockback from large caliber weapons that they get pushed around.
+  Resomi are very lightweight, and as such take knockback from large caliber weapons that they get pushed around.
   Resomi also will receive [color=yellow]Stun Damage[/color] from large caliber weapons for each shot.
   In general, the weapons that will give you knockback are [color=yellow]Rifles, Sniper Rifles, Shotguns, LMGs, HMGs, and Grenade Launchers.[/color]
   Look out especially on Rocket launchers, as since they are recoil-less, you will actually get [color=red]pulled forward with the rocket[/color] for a short distance.

--- a/Resources/ServerInfo/_StarLight/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/_StarLight/Guidebook/Mobs/Resomi.xml
@@ -40,7 +40,7 @@
   Flashes will take [color=yellow]2[/color] times as long as normal for other species, lasting up to [color=#ffa500]10[/color] seconds in the case of a localized flash.
 
   ## Health
-  Resomi have lower health due to their small stature, falling into a critical state at [color=#ffa500]85[/color] points of damage and dying at [color=#ffa500]170[/color] points of damage.
+  Resomi have lower health due to their small stature, falling into a critical state at [color=#ffa500]90[/color] points of damage and dying at [color=#ffa500]180[/color] points of damage.
   Resomi also prefer colder temperatures compared to humans, being roughly akin to Moths.
   Resomi heal airloss from [color=cyan]Ammonia[/color] and [color=cyan]Amoxla[/color]. [color=red]Saline[/color] will burn them, and both [color=red]Dexalin[/color] and [color=red]Dexalin+[/color] are lethal to them. Remember to remind doctors about this!
   Resomi can also withstand in temperatures of up to [color=#1e90ff]-50c before taking cold damage[/color].


### PR DESCRIPTION
## Short description
Removes some drawbacks on the species with hivemind. Merge with [#4549](https://github.com/ss14Starlight/space-station-14/pull/4549).

## Why we need to add this
Lose one thing, have to gain something in return.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: medwia
- remove: Avali no longer take increased knockback from firearms.
- tweak: Resomi now take equal knockback to Felionoids.
- tweak: Resomi and Avali now have 5 more health/crit at 10 higher.
- tweak: Diona now have 10 more health/crit at 20 higher, like Dwarves.
- tweak: Saline, Dexalin, and DexalinPlus are now half as lethal against those poisoned by it.
