### PR TITLE
Fix Implant Gibbing

### DIFF
--- a/Content.Server/_Starlight/Medical/Surgery/OrganSystem.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/OrganSystem.cs
@@ -3,6 +3,7 @@ using Content.Server._Starlight.Language;
 using Content.Server.Humanoid;
 using Content.Shared.Actions;
 using Content.Shared.CollectiveMind;
+using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Eye.Blinding.Components;
@@ -19,6 +20,7 @@ using Content.Shared.Starlight.Medical.Surgery.Steps.Parts;
 using Content.Shared.Tag;
 using Content.Shared.VentCrawl;
 using Robust.Shared.Containers;
+using Content.Shared.FixedPoint;
 using Robust.Shared.Timing;
 
 namespace Content.Server._Starlight.Medical.Surgery;
@@ -165,9 +167,16 @@ public sealed partial class OrganSystem : EntitySystem
 
     private void OnOrganImplanted(Entity<DamageableComponent> ent, ref SurgeryOrganImplantationCompleted args)
     {
-        if (!TryComp<DamageableComponent>(args.Body, out var bodyDamageable)) return;
+        if (!TryComp<OrganDamageComponent>(ent.Owner, out var damageRule)
+         || damageRule.Damage is null
+         || !TryComp<DamageableComponent>(args.Body, out _))
+            return;
 
-        var change = _damageableSystem.ChangeDamage(args.Body, ent.Comp.Damage, true, false);
+        var transferredDamage = GetImplantTransferredDamage(ent.Comp.Damage, damageRule.Damage);
+        if (transferredDamage.Empty)
+            return;
+
+        var change = _damageableSystem.ChangeDamage(args.Body, transferredDamage, true, false);
         if (change is not null)
             _damageableSystem.ChangeDamage(ent.Owner, change.Invert(), true, false);
     }
@@ -191,6 +200,24 @@ public sealed partial class OrganSystem : EntitySystem
         if (ent.Comp.Organ == AbductorOrganType.Vent)
             AddComp<VentCrawlerComponent>(args.Body);
     }
+
+    private static DamageSpecifier GetImplantTransferredDamage(DamageSpecifier organDamage, DamageSpecifier limit)
+    {
+        var transferredDamage = new DamageSpecifier();
+
+        foreach (var (type, maxAmount) in limit.DamageDict)
+        {
+            if (!organDamage.DamageDict.TryGetValue(type, out var currentDamage)
+             || currentDamage <= FixedPoint2.Zero
+             || maxAmount <= FixedPoint2.Zero)
+                continue;
+
+            transferredDamage.DamageDict[type] = FixedPoint2.Min(currentDamage, maxAmount);
+        }
+
+        return transferredDamage;
+    }
+
     private void OnAbductorOrganExtracted(Entity<AbductorOrganComponent> ent, ref SurgeryOrganExtracted args)
     {
         if (TryComp<AbductorVictimComponent>(args.Body, out var victim))


### PR DESCRIPTION

## Short description
<!-- What do you propose to change with your PR? -->
Clamps organ implanted damage transfer to defined maximums and only damage types defined in that rule.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Currently organs will transfer all their damage when implanted leading to someone instantly gibbing when an organ with high damage is implanted (ie from explosions or similar) 

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
No media needed. 

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: FeralCreature
- fix: Implants (and other organs) are no longer capable of instantly gibbing you when implanted.
