### PR TITLE
Make the Secure Terminal actually summon the Emergency Medical Pod

### DIFF
--- a/Resources/Prototypes/_Starlight/secureterminal_requests.yml
+++ b/Resources/Prototypes/_Starlight/secureterminal_requests.yml
@@ -383,8 +383,8 @@
   activationDelaySecs: 300
   fee: 5000
   salaryPenalty: 0.05
-  actionType: GameRule
-  gameruleId: ERTMedicalShuttleSpawn
+  actionType: Armory
+  armoryKey: medical
   sortOrder: 30
   authGroups:
     - [Captain, ChiefMedicalOfficer]


### PR DESCRIPTION
## Short description
The secure terminal has been in the server for a little under a month now, and since it was merged, the Emergency Medical Pod hasn't worked. 

This is because the way the Emergency Medical Pod option currently works is that it adds the ERTMedicalShuttleSpawn Gamerule, and this is wrong for two reasons.

1. It spawns an empty shuttle, in a different map that no one can get to without admin intervention, making it so the Shuttle is stuck in place for the entire game with absolutely no benefit whatsoever to the station.
2. But what I said just above is irrelevant, because its supposed to be an Emergency Medical Pod, not an ERT Medical Shuttle.

Not only that, but the Emergency Medical Pod is classified as an armory, and like the Gamma and Psi armories, its already spawned in, and only needs to be deployed.

## Why we need to add this
Because the Emergency Medical Pod option in the Secure Terminal is useless as of right now, and just a credit sink for whoever doesn't know that it doesn't work.

## Media (Video/Screenshots)
(Sorry, but github says its too big to be posted)
https://medal.tv/games/requested/clips/mMBlTyabyZ-U9dUMR

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RubiconLocked
- fix: The Emergency Medical Pod option of the Secure Terminal now correctly deploys an Emergency Medical Pod.
