### PR TITLE
Activate posi on Ion Storm

### DIFF
--- a/Content.Server/Ghost/Roles/Components/ToggleableGhostRoleComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/ToggleableGhostRoleComponent.cs
@@ -86,4 +86,37 @@ public sealed partial class ToggleableGhostRoleComponent : Component
     /// </summary>
     [DataField("job")]
     public ProtoId<JobPrototype>? JobProto;
+
+    #region Starlight
+    /// <summary>
+    /// Event prototype IDs that can automatically toggle this ghost role.
+    /// </summary>
+    [DataField]
+    public List<string> ToggleOnEvents = [];
+
+    /// <summary>
+    /// What the event should do when toggling this ghost role.
+    /// </summary>
+    [DataField]
+    public EventToggleMode ToggleOnEventMode = EventToggleMode.Activate;
+
+    /// <summary>
+    /// Chance for the station event to toggle this ghost role.
+    /// 1 = always, 0.5 = 50%, 0 = never.
+    /// </summary>
+    [DataField]
+    public float ToggleOnEventChance = 1f;
+
+    /// <summary>
+    /// Controls how station events interact with this toggleable ghost role.
+    /// </summary>
+    [Flags]
+    public enum EventToggleMode : byte
+    {
+        None = 0,
+        Activate = 1 << 0,
+        Deactivate = 1 << 1,
+        Both = Activate | Deactivate,
+    }
+    #endregion
 }

--- a/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/ToggleableGhostRoleSystem.cs
@@ -5,6 +5,12 @@ using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
+#region Starlight
+using Content.Server.StationEvents.Components;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Station.Components;
+using Robust.Shared.Random;
+#endregion
 
 namespace Content.Server.Ghost.Roles;
 
@@ -16,6 +22,9 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
+    #region Starlight
+    [Dependency] private IRobustRandom _random = default!;
+    #endregion
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -25,6 +34,9 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
         SubscribeLocalEvent<ToggleableGhostRoleComponent, MindAddedMessage>(OnMindAdded);
         SubscribeLocalEvent<ToggleableGhostRoleComponent, MindRemovedMessage>(OnMindRemoved);
         SubscribeLocalEvent<ToggleableGhostRoleComponent, GetVerbsEvent<ActivationVerb>>(AddWipeVerb);
+        #region Starlight
+        SubscribeLocalEvent<StationEventComponent, GameRuleStartedEvent>(OnStationEventStarted);
+        #endregion
     }
 
     private void OnUseInHand(EntityUid uid, ToggleableGhostRoleComponent component, UseInHandEvent args)
@@ -45,11 +57,19 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
             _popup.PopupEntity(Loc.GetString(component.ExamineTextMindSearching), uid, args.User);
             return;
         }
+
+        // Starlight Start
+        if (!TrySetSearching((uid, component), true))
+            return;
+        // Starlight End
+
         _popup.PopupEntity(Loc.GetString(component.BeginSearchingText), uid, args.User);
 
-        UpdateAppearance(uid, ToggleableGhostRoleStatus.Searching);
+        // Starlight edit Start: Moved
+        // UpdateAppearance(uid, ToggleableGhostRoleStatus.Searching);
 
-        ActivateGhostRole((uid, component));
+        // ActivateGhostRole((uid, component));
+        // Starlight edit End
     }
 
     public void ActivateGhostRole(Entity<ToggleableGhostRoleComponent?> ent)
@@ -135,13 +155,15 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
                 Text = Loc.GetString(component.StopSearchVerbText),
                 Act = () =>
                 {
-                    if (component.Deleted || !HasComp<GhostTakeoverAvailableComponent>(uid))
+                    if (!TrySetSearching((uid, component), false)) // Starlight Edit: Changed to Helper
                         return;
 
-                    RemCompDeferred<GhostTakeoverAvailableComponent>(uid);
-                    RemCompDeferred<GhostRoleComponent>(uid);
+                    // Starlight edit Start: Moved
+                    // RemCompDeferred<GhostTakeoverAvailableComponent>(uid);
+                    // RemCompDeferred<GhostRoleComponent>(uid);
+                    // Starlight edit End
                     _popup.PopupEntity(Loc.GetString(component.StopSearchVerbPopup), uid, args.User);
-                    UpdateAppearance(uid, ToggleableGhostRoleStatus.Off);
+                    // UpdateAppearance(uid, ToggleableGhostRoleStatus.Off); // Starlight Edit: Moved
                 }
             };
             args.Verbs.Add(verb);
@@ -162,11 +184,86 @@ public sealed class ToggleableGhostRoleSystem : EntitySystem
             _mind.TransferTo(mindId, null, mind: mind);
         }
 
-        if (!HasComp<GhostTakeoverAvailableComponent>(uid))
+        // Starlight edit Start
+        if (TryComp<ToggleableGhostRoleComponent>(uid, out var component))
+            TrySetSearching((uid, component), false, allowMind: true);
+        // Starlight edit End
+    }
+
+    #region Starlight
+    private void OnStationEventStarted(Entity<StationEventComponent> ent, ref GameRuleStartedEvent args)
+    {
+        var query = EntityQueryEnumerator<ToggleableGhostRoleComponent, TransformComponent>();
+
+        while (query.MoveNext(out var uid, out var toggleable, out var xform))
+        {
+            if (!ShouldEventToggle((uid, toggleable, xform), args.RuleId, ent.Comp.TargetStation))
+                continue;
+
+            ApplyEventToggle((uid, toggleable));
+        }
+    }
+
+    private bool ShouldEventToggle(
+        Entity<ToggleableGhostRoleComponent, TransformComponent> ent,
+        string eventId,
+        EntityUid? targetStation)
+        => ent.Comp1.ToggleOnEvents.Contains(eventId)
+            && (targetStation == null
+            || (CompOrNull<StationMemberComponent>(ent.Comp2.GridUid)?.Station) == targetStation)
+            && _random.Prob(Math.Clamp(ent.Comp1.ToggleOnEventChance, 0f, 1f));
+
+    private void ApplyEventToggle(Entity<ToggleableGhostRoleComponent> ent)
+    {
+        var mode = ent.Comp.ToggleOnEventMode;
+
+        if (mode == ToggleableGhostRoleComponent.EventToggleMode.None)
             return;
 
-        RemCompDeferred<GhostTakeoverAvailableComponent>(uid);
-        RemCompDeferred<GhostRoleComponent>(uid);
-        UpdateAppearance(uid, ToggleableGhostRoleStatus.Off);
+        if (mode.HasFlag(ToggleableGhostRoleComponent.EventToggleMode.Deactivate)
+            && HasComp<GhostTakeoverAvailableComponent>(ent.Owner))
+        {
+            TrySetSearching(ent, false);
+            return;
+        }
+
+        if (mode.HasFlag(ToggleableGhostRoleComponent.EventToggleMode.Activate))
+        {
+            TrySetSearching(ent, true);
+        }
     }
+
+    private bool TrySetSearching(Entity<ToggleableGhostRoleComponent> ent, bool searching, bool allowMind = false)
+    {
+        var hasMind = TryComp<MindContainerComponent>(ent.Owner, out var mindContainer) && mindContainer.HasMind;
+
+        if (searching)
+        {
+            if (hasMind)
+                return false;
+
+            if (HasComp<GhostTakeoverAvailableComponent>(ent.Owner))
+                return false;
+
+            if (HasComp<GhostRoleComponent>(ent.Owner))
+                return false;
+
+            UpdateAppearance(ent.Owner, ToggleableGhostRoleStatus.Searching);
+            ActivateGhostRole((ent.Owner, ent.Comp));
+            return true;
+        }
+
+        if (hasMind && !allowMind)
+            return false;
+
+        if (!HasComp<GhostTakeoverAvailableComponent>(ent.Owner)
+            && !HasComp<GhostRoleComponent>(ent.Owner))
+            return false;
+
+        RemCompDeferred<GhostTakeoverAvailableComponent>(ent.Owner);
+        RemCompDeferred<GhostRoleComponent>(ent.Owner);
+        UpdateAppearance(ent.Owner, ToggleableGhostRoleStatus.Off);
+        return true;
+    }
+    #endregion
 }

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -102,6 +102,13 @@
       stopSearchVerbText: positronic-brain-stop-searching-verb-text
       stopSearchVerbPopup: positronic-brain-stopped-searching
       job: Borg
+      # Starlight Start: Ion storms activate disabled posi brains.
+      toggleOnEvents:
+      - IonStorm
+      - IonStormPlus
+      toggleOnEventMode: Activate
+      toggleOnEventChance: 1
+      # Starlight End
     - type: BlockMovement
     - type: Examiner
     - type: BorgBrain

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -194,7 +194,7 @@
   - type: IPCBrainHolder
   - type: ContainerFill
     containers:
-      borg_brain: [ PositronicBrain ]
+      borg_brain: [ PositronicBrainNoIon ]
   - type: GlitchOnIonStorm
     duration: 40
     ramp: 5

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/mmi.yml
@@ -48,3 +48,26 @@
         - SecretStash
     - type: StationAIShunt # allow shunting into this brain.
     - type: LanguageSpeaker
+
+- type: entity
+  parent: PositronicBrain
+  id: PositronicBrainNoIon
+  name: positronic brain
+  components:
+    - type: ToggleableGhostRole
+      examineTextMindPresent: positronic-brain-installed
+      examineTextMindSearching: positronic-brain-still-searching
+      examineTextNoMind: positronic-brain-off
+      beginSearchingText: positronic-brain-searching
+      roleName: positronic-brain-role-name
+      roleDescription: positronic-brain-role-description
+      roleRules: ghost-role-information-silicon-rules
+      mindRoles:
+      - MindRoleGhostRoleSilicon
+      wipeVerbText: positronic-brain-wipe-device-verb-text
+      wipeVerbPopup: positronic-brain-wiped-device
+      stopSearchVerbText: positronic-brain-stop-searching-verb-text
+      stopSearchVerbPopup: positronic-brain-stopped-searching
+      job: Borg
+      toggleOnEventMode: None
+      toggleOnEventChance: 0

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/mmi.yml
@@ -55,19 +55,5 @@
   name: positronic brain
   components:
     - type: ToggleableGhostRole
-      examineTextMindPresent: positronic-brain-installed
-      examineTextMindSearching: positronic-brain-still-searching
-      examineTextNoMind: positronic-brain-off
-      beginSearchingText: positronic-brain-searching
-      roleName: positronic-brain-role-name
-      roleDescription: positronic-brain-role-description
-      roleRules: ghost-role-information-silicon-rules
-      mindRoles:
-      - MindRoleGhostRoleSilicon
-      wipeVerbText: positronic-brain-wipe-device-verb-text
-      wipeVerbPopup: positronic-brain-wiped-device
-      stopSearchVerbText: positronic-brain-stop-searching-verb-text
-      stopSearchVerbPopup: positronic-brain-stopped-searching
-      job: Borg
       toggleOnEventMode: None
       toggleOnEventChance: 0


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Makes Positronic brains activate on Ion Storm
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fun little interaction that helps those discarded posi brains get filled!
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- add: Ion Storms will now activate any de-active Positronic Brains.