### PR TITLE
No Nexus while Crit or Asleep

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -532,7 +532,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             return;
 
         //raise the message event for modifications
-        var evMsg = new CollectiveMindMessageAttemptEvent(source, message);
+        var evMsg = new CollectiveMindMessageAttemptEvent(source, message, collectiveMind);
         RaiseLocalEvent(source, evMsg, false);
         if (evMsg.Cancelled)
             return;

--- a/Content.Server/_Starlight/CollectiveMind/CollectiveMind.cs
+++ b/Content.Server/_Starlight/CollectiveMind/CollectiveMind.cs
@@ -30,7 +30,7 @@ public sealed partial class CollectiveMind : SharedCollectiveMindSystem
             {
                 if (ent.Comp.CorruptWhenUnconscious)
                     args.Message = Corrupt(args.Message, ref ent.Comp);
-                if (ent.Comp.BlockWhenUnconscious)
+                if (ent.Comp.BlockWhenUnconscious || args.CollectiveMind.BlockWhenUnconscious)
                     args.Cancel();
             }
         }

--- a/Content.Shared/_Starlight/CollectiveMind/CollectiveMindMessageAttemptEvent.cs
+++ b/Content.Shared/_Starlight/CollectiveMind/CollectiveMindMessageAttemptEvent.cs
@@ -8,14 +8,20 @@ public sealed class CollectiveMindMessageAttemptEvent : CancellableEntityEventAr
     public EntityUid Entity { get; }
 
     /// <summary>
+    /// The collective mind channel being spoken into.
+    /// </summary>
+    public CollectiveMindPrototype CollectiveMind { get; }
+
+    /// <summary>
     ///     The message being sent.
     ///     Modify this to apply effects to the text.
     /// </summary>
     public string Message { get; set; }
 
-    public CollectiveMindMessageAttemptEvent(EntityUid entity, string message)
+    public CollectiveMindMessageAttemptEvent(EntityUid entity, string message, CollectiveMindPrototype collectiveMind)
     {
         Entity = entity;
         Message = message;
+        CollectiveMind = collectiveMind;
     }
 }

--- a/Content.Shared/_Starlight/CollectiveMind/CollectiveMindPrototype.cs
+++ b/Content.Shared/_Starlight/CollectiveMind/CollectiveMindPrototype.cs
@@ -46,4 +46,10 @@ public sealed partial class CollectiveMindPrototype : IPrototype
 
     [DataField]
     public List<ProtoId<TagPrototype>> CanSpeakTags { get; set; } = new();
+
+    /// <summary>
+    /// Blocks speaking on this collective mind while crit or sleeping.
+    /// </summary>
+    [DataField]
+    public bool BlockWhenUnconscious = false;
 }

--- a/Resources/Prototypes/_Starlight/CollectiveMinds/collective_mind.yml
+++ b/Resources/Prototypes/_Starlight/CollectiveMinds/collective_mind.yml
@@ -69,6 +69,7 @@
   name: collective-mind-nexus
   keycode: 'n'
   color: "#FF7922"
+  blockWhenUnconscious: true
   requiredTags:
   - Nexus
 


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Remake of https://github.com/ss14Starlight/space-station-14/pull/2347 but component driven.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The spam of Nexus when any bird goes crit is honestly kinda stupid and gets annoying. The garble helps but didn't stop the spam, which was brought up but ignored when the garble was upped.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- tweak: Nexus can no longer be used while crit or asleep. No more Nexus spam.