### PR TITLE
Add playing card objects to chameleon projector blacklist

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
@@ -28,7 +28,7 @@
       - Pda # PDAs currently make you invisible /!\
       - SubFloorHide # no hiding under the floor
       # Moffstation - Start - Playing cards, hands and deck are invisible due to heavily layered visuals.
-      - PlayingCard 
+      - PlayingCard
       - PlayingCardHand
       - PlayingCardDeck
       # Moffstation - End

--- a/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
@@ -27,6 +27,11 @@
       - MindContainer # no
       - Pda # PDAs currently make you invisible /!\
       - SubFloorHide # no hiding under the floor
+      # Moffstation - Start - Playing cards, hands and deck are invisible due to heavily layered visuals.
+      - PlayingCard 
+      - PlayingCardHand
+      - PlayingCardDeck
+      # Moffstation - End
       tags:
       - Catwalk # Catwalks make you invisible
       - Wall # Walls make you invisible


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Due to the heavy multi-layered visuals. Using a Chameleon projector on any Playing Card, Hand or Deck causes the person to be invisible.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Unintended behaviour. Bugfix.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
before:
<img width="735" height="647" alt="image" src="https://github.com/user-attachments/assets/3e0d4468-ac5c-4903-bece-ab9e5979f85a" />
after:
<img width="735" height="647" alt="image" src="https://github.com/user-attachments/assets/51208383-8579-4ed0-bb93-577c459ac166" />



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Huaqas
- fix: Using a Chameleon Projector on a Playing Card, Hand or Deck no longer turns you invisible.