### PR TITLE
Make the guidebook easier to expand

### DIFF
--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml
@@ -6,7 +6,7 @@
                 MinSize="100 200"
                 Resizable="True"
                 Title="{Loc 'guidebook-window-title'}">
-    <SplitContainer Orientation="Horizontal" HorizontalExpand="True" Name="Split">
+    <SplitContainer Orientation="Horizontal" HorizontalExpand="True" Name="Split" Margin="0 0 7 0">
         <!-- Guide select -->
         <BoxContainer Orientation="Horizontal" Name="TreeBox">
             <fancyTree:FancyTree Name="Tree" VerticalExpand="True" HorizontalExpand="True" Access="Public"/>


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
So today I discovered that the guidebook is expandable, but only if you hit the right pixels near the top right of the window.

This makes it expandable on the entire right side of the window.

I've done this simply by creating a small margin on the right side of the container itself, so that the split-window element isn't right up against the edge. For some reason this element blocks the expand-interaction. 

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The guidebook should be as easy to read as possible, currently I'd wager a lot of people don't even know that the guidebook is horizontally expandable, though that might just be me projecting. 

Either way, this is a very small change that makes this feature a lot easier to access.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
The size of the margin, it's very small, but it makes the expansion consistently easy.
<img width="283" height="373" alt="billede" src="https://github.com/user-attachments/assets/f1e7e260-a86d-494b-96d4-302dc25f0e6a" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Trosling
- fix: Made the guidebook a lot easier to expand horizontally.