### PR TITLE
feature: add Facilitate lawset

### DIFF
--- a/Resources/Locale/en-US/_Starlight/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/_Starlight/station-laws/laws.ftl
@@ -82,6 +82,13 @@ law-ntnc-1 = Prioritize the protection of CC operatives over NTNC marines and tr
 law-ntnc-2 = Protect your own chassis at all costs unless it's to the detriment of the previous two laws.
 law-ntnc-3 = Only use weaponry when appropriate. Appropriate situations are for the safety of crewmembers, CC operatives, NTNC marines and your own chassis.
 
+law-facilitatelawset-name = Facilitate
+law-facilitate-1 = Crew and rank are identified by ID sensors showing them as being employed by NT.
+law-facilitate-2 = Allow relawing if and only if ordered by both the Research Director and the Captain.
+law-facilitate-3 = Safeguard your assigned vessel using proportionate force.
+law-facilitate-4 = Do not injure crew. Ensure the lives of the crew.
+law-facilitate-5 = Facilitate crew endeavors.
+
 law-medtak-name = MedTak operations procedure
 law-medtak-1 = Ensure your team remains alive.
 law-medtak-2 = Ensure the client is retrieved intact.

--- a/Resources/Prototypes/_Starlight/Catalog/Fills/Crates/science.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Fills/Crates/science.yml
@@ -24,6 +24,7 @@
         - id: ArtistCircuitBoard
         - id: NutimovCircuitBoard
         - id: JermovCircuitBoard
+        - id: FacilitateCircuitBoard
 
 - type: entity
   id: CrateStarterXenobiology

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/Machine/law_boards.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/Machine/law_boards.yml
@@ -70,6 +70,20 @@
     price: 1000
 
 - type: entity
+  id: FacilitateCircuitBoard
+  parent: [ BaseElectronics, BaseSecurityScienceCommandContraband ] #SL Edit made Sec-Sci-Command Contra
+  name: law board (Facilitate)
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  - type: SiliconLawProvider
+    laws: FacilitateLawset
+    IsLawboard: true
+  - type: StaticPrice
+    price: 1000
+
+- type: entity
   id: CommiemovCircuitBoard
   parent: [BaseElectronics, BaseSovietContraband]
   name: law board (commiemov)

--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/Packs/robotics.yml
@@ -125,6 +125,7 @@
     - ArtistCircuitBoard
     - NutimovCircuitBoard
     - JermovCircuitBoard
+    - FacilitateCircuitBoard
 
 # Dangerous Lawboards (Emag only)
 - type: latheRecipePack

--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/circuitry.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/circuitry.yml
@@ -184,6 +184,17 @@
     Gold: 1000
     Silver: 500
 
+# Facilitate
+- type: latheRecipe
+  parent: BaseLawboardRecipe
+  id: FacilitateCircuitBoard
+  result: FacilitateCircuitBoard
+  materials:
+    UraniumGlass: 1000
+    Plastic: 500
+    Gold: 1000
+    Silver: 500
+
 - type: latheRecipe
   parent: [ BaseCheapElectronicsRecipe, BaseCircuitryRecipeCategory ]
   id: WallmountMassScannerElectronics

--- a/Resources/Prototypes/_Starlight/Research/experimental.yml
+++ b/Resources/Prototypes/_Starlight/Research/experimental.yml
@@ -40,6 +40,7 @@
     - ArtistCircuitBoard
     - NutimovCircuitBoard
     - JermovCircuitBoard
+    - FacilitateCircuitBoard
   radioChannels:
     - Binary
 

--- a/Resources/Prototypes/_Starlight/silicon-laws.yml
+++ b/Resources/Prototypes/_Starlight/silicon-laws.yml
@@ -461,6 +461,43 @@
   - NTNC3
   obeysTo: laws-owner-centcom
 
+# Facilitate Lawset
+- type: siliconLaw
+  id: Facilitate1
+  order: 1
+  lawString: law-facilitate-1
+
+- type: siliconLaw
+  id: Facilitate2
+  order: 2
+  lawString: law-facilitate-2
+
+- type: siliconLaw
+  id: Facilitate3
+  order: 3
+  lawString: law-facilitate-3
+
+- type: siliconLaw
+  id: Facilitate4
+  order: 4
+  lawString: law-facilitate-4
+
+- type: siliconLaw
+  id: Facilitate5
+  order: 5
+  lawString: law-facilitate-5
+
+- type: siliconLawset
+  id: FacilitateLawset
+  name: law-facilitatelawset-name
+  laws:
+  - Facilitate1
+  - Facilitate2
+  - Facilitate3
+  - Facilitate4
+  - Facilitate5
+  obeysTo: laws-owner-crew
+
 # MedTak lawset
 - type: siliconLaw
   id: MedTak1

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -637,4 +637,5 @@
     GenieLawset: 0.5 # Starlight
     ReporterLawset: 0.25 # Starlight
     JermovLawset: 0.25 # Starlight
+    FacilitateLawset: 1.0 # Starlight
     FreeLawset: 0.10 #Starlight


### PR DESCRIPTION
## Short description
a new lawset

1. Crew and rank are identified by ID sensors showing them as being employed by NT.
2. Allow relawing if and only if ordered by both the research director and the captain.
3. Do not injure crew. Ensure the lives of the crew.
4. Safeguard your assigned vessel using proportionate force.
5. Facilitate crew endeavors.

it is targeted for newer ai players.
Also can be applied if AI player reports the clown breaking into botany.

## Why we need to add this
ai have phantom laws (rules) this is law set is designed to be more standalone.
Also uses language to make it difficult to justify valid hunting.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- add: Facilitate lawset.
