### PR TITLE
fixing some pistol whip damages and command drip contra

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/Head/Hats.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/Head/Hats.yml
@@ -1,4 +1,5 @@
-﻿- type: entity
+﻿#Surgical caps
+- type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatSurgcapBlack
   name: black surgical cap
@@ -52,6 +53,7 @@
     - type: Sprite
       sprite: DeltaV/Clothing/Head/Hats/surgcap_white.rsi
 
+#Autodrobe
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatWrestlingMaskLuchaBlue
@@ -76,8 +78,9 @@
       slots:
         - Hair
 
+#Duty officer
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BaseSecurityContraband]
   id: ClothingHeadHatDutyOfficerOrange
   name: duty officer's orange cap
   description: The orange hat signifies your superiority towards the poor inmates that have to stand you.
@@ -85,8 +88,9 @@
     - type: Sprite
       sprite: DeltaV/Clothing/Head/Hats/prisonguard.rsi
 
+#HoP
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BaseCommandContraband]
   id: ClothingHeadHatHopCapFormal
   name: head of personnel's formal cap
   description: An ever so slightly bluer cap to complement the dashing outfit of the modern HoP.

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/Uniforms/Jumpskirt.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/Uniforms/Jumpskirt.yml
@@ -1,6 +1,6 @@
 ﻿#CMO
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpskirtCmoFormal
   name: chief medical officer's formal skirtsuit
   description: A lavish greenish blue skirtsuit with golden buttons and a green cross pin, fitted for the head of medical.
@@ -9,7 +9,7 @@
       sprite: DeltaV/Clothing/Uniforms/Jumpskirt/cmo_formal.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpskirtCmoVest
   name: chief medical officer's vest jumpskirt
   description: A cozy teal cotton vest with a green cross pin paired with a white button-up.
@@ -19,7 +19,7 @@
 
 #HOP
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpskirtHopFormal
   name: head of personnel's formal dress
   description: A well-made dress with gold buttons and a red trim. Might as well look sharp when botany goes up in flames.
@@ -29,7 +29,7 @@
 
 #QM
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpskirtQmFormal
   name: quartermaster's formal dress
   description: Inspired by the logistics officers of military's past, the perfect outfit for supplying a formal occasion.
@@ -39,7 +39,7 @@
 
 #Duty officer
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseSecurityContraband]
   id: ClothingUniformJumpskirtDutyOfficerOrange
   name: duty officer's orange uniform
   description: A bright security skirt to distinguish yourself from the warden, while giving them an excuse to beat you saying you looked like a prisoner.

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/Uniforms/Jumpsuit.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/Uniforms/Jumpsuit.yml
@@ -10,7 +10,7 @@
 
 #CMO
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpsuitCmoFormal
   name: chief medical officer's formal suit
   description: A lavish greenish blue suit with golden buttons and a green cross pin, fitted for the head of medical.
@@ -19,7 +19,7 @@
       sprite: DeltaV/Clothing/Uniforms/Jumpsuit/cmo_formal.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpsuitCmoSummer
   name: chief medical officer's summer shirt
   description: The cyan aloha shirt with a green floral design is perfect to catch the wind on a hot summer day, it almost makes you forget you have people to heal.
@@ -28,7 +28,7 @@
       sprite: DeltaV/Clothing/Uniforms/Jumpsuit/cmo_summer.rsi
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpsuitCmoVest
   name: chief medical officer's vest jumpsuit
   description: A cozy teal cotton vest with a green cross pin paired with a white button-up.
@@ -38,7 +38,7 @@
 
 #HOP
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseCommandContraband]
   id: ClothingUniformJumpsuitHopFormal
   name: head of personnel's formal suit
   description: A well-made suit with gold buttons and a red trim. Might as well look sharp when botany goes up in flames.
@@ -103,7 +103,7 @@
 
 #Duty Officer
 - type: entity
-  parent: ClothingUniformBase
+  parent: [ClothingUniformBase, BaseSecurityContraband]
   id: ClothingUniformJumpsuitDutyOfficerOrange
   name: duty officer's orange uniform
   description: A bright security suit to distinguish yourself from the warden, while giving them an excuse to beat you saying you looked like a prisoner.

--- a/Resources/Prototypes/Entities/Objects/Fun/weapons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/weapons.yml
@@ -23,6 +23,18 @@
   - type: Item
     size: Normal
     sprite: Objects/Fun/Foam/foam_crossbow.rsi
+    # starlight start
+  - type: MeleeWeapon
+    wideAnimationRotation: 0
+    damage:
+      types:
+        Blunt: 1
+    angle: 0
+    animation: WeaponArcThrust
+    soundHit:
+      collection: WeakHit
+  - type: AltFireMelee
+    # starlight end
   - type: Gun
     fireRate: 0.5
     selectedMode: SemiAuto
@@ -49,6 +61,12 @@
   description: A premium foam rifle of the highest quality. Its plastic feels rugged, and its mechanisms sturdy.
   components:
   # Starlight start
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 1
+    soundHit:
+      collection: WeakHit
   - type: KnockbackByUserTag
     doestContain:
       Resomi:
@@ -114,6 +132,18 @@
     - Sidearm
     - ToySidearm
   - type: AmmoCounter
+    # starlight start
+  - type: MeleeWeapon
+    wideAnimationRotation: 0
+    damage:
+      types:
+        Blunt: 1
+    angle: 0
+    animation: WeaponArcThrust
+    soundHit:
+      collection: WeakHit
+  - type: AltFireMelee
+    # starlight end
   - type: Gun
     selectedMode: SemiAuto
     availableModes:


### PR DESCRIPTION
## Short description
fixing foam rifle melee damage to not be a usable as a real weapon, added pathetic pistol whipping to cap guns and foam crossbow, and added missing contra tags to outfits from my drip update

## Why we need to add this
it would make me really happy

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/890871fc-7b17-4228-b4a8-d64230c5179d


https://github.com/user-attachments/assets/62363cc6-9ea3-4344-8e6c-b2f1e817ffef

<img width="695" height="347" alt="image" src="https://github.com/user-attachments/assets/fc3be008-1f7e-443e-9ece-e3ef840c2fb4" />


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: StrangerOfParadiseOG
- add: added a silly weak pistol whipping to cap guns and foam crossbows.
- tweak: lowered the foam rifle melee damage to one.
- fix: fixed drip update outfits not showing as their respective contraband types.
