### PR TITLE
Nerfs the LR30 bullet damage.

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/battery.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/battery.yml
@@ -27,3 +27,11 @@
   components:
   - type: CartridgeAmmo
     proto: RedLaserBeam
+
+- type: entity
+  id: CartridgeBatteryLr30
+  name: cartridge (laser)
+  parent: BaseCartridgeBattery
+  components:
+  - type: CartridgeAmmo
+    proto: RedLaserBeamLr30

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/battery.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Ammunition/Magazines/battery.yml
@@ -39,7 +39,7 @@
   parent: BaseMagazineBattery
   components:
   - type: BallisticAmmoProvider
-    proto: CartridgeBattery
+    proto: CartridgeBatteryLr30
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -1281,6 +1281,17 @@
         Heat: 20
 
 - type: entity
+  id: RedLaserBeamLr30
+  name: laser beam
+  parent: LaserTrace
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: HitscanBasicDamage
+    damage:
+      types:
+        Heat: 10
+
+- type: entity
   parent: BasicHitscan
   id: IgnitionRedLaser
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
## Short description
Nerfs the LR 30s bullet type

## Why we need to add this
Alright so cut and clear the LR 30 currently has the following
5 firerate
PIN point accuracy
and a staggering **20 heat**
pair that with hitscan it makes it extremely powerfull
Sure you can say the downside is 12 ammo but with how cheap and easy it is to obtain the ammo. Plus you can fire instantly afterereloading no gun bolting or anything
The LR 30 remians a opressive but not a overpowered weapon by any means, its still strong. but using it wrong will kill you.

## Media (Video/Screenshots)
NA

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: Scarlet.
- tweak: Changed the LR 30s laser bullet type to be 10 heat!.
