### PR TITLE
Temporary Antag Scaling Tweaks

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -23,9 +23,9 @@
     - id: Thief
       prob: 0.4 #SL 0.5 -> 0.4 to account for more subgamemodes existing
     - id: SLChangeling #Starlight lings
-      prob: 0.25 #0.4 -> 0.25 to account for more subgamemodes existing now
+      prob: 0.20 #0.4 -> 0.25 to account for more subgamemodes existing now
     - id: VampireLess # Starlight reworked
-      prob: 0.25 # Starlight
+      prob: 0.20 # Starlight
     - id: SubWizard
       prob: 0.05 # Starlight. We can go back down to 0.05, since they scale now.
     - id: SubXenoborgs # Starlight, subgamemode replaced with SubXenoborgs
@@ -33,7 +33,7 @@
     - id: Brighteye
       prob: 0.05
     - id: SiliconLiberation
-      prob: 0.2 #Starlight end
+      prob: 0.20 #Starlight end
 
 - type: entity
   parent: BaseGameRule
@@ -44,15 +44,15 @@
     - id: Thief
       prob: 0.42 # Starlight start, 0.5 -> 0.4 to account for more subgamemodes existing
     - id: SLChangeling # StarlightLings
-      prob: 0.25 #0.4 -> 0.25 to account for more subgamemodes existing now
+      prob: 0.20 #0.4 -> 0.25 to account for more subgamemodes existing now
     - id: VampireLess # Reworked
-      prob: 0.25
+      prob: 0.20
     - id: SubXenoborgs # Starlight, subgamemode replaced with SubXenoborgs
       prob: 0.05 # Equalizing subgamemodes
     - id: Brighteye
       prob: 0.05
     - id: SiliconLiberation
-      prob: 0.2 #Starlight end
+      prob: 0.20 #Starlight end
 
 - type: entity
   parent: BaseGameRule
@@ -63,15 +63,15 @@
     - id: Thief
       prob: 0.62 # Starlight. Its a tamer mode, high thief chance.
     - id: SLChangeling # Starlight Lings
-      prob: 0.25 # Starlight, Xenoborgs need a little bit of a distraction
+      prob: 0.20 # Starlight, Xenoborgs need a little bit of a distraction
     - id: VampireLess # Starlight reworked
-      prob: 0.25 # Starlight, Xenoborgs need a little bit of a distraction
+      prob: 0.20 # Starlight, Xenoborgs need a little bit of a distraction
     - id: SubWizard
       prob: 0.05 # Starlight Space is dangerous, yo.
     - id: Brighteye # Starlight
       prob: 0.05
     - id: SiliconLiberation #Starlight
-      prob: 0.2 #Starlight
+      prob: 0.20 #Starlight
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -61,7 +61,7 @@
       tags:
         - CantBecomeRevolutionary
   - type: DynamicRuleCost
-    cost: 75      
+    cost: 75
       # Starlight-end
 
 - type: entity

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -46,8 +46,8 @@
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
-      max: 6 # Starlight, same reasoning as the roundstart changeling change, for alpha.
-      playerRatio: 30 # Starlight. You should stop seeing 6 lings all the time now.
+      max: 5 # Starlight, same reasoning as the roundstart changeling change, for alpha.
+      playerRatio: 32 # Starlight. You should stop seeing 6 lings all the time now.
       lateJoinAdditional: true
       allowNonHumans: false
       multiAntagSetting: None
@@ -60,6 +60,8 @@
       # Starlight-start
       tags:
         - CantBecomeRevolutionary
+  - type: DynamicRuleCost
+    cost: 75      
       # Starlight-end
 
 - type: entity
@@ -83,8 +85,8 @@
     selectionTime: IntraPlayerSpawn # Starlight. Only select vamps on round start
     definitions:
     - prefRoles: [ Vampire ]
-      max: 12 # Starlight. Full gamemode Vamps scale higher to account for scaling.
-      playerRatio: 18 # Starlight. Accounting for scaling. This is for the full vampire gamemode, so it can keep this value.
+      max: 10 # Starlight. Full gamemode Vamps scale higher to account for scaling.
+      playerRatio: 20 # Starlight. Accounting for scaling. This is for the full vampire gamemode, so it can keep this value.
       lateJoinAdditional: true
       allowNonHumans: True
       multiAntagSetting: None

--- a/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
@@ -22,7 +22,7 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.60 # Starlight. Adds up to 1.
+      prob: 0.50 # Starlight. Adds up to 1.
     - id: VampireLess # Starlight. The rework is here.
       prob: 0.25
     - id: SubWizard
@@ -43,9 +43,9 @@
     - id: ThiefLess # So that only 3 thieves max spawn in rev games.
       prob: 0.41 # Starlight
     - id: SLChangeling #Starlight lings
-      prob: 0.22
+      prob: 0.15
     - id: VampireLess # Starlight reworked
-      prob: 0.22
+      prob: 0.20
     - id: SubWizard
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
@@ -63,7 +63,7 @@
     - id: Thief
       prob: 0.60 # Same as NoChangelings
     - id: SLChangeling #Starlight lings
-      prob: 0.35 # Can be a little higher now, since lings don't have their standalone anymore.
+      prob: 0.20 # Can be a little higher now, since lings don't have their standalone anymore.
     - id: SubWizard
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
@@ -80,7 +80,7 @@
   - type: SubGamemodes
     rules:
     - id: ThiefLess # So that only 3 thieves max spawn in rev games.
-      prob: 0.85 # Starlight, to account for Wizard and Xenoborgs
+      prob: 0.30 # Starlight, to account for Wizard and Xenoborgs
     - id: SubWizard
       prob: 0.05
     - id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
@@ -88,7 +88,7 @@
     - id: Brighteye
       prob: 0.05
     - id: SiliconLiberation
-      prob: 0.20
+      prob: 0.15
 
 - type: entity
   parent: BaseGameRule
@@ -99,17 +99,17 @@
     - id: ThiefLess
       prob: 0.50
     - id: SubTraitor # Special traitors with a curated set of objectives; they do not have Kill/Lesson/DAGD, and scale a lot less.
-      prob: 0.20
-    - id: VampireLess # This is probably the most interesting sub-gamemode for them.
-      prob: 0.32
-    - id: SLChangelingLess # I have managed to make changelings lose their abilities when they turn into zombies, so the concern with them is gone.
       prob: 0.25
+    - id: VampireLess # This is probably the most interesting sub-gamemode for them.
+      prob: 0.25
+    - id: SLChangelingLess # I have managed to make changelings lose their abilities when they turn into zombies, so the concern with them is gone.
+      prob: 0.15
     - id: SubXenoborgs # I think there's interesting roleplay opportunity if Xenoborgs spawn. You could willingly choose to get borged to prevent infection. I want to see how this plays out.
       prob: 0.05
     - id: Brighteye
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation # I mean technically there's nothing inherently wrong with them showing up.
-      prob: 0.20
+      prob: 0.15
 
 - type: entity
   parent: BaseGameRule
@@ -120,15 +120,15 @@
     - id: Thief
       prob: 0.50
     - id: SLChangelingLess # 6 changelings makes it too hard to arm crew on warops
-      prob: 0.20
+      prob: 0.15
     - id: VampireLess
-      prob: 0.20
+      prob: 0.15
     - id: SubWizard
       prob: 0.05
     - id: SubXenoborgs
       prob: 0.05
     - id: SiliconLiberation
-      prob: 0.20
+      prob: 0.15
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_Starlight/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/subgamemodes.yml
@@ -81,7 +81,10 @@
       # Starlight-start
       tags:
         - CantBecomeRevolutionary
+  - type: DynamicRuleCost
+    cost: 75
     # Starlight-end
+
 
 #Subgamemode Lings for Vamptraitorlings.
 - type: entity
@@ -94,7 +97,7 @@
     definitions:
     - prefRoles: [ Changeling ]
       max: 4 # Starlight, same reasoning as the roundstart changeling change, for alpha.
-      playerRatio: 32 # Starlight, to make sure Beta doesn't get more than 2 changelings as a submode on VTL. Same justification as Thieves. Should be harder to get 4 lings on VTL now.
+      playerRatio: 35 # Starlight, to make sure Beta doesn't get more than 2 changelings as a submode on VTL. Same justification as Thieves. Should be harder to get 4 lings on VTL now.
       lateJoinAdditional: true
       allowNonHumans: false
       multiAntagSetting: None
@@ -107,6 +110,8 @@
       # Starlight-start
       tags:
         - CantBecomeRevolutionary
+  - type: DynamicRuleCost
+    cost: 80
 
 - type: entity
   parent: Traitor
@@ -170,7 +175,6 @@
         clumsyVaulting: false
       tags:
         - CantBecomeRevolutionary
-
   - type: DynamicRuleCost
     cost: 100
 

--- a/Resources/Prototypes/_Starlight/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/subgamemodes.yml
@@ -82,7 +82,7 @@
       tags:
         - CantBecomeRevolutionary
   - type: DynamicRuleCost
-    cost: 75
+    cost: 60
     # Starlight-end
 
 
@@ -111,7 +111,7 @@
       tags:
         - CantBecomeRevolutionary
   - type: DynamicRuleCost
-    cost: 80
+    cost: 70
 
 - type: entity
   parent: Traitor


### PR DESCRIPTION
## Short description
Nudges the chances and scaling of most antags down slightly, and added DynamicRuleCost to others that lacked them.

**Round Start Rules**

SubGamemodesRule
- SLChangelings 25% > 20%
- VampireLess 25% > 20%

SubGamemodesRuleNoWizard
- SLChangelings 25% > 20%
- VampireLess 25% > 20%

SubGamemodesRuleNoXenoborg
- SLChangelings 25% > 20%
- VampireLess 25% > 20%

SubGamemodesRuleNoChangelings
- Thief 60% > 50%

SubGamemodesRuleLessThieves
- SLChangelings 22% > 15%
- VampireLess 22% > 20%

SubGamemodesRuleVampTraitorLing
- ThiefLess 85% > 30% (this mode has every damn antag dear god)
- SELF 20% > 15%

SubGamemodesRuleZombieCompliantAntags
- SubTraitor 20% > 25%
- VampireLess 32% > 25%
- SLChangelingLess 25% > 15%
- SELF 20% > 15%

SubGamemodesRuleNuclearOperativeScaling
- SLChangelingLess 20% > 15%
- VampireLess 20% > 15%
- SELF 20% > 15%


**Sub Gamemodes**

SLChangeling
- max 6 > 5
- player ratio 30 > 32
- dynamic rule cost 0 > 75

Vampire
- max 12 > 10
- player ratio 18 > 20

VampireLess
- dynamic rule cost 0 > 60

SLChangelingLess
- player ratio 32 > 35
- dynamic rule cost 0 > 70


## Why we need to add this
Currently we regularly have 20-25 antags at 200-250 pop. That is an average of 1 in 10 crew members being antag- worse if you subtract security from that count. Security usually has at most 12-15 players. Paired with the fact that these ratios only roll on extreme-high pop (200+) when Security is already stretched thin dealing with tiders and new players, it is making Security very depressing, stressful, and exhausting to play.

I like most of the antag scaling ideas presented by Sinon- Wizard Duel was genius- but they could not have predicted us getting a huge tide from a youtuber right after increasing the antag scaling. Maybe it would be less bad if that hadn't happened, but it's bad right now so we need a temporary fix until we can more critically analyze it at a future point.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- tweak: Adjusted antag scaling **temporarily** to be **lower on average**. Odds of several things rolling in gamemodes was reduced to make it less likely we roll every type of antag always every round. Dynamic rule cost was added to some rules to reduce the likelihood of antag types stacking as well.

