### PR TITLE
Reworks movement controller

### DIFF
--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -4,6 +4,7 @@ using Content.Shared.Friction;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Starlight.CCVar;
 using Robust.Client.Physics;
 using Robust.Client.Player;
 using Robust.Shared.Configuration;
@@ -19,6 +20,16 @@ public sealed class MoverController : SharedMoverController
     [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
 
+    // Starlight start
+    // same gating as the server, otherwise we predict per-substep, server does it per-tick and we
+    // rubber-band. replicated cvar so we just follow whatever the server's set to.
+    private bool _substepGating;
+    private GameTick _lastUpdateTick;
+    // who was active on the first substep. UpdateAfterSolve clears the used-set so we re-stamp it on
+    // coasted substeps, else the client friction controller stops skipping our movers.
+    private readonly List<EntityUid> _predictedUsed = new();
+    // Starlight end
+
     public override void Initialize()
     {
         base.Initialize();
@@ -30,6 +41,10 @@ public sealed class MoverController : SharedMoverController
         SubscribeLocalEvent<InputMoverComponent, UpdateIsPredictedEvent>(OnUpdatePredicted);
         SubscribeLocalEvent<MovementRelayTargetComponent, UpdateIsPredictedEvent>(OnUpdateRelayTargetPredicted);
         SubscribeLocalEvent<PullableComponent, UpdateIsPredictedEvent>(OnUpdatePullablePredicted);
+
+        // Starlight start
+        Subs.CVar(_cfg, StarlightCCVars.PhysicsMoverSubstepGating, value => _substepGating = value, true);
+        // Starlight end
     }
 
     private void OnUpdatePredicted(Entity<InputMoverComponent> entity, ref UpdateIsPredictedEvent args)
@@ -92,10 +107,35 @@ public sealed class MoverController : SharedMoverController
         if (_playerManager.LocalEntity is not {Valid: true} player)
             return;
 
-        if (RelayQuery.TryGetComponent(player, out var relayMover))
-            HandleClientsideMovement(relayMover.RelayEntity, frameTime);
+        // Starlight start
+        // same deal as the server: predict velocity once per tick (over the full tick) then coast the
+        // rest of the substeps, just putting the used-set back so friction keeps skipping our movers.
+        if (_substepGating)
+        {
+            if (_timing.CurTick == _lastUpdateTick)
+            {
+                for (var i = 0; i < _predictedUsed.Count; i++)
+                    UsedMobMovement[_predictedUsed[i]] = true;
+                return;
+            }
+            _lastUpdateTick = _timing.CurTick;
+        }
 
-        HandleClientsideMovement(player, frameTime);
+        var moverFrameTime = _substepGating ? (float)_timing.TickPeriod.TotalSeconds : frameTime;
+
+        _predictedUsed.Clear();
+
+        if (RelayQuery.TryGetComponent(player, out var relayMover))
+        {
+            HandleClientsideMovement(relayMover.RelayEntity, moverFrameTime);
+            if (_substepGating && UsedMobMovement.TryGetValue(relayMover.RelayEntity, out var relayUsed) && relayUsed)
+                _predictedUsed.Add(relayMover.RelayEntity);
+        }
+
+        HandleClientsideMovement(player, moverFrameTime);
+        if (_substepGating && UsedMobMovement.TryGetValue(player, out var playerUsed) && playerUsed)
+            _predictedUsed.Add(player);
+        // Starlight end
     }
 
     private void HandleClientsideMovement(EntityUid player, float frameTime)

--- a/Content.Server/_Starlight/Physics/HandleMobMovementJob.cs
+++ b/Content.Server/_Starlight/Physics/HandleMobMovementJob.cs
@@ -1,6 +1,7 @@
 ﻿using System.Numerics;
 using Content.Shared._Starlight.Sound;
 using Content.Shared.Movement.Components;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Threading;
 
 namespace Content.Server._Starlight.Physics;
@@ -15,6 +16,9 @@ public struct HandleMobMovementJob(SLMoverController moverController) : IParalle
     private Vector2?[] _velocities = [];
     private Angle?[] _rotations = [];
     private SoundEvent?[] _sounds = [];
+    private bool[] _used = [];
+    private PhysicsComponent?[] _bodies = [];
+    private TransformComponent?[] _xforms = [];
 
     public void Prepare(List<Entity<InputMoverComponent>> entities)
     {
@@ -22,20 +26,31 @@ public struct HandleMobMovementJob(SLMoverController moverController) : IParalle
         EnsureCapacity(ref _velocities, entities.Count);
         EnsureCapacity(ref _rotations, entities.Count);
         EnsureCapacity(ref _sounds, entities.Count);
+        EnsureCapacity(ref _used, entities.Count);
+        EnsureCapacity(ref _bodies, entities.Count);
+        EnsureCapacity(ref _xforms, entities.Count);
     }
 
     public readonly Span<Vector2?> Velocities => _velocities.AsSpan(.._input.Count);
     public readonly Span<Angle?> Rotations => _rotations.AsSpan(.._input.Count);
     public readonly Span<SoundEvent?> Sounds => _sounds.AsSpan(.._input.Count);
+    public readonly Span<bool> Used => _used.AsSpan(.._input.Count);
+
+    // stuff the workers already resolved, so the scatter loop doesn't query it all over again.
+    public readonly Span<PhysicsComponent?> Bodies => _bodies.AsSpan(.._input.Count);
+    public readonly Span<TransformComponent?> Xforms => _xforms.AsSpan(.._input.Count);
 
     public void Execute(int index)
     {
         try
         {
-            var velocity = moverController.HandleAIMobMovement(_input[index], FrameTime, out var playSound, out var rotation);
+            var velocity = moverController.HandleAIMobMovement(_input[index], FrameTime, out var playSound, out var rotation, out var used, out var body, out var xform);
             _velocities[index] = velocity;
             _sounds[index] = playSound;
             _rotations[index] = rotation;
+            _used[index] = used;
+            _bodies[index] = body;
+            _xforms[index] = xform;
         }
         catch (Exception)
         {

--- a/Content.Server/_Starlight/Physics/MoverController.cs
+++ b/Content.Server/_Starlight/Physics/MoverController.cs
@@ -1,6 +1,9 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Content.Server.Shuttles.Systems;
+using Content.Shared._Starlight.Movement;
 using Content.Shared._Starlight.Sound;
 using Content.Shared.Maps;
 using Content.Shared.Movement.Components;
@@ -8,15 +11,19 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.Systems;
+using Content.Shared.Starlight.CCVar;
 using Prometheus;
 using Robust.Server.Player;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Threading;
+using Robust.Shared.Timing;
 using DependencyAttribute = Robust.Shared.IoC.DependencyAttribute;
 using DroneConsoleComponent = Content.Server.Shuttles.DroneConsoleComponent;
+using Stopwatch = System.Diagnostics.Stopwatch;
 
 namespace Content.Server._Starlight.Physics;
 
@@ -24,19 +31,56 @@ public sealed class SLMoverController : SharedMoverController
 {
     private static readonly Gauge _activeMoverGauge = Metrics.CreateGauge(
         "physics_active_mover_count",
-        "Active amount of InputMovers being processed by MoverController");
+        "InputMovers processed in parallel by MoverController");
 
     private static readonly Gauge _activePrioritizedMoverGauge = Metrics.CreateGauge(
-    "physics_active_prioritized_mover_count"    ,
-    "Active amount of prioritized InputMovers being processed by MoverController");
+        "physics_active_prioritized_mover_count",
+        "Prioritized (relay-source) InputMovers processed serially by MoverController");
+
+    private static readonly Gauge _movedMoverGauge = Metrics.CreateGauge(
+        "physics_moved_mover_count",
+        "InputMovers whose velocity actually changed this tick");
+
+    // per-phase wall time of UpdateBeforeSolve. histogram so we get percentiles over a scrape window
+    // instead of the old log line. children are cached below so the hot path skips the label lookup.
+    private static readonly Histogram _moverUpdateDuration = Metrics.CreateHistogram(
+        "physics_mover_update_duration_seconds",
+        "Time spent per phase of MoverController.UpdateBeforeSolve",
+        new HistogramConfiguration
+        {
+            LabelNames = ["phase"],
+            Buckets = Histogram.ExponentialBuckets(0.00005, 2, 10), // 50us .. ~25ms
+        });
+
+    private readonly IHistogram _durBuild = _moverUpdateDuration.WithLabels("build");
+    private readonly IHistogram _durPrio = _moverUpdateDuration.WithLabels("prio_serial");
+    private readonly IHistogram _durParallel = _moverUpdateDuration.WithLabels("parallel");
+    private readonly IHistogram _durScatter = _moverUpdateDuration.WithLabels("scatter");
+    private readonly IHistogram _durDirtySound = _moverUpdateDuration.WithLabels("dirty_sound");
+    private readonly IHistogram _durShuttle = _moverUpdateDuration.WithLabels("shuttle");
+    private readonly IHistogram _durTotal = _moverUpdateDuration.WithLabels("total");
 
     [Dependency] private readonly ThrusterSystem _thruster = default!;
     [Dependency] private readonly SharedTransformSystem _xformSystem = default!;
     [Dependency] private readonly IParallelManager _parallel = default!;
     [Dependency] private readonly IPlayerManager _players = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     private HandleMobMovementJob _handleMobMovementJob;
+
+    // this runs once per substep (2 by default). input doesn't change mid-tick and only the last
+    // substep gets networked, so just solve once and coast the rest.
+    private bool _substepGating;
+    private GameTick _lastUpdateTick;
+    // who was active on the first substep. UpdateAfterSolve nukes the used-set every substep so we
+    // re-stamp it on coasted ones, otherwise friction/conveyor start grabbing our movers.
+    private readonly List<EntityUid> _usedMovers = new();
+
+    // Worker threads must not touch shared dirty/PVS state. Dirty calls raised during the parallel
+    // mover pass are deferred here and flushed on the main thread.
+    private volatile bool _inParallelMove;
+    private readonly ConcurrentQueue<(EntityUid Uid, InputMoverComponent Mover)> _deferredDirty = new();
 
     private Dictionary<EntityUid, (ShuttleComponent, List<(EntityUid, PilotComponent, TransformComponent)>)> _shuttlePilots = new();
 
@@ -47,6 +91,8 @@ public sealed class SLMoverController : SharedMoverController
         SubscribeLocalEvent<RelayInputMoverComponent, PlayerDetachedEvent>(OnRelayPlayerDetached);
         SubscribeLocalEvent<InputMoverComponent, PlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<InputMoverComponent, PlayerDetachedEvent>(OnPlayerDetached);
+
+        Subs.CVar(_cfg, StarlightCCVars.PhysicsMoverSubstepGating, value => _substepGating = value, true);
 
         _handleMobMovementJob = new HandleMobMovementJob(this);
     }
@@ -72,6 +118,16 @@ public sealed class SLMoverController : SharedMoverController
     protected override bool CanSound()
         => true;
 
+    protected override void DirtyMover(EntityUid uid, InputMoverComponent mover)
+    {
+        // Dirty -> EntityDirtied -> PVS is not thread-safe and contends across cores. While movers are
+        // processed in parallel we queue the dirty and apply it on the main thread after the job ends.
+        if (_inParallelMove)
+            _deferredDirty.Enqueue((uid, mover));
+        else
+            base.DirtyMover(uid, mover);
+    }
+
     private readonly HashSet<EntityUid> _moverAdded = new();
     private readonly List<Entity<InputMoverComponent>> _movers = [];
     private readonly List<Entity<InputMoverComponent>> _prioritizedMovers = [];
@@ -90,7 +146,11 @@ public sealed class SLMoverController : SharedMoverController
         if (!_moverAdded.Add(source.Owner))
             return;
 
-        if(prioritized)
+        // A relay source mutates *another* entity's mover component (its relay target), so it can't be
+        // run concurrently with that target. Everything else — including ordinary players — is pure
+        // value computation in the parallel pass (writes are applied on the main thread during scatter),
+        // so it no longer needs to be spun serially.
+        if (prioritized || RelayQuery.HasComp(source.Owner))
             _prioritizedMovers.Add(source);
         else
             _movers.Add(source);
@@ -100,61 +160,147 @@ public sealed class SLMoverController : SharedMoverController
     {
         base.UpdateBeforeSolve(prediction, frameTime);
 
+        // already did this tick -> coast. velocity's still on the bodies, just put the used-set back.
+        // shuttles can't coast (they integrate force every substep) so keep running those.
+        if (_substepGating)
+        {
+            if (Timing.CurTick == _lastUpdateTick)
+            {
+                for (var i = 0; i < _usedMovers.Count; i++)
+                    UsedMobMovement[_usedMovers[i]] = true;
+
+                HandleShuttleMovement(frameTime);
+                return;
+            }
+            _lastUpdateTick = Timing.CurTick;
+        }
+
+        // solve once but physics still integrates every substep, so feed it the whole tick. a substep
+        // slice would run accel at half rate and the client (which sees full ticks) starts rubber-banding.
+        var moverFrameTime = _substepGating ? (float)Timing.TickPeriod.TotalSeconds : frameTime;
+
+        var perfStart = Stopwatch.GetTimestamp();
+
+        _usedMovers.Clear();
         _moverAdded.Clear();
         _prioritizedMovers.Clear();
         _movers.Clear();
 
+        // Players used to be forced onto the serial path; they now flow through InsertMover like any
+        // other mover and only end up prioritized if they're a relay source.
         foreach ( var session in _players.Sessions)
             if(session.AttachedEntity.HasValue
                 && TryComp<InputMoverComponent>(session.AttachedEntity.Value, out var mover))
-                InsertMover((session.AttachedEntity.Value, mover), true);
+                InsertMover((session.AttachedEntity.Value, mover));
 
         var inputQueryEnumerator = EntityQueryEnumerator<InputMoverComponent>();
         while (inputQueryEnumerator.MoveNext(out var uid, out var mover))
             InsertMover((uid, mover));
 
-        foreach (var mover in _prioritizedMovers)
-            HandleMobMovement(mover, frameTime);
+        var perfBuilt = Stopwatch.GetTimestamp();
 
-        _handleMobMovementJob.FrameTime = frameTime;
+        foreach (var mover in _prioritizedMovers)
+        {
+            HandleMobMovement(mover, moverFrameTime);
+            // base already wrote UsedMobMovement, grab the active ones so we can replay them while coasting.
+            if (_substepGating && UsedMobMovement.TryGetValue(mover.Owner, out var prioUsed) && prioUsed)
+                _usedMovers.Add(mover.Owner);
+        }
+
+        var perfPrio = Stopwatch.GetTimestamp();
+
+        _handleMobMovementJob.FrameTime = moverFrameTime;
         _handleMobMovementJob.Prepare(_movers);
 
-        _parallel.ProcessNow(_handleMobMovementJob, _movers.Count);
+        _inParallelMove = true;
+        try
+        {
+            _parallel.ProcessNow(_handleMobMovementJob, _movers.Count);
+        }
+        finally
+        {
+            _inParallelMove = false;
+        }
+
+        var perfParallel = Stopwatch.GetTimestamp();
 
         var velocities = _handleMobMovementJob.Velocities;
         var rotations = _handleMobMovementJob.Rotations;
+        var used = _handleMobMovementJob.Used;
+        var bodies = _handleMobMovementJob.Bodies;
+        var xforms = _handleMobMovementJob.Xforms;
+        var movedCount = 0;
         for (var i = 0; i < velocities.Length; i++)
         {
             ref readonly var velocity = ref velocities[i];
             ref readonly var rotation = ref rotations[i];
             var (uid, mover) = _movers[i];
+
+            // workers only read this, write it back here on the main thread.
+            UsedMobMovement[uid] = used[i];
+            if (_substepGating && used[i])
+                _usedMovers.Add(uid);
+
             if (velocity.HasValue)
             {
-                PhysicsSystem.SetLinearVelocity(uid, velocity.Value);
-                PhysicsSystem.SetAngularVelocity(uid, 0);
+                movedCount++;
+                // hand it the body the worker already resolved so it doesn't do the dict lookup again (x2).
+                var body = bodies[i];
+                PhysicsSystem.SetLinearVelocity(uid, velocity.Value, body: body);
+                // nothing spins normally, don't bother with the angular write unless there's spin to kill.
+                if (body!.AngularVelocity != 0f)
+                    PhysicsSystem.SetAngularVelocity(uid, 0, body: body);
             }
-            if(rotation.HasValue)
-                _transform.SetLocalRotation(uid, rotation.Value);
+            if (rotation.HasValue)
+                _transform.SetLocalRotation(uid, rotation.Value, xforms[i]);
 
         }
+
+        var perfScatter = Stopwatch.GetTimestamp();
+
+        // Flush the dirties deferred from the worker threads.
+        while (_deferredDirty.TryDequeue(out var deferred))
+            Dirty(deferred.Uid, deferred.Mover);
+
         foreach (ref readonly var sound in _handleMobMovementJob.Sounds)
             if (sound.HasValue)
                 _audio.PlayPredicted(sound.Value.SoundSpecifier, sound.Value.Source, sound.Value.User, sound.Value.AudioParams);
 
-        _activeMoverGauge.Set(_movers.Count);
-        _activePrioritizedMoverGauge.Set(_prioritizedMovers.Count);
+        var perfDirtySounds = Stopwatch.GetTimestamp();
 
         HandleShuttleMovement(frameTime);
+
+        var perfEnd = Stopwatch.GetTimestamp();
+
+        _activeMoverGauge.Set(_movers.Count);
+        _activePrioritizedMoverGauge.Set(_prioritizedMovers.Count);
+        _movedMoverGauge.Set(movedCount);
+
+        static double Sec(long a, long b) => Stopwatch.GetElapsedTime(a, b).TotalSeconds;
+        _durBuild.Observe(Sec(perfStart, perfBuilt));
+        _durPrio.Observe(Sec(perfBuilt, perfPrio));
+        _durParallel.Observe(Sec(perfPrio, perfParallel));
+        _durScatter.Observe(Sec(perfParallel, perfScatter));
+        _durDirtySound.Observe(Sec(perfScatter, perfDirtySounds));
+        _durShuttle.Observe(Sec(perfDirtySounds, perfEnd));
+        _durTotal.Observe(Sec(perfStart, perfEnd));
     }
 
     public Vector2? HandleAIMobMovement(
         Entity<InputMoverComponent> entity,
         float frameTime,
         out SoundEvent? soundEvent,
-        out Angle? rotation)
+        out Angle? rotation,
+        out bool used,
+        out PhysicsComponent? resolvedBody,
+        out TransformComponent? resolvedXform)
     {
         soundEvent = null;
         rotation = null;
+        used = false;
+        // give these back so the scatter loop reuses them instead of re-querying.
+        resolvedBody = null;
+        resolvedXform = null;
         var uid = entity.Owner;
         var mover = entity.Comp;
 
@@ -174,7 +320,6 @@ public sealed class SLMoverController : SharedMoverController
             || !PhysicsQuery.TryComp(uid, out var physicsComponent)
             || (PullableQuery.TryGetComponent(uid, out var pullable) && pullable.BeingPulled))
         {
-            UsedMobMovement[uid] = false;
             return null;
         }
 
@@ -186,15 +331,36 @@ public sealed class SLMoverController : SharedMoverController
         {
             if (!weightless)
             {
-                UsedMobMovement[uid] = false;
                 return null;
             }
             inAirHelpless = true;
         }
 
-        UsedMobMovement[uid] = true;
+        used = true;
 
         var moveSpeedComponent = ModifierQuery.CompOrNull(uid);
+
+        // Idle fast-path. The overwhelming majority of movers stand still on any given tick, and the
+        // controller runs at physics rate (2x networking), so the heavy work below is mostly wasted.
+        // When there is no movement input AND the body has already settled (linear speed under the
+        // friction floor, no residual spin) the full pass is provably a no-op: Friction() early-returns
+        // below MinimumFrictionSpeed, Accelerate() early-returns with a zero wish dir, and the
+        // rotation/footstep blocks only run for a non-zero wish dir. So we skip IsWeightless, the
+        // weightless event, tile lookups and sound resolution entirely and leave velocity untouched.
+        var (idleWalk, idleSprint) = GetVelocityInput(mover);
+        if (idleWalk == Vector2.Zero
+            && idleSprint == Vector2.Zero
+            && physicsComponent.AngularVelocity == 0f)
+        {
+            var minFrictionSpeed = moveSpeedComponent?.MinimumFrictionSpeed ?? MovementSpeedModifierComponent.DefaultMinimumFrictionSpeed;
+            if (physicsComponent.LinearVelocity.LengthSquared() < minFrictionSpeed * minFrictionSpeed)
+            {
+                // WishDir is already zero for a settled mover; this is a no-op in the common case and
+                // only clears a stale value (deferred-dirtied on the main thread) on the stopping tick.
+                SetWishDir((uid, mover), Vector2.Zero);
+                return null;
+            }
+        }
 
         float friction;
         float accel;
@@ -218,6 +384,11 @@ public sealed class SLMoverController : SharedMoverController
             RaiseLocalEvent(uid, ref ev, true);
 
             touching = ev.CanMove || xform.GridUid != null || MapGridQuery.HasComp(xform.GridUid);
+
+            // If we're not on a grid, and not able to move in space, check if we're close enough to a
+            // grid to push off it. Now safe in parallel since IsAroundCollider no longer shares a buffer.
+            if (!touching && MobMoverQuery.TryComp(uid, out var weightlessMobMover))
+                touching |= IsAroundCollider(_lookup, (uid, physicsComponent, weightlessMobMover, xform));
 
             // If we're touching then use the weightless values
             if (touching)
@@ -268,10 +439,21 @@ public sealed class SLMoverController : SharedMoverController
             friction = Math.Min(friction, accel);
         friction = Math.Max(friction, _minDamping);
         var minimumFrictionSpeed = moveSpeedComponent?.MinimumFrictionSpeed ?? MovementSpeedModifierComponent.DefaultMinimumFrictionSpeed;
-        Friction(minimumFrictionSpeed, frameTime, friction, ref velocity);
 
-        if (!weightless || touching)
-            Accelerate(ref velocity, in wishDir, accel, frameTime);
+        var solve = new MoverSolver.MoverParams
+        {
+            Velocity = velocity,
+            AngularVelocity = physicsComponent.AngularVelocity,
+            WishDir = wishDir,
+            FrictionInput = friction,
+            FrictionNoInput = friction,
+            Accel = accel,
+            MinimumFrictionSpeed = minimumFrictionSpeed,
+            MinDamping = _minDamping,
+            Weightless = weightless,
+            Touching = touching,
+        };
+        MoverSolver.TrySolve(in solve, frameTime, out velocity);
 
         SetWishDir((uid, mover), wishDir);
 
@@ -319,6 +501,10 @@ public sealed class SLMoverController : SharedMoverController
                 soundEvent = new SoundEvent(sound, uid, uid, audioParams);
             }
         }
+
+        // stash what we resolved, scatter loop picks it up.
+        resolvedBody = physicsComponent;
+        resolvedXform = xform;
         return velocity;
     }
 

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -257,7 +257,9 @@ namespace Content.Shared.Movement.Systems
             mover.RelativeRotation -= diff;
 
             mover.RelativeEntity = relative;
-            Dirty(uid, mover);
+            // Starlight start
+            DirtyMover(uid, mover);
+            // Starlight end
             return true;
         }
 

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -88,9 +88,9 @@ public abstract partial class SharedMoverController : VirtualController
     /// <summary>
     /// Cache the mob movement calculation to re-use elsewhere.
     /// </summary>
-    public ConcurrentDictionary<EntityUid, bool> UsedMobMovement = new(); // Starlight
-
-    private readonly HashSet<EntityUid> _aroundColliderSet = [];
+    // Starlight start
+    public ConcurrentDictionary<EntityUid, bool> UsedMobMovement = new();
+    // Starlight end
 
     public override void Initialize()
     {
@@ -410,8 +410,19 @@ public abstract partial class SharedMoverController : VirtualController
             return;
 
         mover.Comp.WishDir = wishDir;
-        Dirty(mover);
+        // Starlight start
+        DirtyMover(mover.Owner, mover.Comp);
+        // Starlight end
     }
+
+    // Starlight start
+    /// <summary>
+    /// Marks an input mover dirty. Virtual so the server can defer dirtying while movers are processed
+    /// on worker threads — Dirty -> DirtyEntity -> EntityDirtied (PVS) is not thread-safe and contends
+    /// across cores. The default behaviour is an immediate dirty.
+    /// </summary>
+    protected virtual void DirtyMover(EntityUid uid, InputMoverComponent mover) => Dirty(uid, mover);
+    // Starlight end
 
     public void LerpRotation(EntityUid uid, InputMoverComponent mover, float frameTime)
     {
@@ -435,12 +446,16 @@ public abstract partial class SharedMoverController : VirtualController
             }
 
             mover.RelativeRotation = (mover.RelativeRotation + adjustment).FlipPositive();
-            Dirty(uid, mover);
+            // Starlight start
+            DirtyMover(uid, mover);
+            // Starlight end
         }
         else if (!angleDiff.Equals(Angle.Zero))
         {
             mover.RelativeRotation = mover.TargetRelativeRotation.FlipPositive();
-            Dirty(uid, mover);
+            // Starlight start
+            DirtyMover(uid, mover);
+            // Starlight end
         }
     }
 
@@ -501,9 +516,13 @@ public abstract partial class SharedMoverController : VirtualController
         var (uid, collider, mover, transform) = entity;
         var enlargedAABB = _lookup.GetWorldAABB(entity.Owner, transform).Enlarged(mover.GrabRange);
 
-        _aroundColliderSet.Clear();
-        lookupSystem.GetEntitiesIntersecting(transform.MapID, enlargedAABB, _aroundColliderSet);
-        foreach (var otherEntity in _aroundColliderSet)
+        // Starlight start
+        // Local set so this is safe to call from the parallel mover pass: the broadphase trees are only
+        // read here (they aren't mutated until the physics solve runs), and there's no shared buffer.
+        var aroundColliderSet = new HashSet<EntityUid>();
+        // Starlight end
+        lookupSystem.GetEntitiesIntersecting(transform.MapID, enlargedAABB, aroundColliderSet);
+        foreach (var otherEntity in aroundColliderSet)
         {
             if (otherEntity == uid)
                 continue; // Don't try to push off of yourself!

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVar.Physics.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVar.Physics.cs
@@ -7,4 +7,13 @@ public sealed partial class StarlightCCVars
     // Taken from https://github.com/RMC-14/RMC-14
     public static readonly CVarDef<bool> PhysicsActiveInputMoverEnabled =
         CVarDef.Create("physics.active_input_mover_enabled", true, CVar.REPLICATED | CVar.SERVER);
+
+    /// <summary>
+    /// solve mover velocities once per tick instead of every substep. input doesn't change mid-tick and
+    /// only the last substep gets networked anyway, so the rest just coast. roughly halves the mover pass
+    /// at substeps=2. left as a toggle in case the accel/friction feel ends up off. replicated so the
+    /// client gates the same way, otherwise it mispredicts and you rubber-band.
+    /// </summary>
+    public static readonly CVarDef<bool> PhysicsMoverSubstepGating =
+        CVarDef.Create("physics.mover_substep_gating", false, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/_Starlight/Movement/MoverSolver.cs
+++ b/Content.Shared/_Starlight/Movement/MoverSolver.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Content.Shared._Starlight.Movement;
+
+public static class MoverSolver
+{
+    /// <summary>
+    /// everything the solve needs, after the controller already decoded the wish dir and looked up the
+    /// tile-multiplied friction/accel. nothing else.
+    /// </summary>
+    public struct MoverParams
+    {
+        /// <summary>current linear velocity (body's LinearVelocity).</summary>
+        public Vector2 Velocity;
+
+        /// <summary>current spin. any spin kills the idle fast-path.</summary>
+        public float AngularVelocity;
+
+        /// <summary>wish dir scaled by walk/sprint speed (post AssertValidWish). zero = no input.</summary>
+        public Vector2 WishDir;
+
+        /// <summary>friction when there IS input, already tile-multiplied.</summary>
+        public float FrictionInput;
+
+        /// <summary>friction when there is NO input, already tile-multiplied.</summary>
+        public float FrictionNoInput;
+
+        /// <summary>acceleration, already tile-multiplied.</summary>
+        public float Accel;
+
+        /// <summary>speed floor below which friction doesn't apply.</summary>
+        public float MinimumFrictionSpeed;
+
+        /// <summary>engine-wide min damping floor (_minDamping).</summary>
+        public float MinDamping;
+
+        /// <summary>body weightless this tick?</summary>
+        public bool Weightless;
+
+        /// <summary>weightless body touching something to push off?</summary>
+        public bool Touching;
+    }
+
+    /// <summary>
+    /// solves one mover. true + new velocity when it did work, false when the idle fast-path fired and
+    /// velocity is untouched (controller leaves the body alone, same as before).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TrySolve(in MoverParams p, float frameTime, out Vector2 newVelocity)
+    {
+        newVelocity = p.Velocity;
+        var hasWish = p.WishDir != Vector2.Zero;
+
+        // no input, no spin, already settled under the friction floor -> provable no-op
+        // (Friction early-returns, Accelerate early-returns on a zero wish dir). bail.
+        if (!hasWish
+            && p.AngularVelocity == 0f
+            && p.Velocity.LengthSquared() < p.MinimumFrictionSpeed * p.MinimumFrictionSpeed)
+        {
+            return false;
+        }
+
+        var friction = hasWish ? p.FrictionInput : p.FrictionNoInput;
+
+        // friction never beats accel while moving.
+        if (hasWish)
+            friction = MathF.Min(friction, p.Accel);
+        friction = MathF.Max(friction, p.MinDamping);
+
+        Friction(p.MinimumFrictionSpeed, frameTime, friction, ref newVelocity);
+
+        if (!p.Weightless || p.Touching)
+            Accelerate(ref newVelocity, in p.WishDir, p.Accel, frameTime);
+
+        return true;
+    }
+
+    public static void Friction(float minimumFrictionSpeed, float frameTime, float friction, ref Vector2 velocity)
+    {
+        var speed = velocity.Length();
+        if (speed < minimumFrictionSpeed)
+            return;
+
+        velocity *= Math.Clamp(1.0f - frameTime * friction, 0.0f, 1.0f);
+    }
+
+    public static void Accelerate(ref Vector2 currentVelocity, in Vector2 velocity, float accel, float frameTime)
+    {
+        var wishDir = velocity != Vector2.Zero ? Vector2.Normalize(velocity) : Vector2.Zero;
+        var wishSpeed = velocity.Length();
+
+        var currentSpeed = Vector2.Dot(currentVelocity, wishDir);
+        var addSpeed = wishSpeed - currentSpeed;
+
+        if (addSpeed <= 0f)
+            return;
+
+        var accelSpeed = accel * frameTime * wishSpeed;
+        accelSpeed = MathF.Min(accelSpeed, addSpeed);
+
+        currentVelocity += wishDir * accelSpeed;
+    }
+}


### PR DESCRIPTION
## Short description
Reworks the SLMoverController to run the per-mover velocity solve in parallel and adds an optional per-tick substep-gating mode, with matching client prediction.

## Why we need to add this
Expected optimization is around 3.5 ms per tick on alpha.


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- tweak: Physics optimization.
