### PR TITLE
Biosuits can now prevent infection on dead bodies, as they should

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -283,7 +283,7 @@ namespace Content.Server.Zombies
                 else
                 {
                     if (HasComp<ZombieImmuneComponent>(uid) || cannotSpread
-                    || !_random.Prob(GetZombieInfectionChance(uid, entity.Comp))) //Starlight fix: Infection-proof suits don't just loose their resistance on death.
+                    || !_random.Prob(GetZombieInfectionChance(uid, entity.Comp))) //Starlight fix: Infection-proof suits don't just lose their resistance on death.
                         continue;
 
                     // If the target is dead and can be infected, infect.

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -282,7 +282,8 @@ namespace Content.Server.Zombies
                 }
                 else
                 {
-                    if (HasComp<ZombieImmuneComponent>(uid) || cannotSpread)
+                    if (HasComp<ZombieImmuneComponent>(uid) || cannotSpread
+                    || !_random.Prob(GetZombieInfectionChance(uid, entity.Comp))) //Starlight fix: Infection-proof suits don't just loose their resistance on death.
                         continue;
 
                     // If the target is dead and can be infected, infect.


### PR DESCRIPTION
## Short description
Fixes biosuits and similar to still apply their infection prevention while the target is dead.

## Why we need to add this
Bio suits on dead targets somehow just loose all of their protection... instantly. This was a simple oversight, in that the chance is just not checked on dead targets. This PR fixes that issue.
(You still die, it just takes effort to infect you now, as it should)

## Media (Video/Screenshots)
<img width="396" height="272" alt="image" src="https://github.com/user-attachments/assets/1534f94b-1875-42d7-9bf5-92ed8082850e" />
Dead, but not zombified

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Biosuits now properly protect you after death.
