### PR TITLE
Comment out the inf crayon due to lag 32 05 26

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -699,7 +699,7 @@
     - id: FoamBlade
     - id: ClothingHeadHatBunny
     - id: PersonalAI
-    - id: CrayonMagic # Starlight-edit
+    #- id: CrayonMagic # Starlight-edit commented out due to lag for now - 31-05-2026
     - id: ToySword
     - id: RevolverCapGun
     - id: ToyRubberDuck

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -115,7 +115,7 @@
   - DaBling
   - CrapPlushie ##not a typo
   - LighterGatcha
-  - MagicCrayon
+  #- MagicCrayon starlight edit commented out for now due to lag - 31-05-2026
   - HappyHonk
   - LeftRipperArm
   - RightMechwrightArm

--- a/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
@@ -471,16 +471,16 @@
     - MysteryLighterBox
   groupBy: "smokeables"
 
-- type: loadout
-  id: MagicCrayon
-  effects:
-    - !type:JobRequirementLoadoutEffect
-      requirement:
-        !type:OverallPlaytimeRequirement
-        time: 360000 # 100hr
-  storage:
-    back:
-      - CrayonMagic
+#- type: loadout
+#  id: MagicCrayon
+#  effects:
+#    - !type:JobRequirementLoadoutEffect
+#      requirement:
+#        !type:OverallPlaytimeRequirement
+#        time: 360000 # 100hr
+#  storage:
+#    back:
+#      - CrayonMagic
 
 - type: loadout
   id: HappyHonk


### PR DESCRIPTION
## Short description
Comment out the magical crayon

## Why we need to add this
Currently as of 31-05-2026, the lag caused by decal art is immense and until a fix is made. Playability should be the focus.

## Media (Video/Screenshots)
NA
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: Scarlet Lightweaver
- remove: Removed the magical crayon for now due to the ongoning lag issues.