### PR TITLE
Add a few access variants of the CentComm turnstiles

### DIFF
--- a/Resources/Maps/_Starlight/Centcomms/CC_Outpost_GNT9.yml
+++ b/Resources/Maps/_Starlight/Centcomms/CC_Outpost_GNT9.yml
@@ -52505,8 +52505,7 @@ entities:
       pos: 0.5,2.5
       parent: 1
     - type: AccessReader
-      accessListsOriginal:
-      - - Command
+      accessListsOriginal: []
 - proto: TurnstileCentCommDebrief
   entities:
   - uid: 7532

--- a/Resources/Maps/_Starlight/Shuttles/SecureTerminal/CBURNDroppod.yml
+++ b/Resources/Maps/_Starlight/Shuttles/SecureTerminal/CBURNDroppod.yml
@@ -9130,7 +9130,7 @@ entities:
     - type: Transform
       pos: 13.5,-10.5
       parent: 1
-- proto: TurnstileCentComm
+- proto: TurnstileCentCommCommand
   entities:
   - uid: 1213
     components:

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
@@ -25,29 +25,19 @@
 
 - type: entity
   id: TurnstileCentCommCommand
-  parent: Turnstile
+  parent: TurnstileCentComm
   name: central command turnstile
   suffix: Command
   components:
-    - type: Sprite
-      sprite: _Starlight/Structures/Doors/cc-turnstile.rsi
-      layers:
-        - state: turnstile
-          map: [ "enum.TurnstileVisualLayers.Base" ]
     - type: AccessReader
       access: [["Command"]]
 
 - type: entity
   id: TurnstileCentCommCentralCommand
-  parent: Turnstile
+  parent: TurnstileCentComm
   name: central command turnstile
   suffix: Central Command
   components:
-    - type: Sprite
-      sprite: _Starlight/Structures/Doors/cc-turnstile.rsi
-      layers:
-        - state: turnstile
-          map: [ "enum.TurnstileVisualLayers.Base" ]
     - type: AccessReader
       access: [["Central Command"]]
 

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
@@ -37,7 +37,7 @@
   suffix: Central Command
   components:
     - type: AccessReader
-      access: [["Central Command"]]
+      access: [["CentralCommand"]]
 
 - type: entity
   id: TurnstileCentCommDebrief

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
@@ -20,8 +20,6 @@
       layers:
         - state: turnstile
           map: [ "enum.TurnstileVisualLayers.Base" ]
-    - type: AccessReader
-      access: [] # All access
 
 - type: entity
   id: TurnstileCentCommCommand

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
@@ -14,6 +14,19 @@
   id: TurnstileCentComm
   parent: Turnstile
   name: central command turnstile
+  components:
+    - type: Sprite
+      sprite: _Starlight/Structures/Doors/cc-turnstile.rsi
+      layers:
+        - state: turnstile
+          map: [ "enum.TurnstileVisualLayers.Base" ]
+    - type: AccessReader
+      access: [] # All access
+
+- type: entity
+  id: TurnstileCentCommCommand
+  parent: Turnstile
+  name: central command turnstile
   suffix: Command
   components:
     - type: Sprite
@@ -23,6 +36,20 @@
           map: [ "enum.TurnstileVisualLayers.Base" ]
     - type: AccessReader
       access: [["Command"]]
+
+- type: entity
+  id: TurnstileCentCommCentralCommand
+  parent: Turnstile
+  name: central command turnstile
+  suffix: Central Command
+  components:
+    - type: Sprite
+      sprite: _Starlight/Structures/Doors/cc-turnstile.rsi
+      layers:
+        - state: turnstile
+          map: [ "enum.TurnstileVisualLayers.Base" ]
+    - type: AccessReader
+      access: [["Central Command"]]
 
 - type: entity
   id: TurnstileCentCommDebrief


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

For mapping purposes and for sake of fixing the `TurnstileCentComm` proto not being an all access variant despite the prototype name.

Communicated with @CawsForConcern about the existing mapped ones. There's only two existing mapped sets of `TurnstileCentComm`:

  - One is on `CC_Outpost_GNT9.yml`, this one is an exit-only turnstile from a secure area so it's fine if it's AA.
  - The other is on `SecureTerminal/CBURNDroppod.yml`, this one is clearly intended to be for Command as it's the shuttle bridge. Adjusted the proto manually.

Requires @CawsForConcern review and approval

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Fixes the prototype naming, more clear mapping variants, including one actually with `Central Command` access.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Protos

<img width="550" height="287" alt="image" src="https://github.com/user-attachments/assets/3df664c8-5c3e-4a81-b266-52eeb007734c" />


### CC_Outpost_GNT9.yml

<img width="1435" height="946" alt="image" src="https://github.com/user-attachments/assets/3e0caede-e547-4081-afe4-21852e0ffd21" />


### CBURNDroppod.yml

<img width="1381" height="1137" alt="image" src="https://github.com/user-attachments/assets/04bf99ab-91f4-4884-a659-515a3936c8a4" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.


Not user facing, no CL