### PR TITLE
Fix height slider lag

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -299,12 +299,12 @@ namespace Content.Client.Lobby.UI
 
             WidthSlider.OnValueChanged += args =>
             {
-                SetWidth(args.Value);
+                SetCharacterWidth(args.Value);
             };
 
             HeightSlider.OnValueChanged += args =>
             {
-                SetHeight(args.Value);
+                SetCharacterHeight(args.Value);
             };
 
             WidthResetButton.OnPressed += _ =>
@@ -1633,20 +1633,20 @@ namespace Content.Client.Lobby.UI
             }
         }
 
-        private void SetWidth(float newWidth)
+        private void SetCharacterWidth(float newWidth)
         {
             if (Profile is null) return;
-            Profile.Appearance = Profile.Appearance.WithWidth(newWidth);
+            Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithWidth(newWidth));
             UpdateSizeText();
-            ReloadPreview();
+            ReloadProfilePreview();
         }
 
-        private void SetHeight(float newHeight)
+        private void SetCharacterHeight(float newHeight)
         {
             if (Profile is null) return;
-            Profile.Appearance = Profile.Appearance.WithHeight(newHeight);
+            Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithHeight(newHeight));
             UpdateSizeText();
-            ReloadPreview();
+            ReloadProfilePreview();
         }
         //starlight end
 

--- a/Content.Shared/Access/Components/IdCardComponent.cs
+++ b/Content.Shared/Access/Components/IdCardComponent.cs
@@ -27,7 +27,7 @@ public sealed partial class IdCardComponent : Component
     private string? _jobTitle;
 
     [Access(typeof(SharedIdCardSystem), typeof(SharedPdaSystem), typeof(SharedAgentIdCardSystem), Other = AccessPermissions.ReadWriteExecute)]
-    public string? LocalizedJobTitle { set => _jobTitle = value; get => _jobTitle ?? Loc.GetString(JobTitle ?? string.Empty); }
+    public string? LocalizedJobTitle { set => _jobTitle = value; get => _jobTitle ?? (JobTitle is null ? "" : Loc.GetString(JobTitle)); } // starlight, fix null loc bug for default IDs
 
     /// <summary>
     /// The state of the job icon rsi.


### PR DESCRIPTION
## Short description
For some reason, recently the full profile reload has become magnitudes more computationally expensive, causing fps drop when changing height sliders

Switched to slim profile reload, which sliders should have been using the entire time lol (forgive me it was like my first ss14 c# pr ever)

At some point want to rework entire thing into a system, but will have to wait and see what newmed brings

Has a free locale warning spam fix in
also renamed methods because it was overriding some unused ui component, bad practice

## Why we need to add this
ui experience


## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.\
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- fix: Fix low fps when changing character size in the profile editor.
