### PR TITLE
The Place where it Chilled

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
@@ -10,7 +10,17 @@
     ClothingNeckScarfStripedOrange: 3
     ClothingNeckScarfStripedPurple: 3
     ClothingOuterCoatTrench: 6
-    ClothingOuterWinterCoat: 6
+    ClothingOuterWinterColorWhite: 3 #Starlight start, adding the colored coats
+    ClothingOuterWinterColorGray: 3
+    ClothingOuterWinterColorBlack: 3
+    ClothingOuterWinterColorBlue: 3
+    ClothingOuterWinterColorGreen: 3
+    ClothingOuterWinterColorOrange: 3
+    ClothingOuterWinterColorRed: 3
+    ClothingOuterWinterColorYellow: 3
+    ClothingOuterWinterColorPurple: 3
+    ClothingOuterWinterColorLightBrown: 3
+    ClothingOuterWinterColorBrown: 3 # Starlight end
     ClothingShoesBootsWinter: 6
     ClothingOuterFlannelRed: 2
     ClothingOuterFlannelBlue: 2

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -334,6 +334,7 @@
     butcheringType: Knife
     spawned:
     - id: ClothingHandsGlovesFingerlessInsulated
+    - id: InsulatedFabric # Starlight
   - type: Insulated
   - type: Fiber
     fiberMaterial: fibers-insulative
@@ -371,7 +372,8 @@
   - type: Butcherable #SL start
     butcheringType: Knife
     spawned:
-      - id: CheapInsulatedFabric #SL end
+      - id: CheapInsulatedFabric
+      - id: ClothingHandsGlovesFingerlessBudget #SL end
 
 # Conductive Insulated Gloves
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -723,6 +723,13 @@
         color: "#a60b0b"
       - state: pompom-equipped-HELMET
         color: "#a60b0b"
+  - type: TemperatureProtection # Starlight start
+    heatingCoefficient: 1
+    coolingCoefficient: 0.75
+  - type: Armor
+    modifiers:
+      coefficients:
+        Cold: 0.9 # Starlight end
 
 - type: entity
   parent: ClothingHeadHatWizardBase

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -263,6 +263,8 @@
         children:
         - id: ClothingHandsGlovesColorYellowBudget
           weight: 5
+        - id: ClothingHandsGlovesFingerlessBudget # Starlight
+          weight: 3 # Starlight
         - id: ClothingHandsGlovesFingerlessInsulated
           weight: 0.5
         - id: ClothingHandsGlovesColorYellow
@@ -455,9 +457,11 @@
   table: !type:GroupSelector
     children:
     - id: ClothingHandsGlovesColorYellowBudget # budget insuls
-      weight: 85
+      weight: 80 # Starlight
     - id: ClothingHandsGlovesColorYellow # true insuls
       weight: 10
+    - id: ClothingHandsGlovesFingerlessBudget # fingerless budget insuls
+      weight: 5 # Starlight
     - id: ClothingHandsGlovesFingerlessInsulated # fingerless
       weight: 4
     - id: ClothingHandsGlovesConducting # conducting

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/assistant.yml
@@ -106,13 +106,13 @@
   - !type:GroupLoadoutEffect
     proto: HonoredAssistant
   equipment:
-    gloves: ClothingHandsGlovesFingerlessInsulated
+    gloves: ClothingHandsGlovesFingerlessBudget # Starlight, replace with fingerless budget insuls
 
 # Outerclothing
 - type: loadout
   id: AssistantWintercoat
   equipment:
-    outerClothing: ClothingOuterWinterCoat
+    outerClothing: ClothingOuterWinterColorGray # Starlight, it has a hood
 
 # Feet
 - type: loadout

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -368,6 +368,7 @@
   minLimit: 0
   loadouts:
   - AssistantGloves
+  - AssistantMittens # Starlight
   - GreyGloves #starlight
 
 - type: loadoutGroup

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Hands/gloves.yml
@@ -46,6 +46,24 @@
     fiberMaterial: fibers-red-and-black-woven
 
 - type: entity
+  parent: ClothingHandsBase
+  id: ClothingHandsGlovesFingerlessBudget
+  name: fingerless budget insulated gloves
+  description: You're not sure what's more insulting, the fact that these are fingerless, or the fact that they're not even real insuls.
+  components:
+  - type: Sprite
+    sprite: Clothing/Hands/Gloves/fingerlessinsuls.rsi
+  - type: Clothing
+    sprite: Clothing/Hands/Gloves/fingerlessinsuls.rsi
+  - type: Fiber
+    fiberMaterial: fibers-insulative-frayed
+    fiberColor: fibers-yellow
+  - type: DamageOnInteractProtection
+    damageProtection:
+      flatReductions:
+        Heat: 0
+
+- type: entity
   parent: ClothingHandsMittensBase # That's why these exist in real life.
   id: ClothingHandsCatPaws
   name: cat paw mittens

--- a/Resources/Prototypes/_Starlight/Loadouts/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Jobs/Civilian/assistant.yml
@@ -468,6 +468,14 @@
   equipment:
     gloves: ClothingHandsGlovesColorGray
 
+- type: loadout
+  id: AssistantMittens
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: HonoredAssistant
+  equipment:
+    gloves: ClothingHandsMittensColorYellow # Starlight, replace with fingerless budget insuls
+
 # Outerclothing
 - type: loadout
   id: GreyHoodieA


### PR DESCRIPTION
## Short description
The WinterDrobe now has access to the other generic colored winter coats instead of just the gray one. (It also has the gray one that actually has a hood now.)

The beanie now has 10% cold armor.

Assistants can now spawn with yellow mittens.

Replaced fingerless insuls in assistant loadout with fingerless budget insuls.

## Why we need to add this
For the coats, seems like an oversight that they exist and aren't in the drobe. For the Assistant changes, it's been brought up that it's too easy to get insuls now, since all assistants can start with fingerless insuls, skipping half of the insuls crafing side-quest.

## Media (Video/Screenshots)
<img width="336" height="324" alt="image" src="https://github.com/user-attachments/assets/12b8e98b-be77-487f-bfa0-5de56afec6ef" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- add: The WinterDrobe now has access to the other generic colored winter coats instead of just the gray one.
- add: Added fingerless budget insulated gloves. Assistants can now spawn with them instead of the normal fingerless insuls.
- add: Assistants can now spawn with the yellow mittens.
- tweak: Assistants can now spawn with the correct gray winter coat. (The one with a hood option.).

