### PR TITLE
Minor bugfixes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -310,7 +310,7 @@
         - id: ClothingEyesChameleon
         - id: ClothingHeadsetChameleon
         - id: ClothingShoesChameleon
-        - id: ChameleonControllerImplanter
+        - id: ClothingMiscChameleon # Starlight Removed the Implanter from the backpack to make space for the Medal slot item.
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateBundle

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1820,11 +1820,25 @@
   categories:
   - UplinkWearables
 
+# Starlight, listing disabled and replaced with chameleon crate
+# - type: listing
+#  id: UplinkChameleon
+#  name: uplink-chameleon-name
+#  description: uplink-chameleon-desc
+#  productEntity: ClothingBackpackChameleonFill
+#  icon: { sprite: /Textures/Clothing/Uniforms/Jumpsuit/rainbow.rsi, state: icon }
+#  discountCategory: usualDiscounts
+#  discountDownTo:
+#    Telecrystal: 2
+#  cost:
+#    Telecrystal: 4
+#  categories:
+#    - UplinkWearables
 - type: listing
-  id: UplinkChameleon
-  name: uplink-chameleon-name
-  description: uplink-chameleon-desc
-  productEntity: ClothingBackpackChameleonFillAgent
+  id: UplinkChameleonBundle
+  name: uplink-chameleon-bundle-name
+  description: uplink-chameleon-bundle-desc
+  productEntity: CrateSyndicateChameleonBundle
   icon: { sprite: /Textures/Clothing/Uniforms/Jumpsuit/rainbow.rsi, state: icon }
   discountCategory: usualDiscounts
   discountDownTo:
@@ -1833,6 +1847,7 @@
     Telecrystal: 4
   categories:
     - UplinkWearables
+# Starlight end
 
 - type: listing
   id: UplinkClothingNoSlipsShoes

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -122,6 +122,10 @@
     tags:
     - Soup
     - Fruit # I don't know what this is but its' a salad so sure
+  - type: Edible #Starlight
+    utensil:
+    - Fork
+    - Spoon
 
 - type: entity
   name: herb salad
@@ -154,6 +158,10 @@
     tags:
     - Fruit
     - Soup
+  - type: Edible #Starlight
+    utensil:
+    - Fork
+    - Spoon
 
 - type: entity
   name: valid salad
@@ -187,6 +195,10 @@
     - Meat
     - Fruit
     - Soup
+  - type: Edible #Starlight
+    utensil:
+    - Fork
+    - Spoon
 
 - type: entity
   name: coleslaw
@@ -214,6 +226,10 @@
           Quantity: 10
         - ReagentId: Allicin
           Quantity: 8
+  - type: Edible #Starlight
+    utensil:
+    - Fork
+    - Spoon
 
 - type: entity
   name: caesar salad
@@ -240,6 +256,10 @@
           Quantity: 15
         - ReagentId: Vitamin
           Quantity: 30
+  - type: Edible #Starlight
+    utensil:
+    - Fork
+    - Spoon
 
 - type: entity
   name: kimchi salad
@@ -267,6 +287,10 @@
           Quantity: 15
         - ReagentId: Allicin
           Quantity: 2
+  - type: Edible #Starlight
+    utensil:
+    - Fork
+    - Spoon
 
 - type: entity
   name: fruit salad
@@ -294,6 +318,10 @@
     tags:
     - Fruit
     - Soup
+  - type: Edible #Starlight
+    utensil:
+    - Fork
+    - Spoon
 
 - type: entity
   name: jungle salad
@@ -322,6 +350,10 @@
     tags:
     - Fruit
     - Soup
+  - type: Edible #Starlight
+    utensil:
+    - Fork
+    - Spoon
 
 - type: entity
   name: citrus salad
@@ -350,6 +382,10 @@
     tags:
     - Fruit
     - Soup
+  - type: Edible #Starlight
+    utensil:
+    - Fork
+    - Spoon
 
 - type: entity
   name: salad of eden
@@ -376,6 +412,10 @@
           Quantity: 5
         - ReagentId: Omnizine
           Quantity: 5
+  - type: Edible #Starlight
+    utensil:
+    - Fork
+    - Spoon
 
 # Rice
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -360,6 +360,10 @@
   - type: Stack
     stackType: AloeCream
     count: 10
+  - type: Item # Starlight start
+    storedSprite:
+      state: cream
+      sprite: Objects/Specific/Hydroponics/aloe.rsi # Starlight end
 
 - type: entity
   parent: BaseHealingItem

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
@@ -22,6 +22,9 @@
             - !type:SpawnPrototype
               prototype: SheetSteel1
               amount: 5
+            - !type:SpawnPrototype # Starlight
+              prototype: SheetPlasteel1 # Starlight
+              amount: 1 # Starlight
             - !type:EmptyAllContainers {}
             - !type:DestroyEntity {}
           conditions:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
@@ -22,9 +22,6 @@
             - !type:SpawnPrototype
               prototype: SheetSteel1
               amount: 5
-            - !type:SpawnPrototype # Starlight
-              prototype: SheetPlasteel1 # Starlight
-              amount: 1 # Starlight
             - !type:EmptyAllContainers {}
             - !type:DestroyEntity {}
           conditions:

--- a/Resources/Prototypes/_Starlight/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Fills/Crates/syndicate.yml
@@ -9,6 +9,6 @@
     containers:
       entity_storage: !type:AllSelector
         children:
-        - id: ClothingBackpackChameleonFill
+        - id: ClothingBackpackChameleonFillAgent
         - id: ChameleonControllerImplanter
 


### PR DESCRIPTION
## Short description
- Aloe cream shows up with the proper sprite in an inventory.
- Salads can now be eaten with a fork.
- Thief chameleon kit no longer spawns with two chameleon implanters, and gets the missing medal slot. Traitor chameleon kit gets the missing medal slot, and spawns in a crate as it was supposed to.

## Why we need to add this
Bugs are bad

## Media (Video/Screenshots)
<img width="190" height="133" alt="image" src="https://github.com/user-attachments/assets/c21bc445-2bd3-4de7-bb3b-9b1b86f0d879" />
<img width="254" height="105" alt="image" src="https://github.com/user-attachments/assets/b3f0580d-6218-469b-91d9-faa6dc18cdd6" />
<img width="288" height="205" alt="image" src="https://github.com/user-attachments/assets/d17fe63e-9dbc-4c23-98f1-5d9708d9a8e2" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
