### PR TITLE
Add missing autolog setalertlevel message

### DIFF
--- a/Resources/Locale/en-US/_Starlight/administration/autolog.ftl
+++ b/Resources/Locale/en-US/_Starlight/administration/autolog.ftl
@@ -5,5 +5,6 @@ autolog-admin-mouse = Became Admin Mouse
 autolog-mentor-mouse = Became Mentor Mouse
 
 autolog-setgamemap = Map forced to {$map} by {$admin}
+autolog-setalertlevel = Alert level forced to {$level} by {$admin} (locked: {$locked})
 autolog-announce = {$admin} sent a announcement {$sender} Announcement: {$message}
 autolog-tippy = Sent a tippy {$message} with {$prototype} prototype


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Adds missing FTL key for `autolog-setalertlevel`

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

In the [\#pushlog-stream](https://discord.com/channels/1272545509562777621/1484599832227348724) admin channel, alert level changes currently just say "autolog-setalertlevel" instead of a proper message.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

N/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

Not player facing, no CL
