### PR TITLE
Proto-Reptilians are no longer super ultra fire resistant

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_FarHorizons/Damage/modifier_sets.yml
@@ -75,7 +75,7 @@
   coefficients: # Swaps heat with cold
     Shock: 1.25
     Cold: 1.15 # Starlight, they can actually lose a little.
-    Heat: 0.5
+    Heat: 0.85 # Starlight, wow I actually missed this
     Slash: 0.9 # Something they should have with "tougher skin" according to the notes in the other modifer file
     Blunt: 1.1
 

--- a/Resources/Prototypes/_FarHorizons/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_FarHorizons/Damage/modifier_sets.yml
@@ -75,7 +75,7 @@
   coefficients: # Swaps heat with cold
     Shock: 1.25
     Cold: 1.15 # Starlight, they can actually lose a little.
-    Heat: 0.85 # Starlight, wow I actually missed this
+    Heat: 0.85 # Starlight, 50% was a bit too much.
     Slash: 0.9 # Something they should have with "tougher skin" according to the notes in the other modifer file
     Blunt: 1.1
 

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/SubMobs/ProtoReptilian.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/SubMobs/ProtoReptilian.xml
@@ -7,5 +7,5 @@
 
   ## Resistances
   - Receive [color=#8147ff]25% more shock damage[/color], [color=#FF3636]10% more blunt damage[/color], and [color=#1e90ff]15% more cold damage[/color].
-  - Receive [color=#ffa500]50% less heat damage[/color] and [color=#65807d]10% less slash damage[/color].
+  - Receive [color=#ffa500]15% less heat damage[/color] and [color=#65807d]10% less slash damage[/color].
 </Document>


### PR DESCRIPTION
## Short description
Changed their cold value, forgot to change their heat value

## Why we need to add this
Not healthy to have a species with 50% heat resist.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Proto-Reptilians now have their intended 15% heat resist instead of 50%.

