### PR TITLE
Botanist round start ghost role pet

### DIFF
--- a/Resources/Locale/en-US/_Starlight/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/ghost/roles/ghost-role-component.ftl
@@ -101,3 +101,6 @@ ghost-role-information-monkey-advanced-description = Why, I daresay I could go f
 
 ghost-role-information-kobold-advanced-name = Advanced Kobold
 ghost-role-information-kobold-advanced-description = You have a craving for filet mignon.
+
+ghost-role-information-kiki-name = Kiki
+ghost-role-information-kiki-description = An honorable member of the kobold society in charge of botany and helping the botanists in any way she can.

--- a/Resources/Prototypes/_Starlight/Entities/Markers/Spawners/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Markers/Spawners/pets.yml
@@ -1,0 +1,14 @@
+- type: entity
+  parent: MarkerBase
+  id: SpawnMobKoboldKiki
+  name: Kiki Spawner
+  suffix: Botanist Pet
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - state: kobold
+      sprite: Mobs/Animals/kobold.rsi
+  - type: ConditionalSpawner
+    prototypes:
+    - MobKoboldKiki

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
@@ -42,6 +42,11 @@
     - Ancestor
     - GalacticCommon
     - Draconic
+  - type: RandomSprite # Using random sprite since we need to overwrite the parent's random sprite, even if we're actually giving her a fixed appearance.
+    getAllGroups: true
+    available:
+      - horns:
+          horns_floppy_kobold_ears: Inherit
   - type: GhostRole
     prob: 1
     makeSentient: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
@@ -28,6 +28,51 @@
     - VimPilot
 
 - type: entity
+  name: Kiki
+  parent: MobKoboldAdvanced
+  id: MobKoboldKiki
+  suffix: AI
+  description: A prominent representative of kobolds with unlimited access to that which she doesn't want to eat.
+  components:
+  - type: LanguageKnowledge
+    speaks:
+    - Ancestor
+    - Draconic
+    understands:
+    - Ancestor
+    - GalacticCommon
+    - Draconic
+  - type: GhostRole
+    prob: 1
+    makeSentient: true
+    allowSpeech: true
+    allowMovement: true
+    name: ghost-role-information-kiki-name
+    description: ghost-role-information-kiki-description
+    rules: ghost-role-information-nonantagonist-rules
+    job: Botanist # 2hr botany requirement
+  - type: GhostTakeoverAvailable
+  - type: Butcherable
+    butcheringType: Spike
+    spawned:
+    - id: FoodMeat
+      amount: 3
+    - id: ChemistryBottleUnstableMutagen
+      amount: 1
+  - type: Tag
+    tags:
+    - CannotSuicide
+    - DoorBumpOpener
+    - VimPilot
+    - AnomalyHost
+  - type: Loadout
+    prototypes: [ MobKoboldGear ]
+  - type: Grammar
+    attributes:
+      proper: true
+      gender: female
+
+- type: entity
   parent: MobMouse
   id: MobMouseRemy
   name: Remy

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
@@ -50,7 +50,7 @@
     name: ghost-role-information-kiki-name
     description: ghost-role-information-kiki-description
     rules: ghost-role-information-nonantagonist-rules
-    job: Botanist # 2hr botany requirement
+    job: Botanist
   - type: GhostTakeoverAvailable
   - type: Butcherable
     butcheringType: Spike

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/pda.yml
@@ -519,6 +519,15 @@
     state: pda-punpun
 
 - type: entity
+  parent: BotanistPDA
+  id: KikiPDA
+  name: kiki's PDA
+  description: Has an earthy scent.
+  components:
+  - type: Pda
+    id: KikiIDCard
+
+- type: entity
   parent: BasePDA
   id: CommanderPDA
   name: commander PDA

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/identification_cards.yml
@@ -255,6 +255,28 @@
 
 - type: entity
   parent: IDCardStandard
+  id: KikiIDCard
+  name: kiki's ID card
+  components:
+  - type: Sprite
+    layers:
+    - state: default
+    - state: stripe_top
+      color: *color-service-top
+    - state: stripe_bottom
+      color: *color-service-bottom
+    - sprite: *icon-rsi
+      offset: *icon-offset
+      state: Botanist
+  - type: PresetIdCard
+    job: Botanist
+    name: Kiki
+  - type: Tag # Ignore Chameleon tags
+    tags:
+    - DoorBumpOpener
+
+- type: entity
+  parent: IDCardStandard
   id: SovietIdCard
   name: soviet id card
   components:

--- a/Resources/Prototypes/_Starlight/Roles/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Fun/misc_startinggear.yml
@@ -1,0 +1,8 @@
+- type: startingGear
+  id: MobKoboldGear
+  equipment:
+    head: ClothingHeadBandBotany
+    ears: ClothingHeadsetService
+    jumpsuit: ClothingUniformJumpskirtHydroponics
+    belt: ClothingBeltPlantFilled
+    id: KikiPDA


### PR DESCRIPTION
## Short description
Adds a "Pun Pun" equivalent to Botany, an advanced kobold named Kiki.

## Why we need to add this
Requested in mapping, and it's another ghost role players can use.

## Media (Video/Screenshots)
<img width="140" height="132" alt="image" src="https://github.com/user-attachments/assets/de6203f5-a0c7-4517-8533-fee770aa0dec" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: Added a new Botanist pet/ghost role, Kiki. She's like Pun Pun, but for botany. Comes with her own PDA, botany belt, clothes, and headset.
