### PR TITLE
Door runtime no longer opens all doors at the end of the event

### DIFF
--- a/Content.Server/_Starlight/GameTicking/Rules/Components/DoorRuntimeRuleComponent.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/Components/DoorRuntimeRuleComponent.cs
@@ -7,10 +7,4 @@ namespace Content.Server._Starlight.GameTicking.Rules.Components;
 public sealed partial class DoorRuntimeRuleComponent : Component
 {
     public readonly HashSet<EntityUid> AffectedEntities = new();
-
-    [DataField]
-    public EntityWhitelist? Whitelist;
-
-    [DataField]
-    public EntityWhitelist? Blacklist;
 }

--- a/Content.Server/_Starlight/GameTicking/Rules/DoorRuntimeRule.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/DoorRuntimeRule.cs
@@ -6,7 +6,6 @@ using Content.Shared.Electrocution;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Silicons.StationAi;
 using Content.Shared.Station.Components;
-using Content.Shared.Whitelist;
 using Robust.Shared.Timing;
 
 namespace Content.Server.StationEvents.Events;
@@ -16,7 +15,6 @@ public sealed class DoorRuntimeRule : StationEventSystem<DoorRuntimeRuleComponen
     [Dependency] private readonly SharedDoorSystem _door = default!;
     [Dependency] private readonly SharedElectrocutionSystem _electrocution = default!;
     [Dependency] private readonly SharedAirlockSystem _airlock = default!;
-    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
 
     protected override void Started(EntityUid uid, DoorRuntimeRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
@@ -88,9 +86,6 @@ public sealed class DoorRuntimeRule : StationEventSystem<DoorRuntimeRuleComponen
 
             if (TryComp<ElectrifiedComponent>(ent, out var electrified))
                 _electrocution.SetElectrified((ent, electrified), false);
-
-            if (!_whitelist.CheckBoth(ent, comp.Blacklist, comp.Whitelist))
-                continue;
         }
 
         comp.AffectedEntities.Clear();

--- a/Content.Server/_Starlight/GameTicking/Rules/DoorRuntimeRule.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/DoorRuntimeRule.cs
@@ -54,13 +54,13 @@ public sealed class DoorRuntimeRule : StationEventSystem<DoorRuntimeRuleComponen
             if (TryComp<ElectrifiedComponent>(ent, out var electrified))
                 _electrocution.SetElectrified((ent, electrified), true);
 
+            // turn off the airlock safety - we want to force doors to close (even if people are present)
+            if (TryComp<AirlockComponent>(ent, out var airlockComp) && airlockComp.Powered)
+                _airlock.SetSafety(airlockComp, false);
+
             // bolt all eligible doors
             if (TryComp<DoorBoltComponent>(ent, out var boltComp))
             {
-                // turn off the airlock safety - we want to force doors to close (even if people are present)
-                if (TryComp<AirlockComponent>(ent, out var airlockComp) && airlockComp.Powered)
-                    _airlock.SetSafety(airlockComp, false);
-
                 // bolt doors if welded or closed; if doors are open, try to close them before bolting
                 if (doorComp.State is DoorState.Welded or DoorState.Closed)
                     _door.SetBoltsDown((ent, boltComp), true);

--- a/Content.Server/_Starlight/GameTicking/Rules/DoorRuntimeRule.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/DoorRuntimeRule.cs
@@ -18,6 +18,7 @@ public sealed class DoorRuntimeRule : StationEventSystem<DoorRuntimeRuleComponen
     [Dependency] private readonly SharedDoorSystem _door = default!;
     [Dependency] private readonly SharedElectrocutionSystem _electrocution = default!;
     [Dependency] private readonly SharedAirlockSystem _airlock = default!;
+    private const float DoorCloseBoltDelay = 0.5f;
 
     /// <summary>
     /// Bolts, electrifies, and turns off the safety wire of any door with AI access.
@@ -64,7 +65,7 @@ public sealed class DoorRuntimeRule : StationEventSystem<DoorRuntimeRuleComponen
                 if (doorComp.State is DoorState.Welded or DoorState.Closed)
                     _door.SetBoltsDown((ent, boltComp), true);
                 else if (_door.TryClose(ent, doorComp))
-                    Timer.Spawn(TimeSpan.FromSeconds(0.5f), () => _door.SetBoltsDown((ent, boltComp), true));
+                    Timer.Spawn(TimeSpan.FromSeconds(DoorCloseBoltDelay), () => _door.SetBoltsDown((ent, boltComp), true));
             }
 
             // add to list so we can undo all of this later

--- a/Content.Server/_Starlight/GameTicking/Rules/DoorRuntimeRule.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/DoorRuntimeRule.cs
@@ -10,82 +10,90 @@ using Robust.Shared.Timing;
 
 namespace Content.Server.StationEvents.Events;
 
+/// <summary>
+/// A gamerule themed around a hostile virus-like program that bolts and electrifes doors on the station.
+/// </summary>
 public sealed class DoorRuntimeRule : StationEventSystem<DoorRuntimeRuleComponent>
 {
     [Dependency] private readonly SharedDoorSystem _door = default!;
     [Dependency] private readonly SharedElectrocutionSystem _electrocution = default!;
     [Dependency] private readonly SharedAirlockSystem _airlock = default!;
 
+    /// <summary>
+    /// Bolts, electrifies, and turns off the safety wire of any door with AI access.
+    /// </summary>
     protected override void Started(EntityUid uid, DoorRuntimeRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, comp, gameRule, args);
 
         EntityUid? chosenStation = null;
-        if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent))
+            return;
+
         chosenStation = stationEvent.TargetStation;
+
         if (chosenStation is null)
             if (!TryGetRandomStation(out chosenStation))
                 return;
 
+        // get all airlocks on station that are AI accessible (e.g. excludes doors with AI wire snipped)
         var airlockQuery = AllEntityQuery<DoorComponent, StationAiWhitelistComponent, TransformComponent>();
+
         while (airlockQuery.MoveNext(out var ent, out var doorComp, out var aiComp, out var xform))
         {
+            // ensure airlock is on the target station
             if (CompOrNull<StationMemberComponent>(xform.GridUid)?.Station != chosenStation)
                 continue;
 
+            // skip firelocks, skip doors that the station AI cannot control (usually snipped AI access wire)
             if (HasComp<FirelockComponent>(ent) || !aiComp.Enabled)
                 continue;
 
-            if (TryComp<AirlockComponent>(ent, out var airlockComp))
-            {
-                if (!airlockComp.Powered)
-                    continue;
+            // electrify all eligible doors
+            if (TryComp<ElectrifiedComponent>(ent, out var electrified))
+                _electrocution.SetElectrified((ent, electrified), true);
 
-                _airlock.SetSafety(airlockComp, false);
-            }
-
+            // bolt all eligible doors
             if (TryComp<DoorBoltComponent>(ent, out var boltComp))
+            {
+                // turn off the airlock safety - we want to force doors to close (even if people are present)
+                if (TryComp<AirlockComponent>(ent, out var airlockComp) && airlockComp.Powered)
+                    _airlock.SetSafety(airlockComp, false);
+
+                // bolt doors if welded or closed; if doors are open, try to close them before bolting
                 if (doorComp.State is DoorState.Welded or DoorState.Closed)
                     _door.SetBoltsDown((ent, boltComp), true);
                 else if (_door.TryClose(ent, doorComp))
                     Timer.Spawn(TimeSpan.FromSeconds(0.5f), () => _door.SetBoltsDown((ent, boltComp), true));
-            else
-                {
-                    if (TryComp<AirlockComponent>(ent, out var airlockComp2))
-                        _airlock.SetSafety(airlockComp2, true);
+            }
 
-                    continue;
-                }
-
-            if (TryComp<ElectrifiedComponent>(ent, out var electrified))
-                _electrocution.SetElectrified((ent, electrified), true);
-
+            // add to list so we can undo all of this later
             comp.AffectedEntities.Add(ent);
         }
     }
 
+    /// <summary>
+    /// Unbolts, unelectrifies, and restores the safety of all of the doors affected by the event.
+    /// </summary>
     protected override void Ended(EntityUid uid, DoorRuntimeRuleComponent comp, GameRuleComponent gameRule, GameRuleEndedEvent args)
     {
         base.Ended(uid, comp, gameRule, args);
 
+        // run through the list to undo the gamerule
         foreach (var ent in comp.AffectedEntities)
         {
-            if (TryComp<StationAiWhitelistComponent>(ent, out var aiComp) && !aiComp.Enabled)
-                continue;
-
+            // restore door safety - we want to do this even if the door isn't powered to avoid an edge-case
+            // e.g. door safety is turned off when door is powered, then door loses power before the end of the event
             if (TryComp<AirlockComponent>(ent, out var airlockComp))
-            {
-                if (!airlockComp.Powered)
-                    continue;
-
                 _airlock.SetSafety(airlockComp, true);
-            }
 
-            if (TryComp<DoorBoltComponent>(ent, out var boltComp))
-                _door.SetBoltsDown((ent, boltComp), false);
-
+            // unelectrify door
             if (TryComp<ElectrifiedComponent>(ent, out var electrified))
                 _electrocution.SetElectrified((ent, electrified), false);
+
+            // unbolt door
+            if (TryComp<DoorBoltComponent>(ent, out var boltComp))
+                _door.SetBoltsDown((ent, boltComp), false);
         }
 
         comp.AffectedEntities.Clear();

--- a/Content.Server/_Starlight/GameTicking/Rules/DoorRuntimeRule.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/DoorRuntimeRule.cs
@@ -91,8 +91,6 @@ public sealed class DoorRuntimeRule : StationEventSystem<DoorRuntimeRuleComponen
 
             if (!_whitelist.CheckBoth(ent, comp.Blacklist, comp.Whitelist))
                 continue;
-
-            _door.TryOpen(ent);
         }
 
         comp.AffectedEntities.Clear();

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/external.yml
@@ -20,11 +20,6 @@
     layoutId: AirlockExternal
   - type: Paintable
     group: null
-  # Starlight Start
-  - type: Tag
-    tags:
-      - ExternalAirlock
-  # Starlight End
 
 - type: entity
   parent: AirlockExternal

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -79,7 +79,6 @@
   - type: Tag
     tags:
       - ForceNoFixRotations
-      - ExternalAirlock # Starlight
   - type: Construction
     graph: AirlockShuttle
     node: airlock

--- a/Resources/Prototypes/_Starlight/GameRules/passiveevent.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/passiveevent.yml
@@ -51,6 +51,7 @@
       duration: 90
       reoccurrenceDelay: 20
       maxOccurrences: 2
+    - type: DoorRuntimeRule
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_Starlight/GameRules/passiveevent.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/passiveevent.yml
@@ -51,10 +51,6 @@
       duration: 90
       reoccurrenceDelay: 20
       maxOccurrences: 2
-    - type: DoorRuntimeRule
-      blacklist:
-        tags:
-          - ExternalAirlock
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -225,9 +225,6 @@
   id: EmergencyWelder
 
 - type: Tag
-  id: ExternalAirlock
-
-- type: Tag
   id: Felionoid
 
 - type: Tag


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
This PR does two things:
- Removes the 'force open all doors' effect at the end of a door runtime event.
- Rewrites the event logic to fix some edge cases.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
#4000 attempted to fix the door runtime event spacing the entire station when the event ended.

However:
- It hasn't fixed the issue. The station still regularly gets spaced by the event, typically due to non-external spacing being spread around the station.
- Player feedback around this event is still extremely negative. This is reported as an issue nearly weekly in the bugs channel.
- Mass spacing of the entire station isn't fun.

Making the doors not open at the end of the event is a permanent and reliable fix to not spacing the station.

In the future, I would recommend that this event is re-tooled entirely. Maybe it could affect one department instead of the whole station - that'd reduce the "space the whole dang station" issue and be more in-line with other events (like door lagger).

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/a92e7272-2f50-4627-9497-e09dac4f93d0

fig. 1 - Video demonstration. The doors aren't forced open at the end of the event anymore.

https://github.com/user-attachments/assets/5e78797d-2433-4790-8880-bf8dd862e381

fig. 2 - Video demonstration. Doors with the AI wire snipped aren't affected as intended.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: The 'door runtime' event no longer force-opens doors at the end of the event.
- fix: The 'door runtime' event correctly restores the safety wire of doors it affects after the event ends.