### PR TITLE
Add AstroNav to TA

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -204,6 +204,17 @@
     accentVColor: "#949137"
   - type: Icon
     state: pda-interntech
+    # Starlight BEGIN
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NanoTaskCartridge
+      - NewsReaderCartridge
+      - AstroNavCartridge
+      - NanoChatCartridge
+    # Starlight END
 
 - type: entity
   parent: BaseMedicalPDA


### PR DESCRIPTION
## Short description
Giving Technical Assistants AstroNav to their PDA

## Why we need to add this
#3788 added AstroNav to the other engineering roles. Technical Assistants were missed and I am tired of giving TAs AstroNav when playing CE

## Media (Video/Screenshots)
<img width="270" height="142" alt="pasted file" src="https://github.com/user-attachments/assets/5edf948d-b7c1-42a6-ad1a-52a364d6c770" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: SiTW
- tweak: Technical Assistants now get AstroNav.


