### PR TITLE
Protogen playtest fixes

### DIFF
--- a/Content.Server/Atmos/Components/BarotraumaComponent.cs
+++ b/Content.Server/Atmos/Components/BarotraumaComponent.cs
@@ -28,8 +28,18 @@ namespace Content.Server.Atmos.Components
         ///     These are the inventory slots that are checked for pressure protection. If a slot is missing protection, no protection is applied.
         /// </summary>
         [DataField("protectionSlots")]
-        public List<string> ProtectionSlots = new() { "head", "outerClothing" };
-
+        public List<string> ProtectionSlots = new() { "head" }; // Starlight, outerClothing moved to alternativeProtectionSlots
+        #region Starlight
+        /// <summary>
+        /// Groups of inventory slots where at least one slot in each group must have pressure protection.
+        /// Example: [["outerClothing", "outerClothing2"]] means either suit slot works.
+        /// </summary>
+        [DataField("alternativeProtectionSlots")]
+        public List<List<string>> AlternativeProtectionSlots = new()
+        {
+            new() { "outerClothing" }
+        };
+        #endregion
         /// <summary>
         /// Cached pressure protection values
         /// </summary>

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -141,6 +141,11 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     var found = false;
 
+                    var groupHPModifier = 0f;
+                    var groupHPMultiplier = 1f;
+                    var groupLPModifier = 0f;
+                    var groupLPMultiplier = 1f;
+
                     foreach (var slot in group)
                     {
                         if (!TryGetProtectionFromSlot(uid, slot, inv, contMan,
@@ -152,11 +157,10 @@ namespace Content.Server.Atmos.EntitySystems
 
                         found = true;
 
-                        hPModifier = Math.Max(hPModifier, itemHighModifier.Value);
-                        hPMultiplier = Math.Max(hPMultiplier, itemHighMultiplier.Value);
-                        lPModifier = Math.Min(lPModifier, itemLowModifier.Value);
-                        lPMultiplier = Math.Min(lPMultiplier, itemLowMultiplier.Value);
-                        break;
+                        groupHPModifier = Math.Max(groupHPModifier, itemHighModifier.Value);
+                        groupHPMultiplier = Math.Max(groupHPMultiplier, itemHighMultiplier.Value);
+                        groupLPModifier = Math.Min(groupLPModifier, itemLowModifier.Value);
+                        groupLPMultiplier = Math.Min(groupLPMultiplier, itemLowMultiplier.Value);
                     }
 
                     if (!found)
@@ -167,6 +171,11 @@ namespace Content.Server.Atmos.EntitySystems
                         lPMultiplier = 1f;
                         break;
                     }
+
+                    hPModifier = Math.Max(hPModifier, groupHPModifier);
+                    hPMultiplier = Math.Max(hPMultiplier, groupHPMultiplier);
+                    lPModifier = Math.Min(lPModifier, groupLPModifier);
+                    lPMultiplier = Math.Min(lPMultiplier, groupLPMultiplier);
                 }
                 #endregion
 

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq; // Starlight
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.Components;
 using Content.Shared.Alert;
@@ -65,18 +66,33 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnPressureProtectionEquipped(EntityUid uid, PressureProtectionComponent pressureProtection, GotEquippedEvent args)
         {
-            if (TryComp<BarotraumaComponent>(args.Equipee, out var barotrauma) && barotrauma.ProtectionSlots.Contains(args.Slot))
-            {
-                UpdateCachedResistances(args.Equipee, barotrauma);
-            }
+            #region Starlight
+            //if (TryComp<BarotraumaComponent>(args.Equipee, out var barotrauma) && barotrauma.ProtectionSlots.Contains(args.Slot))
+            //{
+            //    UpdateCachedResistances(args.Equipee, barotrauma);
+            //}
+            if (!TryComp<BarotraumaComponent>(args.Equipee, out var barotrauma))
+                return;
+
+            // Check for alternative slots too, since we're supporting that now.
+            if (!barotrauma.ProtectionSlots.Contains(args.Slot) &&
+                !barotrauma.AlternativeProtectionSlots.Any(group => group.Contains(args.Slot)))
+                return;
+
+            UpdateCachedResistances(args.Equipee, barotrauma);
+            #endregion
         }
 
         private void OnPressureProtectionUnequipped(EntityUid uid, PressureProtectionComponent pressureProtection, GotUnequippedEvent args)
         {
-            if (TryComp<BarotraumaComponent>(args.Equipee, out var barotrauma) && barotrauma.ProtectionSlots.Contains(args.Slot))
-            {
-                UpdateCachedResistances(args.Equipee, barotrauma);
-            }
+            if (!TryComp<BarotraumaComponent>(args.Equipee, out var barotrauma))
+                return;
+
+            if (!barotrauma.ProtectionSlots.Contains(args.Slot) &&
+                !barotrauma.AlternativeProtectionSlots.Any(group => group.Contains(args.Slot)))
+                return;
+
+            UpdateCachedResistances(args.Equipee, barotrauma);
         }
 
         /// <summary>
@@ -99,8 +115,7 @@ namespace Content.Server.Atmos.EntitySystems
 
                 foreach (var slot in barotrauma.ProtectionSlots)
                 {
-                    if (!_inventorySystem.TryGetSlotEntity(uid, slot, out var equipment, inv, contMan)
-                        || !TryGetPressureProtectionValues(equipment.Value,
+                    if (!TryGetProtectionFromSlot(uid, slot, inv, contMan, // Starlight
                             out var itemHighMultiplier,
                             out var itemHighModifier,
                             out var itemLowMultiplier,
@@ -120,6 +135,40 @@ namespace Content.Server.Atmos.EntitySystems
                     lPModifier = Math.Min(lPModifier, itemLowModifier.Value);
                     lPMultiplier = Math.Min(lPMultiplier, itemLowMultiplier.Value);
                 }
+                #region Starlight
+                // Alternative slot stuff here
+                foreach (var group in barotrauma.AlternativeProtectionSlots)
+                {
+                    var found = false;
+
+                    foreach (var slot in group)
+                    {
+                        if (!TryGetProtectionFromSlot(uid, slot, inv, contMan,
+                                out var itemHighMultiplier,
+                                out var itemHighModifier,
+                                out var itemLowMultiplier,
+                                out var itemLowModifier))
+                            continue;
+
+                        found = true;
+
+                        hPModifier = Math.Max(hPModifier, itemHighModifier.Value);
+                        hPMultiplier = Math.Max(hPMultiplier, itemHighMultiplier.Value);
+                        lPModifier = Math.Min(lPModifier, itemLowModifier.Value);
+                        lPMultiplier = Math.Min(lPMultiplier, itemLowMultiplier.Value);
+                        break;
+                    }
+
+                    if (!found)
+                    {
+                        hPModifier = 0f;
+                        hPMultiplier = 1f;
+                        lPModifier = 0f;
+                        lPMultiplier = 1f;
+                        break;
+                    }
+                }
+                #endregion
 
                 barotrauma.HighPressureModifier = hPModifier;
                 barotrauma.HighPressureMultiplier = hPMultiplier;
@@ -293,5 +342,29 @@ namespace Content.Server.Atmos.EntitySystems
                 }
             }
         }
+        #region Starlight
+        private bool TryGetProtectionFromSlot(
+                    EntityUid uid,
+                    string slot,
+                    InventoryComponent inv,
+                    ContainerManagerComponent contMan,
+                    [NotNullWhen(true)] out float? highMultiplier,
+                    [NotNullWhen(true)] out float? highModifier,
+                    [NotNullWhen(true)] out float? lowMultiplier,
+                    [NotNullWhen(true)] out float? lowModifier)
+        {
+            highMultiplier = null;
+            highModifier = null;
+            lowMultiplier = null;
+            lowModifier = null;
+
+            return _inventorySystem.TryGetSlotEntity(uid, slot, out var equipment, inv, contMan)
+                && TryGetPressureProtectionValues(equipment.Value,
+                    out highMultiplier,
+                    out highModifier,
+                    out lowMultiplier,
+                    out lowModifier);
+        }
+        #endregion
     }
 }

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -251,7 +251,11 @@ public abstract partial class InventorySystem
             return false;
 
         DebugTools.Assert(slotDefinition.Name == slot);
-        if (slotDefinition.DependsOn != null)
+        #region Starlight
+        // We're going to check for alternative dependencies here, so we'll have to extend this down below.
+        if (!AreSlotDependenciesMet(target, itemUid, slotDefinition, inventory))
+            return false;
+        /*if (slotDefinition.DependsOn != null)
         {
             if (!TryGetSlotEntity(target, slotDefinition.DependsOn, out EntityUid? slotEntity, inventory))
                 return false;
@@ -268,7 +272,8 @@ public abstract partial class InventorySystem
                         return false;
                 }
             }
-        }
+        }*/
+        #endregion
 
         var fittingInPocket = slotDefinition.SlotFlags.HasFlag(SlotFlags.POCKET) &&
                               item != null &&
@@ -468,11 +473,20 @@ public abstract partial class InventorySystem
 
         foreach (var slotDef in inventory.Slots)
         {
-            if (slotDef != slotDefinition && slotDef.DependsOn == slotDefinition.Name)
-            {
+        #region Starlight
+                if (slotDef == slotDefinition || !SlotDependsOn(slotDef, slotDefinition.Name))
+                    continue;
+
+                // If this slot has an OR dependency, do not drop it as long as one of the other dependency slots is still occupied
+                // and satisfies dependsOnComponents.
+                if (TryGetSlotEntity(target, slotDef.Name, out var dependentItem, inventory) &&
+                    AreSlotDependenciesMet(target, dependentItem.Value, slotDef, inventory))
+                    continue;
+        #endregion
+            //{ // Starlight
                 //this recursive call might be risky
                 TryUnequip(actor, target, slotDef.Name, out _, ref itemsDropped, true, true, predicted, inventory, reparent: reparent);
-            }
+            //} // Starlight
         }
 
         // we check if any items were dropped, and make a popup if they were.
@@ -555,7 +569,58 @@ public abstract partial class InventorySystem
 
         return true;
     }
+    #region Starlight
+    // Extended alternative slot region.
+    private bool AreSlotDependenciesMet(EntityUid target, EntityUid itemUid, SlotDefinition slotDefinition, InventoryComponent inventory)
+    {
+        if (slotDefinition.DependsOn != null &&
+            !IsDependencySlotValid(target, itemUid, slotDefinition, slotDefinition.DependsOn, inventory))
+            return false;
 
+        if (slotDefinition.DependsOnAny.Count > 0)
+        {
+            // I don't like how many fors this gets into, but since realistically the most anyone will ever use this for is 2 or 3... it's not the worst, right?
+            foreach (var dependencySlot in slotDefinition.DependsOnAny)
+            {
+                if (IsDependencySlotValid(target, itemUid, slotDefinition, dependencySlot, inventory))
+                    return true;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool IsDependencySlotValid(EntityUid target, EntityUid itemUid, SlotDefinition slotDefinition, string dependencySlot, InventoryComponent inventory)
+    {
+        if (!TryGetSlotEntity(target, dependencySlot, out EntityUid? slotEntity, inventory))
+            return false;
+
+        if (slotDefinition.DependsOnComponents is not { } componentRegistry)
+            return true;
+
+        foreach (var (_, entry) in componentRegistry)
+        {
+            if (!HasComp(slotEntity, entry.Component.GetType()))
+                return false;
+
+            if (TryComp<AllowSuitStorageComponent>(slotEntity, out var comp) &&
+                _whitelistSystem.IsWhitelistFailOrNull(comp.Whitelist, itemUid))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool SlotDependsOn(SlotDefinition slotDefinition, string dependencySlot)
+    {
+        if (slotDefinition.DependsOn == dependencySlot)
+            return true;
+
+        return slotDefinition.DependsOnAny.Contains(dependencySlot);
+    }
+    #endregion
     public bool TryGetSlotEntity(EntityUid uid, string slot, [NotNullWhen(true)] out EntityUid? entityUid, InventoryComponent? inventoryComponent = null, ContainerManagerComponent? containerManagerComponent = null)
     {
         entityUid = null;

--- a/Content.Shared/Inventory/InventoryTemplatePrototype.cs
+++ b/Content.Shared/Inventory/InventoryTemplatePrototype.cs
@@ -36,7 +36,11 @@ public sealed partial class SlotDefinition
     [DataField("dependsOn")] public string? DependsOn { get; private set; }
 
     [DataField("dependsOnComponents")] public ComponentRegistry? DependsOnComponents { get; private set; }
-
+    #region Starlight
+    // List of slots that this slot depends on (at least one must be occupied), used in place of dependsOn.
+    [DataField("dependsOnAny")]
+    public List<string> DependsOnAny = new();
+    #endregion
     [DataField("displayName", required: true)]
     public string DisplayName { get; private set; } = string.Empty;
 

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicDamageSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicDamageSystem.cs
@@ -30,7 +30,7 @@ public sealed class HitscanBasicDamageSystem : EntitySystem
                 ignoreResistances: ent.Comp.IgnoreResistances,
                 origin: args.Data.Gun,
                 armorPenetration: ent.Comp.ArmorPenetration,
-                canHeal: false
+                canHeal: true // Need this true to be able to deal extra damage on weakness.
             );
         // Starlight end
 

--- a/Resources/Prototypes/_FarHorizons/Body/Organs/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Organs/protogen.yml
@@ -362,12 +362,23 @@
     - id: Narcotic
 
 # Starlight start
+# Laspi
+- type: entity
+  id: SentientProtoSlimeCore
+  parent: SentientSlimeCore
+  name: augmented sentient slime core
+  description: "The source of incredible, unending gooeyness."
+  components:
+    - type: Stomach
+      specialDigestible:
+        tags:
+        - RamChip
+
 # Cyclorite
 - type: entity
   id: OrganProtoCycloriteLungs
   parent: OrganProtogenLungs
-  name: cybernetic lungs
-  suffix: Cyclorite
+  name: cyclorite cybernetic lungs
   description: Filters nitrogen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier. Entirely cybernetic in nature, working in tandem with the visor's filtration system.
   components:
   - type: Lung
@@ -380,6 +391,19 @@
     groups:
     - id: Gas
       rateModifier: 100.0
+
+- type: entity
+  id: OrganProtoCycloriteHeart
+  parent: OrganProtogenHeart
+  name: cyclorite cybernetic heart
+  components:
+  - type: Metabolizer
+    maxReagents: 2
+    metabolizerTypes: [Cyclorite]
+    groups:
+    - id: Medicine
+    - id: Poison
+    - id: Narcotic
 
 # Starlight end
 
@@ -426,8 +450,7 @@
 - type: entity
   id: OrganProtoVoxLungs
   parent: OrganProtogenLungs
-  name: cybernetic lungs
-  suffix: Vox
+  name: vox cybernetic lungs
   description: Filters nitrogen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier. Entirely cybernetic in nature, working in tandem with the visor's filtration system. #  Starlight, quotation marks removed
   components:
   - type: Metabolizer

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Player/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Player/protogen.yml
@@ -66,7 +66,7 @@
 
 - type: entity
   save: false
-  name: Urist McUrister # Starlight, to match with our Dwarf naming changes
+  name: Urist McHands The Proto-Dwarf # Starlight, to match with our Dwarf naming changes
   parent: BaseMobProtoDwarf # Starlight, Dawi -> Dwarf
   id: MobProtoDwarf # Starlight, Dawi -> Dwarf
 

--- a/Resources/Prototypes/_Starlight/Body/Prototypes/Protogen/cyclorite.yml
+++ b/Resources/Prototypes/_Starlight/Body/Prototypes/Protogen/cyclorite.yml
@@ -21,7 +21,7 @@
       - right leg
       - left leg
       organs:
-        heart: OrganProtogenHeart
+        heart: OrganProtoCycloriteHeart # Starlight
         lungs: OrganProtoCycloriteLungs # Starlight
         stomach: OrganProtogenStomach
         liver: OrganProtogenLiver

--- a/Resources/Prototypes/_Starlight/Body/Prototypes/Protogen/slime.yml
+++ b/Resources/Prototypes/_Starlight/Body/Prototypes/Protogen/slime.yml
@@ -20,7 +20,7 @@
       - left leg
       organs:
         heart: OrganSlimeHeart
-        core: SentientSlimeCore
+        core: SentientProtoSlimeCore # So they can eat ramchips.
         lungs: OrganSlimeLungs
         cavity: null
         brain_implant: null # 🌟Starlight🌟

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/protogen.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/protogen.yml
@@ -1,7 +1,7 @@
 # Moved here due to the significant changes we're making.
 #### Proto-Armor ####
 - type: entity
-  parent: [ClothingOuterBaseMedium, AllowSuitStorageClothing]
+  parent: ClothingOuterBaseMedium
   id: ClothingOuterArmorProtogenBase
   abstract: true
   components:
@@ -156,7 +156,7 @@
     damageCoefficient: 0.75
 
 - type: entity
-  parent: ClothingOuterArmorProtogenBase
+  parent: [ClothingOuterArmorProtogenBase, AllowSuitStorageClothing]
   id: ClothingOuterArmorProtogenHeavySpace
   name: Nyx-Class heavy protogen frame
   description: Comes in-built with heavy insulation for spacefaring. A bit weighty. Removal of this would require killing you.

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/base.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/base.yml
@@ -161,6 +161,11 @@
             sprite: _FarHorizons/Mobs/Species/Protogen/displacement.rsi
             state: jumpsuit-female
   - type: Barotrauma
+    protectionSlots:
+    - head
+    alternativeProtectionSlots:
+    - - outerClothing
+      - outerClothing2
     damage:
       types:
         Blunt: 0.9 #per second, halved compared to normal. / Starlight, changed back to base 0.9.

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/dwarf.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/dwarf.yml
@@ -1,6 +1,6 @@
 - type: entity
   save: false
-  name: Urist McUrister
+  name: Urist McHands The Proto-Dwarf
   parent: [BaseMobProtogen, BaseSpeciesPickupable]
   id: BaseMobProtoDwarf
   abstract: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/shadekin.yml
@@ -157,6 +157,11 @@
                   max: 1
             - !type:BurnBodyBehavior {}
     - type: Barotrauma
+      protectionSlots:
+      - head
+      alternativeProtectionSlots:
+      - - outerClothing
+        - outerClothing2
       damage:
         types:
           Blunt: 0.85 #per second, scales with pressure and other constants.

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/slime.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/slime.yml
@@ -79,6 +79,11 @@
       - ReagentId: Slime
         Quantity: 300
   - type: Barotrauma
+    protectionSlots:
+    - head
+    alternativeProtectionSlots:
+    - - outerClothing
+      - outerClothing2
     damage:
       types:
         Blunt: 1

--- a/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/arachnid_inventory_template.yml
+++ b/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/arachnid_inventory_template.yml
@@ -156,7 +156,9 @@
     stripTime: 3
     uiWindowPos: 2,0
     strippingWindowPos: 2,5
-    dependsOn: outerClothing
+    dependsOnAny:
+    - outerClothing
+    - outerClothing2
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Suit Storage

--- a/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/cyclorite_inventory_template.yml
+++ b/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/cyclorite_inventory_template.yml
@@ -107,7 +107,9 @@
     stripTime: 3
     uiWindowPos: 2,0
     strippingWindowPos: 2,5
-    dependsOn: outerClothing
+    dependsOnAny:
+    - outerClothing
+    - outerClothing2
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Suit Storage
@@ -118,7 +120,9 @@
     stripTime: 3
     uiWindowPos: 2,5
     strippingWindowPos: 2,6
-    dependsOn: outerClothing
+    dependsOnAny:
+    - outerClothing
+    - outerClothing2
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Suit Storage 2

--- a/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/diona_inventory_template.yml
+++ b/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/diona_inventory_template.yml
@@ -100,7 +100,9 @@
     stripTime: 3
     uiWindowPos: 2,0
     strippingWindowPos: 2,5
-    dependsOn: outerClothing
+    dependsOnAny:
+    - outerClothing
+    - outerClothing2
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Suit Storage

--- a/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/protogen_inventory_template.yml
+++ b/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/protogen_inventory_template.yml
@@ -107,7 +107,9 @@
     stripTime: 3
     uiWindowPos: 2,0
     strippingWindowPos: 2,5
-    dependsOn: outerClothing
+    dependsOnAny:
+    - outerClothing
+    - outerClothing2
     dependsOnComponents:
     - type: AllowSuitStorage
     displayName: Suit Storage

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/SubMobs/ProtoMoth.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/SubMobs/ProtoMoth.xml
@@ -11,5 +11,7 @@
   - Receive [color=#ffa500]20% more heat damage[/color], [color=#8147ff]25% more shock damage[/color], and [color=#FF3636]10% more blunt damage[/color].
   - Receive [color=#1e90ff]40% less cold damage[/color].
 
+  Similar to their non-cybernetic brethren, they [color=red]catch on fire more easily and take 350% more fire damage than other species.[/color]
+
   With the advent of advanced cybernetics and with some help from their extensive body modifications, Proto-Moth have been able to get rid of their inability to properly process most foods and as such can enjoy and metabolise just about any food under the sun, including their favorite snack of choice- Boots!
 </Document>


### PR DESCRIPTION
## Short description
Fixes the Hermes-Class and Nyx-Class Protogen Frames, and fixes a bunch of other small Protogen bugs.

When all these PRs are merged, Protogen should be ready for live:
https://github.com/ss14Starlight/space-station-14/pull/4642
https://github.com/ss14Starlight/space-station-14/pull/4645
https://github.com/ss14Starlight/space-station-14/pull/4646
This one.

## AI disclaimer
Note, I used AI heavily to complete the C# segments of this PR, as the functionality I needed to match is outside of my knowledge-scope. It will need a closer review.

## Why we need to add this
Fixes a lot of stuff, adds extra functionality in C# needed to implement said changes.

## Media (Video/Screenshots)
<img width="181" height="182" alt="image" src="https://github.com/user-attachments/assets/0bad1c5c-918f-4de2-9616-8f589c6b84c0" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: Added functionality for allowing clothing slots to depend on multiple clothing slots alternatively.
- add: The Nyx-Class Protogen frame can now equip an item to your suit storage slot.
- add: Added functionality for barotrauma protection to accept alternative clothing slots.
- add: Hitscan weapons can now deal extra damage to people wearing armor with negative resistances.
- add: Added a section to Proto-Moth's guidebook entry mentioning their severe fire weakness more directly.
- tweak: Renamed Urist McUrister to Urist McHands the Proto-Dwarf.
- fix: The Hermes-Class Protogen frame now correctly increases damage taken by hitscan weapons.
- fix: The Nyx-Class Protogen frame now actually counts as barotrauma protection.
- fix: Proto-Cyclorites now correctly process poisons like normal Cyclorites.
- fix: Proto-Laspi can now eat computer boards.

