### PR TITLE
Fix tests (kinda)

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -132,7 +132,7 @@ jobs:
             exit 0
           fi
           timeout --signal=TERM --kill-after=2m 15m \
-            dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj --logger "trx;LogFileName=results.trx" --logger "console;verbosity=normal" --results-directory /tmp/test-results --blame-hang --blame-hang-timeout 6min -- NUnit.MapWarningTo=Failed NUnit.Where="$FILTER"
+            dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj --logger "trx;LogFileName=results.trx" --logger "console;verbosity=normal" --results-directory /tmp/test-results --blame-hang --blame-hang-timeout 7min -- NUnit.MapWarningTo=Failed NUnit.Where="$FILTER"
 
     - name: Test results
       continue-on-error: true

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -132,7 +132,7 @@ jobs:
             exit 0
           fi
           timeout --signal=TERM --kill-after=2m 15m \
-            dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj --logger "trx;LogFileName=results.trx" --logger "console;verbosity=normal" --results-directory /tmp/test-results --blame-hang --blame-hang-timeout 3min -- NUnit.MapWarningTo=Failed NUnit.Where="$FILTER"
+            dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj --logger "trx;LogFileName=results.trx" --logger "console;verbosity=normal" --results-directory /tmp/test-results --blame-hang --blame-hang-timeout 6min -- NUnit.MapWarningTo=Failed NUnit.Where="$FILTER"
 
     - name: Test results
       continue-on-error: true

--- a/Content.IntegrationTests/Tests/Minds/MindTests.EntityDeletion.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.EntityDeletion.cs
@@ -23,7 +23,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestDeleteVisiting()
     {
-        await using var pair = await SetupPair();
+        await using var pair = await SetupPair(dirty: true); // Starlight, this keeps failing, so I'm going to try seeing if this fixes it.
         var server = pair.Server;
 
         var entMan = server.ResolveDependency<IServerEntityManager>();
@@ -220,7 +220,7 @@ public sealed partial class MindTests
     [Test]
     public async Task TestGhostToAghost()
     {
-        await using var pair = await SetupPair();
+        await using var pair = await SetupPair(dirty: true); // Starlight, this keeps failing because it fails to delete the ghost, so I'm going to try seeing if this fixes it.
         var server = pair.Server;
         var entMan = server.ResolveDependency<IServerEntityManager>();
         var playerMan = server.ResolveDependency<IPlayerManager>();


### PR DESCRIPTION
## Short description
So, I was wondering why shard 6 keeps failing, so I had AI make it a bit more verbose for me. (Not PRing that, since I imagine it's not something we want.)

Doing so, I learned what's probably the cause of shard 6 failing so frequently.

We have about 16000 entities. On my local machine, it takes about 2 and a half minutes to spawn and dirty them via SpawnAndDirtyAllEntities. Tests are given 3 minutes to run before they timeout. The test needs to cleanly delete all the entities too. You can probably figure out what happens next.

So, this is by no means a permanent fix, and it doesn't fix the problems with shard 2, since I can't seem to reproduce them on my end, but at the very least, this should stop shard 6 from timing out when it's actually working fine.

Now, I have no idea how this'll affect the test completion time of actual hung tests, but since I just set the timeout to 6 minutes instead of 3, I imagine the worst time you could "lose" from this is 6 minutes (+3 on the first attempt, +3 on the second attempt).

Ideally, SpawnAndDirtyAllEntities and EvacShuttleTest should be set to run for 6 minutes instead of 3.

Furthermore, shard 2 seems to fail TakeRoleAndReturn, TestGhostToAghost, and SpawnAndDeleteAllEntitiesOnDifferentMaps sometimes, but I can't reproduce this on my end myself.

Update: I managed to reproduce them. From what I can somewhat figure out, SpawnAndDeleteAllEntitiesOnDifferentMaps seems to be suffering the same timeout as the other spawn test, while TakeRoleAndReturn, TestGhostToAghost, and TestDeleteVisiting seem to be having this interaction with each other, where one of TestGhostToAghost or TestDeleteVisiting fails to delete their ghost, leading to TakeRoleAndReturn sometimes failing because it fails if any ghosts still exist, so I've made the two tests count as dirty tests, so TakeRoleAndReturn doesn't try to use them.

We do technically lose efficiency by making those tests dirty, since it has to start up a new server/client after them, but I think them not being flaky is better than them being a little faster.

Oh, and I increased the timeout to 7 minutes after seeing how SpawnAndDeleteAllEntitiesOnDifferentMaps can sometimes take that long on my local.

I really need someone smarter than me to look at this, because I'm just kind of hoping this'll work here.

## Why we need to add this
I have seen Rinary try to merge the same PR 5 times now. My test failures take an hour because the dump takes like 30 minutes.

## Checks
- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
