### PR TITLE
Add character editor to the ghosts

### DIFF
--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -293,7 +293,7 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
         // detach the gui from it's parent (Most of the time the lobby)
         characterGui.Orphan();
 
-        var window = new DefaultWindow
+        var window = new CharacterSetupWindow
         {
             Title = Loc.GetString("character-setup-window-title"),
         };
@@ -310,6 +310,14 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
 
         _characterSetupWindow = window;
         window.OpenCentered();
+    }
+
+    private sealed class CharacterSetupWindow : DefaultWindow
+    {
+        public CharacterSetupWindow()
+        {
+            CloseButton.Visible = false;
+        }
     }
     // end starlight
 

--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Numerics; //🌟Starlight🌟
 using Content.Client.Guidebook;
 using Content.Client.Humanoid;
 using Content.Client.Inventory;
@@ -14,13 +15,14 @@ using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
 using Content.Shared.Roles;
-using Content.Shared.Starlight.CCVar; // Starlight-edit
+using Content.Shared.Starlight.CCVar; //🌟Starlight🌟
 using Content.Shared.Traits;
 using Robust.Client.Player;
 using Robust.Client.ResourceManagement;
 using Robust.Client.State;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controllers;
+using Robust.Client.UserInterface.CustomControls; //🌟Starlight🌟
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
@@ -48,6 +50,13 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
     private HumanoidProfileEditor? _profileEditor;
     private JobPriorityEditor? _jobPriorityEditor;
     private CharacterSetupGuiSavePanel? _savePanel;
+
+    /// begin starlight 
+    /// <summary>
+    /// character editor window, see OpenCharacterSetupWindow()
+    /// </summary>
+    private DefaultWindow? _characterSetupWindow;
+    //end starlight
 
     /// <summary>
     /// Event invoked when any character or job selection or job priority is changed.
@@ -255,8 +264,54 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
         {
             lobbyGui.SwitchState(LobbyGui.LobbyGuiState.Default);
         }
+
+        // make sure the window is closed.
+        _characterSetupWindow?.Close(); // starlight
+
         RefreshLobbyPreview();
     }
+    ///begin starlight
+    /// <summary>
+    /// Opens the character editor in its own window, we reuse the one from the lobby for the sake of simplicity.
+    /// </summary>
+    public void OpenCharacterSetupWindow()
+    {
+        // don't open it more than once.
+        if (_characterSetupWindow is { IsOpen: true })
+        {
+            _characterSetupWindow.MoveToFront();
+            return;
+        }
+
+        var (characterGui, _) = EnsureGui();
+
+        // reload these, the lobby button does this so we do it aswell
+        characterGui.ReloadCharacterPickers();
+        _profileEditor?.ResetToDefault();
+        _jobPriorityEditor?.LoadJobPriorities();
+
+        // detach the gui from it's parent (Most of the time the lobby)
+        characterGui.Orphan();
+
+        var window = new DefaultWindow
+        {
+            Title = Loc.GetString("character-setup-window-title"),
+        };
+        window.MinSize = window.SetSize = new Vector2(1400, 700); // Might need adjusting but felt good to me
+
+        window.Contents.AddChild(characterGui);
+
+        // when the window closes, detach the gui from it so the gui isn't cleaned up with the window.
+        window.OnClose += () =>
+        {
+            characterGui.Orphan();
+            _characterSetupWindow = null;
+        };
+
+        _characterSetupWindow = window;
+        window.OpenCentered();
+    }
+    // end starlight
 
     private void OpenSavePanel(Action saveAction)
     {
@@ -290,6 +345,18 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
         {
             _characterSetup.Visible = true;
             _profileEditor.Visible = true;
+            // begin starlight
+            // we borrow the gui from the lobby, so we need to make sure we return it aswell.
+            if (_stateManager.CurrentState is LobbyState lobbyState
+                && lobbyState.Lobby?.CharacterSetupState is { } container
+                && _characterSetup.Parent != container)
+            {
+                // if the ghost window is open return it.
+                _characterSetupWindow?.Close();
+                _characterSetup.Orphan();
+                container.AddChild(_characterSetup);
+            }
+            // end starlight
             return (_characterSetup, _profileEditor);
         }
 

--- a/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/GhostUIController.cs
@@ -1,5 +1,6 @@
 using Content.Client.Gameplay;
 using Content.Client.Ghost;
+using Content.Client.Lobby; //🌟Starlight🌟
 using Content.Client.UserInterface.Systems.Gameplay;
 using Content.Client.UserInterface.Systems.Ghost.Widgets;
 using Content.Shared.Ghost;
@@ -126,6 +127,7 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
         Gui.ReturnToBodyPressed += ReturnToBody;
         Gui.GhostRolesPressed += GhostRolesPressed;
         Gui.NewLifePressed += NewLifePressed; //🌟Starlight🌟
+        Gui.CharacterEditorPressed += CharacterEditorPressed; //🌟Starlight🌟
         Gui.GhostThemePressed += GhostThemePressed; //🌟Starlight🌟
         Gui.TargetWindow.WarpClicked += OnWarpClicked;
         Gui.TargetWindow.OnGhostnadoClicked += OnGhostnadoClicked;
@@ -142,6 +144,7 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
         Gui.ReturnToBodyPressed -= ReturnToBody;
         Gui.GhostRolesPressed -= GhostRolesPressed;
         Gui.NewLifePressed -= NewLifePressed; //🌟Starlight🌟
+        Gui.CharacterEditorPressed -= CharacterEditorPressed; //🌟Starlight🌟
         Gui.GhostThemePressed -= GhostThemePressed; //🌟Starlight🌟
         Gui.TargetWindow.WarpClicked -= OnWarpClicked;
 
@@ -168,6 +171,11 @@ public sealed class GhostUIController : UIController, IOnSystemChanged<GhostSyst
     private void NewLifePressed() //🌟Starlight🌟
     {
         _system?.OpenNewLife();
+    }
+
+    private void CharacterEditorPressed() //🌟Starlight🌟
+    {
+        UIManager.GetUIController<LobbyUIController>().OpenCharacterSetupWindow();
     }
 
     private void GhostThemePressed() //🌟Starlight🌟

--- a/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml
+++ b/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml
@@ -3,6 +3,7 @@
                   HorizontalAlignment="Center">
     <BoxContainer Orientation="Horizontal">
         <Button Name="NewLifeButton" Text="{Loc ghost-gui-new-life-button}" />
+        <Button Name="CharacterEditorButton" Text="{Loc ghost-gui-character-editor-button}" />
         <Button Name="GhostThemeButton" Text="{Loc ghost-gui-ghost-theme-button}" />
         <Button Name="ReturnToBodyButton" Text="{Loc ghost-gui-return-to-body-button}" />
         <Button Name="GhostWarpButton" Text="{Loc ghost-gui-ghost-warp-button}" />

--- a/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Widgets/GhostGui.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class GhostGui : UIWidget
     public event Action? ReturnToBodyPressed;
     public event Action? GhostRolesPressed;
     public event Action? NewLifePressed;   //🌟Starlight🌟
+    public event Action? CharacterEditorPressed;   //🌟Starlight🌟
     public event Action? GhostThemePressed;   //🌟Starlight🌟
 
     private int _prevNumberRoles;
@@ -32,6 +33,7 @@ public sealed partial class GhostGui : UIWidget
         GhostRolesButton.OnPressed += _ => GhostRolesPressed?.Invoke();
         GhostRolesButton.OnPressed += _ => GhostRolesButton.StyleClasses.Remove(StyleClass.Negative);
         NewLifeButton.OnPressed += _ => NewLifePressed?.Invoke(); //🌟Starlight🌟
+        CharacterEditorButton.OnPressed += _ => CharacterEditorPressed?.Invoke(); //🌟Starlight🌟
         GhostThemeButton.OnPressed += _ => GhostThemePressed?.Invoke(); //🌟Starlight🌟
         NewLifeButton.StyleClasses.Add(StyleClass.Negative);  //🌟Starlight🌟
     }

--- a/Resources/Locale/en-US/_Starlight/ghost/ghost-gui.ftl
+++ b/Resources/Locale/en-US/_Starlight/ghost/ghost-gui.ftl
@@ -1,4 +1,5 @@
 ghost-gui-new-life-button = New life
+ghost-gui-character-editor-button = Character editor
 ghost-new-life-window-title = New life ({$remainingLives} out of {$maxLives} spawns remaining)
 ghost-new-life-window-title-cooldown = New life (On Cooldown! {$time} remaining)
 ghost-new-life-unavailable = lost

--- a/Resources/Locale/en-US/preferences/ui/character-setup-gui.ftl
+++ b/Resources/Locale/en-US/preferences/ui/character-setup-gui.ftl
@@ -1,4 +1,5 @@
 character-setup-gui-character-setup-label = Character setup
+character-setup-window-title = Character Editor
 character-setup-gui-character-setup-adminremarks-button = Admin Remarks
 character-setup-gui-character-setup-stats-button = Stats
 character-setup-gui-character-setup-rules-button = Rules


### PR DESCRIPTION
## Short description
Add the ability for ghost users to open the character editor.

## Why we need to add this
You want to spend more than 2 minutes editing your character before the round starts, being a MRP server it sucks having to rush or missing preferred roles because you want to make adjustments to your character.
https://discord.com/channels/1272545509562777621/1511165536623661116 @

## Media (Video/Screenshots)


https://github.com/user-attachments/assets/47d8a380-1232-429e-93e4-b209bf6af771


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
Not marking this as I have tested almost every situation this could cause an issue with and so far haven't found any besides for if someone dies, edits their character, then for whatever reason an admin wants to force respawn them the character will be different.

If someone that is more experienced with aTools and fuck around and try to break it, or find edge cases, I would greatly appreciate it.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Mack
- add: Allow ghosts to use the character editor.