### PR TITLE
Fixes jug prototypes for Psi Armory and CC medical crate

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/chemical-containers.yml
@@ -8,7 +8,7 @@
     currentLabel: reagent-name-uranium
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Uranium
           Quantity: 200
@@ -38,7 +38,7 @@
     currentLabel: reagent-name-arithrazine
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Arithrazine
           Quantity: 200
@@ -53,7 +53,7 @@
     currentLabel: reagent-name-diphenhydramine
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Diphenhydramine
           Quantity: 200
@@ -68,7 +68,7 @@
     currentLabel: reagent-name-cryoxadone
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Cryoxadone
           Quantity: 200
@@ -83,7 +83,7 @@
     currentLabel: reagent-name-doxarubixadone
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Doxarubixadone
           Quantity: 200
@@ -98,7 +98,7 @@
     currentLabel: reagent-name-aloxadone
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Aloxadone
           Quantity: 200
@@ -113,7 +113,7 @@
     currentLabel: reagent-name-sigynate
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Sigynate
           Quantity: 200
@@ -128,7 +128,7 @@
     currentLabel: reagent-name-leporazine
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Leporazine
           Quantity: 200
@@ -143,7 +143,7 @@
     currentLabel: reagent-name-bruizine
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Bruizine
           Quantity: 200
@@ -158,7 +158,7 @@
     currentLabel: reagent-name-lacerinol
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Lacerinol
           Quantity: 200
@@ -173,7 +173,7 @@
     currentLabel: reagent-name-pyrazine
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Pyrazine
           Quantity: 200
@@ -188,7 +188,7 @@
     currentLabel: reagent-name-insuzine
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Insuzine
           Quantity: 200
@@ -203,7 +203,7 @@
     currentLabel: reagent-name-ambuzol
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Ambuzol
           Quantity: 200
@@ -218,7 +218,7 @@
     currentLabel: reagent-name-ambuzol-plus
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: AmbuzolPlus
           Quantity: 200
@@ -233,7 +233,7 @@
     currentLabel: reagent-name-amoxla
   - type: SolutionContainerManager
     solutions:
-      beaker:
+      drink:
         reagents:
         - ReagentId: Amoxla
           Quantity: 200


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
I got a bug report that the uranium jug on the Psi Armory starts empty. Turns out the jug actually was just in a bad state due the solution being `beaker` instead of `drink`.

The jug does contain uranium when inspected with Edit Solutions, but the contents cannot be interacted with in most typical ways (can't drink it, can't pour it into another jug or beaker, etc).

This PR fixes that. It also fixes several other jugs that are used in `CrateCentralCommandSecureChemicalFilled`, an admin spawned medical crate.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix for both the Psi Armory and `CrateCentralCommandSecureChemicalFilled`.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/abc0ff8b-41c3-4df3-880c-8fce93c2bd31

fig. 1 - The uranium in the jug works as intended now. You can do chemistry stuff with it (or chug it as pictured).

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Some special pre-mapped jugs, like the uranium jug on the Code Psi Armory, should now work as intended.
