### PR TITLE
Insulative gloves are now engineering contraband

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -320,7 +320,7 @@
 # Insulated Gloves (Yellow Gloves)
 # Currently can not be greyscaled without looking like shit.
 - type: entity
-  parent: ClothingHandsBase
+  parent: [ClothingHandsBase, BaseEngineeringContraband] # SL edit: engineering contraband
   id: ClothingHandsGlovesColorYellow
   name: insulated gloves
   description: These gloves will protect the wearer from electric shocks.

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -320,7 +320,7 @@
 # Insulated Gloves (Yellow Gloves)
 # Currently can not be greyscaled without looking like shit.
 - type: entity
-  parent: [ClothingHandsBase, BaseEngineeringContraband, BaseScienceContraband] # SL edit: engineering + science contraband
+  parent: [ClothingHandsBase, BaseEngineeringScienceContraband] # SL edit: engineering + science contraband
   id: ClothingHandsGlovesColorYellow
   name: insulated gloves
   description: These gloves will protect the wearer from electric shocks.

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -320,7 +320,7 @@
 # Insulated Gloves (Yellow Gloves)
 # Currently can not be greyscaled without looking like shit.
 - type: entity
-  parent: [ClothingHandsBase, BaseEngineeringContraband] # SL edit: engineering contraband
+  parent: [ClothingHandsBase, BaseEngineeringContraband, BaseScienceContraband] # SL edit: engineering + science contraband
   id: ClothingHandsGlovesColorYellow
   name: insulated gloves
   description: These gloves will protect the wearer from electric shocks.

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -161,6 +161,14 @@
     allowedDepartments: [ Security, Engineering ]
 
 - type: entity
+  id: BaseEngineeringScienceContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Engineering, Science ]
+
+- type: entity
   id: BaseSiliconScienceContraband
   parent: BaseRestrictedContraband
   abstract: true


### PR DESCRIPTION
## Short description
Makes engineering item engineering contraband (And science)

## Why we need to add this
<img width="1192" height="78" alt="image" src="https://github.com/user-attachments/assets/3e2e3877-200b-48b0-89fd-38b6b6b23b2c" />

They're such a meta item for assistants that people will frequently mob engineering, hack vendors roundstart, and otherwise pillage the station to get their hands on a pair. Well, now they're illegal to own as a non-engineer, so if you do any of these and security catches you with a pair they're gonna be taken from you.

Tiders get budget insuls like the unemployed losers they are. This is gambling, but this community loves gambling so I don't forsee any issues 👍 

## Media (Video/Screenshots)
<img width="803" height="177" alt="image" src="https://github.com/user-attachments/assets/b448e837-42af-45dd-bb5a-456acb6df478" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: wubawubadickcheney
- tweak: Insulative gloves are now engineering/sci contraband.

