### PR TITLE
Protomoth LED marking fix

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Customization/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Customization/protogen.yml
@@ -487,7 +487,7 @@
 
 - type: marking
   id: ProtoMothVisor
-  bodyPart: RFoot
+  bodyPart: RHand # Starlight, moth markings are in a different order
   markingCategory: Special
   speciesRestriction: [ProtoMoth]
   sprites:

--- a/Resources/Prototypes/_Starlight/Body/Prototypes/Protogen/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Body/Prototypes/Protogen/shadekin.yml
@@ -12,6 +12,7 @@
         eyes: OrganProtogenEyes
         tongue: OrganProtogenTongueForked
         eye_implant: null
+        brain_implant: null
     torso:
       part: TorsoShadekin
       connections:
@@ -20,8 +21,8 @@
       - right leg
       - left leg
       organs:
-        core: OrganShadekinCore
         heart: OrganProtogenHeart
+        core: OrganShadekinCore
         stomach: OrganProtogenStomach
         liver: OrganProtogenLiver
         kidneys: OrganProtogenKidneys


### PR DESCRIPTION
## Short description
Fixes Protomoth's LED markings to make them actually render.

## Why we need to add this
Bug fix is bug fix.

## Media (Video/Screenshots)
<img width="418" height="408" alt="image" src="https://github.com/user-attachments/assets/64f54346-f81d-45e5-855a-ab218a051a04" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Proto-Moths' LED faces now correctly render.
- fix: ProtoKins' bodies are now arranged in the same order as a normal Shadekin's.

