### PR TITLE
Add refunds to not approved/recalled requests.

### DIFF
--- a/Content.Server/_Starlight/SecureTerminal/SecureCommandTerminalStationComponent.cs
+++ b/Content.Server/_Starlight/SecureTerminal/SecureCommandTerminalStationComponent.cs
@@ -32,6 +32,10 @@ public sealed partial class SecureCommandTerminalStationComponent : Component
     [ViewVariables]
     public readonly Dictionary<string, TimeSpan> DeployedArmories = new();
 
+    /// <summary>Requester of each deployed armory.</summary>
+    [ViewVariables]
+    public readonly Dictionary<string, EntityUid> DeployedArmoryRequesters = new();
+
     /// <summary>When the current alert level was last set (CurTime). Used for RequiresAlertActiveMinutes checks.</summary>
     [ViewVariables]
     public TimeSpan AlertLevelSetAt;
@@ -41,6 +45,9 @@ public sealed partial class SecureCommandTerminalStationComponent : Component
 public sealed class SecureTerminalProposalData
 {
     public string RequestId = string.Empty;
+
+    /// <summary>The player who created the request.</summary>
+    public EntityUid Requester = EntityUid.Invalid;
 
     /// <summary>The reason of the Request.</summary>
     public string Reason = string.Empty;

--- a/Content.Server/_Starlight/SecureTerminal/SecureCommandTerminalSystem.cs
+++ b/Content.Server/_Starlight/SecureTerminal/SecureCommandTerminalSystem.cs
@@ -143,13 +143,23 @@ public sealed class SecureCommandTerminalSystem : EntitySystem
 
             if (toExpire != null)
                 foreach (var requestId in toExpire)
+                {
+                    // Expired proposals are always still Pending, so refund the held fee.
+                    if (stationComp.ActiveProposals.TryGetValue(requestId, out var expiredProposal))
+                        RefundFee(expiredProposal);
                     stationComp.ActiveProposals.Remove(requestId);
+                }
 
             if (toFire != null)
                 foreach (var requestId in toFire)
                 {
                     if (_protos.TryIndex<SecureCommandTerminalRequestPrototype>(requestId, out var proto))
                     {
+                        // grab the requester before the proposal is removed incase of recall
+                        var requester = stationComp.ActiveProposals.TryGetValue(requestId, out var firingProposal)
+                            ? firingProposal.Requester
+                            : EntityUid.Invalid;
+
                         ExecuteAction(stationUid, proto);
                         stationComp.ActiveProposals.Remove(requestId);
                         if (proto.ActionType == SecureTerminalActionType.Armory)
@@ -157,6 +167,7 @@ public sealed class SecureCommandTerminalSystem : EntitySystem
                             // Track as deployed so it can still be recalled
                             var authorizedAt = now - TimeSpan.FromSeconds(proto.ActivationDelaySecs);
                             stationComp.DeployedArmories[requestId] = authorizedAt;
+                            stationComp.DeployedArmoryRequesters[requestId] = requester;
                         }
                         else if (proto.OneTimeUse)
                             stationComp.UsedOnce.Add(requestId);
@@ -301,21 +312,21 @@ public sealed class SecureCommandTerminalSystem : EntitySystem
             return;
         }
 
-        // We check and charge the fee now, deny on sufficient funds.
+        // We charge charge the requester when requested so we don't have to deal with them not having the funds when approved.
         if (proto.Fee > 0)
+        {
             if (_playerResources.TryGetResource(actor, "credits", out var balance) && balance < proto.Fee)
             {
                 _popup.PopupCursor($"Insufficient funds. Required: {proto.Fee}\u20a1", actor, PopupType.Medium);
                 return;
             }
-            else
-            {
-                _playerResources.TryUpdateResource(actor, "credits", -proto.Fee);
-                _popup.PopupCursor($"Debited {proto.Fee}\u20a1. Balance: {balance -= proto.Fee}\u20a1", actor, PopupType.Medium);
-            }
+
+            _playerResources.TryUpdateResource(actor, "credits", -proto.Fee);
+            _popup.PopupCursor($"Held {proto.Fee}\u20a1 pending authorization.", actor, PopupType.Medium);
+        }
 
         // Create the proposal
-        var proposal = new SecureTerminalProposalData { RequestId = msg.RequestId };
+        var proposal = new SecureTerminalProposalData { RequestId = msg.RequestId, Requester = actor };
         stationComp.ActiveProposals[msg.RequestId] = proposal;
 
         if (reason is not null)
@@ -413,7 +424,7 @@ public sealed class SecureCommandTerminalSystem : EntitySystem
         if (stationUid == null) return;
         if (!TryComp<SecureCommandTerminalStationComponent>(stationUid.Value, out var stationComp)) return;
 
-        if (!stationComp.ActiveProposals.ContainsKey(msg.RequestId))
+        if (!stationComp.ActiveProposals.TryGetValue(msg.RequestId, out var deniedProposal))
         {
             _popup.PopupCursor(Loc.GetString("secure-terminal-no-active-proposal"), actor, PopupType.Medium);
             return;
@@ -428,6 +439,9 @@ public sealed class SecureCommandTerminalSystem : EntitySystem
         }
 
         stationComp.ActiveProposals.Remove(msg.RequestId);
+
+        // Refund the held fee if denied
+        RefundFee(deniedProposal);
 
         _adminLog.Add(LogType.Action, LogImpact.Medium,
             $"{ToPrettyString(actor):player} denied secure terminal proposal: {msg.RequestId}");
@@ -510,9 +524,18 @@ public sealed class SecureCommandTerminalSystem : EntitySystem
             }
         }
 
+        // Refund if armory is recalled
+        var refundTarget = hasActivatingArmory && proposal != null
+            ? proposal.Requester
+            : stationComp.DeployedArmoryRequesters.GetValueOrDefault(msg.RequestId, EntityUid.Invalid);
+
         stationComp.ActiveProposals.Remove(msg.RequestId);
         stationComp.DeployedArmories.Remove(msg.RequestId);
+        stationComp.DeployedArmoryRequesters.Remove(msg.RequestId);
         stationComp.UsedOnce.Add(msg.RequestId);
+
+        // Recall refunds 80% of the fee, becuase they had to prepare it and send it and stuff.
+        RefundFee(refundTarget, proto, 0.8f);
 
         _adminLog.Add(LogType.Action, LogImpact.Medium,
             $"{ToPrettyString(actor):player} recalled armory via secure terminal: {msg.RequestId}");
@@ -628,6 +651,25 @@ public sealed class SecureCommandTerminalSystem : EntitySystem
 
         // Apply salary penalty to station
         stationComp.SalaryPenalty = Math.Min(0.8f, stationComp.SalaryPenalty + proto.SalaryPenalty);
+    }
+
+    /// <summary>
+    /// Refund the fee that was held at request time due to it being denied, cancelled, etc.
+    /// </summary>
+    private void RefundFee(SecureTerminalProposalData proposal, float fraction = 1f)
+    {
+        if (_protos.TryIndex<SecureCommandTerminalRequestPrototype>(proposal.RequestId, out var proto))
+            RefundFee(proposal.Requester, proto, fraction);
+    }
+
+    private void RefundFee(EntityUid requester, SecureCommandTerminalRequestPrototype proto, float fraction = 1f)
+    {
+        if (proto.Fee <= 0 || !requester.IsValid())
+            return;
+
+        var amount = (int)(proto.Fee * fraction);
+        if (amount > 0)
+            _playerResources.TryUpdateResource(requester, "credits", amount);
     }
 
     /// <summary>Execute the prototype's configured action against the station.</summary>

--- a/Content.Server/_Starlight/SecureTerminal/SecureCommandTerminalSystem.cs
+++ b/Content.Server/_Starlight/SecureTerminal/SecureCommandTerminalSystem.cs
@@ -524,6 +524,9 @@ public sealed class SecureCommandTerminalSystem : EntitySystem
             }
         }
 
+        // Gonna keep the code here, becuase I put in the time to write it and get it working,
+        // but if an armory is called it is probably going to arrive.
+        // And it can be recalled once on station so it dosen't make much sense for it to be refunded.
         // Refund if armory is recalled
         var refundTarget = hasActivatingArmory && proposal != null
             ? proposal.Requester
@@ -534,8 +537,7 @@ public sealed class SecureCommandTerminalSystem : EntitySystem
         stationComp.DeployedArmoryRequesters.Remove(msg.RequestId);
         stationComp.UsedOnce.Add(msg.RequestId);
 
-        // Recall refunds 80% of the fee, becuase they had to prepare it and send it and stuff.
-        RefundFee(refundTarget, proto, 0.8f);
+        RefundFee(refundTarget, proto, 0f);
 
         _adminLog.Add(LogType.Action, LogImpact.Medium,
             $"{ToPrettyString(actor):player} recalled armory via secure terminal: {msg.RequestId}");

--- a/Content.Shared/_Starlight/SecureTerminal/SecureCommandTerminalRequestPrototype.cs
+++ b/Content.Shared/_Starlight/SecureTerminal/SecureCommandTerminalRequestPrototype.cs
@@ -50,8 +50,7 @@ public sealed partial class SecureCommandTerminalRequestPrototype : IPrototype
     public int ActivationDelaySecs = 600;
 
     /// <summary>
-    /// Credits charged from EACH authorizer when the countdown begins.
-    /// They pay whether they originally requested OR co-signed.
+    /// Credits charged from the requester once it is fully approved and the countdown begins.
     /// </summary>
     [DataField]
     public int Fee = 5000;


### PR DESCRIPTION
## Short description
Changes the behaviour of the ERT/Armory payments to allow for refunds.
A ERT/Armory refunds 80% of the amount when recalled.
This does kinda remove "risk" of calling one without doing all the paperwork first, but like, 5k is a lot of money

## Why we need to add this
You should not get charged up to 5k for something that doesn't even happen.
Related to https://github.com/ss14Starlight/space-station-14/pull/4639 kinda

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Mack
- fix: Fixed issue with secure terminal requests charging money when it isn't approved.