### PR TITLE
Barotrauma protection works again

### DIFF
--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -141,10 +141,10 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     var found = false;
 
-                    var groupHPModifier = 0f;
-                    var groupHPMultiplier = 1f;
-                    var groupLPModifier = 0f;
-                    var groupLPMultiplier = 1f;
+                    var groupHPModifier = float.MinValue;
+                    var groupHPMultiplier = float.MinValue;
+                    var groupLPModifier = float.MaxValue;
+                    var groupLPMultiplier = float.MaxValue;
 
                     foreach (var slot in group)
                     {


### PR DESCRIPTION
## Short description
Makes barotrauma protection work again.

## Why we need to add this
I merged something coderabbitai told me to do last second on the other big protogen fixes pr and it broke barotrauma entirely.

## Media (Video/Screenshots)
I tested it better
<img width="254" height="182" alt="image" src="https://github.com/user-attachments/assets/f891f394-5d67-417d-ac46-de37d9ce9d5a" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Barotrauma protection works again.
