### PR TITLE
Protogens are no longer drunk forever

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Body/Organs/protogen.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Organs/protogen.yml
@@ -181,7 +181,7 @@
   id: OrganProtogenLiver
   parent: [BaseProtogenOrgan, BaseOrganLiver]
   name: cybernetic liver # Starlight, capitalization
-  description: Pairing suggestion, a side of fermented RAM sticks and a nice CPU. #  Starlight, quotation marks removed
+  description: Pairing suggestion, a side of fermented RAM sticks and a nice CPU. # Starlight, quotation marks removed
   components:
   - type: Sprite
     state: liver
@@ -193,7 +193,7 @@
     metabolizerTypes: [Protogen]
     groups:
     - id: Alcohol
-      rateModifier: 0.1
+#      rateModifier: 0.1 # Starlight, not needed, makes them drunk forever.
 
 - type: entity
   id: OrganProtogenKidneys
@@ -218,7 +218,7 @@
 - type: entity
   id: OrganProtoMothStomach
   parent: [OrganAnimalStomach, BaseOrganStomach]
-  name: biological reactor # Starlight, capitalization
+  name: moth biological reactor # Starlight, capitalization
   description: Some call it over-engineered, but it's vital to the function of a protogen. Turns organic matter into organic and electrical energy to power the protogen's cybernetics and flesh. #  Starlight, quotation marks removed
   components:
   - type: Sprite
@@ -248,7 +248,7 @@
 - type: entity
   id: OrganProtoDwarfHeart
   parent: OrganProtogenHeart
-  name: cybernetic heart # Starlight, capitalization
+  name: dwarf cybernetic heart # Starlight, capitalization
   description: Doesn't actually need to beat, simply mimics the movement to provide comfort for the user. #  Starlight, quotation marks removed
   components:
   - type: Metabolizer
@@ -257,8 +257,8 @@
 - type: entity
   id: OrganProtoDwarfLiver
   parent: OrganProtogenLiver
-  name: cybernetic liver # Starlight, capitalization
-  description: Pairing suggestion, fermented RAM sticks and CPU drives.
+  name: dwarf cybernetic liver # Starlight, capitalization
+  description: Pairing suggestion, a side of fermented RAM sticks and a nice CPU. # Starlight
   components:
   - type: Metabolizer
     metabolizerTypes: [Dwarf]
@@ -266,7 +266,7 @@
 - type: entity
   id: OrganProtoDwarfStomach
   parent: OrganProtogenStomach
-  name: biological reactor # Starlight, capitalization
+  name: dwarf biological reactor # Starlight, capitalization
   description: Some call it over-engineered, but it's vital to the function of a protogen. Turns organic matter into organic and electrical energy to power the protogen's cybernetics and flesh. #  Starlight, quotation marks removed
   components:
   - type: Sprite
@@ -297,6 +297,7 @@
 - type: entity
   id: OrganProtoAvaliStomach
   parent: OrganProtogenStomach
+  name: avali biological reactor # Starlight
   categories: [ HideSpawnMenu ]
   components:
   - type: Stomach
@@ -317,6 +318,7 @@
 - type: entity
   id: OrganProtoAvaliHeart
   parent: OrganProtogenHeart
+  name: avali cybernetic heart # Starlight
   categories: [ HideSpawnMenu ]
   components:
   - type: Metabolizer
@@ -330,6 +332,7 @@
 - type: entity
   id: OrganProtoAvaliLiver
   parent: OrganProtogenLiver
+  name: avali cybernetic liver # Starlight
   categories: [ HideSpawnMenu ]
   components:
   - type: Metabolizer # The liver metabolizes certain chemicals only, like alcohol.
@@ -338,14 +341,14 @@
     metabolizerTypes: [Avali]
     groups:
     - id: Alcohol
-      rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink
+#      rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink # Starlight, we don't want them to be drunk forever.
 
 # Arachnid
 
 - type: entity
   id: OrganProtoArachnidHeart
   parent: [BaseProtogenOrgan, OrganProtogenHeart]
-  name: cybernetic heart # Starlight, capitalization
+  name: arachnid cybernetic heart # Starlight, capitalization
   components:
   - type: Sprite
     state: heart-on
@@ -412,6 +415,7 @@
 - type: entity
   id: OrganProtoVoxStomach
   parent: OrganProtogenStomach
+  name: vox biological reactor # Starlight
   categories: [ HideSpawnMenu ]
   components:
   - type: Metabolizer
@@ -435,7 +439,7 @@
 - type: entity
   id: OrganProtoVoxHeart
   parent: [BaseProtogenOrgan, OrganProtogenHeart]
-  name: cybernetic heart # Starlight, capitalization
+  name: vox cybernetic heart # Starlight, capitalization
   components:
   - type: Sprite
     state: heart-on


### PR DESCRIPTION
## Short description
Protogens are no longer drunk forever.

## Why we need to add this
From what I can tell, their rateModifier being 0.1 was actually intentional, but it's not that fun to play with.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Protogens are no longer drunk forever.
- tweak: The species-specific protogen organs now have different names.