### PR TITLE
Fix aghost not seeing protogen health bars

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -124,12 +124,14 @@
       - Inorganic
       - Silicon
       - IPC
+      - Hybrid
   - type: ShowHealthIcons
     damageContainers:
       - Biological
       - Inorganic
       - Silicon
       - IPC
+      - Hybrid
   - type: ShowHungerIcons
   - type: ShowThirstIcons # Starlight END
   - type: ShowContrabandDetails


### PR DESCRIPTION
## Short description
Title

## Why we need to add this
Missing feature & requested by me

## Media (Video/Screenshots)
<img width="310" height="266" alt="image" src="https://github.com/user-attachments/assets/294e7b9a-7479-4531-98e6-b90338ddf091" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl:
- fix: AGhost also sees Protogen health bars.
