### PR TITLE
Fix arachnids randomly gasping for air

### DIFF
--- a/Resources/Prototypes/_Starlight/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/arachnid.yml
@@ -49,7 +49,6 @@
         - ReagentId: UncookedAnimalProteins
           Quantity: 5
   - type: Metabolizer
-    updateInterval: 1.5
 
 - type: entity
   id: OrganArachnidLungs
@@ -63,7 +62,6 @@
       - state: lung-r
   - type: Lung
   - type: Metabolizer
-    updateInterval: 1.5
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
@@ -98,7 +96,6 @@
     size: Small
     heldPrefix: heart
   - type: Metabolizer
-    updateInterval: 1.5
     maxReagents: 2
     metabolizerTypes: [Arachnid]
     groups:
@@ -119,7 +116,6 @@
   - type: Sprite
     state: liver
   - type: Metabolizer # The liver metabolizes certain chemicals only, like alcohol.
-    updateInterval: 1.5
     maxReagents: 1
     metabolizerTypes: [Animal]
     groups:
@@ -141,7 +137,6 @@
     size: Small
     heldPrefix: kidneys
   - type: Metabolizer
-    updateInterval: 1.5
     maxReagents: 5
     metabolizerTypes: [Animal]
     removeEmpty: true


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
- Removes a hidden debuff to Arachnids where their metabolism is $1.5\times$ slower. This is not mentioned anywhere in the guidebook.
- I believe this slow metabolism is causing arachnids to gasp for breath randomly, even when they're in a safe, breathable atmosphere.
- This makes their metabolisms on par with most species ($1$ second)

## Long description
Arachnids have the `updateInterval` for some of their body parts set to $1.5$ seconds.

I think I've identified issues with this:
- Nothing in the guidebook actually implies they should breath faster or that their metabolism should be a different speed, only that they _suffocate_ faster.
<img width="575" height="462" alt="image" src="https://github.com/user-attachments/assets/1351a443-aefa-4cdc-bf40-93ed636a8bb8" />

- This extra suffocation (Asphyxiation) damage is already correctly done through damage modifiers:
```yml
- type: entity
  save: false
  name: Urist McWeb
  parent: BaseMobArachnid
  id: MobArachnid
  components:
  - type: Respirator
    damage:
      types:
        Asphyxiation: 1.5 # This makes space and crit more lethal to arachnids.
    damageRecovery:
      types:
        Asphyxiation: -0.5
```

- An interval of $1.5$ is not $150$% faster - it's an interval of _seconds_.
- This means "do this every $1.5$ seconds."
- Breathing, I think, is done every 2 seconds, but that 2 seconds is provided in `RespiratorComponent` and _not_ in `MetabolizerComponent`.
- But the code in `arachnid.yml` isn't changing the interval for `RespiratorComponent`, it's changing the interval in `MetabolizerComponent`.
- `MetabolizerComponent`'s default interval is $1$ second, _not_ $2$ seconds.
- I believe this means that arachnids actually breathe _slower_ as a result, $\approx66$% of other species.

**tl;dr**
- Arachnids have a slow metabolism for some reason, $1.5\times$ slower than other species.
- That's not in the guidebook.
- I'm positive this is making them randomly gasp for air as a result.

These findings are corroborated with other folks' findings. This screenshot is from WizDen, where they've had similar arachnid lungs issues:
<img width="1170" height="909" alt="image" src="https://github.com/user-attachments/assets/3d581025-09d0-4ede-a918-49dd04c0f4fa" />


## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Arachnid players hate this random gasping in shift. It's an obvious bug, and changing the intervals here was the most obvious solution.

Nothing in the guidebook says their metabolism should be slower nor that they breath quicker, just that they suffocate quicker.

This PR removes the hidden slow metabolism stuff.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Arachnids should no longer gasp for breath randomly.
- remove: Arachnids no longer have a 50% slower metabolism (that wasn't mentioned in the guidebook!).