### PR TITLE
Chem bottle loc fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
@@ -749,7 +749,7 @@
 
 - type: entity
   id: ChemistryBottlePulpedBananaPeel
-  suffix: pulped banana peel          #starlight
+  suffix: pulped banana peel #starlight
   parent: BaseChemistryBottleFilled
   components:
   - type: Label

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-bottles.yml
@@ -168,7 +168,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-aloxadone
+    currentLabel: reagent-name-aloxadone #starlight
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -183,7 +183,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-ambuzol
+    currentLabel: reagent-name-ambuzol #starlight
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -198,7 +198,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-ambuzol-plus
+    currentLabel: reagent-name-ambuzol-plus #starlight
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -228,7 +228,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-barozine
+    currentLabel: reagent-name-barozine #starlight
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -258,7 +258,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-bruizine
+    currentLabel: reagent-name-bruizine #starlight
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -273,7 +273,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-cognizine
+    currentLabel: reagent-name-cognizine #starlight
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -648,7 +648,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-oculine
+    currentLabel: reagent-name-oculine #starlight
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -678,7 +678,7 @@
   parent: BaseChemistryBottleFilled
   components:
   - type: Label
-    currentLabel: reagent-opporozidone
+    currentLabel: reagent-name-opporozidone #starlight
   - type: SolutionContainerManager
     solutions:
       drink:
@@ -749,7 +749,7 @@
 
 - type: entity
   id: ChemistryBottlePulpedBananaPeel
-  suffix: pulped-banana-peel
+  suffix: pulped banana peel          #starlight
   parent: BaseChemistryBottleFilled
   components:
   - type: Label

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Consumable/Drinks/drinks.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Consumable/Drinks/drinks.yml
@@ -33,6 +33,7 @@
 - type: entity
   parent: DrinkWaterBottleFull
   id: DrinkWaterBottleEmpty
+  suffix: Empty
   name: water bottle
   description: Simple clean water of unknown origin. You think that maybe you don't want to know it.
   components:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
manual port of https://github.com/space-wizards/space-station-14/pull/43208
Empty water bottles are correctly suffixed in dev
also why is pulped banana peel the only one with dashes that isn't a shorthand?
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
fix is good
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="816" height="394" alt="image" src="https://github.com/user-attachments/assets/d3ec95c4-5e5c-4820-a13d-dc6951a6c758" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl:

- fix: Some reagent bottles now have the correct labels.