### PR TITLE
Hybrid taser and ion rifle fixed to fit in suit storage

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -27,6 +27,7 @@
   - type: Clothing
     quickEquip: false
     slots:
+    - suitStorage
     - Belt
   - type: Gun
     soundGunshot:
@@ -346,6 +347,7 @@
   - type: Clothing
     quickEquip: false
     slots:
+    - suitStorage
     - Back
   - type: Gun
     fireRate: 0.6


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Basically every gun in the game can fit in your suit storage.

Generally, for pistols:
- They fit in your belt slot.
- They fit in your suit storage slot.

Generally, for rifles:
- They fit in your back slot.
- They fit in your suit storage slot.

The hybrid taser didn't fit in your suit storage, even though the dominator and disabler pistols do. This PR fixes that.

The ion rifle didn't fit on in your suit storage slow, even though all other rifles in the game do. This PR also fixes that.    

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix as far as I can tell + consistency fix. This has driven me insane playing security recently because I usually put my disabler weapons in my suit storage.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="812" height="474" alt="Hybrid Taser" src="https://github.com/user-attachments/assets/cb06360a-c846-463b-8b86-cd0098fa3606" />

fig. 1 - Before and After PR. I'm using the hotkey to put things into suit storage here.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Security's Hybrid Taser now fits in your suit storage, just like the Disabler and Dominator.
- fix: The Ion Rifle now fits in your suit storage, just like other rifles.