### PR TITLE
Removes the experimental RCD from the engineering cyborg module

### DIFF
--- a/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.RCD.Components;
+using Robust.Shared.Network;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.RCD.Systems;
@@ -13,6 +14,7 @@ public sealed class RCDAmmoSystem : EntitySystem
     [Dependency] private readonly SharedChargesSystem _sharedCharges = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!;
 
     public override void Initialize()
     {
@@ -57,7 +59,7 @@ public sealed class RCDAmmoSystem : EntitySystem
         Dirty(uid, comp);
 
         // prevent having useless ammo with 0 charges
-        if (comp.Charges <= 0)
+        if (comp.Charges <= 0 && _net.IsServer) // Starlight - QueueDel would throw an error when deleting RCD ammo
             QueueDel(uid);
     }
 }

--- a/Resources/Locale/en-US/_Starlight/robotics/borg_modules.ftl
+++ b/Resources/Locale/en-US/_Starlight/robotics/borg_modules.ftl
@@ -5,6 +5,7 @@ borg-slot-stunbaton-empty = Stun Baton
 borg-slot-disabler-empty = Disabler
 borg-slot-holoprojector-empty = Holographic Projector
 borg-slot-contrabag-empty = Contraband Bag
+borg-slot-rcd-ammo-empty = RCD Ammo
 
 borg-slot-l6-empty = L6 Saw
 borg-slot-light-box-empty = Magazine Box (Light Rifle)

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -720,17 +720,6 @@
     sprite: Objects/Materials/Sheets/other.rsi
     state: generic_materials
 
-#region Starlight
-- type: entity
-  id: BorgModuleRCDAmmoPlaceholder
-  categories: [ HideSpawnMenu ]
-  parent: BaseItem
-  components:
-  - type: Sprite
-    sprite: Objects/Tools/rcd.rsi
-    state: ammo
-#endregion Starlight
-
 - type: entity
   id: BorgModuleConstruction
   parent: [ BaseBorgModuleEngineering, BaseProviderBorgModule ]

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -713,11 +713,23 @@
 
 - type: entity
   id: BorgModuleConstructionMaterialPlaceholder
+  categories: [ HideSpawnMenu ] # Starlight
   parent: BaseItem
   components:
   - type: Sprite
     sprite: Objects/Materials/Sheets/other.rsi
     state: generic_materials
+
+#region Starlight
+- type: entity
+  id: BorgModuleRCDAmmoPlaceholder
+  categories: [ HideSpawnMenu ]
+  parent: BaseItem
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/rcd.rsi
+    state: ammo
+#endregion Starlight
 
 - type: entity
   id: BorgModuleConstruction
@@ -813,8 +825,16 @@
     - state: icon-rcd
   - type: ItemBorgModule
     hands:
-    - item: RCDRecharging
-    - item: RPDRecharging # Starlight: RPD
+    #region Starlight
+    - item: RCD
+    - hand:
+        emptyRepresentative: RCDAmmo
+        emptyLabel: borg-slot-construction-empty
+        whitelist:
+          components:
+          - RCDAmmo
+    - item: RPDRecharging
+    #endregion Starlight
     - item: BorgFireExtinguisher
     - item: BorgHandheldGPSBasic
     - item: GasAnalyzer

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -818,7 +818,7 @@
     - item: RCD
     - hand:
         emptyRepresentative: RCDAmmo
-        emptyLabel: borg-slot-construction-empty
+        emptyLabel: borg-slot-rcd-ammo-empty
         whitelist:
           components:
           - RCDAmmo


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Replaces the 'experimental RCD' (recharging RCD) of cyborgs with a normal RCD and gives engineering cyborgs a whitelisted hand slot to carry RCD Ammo.

Also included in this PR are some bugfixes:
- `BorgModuleConstructionMaterialPlaceholder` wasn't hidden from the spawn menu when it really should be. It's the placeholder used for borg construction materials - it's not a useful spawn menu entry.
- Depleting RCD ammo whether as a player or a cyborg would throw a giant stack trace. I've included this fix with a Starlight comment for now. I've opened a PR on upstream to fix it as well, since it affects all forks with prediction, I think: https://github.com/space-wizards/space-station-14/pull/44274

Some closing remarks:
- This PR has not touched the experimental RPD. I'm trying to keep the scope of the PR to one thing.
- This PR doesn't touch Xenoborgs. This PR is just about the regular engineering cyborg module available to crew cyborgs.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
For the bugfixes:
- They're bugfixes. If this PR is not accepted, I'll PR those separately.

For the nerf:
- Engineering cyborgs have had a lot of improvements over the year, especially with having whitelisted handslots to carry materials, wires, etc.

They are at the point that many players feel they're just a better Engineer.
- All access, meaning they can get to places much quicker than Engineers who need to wait for people (or the AI) to give access
- Space immune, chemical and gas immune
- Recharging RCD for free repairs
- Recharging holofan, which Station Engineers sadly don't get
- Not slowed down a by a big chunky hardsuit

I'm not a cyborg hater, but let's be honest: Engineering cyborgs are really good. Requiring them to use RCD Ammo is mostly a nerf, though it does have the added buff that you don't have to sit and spin waiting for RCD charges to come back - you can just refill and build much quicker.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/d2b4790b-70f7-4d61-bf3b-1394380383d7

fig. 1 - RCD changes.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- add: Engineering cyborgs now have a 'hand' slot that can pick up RCD ammo, used for refilling RCDs.
- remove: Removed the experimental RCD (recharging RCD) from engineering cyborgs due to budget cuts. Central Command apologies for the inconvenience.
