### PR TITLE
[HOTFIX][ORWELL] Orwell substation wiring correction.

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Orwell.yml
+++ b/Resources/Maps/_Starlight/Stations/Orwell.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/30/2026 01:37:44
-  entityCount: 29409
+  time: 06/10/2026 00:02:19
+  entityCount: 29408
 maps:
 - 1
 grids:
@@ -10368,7 +10368,7 @@ entities:
       pos: -57.5,40.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -47162.582
+      secondsUntilStateChange: -47246.28
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -10775,7 +10775,7 @@ entities:
     - type: DeviceLinkSink
       invokeCounter: 1
     - type: Door
-      secondsUntilStateChange: -184001.86
+      secondsUntilStateChange: -184085.56
       state: Opening
     - type: DeviceLinkSource
       linkedPorts:
@@ -12498,7 +12498,7 @@ entities:
       pos: 18.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -72958.98
+      secondsUntilStateChange: -73042.67
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -12509,7 +12509,7 @@ entities:
       pos: 17.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -72953.91
+      secondsUntilStateChange: -73037.6
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -60721,12 +60721,6 @@ entities:
       parent: 2
 - proto: CableTerminal
   entities:
-  - uid: 9877
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 27.5,-4.5
-      parent: 2
   - uid: 9878
     components:
     - type: Transform


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixing a critical issue with security's wiring that prevents half of security being fed power correctly at every shift start.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Critical issue.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="316" height="321" alt="image" src="https://github.com/user-attachments/assets/89a16044-bf99-4b61-addc-de16a6ae57ce" />

<img width="534" height="598" alt="image" src="https://github.com/user-attachments/assets/bee88518-077d-43ea-bd4b-2d2d32f475e5" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Cvlancer
- fix: Fixed the east side security substation not receiving power by removing a cable terminal.