### PR TITLE
Fix Corporate Frontier spawn crash: register missing background tags

### DIFF
--- a/Content.IntegrationTests/Tests/_StarLight/Traits/BackgroundTraitTagTest.cs
+++ b/Content.IntegrationTests/Tests/_StarLight/Traits/BackgroundTraitTagTest.cs
@@ -1,0 +1,140 @@
+using Content.Client.Lobby;
+using Content.Server.GameTicking;
+using Content.Shared._Starlight.Traits;
+using Content.Shared._Starlight.Traits.Effects;
+using Content.Shared.CCVar;
+using Content.Shared.GameTicking;
+using Content.Shared.Preferences;
+using Content.Shared.Roles;
+using Content.Shared.Tag;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._Starlight.Traits;
+
+/// <summary>
+/// Regression tests for issue #4647: BackgroundEffect builds its tag id at runtime
+/// (background + "TraitBackground"), so a background without a matching TagPrototype
+/// slips past the YAML linter and fails to apply on spawn (with an error log / debug
+/// assert in TagSystem).
+/// </summary>
+[TestFixture]
+public sealed class BackgroundTraitTagTest
+{
+    private const string Map = "BackgroundTraitTagTestMap";
+
+    private static readonly ProtoId<TraitPrototype> BackgroundTrait = "Frontier";
+    private const string ExpectedTag = "FrontierTraitBackground";
+    private static readonly ProtoId<JobPrototype> Passenger = "Assistant";
+
+    [TestPrototypes]
+    private static readonly string Prototypes = $@"
+- type: gameMap
+  id: {Map}
+  mapName: {Map}
+  mapPath: /Maps/Test/empty.yml
+  minPlayers: 0
+  stations:
+    Empty:
+      mapNameTemplate: {Map}
+      stationProto: StandardNanotrasenStation
+      components:
+        - type: StationJobs
+          availableJobs:
+            Assistant: [ -1, -1 ]
+";
+
+    /// <summary>
+    /// Every BackgroundEffect on every trait must reference a registered TagPrototype.
+    /// This is the invariant that the YAML linter cannot check because the tag id is
+    /// constructed in C# at runtime.
+    /// </summary>
+    [Test]
+    public async Task AllBackgroundEffectTagsRegistered()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var protoMan = pair.Server.ResolveDependency<IPrototypeManager>();
+
+        await pair.Server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var trait in protoMan.EnumeratePrototypes<TraitPrototype>())
+                {
+                    foreach (var effect in trait.Effects)
+                    {
+                        if (effect is not BackgroundEffect background)
+                            continue;
+
+                        var tagId = background.Background + "TraitBackground";
+                        Assert.That(protoMan.HasIndex<TagPrototype>(tagId),
+                            $"Trait '{trait.ID}' has a BackgroundEffect that requires tag '{tagId}', " +
+                            "but no such TagPrototype is registered in tags.yml. " +
+                            "The background will fail to apply on spawn (issue #4647).");
+                    }
+                }
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Public-path check: a character whose profile selects a background trait must
+    /// actually spawn with the corresponding tag applied.
+    /// </summary>
+    [Test]
+    public async Task BackgroundTraitAppliesOnSpawn()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            DummyTicker = false,
+            Connected = true,
+            InLobby = true,
+        });
+        pair.Server.CfgMan.SetCVar(CCVars.GameMap, Map);
+
+        var ticker = pair.Server.System<GameTicker>();
+        ticker.SetGamePreset("Extended");
+
+        var cPref = pair.Client.ResolveDependency<IClientPreferencesManager>();
+        var cProto = pair.Client.ResolveDependency<IPrototypeManager>();
+
+        await pair.ReallyBeIdle();
+
+        await pair.Client.WaitAssertion(() =>
+        {
+            var profile = HumanoidCharacterProfile.Random()
+                .AsEnabled()
+                .WithJobPreferences([Passenger])
+                .WithTraitPreference(BackgroundTrait, cProto);
+
+            Assert.That(profile.TraitPreferences, Does.Contain(BackgroundTrait),
+                $"Profile rejected the '{BackgroundTrait}' trait preference.");
+
+            cPref.CreateCharacter(profile);
+
+            // delete the default character so the new one is the only candidate
+            cPref.DeleteCharacter(0);
+
+            cPref.UpdateJobPriorities(new() { { Passenger, JobPriority.High } });
+        });
+
+        await pair.ReallyBeIdle();
+
+        ticker.ToggleReadyAll(true);
+        await pair.Server.WaitPost(() => ticker.StartRound());
+        await pair.RunTicksSync(30);
+
+        Assert.That(ticker.PlayerGameStatuses[pair.Client.User!.Value], Is.EqualTo(PlayerGameStatus.JoinedGame));
+
+        var mob = pair.Player!.AttachedEntity!.Value;
+        Assert.That(pair.Server.EntMan.TryGetComponent<TagComponent>(mob, out var tags));
+        // check Tags directly instead of TagSystem.HasTag, so that an unregistered tag id
+        // reports a clean failure instead of tripping the same debug assert under test
+        Assert.That(tags!.Tags, Does.Contain(new ProtoId<TagPrototype>(ExpectedTag)),
+            $"Spawned character is missing the '{ExpectedTag}' tag: the background trait effect did not apply.");
+
+        await pair.Server.WaitPost(() => ticker.RestartRound());
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -255,6 +255,12 @@
   id: FormerSoldierTraitBackground
 
 - type: Tag
+  id: FringeTraitBackground
+
+- type: Tag
+  id: FrontierTraitBackground
+
+- type: Tag
   id: FlatpackBlacklist
 
 - type: Tag
@@ -301,6 +307,9 @@
 
 - type: Tag
   id: HiltWood
+
+- type: Tag
+  id: HuntedTraitBackground
 
 - type: Tag
   id: ImprovisedAmmoBox
@@ -479,6 +488,9 @@
   id: OvenMachineBoard
 
 - type: Tag
+  id: ParadoxCloneTraitBackground
+
+- type: Tag
   id: ParaKnife
 
 - type: Tag
@@ -629,6 +641,9 @@
 
 - type: Tag
   id: UnDissolvable
+
+- type: Tag
+  id: USSPTraitBackground
 
 - type: Tag
   id: Vial


### PR DESCRIPTION
## Short description

Registers the five missing `*TraitBackground` tag prototypes (`Fringe`, `Frontier`, `Hunted`, `ParadoxClone`, `USSP`) in `Resources/Prototypes/_Starlight/tags.yml`.

Fixes #4647.

## Why we need to add this

Spawning a character with the **Corporate Frontier** background (trait id `Frontier`) crashes the game on DEBUG builds, as reported in #4647.

Root cause: `BackgroundEffect.Apply` ([Content.Shared/_Starlight/Traits/Effects/BackgroundEffect.cs#L22](https://github.com/ss14Starlight/space-station-14/blob/starlight-dev/Content.Shared/_Starlight/Traits/Effects/BackgroundEffect.cs#L22)) builds the tag id at runtime by string concatenation:

```csharp
var tag = new ProtoId<TagPrototype>(Background + "TraitBackground");
tagsystem.TryAddTag(ctx.Player, tag);
```

`background.yml` defines 15 backgrounds, but only 10 of the corresponding tags were registered in `tags.yml`. For the other five, `TagSystem.AddTag` hits `AssertValidTag` (`Unknown tag: FrontierTraitBackground`) and throws during player spawn on DEBUG builds. On RELEASE builds the unregistered tag is silently added instead. Because the tag id is assembled in C# at runtime, the YAML linter cannot catch the dangling reference, which is how this slipped through CI (likely with #4312 "Background Overhaul").

Besides Corporate Frontier, the same crash affects the **Fringe**, **Hunted**, **Paradox Clone**, and **USSP** backgrounds, so this PR registers all five missing tags.

Verified locally: every `background:` referenced by a `BackgroundEffect` in `background.yml` now has a matching `<Background>TraitBackground` tag prototype, with no duplicate tag ids, and the YAML Linter passes.

## Media (Video/Screenshots)

No in-game visual changes (data-only fix; adds tag prototypes).

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
