### PR TITLE
Fix ID card console failing to apply access changes (grant all, presets, special IDs)

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -131,10 +131,20 @@ namespace Content.Client.Access.UI
 
         private void SetAllAccess(bool enabled)
         {
-            _pendingPressedAccessLevels.Clear(); // Starlight-edit
-            foreach (var button in _accessButtons.ButtonsList.Values)
-                if (!button.Disabled && button.Pressed != enabled)
-                    button.Pressed = enabled;
+            // Starlight-edit: Start - setting Pressed programmatically does not raise
+            // OnPressed, so the pending submission set must be updated here too (#3813).
+            foreach (var (id, button) in _accessButtons.ButtonsList)
+            {
+                if (button.Disabled)
+                    continue;
+
+                button.Pressed = enabled;
+                if (enabled)
+                    _pendingPressedAccessLevels.Add(id);
+                else
+                    _pendingPressedAccessLevels.Remove(id);
+            }
+            // Starlight-edit: End
         }
 
         private void SelectJobPreset(OptionButton.ItemSelectedEventArgs args)

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -258,39 +258,21 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
                 allGroupTags.UnionWith(groupPrototype.Tags);
         }
 
-        if (!newAccessList.TrueForAll(x => allGroupTags.Contains(x)))
-        // Starlight-edit: End
-        {
-            _sawmill.Warning($"User {ToPrettyString(uid)} tried to write unknown access tag.");
-            return;
-        }
-
-        var oldTags = _access.TryGetTags(targetId)?.ToHashSet() ?? new HashSet<ProtoId<AccessLevelPrototype>>(); // Starlight - keep oldTags as a hashset instead of a list
-        // Starlight-edit: Start
+        var oldTags = _access.TryGetTags(targetId)?.ToHashSet() ?? new HashSet<ProtoId<AccessLevelPrototype>>();
         var privilegedPerms = _accessReader.FindAccessTags(privilegedId!.Value).ToHashSet();
-        // For each group, update the tags for that group with the ones from newAccessList
-        var finalTags = oldTags.Except(allGroupTags).ToHashSet(); // preserve tags not in any group
-        foreach (var group in component.AccessGroups.ToList())
-        {
-            if (!_prototype.TryIndex<AccessGroupPrototype>(group, out var groupPrototype))
-                continue;
-            var groupTags = groupPrototype.Tags.ToHashSet();
-            var newGroupTags = newAccessList.Intersect(groupTags).ToHashSet();
-            finalTags.UnionWith(newGroupTags);
-        }
+
+        var (finalTags, disallowed, attemptedUnknown) =
+            ComputeAccessChange(oldTags, newAccessList, allGroupTags, privilegedPerms);
+
+        if (attemptedUnknown)
+            _sawmill.Warning($"User {ToPrettyString(uid)} tried to write unknown access tag.");
+
+        if (disallowed.Count > 0)
+            _sawmill.Warning($"User {ToPrettyString(uid)} tried to modify permissions they could not give/take: [{string.Join(", ", disallowed)}]");
 
         if (oldTags.SetEquals(finalTags))
             return;
 
-        var difference = finalTags.Union(oldTags).Except(finalTags.Intersect(oldTags)).ToHashSet();
-        // Starlight-edit: End
-        if (!difference.IsSubsetOf(privilegedPerms))
-        {
-            _sawmill.Warning($"User {ToPrettyString(uid)} tried to modify permissions they could not give/take!");
-            return;
-        }
-
-        // Starlight-edit: Start
         var addedTags = finalTags.Except(oldTags).Select(tag => "+" + tag).ToList();
         var removedTags = oldTags.Except(finalTags).Select(tag => "-" + tag).ToList();
         _access.TrySetTags(targetId, finalTags);
@@ -300,6 +282,53 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         _adminLogger.Add(LogType.Action,
             $"{player} has modified {targetId} with the following accesses: [{string.Join(", ", addedTags.Union(removedTags))}] [{string.Join(", ", newAccessList)}]");
     }
+
+    // Starlight-start: #3813
+    /// <summary>
+    /// Decides the access tags a target ID ends up with after a console write.
+    /// The client UI submits the target's full access list with the user's changes applied,
+    /// so this must not reject the whole submission outright:
+    /// tags outside the console's access groups are preserved on the target and can be
+    /// neither added nor removed here (the UI echoes existing ones back on submit), and
+    /// changes to tags the privileged ID does not itself hold are reverted while all
+    /// permitted changes still apply.
+    /// </summary>
+    /// <returns>The resulting tag set, the reverted (disallowed) changes, and whether the
+    /// submission tried to add a tag this console cannot grant.</returns>
+    public static (HashSet<ProtoId<AccessLevelPrototype>> FinalTags,
+        List<ProtoId<AccessLevelPrototype>> Disallowed,
+        bool AttemptedUnknown)
+        ComputeAccessChange(
+            HashSet<ProtoId<AccessLevelPrototype>> oldTags,
+            List<ProtoId<AccessLevelPrototype>> newAccessList,
+            HashSet<ProtoId<AccessLevelPrototype>> consoleGroupTags,
+            HashSet<ProtoId<AccessLevelPrototype>> privilegedPerms)
+    {
+        var attemptedUnknown = newAccessList.Exists(x => !consoleGroupTags.Contains(x) && !oldTags.Contains(x));
+
+        // Preserve tags outside the console's groups, replace the rest with the submission.
+        var finalTags = oldTags.Where(x => !consoleGroupTags.Contains(x)).ToHashSet();
+        finalTags.UnionWith(newAccessList.Where(consoleGroupTags.Contains));
+
+        var changed = new HashSet<ProtoId<AccessLevelPrototype>>(finalTags);
+        changed.SymmetricExceptWith(oldTags);
+
+        var disallowed = new List<ProtoId<AccessLevelPrototype>>();
+        foreach (var tag in changed)
+        {
+            if (privilegedPerms.Contains(tag))
+                continue;
+
+            disallowed.Add(tag);
+            if (oldTags.Contains(tag))
+                finalTags.Add(tag);
+            else
+                finalTags.Remove(tag);
+        }
+
+        return (finalTags, disallowed, attemptedUnknown);
+    }
+    // Starlight-end
 
     /// <summary>
     /// Returns true if there is an ID in <see cref="IdCardConsoleComponent.PrivilegedIdSlot"/> and said ID satisfies the requirements of <see cref="AccessReaderComponent"/>.

--- a/Content.Tests/Server/Access/IdCardConsoleAccessChangeTest.cs
+++ b/Content.Tests/Server/Access/IdCardConsoleAccessChangeTest.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server.Access.Systems;
+using Content.Shared.Access;
+using NUnit.Framework;
+using Robust.Shared.Prototypes;
+
+namespace Content.Tests.Server.Access;
+
+/// <summary>
+/// Regression tests for issue #3813: the ID card console rejected entire access
+/// writes when the submission echoed a tag outside the console's access groups
+/// (making such IDs completely uneditable) or contained any single change the
+/// privileged ID could not make (making "grant all" / job presets silently fail).
+/// </summary>
+[TestFixture]
+[TestOf(typeof(IdCardConsoleSystem))]
+public sealed class IdCardConsoleAccessChangeTest
+{
+    private static readonly HashSet<ProtoId<AccessLevelPrototype>> ConsoleGroups =
+        ["Command", "Engineering", "ChiefEngineer", "Theatre", "Maintenance"];
+
+    private static HashSet<ProtoId<AccessLevelPrototype>> Tags(params string[] tags)
+        => tags.Select(t => (ProtoId<AccessLevelPrototype>)t).ToHashSet();
+
+    private static List<ProtoId<AccessLevelPrototype>> Submit(params string[] tags)
+        => tags.Select(t => (ProtoId<AccessLevelPrototype>)t).ToList();
+
+    [Test]
+    public void EchoedTagOutsideConsoleGroupsDoesNotBlockEdit()
+    {
+        // Target ID carries CentralCommand, which this console's groups don't contain.
+        // The client echoes it back on submit; the edit (add Theatre) must still apply.
+        var (final, disallowed, attemptedUnknown) = IdCardConsoleSystem.ComputeAccessChange(
+            oldTags: Tags("Command", "CentralCommand"),
+            newAccessList: Submit("Command", "CentralCommand", "Theatre"),
+            consoleGroupTags: ConsoleGroups,
+            privilegedPerms: Tags("Command", "Theatre"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(final, Is.EquivalentTo(Tags("Command", "CentralCommand", "Theatre")));
+            Assert.That(disallowed, Is.Empty);
+            Assert.That(attemptedUnknown, Is.False);
+        });
+    }
+
+    [Test]
+    public void DisallowedChangeIsRevertedWhileAllowedChangesApply()
+    {
+        // Job preset drops ChiefEngineer (which the operator doesn't hold) and adds
+        // Theatre. Previously the whole write was rejected; now ChiefEngineer is kept
+        // and Theatre is still granted.
+        var (final, disallowed, _) = IdCardConsoleSystem.ComputeAccessChange(
+            oldTags: Tags("Engineering", "ChiefEngineer"),
+            newAccessList: Submit("Engineering", "Theatre"),
+            consoleGroupTags: ConsoleGroups,
+            privilegedPerms: Tags("Engineering", "Theatre"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(final, Is.EquivalentTo(Tags("Engineering", "ChiefEngineer", "Theatre")));
+            Assert.That(disallowed, Is.EquivalentTo(Tags("ChiefEngineer")));
+        });
+    }
+
+    [Test]
+    public void DisallowedAdditionIsReverted()
+    {
+        var (final, disallowed, _) = IdCardConsoleSystem.ComputeAccessChange(
+            oldTags: Tags("Theatre"),
+            newAccessList: Submit("Theatre", "ChiefEngineer"),
+            consoleGroupTags: ConsoleGroups,
+            privilegedPerms: Tags("Theatre"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(final, Is.EquivalentTo(Tags("Theatre")));
+            Assert.That(disallowed, Is.EquivalentTo(Tags("ChiefEngineer")));
+        });
+    }
+
+    [Test]
+    public void TagUnknownToConsoleCannotBeAdded()
+    {
+        // Submitting a tag outside the console's groups that the target doesn't already
+        // have is a smuggle attempt: it must be ignored and flagged.
+        var (final, _, attemptedUnknown) = IdCardConsoleSystem.ComputeAccessChange(
+            oldTags: Tags("Command"),
+            newAccessList: Submit("Command", "CentralCommand"),
+            consoleGroupTags: ConsoleGroups,
+            privilegedPerms: Tags("Command", "CentralCommand"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(final, Is.EquivalentTo(Tags("Command")));
+            Assert.That(attemptedUnknown, Is.True);
+        });
+    }
+
+    [Test]
+    public void TagOutsideConsoleGroupsCannotBeRemoved()
+    {
+        // Omitting an out-of-group tag from the submission must not strip it:
+        // this console doesn't manage that access.
+        var (final, _, _) = IdCardConsoleSystem.ComputeAccessChange(
+            oldTags: Tags("Command", "CentralCommand"),
+            newAccessList: Submit("Command"),
+            consoleGroupTags: ConsoleGroups,
+            privilegedPerms: Tags("Command", "CentralCommand"));
+
+        Assert.That(final, Is.EquivalentTo(Tags("Command", "CentralCommand")));
+    }
+
+    [Test]
+    public void AllowedGrantAndRevokeApply()
+    {
+        var (final, disallowed, attemptedUnknown) = IdCardConsoleSystem.ComputeAccessChange(
+            oldTags: Tags("Maintenance"),
+            newAccessList: Submit("Engineering", "Theatre"),
+            consoleGroupTags: ConsoleGroups,
+            privilegedPerms: Tags("Maintenance", "Engineering", "Theatre"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(final, Is.EquivalentTo(Tags("Engineering", "Theatre")));
+            Assert.That(disallowed, Is.Empty);
+            Assert.That(attemptedUnknown, Is.False);
+        });
+    }
+
+    [Test]
+    public void UnchangedEchoIsNoOp()
+    {
+        var old = Tags("Command", "CentralCommand");
+        var (final, disallowed, _) = IdCardConsoleSystem.ComputeAccessChange(
+            oldTags: old,
+            newAccessList: Submit("Command", "CentralCommand"),
+            consoleGroupTags: ConsoleGroups,
+            privilegedPerms: Tags("Command"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(final, Is.EquivalentTo(old));
+            Assert.That(disallowed, Is.Empty);
+        });
+    }
+}


### PR DESCRIPTION
## Short description

Fixes the ID card console (and the bureaucratic digi-board, which shares the same UI/system) failing to apply access changes — "Grant all"/"Revoke all" doing nothing or even *removing* accesses, job presets silently failing, and some IDs being completely uneditable.

Fixes #3813.

## Why we need to add this

Three separate defects combine into the "console sometimes can't give access" symptom from #3813:

**1. "Grant all" submitted an empty access list (client).**
`SetAllAccess` cleared `_pendingPressedAccessLevels` (the set that actually gets submitted) and then only set `Button.Pressed` programmatically — but the engine's `BaseButton.Pressed` setter does not raise `OnPressed`, so the pending set was never repopulated. "Grant all" therefore submitted an **empty** list: at best the server rejected it, at worst it **revoked** the target's accesses — and the next UI state refresh made all checkboxes "randomly uncheck", exactly as shown in the issue's video. The pending set is now kept in sync with the buttons.

**2. IDs with accesses outside the console's groups were completely uneditable (server).**
The client echoes the target ID's **full** current access list on every submit, but the server rejected the entire write if that list contained any tag outside the console's configured access groups. An ID that picked up e.g. `CentralCommand` (or any of the 14 tags not in the standard 10-group consoles' purview) could not be edited *at all* on those consoles, while consoles with more groups handled it — matching the "works on the ID computer, but not on the digiboard" observation in the issue. Out-of-group tags are now simply preserved: they can be neither added nor removed through that console (an actual attempt to *add* one is still ignored and logged).

**3. One disallowed change rejected the whole operation (server).**
If any single changed access wasn't held by the privileged ID, the entire write was silently dropped — this is what @redmushie diagnosed in the issue, and it's why job presets (which remove accesses the operator may not hold) and bulk operations kept failing with no feedback. Disallowed changes are now reverted while all permitted changes still apply, and the resulting state is reflected back in the UI. The security invariant is unchanged: the privileged ID still can't grant or take any access it doesn't itself hold.

The access-change decision logic is extracted into a pure static function (`IdCardConsoleSystem.ComputeAccessChange`) so it's directly unit-testable.

**Verification:** 7 new unit tests in `Content.Tests/Server/Access/IdCardConsoleAccessChangeTest.cs` cover each bug shape (echoed out-of-group tag, disallowed addition/removal reverted while allowed ones apply, smuggle attempt ignored+logged, out-of-group tag not removable, legit grant/revoke parity with old behavior, no-op echo). All pass; solution builds clean.

## Media (Video/Screenshots)

No new mechanics or visuals — this restores the intended behavior of the existing console UI. I can record a before/after video of the HoP console flow if reviewers want one.

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics. *(behavior-restoring bugfix, verified by unit tests — video available on request)*
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl:
- fix: The ID card computer and bureaucratic digi-board now correctly apply access changes: "Grant all" works, job presets no longer fail silently, and IDs with special accesses can be edited again. Changes the operator's ID isn't privileged for are skipped instead of blocking the whole operation.
