### PR TITLE
Fixes several loopholes for the mime's vow of silence

### DIFF
--- a/Content.Server/CartridgeLoader/Cartridges/NanoTaskCartridgeSystem.cs
+++ b/Content.Server/CartridgeLoader/Cartridges/NanoTaskCartridgeSystem.cs
@@ -7,6 +7,8 @@ using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Shared.Abilities.Mime; // Starlight
+using Content.Server.Popups; // Starlight
 
 namespace Content.Server.CartridgeLoader.Cartridges;
 
@@ -20,6 +22,7 @@ public sealed class NanoTaskCartridgeSystem : SharedNanoTaskCartridgeSystem
     [Dependency] private readonly PaperSystem _paper = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly PopupSystem _popupSystem = default!; // Starlight
 
     public override void Initialize()
     {
@@ -129,6 +132,25 @@ public sealed class NanoTaskCartridgeSystem : SharedNanoTaskCartridgeSystem
                     return;
                 if (_timing.CurTime < ent.Comp.NextPrintAllowedAfter)
                     return;
+
+                #region Starlight
+                // allow mimes to print blank NanoTasks (because it's funny)
+                if(TryComp<MimePowersComponent>(args.Actor, out var mime) && !mime.VowBroken)
+                {
+                    // check that the NanoTask is blank
+                    var isBlankNanoTask
+                    = string.IsNullOrWhiteSpace(task.Item.Description)
+                    && string.IsNullOrWhiteSpace(task.Item.TaskIsFor);
+
+                    // if it's not blank, tell the mime they can't do that while their vow is active
+                    if(!isBlankNanoTask)
+                    {
+                        _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), args.Actor, args.Actor);
+                        return;
+                    }
+
+                }
+                #endregion Starlight
 
                 ent.Comp.NextPrintAllowedAfter = _timing.CurTime + ent.Comp.PrintDelay;
                 var printed = Spawn("PaperNanoTaskItem", Transform(message.Actor).Coordinates);

--- a/Content.Server/DeltaV/AACTablet/AACTabletSystem.cs
+++ b/Content.Server/DeltaV/AACTablet/AACTabletSystem.cs
@@ -1,4 +1,6 @@
 using Content.Server.Chat.Systems;
+using Content.Server.Popups; // Starlight
+using Content.Shared.Abilities.Mime; // Starlight
 using Content.Shared.Chat;
 using Content.Shared.DeltaV.AACTablet;
 using Content.Shared.DeltaV.QuickPhrase;
@@ -14,6 +16,7 @@ public sealed class AACTabletSystem : EntitySystem
     [Dependency] private readonly ILocalizationManager _loc = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!; // Starlight Edit: Timing -> _timing. protected -> private
+    [Dependency] private readonly PopupSystem _popupSystem = default!; // Starlight
 
     public override void Initialize()
     {
@@ -23,6 +26,15 @@ public sealed class AACTabletSystem : EntitySystem
 
     private void OnSendPhrase(EntityUid uid, AACTabletComponent component, AACTabletSendPhraseMessage message)
     {
+        #region Starlight
+        // prevent use of the AAC tablet while a mime's vow of silence is active
+        if (TryComp<MimePowersComponent>(message.Actor, out var mime) && !mime.VowBroken)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), message.Actor, message.Actor);
+            return;
+        }
+        #endregion Starlight
+
         if (component.NextPhrase > _timing.CurTime) // Starlight Edit: Timing -> _timing
             return;
 

--- a/Content.Server/Speech/Muting/MutingSystem.cs
+++ b/Content.Server/Speech/Muting/MutingSystem.cs
@@ -53,25 +53,29 @@ namespace Content.Server.Speech.Muting
             args.Handled = true;
         }
 
-
         private void OnSpeakAttempt(EntityUid uid, MutedComponent component, SpeakAttemptEvent args)
         {
-            // TODO something better than this.
-
-            // Starlight-start: Cannot mute if there's no speech involved
-            var language = _languages.GetLanguage(uid);
-            if (!language.Speech.RequireSpeech)
-                return;
-            // Starlight-end
-
-            if (HasComp<MimePowersComponent>(uid))
+            #region Starlight
+            // Sign language is not pantomiming! Mimes have to break their vow of silence to speak in any form
+            if(TryComp<MimePowersComponent>(uid, out var mime) && !mime.VowBroken)
+            {
                 _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), uid, uid);
-            else if (HasComp<VentriloquistPuppetComponent>(uid))
-                _popupSystem.PopupEntity(Loc.GetString("ventriloquist-puppet-cant-speak"), uid, uid);
-            else
-                _popupSystem.PopupEntity(Loc.GetString("speech-muted"), uid, uid);
+                args.Cancel();
+                return;
+            }
 
-            args.Cancel();
+            // If language requires speech, block it when muted
+            var language = _languages.GetLanguage(uid);
+            if (language.Speech.RequireSpeech)
+            {
+                if (HasComp<VentriloquistPuppetComponent>(uid))
+                    _popupSystem.PopupEntity(Loc.GetString("ventriloquist-puppet-cant-speak"), uid, uid);
+                else
+                    _popupSystem.PopupEntity(Loc.GetString("speech-muted"), uid, uid);
+
+                args.Cancel();
+            }
+            #endregion Starlight
         }
     }
 }

--- a/Content.Server/_CD/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_CD/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -235,7 +235,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
             return;
 
         #region Starlight
-        // Nanochat is not pantomiming! Mimes have to break their vow of silence to speak in any form
+        // NanoChat is not pantomiming! Mimes have to break their vow of silence to speak in any form
         if(TryComp<MimePowersComponent>(msg.Actor, out var mime) && !mime.VowBroken)
         {
             _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), msg.Actor, msg.Actor);

--- a/Content.Server/_CD/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_CD/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -14,6 +14,9 @@ using Content.Shared.PDA;
 using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Content.Shared.Abilities.Mime; // Starlight
+using Robust.Shared.Toolshed.Commands.Values;
+using Content.Server.Popups; // Starlight
 
 namespace Content.Server._CD.CartridgeLoader.Cartridges;
 
@@ -25,6 +28,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedNanoChatSystem _nanoChat = default!;
     [Dependency] private readonly StationSystem _station = default!;
+    [Dependency] private readonly PopupSystem _popupSystem = default!; // Starlight
 
     // Messages in notifications get cut off after this point
     // no point in storing it on the comp
@@ -230,13 +234,20 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
         if (!EnsureRecipientExists(card, msg.RecipientNumber.Value))
             return;
 
-        // Starlight Start
+        #region Starlight
+        // Nanochat is not pantomiming! Mimes have to break their vow of silence to speak in any form
+        if(TryComp<MimePowersComponent>(msg.Actor, out var mime) && !mime.VowBroken)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), msg.Actor, msg.Actor);
+            return;
+        }
+
         var content = msg.Content;
         if (!string.IsNullOrWhiteSpace(content))
         {
             content = content.Trim();
         }
-        // Starlight End
+        #endregion
 
         // Create and store message for sender
         var message = new NanoChatMessage(

--- a/Content.Server/_CD/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_CD/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -15,7 +15,6 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.Abilities.Mime; // Starlight
-using Robust.Shared.Toolshed.Commands.Values;
 using Content.Server.Popups; // Starlight
 
 namespace Content.Server._CD.CartridgeLoader.Cartridges;

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -16,7 +16,7 @@
   - !type:AddComponentSpecial
     components:
     - type: MimePowers
-      preventWriting: false #SL
+      preventWriting: true
     - type: FrenchAccent
 
 - type: startingGear


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
The mime's vow of silence is really easily circumvented. The whole point of miming is **pantomiming.**

This PR makes the vow of silence much stronger, preventing the mime from using the following while their vow is unbroken:
- No writing while the vow is active.
- No using AAC tablets while the vow is active.
- No using sign language or hiveminds (like the Nexus) while the vow is active
- No using NanoChat while the vow is active.
- No printing non-blank NanoTasks. I figured it's funny if the mime can still print NanoTasks whilst maintaining their vow as long as the NanoTask itself is completely blank.

One issue with this PR that I couldn't figure out was how to make the NanoChat messages fail more gracefully (the Mime is prevented from sending NanoChats properly, but the messages appear briefly before flickering out). I would appreciate if someone smarter than me can figure out how to prevent that message flickering.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Writing, AAC tablets, sign language, hiveminds, NanoChat and NanoTasks all circumvent the point of the vow of silence.

Discord support for mimes actually being silent is extremely strong, as seen in this thread:
https://discord.com/channels/1272545509562777621/1513943733492777192
<img width="618" height="94" alt="image" src="https://github.com/user-attachments/assets/6c68c6c6-25f3-40e1-b02b-d04e7d59ba3c" />

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/28d8dd56-f9a9-460f-8646-e480cdd2b9d1

fig. 1 - Demo: AAC tablet prevention, NanoChat prevention, non-verbal language prevention, NanoTask writing prevention, blank NanoTasks are still allowed, writing prevention. Mime vow is then broken and I show that all of these things still work after the mime vow is broken.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Mimes can no longer use AAC tablets while their vow of silence is active.
- tweak: Mimes can no longer bypass their vow of silence by writing.
- tweak: Mimes can no longer bypass their vow of silence using sign language nor hiveminds (e.g. the Nexus).
- tweak: Mimes can no longer bypass their vow of silence by using NanoChat.
- tweak: Mimes can no longer bypass their vow of silence by using NanoTasks (they may only print NanoTasks if the description is blank).
