### PR TITLE
Register missing background trait tags (Corporate Frontier and 4 others)

### DIFF
--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -255,6 +255,12 @@
   id: FormerSoldierTraitBackground
 
 - type: Tag
+  id: FringeTraitBackground
+
+- type: Tag
+  id: FrontierTraitBackground
+
+- type: Tag
   id: FlatpackBlacklist
 
 - type: Tag
@@ -301,6 +307,9 @@
 
 - type: Tag
   id: HiltWood
+
+- type: Tag
+  id: HuntedTraitBackground
 
 - type: Tag
   id: ImprovisedAmmoBox
@@ -479,6 +488,9 @@
   id: OvenMachineBoard
 
 - type: Tag
+  id: ParadoxCloneTraitBackground
+
+- type: Tag
   id: ParaKnife
 
 - type: Tag
@@ -629,6 +641,9 @@
 
 - type: Tag
   id: UnDissolvable
+
+- type: Tag
+  id: USSPTraitBackground
 
 - type: Tag
   id: Vial


### PR DESCRIPTION
## Short description
Five `*TraitBackground` tags were never registered in `tags.yml`, so the Corporate Frontier, Fringe, Hunted, Paradox Clone, and USSP backgrounds don't apply when picked. This adds the five tags. Fixes #4647.

## Why we need to add this
`BackgroundEffect` builds its tag id in C# at runtime (`Background + "TraitBackground"`), so the missing tags never appear as a literal and the YAML linter can't catch them. On a debug build the unknown tag trips an assert that `TraitSystem.ApplyTrait` catches and logs, so the background silently does nothing; on release the unregistered tag is added silently. Either way you don't get the background you selected. (Root cause is the runtime-built tag reference — happy to follow up with a small refactor making `BackgroundEffect` use a validated `ProtoId<TagPrototype>` so the linter catches this class of bug; kept out of here to stay a focused data fix.)

## Media (Video/Screenshots)
Tested in-game on a local build: with the fix, a Corporate Frontier character applies the background (Character → Background, screenshot below); without it the server logs `Unknown tag: FrontierTraitBackground` and it doesn't apply.

<img width="1134" height="678" alt="CorporateFrontier" src="https://github.com/user-attachments/assets/d2d12a24-cdbb-421d-9fa4-023fbfb6c27b" />


## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

> **Note on process:** I used AI assistance to find and write this, but I've reviewed every line and tested it in-game myself (the red/green above). It's a small data-only fix for a real bug. If AI-assisted contributions aren't something you want, let me know and I'll close it.

**Changelog**

:cl: pmjanus
- fix: The Corporate Frontier, Fringe, Hunted, Paradox Clone, and USSP backgrounds now apply correctly instead of silently doing nothing.
