### PR TITLE
Add aielith, IPC, and protogen to AAC tablet

### DIFF
--- a/Resources/Prototypes/_Starlight/QuickPhrases/Species/crew.yml
+++ b/Resources/Prototypes/_Starlight/QuickPhrases/Species/crew.yml
@@ -73,7 +73,7 @@
 - type: quickPhrase
   id: SpeciesProtoslimepersonPhrase
   parent: SpeciesProtogenPhrase
-  text: subspecies-name-protoslime
+  text: subspecies-name-protoslimeperson
 
 - type: quickPhrase
   id: SpeciesProtovulpPhrase

--- a/Resources/Prototypes/_Starlight/QuickPhrases/Species/crew.yml
+++ b/Resources/Prototypes/_Starlight/QuickPhrases/Species/crew.yml
@@ -22,3 +22,105 @@
   id: SpeciesCycloritePhrase
   parent: BaseCrewSpeciesPhrase
   text: species-name-cyclorite
+
+- type: quickPhrase
+  id: SpeciesElfPhrase
+  parent: BaseCrewSpeciesPhrase
+  text: species-name-elf
+
+- type: quickPhrase
+  id: SpeciesIPCPhrase
+  parent: BaseCrewSpeciesPhrase
+  text: species-name-ipc
+
+# Protogens and protogen subspecies
+
+- type: quickPhrase
+  id: SpeciesProtogenPhrase
+  parent: BaseCrewSpeciesPhrase
+  text: species-name-protogen
+
+- type: quickPhrase
+  id: SpeciesTrueProtogenPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-trueprotogen
+
+- type: quickPhrase
+  id: SpeciesProtohumanPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protohuman
+
+- type: quickPhrase
+  id: SpeciesProtodionaPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protodiona
+
+- type: quickPhrase
+  id: SpeciesProtoarachnidPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoarachnid
+
+- type: quickPhrase
+  id: SpeciesProtomothPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protomoth
+
+- type: quickPhrase
+  id: SpeciesProtoreptilianPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoreptilian
+
+- type: quickPhrase
+  id: SpeciesProtoslimepersonPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoslime
+
+- type: quickPhrase
+  id: SpeciesProtovulpPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protovulp
+
+- type: quickPhrase
+  id: SpeciesProtoresomiPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoresomi
+
+- type: quickPhrase
+  id: SpeciesProtoavaliPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoavali
+
+- type: quickPhrase
+  id: SpeciesProtovoxPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protovox
+
+- type: quickPhrase
+  id: SpeciesProtolagomorphPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protolagomorph
+
+- type: quickPhrase
+  id: SpeciesProtofelionoidPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protofelionoid
+
+- type: quickPhrase
+  id: SpeciesProtokinPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protokin
+
+- type: quickPhrase
+  id: SpeciesProtothavenPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protothaven
+
+- type: quickPhrase
+  id: SpeciesProtocycloritePhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protocyclorite
+
+- type: quickPhrase
+  id: SpeciesProtoelfPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoelf


### PR DESCRIPTION
## Short description
This adds aielith, IPC, and protogen buttons to the AAC tablet.

## Why we need to add this
For completeness.

## Media (Video/Screenshots)
Unfortunately, I am unable to run a dev server to test my changes. I keep getting 404 errors from the server side whenever I try to connect.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: salarua
- add: AAC tablet software has been updated: There are now buttons for aielith, IPC, and protogen in the Species tab.