### PR TITLE
Lowercase railing names

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/railing.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/railing.yml
@@ -28,8 +28,8 @@
 - type: entity
   parent: BaseRailing
   id: Railing
-  name: Railing #SL
-  suffix: Steel #SL
+  name: railing #SL
+  suffix: steel #SL
   components:
   - type: Sprite
     sprite: _Starlight/Structures/Walls/railing.rsi #Starlight
@@ -78,8 +78,8 @@
 - type: entity
   parent: BaseRailing
   id: RailingCorner
-  name: Railing #SL
-  suffix: Steel, Corner #SL
+  name: railing #SL
+  suffix: steel, corner #SL
   components:
   - type: Sprite
     sprite: _Starlight/Structures/Walls/railing.rsi #Starlight
@@ -137,8 +137,8 @@
 - type: entity
   parent: BaseRailing
   id: RailingCornerSmall
-  name: Railing #SL
-  suffix: Steel, Corner Small #SL
+  name: railing #SL
+  suffix: steel, corner small #SL
   components:
   - type: Sprite
     sprite: _Starlight/Structures/Walls/railing.rsi #Starlight
@@ -187,8 +187,8 @@
 - type: entity
   parent: BaseRailing
   id: RailingRound
-  name: Railing #SL
-  suffix: Steel, Round #SL
+  name: railing #SL
+  suffix: steel, round #SL
   components:
   - type: Sprite
     sprite: _Starlight/Structures/Walls/railing.rsi #Starlight


### PR DESCRIPTION
## Short description
This makes the names of railing tiles lowercase.

## Why we need to add this
For consistency.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
