### PR TITLE
fixy fixy observer mass scanner bug

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -88,8 +88,6 @@
   - type: ComplexInteraction # Starlight-start
   - type: RadarConsole
     followEntity: true
-  - type: ActivatableUI
-    key: enum.RadarConsoleUiKey.Key
   - type: UserInterface
     interfaces:
         enum.RadarConsoleUiKey.Key:


### PR DESCRIPTION
## Short description
Fixing a bug that allows aghosts to use people like mass scanners

## Why we need to add this
It can get extremely annoying at times as an admin wen your tryna click something thats being followed by an other ghost then BAM mass scanner in your face. https://discord.com/channels/1272545509562777621/1514339844371906611

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- fix: Observers cant be used by aghosts as a mass scanner.
