### PR TITLE
Makes the 'dual-port air vent' DoNotMap

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -518,6 +518,7 @@
 - type: entity
   parent: GasVentPump
   id: GasDualPortVentPump
+  categories: [ DoNotMap ] # Starlight - Blacklisted by WizDen for mapping, extremely easy to use wrong, best to just not map them at all.
   name: dual-port air vent
   description: Has a valve and a pump attached to it. There are two ports, one is an input for releasing air, the other is an output when siphoning.
   placement:

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Atmospherics/freezer.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Atmospherics/freezer.yml
@@ -21,6 +21,8 @@
 - type: entity
   parent: [AirSensorFreezerBase, GasDualPortVentPump]
   id: GasDualPortVentPumpFreezer
+  categories: [ DoNotMap ] # Starlight - Blacklisted by WizDen for mapping, extremely easy to use wrong, best to just not map them at all.
+  suffix: "DO NOT MAP, Freezer Atmosphere" # Starlight - manual suffix due to category inheritance weirdness
   components:
   - type: AtmosPipeLayers
     spriteRsiPaths: {}

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Atmospherics/vox.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Atmospherics/vox.yml
@@ -21,6 +21,8 @@
 - type: entity
   parent: [AirSensorVoxBase, GasDualPortVentPump]
   id: GasDualPortVentPumpVox
+  categories: [ DoNotMap ] # Starlight - Blacklisted by WizDen for mapping, extremely easy to use wrong, best to just not map them at all.
+  suffix: "DO NOT MAP, Vox Atmosphere" # Starlight - manual suffix due to category inheritance weirdness
   components:
   - type: AtmosPipeLayers
     spriteRsiPaths: {}


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
The dual-port air vent sucks. It's [blacklisted by WizDen's mapping guidelines](https://docs.spacestation14.com/en/space-station-14/mapping/guidelines.html), it doesn't do what you *think* it does— people mistake it for an "inline" air vent - it's not. It's a weird air vent scrubber mix, and good luck figuring out which side is which!!

I'll be so real, it should maybe even be removed from the game entirely and replaced with an inline air vent (which _would_ work the way people would want it to).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Blacklisted by WizDen for good reasons. I'm making the decision to prevent mappers making an oopsie by mapping this by doing the same.

Marking it `DoNotMap` will make sure people do not map it. In the future, I think it's worth considering completely removing it.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="517" height="212" alt="image" src="https://github.com/user-attachments/assets/86f05665-5342-47dc-8796-ec8418459fcf" />

fig. 1 - DoNotMap suffix applied. 

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
