### PR TITLE
Group asexual pin with the rest of the pride pins

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -157,6 +157,7 @@
   id: ClothingNeckAsexualPin
   equipment: # Starlight: Move to misc slot
     misc: ClothingNeckAsexualPin
+  groupBy: "pin"
 
 - type: loadout
   id: ClothingNeckBisexualPin

--- a/Resources/Prototypes/_Starlight/QuickPhrases/Species/crew.yml
+++ b/Resources/Prototypes/_Starlight/QuickPhrases/Species/crew.yml
@@ -73,7 +73,7 @@
 - type: quickPhrase
   id: SpeciesProtoslimepersonPhrase
   parent: SpeciesProtogenPhrase
-  text: subspecies-name-protoslime
+  text: subspecies-name-protoslimeperson
 
 - type: quickPhrase
   id: SpeciesProtovulpPhrase

--- a/Resources/Prototypes/_Starlight/QuickPhrases/Species/crew.yml
+++ b/Resources/Prototypes/_Starlight/QuickPhrases/Species/crew.yml
@@ -22,3 +22,105 @@
   id: SpeciesCycloritePhrase
   parent: BaseCrewSpeciesPhrase
   text: species-name-cyclorite
+
+- type: quickPhrase
+  id: SpeciesElfPhrase
+  parent: BaseCrewSpeciesPhrase
+  text: species-name-elf
+
+- type: quickPhrase
+  id: SpeciesIPCPhrase
+  parent: BaseCrewSpeciesPhrase
+  text: species-name-ipc
+
+# Protogens and protogen subspecies
+
+- type: quickPhrase
+  id: SpeciesProtogenPhrase
+  parent: BaseCrewSpeciesPhrase
+  text: species-name-protogen
+
+- type: quickPhrase
+  id: SpeciesTrueProtogenPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-trueprotogen
+
+- type: quickPhrase
+  id: SpeciesProtohumanPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protohuman
+
+- type: quickPhrase
+  id: SpeciesProtodionaPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protodiona
+
+- type: quickPhrase
+  id: SpeciesProtoarachnidPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoarachnid
+
+- type: quickPhrase
+  id: SpeciesProtomothPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protomoth
+
+- type: quickPhrase
+  id: SpeciesProtoreptilianPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoreptilian
+
+- type: quickPhrase
+  id: SpeciesProtoslimepersonPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoslime
+
+- type: quickPhrase
+  id: SpeciesProtovulpPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protovulp
+
+- type: quickPhrase
+  id: SpeciesProtoresomiPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoresomi
+
+- type: quickPhrase
+  id: SpeciesProtoavaliPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoavali
+
+- type: quickPhrase
+  id: SpeciesProtovoxPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protovox
+
+- type: quickPhrase
+  id: SpeciesProtolagomorphPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protolagomorph
+
+- type: quickPhrase
+  id: SpeciesProtofelionoidPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protofelionoid
+
+- type: quickPhrase
+  id: SpeciesProtokinPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protokin
+
+- type: quickPhrase
+  id: SpeciesProtothavenPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protothaven
+
+- type: quickPhrase
+  id: SpeciesProtocycloritePhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protocyclorite
+
+- type: quickPhrase
+  id: SpeciesProtoelfPhrase
+  parent: SpeciesProtogenPhrase
+  text: subspecies-name-protoelf


### PR DESCRIPTION
## Short description
This puts the asexual pin in the same group as the rest of the pride pins in the loadout menu.

## Why we need to add this
Currently the asexual pin is listed separately from the other pride pins, which looks odd.

## Media (Video/Screenshots)
<img width="1006" height="1011" alt="Screenshot From 2026-06-10 22-10-12 (Edit)" src="https://github.com/user-attachments/assets/de0cd296-e2a5-4775-bf0c-a01b501aaadd" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.