### PR TITLE
Diona: Summer of Rebirth

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -370,7 +370,7 @@ namespace Content.Server.Atmos.EntitySystems
 
                 #region Starlight
                 // Don't light on fire if you already have too many fire stacks
-                if ((flammable.FireStacks + component.FireStacks) >= component.MaxFireStacks)
+                if ((flammable.FireStacks + component.FireStacks) > component.MaxFireStacks)
                     return;
                 #endregion
 

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -368,6 +368,12 @@ namespace Content.Server.Atmos.EntitySystems
                 if (value <= component.Threshold)
                     return;
 
+                #region Starlight
+                // Don't light on fire if you already have too many fire stacks
+                if ((flammable.FireStacks + component.FireStacks) >= component.MaxFireStacks)
+                    return;
+                #endregion
+
                 // Ignite that sucker
                 flammable.FireStacks += component.FireStacks;
                 Ignite(uid, uid, flammable);

--- a/Content.Server/Damage/Components/IgniteOnHeatDamageComponent.cs
+++ b/Content.Server/Damage/Components/IgniteOnHeatDamageComponent.cs
@@ -8,7 +8,11 @@ public sealed partial class IgniteOnHeatDamageComponent : Component
 {
     [DataField("fireStacks")]
     public float FireStacks = 1f;
-
+    #region Starlight
+    // Max fire stacks that can be applied by this effect, stop adding fire stacks after this.
+    [DataField("maxFireStacks")]
+    public float MaxFireStacks = 10f;
+    #endregion
     // The minimum amount of damage taken to apply fire stacks
     [DataField("threshold")]
     public FixedPoint2 Threshold = 15;

--- a/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
@@ -16,6 +16,7 @@
   - type: NpcFactionMember
     factions:
     - SimpleHostile
+    - Floral # Starlight
   - type: NPCImprintingOnSpawnBehaviour
     spawnFriendsSearchRadius: 10
     whitelist:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -2798,6 +2798,11 @@
           effectProto: StatusEffectDrowsiness
           time: 1
           type: Remove
+        - !type:SatiateHunger # Starlight start
+          factor: 1 # only vaguely related to water
+          conditions:
+          - !type:MetabolizerTypeCondition
+            type: [ Plant ] # Starlight end
   fizziness: 0.15
 
 - type: reagent

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -71,6 +71,11 @@
       effects:
       - !type:SatiateThirst
         factor: 4 # Coconut water is 94% water
+      - !type:SatiateHunger # Starlight start, diona stuff
+        factor: 2 # I'm not going to make it do MORE than normal water like coconut water, but it can be equal as a nod to that.
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Plant ] # Starlight end
 
 - type: reagent
   id: CreamOfCoconut
@@ -366,6 +371,16 @@
   flavor: fizzy
   color: "#619494"
   fizziness: 0.8
+  metabolisms: # Starlight start, diona stuff
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 3
+      - !type:SatiateHunger
+        factor: 1.5 # it's not pure water
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Plant ] # Starlight end
 
 - type: reagent
   id: SoyLatte
@@ -424,6 +439,16 @@
   flavor: tonicwater
   color: "#0064C8"
   fizziness: 0.4
+  metabolisms: # Starlight start, diona stuff
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 3
+      - !type:SatiateHunger
+        factor: 1.5 # it's not pure water
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Plant ] # Starlight end
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/tonicglass.rsi
     state: icon_empty
@@ -445,7 +470,7 @@
   boilingPoint: 100.0
   meltingPoint: 0.0
   friction: 0.4
-  # Starlight edit start - Make Water work like Ipecac for Dwarfs, but even worse
+  # Starlight edit start - Make Water work like Ipecac for Dwarfs, but even worse, also let Diona treat water as food
   metabolisms:
     Drink:
       effects:
@@ -459,6 +484,11 @@
         - !type:MetabolizerTypeCondition
           type: [ Dwarf ]
         probability: 0.5
+      - !type:SatiateHunger
+        factor: 2
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Plant ]
   # Starlight edit end
     Gas:
       effects:
@@ -490,6 +520,13 @@
       effects:
       - !type:SatiateThirst
         factor: 3 # Slightly worse for quenching thirst than just straight water
+      # Starlight start, diona can eat ice too, ig, just make it a little worse
+      - !type:SatiateHunger
+        factor: 1.5
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Plant ]
+      # Starlight end
   plantMetabolism:
   - !type:PlantAdjustWater
     amount: 1 # The internet tells me I should avoid watering plants with ice, but mostly because of temperature, so this value being the same as water should probably be fine?

--- a/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/juice.yml
@@ -155,6 +155,16 @@
   physicalDesc: reagent-physical-desc-sweet
   flavor: watermelon
   color: "#EF3520"
+  metabolisms: # Starlight start, diona stuff
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 3
+      - !type:SatiateHunger
+        factor: 1.5 # It really isn't water, but it has water in the name, so.
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Plant ] # Starlight end
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/watermelonglass.rsi
     state: icon_empty

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1522,6 +1522,11 @@
       effects:
       - !type:SatiateThirst
         factor: 3
+      - !type:SatiateHunger # Starlight start, diona stuff
+        factor: 2 # It's as infinite as normal water, so it doesn't really matter that it's the same.
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Plant ] # Starlight end
     Medicine:  # Starlight
       effects:
       - !type:HealthChange

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/diona.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/diona.yml
@@ -125,7 +125,8 @@
   - type: IgnoreKudzu
   - type: IgniteOnHeatDamage
     fireStacks: 1
-    threshold: 12
+    maxFireStacks: 3
+    threshold: 30
   - type: GibAction
     actionPrototype: DionaGibAction
     allowedStates:
@@ -139,6 +140,15 @@
             sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
   - type: Rootable
+  - type: NpcFactionMember
+    factions:
+    - NanoTrasen
+    - Floral
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      125: Critical
+      250: Dead
 
 - type: entity
   parent: [BaseProtogenAppearance, BaseSpeciesDummy]

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/diona.yml
@@ -129,9 +129,20 @@
   - type: IgnoreKudzu
   - type: IgniteOnHeatDamage
     fireStacks: 1
-    threshold: 12
+    maxFireStacks: 5
+    threshold: 20
   - type: GibAction
     actionPrototype: DionaGibAction
     allowedStates:
     - Dead
   - type: Rootable
+    speedModifier: 0.85
+  - type: NpcFactionMember
+    factions:
+    - NanoTrasen
+    - Floral
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      125: Critical
+      250: Dead

--- a/Resources/Prototypes/_Starlight/ai_factions.yml
+++ b/Resources/Prototypes/_Starlight/ai_factions.yml
@@ -177,3 +177,6 @@
   - Dragon
   - Gorilla
   - Abductor
+
+- type: npcFaction
+  id: Floral # It's so plant anom creatures don't attack diona.

--- a/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
@@ -7,6 +7,7 @@
 
   They can't wear shoes, but are not slowed by Kudzu.
   They get hungry and thirsty slower.
+  They can restore hunger by drinking certain water-based beverages. <!-- Starlight, water food for diona.-->
   Their "blood" is tree sap and can't be metabolised from Iron.
   Being plants, Weed Killer poisons them, while Robust Harvest heals them (but not without risk when overused!)
 

--- a/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
@@ -12,7 +12,7 @@
 
   They take [color=#1e90ff]30% less Blunt damage and 20% less Slash damage[/color];
   but [color=#ffa500]50% more Heat damage, 20% more Shock damage, and they can easily
-  catch on fire when receiving enough Heat damage from *any* source.[/color]
+  catch on fire when receiving enough Heat damage from *any* source, up to 5 fire stacks.[/color] <!-- Starlight, fire stack cap for this effect.-->
 
   ## Make Like A Tree And Leave
   <Box>

--- a/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Diona.xml
@@ -8,6 +8,8 @@
   They can't wear shoes, but are not slowed by Kudzu.
   They get hungry and thirsty slower.
   They can restore hunger by drinking certain water-based beverages. <!-- Starlight, water food for diona.-->
+  They fall into a critical state at [color=lightgreen]125[/color] points of damage. <!-- Starlight, health changes.-->
+  They die at [color=red]250[/color] points of damage. <!-- Starlight, health changes.-->
   Their "blood" is tree sap and can't be metabolised from Iron.
   Being plants, Weed Killer poisons them, while Robust Harvest heals them (but not without risk when overused!)
 

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/SubMobs/ProtoDiona.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/SubMobs/ProtoDiona.xml
@@ -11,5 +11,7 @@
   - Receive [color=#ffa500]65% more heat damage[/color] and [color=#8147ff]30% more shock damage[/color].
   - Receive [color=#65807d]25% less slash damage[/color], [color=#FF3636]20% less blunt damage[/color], and [color=#1e90ff]35% less cold damage[/color].
 
+In addition, while you may take more [color=#ffa500]heat damage[/color] than your non-cybernetic brethren, it actually takes *more* Heat Damage to light you aflame than them. Furthermore, your cybernetics, while still weak to heat, at the very least, will reduce the max fire stacks from this effect down to 3.
+
 [color=red]WARNING![/color] Splitting into nymphs as a Proto-Diona will [color=red]turn you back into a normal Diona![/color] Choose carefully, is it really worth it to lose your cybernetics?
 </Document>

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/SubMobs/ProtoDiona.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/SubMobs/ProtoDiona.xml
@@ -13,5 +13,7 @@
 
 In addition, while you may take more [color=#ffa500]heat damage[/color] than your non-cybernetic brethren, it actually takes *more* Heat Damage to light you aflame than them. Furthermore, your cybernetics, while still weak to heat, at the very least, will reduce the max fire stacks from this effect down to 3.
 
+While rooted, you're also [color=#fc0303]5% slower than base Diona[/color]. Guess the metal adds enough weight...
+
 [color=red]WARNING![/color] Splitting into nymphs as a Proto-Diona will [color=red]turn you back into a normal Diona![/color] Choose carefully, is it really worth it to lose your cybernetics?
 </Document>


### PR DESCRIPTION
## Short description
Updates Diona to be more modern, giving them a couple new interactions with fire and water, and making the difficulties of their mechanics a little less debilitating.

## Why we need to add this
Diona suck. They fight Cyclorites for the least played species. Heat Damage is incredibly common, and their botany chem healing ability is very underutilized, as botany themselves can sometimes struggle to get them from Chemistry. They've never really had anything given to them, and have only ever received nerf after nerf, the most recent of which being the removal of their hivemind. They're not even marked as a challenge species. Furthermore, their "main benefit" of resurrection, while it may serve a better purpose on LRP servers, or servers without new life, fails to hold up on Starlight, as memories are not kept by diona between resurrections, making it functionally the same as new life, of which, every person on the server has access to. This seeks to alleviate their drawbacks, with the goal of bringing them somewhere near Cyclorites, who have received a series of similar-quality tweaks this year.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: Diona/Proto-Diona now restore a little bit of hunger when drinking things with the word "water" in the name. It varies by type, but they're all less than x1.
- tweak: Diona/Proto-Diona now crit at 125 Health, and die at 250 Health. A bit less than Cyclorites.
- tweak: Diona now gain Fire Stacks at 20 Heat, and can only gain 5 Fire Stacks from this effect at once.
- tweak: Proto-Diona now gain Fire Stacks at 30 Heat, and can only gain 3 Fire Stacks from this effect at once.
- tweak: Diona now move 5% faster while rooted. (-15% as opposed to -20%). Proto-Diona keep the original -20%.
- tweak: The plant anomaly creatures are no longer hostile to Diona/Proto-Diona.

