### PR TITLE
fixes cold resistance values on coats from the drip update

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/Coats.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/Coats.yml
@@ -1,18 +1,12 @@
 ﻿#Long coat
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: ClothingOuterCoatLab
   id: ClothingOuterCoatLabLong
   name: long lab coat
   description: A Nanotrasen standard labcoat for medical personnel but long.
   components:
     - type: Sprite
       sprite: DeltaV/Clothing/OuterClothing/Coats/long_lab.rsi
-    - type: Pierceable
-      level: Metal
-    - type: Armor
-      modifiers:
-        coefficients:
-          Caustic: 0.75
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabLong]
@@ -21,19 +15,13 @@
 
 #Chemist long coat
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: ClothingOuterCoatLabChem
   id: ClothingOuterCoatLabChemistLong
   name: long chemist lab coat
   description: A Nanotrasen standard labcoat for medical personnel but long with bright orange accents.
   components:
     - type: Sprite
       sprite: DeltaV/Clothing/OuterClothing/Coats/chemistry_long_lab.rsi
-    - type: Pierceable
-      level: Metal
-    - type: Armor
-      modifiers:
-        coefficients:
-          Caustic: 0.75
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabChemistLong]
@@ -42,19 +30,13 @@
 
 #CMO long coat
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: ClothingOuterCoatLabCmo
   id: ClothingOuterCoatLabCmoLong
   name: long chief medical officer lab coat
   description: A Nanotrasen blue long lab coat with green accents, designed for chief medical officers.
   components:
     - type: Sprite
       sprite: DeltaV/Clothing/OuterClothing/Coats/cmo_long_lab.rsi
-    - type: Pierceable
-      level: Metal
-    - type: Armor
-      modifiers:
-        coefficients:
-          Caustic: 0.75
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabCmoLong]
@@ -63,19 +45,13 @@
 
 #Geneticist long coat
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: ClothingOuterCoatLabGene
   id: ClothingOuterCoatLabGeneLong
   name: long geneticist lab coat
   description: A Nanotrasen standard labcoat for medical personnel but long with light blue accents.
   components:
     - type: Sprite
       sprite: DeltaV/Clothing/OuterClothing/Coats/medical_long_lab.rsi
-    - type: Pierceable
-      level: Metal
-    - type: Armor
-      modifiers:
-        coefficients:
-          Caustic: 0.75
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabGeneLong]
@@ -84,7 +60,7 @@
 
 #Paramedic jacket
 - type: entity
-  parent: ClothingOuterStorageFoldableBase
+  parent: [ClothingOuterStorageFoldableBase, ClothingOuterColdBase]
   id: ClothingOuterCoatParamedicJacket
   name: paramedic jacket
   description: A stylish dark blue jacket decorated with white stripes and cross. Nine out of ten paramedic recommend "Do Not Revive."
@@ -99,7 +75,7 @@
 
 #Rugged duster
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: [ClothingOuterStorageBase, ClothingOuterColdBase]
   id: ClothingOuterCoatDuster
   name: rugged duster
   description: A rugged duster with a bandana scarf made for keeping off the ash and dust. Not much of that up in space though.


### PR DESCRIPTION
## Short description
changes the parents for the coats added in the drip update so they can have correct defense attributes

## Why we need to add this
feels like the right thing to do

## Media (Video/Screenshots)
<img width="322" height="130" alt="Screenshot 2026-06-11 203654" src="https://github.com/user-attachments/assets/8c9de988-a88d-442e-ba4b-7d93a29eccfe" />


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl:
- fix: fixed cold defense values of the long lab coats, ragged duster and paramedic jacket.