### PR TITLE
shoey fixy

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -48,8 +48,7 @@
   components:
   - type: Matchbox
   - type: Storage
-    grid:
-    - 0,0,0,0
+    grid: []
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
@@ -70,8 +69,7 @@
   suffix: Filled
   components:
   - type: Storage
-    grid:
-    - 0,0,0,0
+    grid: []
   - type: ContainerFill
     containers:
       item:

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -48,7 +48,7 @@
   components:
   - type: Matchbox
   - type: Storage
-    grid: []
+    grid: [] # starlight
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
@@ -69,7 +69,7 @@
   suffix: Filled
   components:
   - type: Storage
-    grid: []
+    grid: [] # starlight
   - type: ContainerFill
     containers:
       item:

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -49,7 +49,7 @@
   - type: Matchbox
   - type: Storage
     grid:
-    - 0,0,1,1
+    - 0,0,0,0
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
@@ -71,7 +71,7 @@
   components:
   - type: Storage
     grid:
-    - 0,0,1,1
+    - 0,0,0,0
   - type: ContainerFill
     containers:
       item:


### PR DESCRIPTION

## Short description
Makes it so people cant put stuff into shoes that shouldnt go in there anyway

## Why we need to add this
Since you cant actually open the storage on the boots, the boots just CONSUME the item basically. https://discord.com/channels/1272545509562777621/1514619157612728350

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- fix: Shoes no longer consume items that you're trying to put into them, they just reject you doing that now.
