### PR TITLE
(Vox QoL) NT coats accept gas tanks

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/coats.yml
@@ -59,7 +59,7 @@
         Cold: 0.85
 
 - type: entity
-  parent: [ClothingOuterBase, BaseNanoTrasenContraband]
+  parent: [ ClothingOuterBase, BaseNanoTrasenContraband, AllowSuitStorageClothingGasTanks ]
   id: ClothingOuterRobesMagistrate
   name: magistrate robes
   description: This robe commands authority. Much more dense than the commoner variants.
@@ -82,7 +82,7 @@
         Cold: 0.85
 
 - type: entity
-  parent: [ ClothingOuterStorageFoldableBase, BaseNanoTrasenContraband ]
+  parent: [ ClothingOuterStorageFoldableBase, BaseNanoTrasenContraband, AllowSuitStorageClothingGasTanks ]
   id: ClothingOuterCoatNtrep
   name: nt representative jacket
   description: A fancy black jacket, standard issue to NanoTrasen Representatives.
@@ -491,7 +491,7 @@
   - type: Item
 
 - type: entity
-  parent: [ ClothingOuterStorageBase, AllowSuitStorageClothing, BaseCommandContraband ]
+  parent: [ ClothingOuterStorageBase, BaseCommandContraband, AllowSuitStorageClothingGasTanks ]
   id: ClothingOuterCoatNCT
   name: nt career trainer's jacket
   description: A sharp black coat with beige trim around the cuffs and collar, offering a mix of professionalism and approachability.

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/nct.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/nct.yml
@@ -51,7 +51,9 @@
     belt: BoxFolderNanoTrasenClipboard
     gloves: ClothingHandsGlovesColorWhite
     outerClothing: ClothingOuterCoatNCT
-    suitstorage: Flash
+  storage:
+    back:
+    - Flash
 
 - type: chameleonOutfit
   id: NanotrasenCareerTrainerChameleonOutfit


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
- Generally, NT roles are expected to be dressed in their issued clothing. Most NT roles spawn with outer wear.
- (Most) NT coats don't accept gas tanks, which makes them painful for Vox to use.
- This PR makes it so those coats accept gas tanks.

Also, the NCT current has a bug. It roundstarts with a flash in suit storage, which once it's taken out can never be put back in. This PR fixes that bug by making it so the flash for the NCT spawns in their backpack instead.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Quality of life update for Vox. It doesn't affect the game very much to allow these articles of clothing to accept gas tanks.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/6e1789b6-0c73-4d99-8974-518132d3be1e

fig. 1 - Showing that the NTR coat, Magistrate coat, and NCT coat accept gas tanks.

<img width="861" height="699" alt="image" src="https://github.com/user-attachments/assets/991ca323-14e7-4260-bffd-e0cf1af8f59c" />

fig. 2 - Showing the changes to NCT. You can see the flash spawned in my backpack instead of on my back. You can also see that the gas tank spawned in my back slot instead of my pockets, which are very full for this role!

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: The NTR's coat can now accept gas tanks in its suit storage. Vox NTRs rejoice.
- tweak: The Magistrates's coat can now accept gas tanks in its suit storage. Vox Magistrates rejoice.
- fix: The NanoTrasen Career Trainer previously had a flash spawn in its suit storage, which you could never put back in. This flash now spawns in your backpack instead of your suit storage slot. This also means that Vox shouldn't have their suit storage blocked when they join as a NT Career Trainer.