### PR TITLE
IK-60 Storage Fix

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -90,6 +90,12 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: Item
     size: Large
+  - type: Clothing
+    sprite: _Starlight/Objects/Weapons/Guns/Rifles/laser_carbine.rsi
+    quickEquip: false
+    slots:
+      - Back
+      - suitStorage
   - type: MagazineAmmoProvider
   - type: ItemSlots
     slots:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Allows for the IK-60 to be stored in the Back and suitStorage Slots.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Another small PR Fix! 
The IK-60, a weapon that spawns in with the ERTMedicalGearArmed (ERT Medical), spawns in attached to the persons suitStorage slot which is fine, however once removed the weapon is unable to be stored in that same slot unlike every other longarm in the game.
This also allows for the Medic to store the weapon and use the hand to drag, while the other can be used for healing.. very important when a lot of action is going on.


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="815" height="91" alt="Content Client_HWA2bwf3sj" src="https://github.com/user-attachments/assets/3dd3e5c1-6e27-4526-9074-f9019c5e249a" />

fig. 1 Before - Starts equipped, but unable to store in both slots once removed.

<img width="819" height="105" alt="Content Client_MvBedPxrSk" src="https://github.com/user-attachments/assets/b1e237e2-f6ed-44b7-8011-06f5ea96ff4c" />

fig. 2 After - Ability to store the IK-60 in both slots after equipping.

## Checks
<!-- check boxes for faster reviewing of your PR -->
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Pon
- fix: Fixed being unable to store the IK-60 once equipped.
