### PR TITLE
Fixes shadekin not dying when they use Succumb or 'Say last words'

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -597,7 +597,12 @@ namespace Content.Server.Ghost
                     }
 
                     // Starlight - Start
+
+                    // Do asphyxiation damage by default
                     var damageType = _prototypeManager.Index(AsphyxiationDamageType);
+
+                    // If the species cannot take asphyxiation damage, check the damage type provided by their DeathgaspComponent
+                    // e.g. IPCs take shock damage when they deathgasp instead of asphyxiation damage
                     if (TryComp<DeathgaspComponent>(playerEntity, out var deathgasp))
                         damageType = _prototypeManager.Index(deathgasp.DamageType);
 

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/shadekin.yml
@@ -52,6 +52,8 @@
     - type: Damageable
       damageContainer: Biological
       damageModifierSet: Shadekin
+    - type: Deathgasp
+      damageType: Bloodloss
     - type: Reactive
       groups:
         Flammable: [Touch]


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
- Shadekin can't take asphyxiation damage
- The crit actions 'Succumb' and 'Say last words' do asphyxiation damage
- As a result, Shadekin can repeatedly use the 'Say last words' command and ghost out before they're actually dead

Thankfully, there's actually already a component to fix this - the `DeathgaspComponent` used for IPCs added in #3998
 (thank you Shades)

This PR adds the `Deathgasp` component to Shadekin - they will now take sufficient bloodloss damage to instantly die. I settled for bloodloss as it's easy to heal, like asphyxiation damage, and it seemed inline with shadekin's weakness to bloodloss damage.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/19bf3635-5e4f-4e80-8989-39111eebff13

fig. 1 - Video demo of deathgasp working on Shadekin.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Shadekin now actually die when using the 'Succumb' or 'Say Last Words' actions while critically injured.
