### PR TITLE
(Vox QoL) Fixed several jobs that did not start with tank harnesses

### DIFF
--- a/Resources/Prototypes/_Starlight/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/role_loadouts.yml
@@ -1,20 +1,4 @@
-- type: roleLoadout
-  id: JobRoboticist
-  groups:
-  - RoboticistHead
-  - RoboticistGoggles
-  - RoboticistJumpsuit
-  - RoboticistGloves
-  - RoboticistOuterClothing
-  - RoboticistBackpack
-  - RoboticistShoes
-  - Survival
-  - Trinkets
-  - Scarves
-  - Pins
-  - Pens
-  - GroupSpeciesBreathTool
-
+# NanoTrasen
 - type: roleLoadout
   id: JobMagistrate
   groups:
@@ -32,27 +16,6 @@
   - Pins
   - LuxuryPens
   - GroupSpeciesBreathTool
-
-
-- type: roleLoadout
-  id: JobSurgeon
-  groups:
-  - GroupTankHarness
-  - MedicalDoctorHead
-  - MedicalMask
-  - MedicalDoctorJumpsuit
-  - MedicalGloves
-  - MedicalBackpack
-  - MedicalDoctorOuterClothing
-  - MedicalShoes
-  - MedicalDoctorPDA
-  - MedicalEyewear
-  - SurvivalMedical
-  - Trinkets
-  - Scarves
-  - Pins
-  - Pens
-  - GroupSpeciesBreathToolMedical
 
 - type: roleLoadout
   id: JobNanoTrasenRepresentative
@@ -73,6 +36,7 @@
 - type: roleLoadout
   id: JobIAA
   groups:
+  - GroupTankHarness # for Vox
   - IAANeck
   - IAAJumpsuit
   - CommonBackpack
@@ -102,13 +66,29 @@
   - Scarves
   - Pins
   - Pens
-  - SurvivalExtended # Starlight
+  - SurvivalExtended
   - GroupSpeciesBreathToolSecurity
 
 - type: roleLoadout
+  id: JobNanotrasenCareerTrainer
+  groups:
+  - NanotrasenCareerTrainerJumpsuit
+  - NanotrasenCareerTrainerHat
+  - NanotrasenCareerTrainerEyewear
+  - NanotrasenCareerTrainerShoes
+  - CommonBackpack
+  - Trinkets
+  - Scarves
+  - Pins
+  - Pens
+  - Survival
+  - GroupSpeciesBreathTool
+
+# Cargo
+- type: roleLoadout
   id: JobMiningSpecialist
   groups:
-  - GroupTankHarness
+  - GroupTankHarness # for Vox
   - SalvageSpecialistBackpack
   - MiningSpecialistJumpsuit
   - SalvageSpecialistOuterClothing
@@ -125,7 +105,7 @@
 - type: roleLoadout
   id: JobMailTech
   groups:
-  - GroupTankHarness
+  - GroupTankHarness # for Vox
   - MailTechnicianHead
   - MailTechnicianJumpsuit
   - MailTechnicianBackpack
@@ -142,6 +122,25 @@
   - Pens
   - GroupSpeciesBreathTool
 
+- type: roleLoadout
+  id: JobSalvageLead
+  groups:
+  - GroupTankHarness # for Vox
+  - SalvageSpecialistBackpack
+  - SalvageLeadJumpsuit
+  - SalvageLeadNeck
+  - SalvageSpecialistOuterClothing
+  - SalvageSpecialistShoes
+  - SalvageLeadPDA
+  - Glasses
+  - Survival
+  - Trinkets
+  - Scarves
+  - Pins
+  - Pens
+  - GroupSpeciesBreathTool
+
+# Security
 - type: roleLoadout
   id: JobBrigmedic
   groups:
@@ -171,7 +170,7 @@
   id: JobDutyOfficer
   groups:
   - DutyOfficerHead
-  - SecurityMask # Starlight
+  - SecurityMask
   - DutyOfficerJumpsuit
   - SecurityBackpack
   - SecurityEyewear
@@ -189,28 +188,51 @@
   - SecurityJobTrinkets
   - GroupSpeciesBreathToolSecurity
 
+# Science
 - type: roleLoadout
-  id: JobSalvageLead
+  id: JobRoboticist
   groups:
-    - GroupTankHarness
-    - SalvageSpecialistBackpack
-    - SalvageLeadJumpsuit
-    - SalvageLeadNeck
-    - SalvageSpecialistOuterClothing
-    - SalvageSpecialistShoes
-    - SalvageLeadPDA
-    - Glasses
-    - Survival
-    - Trinkets
-    - Scarves
-    - Pins
-    - Pens
-    - GroupSpeciesBreathTool
+  - GroupTankHarness # for Vox
+  - RoboticistHead
+  - RoboticistGoggles
+  - RoboticistJumpsuit
+  - RoboticistGloves
+  - RoboticistOuterClothing
+  - RoboticistBackpack
+  - RoboticistShoes
+  - Survival
+  - Trinkets
+  - Scarves
+  - Pins
+  - Pens
+  - GroupSpeciesBreathTool
 
+# Medical
+- type: roleLoadout
+  id: JobSurgeon
+  groups:
+  - GroupTankHarness # for Vox
+  - MedicalDoctorHead
+  - MedicalMask
+  - MedicalDoctorJumpsuit
+  - MedicalGloves
+  - MedicalBackpack
+  - MedicalDoctorOuterClothing
+  - MedicalShoes
+  - MedicalDoctorPDA
+  - MedicalEyewear
+  - SurvivalMedical
+  - Trinkets
+  - Scarves
+  - Pins
+  - Pens
+  - GroupSpeciesBreathToolMedical
+
+# Civilians
 - type: roleLoadout
   id: JobPerformer
   groups:
-  - GroupTankHarness
+  - GroupTankHarness # for Vox
   - PerformerHead
   - PerformerJumpsuit
   - CommonBackpack
@@ -228,6 +250,7 @@
 - type: roleLoadout
   id: JobZookeeper
   groups:
+  - GroupTankHarness # for Vox
   - CommonBackpack
   - CivilianShoes
   - Glasses
@@ -242,6 +265,7 @@
 - type: roleLoadout
   id: JobBoxer
   groups:
+  - GroupTankHarness # for Vox
   - BoxerJumpsuit
   - BoxerGloves
   - CommonBackpack
@@ -276,21 +300,6 @@
   - BrighteyeGloves
   - Scarves
   - Pins
-
-- type: roleLoadout
-  id: JobNanotrasenCareerTrainer
-  groups:
-  - NanotrasenCareerTrainerJumpsuit
-  - NanotrasenCareerTrainerHat
-  - NanotrasenCareerTrainerEyewear
-  - NanotrasenCareerTrainerShoes
-  - CommonBackpack
-  - Trinkets
-  - Scarves
-  - Pins
-  - Pens
-  - Survival
-  - GroupSpeciesBreathTool
 
 # Antag loadouts (Only has species stuff right now)
 - type: roleLoadout


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Generally, if a tank does not have a mandatory piece of outer wear (like a Security Officer's armor vest), that job should start with a tank harness if the player is a Vox.

This was not true for the following jobs:
- Roboticist
- IAA
- Zookeeper
- Boxer

This PR:
- fixes that by adding `GroupTankHarness` to the roles' loadouts.
- organizes the Starlight `role_loadouts.yml` file because it was out of order and a bit messy 


## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Quality of life update for Vox and technically a bugfix. Pairs with #4742 

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1095" height="703" alt="image" src="https://github.com/user-attachments/assets/7a9238f4-b41b-4562-8d95-62b3aebba270" />

fig. 1 - Vox IAAs now correctly start with a tank harness. I tested the same for Boxer, Zookeeper, and Roboticist.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Vox Roboticists now start with a tank harness.
- fix: Vox IAAs now start with a tank harness.
- fix: Vox Zookeepers now start with a tank harness.
- fix: Vox Boxers now start with a tank harness.