### PR TITLE
Fix Rodentia Collision State Breaking

### DIFF
--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -5,7 +5,7 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
-using Content.Shared._Starlight.CrawlUnder;
+using Content.Shared._Starlight.CrawlUnder; // Starlight
 using Content.Shared.Gravity;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
@@ -469,8 +469,11 @@ public abstract partial class SharedStunSystem
     /// </summary>
     private bool IntersectingStandingColliders(Entity<TransformComponent?> entity)
     {
+        // Starlight begin
+        // Allows getting up from crawling while sneaking underneath the collider
         if (TryComp<CrawlUnderObjectsComponent>(entity, out var crawlUnder) && crawlUnder.Enabled)
             return false;
+        // Starlight end
 
         if (!Resolve(entity, ref entity.Comp))
             return false;

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -5,6 +5,7 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
+using Content.Shared._Starlight.CrawlUnder;
 using Content.Shared.Gravity;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
@@ -468,6 +469,9 @@ public abstract partial class SharedStunSystem
     /// </summary>
     private bool IntersectingStandingColliders(Entity<TransformComponent?> entity)
     {
+        if (TryComp<CrawlUnderObjectsComponent>(entity, out var crawlUnder) && crawlUnder.Enabled)
+            return false;
+
         if (!Resolve(entity, ref entity.Comp))
             return false;
 

--- a/Content.Shared/_Starlight/CrawlUnder/SharedCrawlUnderObjectsSystem.cs
+++ b/Content.Shared/_Starlight/CrawlUnder/SharedCrawlUnderObjectsSystem.cs
@@ -149,6 +149,9 @@ public abstract class SharedCrawlUnderObjectsSystem : EntitySystem
                         ? originalMask & ~StandingStateSystem.StandingCollisionLayer
                         : originalMask | StandingStateSystem.StandingCollisionLayer;
 
+                    if (fixture.CollisionMask == targetMask)
+                        continue;
+
                     _physics.SetCollisionMask(uid, key, fixture, targetMask, fixtureComponent);
                 }
             }

--- a/Content.Shared/_Starlight/CrawlUnder/SharedCrawlUnderObjectsSystem.cs
+++ b/Content.Shared/_Starlight/CrawlUnder/SharedCrawlUnderObjectsSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Maps;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
+using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Events;
@@ -138,10 +139,18 @@ public abstract class SharedCrawlUnderObjectsSystem : EntitySystem
         // Restore normal collision masks
         if (TryComp<FixturesComponent>(uid, out var fixtureComponent))
         {
+            var down = TryComp<StandingStateComponent>(uid, out var standing) && !standing.Standing;
+
             foreach (var (key, originalMask) in component.ChangedFixtures)
             {
                 if (fixtureComponent.Fixtures.TryGetValue(key, out var fixture))
-                    _physics.SetCollisionMask(uid, key, fixture, originalMask, fixtureComponent);
+                {
+                    var targetMask = down
+                        ? originalMask & ~StandingStateSystem.StandingCollisionLayer
+                        : originalMask | StandingStateSystem.StandingCollisionLayer;
+
+                    _physics.SetCollisionMask(uid, key, fixture, targetMask, fixtureComponent);
+                }
             }
         }
 


### PR DESCRIPTION
## Short description
Before, rodentia players could crouch, sneak, then get up, and unsneak, and it would not properly set the collision masks to get the player into the correct state. As a result, bugged players could then freely walk on top of tables.

## Media (Video/Screenshots)

The bug:

https://github.com/user-attachments/assets/b436b767-211d-45e7-8aa4-65fc582e0e83

With the fix:

https://github.com/user-attachments/assets/94be9820-3a29-4fe1-b2e2-a9aef8d4e79a

Also, with the change to the SharedStunSystem.Knockdown.cs, Rodentia players can now get up from crawling and sneaking, to just be sneaking, while underneath a collider.

https://github.com/user-attachments/assets/df456304-a14b-4e1e-9614-6e01e23d0764

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- fix: Fixes a bug where Rodentia can break their collision states.