### PR TITLE
Rummaging cooldown resets after 5 minutes

### DIFF
--- a/Content.Shared/RatKing/Components/RummageableComponent.cs
+++ b/Content.Shared/RatKing/Components/RummageableComponent.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Shared.EntityTable.EntitySelectors;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Starlight
 
 namespace Content.Shared.RatKing.Components;
 
@@ -9,7 +10,7 @@ namespace Content.Shared.RatKing.Components;
 /// rummaged through by the rat king to get loot.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-[AutoGenerateComponentState]
+[AutoGenerateComponentState, AutoGenerateComponentPause] // Starlight
 public sealed partial class RummageableComponent : Component
 {
     /// <summary>
@@ -18,6 +19,21 @@ public sealed partial class RummageableComponent : Component
     [DataField("looted"), ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
     public bool Looted;
+
+    // Starlight start
+    /// <summary>
+    /// How long this container stays looted before it can be rummaged again.
+    /// </summary>
+    [DataField("lootResetDelay"), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan LootResetDelay = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// The time at which <see cref="LootResetDelay"/> ends and rummaging can occur again.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    [AutoPausedField]
+    public TimeSpan? NextRummageTime;
+    // Starlight end
 
     /// <summary>
     /// How long it takes to rummage through a rummageable container.

--- a/Content.Shared/RatKing/Systems/RummagerSystem.cs
+++ b/Content.Shared/RatKing/Systems/RummagerSystem.cs
@@ -30,9 +30,14 @@ public sealed class RummagerSystem : EntitySystem
 
     private void OnGetVerb(Entity<RummageableComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
+        Log.Warning("Rummager OnGetVerb hit");
         // Starlight start
         if (ent.Comp.Looted && _timing.CurTime >= ent.Comp.NextRummageTime)
+        {
             ent.Comp.Looted = false;
+            Dirty(ent, ent.Comp);
+            Log.Warning("Container looted expiry met, marking as unlooted.");
+        }
         // Starlight end
 
         if (!HasComp<RummagerComponent>(args.User))
@@ -48,7 +53,8 @@ public sealed class RummagerSystem : EntitySystem
             {
                 if (ent.Comp.Looted)
                 {
-                    _popup.PopupClient(Loc.GetString("rummage-already-looted"), user, user, PopupType.SmallCaution);
+                    Log.Warning("MESSAGE HERE THAT IS ALREADY LOOTED");
+                    _popup.PopupCursor(Loc.GetString("rummage-already-looted"), user, PopupType.SmallCaution);
                     return;
                 }
 
@@ -70,27 +76,29 @@ public sealed class RummagerSystem : EntitySystem
 
     private void OnDoAfterComplete(Entity<RummageableComponent> ent, ref RummageDoAfterEvent args)
     {
+        Log.Warning("Rummager OnDoAfterComplete hit");
         if (args.Cancelled || ent.Comp.Looted)
+        {
+            Log.Warning("DoAfterComplete, aborting");
             return;
+        }
 
-        // Starlight begin
+        // // Starlight begin
         // if (args.Cancelled)
         //     return;
         //
         // if (ent.Comp.Looted)
         // {
-        //     _popup.PopupClient(Loc.GetString("rummage-already-looted"), ent, ent, PopupType.SmallCaution);
+        //     _popup.PopupCursor(Loc.GetString("rummage-already-looted"), args.User, PopupType.SmallCaution);
         //     return;
         // }
         // // Starlight end
 
+        Log.Warning("DoAfterComplete, continuing.");
         ent.Comp.Looted = true;
         ent.Comp.NextRummageTime = _timing.CurTime + ent.Comp.LootResetDelay; // Starlight
         Dirty(ent, ent.Comp);
         _audio.PlayPredicted(ent.Comp.Sound, ent, args.User);
-
-        if (_net.IsClient)
-            return;
 
         var spawns = _entityTable.GetSpawns(ent.Comp.Table);
         var coordinates = Transform(ent).Coordinates;

--- a/Content.Shared/RatKing/Systems/RummagerSystem.cs
+++ b/Content.Shared/RatKing/Systems/RummagerSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing; // Starlight
 
 namespace Content.Shared.RatKing.Systems;
 
@@ -14,6 +15,7 @@ public sealed class RummagerSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly IGameTiming _timing = default!; // Starlight
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -26,6 +28,11 @@ public sealed class RummagerSystem : EntitySystem
 
     private void OnGetVerb(Entity<RummageableComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
+        // Starlight start
+        if (ent.Comp.Looted && _timing.CurTime >= ent.Comp.NextRummageTime)
+            ent.Comp.Looted = false;
+        // Starlight end
+
         if (!HasComp<RummagerComponent>(args.User) || ent.Comp.Looted)
             return;
 
@@ -59,6 +66,7 @@ public sealed class RummagerSystem : EntitySystem
             return;
 
         ent.Comp.Looted = true;
+        ent.Comp.NextRummageTime = _timing.CurTime + ent.Comp.LootResetDelay; // Starlight
         Dirty(ent, ent.Comp);
         _audio.PlayPredicted(ent.Comp.Sound, ent, args.User);
 

--- a/Content.Shared/RatKing/Systems/RummagerSystem.cs
+++ b/Content.Shared/RatKing/Systems/RummagerSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.DoAfter;
 using Content.Shared.EntityTable;
+using Content.Shared.Popups; // Starlight
 using Content.Shared.RatKing.Components;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
@@ -16,6 +17,7 @@ public sealed class RummagerSystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly IGameTiming _timing = default!; // Starlight
+    [Dependency] private readonly SharedPopupSystem _popup = default!; // Starlight
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -33,7 +35,7 @@ public sealed class RummagerSystem : EntitySystem
             ent.Comp.Looted = false;
         // Starlight end
 
-        if (!HasComp<RummagerComponent>(args.User) || ent.Comp.Looted)
+        if (!HasComp<RummagerComponent>(args.User))
             return;
 
         var user = args.User;
@@ -44,6 +46,12 @@ public sealed class RummagerSystem : EntitySystem
             Priority = 0,
             Act = () =>
             {
+                if (ent.Comp.Looted)
+                {
+                    _popup.PopupClient(Loc.GetString("rummage-already-looted"), user, user, PopupType.SmallCaution);
+                    return;
+                }
+
                 _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager,
                     user,
                     ent.Comp.RummageDuration,
@@ -64,6 +72,17 @@ public sealed class RummagerSystem : EntitySystem
     {
         if (args.Cancelled || ent.Comp.Looted)
             return;
+
+        // Starlight begin
+        // if (args.Cancelled)
+        //     return;
+        //
+        // if (ent.Comp.Looted)
+        // {
+        //     _popup.PopupClient(Loc.GetString("rummage-already-looted"), ent, ent, PopupType.SmallCaution);
+        //     return;
+        // }
+        // // Starlight end
 
         ent.Comp.Looted = true;
         ent.Comp.NextRummageTime = _timing.CurTime + ent.Comp.LootResetDelay; // Starlight

--- a/Resources/Locale/en-US/_Starlight/actions/actions/rummage.ftl
+++ b/Resources/Locale/en-US/_Starlight/actions/actions/rummage.ftl
@@ -1,0 +1,1 @@
+rummage-already-looted = It's already been looted! Try again later.


### PR DESCRIPTION
## Short description
Apparently before this, once something was rummaged (by a Rat King, or Rodentia) it was marked as Looted and then was never rummageable again.

This PR gives a 5 minute cooldown before the entity can be rummaged again.

## Media (Video/Screenshots)

The new behavior, with the cooldown set to 5 seconds for the demo. The actual pr is set to a 5 minute cooldown.

https://github.com/user-attachments/assets/9278907e-0f74-4875-a22c-13c58cd57c6b

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- fix: Rummageable entities like disposal bins will now reset their looted state after 5 minutes, allowed them to be rummaged again.
