### PR TITLE
Changes to doxa and ambu +

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -872,9 +872,9 @@
             - !type:ReagentCondition
               reagent: AmbuzolPlus
               min: 5
-          damage:
+          damage: # starlight
             types:
-             Cellular: -2
+             Cellular: -6
         - !type:ReduceRotting # starlight
           seconds: 60
         - !type:AdjustReagent

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -872,7 +872,8 @@
             - !type:ReagentCondition
               reagent: AmbuzolPlus
               min: 5
-          damage: # starlight
+        - !type:HealthChange # starlight
+          damage:
             types:
              Cellular: -6
         - !type:ReduceRotting # starlight

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -872,6 +872,9 @@
             - !type:ReagentCondition
               reagent: AmbuzolPlus
               min: 5
+          damage:
+            types:
+             Cellular: -2
         - !type:ReduceRotting # starlight
           seconds: 60
         - !type:AdjustReagent

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -264,7 +264,6 @@
   physicalDesc: reagent-physical-desc-bubbling
   flavor: medicine
   color: "#32cd32"
-  worksOnTheDead: true # starlight
   metabolisms:
     Medicine:
       effects:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -264,6 +264,7 @@
   physicalDesc: reagent-physical-desc-bubbling
   flavor: medicine
   color: "#32cd32"
+  worksOnTheDead: true # starlight
   metabolisms:
     Medicine:
       effects:


### PR DESCRIPTION
## Short description
Changes doxa to work as what it did originally and make ambu + fix cellular.

## Why we need to add this
Based off feedback from the discord, its come to attention that changing doxarubixadone to work on the dead has had the unintended side effect of messing with gamemodes outside of zombies. This is changing doxa to work the original way while also making ambu + do the job that the doxa rework intended to do. https://discord.com/channels/1272545509562777621/1515389080639115466

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- tweak: Doxarubixadone is back to its original state, doesnt work on the dead anymore.
- tweak: Ambuzol + has been made to fix cellular.
