### PR TITLE
Fixed Xenoroach Pipe Vision/Flash Immunity

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/xenoroach.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Cyborgs/xenoroach.yml
@@ -72,6 +72,13 @@
   - type: MovementAlwaysTouching
   # Vent crawling
   - type: VentCrawler
+  # Blindable limits vision in pipes, Eye protection prevents eye damage
+  - type: Blindable
+  - type: EyeProtection
+  # Allows the cyborg to be flashed
+  - type: StatusEffects
+    allowed:
+    - Flashed
   # Faction
   - type: NpcFactionMember
     factions:


### PR DESCRIPTION
## Short description
This is a bugfix that allows the typical vent crawling vision restrictions to apply to Xenoroaches. This PR also fixes the xenoroaches having flash immunity, as all other borgs can be flashed.

## Why we need to add this
Bugfix. Xenoroaches were missing the components that allow other cyborgs to be flashed and blinded. Lacking these components also granted them unrestricted vision in pipes.

Full vision in pipes has lead to uninteractive gameplay for the xenoroaches, as their pressure and heat immunity incentivizes them to remain within atmos pipes for the entire shift. This PR brings Xenoroaches in line with other vent-crawling mobs by applying the same vision restrictions, full vision in vents, restricted vision in pipes.

## Media (Video/Screenshots)
<img width="699" height="763" alt="image" src="https://github.com/user-attachments/assets/64032d6d-8812-4cc6-8da2-682d67f5b5bc" />
<img width="758" height="604" alt="image" src="https://github.com/user-attachments/assets/5583cae6-00bb-4437-a07d-48699d56fa17" />
<img width="483" height="408" alt="image" src="https://github.com/user-attachments/assets/cd4553f9-318f-4b49-b873-16338f772922" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: AegisShield
- fix: Fixed Xenoroaches having flash immunity.
- fix: Fixed Xenoroaches having full vision in pipes.