### PR TITLE
Modified during Enumeration fix [ HOTFIX ]

### DIFF
--- a/Content.Server/Temperature/Systems/TemperatureSystem.Damage.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.Damage.cs
@@ -35,6 +35,8 @@ public sealed partial class TemperatureSystem
     /// </summary>
     public HashSet<Entity<TemperatureDamageComponent>> ShouldUpdateDamage = new();
 
+    private readonly List<Entity<TemperatureDamageComponent>> _shouldUpdateDamageBuffer = []; // Starlight
+
     /// <summary>
     /// Alert prototype for Temperature.
     /// </summary>
@@ -69,19 +71,30 @@ public sealed partial class TemperatureSystem
 
     private void UpdateDamage()
     {
-        foreach (var entity in ShouldUpdateDamage)
+        #region Starlight Edit
+        // Starlight Edit: Collection modified during Enumeration fix
+        _shouldUpdateDamageBuffer.Clear();
+        _shouldUpdateDamageBuffer.AddRange(ShouldUpdateDamage);
+        ShouldUpdateDamage.Clear();
+
+        foreach (var entity in _shouldUpdateDamageBuffer)
         {
             if (Deleted(entity) || Paused(entity))
                 continue;
 
-            var deltaTime = _gameTiming.CurTime - entity.Comp.LastUpdate;
-            if (entity.Comp.TakingDamage && deltaTime < entity.Comp.UpdateInterval)
+            if (!TryComp<TemperatureDamageComponent>(entity.Owner, out var tempDamage))
                 continue;
 
-            ChangeDamage(entity, deltaTime);
+            var deltaTime = _gameTiming.CurTime - tempDamage.LastUpdate;
+
+            if (tempDamage.TakingDamage && deltaTime < tempDamage.UpdateInterval)
+                continue;
+
+            ChangeDamage((entity.Owner, tempDamage), deltaTime);
+        #endregion
         }
 
-        ShouldUpdateDamage.Clear();
+        // ShouldUpdateDamage.Clear(); // Starlight Edit: Moved up
     }
 
     private void ChangeDamage(Entity<TemperatureDamageComponent> entity, TimeSpan deltaTime)

--- a/Content.Server/Temperature/Systems/TemperatureSystem.Damage.cs
+++ b/Content.Server/Temperature/Systems/TemperatureSystem.Damage.cs
@@ -69,10 +69,10 @@ public sealed partial class TemperatureSystem
         _thermalRegulatorQuery = GetEntityQuery<ThermalRegulatorComponent>();
     }
 
+    #region Starlight Edit
+    // Collection modified during Enumeration fix
     private void UpdateDamage()
     {
-        #region Starlight Edit
-        // Starlight Edit: Collection modified during Enumeration fix
         _shouldUpdateDamageBuffer.Clear();
         _shouldUpdateDamageBuffer.AddRange(ShouldUpdateDamage);
         ShouldUpdateDamage.Clear();
@@ -91,11 +91,11 @@ public sealed partial class TemperatureSystem
                 continue;
 
             ChangeDamage((entity.Owner, tempDamage), deltaTime);
-        #endregion
         }
 
         // ShouldUpdateDamage.Clear(); // Starlight Edit: Moved up
     }
+    #endregion
 
     private void ChangeDamage(Entity<TemperatureDamageComponent> entity, TimeSpan deltaTime)
     {


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Stops collections from ``Temprature.Damage.Update()`` being modified during enumeration.

I would PR this upstream but its a bit of a mess up there, they are welcome to take my fix if they like.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes https://github.com/space-wizards/space-station-14/issues/40730 which should also fix the Xenoborg lag.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1057" height="164" alt="image" src="https://github.com/user-attachments/assets/31fdd5a5-f8c9-4dce-a6fa-b68474a4e987" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Fixed a server-side bug that Is likely the cause for Xenoborg Lag.