### PR TITLE
Guidebook Priority fix

### DIFF
--- a/Resources/Prototypes/_Starlight/Guidebook/roleplayguides.yml
+++ b/Resources/Prototypes/_Starlight/Guidebook/roleplayguides.yml
@@ -4,7 +4,7 @@
   id: RoleplayGuideIntro
   name: guide-entry-roleplay-intro
   text: "/ServerInfo/_Starlight/Guidebook/Roleplay/RoleplayGuides.xml"
-  priority: 0
+  priority: 11
   children:
     - RoleplayGuide01
     - RoleplayGuide02

--- a/Resources/Prototypes/_Starlight/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Starlight/Guidebook/sop.yml
@@ -2,6 +2,7 @@
   id: SOP
   name: guide-entry-sl-sop-intro
   text: "/ServerInfo/Guidebook/StarlightSOP/sop-intro.xml"
+  priority: 12
   children:
     - general-sop
     - departmental-sop


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes the priority in the guidebook so rules are near the top
Rules were originally below SoP
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Rules are important, they need to be easy to find
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="333" height="669" alt="image" src="https://github.com/user-attachments/assets/d3e8e073-7bf5-4ab3-bd4a-b15a5d3be7b2" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- tweak: The rules tab is now near the top of the guidebook.