### PR TITLE
Cyborg access Revoked

### DIFF
--- a/Content.IntegrationTests/Tests/_Starlight/Access/CyborgAllAccessParityTest.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Access/CyborgAllAccessParityTest.cs
@@ -13,7 +13,18 @@ public sealed class CyborgAllAccessParityTest
     /// </summary>
     private static readonly HashSet<ProtoId<AccessLevelPrototype>> _exclusions =
     [
-        new("Debrief") // Borgs are not head of staff, and should not be in debrief.
+        new("Debrief"), // Borgs are not head of staff, and should not be in debrief.
+        new("Captain"),
+        new("HeadOfPersonnel"),
+        new("ChiefEngineer"),
+        new("ChiefMedicalOfficer"),
+        new("HeadOfSecurity"),
+        new("ResearchDirector"),
+        new("Armory"),
+        new("Quartermaster"),
+        new("Magistrate"),
+        new("Ntrep"),
+        new("BlueShield"),
     ];
 
     private static readonly ProtoId<AccessGroupPrototype> _allAccessGroup = "AllAccess";

--- a/Resources/Prototypes/_Starlight/Access/misc.yml
+++ b/Resources/Prototypes/_Starlight/Access/misc.yml
@@ -2,22 +2,14 @@
   id: CyborgAllAccess # Identical to AllAccess, minus Debrief. Parity ensured by CyborgAllAccessParityTest.
   tags:
     - EmergencyShuttleRepealAll
-    - Captain
-    - HeadOfPersonnel
-    - ChiefEngineer
-    - ChiefMedicalOfficer
-    - HeadOfSecurity
-    - ResearchDirector
     - Command
     - Cryogenics
     - Security
     - Detective
-    - Armory
     - Brig
     - Lawyer
     - Engineering
     - Medical
-    - Quartermaster
     - Salvage
     - Cargo
     - Research
@@ -35,11 +27,8 @@
     - GenpopEnter
     - GenpopLeave
     - Cadet
-    - Magistrate
-    - Ntrep
     - IAA
     - Brigmedic
-    - BlueShield
     - Robotics
     - Surgery
     - Paramedic


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Following https://discord.com/channels/1272545509562777621/1516424088942546995 I have removed the following access from Cyborgs:
- Captain
- HeadOfPersonnel
- ChiefEngineer
- ChiefMedicalOfficer
- HeadOfSecurity
- ResearchDirector
- Quartermaster
- Armory
- Ntrep
- BlueShield
- Magistrate

I expect this to be controversial so if you intend to argue in this PR please direct that at the discussion in the discord, collect your thoughts and *then* send them in this PR. 

I am prepared to wait for a server/management vote for this if its deemed necessary.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The suggestion is largely upvoted. Cyborgs are given there extra access's in turn for there lack of Dexterity and Agency, With them getting more content there access should be trimmed to match that, especially with the sheer increase of antagonistic uses for Cyborgs.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="517" height="94" alt="image" src="https://github.com/user-attachments/assets/dafa0498-f3fd-48c2-881e-7252b7d787b4" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- remove: Removed the Following access from Cyborgs, Captain, HoP, ER, CMO, HoS, RD, QM, Armory, NTR, BSO and Magistrate.