### PR TITLE
 Toilet give plasteel on deconstruct

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -72,7 +72,7 @@
   - type: Drain
     autoDrain: false
   - type: StaticPrice
-    price: 100
+    price: 125 # Starlight
   - type: ActivatableUI
     key: enum.DisposalUnitUiKey.Key
     verbOnly: true # Not strictly needed, but we want E to toggle lid

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
@@ -22,6 +22,9 @@
             - !type:SpawnPrototype
               prototype: SheetSteel1
               amount: 5
+            - !type:SpawnPrototype # Starlight
+                prototype: SheetPlasteel1 # Starlight
+                amount: 1 # Starlight
             - !type:EmptyAllContainers {}
             - !type:DestroyEntity {}
           conditions:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/toilet.yml
@@ -23,8 +23,8 @@
               prototype: SheetSteel1
               amount: 5
             - !type:SpawnPrototype # Starlight
-                prototype: SheetPlasteel1 # Starlight
-                amount: 1 # Starlight
+              prototype: SheetPlasteel1 # Starlight
+              amount: 1 # Starlight
             - !type:EmptyAllContainers {}
             - !type:DestroyEntity {}
           conditions:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Now that https://github.com/ss14Starlight/space-station-14/pull/4755 is merged you can get your plasteel back when you deconstruct a toilet, resolving this bug report: https://github.com/ss14Starlight/space-station-14/issues/4622

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Fixes the bug https://github.com/ss14Starlight/space-station-14/issues/4622

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://youtu.be/GOGZJW5ugdc

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Toxyams
- fix: Toilets give plasteel on deconstruct.