### PR TITLE
lets stop killing AI's with pockets

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -174,6 +174,7 @@
           Rebooting: { state: dead }
           Dead: { state: dead }
   - type: Intellicard
+  - type: ForceQuickDraw #Starlight don't pull the posi-brain out when the intelecard is in a pocket and hotkey used to bring it to a player hand
 
 - type: entity
   id: PlayerStationAiPreview


### PR DESCRIPTION
## Short description
Fixes bug where if you quick draw an intelecard with an AI in it, it pulls out the brain of the AI instead of the card itself

## Why we need to add this
Bugs need fixing

## Media (Video/Screenshots)
Current system
https://github.com/user-attachments/assets/3df1ac65-9e5a-4884-90b5-06eff75fb7d5

Fixed system
https://github.com/user-attachments/assets/6a67e52d-8b99-4efd-a3bf-80c792a60816

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Bornstellar
- fix: AI no longer killed when pulling an Intellicard out of your pocket with hotkeys.
