### PR TITLE
Nukies get both codes

### DIFF
--- a/Content.Server/Nuke/NukeCodePaperComponent.cs
+++ b/Content.Server/Nuke/NukeCodePaperComponent.cs
@@ -14,5 +14,13 @@ namespace Content.Server.Nuke
         /// </summary>
         [DataField("allNukesAvailable")]
         public bool AllNukesAvailable;
+
+        #region Starlight
+        /// <summary>
+        /// if true will give all avaialble nuke codes.
+        /// </summary>
+        [DataField]
+        public bool PrintAll;
+        #endregion
     }
 }

--- a/Content.Server/Nuke/NukeCodePaperSystem.cs
+++ b/Content.Server/Nuke/NukeCodePaperSystem.cs
@@ -35,7 +35,7 @@ namespace Content.Server.Nuke
             if (!Resolve(uid, ref component))
                 return;
 
-            if (TryGetRelativeNukeCode(uid, out var paperContent, station, onlyCurrentStation: component.AllNukesAvailable))
+            if (TryGetRelativeNukeCode(uid, out var paperContent, station, onlyCurrentStation: component.AllNukesAvailable, printAll: component.PrintAll)) // Starlight Edit: Added ``printAll``
             {
                 if (TryComp<PaperComponent>(uid, out var paperComp))
                     _paper.SetContent((uid, paperComp), paperContent);
@@ -92,7 +92,8 @@ namespace Content.Server.Nuke
             [NotNullWhen(true)] out string? nukeCode,
             EntityUid? station = null,
             TransformComponent? transform = null,
-            bool onlyCurrentStation = false)
+            bool onlyCurrentStation = false,
+            bool printAll = false) // Starlight
         {
             nukeCode = null;
             if (!Resolve(uid, ref transform))
@@ -125,7 +126,10 @@ namespace Content.Server.Nuke
 
                 codesMessage.PushNewline();
                 codesMessage.AddMarkupOrThrow(Loc.GetString("nuke-codes-list", ("name", MetaData(nukeUid).EntityName), ("code", nuke.Code)));
-                break;
+                // Starlight edit Start
+                if (!printAll)
+                    break;
+                // Starlight edit End
             }
 
             if (!codesMessage.IsEmpty)

--- a/Resources/Maps/Shuttles/ShuttleEvent/instigator.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/instigator.yml
@@ -778,7 +778,7 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: BoxFolderNuclearCodes
+- proto: BoxFolderAllNuclearCodes
   entities:
   - uid: 526
     components:

--- a/Resources/Maps/Shuttles/infiltrator.yml
+++ b/Resources/Maps/Shuttles/infiltrator.yml
@@ -800,7 +800,7 @@ entities:
     - type: Transform
       pos: 0.49331844,-13.366474
       parent: 1
-- proto: BoxFolderNuclearCodes
+- proto: BoxFolderAllNuclearCodes
   entities:
   - uid: 510
     components:

--- a/Resources/Maps/_Starlight/Shuttles/CC-NT/Decimus_Shuttle_Magnus.yml
+++ b/Resources/Maps/_Starlight/Shuttles/CC-NT/Decimus_Shuttle_Magnus.yml
@@ -456,7 +456,7 @@ entities:
     - type: Transform
       pos: -2.5,-4.5
       parent: 1
-- proto: BoxFolderNuclearCodes
+- proto: BoxFolderAllNuclearCodes
   entities:
   - uid: 28
     components:

--- a/Resources/Maps/_Starlight/Shuttles/blackhorse.yml
+++ b/Resources/Maps/_Starlight/Shuttles/blackhorse.yml
@@ -695,7 +695,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 1
-- proto: BoxFolderNuclearCodes
+- proto: BoxFolderAllNuclearCodes
   entities:
   - uid: 36
     components:

--- a/Resources/Maps/_Starlight/Shuttles/leyline.yml
+++ b/Resources/Maps/_Starlight/Shuttles/leyline.yml
@@ -863,7 +863,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 3.5,-7.5
       parent: 1
-- proto: BoxFolderNuclearCodes
+- proto: BoxFolderAllNuclearCodes
   entities:
   - uid: 27
     components:

--- a/Resources/Maps/_Starlight/Shuttles/omen.yml
+++ b/Resources/Maps/_Starlight/Shuttles/omen.yml
@@ -666,7 +666,7 @@ entities:
     - type: Transform
       pos: 12.5,2.5
       parent: 1
-- proto: BoxFolderNuclearCodes
+- proto: BoxFolderAllNuclearCodes
   entities:
   - uid: 18
     components:

--- a/Resources/Maps/_Starlight/Shuttles/widow.yml
+++ b/Resources/Maps/_Starlight/Shuttles/widow.yml
@@ -882,7 +882,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 1
-- proto: BoxFolderNuclearCodes
+- proto: BoxFolderAllNuclearCodes
   entities:
   - uid: 26
     components:

--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -2,6 +2,7 @@
   parent: BaseItem
   id: BoxFolderNuclearCodes
   name: nuclear code folder
+  suffix: Random # Starlight
   components:
   - type: Sprite
     sprite: Objects/Misc/folders.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -372,6 +372,7 @@
   parent: Paper
   id: NukeCodePaper
   name: nuclear authentication codes
+  suffix: Random # Starlight
   components:
   - type: NukeCodePaper
     allNukesAvailable: true

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
@@ -247,3 +247,15 @@
         children:
         - id: PrintedDocumentProductOrder
           amount: 18
+
+- type: entity
+  parent: BoxFolderNuclearCodes
+  id: BoxFolderAllNuclearCodes
+  name: nuclear code folder
+  suffix: All Nukes
+  components:
+  - type: SpawnItemsOnUse
+    items:
+    - id: NukeCodePaperAllNukes
+    sound:
+      path: /Audio/Effects/packetrip.ogg

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/paper.yml
@@ -49,3 +49,12 @@
     contentMargin: 0.0, 0.0, 0.0, 0.0
     headerImagePath: "/Textures/_Starlight/Interface/Paper/paper_heading_nt_cc_logos.svg.96dpi.png"
     headerMargin: 0.0, 0.0, 0.0, 0.0
+
+- type: entity
+  parent: NukeCodePaper
+  id: NukeCodePaperAllNukes
+  suffix: All Nukes
+  components:
+  - type: NukeCodePaper
+    allNukesAvailable: true
+    printAll: true


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Makes nukies get both codes and updates the nukie shuttles to follow this
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Prevents stalling when one nuke is stolen, also prevents a bit of metagaming.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="515" height="137" alt="image" src="https://github.com/user-attachments/assets/b4fe652a-0a61-4ba4-95b5-c00b7fd21880" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- tweak: Nuclear Operatives are now given the codes to both nukes.