### PR TITLE
Splashing a drink on someone now actually cools them down.

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
@@ -14,6 +14,23 @@
       methods: [ Touch ]
       effects:
       - !type:Extinguish
+      - !type:AdjustTemperature #Starlight Start
+        conditions:
+        - !type:TemperatureCondition
+          min: 305
+          max: 999.99
+        amount: -5000
+      - !type:AdjustTemperature 
+        conditions:
+        - !type:TemperatureCondition
+          min: 1000
+          max: 3999.99
+        amount: -25000
+      - !type:AdjustTemperature 
+        conditions:
+        - !type:TemperatureCondition
+          min: 4000
+        amount: -50000 #Starlight End
   plantMetabolism:
   - !type:PlantAdjustWater
     amount: 1

--- a/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/base_drink.yml
@@ -20,13 +20,13 @@
           min: 305
           max: 999.99
         amount: -5000
-      - !type:AdjustTemperature 
+      - !type:AdjustTemperature
         conditions:
         - !type:TemperatureCondition
           min: 1000
           max: 3999.99
         amount: -25000
-      - !type:AdjustTemperature 
+      - !type:AdjustTemperature
         conditions:
         - !type:TemperatureCondition
           min: 4000


### PR DESCRIPTION
## Short description
Sister PR to this: https://github.com/ss14Starlight/space-station-14/pull/4808
It's a widely believed myth that splashing a body, specifically a superheated body, will cool them down. I've witnessed whole medbays use this as a basis for healing after superheating events. **I** even believed it before i started working on this PR. This just makes the myth into reality, each unit of water reducing their temp by 1.6k between 305k and 999k, 8k between 1000k and 3999k, and 16k above 4000k body temp.

## Why we need to add this
A large majority of the playerbase believes that splashing cools someone down, best to just make it true, also will help in reducing ashing and pairs nicely alongside its sister PR as being a cheap but less efficient way to cool down alongside the new chem being a much more expensive but effective method.

## Media (Video/Screenshots)



## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Musiklie
- add: Added cooling component to BaseDrink parent so water will now actually cool targets' temperature when splashed.

