### PR TITLE
Give Humans Hues for skinColoration

### DIFF
--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -6,7 +6,7 @@
   sprites: MobHumanSprites
   markingLimits: MobHumanMarkingLimits
   dollPrototype: AppearanceHuman
-  skinColoration: Hues
+  skinColoration: Hues # Starlight Edit: HumanToned -> Hues
   customName: true # Starlight
   roundstartCyberwareCapacity: 5 # Starlight
 

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -6,7 +6,7 @@
   sprites: MobHumanSprites
   markingLimits: MobHumanMarkingLimits
   dollPrototype: AppearanceHuman
-  skinColoration: HumanToned
+  skinColoration: Hues
   customName: true # Starlight
   roundstartCyberwareCapacity: 5 # Starlight
 


### PR DESCRIPTION
## Short description
Change human skinColoration from HumanToned to Hues.

## Why we need to add this
Humans can already select tails, ears and other bio mods. This change will create more freedom in character creation and present humans as the species that has embraced bio and genetic modification.

It also creates more variations for players to play as without adding species bloat, ie no need to add Orcs when you can play as a Green Human.

## Media (Video/Screenshots)
n/a

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Kasern
- changed human skinColoration from HumanToned to Hues.
