### PR TITLE
Terror Spider Web Adjustments

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/spider_web.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/spider_web.yml
@@ -6,7 +6,7 @@
   components:
   - type: Airtight
   - type: Sprite
-    color: "#ffffffdd"
+    color: "#ffE5F3FD"
   - type: Fixtures
     fixtures:
       fix1:
@@ -19,12 +19,6 @@
         - MidImpassable
   - type: Destructible
     thresholds:
-    - trigger: # Excess damage, don't spawn entities
-        !type:DamageTrigger
-        damage: 75
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 30
@@ -58,12 +52,6 @@
         - MidImpassable
   - type: Destructible
     thresholds:
-    - trigger: # Excess damage, don't spawn entities
-        !type:DamageTrigger
-        damage: 75
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 30
@@ -83,21 +71,18 @@
   name: thick spider web
   description: It's stringy, sticky, opaque and strong.
   components:
+  - type: Sprite
+    color: "#B9BBB6ff"
   - type: Occluder
   - type: Destructible
     thresholds:
-    - trigger: # Excess damage, don't spawn entities
-        !type:DamageTrigger
-        damage: 150
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 60
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+
 - type: entity
   id: SpiderWebSlime
   parent: SpiderWebBase
@@ -118,12 +103,6 @@
         - MidImpassable
   - type: Destructible
     thresholds:
-    - trigger: # Excess damage, don't spawn entities
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 10
@@ -172,7 +151,7 @@
   description: It's stringy, sticky.
   components:
   - type: Sprite
-    color: "#ffffff5e"
+    color: "#ffff5edd"
   - type: Fixtures
     fixtures:
       fix1:
@@ -185,12 +164,6 @@
         - MidImpassable
   - type: Destructible
     thresholds:
-    - trigger: # Excess damage, don't spawn entities
-        !type:DamageTrigger
-        damage: 25
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 5
@@ -211,7 +184,7 @@
   description: It's stringy, sticky. Contains a solution that keeps spiderlings away.
   components:
   - type: Sprite
-    color: "#ffffff5e"
+    color: "#826d8cdd"
   - type: Fixtures
     fixtures:
       fix1:
@@ -231,12 +204,6 @@
         - SpiderlingImpassable
   - type: Destructible
     thresholds:
-    - trigger: # Excess damage, don't spawn entities
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:DoActsBehavior
-        acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
         damage: 10

--- a/Resources/Prototypes/_Starlight/Entities/Structures/spider_web.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/spider_web.yml
@@ -31,7 +31,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-      - !type:SpawnEntitiesBehavior
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.5
     sprintSpeedModifier: 0.5
@@ -71,7 +70,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-      - !type:SpawnEntitiesBehavior
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.5
     sprintSpeedModifier: 0.5
@@ -100,8 +98,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-      - !type:SpawnEntitiesBehavior
-
 - type: entity
   id: SpiderWebSlime
   parent: SpiderWebBase
@@ -134,7 +130,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-      - !type:SpawnEntitiesBehavior
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.3
     sprintSpeedModifier: 0.3
@@ -202,7 +197,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-      - !type:SpawnEntitiesBehavior
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.7
     sprintSpeedModifier: 0.7
@@ -212,10 +206,12 @@
 
 - type: entity
   id: SpiderWebSpiderlings
-  parent: SpiderWeb
+  parent: SpiderWebBase
   name: spiderlings spider web
   description: It's stringy, sticky. Contains a solution that keeps spiderlings away.
   components:
+  - type: Sprite
+    color: "#ffffff5e"
   - type: Fixtures
     fixtures:
       fix1:
@@ -233,3 +229,23 @@
           bounds: "-0.5,-0.5,0.5,0.5"
         layer:
         - SpiderlingImpassable
+  - type: Destructible
+    thresholds:
+    - trigger: # Excess damage, don't spawn entities
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: SpeedModifierContacts
+    walkSpeedModifier: 0.7
+    sprintSpeedModifier: 0.7
+    blacklist:
+      components:
+      - IgnoreSpiderWeb

--- a/Resources/Prototypes/_Starlight/Entities/Structures/spider_web.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/spider_web.yml
@@ -32,10 +32,6 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
       - !type:SpawnEntitiesBehavior
-        spawn:
-          MaterialWebSilk:
-            min: 1
-            max: 3
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.5
     sprintSpeedModifier: 0.5
@@ -76,10 +72,6 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
       - !type:SpawnEntitiesBehavior
-        spawn:
-          MaterialWebSilk:
-            min: 1
-            max: 3
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.5
     sprintSpeedModifier: 0.5
@@ -109,10 +101,6 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
       - !type:SpawnEntitiesBehavior
-        spawn:
-          MaterialWebSilk:
-            min: 1
-            max: 3
 
 - type: entity
   id: SpiderWebSlime
@@ -147,10 +135,6 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
       - !type:SpawnEntitiesBehavior
-        spawn:
-          MaterialWebSilk:
-            min: 0
-            max: 1
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.3
     sprintSpeedModifier: 0.3
@@ -219,10 +203,6 @@
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
       - !type:SpawnEntitiesBehavior
-        spawn:
-          MaterialWebSilk:
-            min: 0
-            max: 1
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.7
     sprintSpeedModifier: 0.7

--- a/Resources/Prototypes/_Starlight/Entities/Structures/spider_web.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/spider_web.yml
@@ -69,7 +69,7 @@
   id: SpiderWebStrongThick
   parent: SpiderWebStrong
   name: thick spider web
-  description: It's stringy, sticky, opaque, and strong.
+  description: It's stringy, sticky, solid, and strong.
   components:
   - type: Sprite
     color: "#826d8cdd"
@@ -128,7 +128,7 @@
   id: SpiderWebPoison
   parent: SpiderWebSlime
   name: poison spider web
-  description: It's stringy, sticky, and feels wet.
+  description: It's stringy, sticky, and sickly.
   components:
   - type: Sprite
     color: "#009926bd"

--- a/Resources/Prototypes/_Starlight/Entities/Structures/spider_web.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/spider_web.yml
@@ -2,11 +2,11 @@
   id: SpiderWebAirtight
   parent: SpiderWebBase
   name: airtight spider web
-  description: It's stringy, sticky and airtight.
+  description: It's stringy, sticky, and airtight.
   components:
   - type: Airtight
   - type: Sprite
-    color: "#ffE5F3FD"
+    color: "#bdd5e7ff"
   - type: Fixtures
     fixtures:
       fix1:
@@ -36,7 +36,7 @@
   id: SpiderWebStrong
   parent: SpiderWebBase
   name: strong spider web
-  description: It's stringy, sticky and strong.
+  description: It's stringy, sticky, and strong.
   components:
   - type: Sprite
     color: "#ffffffdd"
@@ -69,10 +69,10 @@
   id: SpiderWebStrongThick
   parent: SpiderWebStrong
   name: thick spider web
-  description: It's stringy, sticky, opaque and strong.
+  description: It's stringy, sticky, opaque, and strong.
   components:
   - type: Sprite
-    color: "#B9BBB6ff"
+    color: "#826d8cdd"
   - type: Occluder
   - type: Destructible
     thresholds:
@@ -87,7 +87,7 @@
   id: SpiderWebSlime
   parent: SpiderWebBase
   name: slime spider web
-  description: It's stringy and sticky.
+  description: It's stringy, sticky, and slimy.
   components:
   - type: Sprite
     color: "#94ffcdbe"
@@ -128,7 +128,7 @@
   id: SpiderWebPoison
   parent: SpiderWebSlime
   name: poison spider web
-  description: It's stringy and sticky.
+  description: It's stringy, sticky, and feels wet.
   components:
   - type: Sprite
     color: "#009926bd"
@@ -148,10 +148,10 @@
   id: SpiderWebStealth
   parent: SpiderWebBase
   name: stealth spider web
-  description: It's stringy, sticky.
+  description: It's stringy and sticky.
   components:
   - type: Sprite
-    color: "#ffff5edd"
+    color: "#ffffff5e"
   - type: Fixtures
     fixtures:
       fix1:
@@ -181,10 +181,10 @@
   id: SpiderWebSpiderlings
   parent: SpiderWebBase
   name: spiderlings spider web
-  description: It's stringy, sticky. Contains a solution that keeps spiderlings away.
+  description: It's stringy and sticky. Contains a solution that keeps spiderlings away.
   components:
   - type: Sprite
-    color: "#826d8cdd"
+    color: "#eaadc6ff"
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
## Short description
This PR adjusts the webs of terror spiders. 

This PR adjusts the colors of three webs in order to make them more visually distinct from other webs. The "Airtight" webs, the "Thick" webs that create occlusions, and the "Spiderling" webs that repel spiderlings were adjusted. This PR also removes silk drops from terror spider webs, as terror spiders have no use for silk, the crew has extremely limited use, and the silk dropped by webs was creating incredibly large messes when terror spider nests were cleared out.

This PR also adjusts the Spiderling web to use the same parent the other spider webs use for consistency sake/so I don't have to redefine it to drop 0 silk when spider webs have their own drop rate it would inherit.

## Why we need to add this
Visual clarity makes the mode more fun overall. Crew and Spiders should generally know what they're walking over in most cases. Airtight webs in particular were lacking needed visual clarity, which led to spiders often stand on top of them and choking, or other spiders placing over webs that were preventing spacings. Spiderling webs need to be able to be seen so someone can adjust them if spiderlings are behaving oddly. Thick spider webs looked a little funny being bright white in the middle of a shadow.

The messes that were being left behind by raids on terror spider nests were becoming ridiculous. Examples below:
<img width="1936" height="1336" alt="image" src="https://github.com/user-attachments/assets/381a587f-f4d7-4866-996e-37682e897593" />
<img width="1939" height="1297" alt="image" src="https://github.com/user-attachments/assets/c9da2754-e068-4766-8e7c-c5f62f508d2b" />



## Media (Video/Screenshots)
<img width="2435" height="1139" alt="image" src="https://github.com/user-attachments/assets/f20f1c61-cff1-4896-8487-8475acf0cc7a" />

https://github.com/user-attachments/assets/f0e7abdc-5399-4ad2-bac1-a3df06ab3c1c

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: AegisShield
- remove: Removed silk drops from terror spider webs.
- tweak: Tweaked Airtight, Spiderling, and Thick web colors to be more visually distinct.