### PR TITLE
Cosmic God metaAtlas false

### DIFF
--- a/Resources/Textures/_Starlight/CosmicCult/Mobs/cosmicgod.rsi/meta.json
+++ b/Resources/Textures/_Starlight/CosmicCult/Mobs/cosmicgod.rsi/meta.json
@@ -6,6 +6,7 @@
     },
     "license": "CC-BY-SA-3.0",
     "copyright": "State Based Copyright",
+	"metaAtlas": false,
     "states": [
         {
             "name": "god",


### PR DESCRIPTION
## Short description
Sets the Cosmic God's metaAtlas to false within the meta.json file for it's textures.

## Why we need to add this
Consistency. All 'Gods' have metaAtlas set to false to prevent their massive resolution textures from filling the Atlas.

## Media (Video/Screenshots)
<img width="1817" height="1816" alt="image" src="https://github.com/user-attachments/assets/dacf6830-f3f2-4f1c-9819-e6484c60b86d" />

Entire top left corner is just the Cosmic God right now.

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**No public facing changes.**