### PR TITLE
Fix to Modular Machine Parts

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
@@ -30,6 +30,7 @@
       state: micro_mani
     - type: Stack
       stackType: Manipulator
+      count: 1
     - type: Tag
       tags:
       - MicroManipulatorStockPart


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Changes modular machine parts to come in stacks of 1 instead of 30

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes an issue where the Modular Machine Part comes in a stack of thirty. MMP's are max stack of 10 anyways, and when printed or vended come in a stack of 30, causing cases to happen where you want 15 and end up printing 450.
Will make a PR later to make stacks of 1, 5, and 10.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Pon
- fix: Changed modular machine parts to come in stacks of 1 instead of 30.
