### PR TITLE
adding id cards to the whitelist of the purrfus document hand.

### DIFF
--- a/Resources/Locale/en-US/_Starlight/borg/borg_modules.ftl
+++ b/Resources/Locale/en-US/_Starlight/borg/borg_modules.ftl
@@ -1,4 +1,4 @@
-borg-slot-papers-empty = Documents and Stamps
+borg-slot-papers-empty = Documents and Stamps and IDs
 borg-slot-ore-empty = Ore
 borg-slot-fuel-empty = Fuel tanks
 borg-slot-seeds-empty = Seeds

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -732,6 +732,7 @@
           - Document
           components:
           - Stamp
+          - IdCard
     - hand:
         emptyLabel: borg-slot-papers-empty
         emptyRepresentative: BorgModulePaperStampPlaceholder
@@ -740,6 +741,7 @@
           - Document
           components:
           - Stamp
+          - IdCard
     - hand:
         emptyLabel: borg-slot-papers-empty
         emptyRepresentative: BorgModulePaperStampPlaceholder
@@ -748,6 +750,7 @@
           - Document
           components:
           - Stamp
+          - IdCard
   - type: BorgModuleIcon
     icon: { sprite: Objects/Misc/pens.rsi, state: overpriced_pen }
 

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -366,6 +366,7 @@
           - Document
           components:
           - Stamp
+          - IdCard
   - type: BorgModuleIcon
     icon: { sprite: _Starlight/Interface/Actions/actions_borg.rsi, state: paperwork-module }
 


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Added ID Cards to Purrfus Document Hand.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Warden and HoP are likely client's of a purrfus, both often handling ID cards. If not for the recent change to Borg Permission's to Head of Staff doors, they would not require ID cards themselves. And even so stealing an ID card is still kinda impossible. So their use for antagonists should still be limited. So the impact should be minimal, while just rounding off Purrfus job capabilities.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://youtu.be/mnrKE0VOucY

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: EWanderer
- tweak: Purrfus can now hold id cards in their office hand.
