### PR TITLE
Remove non-ghostrole 'mistake' corgi from borgi cube table

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/rehydrateable.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/rehydrateable.yml
@@ -9,11 +9,7 @@
     - SmartSubwooferBorgiChassis
     - SubwooferBorgiChassis
     - StationBorgiChassis
-    - SmartSubwooferBorgiChassis
-    - SubwooferBorgiChassis
-    - StationBorgiChassis
     - MobCorgiSmartGhostrole
-    - MobCorgiSmartNoGalcom
 
 - type: entity
   parent: RehydratableAnimalCube


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Changes the borgi cube table to remove non-sentient corgi chance, keeping the ghost role smart corgi.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Borgi cubes have always had a chance to produce a non-borg corgi.  The last time borgi cubes were touched, I added in a chance that a sentient ghost-role corgi would appear.

The rates were as follows:
- 25% chance of a Smart Subwoofer Borgi (has a midi player installed)
- 25% chance of a Subwoofer Borgi (has a midi player installed)
- 25% chance of a Standard Borgi (no midi player)
- 12.5% chance of a non-sentient 'smart corgi' that cannot speak Galactic Common
- 12.5% chance of a sentient, ghost role 'smart corgi' that cannot speak Galactic Common

There is no outward perceptible difference between the non-sentient and sentient smart corgis other than the fact that one of them might eventually start talking.  The other is left to roam idly for the rest of the round, or to be turned into biomass.
It's disappointing to put in the effort for a borgi and be left guessing whether the 'mistake' corgi is ever going to wake up, so I've dropped the guessing game.  If it's a corgi result, it'll eventually become sentient.

The rates are now as follows:
- 25% chance of a Smart Subwoofer Borgi (has a midi player installed)
- 25% chance of a Subwoofer Borgi (has a midi player installed)
- 25% chance of a Standard Borgi (no midi player)
- 25% chance of a sentient, ghost role 'smart corgi' that cannot speak Galactic Common

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- tweak: Borgi cubes no longer produce 'mistake' smart corgis that aren't sentient; all 'mistake' corgis will now be ghost roles.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
