### PR TITLE
Super Synth Fix

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Fun/Instruments/instruments_percussion.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Fun/Instruments/instruments_percussion.yml
@@ -11,6 +11,8 @@
   - type: Sprite
     sprite: Objects/Fun/Instruments/h_synthesizer.rsi
     state: supersynth
+  - type: ActivatableUI
+    inHandsOnly: false
   - type: Clothing
     quickEquip: false
     slots:


### PR DESCRIPTION
## Short description
Making super synths able to do music on the neck like before like the harmonica

## Why we need to add this
It was unintentionally removed before in a different PR due to a misunderstanding, and this would bring it back to what it was originally supposed to be.
https://discord.com/channels/1272545509562777621/1518000313322180749
https://discord.com/channels/1272545509562777621/1517368655279558657
https://discord.com/channels/1272545509562777621/1515987646944514119
https://discord.com/channels/1272545509562777621/1515858399370154157

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- fix: Super synths can be played on the neck now.
