### PR TITLE
Fix TTS stripping apostrophes

### DIFF
--- a/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
@@ -233,13 +233,17 @@ public sealed partial class TTSSystem : EntitySystem
     private static string CleanText(string text)
     {
         text = TagStripperRegex().Replace(text, "");
+        text = SmartQuotes().Replace(text, "'");
         text = CharFilter().Replace(text, "");
         text = NumberConverter.NumberPattern().Replace(text, match => NumberConverter.Convert(match.Value));
         return text;
     }
 
-    [GeneratedRegex(@"[^a-zA-Z0-9,.\-?! ]")]
+    [GeneratedRegex(@"[^a-zA-Z0-9,.\-?!' ]")]
     private static partial Regex CharFilter();
+
+    [GeneratedRegex(@"[\u2018\u2019]")]
+    private static partial Regex SmartQuotes();
 
     [GeneratedRegex(@"\[[^\]]*\]")]
     private static partial Regex TagStripperRegex();

--- a/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
@@ -230,6 +230,12 @@ public sealed partial class TTSSystem : EntitySystem
             _ignoredRecipients.Add(args.SenderSession);
     }
 
+    /// <summary>
+    /// Cleans and normalizes text for TTS output, preserving apostrophes, normalizing smart quotes,
+    /// stripping formatting tags, and converting numbers to word representations.
+    /// </summary>
+    /// <param name="text">The raw text to be cleaned.</param>
+    /// <returns>The cleaned and normalized text.</returns>
     internal static string CleanText(string text)
     {
         text = TagStripperRegex().Replace(text, "");

--- a/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
@@ -230,7 +230,7 @@ public sealed partial class TTSSystem : EntitySystem
             _ignoredRecipients.Add(args.SenderSession);
     }
 
-    private static string CleanText(string text)
+    internal static string CleanText(string text)
     {
         text = TagStripperRegex().Replace(text, "");
         text = SmartQuotes().Replace(text, "'");

--- a/Content.Tests/Server/TextToSpeech/TTSTests.cs
+++ b/Content.Tests/Server/TextToSpeech/TTSTests.cs
@@ -1,0 +1,42 @@
+using Content.Server._Starlight.TextToSpeech;
+using NUnit.Framework;
+
+namespace Content.Tests.Server.TextToSpeech;
+
+[TestFixture]
+public sealed class TTSTests
+{
+    [Test]
+    public void TestCleanTextPreservesApostrophes()
+    {
+        // Contractions
+        Assert.That(TTSSystem.CleanText("I'm here"), Is.EqualTo("I'm here"));
+        Assert.That(TTSSystem.CleanText("I'll do it"), Is.EqualTo("I'll do it"));
+        Assert.That(TTSSystem.CleanText("don't stop"), Is.EqualTo("don't stop"));
+        Assert.That(TTSSystem.CleanText("won't stop"), Is.EqualTo("won't stop"));
+
+        // Accent ending/beginning and plural apostrophes
+        Assert.That(TTSSystem.CleanText("thinkin'"), Is.EqualTo("thinkin'"));
+        Assert.That(TTSSystem.CleanText("'ello"), Is.EqualTo("'ello"));
+        Assert.That(TTSSystem.CleanText("Chris' coat"), Is.EqualTo("Chris' coat"));
+    }
+
+    [Test]
+    public void TestCleanTextNormalizesSmartQuotes()
+    {
+        // Smart quote normalization
+        Assert.That(TTSSystem.CleanText("I’m here"), Is.EqualTo("I'm here"));
+        Assert.That(TTSSystem.CleanText("I’ll do it"), Is.EqualTo("I'll do it"));
+        Assert.That(TTSSystem.CleanText("don’t stop"), Is.EqualTo("don't stop"));
+        Assert.That(TTSSystem.CleanText("‘ello"), Is.EqualTo("'ello"));
+        Assert.That(TTSSystem.CleanText("Chris’ coat"), Is.EqualTo("Chris' coat"));
+    }
+
+    [Test]
+    public void TestCleanTextStripsInvalidCharacters()
+    {
+        // Standard stripping behavior
+        Assert.That(TTSSystem.CleanText("[color=red]Hello[/color] world!"), Is.EqualTo("Hello world!"));
+        Assert.That(TTSSystem.CleanText("Hello @#$% world!"), Is.EqualTo("Hello  world!"));
+    }
+}

--- a/Content.Tests/Server/TextToSpeech/TTSTests.cs
+++ b/Content.Tests/Server/TextToSpeech/TTSTests.cs
@@ -3,9 +3,15 @@ using NUnit.Framework;
 
 namespace Content.Tests.Server.TextToSpeech;
 
+/// <summary>
+/// Unit tests verifying the text cleaning and normalization behavior in TTSSystem.
+/// </summary>
 [TestFixture]
 public sealed class TTSTests
 {
+    /// <summary>
+    /// Verifies that standard ASCII apostrophes (used in contractions, accents, or plurals) are preserved.
+    /// </summary>
     [Test]
     public void TestCleanTextPreservesApostrophes()
     {
@@ -21,6 +27,9 @@ public sealed class TTSTests
         Assert.That(TTSSystem.CleanText("Chris' coat"), Is.EqualTo("Chris' coat"));
     }
 
+    /// <summary>
+    /// Verifies that unicode smart quotes (both single quotes and smart apostrophes) are normalized to standard ASCII apostrophes.
+    /// </summary>
     [Test]
     public void TestCleanTextNormalizesSmartQuotes()
     {
@@ -32,6 +41,9 @@ public sealed class TTSTests
         Assert.That(TTSSystem.CleanText("Chris’ coat"), Is.EqualTo("Chris' coat"));
     }
 
+    /// <summary>
+    /// Verifies that formatting tags (like BBCode) and non-alphanumeric/non-punctuation characters are stripped.
+    /// </summary>
     [Test]
     public void TestCleanTextStripsInvalidCharacters()
     {


### PR DESCRIPTION
## Short description
Fixes apostrophes being stripped by the TTS system.

## Why we need to add this
Whenever I'm playing, I notice when I say words like "I'm" or "I'll" they come out sounding weird: like "im" or "ill". I had a hunch it might be something to do with apostrophes and it was!

We should add this for better pronunciation of apostrophe'd words, as well as plurals (E.g. Chris' in the current system just becomes Chris, where the plural is pronounced very differently)

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
I haven't tested this locally because I'm not familiar with standing up the TTS system (is that possible?). Instead I've added unit tests to the function I've changed: it's very encapsulated so unless the TTS system has some special behavior around apostrophes, this should be a minor change.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [~] Before posting/requesting review of a PR, I have verified that the changes work. (Sorta? Unit testing?)
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: 
- fix: TTS pronunciation of apostrophe'd words.