### PR TITLE
Cog Hotfix

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Cog.yml
+++ b/Resources/Maps/_Starlight/Stations/Cog.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 06/18/2026 01:49:19
+  time: 06/22/2026 03:02:44
   entityCount: 33043
 maps:
 - 1
@@ -15433,7 +15433,7 @@ entities:
       pos: 20.5,-15.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -93995.13
+      secondsUntilStateChange: -94106.75
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -15565,7 +15565,7 @@ entities:
       pos: -48.5,57.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -16345.897
+      secondsUntilStateChange: -16457.514
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -15576,7 +15576,7 @@ entities:
       pos: -51.5,52.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -17710.08
+      secondsUntilStateChange: -17821.697
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -16722,7 +16722,7 @@ entities:
       pos: 26.5,17.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -101162.26
+      secondsUntilStateChange: -101273.875
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -17031,7 +17031,7 @@ entities:
       pos: 5.5,-3.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -17494.318
+      secondsUntilStateChange: -17605.936
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 1
@@ -18200,7 +18200,7 @@ entities:
       pos: -48.5,48.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -16400.932
+      secondsUntilStateChange: -16512.549
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -186998,28 +186998,27 @@ entities:
     - type: Transform
       pos: 52.670685,1.6892309
       parent: 2
-- proto: TurnstileGenpopEnter
+- proto: TurnstileArmory
   entities:
   - uid: 12244
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -43.5,54.5
       parent: 2
     - type: AccessReader
       accessListsOriginal:
-      - - GenpopEnter
-      - - Security
+      - - Armory
   - uid: 15789
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: -41.5,55.5
       parent: 2
     - type: AccessReader
       accessListsOriginal:
-      - - GenpopEnter
-      - - Security
+      - - Armory
+- proto: TurnstileGenpopEnter
+  entities:
   - uid: 28508
     components:
     - type: Transform
@@ -187035,26 +187034,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,42.5
-      parent: 2
-    - type: AccessReader
-      accessListsOriginal:
-      - - GenpopEnter
-      - - Security
-  - uid: 32965
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -32.5,53.5
-      parent: 2
-    - type: AccessReader
-      accessListsOriginal:
-      - - GenpopEnter
-      - - Security
-  - uid: 32972
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -32.5,55.5
       parent: 2
     - type: AccessReader
       accessListsOriginal:
@@ -187080,6 +187059,26 @@ entities:
     - type: AccessReader
       accessListsOriginal:
       - - GenpopLeave
+      - - Security
+- proto: TurnstileSecurity
+  entities:
+  - uid: 32965
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -32.5,53.5
+      parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Security
+  - uid: 32972
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -32.5,55.5
+      parent: 2
+    - type: AccessReader
+      accessListsOriginal:
       - - Security
 - proto: TwoWayLever
   entities:

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/turnstile.yml
@@ -8,6 +8,30 @@
   - type: AccessReader
     access: [["Command"]]
 
+- type: entity
+  id: TurnstileSecurity
+  parent: Turnstile
+  suffix: Security
+  components:
+  - type: AccessReader
+    access: [["Security"]]
+
+- type: entity
+  id: TurnstileArmory
+  parent: Turnstile
+  suffix: Armory
+  components:
+  - type: AccessReader
+    access: [["Armory"]]
+
+- type: entity
+  id: TurnstileSyndicate
+  parent: Turnstile
+  suffix: Syndicate
+  components:
+  - type: AccessReader
+    access: [["SyndicateAgent"]]
+
 # CentComm turnstiles
 
 - type: entity


### PR DESCRIPTION
## Short description
Adds three new turnstile prototypes for mapping
- Armory
- Security
- Syndicate

## Why we need to add this
Hotfix for genpop prisoners being able to walk out into sec's hallways. More robust pre-setup turnstile prototypes for making mapping easier. Using Genpop Enter where I use it on Cog lets them walk out since Prisoner IDs have Enter perms, and using Genpop Exit would let Prisoners walk out into sec when their time expires which is also not desired.

## Media (Video/Screenshots)
No

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added Security, Armory, and Syndicate Turnstile Prototypes for mapping.
- fix: Fixed Prisoners being able to walk out of Genpop on Cog.
