### PR TITLE
Fixes Proto-Resomi eyes not having night vision and flash vulnerability

### DIFF
--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/resomi.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/resomi.yml
@@ -1,7 +1,22 @@
 - type: entity
+  id: OrganProtoResomiEyes
+  parent: OrganProtogenEyes
+  name: resomi cybernetic eyes
+  suffix: Proto-Resomi
+  description: "Resomi eyes have great nightvision for hunting prey in maintenance tunnels."
+  components:
+  - type: FunctionalOrgan
+    comps:
+    - type: NightVision
+      disabilityBlockable: true
+    - type: FlashModifier
+      modifier: 2
+
+- type: entity
   id: OrganProtoResomiHeart
   parent: OrganProtogenHeart
   name: resomi cybernetic heart
+  suffix: Proto-Resomi
   components:
   - type: Metabolizer
     maxReagents: 2
@@ -15,6 +30,7 @@
   id: OrganProtoResomiLungs
   parent: OrganProtogenLungs
   name: resomi cybernetic lungs
+  suffix: Proto-Resomi
   description: Filters oxygen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier. Entirely cybernetic in nature, working in tandem with the visor's filtration system. #  Starlight, quotation marks removed
   components:
   - type: Metabolizer
@@ -25,4 +41,3 @@
     groups:
     - id: Gas
       rateModifier: 100.0
-

--- a/Resources/Prototypes/_Starlight/Body/Prototypes/Protogen/resomi.yml
+++ b/Resources/Prototypes/_Starlight/Body/Prototypes/Protogen/resomi.yml
@@ -9,7 +9,7 @@
       - torso
       organs:
         brain: OrganProtogenBrain
-        eyes: OrganProtogenEyes
+        eyes: OrganProtoResomiEyes
         tongue: OrganProtogenTongueForked
         eye_implant: null
         brain_implant: BrainImplantNexus


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
During #4797, I moved all of the night vision and flash modifers off the mob's body and onto their eye organs. While I fixed Proto-Cyclorites not having their own eye organs for night vision / flash vulnerability, I missed Proto-Resomi for this change.

This PR adds Proto-Resomi eye organs with night vision and flash vulnerability.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bug reported via Discord.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1130" height="800" alt="image" src="https://github.com/user-attachments/assets/bd301ce2-b4aa-4256-80cf-0adbc70840b9" />

fig. 1 - Proto-Resomi in the dark.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Proto-Resomi eyes now have night vision and flash vulnerability like their non-protogen counterparts.