### PR TITLE
Organ clean up

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Body/Organs/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Body/Organs/ipc.yml
@@ -19,6 +19,7 @@
   id: OrganIPCEyes
   parent: [BaseIPCOrganUnGibbable, BaseOrganEyes]
   name: robotic eyes
+  suffix: IPC
   description: "Decidedly not squishy. Kinda sharp, actually."
   components:
   - type: Sprite
@@ -45,6 +46,7 @@
   id: OrganIPCTongue
   parent: [BaseIPCOrganUnGibbable, BaseOrganTongue]
   name: vocal modulator
+  suffix: IPC
   description: "A vocal modulator, typically used for lying."
   components:
   - type: Sprite
@@ -54,6 +56,7 @@
   id: OrganIPCEars
   parent: [BaseIPCOrganUnGibbable, BaseOrganEars]
   name: robotic ears
+  suffix: IPC
   description: "Process audio at the same quality of station-side cyborgs"
   components:
   - type: Sprite
@@ -63,6 +66,7 @@
   id: OrganIPCHeart
   parent: [BaseIPCOrganUnGibbable, BaseOrganHeart]
   name: micro pump
+  suffix: IPC
   description: "Circulates coolant in a sickingly familiar way."
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Animal/slimes.yml
@@ -34,6 +34,7 @@
   id: OrganSlimesLungs
   parent: BaseHumanOrgan
   name: slimes gas sacs
+  suffix: Slimes
   description: "Collects nitrogen, which slime cells use for maintenance."
   components:
     - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/arachnid.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/arachnid.yml
@@ -2,6 +2,7 @@
   id: OrganProtoArachnidHeart
   parent: [BaseProtogenOrgan, OrganProtogenHeart]
   name: arachnid cybernetic heart
+  suffix: Proto-Arachnid
   components:
   - type: Sprite
     state: heart-on

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/avali.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/avali.yml
@@ -2,6 +2,7 @@
   id: OrganProtoAvaliStomach
   parent: OrganProtogenStomach
   name: avali biological reactor
+  suffix: Proto-Avali
   components:
   - type: Stomach
     specialDigestible:
@@ -22,6 +23,7 @@
   id: OrganProtoAvaliHeart
   parent: OrganProtogenHeart
   name: avali cybernetic heart
+  suffix: Proto-Avali
   components:
   - type: Metabolizer
     maxReagents: 2
@@ -35,6 +37,7 @@
   id: OrganProtoAvaliLiver
   parent: OrganProtogenLiver
   name: avali cybernetic liver
+  suffix: Proto-Avali
   components:
   - type: Metabolizer
     updateInterval: 1.5

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/base.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/base.yml
@@ -32,6 +32,7 @@
   id: OrganProtogenBrain
   parent: [BaseOrganBrain, BaseProtogenOrgan]
   name: cybernetic brain
+  suffix: Protogen
   description: The source of incredible, unending intelligence. 01201020 02102111 01201210 02121012 20121210
   components:
   - type: Sprite
@@ -41,6 +42,7 @@
   id: OrganProtogenEyes
   parent: [BaseProtogenOrgan, BaseOrganEyes]
   name: cybernetic eyes
+  suffix: Protogen
   description: It's still focusing on you.. Creepy.
   components:
   - type: Sprite
@@ -67,6 +69,7 @@
   id: OrganProtogenTongue
   parent: [BaseProtogenOrgan, BaseOrganTongue]
   name: cybernetic tongue
+  suffix: Protogen
   description: A completely glowing organ commonly used for lying or self-expression. Sometimes both. #  Starlight, quotation marks removed
   components:
   - type: Sprite
@@ -84,6 +87,7 @@
   id: OrganProtogenTongueForked
   parent: [BaseProtogenOrgan, BaseOrganTongue]
   name: forked cybernetic tongue
+  suffix: Protogen
   description: A completely glowing organ commonly used for lying or self-expression. Sometimes both. Now split in two. #  Starlight, quotation marks removed
   components:
   - type: Sprite
@@ -93,6 +97,7 @@
   id: OrganProtogenEars
   parent: [BaseProtogenOrgan, BaseOrganEars]
   name: cybernetic ears
+  suffix: Protogen
   description: Process audio at a higher quality than most humanoids, allowing for greater appreciation of techno music #  Starlight, quotation marks removed
   components:
   - type: Sprite
@@ -102,6 +107,7 @@
   id: OrganProtogenLungs
   parent: [BaseProtogenOrgan, BaseOrganLungs]
   name: cybernetic lungs
+  suffix: Protogen
   description: Filters oxygen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier. Entirely cybernetic in nature, working in tandem with the visor's filtration system. #  Starlight, quotation marks removed
   components:
   - type: Sprite
@@ -146,6 +152,7 @@
   id: OrganProtogenHeart
   parent: [BaseProtogenOrgan, BaseOrganHeart]
   name: cybernetic heart
+  suffix: Protogen
   description: Doesn't actually need to beat, simply mimics the movement to provide comfort for the user.
   components:
   - type: Sprite
@@ -173,6 +180,7 @@
   id: OrganProtogenStomach
   parent: [OrganAnimalStomach, BaseOrganStomach]
   name: biological reactor
+  suffix: Protogen
   description: Some call it over-engineered, but it's vital to the function of a protogen. Turns organic matter into organic and electrical energy to power the protogen's cybernetics and flesh. #  Starlight, quotation marks removed
   components:
   - type: Sprite
@@ -208,6 +216,7 @@
   id: OrganProtogenLiver
   parent: [BaseProtogenOrgan, BaseOrganLiver]
   name: cybernetic liver
+  suffix: Protogen
   description: Pairing suggestion, a side of fermented RAM sticks and a nice CPU.
   components:
   - type: Sprite
@@ -233,6 +242,7 @@
   id: OrganProtogenKidneys
   parent: [BaseProtogenOrgan, BaseOrganKidneys]
   name: cybernetic kidneys
+  suffix: Protogen
   description: Pumps toxins out of the bloodstream and serves as a minor biological battery for electrical components #  Starlight, quotation marks removed
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/cyclorite.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/cyclorite.yml
@@ -2,6 +2,7 @@
   id: OrganProtoCycloriteLungs
   parent: OrganProtogenLungs
   name: cyclorite cybernetic lungs
+  suffix: Proto-Cyclorite
   description: Filters nitrogen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier. Entirely cybernetic in nature, working in tandem with the visor's filtration system.
   components:
   - type: Lung
@@ -19,6 +20,7 @@
   id: OrganProtoCycloriteEye
   parent: OrganProtogenEyes
   name: cyclorite cybernetic eye
+  suffix: Proto-Cyclorite
   description: "Cyclorites see the world slightly differently."
   components:
   - type: Sprite
@@ -39,6 +41,7 @@
   id: OrganProtoCycloriteHeart
   parent: OrganProtogenHeart
   name: cyclorite cybernetic heart
+  suffix: Proto-Cyclorite
   components:
   - type: Metabolizer
     maxReagents: 2

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/diona.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/diona.yml
@@ -31,31 +31,9 @@
         Radiation: 10
 
 - type: entity
-  id: OrganProtoDionaStomachNymph
-  parent: OrganProtoDionaStomach
-  categories: [ HideSpawnMenu ]
-  name: stomach
-  description: "Gross. This is hard to stomach."
-  components:
-  - type: Nymph
-    entityPrototype: OrganProtoDionaNymphStomach
-
-- type: entity
-  id: OrganProtoDionaNymphStomach
-  parent: MobDionaNymphAccent
-  categories: [ HideSpawnMenu ]
-  name: proto diona nymph
-  suffix: Stomach
-  description: Contains the stomach of a formerly fully-formed Proto-Diona. It doesn't taste any better for it.
-  components:
-  - type: IsDeadIC
-  - type: Body
-    prototype: AnimalProtoNymphStomach
-
-- type: entity
   id: OrganProtoDionaLungs
   parent: OrganDionaLungs
-  name: augmented lungs
+  name: diona augmented lungs
   suffix: Proto-Diona
   description: "A spongy mess of slimy, leaf-like structures. Capable of breathing both carbon dioxide and oxygen."
   components:
@@ -67,11 +45,36 @@
         Bloodloss: 20
         Radiation: 30
 
+# Organs that turn into nymphs on removal
+- type: entity
+  id: OrganProtoDionaStomachNymph
+  categories: [ HideSpawnMenu ]
+  parent: OrganProtoDionaStomach
+  name: proto-diona nymph stomach
+  suffix: Proto-Diona Nymph
+  description: "Gross. This is hard to stomach."
+  components:
+  - type: Nymph
+    entityPrototype: OrganProtoDionaNymphStomach
+
+- type: entity
+  id: OrganProtoDionaNymphStomach
+  categories: [ HideSpawnMenu ]
+  parent: MobDionaNymphAccent
+  name: proto-diona nymph stomach
+  suffix: Proto-Diona Nymph
+  description: Contains the stomach of a formerly fully-formed Proto-Diona. It doesn't taste any better for it.
+  components:
+  - type: IsDeadIC
+  - type: Body
+    prototype: AnimalProtoNymphStomach
+
 - type: entity
   id: OrganProtoDionaLungsNymph
-  parent: OrganProtoDionaLungs
   categories: [ HideSpawnMenu ]
-  name: lungs
+  parent: OrganProtoDionaLungs
+  name: proto-diona nymph lungs
+  suffix: Proto-Diona Nymph
   description: "Filters oxygen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier."
   components:
   - type: Nymph
@@ -79,10 +82,10 @@
 
 - type: entity
   id: OrganProtoDionaNymphLungs
-  parent: MobDionaNymphAccent
   categories: [ HideSpawnMenu ]
-  name: proto diona nymph
-  suffix: Lungs
+  parent: MobDionaNymphAccent
+  name: proto-diona nymph lungs
+  suffix: Proto-Diona Nymph
   description: Contains the lungs of a formerly fully-formed Proto-Diona. Breathtaking.
   components:
   - type: IsDeadIC

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/dwarf.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/dwarf.yml
@@ -2,6 +2,7 @@
   id: OrganProtoDwarfHeart
   parent: OrganProtogenHeart
   name: dwarf cybernetic heart
+  suffix: Proto-Dwarf
   description: Doesn't actually need to beat, simply mimics the movement to provide comfort for the user.
   components:
   - type: Metabolizer
@@ -11,6 +12,7 @@
   id: OrganProtoDwarfLiver
   parent: OrganProtogenLiver
   name: dwarf cybernetic liver
+  suffix: Proto-Dwarf
   description: Pairing suggestion, a side of fermented RAM sticks and a nice CPU.
   components:
   - type: Metabolizer
@@ -20,6 +22,7 @@
   id: OrganProtoDwarfStomach
   parent: OrganProtogenStomach
   name: dwarf biological reactor
+  suffix: Proto-Dwarf
   description: Some call it over-engineered, but it's vital to the function of a protogen. Turns organic matter into organic and electrical energy to power the protogen's cybernetics and flesh.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/lagomorph.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/lagomorph.yml
@@ -2,6 +2,7 @@
   id: OrganProtoLagomorphStomach
   parent: OrganProtogenStomach
   name: lagomorph biological reactor
+  suffix: Proto-Lagomorph
   components:
   - type: Metabolizer
     updateInterval: 0.75
@@ -15,6 +16,7 @@
   id: OrganProtoLagomorphHeart
   parent: OrganProtogenHeart
   name: lagomorph cybernetic heart
+  suffix: Proto-Lagomorph
   components:
   - type: Metabolizer
     updateInterval: 0.75

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/moth.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/moth.yml
@@ -2,6 +2,7 @@
   id: OrganProtoMothStomach
   parent: [OrganAnimalStomach, BaseOrganStomach]
   name: moth biological reactor
+  suffix: Proto-Moth
   description: Some call it over-engineered, but it's vital to the function of a protogen. Turns organic matter into organic and electrical energy to power the protogen's cybernetics and flesh. #  Starlight, quotation marks removed
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/resomi.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/resomi.yml
@@ -3,7 +3,7 @@
   parent: OrganProtogenEyes
   name: resomi cybernetic eyes
   suffix: Proto-Resomi
-  description: "Resomi eyes have great nightvision for hunting prey in maintenance tunnels."
+  description: "These cybernetic eyes have great night vision for hunting prey in maintenance tunnels, but are very sensitive to bright flashes."
   components:
   - type: FunctionalOrgan
     comps:

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/shadekin.yml
@@ -2,6 +2,8 @@
   id: OrganProtokinEyes
   parent: OrganProtogenEyes
   name: shadekin cybernetic eyes
+  suffix: Protokin
+  description: "Cybernetic eyes of a Black-eye Shadekin that can never see their home reality again. These eyes have excellent night vision, but are very sensitive to bright flashes as a result."
   components:
   - type: FunctionalOrgan
     comps:

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/slime.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/slime.yml
@@ -2,6 +2,7 @@
   id: SentientProtoSlimeCore
   parent: SentientSlimeCore
   name: augmented sentient slime core
+  suffix: Proto-Slime
   description: "The source of incredible, unending gooeyness."
   components:
     - type: Stomach
@@ -31,6 +32,7 @@
   id: OrganProtoSlimeHeart
   parent: OrganSlimeHeart
   name: augmented slime circulator
+  suffix: Proto-Slime
   description: "A little circulator what makes the fluid move through the slime body."
   components:
   - type: Metabolizer
@@ -54,6 +56,7 @@
   id: OrganProtoSlimeLungs
   parent: OrganSlimeLungs
   name: augmented slime gas sacs
+  suffix: Proto-Slime
   description: "Collects nitrogen, which slime cells use for maintenance."
   components:
   - type: OrganDamage
@@ -68,6 +71,7 @@
   id: OrganProtoSlimePeepoids
   parent: OrganSlimePeepoids
   name: augmented peepoids
+  suffix: Proto-Slime
   description: "Primitive and goopy, but more or less just as good as the human equivalent."
   components:
   - type: Sprite
@@ -93,6 +97,7 @@
   id: OrganProtoSlimeSlurpoid
   parent: OrganSlimeSlurpoid
   name: augmented slurpoid
+  suffix: Proto-Slime
   description: "It has all the consistency of gelatin."
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Organs/Protogen/vox.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Protogen/vox.yml
@@ -2,6 +2,7 @@
   id: OrganProtoVoxStomach
   parent: OrganProtogenStomach
   name: vox biological reactor
+  suffix: Proto-Vox
   components:
   - type: Metabolizer
     metabolizerTypes: [Vox] # They don't need animal since Vox inherits the same properties anyways.
@@ -25,6 +26,7 @@
   id: OrganProtoVoxHeart
   parent: [BaseProtogenOrgan, OrganProtogenHeart]
   name: vox cybernetic heart
+  suffix: Proto-Vox
   components:
   - type: Sprite
     state: heart-on
@@ -38,6 +40,7 @@
   id: OrganProtoVoxLungs
   parent: OrganProtogenLungs
   name: vox cybernetic lungs
+  suffix: Proto-Vox
   description: Filters nitrogen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier. Entirely cybernetic in nature, working in tandem with the visor's filtration system. #  Starlight, quotation marks removed
   components:
   - type: Metabolizer

--- a/Resources/Prototypes/_Starlight/Body/Organs/abductor.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/abductor.yml
@@ -30,8 +30,9 @@
 - type: entity
   id: OrganAbductorBrain
   parent: [BaseOrganBrain, BaseAbductorOrgan]
-  name: brain
-  description: "The source of incredible, unending intelligence. Honk."
+  name: strange brain
+  suffix: Abductor
+  description: "The source of incredible yet strange intelligence."
   components:
   - type: Sprite
     state: brain
@@ -39,8 +40,9 @@
 - type: entity
   id: OrganAbductorEyes
   parent: [BaseAbductorOrgan, BaseOrganEyes]
-  name: eye
-  description: "I see you!"
+  name: strange eyes
+  suffix: Abductor
+  description: "These large beady eyes silently stare at you."
   components:
   - type: Sprite
     layers:
@@ -53,8 +55,9 @@
 - type: entity
   id: OrganAbductorEars
   parent: [BaseAbductorOrgan, BaseOrganEars]
-  name: ears
-  description: "There are three parts to the ear. Inner, middle and outer. Only one of these parts should normally be visible."
+  name: strange ears
+  suffix: Abductor
+  description: "There are three parts to the ear: inner, middle and outer. Only one of these parts should normally be visible."
   components:
   - type: Sprite
     state: ears
@@ -62,7 +65,8 @@
 - type: entity
   id: OrganAbductorLungs
   parent: [BaseAbductorOrgan, BaseOrganLungs]
-  name: lungs
+  name: strange lungs
+  suffix: Abductor
   description: "Filters oxygen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier."
   components:
   - type: Sprite
@@ -73,8 +77,9 @@
 - type: entity
   id: OrganAbductorHeart
   parent: [BaseAbductorOrgan, BaseOrganHeart]
-  name: heart
-  description: "I feel bad for the heartless bastard who lost this."
+  name: strange heart
+  suffix: Abductor
+  description: "Doesn't look like this one was experimented on."
   components:
   - type: Sprite
     state: heart-on
@@ -92,8 +97,9 @@
 - type: entity
   id: OrganAbductorStomach
   parent: [BaseAbductorOrgan, BaseOrganStomach]
-  name: stomach
-  description: "Gross. This is hard to stomach."
+  name: strange stomach
+  suffix: Abductor
+  description: "May yearn for grilled cheese."
   components:
   - type: Sprite
     state: stomach
@@ -121,8 +127,9 @@
 - type: entity
   id: OrganAbductorLiver
   parent: [BaseAbductorOrgan, BaseOrganLiver]
-  name: liver
-  description: "Pairing suggestion: chianti and fava beans."
+  name: strange liver
+  suffix: Abductor
+  description: "This odd liver is rather poor at breaking down alcohol."
   components:
   - type: Sprite
     state: liver
@@ -136,8 +143,9 @@
 - type: entity
   id: OrganAbductorKidneys
   parent: [BaseAbductorOrgan, BaseOrganKidneys]
-  name: kidneys
-  description: "Filters toxins from the bloodstream."
+  name: strange kidneys
+  suffix: Abductor
+  description: "Filters strange toxins from its strange bloodstream."
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Starlight/Body/Organs/animal.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/animal.yml
@@ -1,27 +1,9 @@
-# Borgi Animal Body
-
 - type: entity
-  parent: PartAnimal
-  id: LeftHandAdmemeCorgi
-  name: corgi hand
+  id: OrganCorgiLungs
+  parent: OrganAnimalLungs
+  name: corgi lungs
   suffix: Corgi
+  description: "Used for barking."
   components:
-  - type: Sprite
-    layers:
-    - state: l_hand
-  - type: BodyPart
-    partType: Hand
-    symmetry: Left
-
-- type: entity
-  parent: PartAnimal
-  id: RightHandAdmemeCorgi
-  name: corgi hand
-  suffix: Corgi
-  components:
-  - type: Sprite
-    layers:
-    - state: r_hand
-  - type: BodyPart
-    partType: Hand
-    symmetry: Right
+  - type: Lung
+    alert: CorgiLowOxygen

--- a/Resources/Prototypes/_Starlight/Body/Organs/animal.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/animal.yml
@@ -4,7 +4,7 @@
   parent: PartAnimal
   id: LeftHandAdmemeCorgi
   name: corgi hand
-  categories: [ HideSpawnMenu ]
+  suffix: Corgi
   components:
   - type: Sprite
     layers:
@@ -17,7 +17,7 @@
   parent: PartAnimal
   id: RightHandAdmemeCorgi
   name: corgi hand
-  categories: [ HideSpawnMenu ]
+  suffix: Corgi
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Starlight/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/arachnid.yml
@@ -28,7 +28,8 @@
 - type: entity
   id: OrganArachnidStomach
   parent: [OrganAnimalStomach, BaseOrganStomach]
-  name: animal stomach
+  name: arachnid stomach
+  suffix: Arachnid
   description: "Gross. This is hard to stomach."
   components:
   - type: Sprite
@@ -53,7 +54,8 @@
 - type: entity
   id: OrganArachnidLungs
   parent: [BaseArachnidOrgan, BaseOrganLungs]
-  name: lungs
+  name: arachnid lungs
+  suffix: Arachnid
   description: "Filters oxygen from an atmosphere... just more greedily."
   components:
   - type: Sprite
@@ -87,7 +89,8 @@
 - type: entity
   id: OrganArachnidHeart
   parent: [BaseArachnidOrgan, BaseOrganHeart]
-  name: heart
+  name: arachnid heart
+  suffix: Arachnid
   description: "A disgustingly persistent little biological pump made for spiders."
   components:
   - type: Sprite
@@ -106,9 +109,9 @@
 - type: entity
   id: OrganArachnidLiver
   parent: [BaseHumanOrgan, BaseOrganLiver]
-  name: liver
+  name: arachnid liver
+  suffix: Arachnid
   description: "Pairing suggestion: chianti and fava beans."
-  categories: [ HideSpawnMenu ]
   components:
   - type: Item
     size: Small
@@ -124,9 +127,9 @@
 - type: entity
   id: OrganArachnidKidneys
   parent: [BaseHumanOrgan, BaseOrganKidneys]
-  name: kidneys
+  name: arachnid kidneys
+  suffix: Arachnid
   description: "Filters toxins from the bloodstream."
-  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     layers:
@@ -144,7 +147,8 @@
 - type: entity
   id: OrganArachnidEyes
   parent: [BaseArachnidOrgan, BaseOrganEyes]
-  name: eyes
+  name: arachnid eyes
+  suffix: Arachnid
   description: "Two was already too many."
   components:
   - type: Sprite
@@ -164,7 +168,8 @@
 - type: entity
   id: OrganArachnidTongue
   parent: [BaseArachnidOrgan, BaseOrganTongue]
-  name: tongue
+  name: arachnid tongue
+  suffix: Arachnid
   description: "A fleshy muscle mostly used for lying."
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
@@ -1,9 +1,9 @@
 - type: entity
   id: OrganAvaliStomach
   parent: OrganAnimalStomach
+  name: avali stomach
   suffix: Avali
-  name: stomach
-  description: "The stomach of an avali, on closer inspection, actually consists of two stomachs."
+  description: "On closer inspection, actually consists of two stomachs."
   components:
   - type: Stomach
     specialDigestible:
@@ -29,8 +29,9 @@
 - type: entity
   id: OrganAvaliHeart
   parent: OrganHumanHeart
+  name: avali heart
   suffix: Avali
-  description: "The heart of an avali."
+  description: "The heart of an Avali."
   components:
   - type: Metabolizer
     maxReagents: 2
@@ -46,8 +47,9 @@
 - type: entity
   id: OrganAvaliLiver
   parent: OrganHumanLiver
+  name: avali liver
   suffix: Avali
-  description: "The liver of an avali."
+  description: "The liver of an Avali."
   components:
   - type: Metabolizer # The liver metabolizes certain chemicals only, like alcohol.
     maxReagents: 1
@@ -61,8 +63,9 @@
 - type: entity
   id: OrganAvaliKidneys
   parent: OrganHumanKidneys
+  name: avali kidneys
   suffix: Avali
-  description: "The kidneys of an avali."
+  description: "The kidneys of an Avali."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Avali/organs.rsi
@@ -73,8 +76,9 @@
 - type: entity
   id: OrganAvaliLungs
   parent: OrganHumanLungs
+  name: avali lungs
   suffix: Avali
-  description: "The lungs of an avali."
+  description: "The lungs of an Avali."
   components:
   - type: Metabolizer
     removeEmpty: true
@@ -93,7 +97,7 @@
 - type: entity
   id: OrganAvaliEyes
   parent: OrganHumanEyes
-  name: eyes
+  name: avali eyes
   suffix: Avali
   description: "The eyes of an Avali."
   components:
@@ -105,8 +109,9 @@
 - type: entity
   id: OrganAvaliBrain
   parent: OrganHumanBrain
+  name: avali brain
   suffix: Avali
-  description: "The brain of an Avali. Where Avali think of evil thoughts"
+  description: "Where Avali think evil thoughts."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Avali/organs.rsi

--- a/Resources/Prototypes/_Starlight/Body/Organs/cyber_organs.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/cyber_organs.yml
@@ -46,7 +46,7 @@
 
 - type: entity
   id: CyberEyeThermal
-  name: thermalvision cyber eyes
+  name: thermal vision cyber eyes
   description: Enables you to see in the dark and detect warm objects through walls.
   parent: [OrganCyber, BaseOrganEyes]
   components:

--- a/Resources/Prototypes/_Starlight/Body/Organs/cyber_organs.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/cyber_organs.yml
@@ -20,7 +20,7 @@
 
 - type: entity
   id: CyberEyeNightVision
-  name: nightvision cyber eyes
+  name: night vision cyber eyes
   description: Enables you to see in the dark.
   parent: [OrganCyber, BaseOrganEyes]
   components:

--- a/Resources/Prototypes/_Starlight/Body/Organs/cyclorite.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/cyclorite.yml
@@ -30,7 +30,8 @@
 - type: entity
   id: OrganCycloriteBrain
   parent: [BaseOrganBrain, BaseCycloriteOrgan]
-  name: brain
+  name: cyclorite brain
+  suffix: Cyclorite
   description: "The source of incredible, unending intelligence. Honk."
   components:
   - type: Sprite
@@ -39,7 +40,8 @@
 - type: entity
   id: OrganCycloriteEye
   parent: [BaseCycloriteOrgan, BaseOrganEyes]
-  name: eye
+  name: cyclorite eye
+  suffix: Cyclorite
   description: "Cyclorites see the world slightly differently."
   components:
   - type: Sprite
@@ -58,7 +60,8 @@
 - type: entity
   id: OrganCycloriteTongue
   parent: [BaseCycloriteOrgan, BaseOrganTongue]
-  name: tongue
+  name: cyclorite tongue
+  suffix: Cyclorite
   description: "A fleshy muscle mostly used for lying."
   components:
   - type: Sprite
@@ -67,8 +70,9 @@
 - type: entity
   id: OrganCycloriteEars
   parent: [BaseCycloriteOrgan, BaseOrganEars]
-  name: ears
-  description: "There are three parts to the ear. Inner, middle and outer. Only one of these parts should normally be visible."
+  name: cyclorite ears
+  suffix: Cyclorite
+  description: "There are three parts to the ear: inner, middle and outer. Only one of these parts should normally be visible."
   components:
   - type: Sprite
     state: ears
@@ -76,7 +80,8 @@
 - type: entity
   id: OrganCycloriteLungs
   parent: [BaseCycloriteOrgan, BaseOrganLungs]
-  name: lungs
+  name: cyclorite lungs
+  suffix: Cyclorite
   description: "Cyclorite lungs filter nitrogen from the atmosphere to breathe."
   components:
   - type: Sprite
@@ -111,7 +116,8 @@
 - type: entity
   id: OrganCycloriteHeart
   parent: [BaseCycloriteOrgan, BaseOrganHeart]
-  name: heart
+  name: cyclorite heart
+  suffix: Cyclorite
   description: "I feel bad for the heartless bastard who lost this."
   components:
   - type: Sprite
@@ -130,7 +136,8 @@
 - type: entity
   id: OrganCycloriteStomach
   parent: [BaseCycloriteOrgan, BaseOrganStomach]
-  name: stomach
+  name: cyclorite stomach
+  suffix: Cyclorite
   description: "Gross. This is hard to stomach."
   components:
   - type: Sprite
@@ -159,7 +166,8 @@
 - type: entity
   id: OrganCycloriteLiver
   parent: [BaseCycloriteOrgan, BaseOrganLiver]
-  name: liver
+  name: cyclorite liver
+  suffix: Cyclorite
   description: "Pairing suggestion: chianti and fava beans."
   components:
   - type: Sprite
@@ -173,7 +181,8 @@
 - type: entity
   id: OrganCycloriteKidneys
   parent: [BaseCycloriteOrgan, BaseOrganKidneys]
-  name: kidneys
+  name: cyclorite kidneys
+  suffix: Cyclorite
   description: "Filters toxins from the bloodstream."
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Organs/diona.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/diona.yml
@@ -128,8 +128,9 @@
 # Organs that turn into nymphs on removal
 - type: entity
   id: OrganDionaBrainNymph
+  categories: [ HideSpawnMenu ]
   parent: OrganDionaBrain
-  name: diona brain
+  name: diona nymph brain
   suffix: Diona
   description: "The source of incredible, unending intelligence. Honk."
   components:
@@ -140,9 +141,10 @@
 
 - type: entity
   id: OrganDionaStomachNymph
+  categories: [ HideSpawnMenu ]
   parent: OrganDionaStomach
-  name: diona stomach
-  suffix: Diona
+  name: diona nymph stomach
+  suffix: Diona Nymph
   description: "Gross. This is hard to stomach."
   components:
   - type: Nymph
@@ -150,9 +152,10 @@
 
 - type: entity
   id: OrganDionaLungsNymph
+  categories: [ HideSpawnMenu ]
   parent: OrganDionaLungs
-  name: diona lungs
-  suffix: Diona
+  name: diona nymph lungs
+  suffix: Diona Nymph
   description: "Filters oxygen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier."
   components:
   - type: Nymph
@@ -161,6 +164,7 @@
 # Nymphs that the organs will turn into
 - type: entity
   id: OrganDionaNymphBrain
+  categories: [ HideSpawnMenu ]
   parent: MobDionaNymph #starlight Nubody will not pass.
   name: diona nymph
   suffix: Diona Nymph
@@ -174,6 +178,7 @@
 
 - type: entity
   id: OrganDionaNymphStomach
+  categories: [ HideSpawnMenu ]
   parent: MobDionaNymphAccent #starlight Nubody will not pass.
   name: diona nymph stomach
   suffix: Diona Nymph
@@ -187,6 +192,7 @@
 
 - type: entity
   id: OrganDionaNymphLungs
+  categories: [ HideSpawnMenu ]
   parent: MobDionaNymphAccent #starlight Nubody will not pass.
   name: diona nymph lungs
   suffix: Diona Nymph

--- a/Resources/Prototypes/_Starlight/Body/Organs/diona.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/diona.yml
@@ -28,7 +28,8 @@
 - type: entity
   id: OrganDionaBrain
   parent: [BaseOrganBrain, BaseDionaOrgan]
-  name: brain
+  name: diona brain
+  suffix: Diona
   description: "The central hub of a diona's pseudo-neurological activity, its root-like tendrils search for its former body."
   components:
   - type: Sprite
@@ -38,7 +39,8 @@
 - type: entity
   id: OrganDionaEyes
   parent: [BaseDionaOrgan, BaseOrganEyes]
-  name: eyes
+  name: diona eyes
+  suffix: Diona
   description: "I see you!"
   components:
   - type: Sprite
@@ -55,7 +57,8 @@
 - type: entity
   id: OrganDionaStomach
   parent: [BaseDionaOrgan, BaseOrganStomach]
-  name: stomach
+  name: diona stomach
+  suffix: Diona
   description: "The diona's equivalent of a stomach, it reeks of asparagus and vinegar."
   components:
   - type: Sprite
@@ -88,7 +91,8 @@
 - type: entity
   id: OrganDionaLungs
   parent: [BaseDionaOrgan, BaseOrganLungs]
-  name: lungs
+  name: diona lungs
+  suffix: Diona
   description: "A spongy mess of slimy, leaf-like structures. Capable of breathing both carbon dioxide and oxygen."
   components:
   - type: Sprite
@@ -125,8 +129,8 @@
 - type: entity
   id: OrganDionaBrainNymph
   parent: OrganDionaBrain
-  categories: [ HideSpawnMenu ]
-  name: brain
+  name: diona brain
+  suffix: Diona
   description: "The source of incredible, unending intelligence. Honk."
   components:
   - type: Brain
@@ -137,8 +141,8 @@
 - type: entity
   id: OrganDionaStomachNymph
   parent: OrganDionaStomach
-  categories: [ HideSpawnMenu ]
-  name: stomach
+  name: diona stomach
+  suffix: Diona
   description: "Gross. This is hard to stomach."
   components:
   - type: Nymph
@@ -147,8 +151,8 @@
 - type: entity
   id: OrganDionaLungsNymph
   parent: OrganDionaLungs
-  categories: [ HideSpawnMenu ]
-  name: lungs
+  name: diona lungs
+  suffix: Diona
   description: "Filters oxygen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier."
   components:
   - type: Nymph
@@ -158,9 +162,8 @@
 - type: entity
   id: OrganDionaNymphBrain
   parent: MobDionaNymph #starlight Nubody will not pass.
-  categories: [ HideSpawnMenu ]
   name: diona nymph
-  suffix: Brain
+  suffix: Diona Nymph
   description: Contains the brain of a formerly fully-formed Diona. Killing this would kill the Diona forever. You monster.
   components:
   - type: IsDeadIC
@@ -172,9 +175,8 @@
 - type: entity
   id: OrganDionaNymphStomach
   parent: MobDionaNymphAccent #starlight Nubody will not pass.
-  categories: [ HideSpawnMenu ]
-  name: diona nymph
-  suffix: Stomach
+  name: diona nymph stomach
+  suffix: Diona Nymph
   description: Contains the stomach of a formerly fully-formed Diona. It doesn't taste any better for it.
   components:
   - type: IsDeadIC
@@ -186,9 +188,8 @@
 - type: entity
   id: OrganDionaNymphLungs
   parent: MobDionaNymphAccent #starlight Nubody will not pass.
-  categories: [ HideSpawnMenu ]
-  name: diona nymph
-  suffix: Lungs
+  name: diona nymph lungs
+  suffix: Diona Nymph
   description: Contains the lungs of a formerly fully-formed Diona. Breathtaking.
   components:
   - type: IsDeadIC

--- a/Resources/Prototypes/_Starlight/Body/Organs/diona.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/diona.yml
@@ -131,7 +131,7 @@
   categories: [ HideSpawnMenu ]
   parent: OrganDionaBrain
   name: diona nymph brain
-  suffix: Diona
+  suffix: Diona Nymph
   description: "The source of incredible, unending intelligence. Honk."
   components:
   - type: Brain

--- a/Resources/Prototypes/_Starlight/Body/Organs/dwarf.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/dwarf.yml
@@ -2,6 +2,7 @@
   id: OrganDwarfHeart
   parent: OrganHumanHeart
   name: dwarf heart
+  suffix: Dwarf
   components:
   - type: Metabolizer
     metabolizerTypes: [Dwarf, Protogen]
@@ -10,6 +11,7 @@
   id: OrganDwarfLiver
   parent: OrganHumanLiver
   name: dwarf liver
+  suffix: Dwarf
   components:
   - type: Metabolizer
     metabolizerTypes: [Dwarf]
@@ -18,6 +20,7 @@
   id: OrganDwarfStomach
   parent: OrganHumanStomach
   name: dwarf stomach
+  suffix: Dwarf
   components:
   - type: Sprite
     state: stomach

--- a/Resources/Prototypes/_Starlight/Body/Organs/felionoid.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/felionoid.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: OrganFelionoidEyes
   parent: OrganHumanEyes
-  name: eyes
+  name: felionoid eyes
   suffix: Felionoid
   description: "The eyes of a Felionoid."
   components:

--- a/Resources/Prototypes/_Starlight/Body/Organs/lagomorph.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/lagomorph.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: OrganLagomorphEyes
   parent: OrganHumanEyes
-  name: eyes
+  name: lagomorph eyes
   suffix: Lagomorph
   description: "Couldn't have seen that one coming."
   components:
@@ -13,8 +13,9 @@
 - type: entity
   id: OrganLagomorphStomach
   parent: [OrganAnimalStomach, BaseOrganStomach]
-  name: stomach
-  description: "Gross. This is hard to stomach."
+  name: lagomorph stomach
+  suffix: Lagomorph
+  description: "Yearns for fresh produce."
   components:
   - type: Sprite
     sprite: Mobs/Species/Human/organs.rsi
@@ -37,8 +38,9 @@
 - type: entity
   id: OrganLagomorphHeart
   parent: OrganAnimalHeart
-  name: heart
-  description: "Gross. This is hard to stomach."
+  name: lagomorph heart
+  suffix: Lagomorph
+  description: "The rapidly beating heart of a Lagomorph."
   components:
   - type: Sprite
     sprite: Mobs/Species/Human/organs.rsi

--- a/Resources/Prototypes/_Starlight/Body/Organs/moth.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/moth.yml
@@ -1,9 +1,9 @@
 - type: entity
   id: OrganMothEyes
   parent: OrganHumanEyes
-  name: eyes
+  name: moth eyes
   suffix: Moth
-  description: "Moth eyes are very big, to catch the light"
+  description: "Large compound eyes used to catch light."
   components:
   - type: OrganVisualization
     layer: Eyes
@@ -13,7 +13,9 @@
 - type: entity
   id: OrganMothStomach
   parent: [OrganAnimalStomach, OrganHumanStomach]
-  categories: [ HideSpawnMenu ]
+  name: moth stomach
+  description: "A stomach specialized for digesting normally inedible cloth."
+  suffix: Moth
   components:
   - type: Stomach
     specialDigestible:

--- a/Resources/Prototypes/_Starlight/Body/Organs/rat.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/rat.yml
@@ -1,7 +1,9 @@
 - type: entity
   id: OrganRatLungs
   parent: OrganHumanLungs
-  suffix: "rat"
+  name: rat lungs
+  description: "It ain't easy to stay breathing in these tunnels."
+  suffix: Rat
   components:
   - type: Metabolizer
     metabolizerTypes: [ Rat ]
@@ -9,7 +11,9 @@
 - type: entity
   id: OrganRatStomach
   parent: OrganAnimalStomach
-  suffix: "rat"
+  name: rat stomach
+  description: "Yearns for cheese."
+  suffix: Rat
   components:
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/_Starlight/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/reptilian.yml
@@ -1,7 +1,8 @@
 ﻿- type: entity
   id: OrganReptilianStomach
   parent: [OrganAnimalStomach, BaseOrganStomach]
-  categories: [ HideSpawnMenu ]
+  name: reptilian stomach
+  suffix: Reptilian
   components:
   - type: Stomach
     specialDigestible:

--- a/Resources/Prototypes/_Starlight/Body/Organs/resomi.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/resomi.yml
@@ -1,9 +1,9 @@
 - type: entity
   id: OrganResomiEyes
   parent: OrganHumanEyes
-  name: eyes
+  name: resomi eyes
   suffix: Resomi
-  description: "Resomi eyes have great nightvision for hunting prey in maintenance tunnels."
+  description: "Resomi eyes have great night vision for hunting prey in maintenance tunnels, but are very sensitive to bright flashes."
   components:
   - type: OrganVisualization
     layer: Eyes
@@ -19,8 +19,9 @@
 - type: entity # Starlight
   id: OrganResomiHeart
   parent: OrganHumanHeart
+  name: resomi heart
   suffix: Resomi
-  description: "The heart of a resomi."
+  description: "The heart of a Resomi."
   components:
   - type: Metabolizer
     maxReagents: 2
@@ -36,9 +37,9 @@
 - type: entity
   id: OrganResomiLiver
   parent: OrganHumanLiver
-  name: liver
+  name: resomi liver
   suffix: Resomi
-  description: "The liver of a resomi."
+  description: "The liver of a Resomi."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Resomi/organs.rsi
@@ -47,9 +48,9 @@
 - type: entity
   id: OrganResomiKidneys
   parent: OrganHumanKidneys
-  name: kidney
+  name: resomi kidney
   suffix: Resomi
-  description: "The kidneys of a resomi."
+  description: "The kidneys of a Resomi."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Resomi/organs.rsi
@@ -60,9 +61,9 @@
 - type: entity
   id: OrganResomiLungs
   parent: OrganHumanLungs
-  name: lungs
+  name: resomi lungs
   suffix: Resomi
-  description: "The lungs of a resomi."
+  description: "The lungs of a Resomi."
   components:
   - type: Metabolizer
     removeEmpty: true
@@ -81,9 +82,9 @@
 - type: entity
   id: OrganResomiBrain
   parent: OrganHumanBrain
-  name: brain
+  name: resomi brain
   suffix: Resomi
-  description: "The brain of a Resomi. Where Resomi think of evil thoughts."
+  description: "Where Resomi think evil thoughts."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Resomi/organs.rsi
@@ -92,9 +93,9 @@
 - type: entity
   id: OrganResomiStomach
   parent: OrganHumanStomach
-  name: stomach
+  name: resomi stomach
   suffix: Resomi
-  description: "The dual chamber stomach of a resomi."
+  description: "The dual chamber stomach of a Resomi."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Resomi/organs.rsi

--- a/Resources/Prototypes/_Starlight/Body/Organs/rodentia.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/rodentia.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: OrganRodentiaEyes
   parent: OrganHumanEyes
-  name: eyes
+  name: rodentia eyes
   suffix: Rodentia
   description: "The beady eyes of a Rodentia."
   components:
@@ -13,7 +13,7 @@
 - type: entity
   id: OrganRodentiaStomach
   parent: OrganHumanStomach
-  name: stomach
+  name: rodentia stomach
   suffix: Rodentia
   description: "The resistant stomach of a Rodentia."
   components:
@@ -23,7 +23,7 @@
 - type: entity
   id: OrganRodentiaHeart
   parent: OrganHumanHeart
-  name: heart
+  name: rodentia heart
   suffix: Rodentia
   description: "The animal-like heart of a Rodentia."
   components:

--- a/Resources/Prototypes/_Starlight/Body/Organs/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/shadekin.yml
@@ -1,6 +1,8 @@
 - type: entity
   id: OrganShadekinBrain
   parent: OrganHumanBrain
+  name: shadekin brain
+  suffix: Shadekin
   description: "The source of incredible, unending intelligence. Marr."
   components:
   - type: Sprite
@@ -10,8 +12,9 @@
 - type: entity
   id: OrganShadekinEyes
   parent: OrganHumanEyes
+  name: shadekin eyes
   suffix: Shadekin
-  description: "Eyes of a BlackEye shadekin that can never see their home reality again."
+  description: "Eyes of a Black-eye shadekin that can never see their home reality again. These eyes have excellent night vision, but are very sensitive to bright flashes as a result."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi
@@ -34,7 +37,9 @@
 - type: entity
   id: OrganShadekinTongue
   parent: OrganHumanTongue
+  name: shadekin tongue
   suffix: Shadekin
+  description: "Used to marr and occasionally wurble."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi
@@ -43,6 +48,7 @@
 - type: entity
   id: OrganShadekinAppendix
   parent: OrganHumanAppendix
+  name: shadekin appendix
   suffix: Shadekin
   components:
   - type: Sprite
@@ -53,6 +59,7 @@
 - type: entity
   id: OrganShadekinHeart
   parent: OrganHumanHeart
+  name: shadekin heart
   suffix: Shadekin
   components:
   - type: Sprite
@@ -62,6 +69,7 @@
 - type: entity
   id: OrganShadekinStomach
   parent: OrganHumanStomach
+  name: shadekin stomach
   suffix: Shadekin
   components:
   - type: Sprite
@@ -80,6 +88,7 @@
 - type: entity
   id: OrganShadekinLiver
   parent: OrganHumanLiver
+  name: shadekin liver
   suffix: Shadekin
   components:
   - type: Sprite
@@ -89,6 +98,7 @@
 - type: entity
   id: OrganShadekinKidneys
   parent: OrganHumanKidneys
+  name: shadekin kidneys
   suffix: Shadekin
   components:
   - type: Sprite
@@ -100,6 +110,7 @@
   id: OrganShadekinCore
   parent: BaseItem
   name: shadekin core
+  suffix: Shadekin
   description: A core of a shadekin, a mysterious and powerful organ that seems to be the source of their energy.
   components:
   - type: OrganShadekinCore
@@ -119,7 +130,7 @@
   id: OrganShadekinCoreUndamaged
   parent: OrganShadekinCore
   name: bright-eye core
-  suffix: Undamaged
+  suffix: Bright-eye
   components:
   - type: OrganShadekinCore
     damaged: false

--- a/Resources/Prototypes/_Starlight/Body/Organs/shadekin.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/shadekin.yml
@@ -14,7 +14,7 @@
   parent: OrganHumanEyes
   name: shadekin eyes
   suffix: Shadekin
-  description: "Eyes of a Black-eye shadekin that can never see their home reality again. These eyes have excellent night vision, but are very sensitive to bright flashes as a result."
+  description: "Eyes of a Black-eye Shadekin that can never see their home reality again. These eyes have excellent night vision, but are very sensitive to bright flashes as a result."
   components:
   - type: Sprite
     sprite: _Starlight/Mobs/Species/Shadekin/organs.rsi
@@ -111,7 +111,7 @@
   parent: BaseItem
   name: shadekin core
   suffix: Shadekin
-  description: A core of a shadekin, a mysterious and powerful organ that seems to be the source of their energy.
+  description: A core of a Shadekin, a mysterious and powerful organ that seems to be the source of their energy.
   components:
   - type: OrganShadekinCore
   - type: Organ

--- a/Resources/Prototypes/_Starlight/Body/Organs/slime.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/slime.yml
@@ -2,6 +2,7 @@
   id: SentientSlimeCore
   parent: [BaseItem, BaseOrganBrain]
   name: sentient slime core
+  suffix: Slime
   description: "The source of incredible, unending gooeyness."
   components:
     - type: Sprite
@@ -31,6 +32,7 @@
   id: OrganSlimeLungs
   parent: [BaseHumanOrgan, BaseOrganLungs]
   name: slime gas sacs
+  suffix: Slime
   description: "Collects nitrogen, which slime cells use for maintenance."
   components:
   - type: Sprite
@@ -70,6 +72,7 @@
   id: OrganSlimeHeart
   parent: [BaseHumanOrgan, BaseOrganHeart]
   name: slime circulator
+  suffix: Slime
   description: "A little circulator what makes the fluid move through the slime body."
   components:
   - type: Sprite
@@ -92,6 +95,7 @@
   id: OrganSlimePeepoids
   parent: [BaseHumanOrgan, BaseOrganEyes]
   name: peepoids
+  suffix: Slime
   description: "Primitive and goopy, but more or less just as good as the human equivalent."
   components:
   - type: Sprite
@@ -109,6 +113,7 @@
   id: OrganSlimeSlurpoid
   parent: OrganHumanTongue
   name: slurpoid
+  suffix: Slime
   description: "It has all the consistency of gelatin."
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Organs/thaven.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/thaven.yml
@@ -2,6 +2,7 @@
   id: OrganThavenBrain
   parent: [BaseItem, OrganHumanBrain]
   name: thaven brain
+  suffix: Thaven
   description: "An organic positronic brain. Quite remarkable, really."
   components:
     - type: BorgBrain
@@ -12,7 +13,7 @@
 - type: entity
   id: OrganThavenEyes
   parent: OrganHumanEyes
-  name: eyes
+  name: thaven eyes
   suffix: Thaven
   description: "The eyes of a Thaven."
   components:

--- a/Resources/Prototypes/_Starlight/Body/Organs/vox.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/vox.yml
@@ -2,6 +2,7 @@
   parent: OrganHumanBrain
   id: OrganVoxBrain
   name: vox cortical stack
+  suffix: Vox
   description: "A cortical stack from a vox, time to find a new sleeve."
   components:
   - type: BorgBrain
@@ -30,8 +31,9 @@
 - type: entity
   id: OrganVoxLungs
   parent: OrganHumanLungs
+  name: vox lungs
   description: "The blue, anaerobic lungs of a vox, they intake nitrogen to breathe. Any form of gaseous oxygen is lethally toxic if breathed in."
-  suffix: "vox"
+  suffix: Vox
   components:
   - type: Sprite
     sprite: Mobs/Species/Vox/organs.rsi
@@ -46,7 +48,8 @@
 - type: entity
   parent: OrganHumanStomach
   id: OrganVoxStomach
-  name: stomach
+  name: vox stomach
+  suffix: Vox
   description: "A stomach that smells of ammonia."
   components:
   - type: Metabolizer #Skreeeee!
@@ -63,7 +66,8 @@
 - type: entity
   parent: OrganHumanLiver
   id: OrganVoxLiver
-  name: liver
+  name: vox liver
+  suffix: Vox
   description: "Smells flammable."
   components:
   - type: Metabolizer
@@ -84,7 +88,8 @@
 - type: entity
   parent: OrganHumanHeart
   id: OrganVoxHeart
-  name: heart
+  name: vox heart
+  suffix: Vox
   description: "The strange heart of a vox."
   components:
   - type: Metabolizer
@@ -95,7 +100,8 @@
 - type: entity
   parent: OrganHumanKidneys
   id: OrganVoxKidneys
-  name: kidney
+  name: vox kidneys
+  suffix: Vox
   description: "Smells flammable."
   components:
   - type: Metabolizer
@@ -106,7 +112,8 @@
 - type: entity
   id: OrganVoxEyes
   parent: OrganHumanEyes
-  name: eyes
+  name: vox eyes
+  suffix: Vox
   components:
   - type: Sprite
     sprite: Mobs/Species/Vox/organs.rsi
@@ -124,7 +131,8 @@
 - type: entity
   id: OrganVoxTongueA
   parent: OrganHumanTongue
-  name: tongue
+  name: vox tongue
+  suffix: Vox
   description: "A fleshy muscle mostly used for screaming."
   components:
   - type: Sprite
@@ -135,7 +143,8 @@
 - type: entity
   id: OrganVoxTongueB
   parent: OrganHumanTongue
-  name: tongue
+  name: vox tongue
+  suffix: Vox
   description: "A fleshy muscle mostly used for screaming."
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Organs/vox.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/vox.yml
@@ -129,19 +129,7 @@
 # Starlight End
 
 - type: entity
-  id: OrganVoxTongueA
-  parent: OrganHumanTongue
-  name: vox tongue
-  suffix: Vox
-  description: "A fleshy muscle mostly used for screaming."
-  components:
-  - type: Sprite
-    sprite: Mobs/Species/Vox/organs.rsi
-  - type: Item
-    size: Small
-
-- type: entity
-  id: OrganVoxTongueB
+  id: OrganVoxTongue
   parent: OrganHumanTongue
   name: vox tongue
   suffix: Vox

--- a/Resources/Prototypes/_Starlight/Body/Organs/vulpkanin.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/vulpkanin.yml
@@ -1,7 +1,8 @@
 ﻿- type: entity
   id: OrganVulpkaninHeart
   parent: OrganAnimalHeart
-  name: heart
+  name: vulpkanin heart
+  suffix: Vulpkanin
   description: "A disgustingly hyperactive pump designed to keep things animate."
   components:
     - type: Metabolizer
@@ -10,9 +11,9 @@
 - type: entity
   id: OrganVulpkaninStomach
   parent: [OrganAnimalStomach, BaseOrganStomach] # Starlight - add BaseOrganStomach
-  name: stomach # Starlight
-  description: "Gross. This is hard to stomach." # Starlight
-  #categories: [ HideSpawnMenu ] # Starlight
+  name: vulpkanin stomach # Starlight
+  suffix: Vulpkanin
+  description: "A nearly bottomless caloric pit." # Starlight
   components:
     # Starlight start
     - type: Sprite

--- a/Resources/Prototypes/_Starlight/Body/Parts/animal.yml
+++ b/Resources/Prototypes/_Starlight/Body/Parts/animal.yml
@@ -33,9 +33,9 @@
 
 - type: entity
   id: HandsAnimal
+  categories: [ HideSpawnMenu ]
   name: animal hands
   parent: PartAnimal
-  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     layers:
@@ -48,8 +48,8 @@
 - type: entity
   parent: PartAnimal
   id: LeftHandAnimal
-  name: left animal hand
   categories: [ HideSpawnMenu ]
+  name: left animal hand
   components:
   - type: Sprite
     layers:
@@ -61,8 +61,8 @@
 - type: entity
   parent: PartAnimal
   id: RightHandAnimal
-  name: right animal hand
   categories: [ HideSpawnMenu ]
+  name: right animal hand
   components:
   - type: Sprite
     layers:
@@ -73,9 +73,9 @@
 
 - type: entity
   id: LegsAnimal
+  categories: [ HideSpawnMenu ]
   name: animal legs
   parent: PartAnimal
-  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     layers:
@@ -87,9 +87,9 @@
 
 - type: entity
   id: FeetAnimal
+  categories: [ HideSpawnMenu ]
   name: animal feet
   parent: PartAnimal
-  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     layers:
@@ -100,9 +100,9 @@
 
 - type: entity
   id: TorsoAnimal
+  categories: [ HideSpawnMenu ]
   name: animal torso
   parent: PartAnimal
-  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     layers:
@@ -121,9 +121,9 @@
 
 - type: entity
   id: HeadAnimal
+  categories: [ HideSpawnMenu ]
   name: animal head
   parent: PartAnimal
-  categories: [ HideSpawnMenu ]
   components:
     - type: Sprite
       layers:
@@ -134,8 +134,8 @@
 - type: entity
   parent: PartAnimal
   id: LeftHandSmartCorgi
-  name: corgi hand
   categories: [ HideSpawnMenu ]
+  name: corgi hand
   components:
   - type: Sprite
     layers:
@@ -147,8 +147,8 @@
 - type: entity
   parent: PartAnimal
   id: RightHandSmartCorgi
-  name: corgi hand
   categories: [ HideSpawnMenu ]
+  name: corgi hand
   components:
   - type: Sprite
     layers:
@@ -157,9 +157,35 @@
     partType: Hand
     symmetry: Right
 
+# Borgi Animal Body
+
 - type: entity
-  id: OrganCorgiLungs
-  parent: OrganAnimalLungs
+  parent: PartAnimal
+  id: LeftHandAdmemeCorgi
+  categories: [ HideSpawnMenu ]
+  name: corgi hand
+  suffix: Corgi
   components:
-  - type: Lung
-    alert: CorgiLowOxygen
+  - type: Sprite
+    layers:
+    - state: l_hand
+  - type: BodyPart
+    partType: Hand
+    symmetry: Left
+
+- type: entity
+  parent: PartAnimal
+  id: RightHandAdmemeCorgi
+  categories: [ HideSpawnMenu ]
+  name: corgi hand
+  suffix: Corgi
+  components:
+  - type: Sprite
+    layers:
+    - state: r_hand
+  - type: BodyPart
+    partType: Hand
+    symmetry: Right
+
+
+

--- a/Resources/Prototypes/_Starlight/Body/Prototypes/arachnid.yml
+++ b/Resources/Prototypes/_Starlight/Body/Prototypes/arachnid.yml
@@ -10,7 +10,7 @@
       organs:
         brain: OrganHumanBrain
         eyes: OrganArachnidEyes
-        tongue: OrganHumanTongue
+        tongue: OrganArachnidTongue
         eye_implant: null
         brain_implant: null # 🌟Starlight🌟
     torso:

--- a/Resources/Prototypes/_Starlight/Body/Prototypes/vox.yml
+++ b/Resources/Prototypes/_Starlight/Body/Prototypes/vox.yml
@@ -10,7 +10,7 @@
       organs:
         brain: OrganVoxBrain # starlight
         eyes: OrganVoxEyes
-        tongue: OrganHumanTongue
+        tongue: OrganVoxTongue
         eye_implant: null
         brain_implant: null # 🌟Starlight🌟
     torso:

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Resomi.xml
@@ -32,7 +32,7 @@
   Using HUD variants allows you to keep your innate vision, at the cost of losing flash immunity.
   You can configure if you start with glasses or HUD in the loadouts for all relevant roles.
   <Box>
-    <GuideEntityEmbed Entity="ClothingEyesGlassesSecurity" Scale="5" Caption="Security Glasses\nNo Night vision\nHas flash immunity"/>
+    <GuideEntityEmbed Entity="ClothingEyesGlassesSecurity" Scale="5" Caption="Security Glasses\nNo night vision\nHas flash immunity"/>
     <GuideEntityEmbed Entity="ClothingEyesHudSecurity" Scale="5" Caption="Security Hud\nNight vision\nNo flash immunity"/>
   </Box>
   ## Flash Duration

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Resomi.xml
@@ -25,15 +25,15 @@
   Resomi station identities will list their nickname first, followed by their pack name. For example, [color=yellow]Tashira, Darkfeathers Pack[/color].
   Some Resomi forego this system and go by other nicknames or names.
 
-  ## Nightvision
+  ## Night Vision
   Resomi have a innate night vision given to them by their eyes.
   This allows them to see in pure darkness farther than any normal handheld lightsource would provide.
   They will have normal vision when wearing any equipment that provides flash immunity.
   Using HUD variants allows you to keep your innate vision, at the cost of losing flash immunity.
   You can configure if you start with glasses or HUD in the loadouts for all relevant roles.
   <Box>
-    <GuideEntityEmbed Entity="ClothingEyesGlassesSecurity" Scale="5" Caption="Security Glasses\nNo Nightvision\nHas flash immunity"/>
-    <GuideEntityEmbed Entity="ClothingEyesHudSecurity" Scale="5" Caption="Security Hud\nNightvision\nNo flash immunity"/>
+    <GuideEntityEmbed Entity="ClothingEyesGlassesSecurity" Scale="5" Caption="Security Glasses\nNo Night vision\nHas flash immunity"/>
+    <GuideEntityEmbed Entity="ClothingEyesHudSecurity" Scale="5" Caption="Security Hud\nNight vision\nNo flash immunity"/>
   </Box>
   ## Flash Duration
   Due to their eyes being more sensitive to light, Resomi will be stunned for a longer duration when flashed.

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Resomi.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Resomi.xml
@@ -26,7 +26,7 @@
   Some Resomi forego this system and go by other nicknames or names.
 
   ## Nightvision
-  Resomi have a innate nightvision given to them by their eyes.
+  Resomi have a innate night vision given to them by their eyes.
   This allows them to see in pure darkness farther than any normal handheld lightsource would provide.
   They will have normal vision when wearing any equipment that provides flash immunity.
   Using HUD variants allows you to keep your innate vision, at the cost of losing flash immunity.

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Shadekin.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Shadekin.xml
@@ -31,20 +31,20 @@
   There are instances as well of some Shadekin whom have become acclimated to provide their own titles, replacing previous ones.
   This is not an aspect taken lightly by them nor other Shadekin, such a decision is akin to throwing away their previous selves.
 
-  ## Nightvision
+  ## Night Vision
   Shadekin due to their natural adaptation to their home dimension have innate night vision.
   Capable of seeing and viewing things even in the most abyss-like darknesses, not needing any form of light providing device.
   When wearing flash resistant equipment their vision will be normal.
   This can be easily sorted by the Shadekin wearing a HUD variant, no longer having flash resistance, but keeping the utility that their night vision and the HUD provide.
   <Box>
-    <GuideEntityEmbed Entity="ClothingEyesGlassesSecurity" Scale="5" Caption="Security Glasses\nNo Nightvision\nHas flash immunity"/>
-    <GuideEntityEmbed Entity="ClothingEyesHudSecurity" Scale="5" Caption="Security Hud\nNightvision\nNo flash immunity"/>
+    <GuideEntityEmbed Entity="ClothingEyesGlassesSecurity" Scale="5" Caption="Security Glasses\nNo Night vision\nHas flash immunity"/>
+    <GuideEntityEmbed Entity="ClothingEyesHudSecurity" Scale="5" Caption="Security Hud\nNight vision\nNo flash immunity"/>
   </Box>
 
   ## LIGHT SENSITIVITY
   [color=yellow]Light Exposure: Dark[/color]
   - Passive Regeneration is buffed.
-  - Nightvision.
+  - Night Vision.
 
   [color=yellow]Light Exposure: Low[/color]
   - No Buffs/Nerfs.

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Shadekin.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Shadekin.xml
@@ -32,7 +32,7 @@
   This is not an aspect taken lightly by them nor other Shadekin, such a decision is akin to throwing away their previous selves.
 
   ## Nightvision
-  Shadekin due to their natural adaptation to their home dimension have innate Night-vision.
+  Shadekin due to their natural adaptation to their home dimension have innate night vision.
   Capable of seeing and viewing things even in the most abyss-like darknesses, not needing any form of light providing device.
   When wearing flash resistant equipment their vision will be normal.
   This can be easily sorted by the Shadekin wearing a HUD variant, no longer having flash resistance, but keeping the utility that their night vision and the HUD provide.

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Shadekin.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Shadekin.xml
@@ -37,7 +37,7 @@
   When wearing flash resistant equipment their vision will be normal.
   This can be easily sorted by the Shadekin wearing a HUD variant, no longer having flash resistance, but keeping the utility that their night vision and the HUD provide.
   <Box>
-    <GuideEntityEmbed Entity="ClothingEyesGlassesSecurity" Scale="5" Caption="Security Glasses\nNo Night vision\nHas flash immunity"/>
+    <GuideEntityEmbed Entity="ClothingEyesGlassesSecurity" Scale="5" Caption="Security Glasses\nNo night vision\nHas flash immunity"/>
     <GuideEntityEmbed Entity="ClothingEyesHudSecurity" Scale="5" Caption="Security Hud\nNight vision\nNo flash immunity"/>
   </Box>
 

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Shadekin.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Shadekin.xml
@@ -35,7 +35,7 @@
   Shadekin due to their natural adaptation to their home dimension have innate Night-vision.
   Capable of seeing and viewing things even in the most abyss-like darknesses, not needing any form of light providing device.
   When wearing flash resistant equipment their vision will be normal.
-  This can be easily sorted by the Shadekin wearing a HUD variant, no longer having flash resistance, but keeping the utility that their nightvision and the HUD provide.
+  This can be easily sorted by the Shadekin wearing a HUD variant, no longer having flash resistance, but keeping the utility that their night vision and the HUD provide.
   <Box>
     <GuideEntityEmbed Entity="ClothingEyesGlassesSecurity" Scale="5" Caption="Security Glasses\nNo Nightvision\nHas flash immunity"/>
     <GuideEntityEmbed Entity="ClothingEyesHudSecurity" Scale="5" Caption="Security Hud\nNightvision\nNo flash immunity"/>


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Maintenance work on the various organs we have for our species, follow up to #4892 after I saw how messy the organ files were.

**This _should_ not have any mechanical changes to organs within, just organizational and naming changes.**

**Organ Naming**:
- Added the `Suffix` tag to all organs. This was implemented extremely inconsistently, now it should be way more consistent.
- Most organs will say what species they come from. If it's eyes specific to a resomi, it'll say "resomi eyes". This was applied _incredibly_ inconsistently across organs in the game, and now it should be moderately more consistent.
- The big exception to the above is "generic" (human) organs. They don't specify they're human because a bunch of our species still use human organs.

**Miscellaneous Tidying**:
- Fixed typos in some descriptions - small stuff like "nightvision" (typo of "night vision")
- Added a few flavour descriptions to organs that didn't have any.
- Removed `HideSpawnMenu` from most organs, but applied it consistently across all Diona Nymph organs. Most of our organs weren't hidden from the spawn menu, but some still were. The nymph ones are weird and definitely should remain hidden.
- The Starlight animal organs folder contain zero organs but two Admeme hands, while Corgi lungs were in a Starlight animal _parts_ folder. I've put the Corgi lungs in the organs file and the Admeme hands in the parts file.

**Bugfixes**:
- Arachnids were using human tongues. There's an Arachnid tongue prototype. They now use Arachnid tongues.
- Vox had _two_ tongue prototypes and _neither_ were used. I've collapsed `OrganVoxTongueA` and `OrganVoxTongueB` into one organ `OrganBoxTongue` and made Vox use this tongue (they were using human tongues).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Improves consistency of how organs appear in the spawn menu - it sucks to see 20 different kinds of eyes but not know which one is the eyes you actually need to spawn for someone.

Also improves consistency for Surgeon players. You can just examine an organ to see what species its from if it doesn't have a unique sprite.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="607" height="791" alt="image" src="https://github.com/user-attachments/assets/8263bcc9-b472-477d-b8d7-e66cfafa2ff2" />
<img width="619" height="805" alt="image" src="https://github.com/user-attachments/assets/e60c94ad-85e0-413d-ab53-45eb3bcee08e" />

fig. 1 - Some examples of the spawn menu after this PR. Not every single organ is suffixed yet, but it's wayyy better.

<img width="547" height="443" alt="image" src="https://github.com/user-attachments/assets/8985618e-c8b5-4723-a179-ee95c691012c" />
<img width="529" height="458" alt="image" src="https://github.com/user-attachments/assets/226f8e01-2bae-4c91-a5ca-efe35e44c9d5" />

fig. 2 - Guidebook changes for Shadekin and Resomi where night vision is spelled consistently, not as "Nightvision" or "Night-vision"

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Most species organs are now consistently labelled as "(species name) (organ name)", e.g. "vox eyes" "resomi stomach" "vulpkanin heart", etc. Surgeons rejoice.
- fix: Arachnids now have arachnid tongues instead of human tongues.
- fix: Vox now have vox tongues instead of human tongues.

