### PR TITLE
Add concurrency groups and cancel old CI jobs on PRs

### DIFF
--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -1,5 +1,10 @@
 ﻿name: Build & Test Map Renderer
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [ master, staging, stable ]

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -1,5 +1,10 @@
 name: Build & Test Debug
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [ master, staging, stable, Starlight, starlight-dev, upstream-devtest, fix/tests ]

--- a/.github/workflows/changelog-validator.yml
+++ b/.github/workflows/changelog-validator.yml
@@ -3,7 +3,7 @@ name: Changelog Validator
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/changelog-validator.yml
+++ b/.github/workflows/changelog-validator.yml
@@ -1,5 +1,10 @@
 name: Changelog Validator
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -3,7 +3,7 @@
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -1,5 +1,10 @@
 ﻿name: EditorConfig Check
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/directory-validator.yml
+++ b/.github/workflows/directory-validator.yml
@@ -3,7 +3,7 @@ name: Check Starlight Directories
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/directory-validator.yml
+++ b/.github/workflows/directory-validator.yml
@@ -1,5 +1,10 @@
 name: Check Starlight Directories
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]

--- a/.github/workflows/labeler-conflict.yml
+++ b/.github/workflows/labeler-conflict.yml
@@ -1,5 +1,10 @@
 name: Check Merge Conflicts
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request_target:
     types:

--- a/.github/workflows/labeler-conflict.yml
+++ b/.github/workflows/labeler-conflict.yml
@@ -3,7 +3,7 @@ name: Check Merge Conflicts
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request_target:

--- a/.github/workflows/labeler-needsreview.yml
+++ b/.github/workflows/labeler-needsreview.yml
@@ -1,5 +1,10 @@
 ﻿name: "Labels: Needs Review"
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request_target:
     types: [review_requested, opened]

--- a/.github/workflows/labeler-needsreview.yml
+++ b/.github/workflows/labeler-needsreview.yml
@@ -3,7 +3,7 @@
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request_target:

--- a/.github/workflows/labeler-pr.yml
+++ b/.github/workflows/labeler-pr.yml
@@ -3,7 +3,7 @@
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
 - pull_request_target

--- a/.github/workflows/labeler-pr.yml
+++ b/.github/workflows/labeler-pr.yml
@@ -1,5 +1,10 @@
 ﻿name: "Labels: PR"
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
 - pull_request_target
 

--- a/.github/workflows/labeler-review.yml
+++ b/.github/workflows/labeler-review.yml
@@ -1,5 +1,10 @@
 name: "Labels: Review"
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review, edited, review_requested, review_request_removed]

--- a/.github/workflows/labeler-review.yml
+++ b/.github/workflows/labeler-review.yml
@@ -3,7 +3,7 @@ name: "Labels: Review"
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request_target:

--- a/.github/workflows/labeler-size.yml
+++ b/.github/workflows/labeler-size.yml
@@ -1,5 +1,12 @@
 name: "Labels: Size"
+
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on: pull_request_target
+
 jobs:
   size-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler-size.yml
+++ b/.github/workflows/labeler-size.yml
@@ -3,7 +3,7 @@ name: "Labels: Size"
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on: pull_request_target
 

--- a/.github/workflows/labeler-stable.yml
+++ b/.github/workflows/labeler-stable.yml
@@ -1,5 +1,10 @@
 name: "Labels: Branch stable"
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request_target:
     types:

--- a/.github/workflows/labeler-stable.yml
+++ b/.github/workflows/labeler-stable.yml
@@ -3,7 +3,7 @@ name: "Labels: Branch stable"
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request_target:

--- a/.github/workflows/labeler-staging.yml
+++ b/.github/workflows/labeler-staging.yml
@@ -1,5 +1,10 @@
 name: "Labels: Branch staging"
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request_target:
     types:

--- a/.github/workflows/labeler-staging.yml
+++ b/.github/workflows/labeler-staging.yml
@@ -3,7 +3,7 @@ name: "Labels: Branch staging"
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request_target:

--- a/.github/workflows/labeler-untriaged.yml
+++ b/.github/workflows/labeler-untriaged.yml
@@ -1,5 +1,10 @@
 ﻿name: "Labels: Untriaged"
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   issues:
     types: [opened]

--- a/.github/workflows/labeler-untriaged.yml
+++ b/.github/workflows/labeler-untriaged.yml
@@ -3,7 +3,7 @@
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 on:
   issues:

--- a/.github/workflows/no-submodule-update.yml
+++ b/.github/workflows/no-submodule-update.yml
@@ -3,7 +3,7 @@ name: No submodule update checker
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/no-submodule-update.yml
+++ b/.github/workflows/no-submodule-update.yml
@@ -1,5 +1,10 @@
 name: No submodule update checker
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -1,5 +1,10 @@
 name: Diff RSIs
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request_target:
     paths:

--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -3,7 +3,7 @@ name: Diff RSIs
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request_target:

--- a/.github/workflows/target-branch-validation.yml
+++ b/.github/workflows/target-branch-validation.yml
@@ -3,7 +3,7 @@ name: Check PR Target Branch
 # Cancel older jobs on PRs when new changes are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/target-branch-validation.yml
+++ b/.github/workflows/target-branch-validation.yml
@@ -1,5 +1,10 @@
 name: Check PR Target Branch
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -1,5 +1,10 @@
 ﻿name: Test Packaging
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [ master, staging, stable, Starlight ]

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -1,4 +1,10 @@
 name: RGA schema validator
+
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [ master, staging, stable, Starlight ]

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -1,5 +1,10 @@
 name: RSI Validator
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [ master, staging, stable, Starlight ]

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -1,4 +1,10 @@
 name: Map file schema validator
+
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [ master, staging, stable ]

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -1,5 +1,10 @@
 name: YAML Linter
 
+# Cancel older jobs on PRs when new changes are pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [ master, staging, stable, Starlight, starlight-dev ]


### PR DESCRIPTION

## Short description

When you push new changes to your PR, the old jobs are cancelled, and new ones are queued for the latest changes, instead of the old jobs continuing to exist/run.

Relevant docs here: https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

## Why we need to add this

If you push four times in rapid succession, basically all jobs on the PR are queued four times, including e.g. build-test-debug which triggers 8 sub-jobs. Older ones are not cancelled. This causes serious congestion and slow-downs of the merge queue as a result of worker exhaustion.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

N/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
