### PR TITLE
Include NullLink PlayTime in Requirements

### DIFF
--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
@@ -40,7 +40,6 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
     [Dependency] private IPrototypeManager _prototypes = default!;
     [Dependency] private SharedRoleSystem _roles = default!;
     [Dependency] private PlayTimeTrackingManager _tracking = default!;
-    [Dependency] private NullLinkPlayerManager _nullLinkPlayer = default!;
 
     public override void Initialize()
     {
@@ -219,18 +218,10 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
                 playTimes = outPlayTimes;
             }
 
-            // NullLink-start: NullLink PlayTime
+            // NullLink-start
 
-            if (_nullLinkPlayer.TryGetPlayerData(player.UserId, out var data))
+            if (_tracking.TryGetTrackerTimes(player, out var rolePlayTime))
             {
-                var rolePlayTime = data.RolePlayTimePerServer
-                    .SelectMany(server => server.Value)
-                    .GroupBy(x => x.Key)
-                    .ToDictionary(
-                        g => g.Key,
-                        g => new TimeSpan(g.Sum(x => x.Value.Ticks))
-                    );
-
                 playTimes ??= new Dictionary<string, TimeSpan>();
 
                 foreach (var (role, time) in rolePlayTime)

--- a/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
+++ b/Content.Server/Players/PlayTimeTracking/PlayTimeTrackingSystem.cs
@@ -7,7 +7,6 @@ using Content.Server.GameTicking;
 using Content.Server.GameTicking.Events;
 using Content.Server.Preferences.Managers;
 using Content.Server.Station.Events;
-using Content.Shared._Starlight;
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
 using Content.Shared.Mobs;
@@ -21,6 +20,10 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+
+#region NullLink
+using Content.Server._NullLink.PlayerData;
+#endregion
 
 namespace Content.Server.Players.PlayTimeTracking;
 
@@ -37,6 +40,7 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
     [Dependency] private IPrototypeManager _prototypes = default!;
     [Dependency] private SharedRoleSystem _roles = default!;
     [Dependency] private PlayTimeTrackingManager _tracking = default!;
+    [Dependency] private NullLinkPlayerManager _nullLinkPlayer = default!;
 
     public override void Initialize()
     {
@@ -214,6 +218,30 @@ public sealed partial class PlayTimeTrackingSystem : EntitySystem
             {
                 playTimes = outPlayTimes;
             }
+
+            // NullLink-start: NullLink PlayTime
+
+            if (_nullLinkPlayer.TryGetPlayerData(player.UserId, out var data))
+            {
+                var rolePlayTime = data.RolePlayTimePerServer
+                    .SelectMany(server => server.Value)
+                    .GroupBy(x => x.Key)
+                    .ToDictionary(
+                        g => g.Key,
+                        g => new TimeSpan(g.Sum(x => x.Value.Ticks))
+                    );
+
+                playTimes ??= new Dictionary<string, TimeSpan>();
+
+                foreach (var (role, time) in rolePlayTime)
+                {
+                    playTimes[role] = playTimes.TryGetValue(role, out var existing)
+                        ? existing + time
+                        : time;
+                }
+            }
+
+            // NullLink-end
         }
         return playTimes;
     }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Adds NullLink PlayTime in `GetPlayTimesIfEnabled`, so it will be included in Requirements to fix issue, when you can select some loadout options on alpha, but can't on beta.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Bugfix.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rinary
- fix: Fixed bug when character spawns without loadout options on beta because due to a lack of play time.