### PR TITLE
Disables jetpack jumping when not on a grid

### DIFF
--- a/Content.Shared/_Starlight/Actions/EntitySystems/SharedJumpSystem.cs
+++ b/Content.Shared/_Starlight/Actions/EntitySystems/SharedJumpSystem.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Map;
 using Content.Shared.Stunnable;
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
+using Content.Shared.Popups;
 
 namespace Content.Shared._Starlight.Actions.EntitySystems;
 
@@ -25,6 +26,7 @@ public abstract partial class SharedJumpSystem : EntitySystem
     [Dependency] private ActionContainerSystem _actionContainer = default!;
     [Dependency] private SharedStunSystem _stun = default!;
     [Dependency] private SharedChargesSystem _chargesSystem = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -98,12 +100,24 @@ public abstract partial class SharedJumpSystem : EntitySystem
         args.Handled = true;
     }
 
+    /// <summary>
+    /// Attempts to make this entity jump somewhere.
+    /// </summary>
+    /// <param name="performer">The entity performing the jump. In the case of jetpacks, the jetpack is the performer!</param>
+    /// <param name="target">The entity that will be moved by the jump.</param>
     private void Jump(EntityUid performer, EntityUid target, EntityCoordinates targetCoords, JumpActionEvent args)
     {
         var userTransform = Transform(target);
         var userMapCoords = _transform.GetMapCoordinates(userTransform);
 
-        if (args.FromGrid && !_mapMan.TryFindGridAt(userMapCoords, out _, out _)) return;
+        // check if this jump requires a grid to 'jump off of'
+        if (args.FromGrid && !_mapMan.TryFindGridAt(userMapCoords, out _, out _))
+        {
+            // tell the user why the jump failed
+            var msg = Loc.GetString(args.JumpFailPopup);
+            _popup.PopupClient(msg, target, target);
+            return;
+        }
 
         TryJump(performer, targetCoords, args, target, 15f, args.ToPointer, args.Sound, args.Distance);
     }

--- a/Content.Shared/_Starlight/Actions/Events/JumpActionEvent.cs
+++ b/Content.Shared/_Starlight/Actions/Events/JumpActionEvent.cs
@@ -6,27 +6,57 @@ namespace Content.Shared._Starlight.Actions.Events;
 [Virtual]
 public partial class JumpActionEvent : WorldTargetActionEvent
 {
+    /// <summary>
+    /// Distance in tiles to jump. Depending on speed, the distance will be slightly longer than expected
+    /// due to friction taking time to slow you down after landing.
+    /// </summary>
     [DataField]
     public float Distance = 5f;
 
+    /// <summary>
+    /// When true, the target will jump to the pointer's position precisely, including avoiding overshooting the pointer.
+    /// When false, the target will jump in the direction of the pointer, but can overshoot or undershoot the pointer.
+    /// </summary>
     [DataField]
     public bool ToPointer = true;
 
+    /// <summary>
+    /// Flag that determines if the user needs to be standing on a grid to have this jump actually move them.
+    /// Effectively prevents using jumping in space when set to true.
+    /// </summary>
     [DataField]
     public bool FromGrid = true;
 
+    /// <summary>
+    /// Speed of the jump.
+    /// </summary>
     [DataField]
     public float Speed = 15F;
 
+    /// <summary>
+    /// Sound effect to play when starting the jump.
+    /// </summary>
     [DataField]
     public SoundSpecifier? Sound = default;
 
+    /// <summary>
+    /// Flag that determines if this jump is from a cybernetic implant.
+    /// </summary>
     [DataField]
     public bool IsCybernetic = false;
+
+    /// <summary>
+    /// Message shown to the user if a jump fails.
+    /// </summary>
+    [DataField]
+    public string JumpFailPopup = "jump-failed-because-off-grid";
 }
 
 public sealed partial class JetJumpActionEvent : JumpActionEvent
 {
+    /// <summary>
+    /// Gas usage of one jump.
+    /// </summary>
     [DataField]
     public float MoleUsage = 0.24f; // 20x
 }

--- a/Resources/Locale/en-US/_Starlight/actions/actions/jump.ftl
+++ b/Resources/Locale/en-US/_Starlight/actions/actions/jump.ftl
@@ -1,0 +1,2 @@
+jump-failed-because-off-grid = There's nothing to jump off of!
+jump-failed-because-jetpack = Toggle the jetpack to navigate in zero-G.

--- a/Resources/Prototypes/_Starlight/Actions/jump.yml
+++ b/Resources/Prototypes/_Starlight/Actions/jump.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: Jump
   name: Jump
-  description: You jumps at the selected direction.
+  description: Jump toward your mouse cursor.
   categories: [ HideSpawnMenu ]
   components:
   - type: Action
@@ -83,8 +83,8 @@
   - type: WorldTargetAction
     event: !type:JetJumpActionEvent
       distance: 10
-      fromGrid: false
       toPointer: false
+      jumpFailPopup: jump-failed-because-jetpack
       sound:
         path: /Audio/_Starlight/Effects/Jump/jetpack.ogg
 
@@ -120,7 +120,7 @@
   - type: WorldTargetAction
     event: !type:JumpActionEvent
       distance: 10
-      fromGrid: false
       toPointer: false
+      jumpFailPopup: jump-failed-because-jetpack
       sound:
         path: /Audio/_Starlight/Effects/Jump/jetpack.ogg


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
This PR does two things:
- Disables the ability to use the jetpack's jumpjet action when not standing on a grid.
- Adds a message that tells you why a jump didn't work.
- Tweaked the jump action's text.

I added some comments to help explain what each of the jump parameters do also because they weren't documented before.

**Not in scope for this PR:**
- Making it so that if a jump fails, it doesn't go on cooldown.
- Making it so that moth's 'jump' works based on an atmosphere being present rather than being based on whether or not they're on a grid.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This PR was made in response to community feedback about jetpacks here: https://discord.com/channels/1272545509562777621/1518574223352664147

The short version is:
- You can already use jetpacks in space via the toggle action.
- Jetpacks have big particle trails to make jetpack space stuff easier to parse (tell where people are going, follow them even if they're going off screen in space). Jetpack jumps don't have this!
- The jetpack jump is just _too fast_ in space and you can shake people too easily with it.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="271" height="274" alt="image" src="https://github.com/user-attachments/assets/a5922c4a-4377-42ff-894f-f5e74fd50963" />

fig. 1 - Message that shows when you try to use a species jump when not on a grid.

<img width="355" height="287" alt="image" src="https://github.com/user-attachments/assets/70a9ed09-6585-4f9e-b416-8398a7d21af2" />

fig. 2 - Message that shows when you try to use a jetpack jump when not on a grid.

https://github.com/user-attachments/assets/33523a6f-f9fa-422f-850b-006fb567981f

fig. 3 - Video demo

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- add: Trying to jump as a resomi or moth when not on a grid will give you a pop-up message telling you why you couldn't jump (instead of silently failing).
- tweak: Jetpack jumping can no longer be used on space - you can only jetpack jump while on a grid.