### PR TITLE
Adds a magnet for the material silo

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/silo.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/silo.yml
@@ -17,7 +17,6 @@
         base:
           True: { state: silo_active }
           False: { state: silo }
-
   - type: OreSilo
   - type: MaterialStorage
     whitelist:

--- a/Resources/Prototypes/Entities/Structures/Machines/silo.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/silo.yml
@@ -17,6 +17,7 @@
         base:
           True: { state: silo_active }
           False: { state: silo }
+
   - type: OreSilo
   - type: MaterialStorage
     whitelist:
@@ -24,6 +25,27 @@
       - Sheet
       - RawMaterial
       - Ingot
+  # Starlight Edit Start - Add toggleable magnet pickup
+  - type: ItemToggle
+    onUse: false
+    onActivate: false
+    verbToggleOn: verb-toggle-magnet-activate
+    verbToggleOff: verb-toggle-magnet-deactivate
+    soundActivate:
+      collection: sparks
+      params:
+        variation: 0.250
+    soundDeactivate:
+      collection: sparks
+      params:
+        variation: 0.250
+  - type: AltUseToggle
+  - type: ComponentToggler
+    components:
+    - type: MagnetPickup
+      requiresEquipping: false
+      slotFlags: 0
+  # Starlight Edit End
   - type: ActivatableUI
     key: enum.OreSiloUiKey.Key
   - type: ActivatableUIRequiresPower


### PR DESCRIPTION
## Short description
Adds a magnet for the material silo

## Why we need to add this
So you dont need to put in materials one stack at a time

## Media (Video/Screenshots)
nah

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Scarlet Lightweaver and all the space stations.
- add: Added a magnet to the material silo departments hooray.