### PR TITLE
[Hotfix] Fix Ripleys being unable to pick up tamper-sealed crates

### DIFF
--- a/Content.Shared/_Starlight/Cargo/TamperSeal/SharedTamperSealSystem.cs
+++ b/Content.Shared/_Starlight/Cargo/TamperSeal/SharedTamperSealSystem.cs
@@ -73,7 +73,7 @@ public abstract partial class SharedTamperSealSystem : EntitySystem
     /// </summary>
     private void OnActivateInWorld(EntityUid uid, TamperSealComponent seal, ref ActivateInWorldEvent args)
     {
-        if (seal.Opened || args.Handled)
+        if (seal.Opened || args.Handled || !args.Complex)
             return;
 
         TryUnseal(uid, args.User, seal);


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Fixes Ripleys not picking up tamper-sealed crates.

Hotfix because tamper seals prevent combining multiple crates into one, so it makes the Ripley a must-use.. except it doesn't work.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Tamper seals prevent combining multiple crates into one, so it makes the Ripley a must-use.. except it's completely unable to pick up tamper-sealed crates!

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/00e4f913-1d99-4541-a9d0-d5fab4346c5c

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: Ripleys with hydraulic clamps can actually pick up tamper-sealed crates.
