### PR TITLE
Remove tamper seal integrity time-based record expungement

### DIFF
--- a/Content.Server/_Starlight/Cargo/TamperSeal/Components/TamperSealIntegrityTrackerComponent.cs
+++ b/Content.Server/_Starlight/Cargo/TamperSeal/Components/TamperSealIntegrityTrackerComponent.cs
@@ -1,4 +1,6 @@
+using JetBrains.Annotations;
 using Robust.Shared.Audio;
+using Robust.Shared.Serialization;
 
 namespace Content.Server._Starlight.Cargo.TamperSeal.Components;
 
@@ -12,43 +14,29 @@ public sealed partial class TamperSealIntegrityTrackerComponent : Component
     /// <summary>
     /// The ID of the station that this tracking component belongs to.
     /// </summary>
-    public EntityUid StationId;
-
-    #region History
-
-    /// <summary>
-    /// Historical tamper seal results.
-    /// </summary>
-    public List<TamperSealResult> Records { get; private set; } = new();
-
-    /// <summary>
-    /// The minimum number of records to keep in history. Only affects time-based record expungement.
-    /// </summary>
-    public int MinRecords = 10;
-
-    /// <summary>
-    /// The maximum number of records to keep in history.
-    /// </summary>
-    public int MaxRecords = 40;
-
-    /// <summary>
-    /// The maximum age of records to keep in history. Only affects time-based record expungement.
-    /// </summary>
-    public TimeSpan RecordLifetime = TimeSpan.FromMinutes(20);
-
-    #endregion
-    #region Judgement
+    [ViewVariables(VVAccess.ReadOnly)] public EntityUid StationId;
 
     /// <summary>
     /// Whether we're judging delivery performance.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    public bool JudgementEnabled = true;
+    [ViewVariables(VVAccess.ReadWrite)] public bool Enabled = true;
+
+    #region State
+
+    /// <summary>
+    /// Historical tamper seal results.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)] public Queue<TamperSealResult> Records = new(40);
 
     /// <summary>
     /// Minimum number of records required before judging.
     /// </summary>
-    public int? JudgementMinRecords = 8;
+    [ViewVariables(VVAccess.ReadWrite)] public int? MinRecords = 8;
+
+    /// <summary>
+    /// The maximum number of records to keep in history.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)] public int MaxRecords = 40;
 
     #endregion
     #region Failure
@@ -56,17 +44,23 @@ public sealed partial class TamperSealIntegrityTrackerComponent : Component
     /// <summary>
     /// Whether we are currently below the failure threshold, and as such have already sent an announcement.
     /// </summary>
-    public bool Failure = false;
+    [ViewVariables(VVAccess.ReadWrite)] public bool Failure = false;
+
+    /// <summary>
+    /// The last recorded success fraction.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly), UsedImplicitly]
+    public float SuccessFraction;
 
     /// <summary>
     /// When the delivery success rate falls below this threshold, we announce and set the failure flag.
     /// </summary>
-    public float FailureSetThreshold = .7f;
+    [ViewVariables(VVAccess.ReadWrite)] public float FailureSetThreshold = .7f;
 
     /// <summary>
     /// Once the success rate meets or exceeds this threshold, we clear the failure flag.
     /// </summary>
-    public float FailureClearThreshold = .8f;
+    [ViewVariables(VVAccess.ReadWrite)] public float FailureClearThreshold = .8f;
 
     /// <summary>
     /// The sound to play with the failure announcement.
@@ -81,6 +75,7 @@ public sealed partial class TamperSealIntegrityTrackerComponent : Component
     #endregion
 }
 
+[Serializable]
 public sealed class TamperSealResult(TimeSpan time, bool success)
 {
     public TimeSpan Time { get; } = time;

--- a/Content.Server/_Starlight/Cargo/TamperSeal/TamperSealIntegritySystem.cs
+++ b/Content.Server/_Starlight/Cargo/TamperSeal/TamperSealIntegritySystem.cs
@@ -53,14 +53,15 @@ public sealed partial class TamperSealIntegritySystem : EntitySystem
     /// </summary>
     private void ReassessPerformance(TamperSealIntegrityTrackerComponent tracker)
     {
-        if (!tracker.JudgementEnabled) return;
-        if (tracker.Records.Count < tracker.JudgementMinRecords) return;
-
+        // Before guards so we can read out the success fraction via VV.
         var successCount = tracker.Records.Count(x => x.Success);
-        var successRate = (float)successCount / tracker.Records.Count;
+        var successFraction = tracker.SuccessFraction = (float)successCount / tracker.Records.Count;
 
-        var shouldSet = successRate < tracker.FailureSetThreshold;
-        var shouldClear = successRate >= tracker.FailureClearThreshold;
+        if (!tracker.Enabled) return;
+        if (tracker.Records.Count < tracker.MinRecords) return;
+
+        var shouldSet = successFraction < tracker.FailureSetThreshold;
+        var shouldClear = successFraction >= tracker.FailureClearThreshold;
 
         // If state should change from "Not failing" to "Failing".
         if (shouldSet && !tracker.Failure)
@@ -88,37 +89,9 @@ public sealed partial class TamperSealIntegritySystem : EntitySystem
     private void RecordPerformance(TamperSealIntegrityTrackerComponent tracker, bool success)
     {
         var record = new TamperSealResult(_timing.CurTime, success);
-        tracker.Records.Add(record);
-
-        ExpungeOverflowedRecords(tracker);
-        ExpungeOutdatedRecords(tracker);
-    }
-
-    private void ExpungeOverflowedRecords(TamperSealIntegrityTrackerComponent tracker)
-    {
-        var records = tracker.Records;
-        var overflow = records.Count - tracker.MaxRecords;
-        if (overflow <= 0)
-            return;
-
-        records.RemoveRange(0, overflow);
-    }
-
-    private void ExpungeOutdatedRecords(TamperSealIntegrityTrackerComponent tracker)
-    {
-        var removable = tracker.Records.Count - tracker.MinRecords;
-        if (removable <= 0)
-            return;
-
-        var cutoff = _timing.CurTime - tracker.RecordLifetime;
-        for (var i = 0; i < removable; i++)
-        {
-            var record = tracker.Records[0];
-            if (record.Time >= cutoff)
-                break;
-
-            tracker.Records.RemoveAt(0);
-        }
+        if (tracker.Records.Count == tracker.MaxRecords)
+            tracker.Records.Dequeue();
+        tracker.Records.Enqueue(record);
     }
 
     private TamperSealIntegrityTrackerComponent GetTracker(EntityUid stationId)


### PR DESCRIPTION


## Short description
<!-- What do you propose to change with your PR? -->

- Remove time-based record expungement from the tamper seal integrity tracking.
- Simplify and make TamperSealIntegrityTracker more VV'able.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Turns out that the ITG announcing mail fraud when you _successfully_ open a crate is very confusing.

This happens because the time-based check only happens on update, but may remove e.g. 5 success records at once, causing it to drop below the threshold if the remaining records have a significant portion of failures.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="911" height="612" alt="image" src="https://github.com/user-attachments/assets/a6966398-25d5-4871-9ef1-31b096133c17" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: Changed the behavior of tamper-seal integrity tracking to be less confusing.
