### PR TITLE
Fix Dynamic Rule

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -364,6 +364,7 @@ namespace Content.Server.GameTicking
                 return;
 
             _startingRound = true;
+            RoundStartTimeSpan = _gameTiming.CurTime;
 
             if (RoundId == 0)
                 IncrementRoundNumber();
@@ -433,7 +434,6 @@ namespace Content.Server.GameTicking
             _roundStartDateTime = DateTime.UtcNow;
             RunLevel = GameRunLevel.InRound;
 
-            RoundStartTimeSpan = _gameTiming.CurTime;
             SendStatusToAll();
             ReqWindowAttentionAll();
             UpdateLateJoinStatus();

--- a/Content.Server/GameTicking/Rules/DynamicRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/DynamicRuleSystem.cs
@@ -22,7 +22,7 @@ public sealed partial class DynamicRuleSystem : GameRuleSystem<DynamicRuleCompon
     {
         base.Added(uid, component, gameRule, args);
 
-        component.Budget = _random.Next(component.StartingBudgetMin, component.StartingBudgetMax);;
+        component.Budget = _random.Next(component.StartingBudgetMin, component.StartingBudgetMax);
         component.NextRuleTime = Timing.CurTime + _random.Next(component.MinRuleInterval, component.MaxRuleInterval);
     }
 
@@ -81,7 +81,7 @@ public sealed partial class DynamicRuleSystem : GameRuleSystem<DynamicRuleCompon
     /// </summary>
     private void UpdateBudget(Entity<DynamicRuleComponent> entity)
     {
-        var duration = (float) (Timing.CurTime - entity.Comp.LastBudgetUpdate).TotalSeconds;
+        var duration = (float)(Timing.CurTime - entity.Comp.LastBudgetUpdate).TotalSeconds;
 
         entity.Comp.Budget += duration * entity.Comp.BudgetPerSecond;
         entity.Comp.LastBudgetUpdate = Timing.CurTime;

--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -127,7 +127,7 @@
           - !type:RoundDurationCondition
             min: 900 # 15 minutes
         - id: ParadoxCloneSpawn
-          weight: 25
+          weight: 20 # Starlight, this doesn't need to be 25, it's not *that* interesting.
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -172,7 +172,7 @@
           - !type:RoundDurationCondition
             min: 1800 # 30 minutes
         - id: Brighteye # Starlight start
-          weight: 1
+          weight: 5
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition

--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -172,7 +172,7 @@
           - !type:RoundDurationCondition
             min: 1800 # 30 minutes
         - id: Brighteye # Starlight start
-          weight: 5
+          weight: 1
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition

--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -58,7 +58,7 @@
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 25
-        - id: TerrorSpiderSpawn
+        - id: TerrorSpidersSpawn
           weight: 10
           conditions:
           - !type:HasBudgetCondition

--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -32,11 +32,11 @@
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
-         - id: CosmicCult
-           weight: 10 # Starlight, roughly equal to its place in Alpha's normal secret weights.
-           conditions:
-           - !type:HasBudgetCondition
-           - !type:MaxRuleOccurenceCondition
+        - id: CosmicCult
+          weight: 10 # Starlight, roughly equal to its place in Alpha's normal secret weights.
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
         - id: Zombie
           weight: 10 # Starlight, roughly equal to its place in Alpha's normal secret weights.
           conditions:

--- a/Resources/Prototypes/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/GameRules/dynamic_rules.yml
@@ -6,62 +6,99 @@
     minPlayers: 5 # <5 is greenshift hours, buddy.
   - type: DynamicRule
     startingBudgetMin: 200
-    startingBudgetMax: 350
+    startingBudgetMax: 550 # Starlight, might as well give it a chance to spawn 2 majors, yeah?
     table: !type:AllSelector
       children:
       # Roundstart Major Rules
       - !type:GroupSelector
         conditions:
         - !type:RoundDurationCondition
-          max: 1
+          max: 2 # Starlight, let's try 2.
         children:
         - id: Traitor
-          weight: 60
+          weight: 35 # Starlight, equal to its place in Alpha's normal secret weights.
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
         - id: Nukeops
-          weight: 25
+          weight: 10 # Starlight, roughly equal to its place in Alpha's normal secret weights.
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 20
         - id: Revolutionary
-          weight: 5
+          weight: 10 # Starlight, roughly equal to its place in Alpha's normal secret weights.
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
-        # - id: CosmicCult
-        #   weight: 5
-        #   conditions:
-        #   - !type:HasBudgetCondition
-        #   - !type:MaxRuleOccurenceCondition
+         - id: CosmicCult
+           weight: 10 # Starlight, roughly equal to its place in Alpha's normal secret weights.
+           conditions:
+           - !type:HasBudgetCondition
+           - !type:MaxRuleOccurenceCondition
         - id: Zombie
-          weight: 5
+          weight: 10 # Starlight, roughly equal to its place in Alpha's normal secret weights.
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 20
-        - id: Wizard
+        - id: WizardDuel # Starlight, Wizard Duel instead of Wizard
           weight: 5
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
-            min: 10
+            min: 30 # Starlight
+        - id: Xenoborgs # Starlight start, they're basically a major now...
+          weight: 10
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+          - !type:PlayerCountCondition
+            min: 25
+        - id: TerrorSpiderSpawn
+          weight: 10
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+          - !type:PlayerCountCondition
+            min: 25
+            # Starlight end
       # Roundstart Minor Rules
       - !type:GroupSelector
         conditions:
         - !type:RoundDurationCondition
-          max: 1
+          max: 3 # Starlight, let's try 3.
         children:
         - id: Thief
-          prob: 0.5
+          prob: 0.4
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
+        # Starlight start
+        - id: VampireLess
+          prob: 0.15
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+        - id: SLChangeling
+          prob: 0.15
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+        - id: SiliconLiberation
+          prob: 0.15
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+        - id: SubWizard
+          prob: 0.05
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+          # Starlight end
       # Midround rules
       - !type:GroupSelector
         conditions:
@@ -97,6 +134,14 @@
             max: 2
           - !type:RoundDurationCondition
             min: 600 # 10 minutes
+        - id: ParadoxCrisisSpawn # Starlight start
+          weight: 10
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+            max: 2
+          - !type:RoundDurationCondition
+            min: 1200 # 20 minutes # Starlight end
         # region starlight - NO MORE MIDROUND ZEDS
         # - id: ZombieOutbreak
         #   weight: 2.5
@@ -117,7 +162,16 @@
             min: 20
           - !type:RoundDurationCondition
             min: 2100 # 35 minutes
-        - id: Brighteye # Starlight
+        - id: WizardSpawn
+          weight: 1
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+          - !type:PlayerCountCondition
+            min: 30
+          - !type:RoundDurationCondition
+            min: 1800 # 30 minutes
+        - id: Brighteye # Starlight start
           weight: 1
           conditions:
           - !type:HasBudgetCondition
@@ -126,4 +180,4 @@
           - !type:PlayerCountCondition
             min: 20
           - !type:RoundDurationCondition
-            min: 600 # 10 minutes
+            min: 600 # Starlight end, 10 minutes

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -402,6 +402,8 @@
         - CantBecomeRevolutionary
         - Wizard
       # Starlight-end
+  - type: DynamicRuleCost
+    cost: 75
 
 # disabled until event is rewritten to be more interesting
 #- type: entity

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -136,6 +136,8 @@
         - Wizard
       allowNonHumans: true
       # Starlight-end
+  - type: DynamicRuleCost
+    cost: 100
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_Impstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/events.yml
@@ -24,3 +24,5 @@
       pickPlayer: false
       mindRoles:
       - MindRoleGhostRoleTeamAntagonist
+  - type: DynamicRuleCost # Starlight
+    cost: 75 # Starlight

--- a/Resources/Prototypes/_Starlight/GameRules/events.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/events.yml
@@ -440,4 +440,4 @@
       mindRoles:
       - MindRoleParadoxClone
   - type: DynamicRuleCost
-    cost: 50
+    cost: 125

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -138,7 +138,7 @@
   name: dynamic-title
   showInVote: false # admin-only for now until we fix some bugs
   description: dynamic-description
-  minPlayers: 5 # 🌟Starlight🌟
+  minPlayers: 50 # 🌟Starlight🌟
   rules:
   - DynamicRule
   - DummyNonAntag


### PR DESCRIPTION
## Short description
Ports https://github.com/space-wizards/space-station-14/pull/43039 / https://github.com/Space-Wizards-Federation/space-station-14/pull/52, they're the same PR.

It fixes a bug where dynamic rule didn't create roundstart antagonists, and then I went in and added in the rest of our major gamemodes and tweaked Dynamic. Should only be run by event/admins, since it's physically impossible to test Dynamic locally due to the player count requirement. I want to run this on Delta/Alpha through planned events to get a scope of how the gamemode functions.

## Why we need to add this
Bugs are bad. Dynamic rules are cool.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld, Golub
- add: Added Cosmic Cult, Wizard Duel, Xenoborgs, Terror Spiders, Vampires, Changelings, SELF, Sub Wizards, and Paradox Crisis to Dynamic.
- add: Added a higher ceiling to Dynamic's roundstart budget.
- tweak: Tweaked Dynamic weights.
- fix: Dynamic will now actually select roundstart antagonists.

