### PR TITLE
Make all Service employees have Service access

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1260,7 +1260,7 @@
   - type: PointLight
     color: "#afe837"
   - type: AccessReader
-    access: [["Service"], ["Theatre"]]
+    access: [["Service"]] # Starlight: Service is actually everyone in Service now.
 
 - type: entity
   id: ComputerCargoBounty

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -9,6 +9,7 @@
   access:
   - Chapel
   - Maintenance
+  - Service # Starlight
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -9,6 +9,7 @@
   access:
   - Theatre
   - Maintenance
+  - Service # Starlight
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -12,6 +12,7 @@
   access:
   - Theatre
   - Maintenance
+  - Service # Starlight
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -9,6 +9,7 @@
   access:
   - Maintenance # TODO Remove maint access for all gimmick jobs once access work is completed
   - Theatre
+  - Service # Starlight
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: MikuDay


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Gives all Service jobs the `Service` access.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

For some reason, Service is the only department where not all jobs have the access that corresponds to.. well, their department.

This is horribly confusing and basically makes `Service` useless for the purposes of restricting something to the Service department. Every other department has an access level for department-wide access, except Service apparently.

Turns out there's consequences of this too. The service request console for example was limited to `Service` and `Theater`, but Chaplain has neither of those and has just been unable to use it **this entire time**.

Per my tamper seal PR, it also came to my attention that the four affected jobs couldn't open those, so this fixes that too.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

| Job | Before | After |
|-|-|-|
| Botanist | :heavy_check_mark: | :heavy_check_mark: |
| Chaplain | :x: | :heavy_check_mark: |
| Chef | :heavy_check_mark: | :heavy_check_mark: |
| Clown | :x: | :heavy_check_mark: |
| Janitor | :heavy_check_mark: | :heavy_check_mark: |
| Lawyer | :heavy_check_mark: | :heavy_check_mark: |
| Librarian | :heavy_check_mark: | :heavy_check_mark: |
| Mime | :x: | :heavy_check_mark: |
| Musician | :x: | :heavy_check_mark: |

As an example, Chaplain ID card now having Service access:

<img width="860" height="715" alt="image" src="https://github.com/user-attachments/assets/3e52caef-ac24-4143-a3d9-c247ff2cc3a0" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: All Service jobs now have Service access. Chaplain, Clown, Mime and Musician did not have it previously.
- tweak: The service request console now only uses Service access.
