### PR TITLE
Fix request computers not checking access

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1075,11 +1075,12 @@
         type: WiresBoundUserInterface
   - type: Computer
     board: CargoRequestComputerCircuitboard
-  # Starlight Start - Immersive Lighting PR
-  - type: PointLight
+  # Starlight Start
+  - type: PointLight # Immersive lighting PR
     radius: 2.5
     energy: 1.5
     color: "#b89f25"
+  - type: ActivatableUIRequiresAccess # Actually check access.
   # Starlight End
   - type: AccessReader
     access: [["Cargo"]]


### PR DESCRIPTION
## Short description

Fix request computers not checking access.

## Why we need to add this

They have access readers. They don't do anything. Anyone can print orders on any console they happen to be near. That's not great. They can spend funds of departments they don't belong to. The most egregious example is the service request computer as that one is typically mapped in public areas.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/22cfce27-5a38-481c-8ad4-6e5a4f817c91

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: redmushie
- fix: Request computers actually check access now.
