### PR TITLE
Gives CE's locker an air grenade and a Holoprojector

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -248,6 +248,8 @@
     - id: RubberStampCE
     - id: MetalFoamGrenade
     - id: PlushieMatthew #starlight
+    - id: HoloprojectorEngineering # Starlight
+    - id: AirGrenade # Starlight
     - id: PrintedDocumentGreenshiftAlert #SL
       conditions: #SL
       - !type:GamemodeCondition #SL


### PR DESCRIPTION
## Short description
Adds an Air grenade and Holoprojector to the CE's locker

## Why we need to add this
Holoprojector already starts in the locker of engineers, so it should probably be in the CE's locker too. Air grenade is a QoL update since atmos lockers have one. CE should be able to rapidly refill a room with air as well.

## Media (Video/Screenshots)
<img width="492" height="269" alt="Screenshot 2026-06-24 164743" src="https://github.com/user-attachments/assets/67681aa0-eed6-4aaf-9b8b-ef240cec4af8" />
<img width="458" height="175" alt="Screenshot 2026-06-24 164804" src="https://github.com/user-attachments/assets/4a5d1d28-2ca0-4909-9afc-62ef0d2aa888" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Musiklie
- add: Gave CE locker a Holoprojector and Air Grenade.

