### PR TITLE
Vox lungs in med dispenser

### DIFF
--- a/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/medical.yml
@@ -251,3 +251,13 @@
   - SLSurgery
   conditions:
   - !type:BuyerAccessCondition
+
+- type: listing
+  id: VendorMobOrganVoxLungs
+  productEntity: OrganVoxLungs
+  cost:
+    NTCredit: 297
+  categories:
+  - SLSurgery
+  conditions:
+  - !type:BuyerAccessCondition


### PR DESCRIPTION
## Short description
Adding vox lungs as a buyable option in the med vend

## Why we need to add this
It allows people to optionally debuff themselves incase they ever lose their lungs. Im not sure but yeah lotta people want it. https://discord.com/channels/1272545509562777621/1519585875736920124

## Media (Video/Screenshots)
<img width="388" height="109" alt="image" src="https://github.com/user-attachments/assets/8fc1883a-7ace-4680-93fe-ebe706fca843" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- add: Added vox lungs in med vend cuz people want it.
