### PR TITLE
Portable cooling units now fit in any outer wear that accepts gas tanks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/base_clothing.yml
+++ b/Resources/Prototypes/Entities/Clothing/base_clothing.yml
@@ -36,6 +36,7 @@
     whitelist:
       components:
       - GasTank
+      - CoolingUnit # Starlight - anywhere a Gas Tank should be allowed, a CoolingUnit should be allowed
 
 # for clothing that has a single item slot to insert and alt click out.
 # inheritors add a whitelisted slot named item


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
You couldn't wear a portable cooling units while wearing stuff like a tank harness. However, portable cooling units are available in stuff like the gas tank dispensers.

<img width="355" height="215" alt="image" src="https://github.com/user-attachments/assets/c88bedfa-c81e-4182-9974-727c990d88be" />

This PR edits `AllowSuitStorageClothingGasTanks` to accept `CoolingUnit` in its whitelist. This lets you wear a cooling unit for any outer clothing that would accept a gas tank in its suit storage.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Community suggestion: https://discord.com/channels/1272545509562777621/1517665548400464142

This is just QoL for IPCs. The main use case for it is having things like tank harnesses be able to accept portable cooling units (see Media).

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1052" height="623" alt="image" src="https://github.com/user-attachments/assets/a715bd86-be80-4c26-88b4-1739071cf080" />

fig. 1 - Wearing a portable cooling unit with a tank harness on.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Any outer clothing that accepts a gas tank in its suit storage will now also accept portable cooling units as well.