### PR TITLE
Cosmic Cult minPlayers decreased from 30 readied players to 20 readied players

### DIFF
--- a/Resources/Prototypes/_Starlight/CosmicCult/game_presets.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/game_presets.yml
@@ -4,7 +4,7 @@
     - cosmic
   name: cosmiccult-title
   description: cosmiccult-description
-  minPlayers: 30
+  minPlayers: 20
   showInVote: true
   rules:
     - CosmicCult
@@ -21,7 +21,7 @@
     - secretcosmic
   name: secret-title
   description: secret-description
-  minPlayers: 30
+  minPlayers: 20
   showInVote: false
   rules:
     - CosmicCult

--- a/Resources/Prototypes/_Starlight/CosmicCult/roundstart.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/roundstart.yml
@@ -4,7 +4,7 @@
   components:
   - type: CosmicCultRule
   - type: GameRule
-    minPlayers: 25
+    minPlayers: 20
     delay:
       min: 60
       max: 120


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Similar PR to #2841

Decreases the required number of **readied** players for Cosmic Cult from 30 down to 20.
- This is the same as gamemodes like Nukeops and Xenoborgs
- This is still higher than stuff like Revolutionaries, which needs 15 readied players

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Beta has a server culture of not Readying up. It's very typical for only 20-25 people to Ready up even when the server at its cap of 65 players.

As mentioned in #2841, the `minPlayers` parameter is somewhat misleading. It doesn't check for how many players are connected to the server, it checks for how many people are Ready.

If there's ~20 players Ready on Beta, it means that the server's pop is 30-40+, which is fine for Cosmic Cult.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Lowered the required number of readied players for Cosmic Cult to 20 (down from 30).
