### PR TITLE
Tweaks to the pierceable system so armor and shields actually block bullets from passing though an entity

### DIFF
--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -43,7 +43,7 @@ public partial class InventorySystem
 {
     public void InitializeRelay()
     {
-        SubscribeLocalEvent<InventoryComponent, HitScanPierceAttemptEvent>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, HitScanPierceAttemptEvent>(RefRelayInventoryEvent); // Starlight: Should be RefRelay
         SubscribeLocalEvent<InventoryComponent, DamageModifyEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, StaminaModifyEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, ElectrocutionAttemptEvent>(RelayInventoryEvent);
@@ -64,7 +64,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, ZombificationResistanceQueryEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, IsEquippingTargetAttemptEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, IsUnequippingTargetAttemptEvent>(RelayInventoryEvent);
-        SubscribeLocalEvent<InventoryComponent, ChameleonControllerOutfitSelectedEvent>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, ChameleonControllerOutfitSelectedEvent>(RefRelayInventoryEvent); // Starlight: Should be RefRelay
         SubscribeLocalEvent<InventoryComponent, BeforeEmoteEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, StoodEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, DownedEvent>(RelayInventoryEvent);

--- a/Content.Shared/_Starlight/Weapons/Hitscan/Systems/HitscanPierceSystem.cs
+++ b/Content.Shared/_Starlight/Weapons/Hitscan/Systems/HitscanPierceSystem.cs
@@ -6,14 +6,21 @@ using Robust.Shared.Map;
 using Robust.Shared.Random;
 using Content.Shared._Starlight.Weapons.Hitscan.Components;
 using Content.Shared._Starlight.Weapons.Hitscan.Events;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Tag;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._Starlight.Weapons.Hitscan.Systems;
 
 public sealed partial class PierceSystem : EntitySystem
 {
     [Dependency] private IRobustRandom _rand = default!;
+    [Dependency] private SharedHandsSystem _handsSystem = default!;
+    [Dependency] private TagSystem _tag = default!;
 
     private EntityQuery<HitscanReflectComponent> _reflectQuery;
+    private static readonly ProtoId<TagPrototype> _shieldTag = "Shield";
 
     public override void Initialize()
     {
@@ -41,6 +48,18 @@ public sealed partial class PierceSystem : EntitySystem
 
         var ev = new HitScanPierceAttemptEvent(hitscan.Comp.PierceLevel, true);
         RaiseLocalEvent(data.HitEntity.Value, ref ev);
+
+        //Check to see if a hand held shield is equipped to block piercing
+        if (ev.Pierced) //If the bullet still piercing the entity, check to see if anything in hand will block the bullet from piercing. If armor has already blocked the bullet, no need to check for a shield in hand.
+            foreach (var held in _handsSystem.EnumerateHeld(data.HitEntity.Value)) //check each hand slot
+            {
+                if (!_tag.HasTag(held, _shieldTag) //Check if the item can be used as a shield, a hand held hardsuit isn't a shield.
+                    || !TryComp<PierceableComponent>(held, out var pierceable) || pierceable.Level <= hitscan.Comp.PierceLevel //Check to see if the shield has the stopping power
+                    || (TryComp<ItemToggleComponent>(held, out var itemToggle) && !itemToggle.Activated)) //If the shield has a toggle comp, it needs to be toggled on to be of use
+                    continue;
+                ev.Pierced = false;
+                break; //Once we know the bullet is being stopped by something, no need to check other hand slots
+            }
 
         if (!ev.Pierced)
             return;

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -571,7 +571,7 @@
       tags:
         - Shield
     - type: Pierceable
-      level: Metal
+      level: HardenedMetal
     # Starlight-end
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -59,13 +59,15 @@
                 SheetGlass:
                   min: 2
                   max: 2
+    - type: StaticPrice
+      price: 100
     # Starlight-start
+    - type: Pierceable
+      level: Flesh
     - type: Tag
       tags:
         - Shield
-    # Starlight-end
-    - type: StaticPrice
-      price: 100
+    #Starlight-end
 
 - type: entity
   name: base repairable shield
@@ -83,6 +85,10 @@
     fuelCost: 10 # 1/2 of a Welder for a full repair
     doAfterDelay: 5
     allowSelfRepair: false
+  #Starlight-start
+  - type: Pierceable
+    level: Metal
+  # Starlight-end
 
 #Security Shields
 
@@ -203,6 +209,8 @@
                   max: 5
     - type: StaticPrice
       price: 150
+    - type: Pierceable #Starlight
+      level: Wood
 
 #Starlight Changes Start
 
@@ -318,6 +326,8 @@
                 SheetSteel:
                   min: 1
                   max: 2
+    - type: Pierceable #Starlight
+      level: Wood
 
 #Starlight Changes End
 
@@ -373,6 +383,8 @@
             - !type:PlaySoundBehavior
               sound:
                 collection: WoodDestroy
+    - type: Pierceable #Starlight
+      level: Wood
 
 #Magic/Cult Shields (give these to wizard for now)
 
@@ -554,6 +566,13 @@
                   max: 1
     - type: StaticPrice
       price: 350
+    # Starlight-start
+    - type: Tag
+      tags:
+        - Shield
+    - type: Pierceable
+      level: Metal
+    # Starlight-end
 
 - type: entity
   name: broken energy shield

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
@@ -76,6 +76,11 @@
       fuelCost: 10 # 1/2 of a Welder for a full repair
       doAfterDelay: 5
       allowSelfRepair: false
+    - type: Tag
+      tags:
+        - Shield
+    - type: Pierceable
+      level: Metal
 
 - type: entity
   name: paladin greatshield
@@ -393,6 +398,11 @@
           Heat: 7
     - type: StaticPrice
       price: 350
+    - type: Tag
+      tags:
+        - Shield
+    - type: Pierceable
+      level: Metal
 
 - type: entity
   name: greenlight shield

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
@@ -402,7 +402,7 @@
       tags:
         - Shield
     - type: Pierceable
-      level: Metal
+      level: HardenedMetal
 
 - type: entity
   name: greenlight shield


### PR DESCRIPTION
## Short description
Fixes to pierceable system, spit off from Blueshield-Shield #4903

## Why we need to add this
Currently bullets can pass though entities that are wearing armor that should stop piercing. This change fixes this issue and adds the ability for hand held shields to also block bullet pierce.

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: BornStellat
- add: Pierceable comp to hand held shields.
- fix: Worn armor and handheld items with the shield tag will now stop bullets from piercing the entity if the bullet pierce level is lower than the armor value.
