### PR TITLE
Silicons can now understand Felyaic

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Base/language.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Base/language.yml
@@ -28,6 +28,7 @@
       - Classical
       - Grumbakul
       - Aielic
+      - Felyaic
       - Lagomorphian
 
 - type: entity
@@ -62,6 +63,7 @@
       - Classical
       - Grumbakul
       - Aielic
+      - Felyaic
       - Lagomorphian
 
 - type: entity
@@ -107,6 +109,7 @@
       - Classical
       - Grumbakul
       - Aielic
+      - Felyaic
       - Lagomorphian
       - Xeno
       - Xenomind
@@ -143,5 +146,6 @@
       - Classical
       - Grumbakul
       - Aielic
+      - Felyaic
       - Lagomorphian
       - Xeno


### PR DESCRIPTION
## Short description
Elves have 4 related languages: Aielic, Sylvan, Darktongue, and Felyaic

Borgs could only understand 3 of these - Felyaic was forgotten. This PR fixes that.

## Why we need to add this
Bugfix

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- fix: Silicon's now understand the Elvish language Felyaic.
