### PR TITLE
Fix Arrivals and Evacuation docking logic

### DIFF
--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -135,7 +135,7 @@ public sealed partial class ArrivalsSystem : EntitySystem
 
         // Just saves mappers forgetting. (v2 boogaloo)
         args.Handled = true;
-        args.Tag = "DockArrivals";
+        args.Tag = ArrivalsPriorityTag; // Starlight: Use constant
     }
 
     private CompletionResult ArrivalsCompletion(IConsoleShell shell, string[] args)

--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -525,8 +525,7 @@ public sealed partial class ArrivalsSystem : EntitySystem
                         targetGrid = mainGridId;
 
                     // If that didn't work, try to find the biggest grid.
-                    if (targetGrid != null)
-                        targetGrid = _station.GetLargestGrid(comp.Station);
+                    targetGrid ??= _station.GetLargestGrid(comp.Station);
 
                     // Only FTL if we found somewhere to go to.
                     if (targetGrid.HasValue)

--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -86,6 +86,8 @@ public sealed partial class ArrivalsSystem : EntitySystem
     /// </summary>
     private const float RoundStartFTLDuration = 10f;
 
+    private const string ArrivalsPriorityTag = "DockArrivals"; // Starlight
+
     private readonly List<ProtoId<BiomeTemplatePrototype>> _arrivalsBiomeOptions = new()
     {
         "Grasslands",
@@ -514,10 +516,22 @@ public sealed partial class ArrivalsSystem : EntitySystem
                 // Go to station
                 else
                 {
-                    var targetGrid = _station.GetLargestGrid(comp.Station);
+                    // Starlight BEGIN
+                    EntityUid? targetGrid = null;
 
+                    // Grab the "main grid" from the StationData comp.
+                    if (TryComp<StationDataComponent>(comp.Station, out var stationData) &&
+                        stationData.MainGrids.TryFirstOrNull(out var mainGridId))
+                        targetGrid = mainGridId;
+
+                    // If that didn't work, try to find the biggest grid.
                     if (targetGrid != null)
-                        _shuttles.FTLToDock(uid, shuttle, targetGrid.Value);
+                        targetGrid = _station.GetLargestGrid(comp.Station);
+
+                    // Only FTL if we found somewhere to go to.
+                    if (targetGrid.HasValue)
+                        _shuttles.FTLToDock(uid, shuttle, targetGrid.Value, priorityTag: ArrivalsPriorityTag);
+                    // Starlight END
 
                     // The ArrivalsCooldown includes the trip there, so we only need to add the time taken for
                     // the trip back.

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -329,7 +329,17 @@ public sealed partial class EmergencyShuttleSystem : SharedEmergencyShuttleSyste
             return null;
         }
 
-        var targetGrid = _station.GetLargestGrid(stationUid);
+        // Starlight BEGIN
+        EntityUid? targetGrid = null;
+
+        // Grab the "main grid" from the StationData comp.
+        if (TryComp<StationDataComponent>(stationUid, out var stationData) &&
+            stationData.MainGrids.TryFirstOrNull(out var mainGridId))
+            targetGrid = mainGridId;
+
+        // If that didn't work, try to find the biggest grid.
+        targetGrid ??= _station.GetLargestGrid(stationUid);
+        // Starlight END
 
         DockTime = _timing.CurTime;
 


### PR DESCRIPTION
## Short description

- Makes Arrivals and Evacuation shuttles _actually_ prefer the main station grid instead of "the biggest station-affiliated grid".
- Makes Arrivals shuttle _actually_ prefer docking ports labeled as Arrivals.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Before, it would just find the largest grid.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Before

<img width="1557" height="1042" alt="image" src="https://github.com/user-attachments/assets/3e0ff300-6807-4fdb-9aa4-34bcb0094e1c" />

### After: Arrivals

<img width="1342" height="1078" alt="image" src="https://github.com/user-attachments/assets/09a33685-96d7-4923-953c-ad1b914411f2" />

### After: Evacuation

<img width="1359" height="1015" alt="image" src="https://github.com/user-attachments/assets/f37b86d4-5803-44cc-ae69-e8d598e239c5" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: The Arrivals and Evacuation shuttles now actually try to dock to the station instead of just the largest grid.
- fix: The Arrivals shuttle now actually prefers Arrivals docking ports.
