### PR TITLE
Adding trait restrictions to command/NT staff

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -13,6 +13,11 @@
     - !type:DepartmentTimeRequirement
       department: Cargo
       time: 30h # Starlight
+    - !type:TraitsRequirement # Starlight
+      traits:
+        - Iterator
+        - Muted
+      inverted: true
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuartermaster" #Starlight

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -16,6 +16,11 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 25h # Starlight
+    - !type:TraitsRequirement # Starlight
+      traits:
+        - Iterator
+        - Muted
+      inverted: true
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -20,7 +20,6 @@
     - !type:TraitsRequirement # Starlight
       traits:
         - Iterator
-        - Muted
       inverted: true
   weight: 20
   startingGear: HoPGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -17,7 +17,11 @@
     - !type:RoleTimeRequirement
       role: JobJanitor
       time: 3h
-
+    - !type:TraitsRequirement # Starlight
+      traits:
+        - Iterator
+        - Muted
+      inverted: true
   weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -13,6 +13,11 @@
     - !type:DepartmentTimeRequirement
       department: Engineering
       time: 20h # Starlight
+    - !type:TraitsRequirement # Starlight
+      traits:
+        - Iterator
+        - Muted
+      inverted: true
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,6 +15,11 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 20h # Starlight
+    - !type:TraitsRequirement # Starlight
+      traits:
+        - Iterator
+        - Muted
+      inverted: true
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -13,7 +13,11 @@
   - !type:DepartmentTimeRequirement
     department: Science
     time: 20h # Starlight
-
+  - !type:TraitsRequirement # Starlight
+    traits:
+      - Iterator
+      - Muted
+    inverted: true
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -16,7 +16,11 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 50h # Starlight - Literally the most pressured role in the game, you need extensive knowledge of your department
-
+    - !type:TraitsRequirement # Starlight
+      traits:
+        - Iterator
+        - Muted
+      inverted: true
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/blueshield.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/blueshield.yml
@@ -15,6 +15,10 @@
       time: 3h # Lower stakes version of the same role, and forces you to get Paramed time too. Totals to about 8 hours paramed+brigmed combined.
     - !type:RolesRequirement
       proto: ExtRolesReq
+    - !type:TraitsRequirement
+      traits:
+        - Iterator
+      inverted: true
   startingGear: BlueShieldGear
   icon: JobIconBlueShield
   rules: job-rules-corporate-aligned

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/iaa.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/iaa.yml
@@ -10,6 +10,10 @@
   - !type:DepartmentTimeRequirement
     department: Security
     time: 36000 # 10h
+  - !type:TraitsRequirement # Starlight
+    traits:
+      - Iterator
+    inverted: true
   startingGear: IAAGear
   icon: "JobIconIAA"
   rules: job-rules-corporate-aligned

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/magistrate.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/magistrate.yml
@@ -12,6 +12,11 @@
       time: 36000 # 10h
     - !type:RolesRequirement
       proto: ExtRolesReq
+    - !type:TraitsRequirement
+      traits:
+        - Iterator
+        - Muted
+      inverted: true
   startingGear: MagistrateGear
   icon: "JobIconMagistrate"
   rules: job-rules-corporate-aligned

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/nanotrasenrepresentative.yml
@@ -9,6 +9,11 @@
       time: 30h # Still less than Magistrate. You should be experienced with Command before you tell them how to do their jobs.
     - !type:RolesRequirement
       proto: ExtRolesReq
+    - !type:TraitsRequirement
+      traits:
+        - Iterator
+        - Muted
+      inverted: true
   startingGear: NanoTrasenRepresentativeGear
   icon: JobIconNanoTrasenRepresentative
   rules: job-rules-corporate-aligned


### PR DESCRIPTION
## Short description
In this PR, I plan on adding a restriction to types of traits that command and NT jobs can have. Primarily focusing on restricting muted and iterator.

## Why we need to add this
Command staff are supposed to lead, be the head of their department, and primarily communicate with said department. Muted and iterator heavily restricts this to basically only being able to write or use announcements. Based off some talking with others and general experience ive had with such, that basically just doesnt make sense both OOC and IC. Why would CC or NT even hire someone in a position like such if they literally cant communicate as effectively as others. OOCly its also generally unfun to try to work with a head of staff that literally cant speak to you via radio.

## Media (Video/Screenshots)
https://cdn.discordapp.com/attachments/1290858096767533128/1522033804485853204/image.png?ex=6a46fff1&is=6a45ae71&hm=1dcbd05c6fe447c917054b2324b080962191a3c71b50ac2cf67c9dbe622b6fe1&

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- add: Added some trait restrictions to both command and NT staff. 
