### PR TITLE
Extended Alfa

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,21 +3,22 @@
   id: Secret
   weights:
     Nukeops: 0.088 # SL
-    Traitor: 0.2 # SL
+    Traitor: 0.18 # SL
     Zombie: 0.078 # SL
     Zombieteors: 0.01 # SL
     Survival: 0.078 # SL
     KesslerSyndrome: 0.01 # SL
-    Revolutionary: 0.088 # SL
-    CosmicCult: 0.088 # SL
+    Revolutionary: 0.085 # SL
+    CosmicCult: 0.085 # SL
     Vampire: 0.06 # SL
     WizardDuel: 0.05 # SL + Moff Station
-    Traitorling: 0.06 #SL
-    ShitStation: 0.05 #SL
+    Traitorling: 0.05 #SL
+    ShitStation: 0.04 #SL
     Xenoborgs: 0.05 #SL
-    Vamptraitorling: 0.03 #SL
+    Vamptraitorling: 0.02 #SL
     AlmostAllAtOnce: 0.01 #SL
     TerrorSpiders: 0.05 # SL: Should be changed if too high
+    Extended: 0.056 #SL
 
 # Starlight - Beta's Secret Pool
 - type: weightedRandom


### PR DESCRIPTION
## Short description
Added the 'Extended' gamemode to Alfa's Secret Weights. Had to adjust other weights slightly so they still add up to 100, listed below:
- Extended: 5.6% (New)
- Traitor: 20% -> 18%
- Revolution: 8.8% -> 8.5%
- Cosmic Cult: 8.8% -> 8.5%
- TraitorLing: 6% -> 5%
- ShitStation: 5% -> 4%
- VampTraitorLing 3% -> 2%

## Why we need to add this
Alfa desperately needs occasional 'calm' shifts in order for new players to be taught how to do their jobs and roleplay, especially Security. Pacing is important. This has been suggested often, by players and staff alike, so I'm doing it finally.

Think of it as the difference between a Michael Bay movie and anyone else who knows how to actually direct. Michael Bay just spams explosions and boobs, which is overstimulating if you just try to binge his shit back to back. Good directors will have calmer scenes in their movies to get you invested and give your brain down time so the explosions and action scenes hit harder.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed Alfa's Secret Weights. Due to frequent request, Extended can now roll from Secret with a 5.6% chance. To make room for this, the following were adjusted: Traitor 20->18%, Revolution and Cosmic Cult 8.8->8.5% each, TraitorLing 6->5%, ShitStation 5-4%, VampTraitorLing 3->2%.

