### PR TITLE
Butchering surgery bugfix

### DIFF
--- a/Content.Shared/_Starlight/Kitchen/EntitySystems/SharedSharpSystem.cs
+++ b/Content.Shared/_Starlight/Kitchen/EntitySystems/SharedSharpSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Content.Shared._Starlight.Medical.Surgery.Components;
 using Robust.Shared.Containers;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Shared._Starlight.Kitchen.EntitySystems;
@@ -24,6 +25,7 @@ public abstract partial class SharedSharpSystem : EntitySystem
     [Dependency] protected SharedPopupSystem PopupSystem = default!;
     [Dependency] protected SharedContainerSystem ContainerSystem = default!;
     [Dependency] protected MobStateSystem MobStateSystem = default!;
+    [Dependency] protected IGameTiming Timing = default!;
 
     /// <summary>
     ///     Subscribes standard interaction and verb-gathering events.
@@ -79,7 +81,9 @@ public abstract partial class SharedSharpSystem : EntitySystem
 
         if (butcher.Type != ButcheringType.Knife && target != user)
         {
-            PopupSystem.PopupEntity(Loc.GetString("butcherable-different-tool", ("target", target)), knife, user);
+            if (Timing.IsFirstTimePredicted)
+                PopupSystem.PopupEntity(Loc.GetString("butcherable-different-tool", ("target", target)), knife, user);
+
             return false;
         }
 

--- a/Content.Shared/_Starlight/Kitchen/EntitySystems/SharedSharpSystem.cs
+++ b/Content.Shared/_Starlight/Kitchen/EntitySystems/SharedSharpSystem.cs
@@ -11,7 +11,6 @@ using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Content.Shared._Starlight.Medical.Surgery.Components;
 using Robust.Shared.Containers;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Shared._Starlight.Kitchen.EntitySystems;
@@ -25,7 +24,6 @@ public abstract partial class SharedSharpSystem : EntitySystem
     [Dependency] protected SharedPopupSystem PopupSystem = default!;
     [Dependency] protected SharedContainerSystem ContainerSystem = default!;
     [Dependency] protected MobStateSystem MobStateSystem = default!;
-    [Dependency] protected IGameTiming Timing = default!;
 
     /// <summary>
     ///     Subscribes standard interaction and verb-gathering events.
@@ -81,9 +79,7 @@ public abstract partial class SharedSharpSystem : EntitySystem
 
         if (butcher.Type != ButcheringType.Knife && target != user)
         {
-            if (Timing.IsFirstTimePredicted)
-                PopupSystem.PopupEntity(Loc.GetString("butcherable-different-tool", ("target", target)), knife, user);
-
+            PopupSystem.PopupPredicted(Loc.GetString("butcherable-different-tool", ("target", target)), knife, user);
             return false;
         }
 

--- a/Content.Shared/_Starlight/Kitchen/EntitySystems/SharedSharpSystem.cs
+++ b/Content.Shared/_Starlight/Kitchen/EntitySystems/SharedSharpSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
+using Content.Shared._Starlight.Medical.Surgery.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.Utility;
 
@@ -41,6 +42,10 @@ public abstract partial class SharedSharpSystem : EntitySystem
     private void OnAfterInteract(EntityUid uid, SharpComponent component, AfterInteractEvent args)
     {
         if (args.Handled || args.Target is null || !args.CanReach)
+            return;
+
+        // Check to see if we can do surgery first.
+        if (HasComp<SurgeryToolComponent>(uid) && HasComp<SurgeryTargetComponent>(args.Target.Value))
             return;
 
         if (TryStartButcherDoafter(uid, args.Target.Value, args.User))


### PR DESCRIPTION
## Short description
Fixes an issue where if you tried to do surgery on a dead person you would get "You can't butcher with this tool" 12 times.

## Why we need to add this
bugfix

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.


- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Mack
- fix: Fix issue with butchering and surgery conflicting.