### PR TITLE
Fix limited-use implants recharging on extract-and-reinstall

### DIFF
--- a/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
+++ b/Content.Shared/Implants/SharedSubdermalImplantSystem.cs
@@ -64,7 +64,6 @@ public abstract partial class SharedSubdermalImplantSystem : EntitySystem
 
         EntityManager.RemoveComponents(ent.Comp.ImplantedEntity.Value, ent.Comp.ImplantComponents);
         _actions.RemoveAction(ent.Comp.ImplantedEntity.Value, ent.Comp.Action);
-        ent.Comp.Action = null;
 
         var ev = new ImplantRemovedEvent(ent.Owner, ent.Comp.ImplantedEntity.Value);
         RaiseLocalEvent(ent.Owner, ref ev);


### PR DESCRIPTION
## Short description
Keep SubdermalImplantComponent.Action set when an implant is removed so the same action entity (and its state, e.g. remaining LimitedCharges) is reused on re-injection. Previously clearing it spawned a fresh full-charge action, letting freedom/EMP/scram implants be recharged by extracting and reinstalling.

## Why we need to add this
Closes #4929 

You can extract an implant and reinstall it to restore all of its uses. This allows traitors to break out of cuffs instantly, EMP sec and scram to a random position infinite times, rendering them nearly impossible to apprehend. The implants are supposed to be balanced by their limited uses, which is why the bug is extremely exploitable.


## Media (Video/Screenshots)
<img width="1920" height="1080" alt="implanter" src="https://github.com/user-attachments/assets/a023236b-a795-46e8-a0c1-446ba0a966de" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: ku-mo
- fix: Implant charges no longer reset when extracted.
