### PR TITLE
Add document printer to Ming Supply

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Ming.yml
+++ b/Resources/Maps/_Starlight/Stations/Ming.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 07/01/2026 00:31:31
-  entityCount: 29841
+  time: 07/04/2026 22:53:50
+  entityCount: 29842
 maps:
 - 1
 grids:
@@ -139942,6 +139942,18 @@ entities:
     components:
     - type: Transform
       pos: 9.5,-30.5
+      parent: 2
+    - type: TechnologyDatabase
+      supportedDisciplines:
+      - Industrial
+      - Arsenal
+      - Experimental
+      - CivilianServices
+      - Biochemical
+  - uid: 29842
+    components:
+    - type: Transform
+      pos: 3.5,-62.5
       parent: 2
     - type: TechnologyDatabase
       supportedDisciplines:


### PR DESCRIPTION
## Short description
Added document printer to Supply in Ming Station

## Why we need to add this
Closes #4959 

There is no document printer in the Supply department on Ming

## Media (Video/Screenshots)
<img width="720" height="702" alt="image" src="https://github.com/user-attachments/assets/d76232b0-77e5-4c07-99be-6ae43cca673d" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: ku-mo
- add: Added Document Printer to the Supply department on Ming.