### PR TITLE
Fix unknown loc warnings

### DIFF
--- a/Content.Client/Humanoid/MarkingPicker.xaml.cs
+++ b/Content.Client/Humanoid/MarkingPicker.xaml.cs
@@ -254,7 +254,7 @@ public sealed partial class MarkingPicker : Control
         var sortedMarkings = GetMarkings(_selectedMarkingCategory).Values.Where(m =>
             m.ID.ToLower().Contains(filter.ToLower()) ||
             GetMarkingName(m).ToLower().Contains(filter.ToLower())
-        ).OrderBy(p => Loc.GetString(GetMarkingName(p)));
+        ).OrderBy(p => GetMarkingName(p)); // Starlight
 
         foreach (var marking in sortedMarkings)
         {

--- a/Content.Client/Materials/UI/MaterialDisplay.xaml.cs
+++ b/Content.Client/Materials/UI/MaterialDisplay.xaml.cs
@@ -87,7 +87,7 @@ public sealed partial class MaterialDisplay : PanelContainer
             {
                 Name = $"{sheetsToEject}",
                 Access = AccessLevel.Public,
-                Text = Loc.GetString($"{sheetsToEject}"),
+                Text = $"{sheetsToEject}", // Starlight
                 MinWidth = 45,
                 StyleClasses = { styleClass }
             };

--- a/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
@@ -60,16 +60,20 @@ public sealed partial class RoleTimeRequirement : JobRequirement
 
         // Starlight start
         // Handle non-job role time requirements
+        var roleName = protoManager.TryIndex<PlayTimeTrackerPrototype>(proto, out var tracker)
+            ? tracker.LocalizedName
+            : Loc.GetString(proto);
+
         reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
             Inverted ? "role-timer-not-too-high" : "role-timer-role-sufficient",
             ("current", formattedCurrent),
             ("required", formattedRequired),
-            ("job", Loc.GetString(proto)),
+            ("job", roleName),
             ("departmentColor", departmentColor.ToHex())));
 
         if (jobProto is null)
         {
-            if (!protoManager.TryIndex<PlayTimeTrackerPrototype>(proto, out var tracker))
+            if (tracker is null)
                 return false;
 
             if (!Inverted)

--- a/Resources/Locale/en-US/_Starlight/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/_Starlight/prototypes/roles/antags.ftl
@@ -6,3 +6,6 @@ roles-antag-pirate-objective = You are a crew member of the pirate vessel. Follo
 roles-antag-devil-name = Devil
 roles-antag-devil-description = Sign away the souls of the weak, be canonically evil.
 roles-antag-devil-objective = Get the crew to sign contracts to reap their souls, promising them fickle material benefits in return.
+
+roles-antag-ssf-name = Soviet Special Forces
+roles-antag-ssf-objective = Carry out your mission for the Union and eliminate any threats to it.


### PR DESCRIPTION
## Short description
- MarkingPicker: drop the redundant Loc.GetString wrapper on GetMarkingName, which already returns a localized string (spammed marking display names).
- MaterialDisplay: don't localize the bare sheet-eject count ('1'/'5'/'10').
- RoleTimeRequirement: use the play-time tracker's LocalizedName instead of localizing the raw tracker id, which warned for non-job trackers (AntagTraitor/AntagNukeops/AntagThief).
- Add missing roles-antag-ssf-name / -objective loc strings.

## Why we need to add this
Closes #4807
Cleans up logged warnings

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: ku-mo
- fix: Marking names in the character editor no longer spam localization warnings.
- fix: Material storage eject buttons no longer spam localization warnings.
- fix: Antag playtime requirements no longer spam localization warnings.
