### PR TITLE
Update Lobby's Observe Warning Pt 2

### DIFF
--- a/Content.Client/Lobby/UI/ObserveWarningWindow.xaml
+++ b/Content.Client/Lobby/UI/ObserveWarningWindow.xaml
@@ -5,7 +5,6 @@
         <!-- Starlight begin - updated for our New Life system -->
         <Label Text="{Loc 'starlight-observe-warning-1'}"/>
         <Label Text="{Loc 'starlight-observe-warning-2'}"/>
-        <Label Text="{Loc 'starlight-observe-warning-3'}"/>
         <!-- Starlight end -->
         <BoxContainer Orientation="Horizontal">
             <Button Name="NevermindButton" Text="{Loc 'observe-nevermind'}" SizeFlagsStretchRatio="1"/>

--- a/Resources/Locale/en-US/_Starlight/lobby/observe-new-life.ftl
+++ b/Resources/Locale/en-US/_Starlight/lobby/observe-new-life.ftl
@@ -1,3 +1,2 @@
 starlight-observe-warning-1 = Are you sure you want to observe?
-starlight-observe-warning-2 = You will still be able to join the round with one of your existing characters.
-starlight-observe-warning-3 = You will not be able to customize or return to lobby until the round ends.
+starlight-observe-warning-2 = You will still be able to join the round later, and edit your characters.


### PR DESCRIPTION
## Short description
Update on https://github.com/ss14Starlight/space-station-14/pull/2269, now that we can customize characters ingame and not just in lobby.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)

### Before

<img width="593" height="154" alt="image" src="https://github.com/user-attachments/assets/e72dd25f-7abc-43b3-8f55-7cf5647b1d89" />


### After

<img width="1051" height="238" alt="image" src="https://github.com/user-attachments/assets/696886dd-4731-467e-a9f7-a2b6e5e0a5e1" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- tweak: Updated lobby observe warning text to make more sense now that players can edit their character in-round.
