### PR TITLE
Protogen Fixes 6

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -55,7 +55,8 @@ namespace Content.Server.Zombies
             SlotFlags.MASK |
             SlotFlags.NECK |
             SlotFlags.INNERCLOTHING |
-            SlotFlags.OUTERCLOTHING;
+            SlotFlags.OUTERCLOTHING | // Starlight
+            SlotFlags.OUTERCLOTHING2; // Starlight
 
         public override void Initialize()
         {

--- a/Content.Shared/Inventory/SlotFlags.cs
+++ b/Content.Shared/Inventory/SlotFlags.cs
@@ -27,6 +27,7 @@ public enum SlotFlags
     FEET = 1 << 14,
     SUITSTORAGE = 1 << 15,
     MISC = 1 << 16, // Starlight
+    OUTERCLOTHING2 = 1 << 17, // Starlight
     All = ~NONE,
 
     WITHOUT_POCKET = All & ~POCKET

--- a/Resources/Prototypes/_FarHorizons/Voice/protogen_speech_emotes_sounds.yml
+++ b/Resources/Prototypes/_FarHorizons/Voice/protogen_speech_emotes_sounds.yml
@@ -270,7 +270,7 @@
     Cough:
       path: /Audio/_Starlight/Voice/Resomi/resomi_cough.ogg
     Yawn:
-      path: /Audio/_Starlight/Voice/Resomi/resomi_yawn.ogg # Starligth end
+      path: /Audio/_Starlight/Voice/Resomi/resomi_yawn.ogg # Starlight end
 
 - type: emoteSounds
   parent: ProtoHumanMSounds
@@ -422,6 +422,8 @@
       collection: ProtoMothYawn
     Sigh:
       collection: ProtoMothSigh
+    DefaultDeathgasp: # Starlight
+      collection: MothDeathGasp # Starlight
 
 - type: emoteSounds
   parent: ProtoHumanFSounds
@@ -439,6 +441,8 @@
       collection: ProtoMothYawn
     Sigh:
       collection: ProtoMothSigh
+    DefaultDeathgasp: # Starlight
+      collection: MothDeathGasp # Starlight
 
 - type: emoteSounds
   parent: ProtoHumanMSounds

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/protogen.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/protogen.yml
@@ -9,6 +9,8 @@
     sprite: Clothing/OuterClothing/Armor/security.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/security.rsi # Just a placeholder, since it's overwritten below.
+    slots:
+    - outerClothing2
     equipSound: /Audio/Mecha/mechmove03.ogg
     unequipSound: /Audio/Mecha/mechmove03.ogg
   - type: ArmorSparkEffect
@@ -207,7 +209,7 @@
   id: ChangelingClothingProtogenArmor
   name: Basic-Class light protogen frame
   description: Comes in-built with light armor plating to shield the cybernetics within. Removal of this would require killing you.
-  suffix: Unremoveable
+  suffix: Changeling
   components:
   - type: Sprite
     sprite: _FarHorizons/Clothing/OuterClothing/Armor/protogen.rsi

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/arachnid.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/arachnid.yml
@@ -15,7 +15,6 @@
     - Machine
     - Chittin
   - type: IgnoreSpiderWeb
-  - type: Absorbable
   - type: Body
     prototype: ProtoArachnid
     requiredLegs: 2

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/arachnid.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/arachnid.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McWebster
-  parent: [BaseMobProtogen, BaseSpeciesPickupableLarge]
+  parent: BaseMobProtogen
   id: BaseMobProtoArachnid
   abstract: true
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/avali.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/avali.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McAvalister
-  parent: [ BaseMobProtogen, BaseColdBird, BaseSpeciesPickupable ]
+  parent: [ BaseSpeciesPickupable, BaseMobProtogen, BaseColdBird ]
   id: BaseMobProtoAvali
   abstract: true
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/base.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/base.yml
@@ -73,6 +73,7 @@
   - type: Icon
     sprite: _FarHorizons/Mobs/Species/Protogen/parts.rsi
     state: full
+  - type: Absorbable
   - type: Thirst
   - type: Damageable
     damageContainer: Hybrid

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/cyclorites.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/cyclorites.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseMobProtogen, BaseSpeciesPickupableHuge]
+  parent: [BaseSpeciesPickupableHuge, BaseMobProtogen]
   id: BaseMobProtoCyclorite
   name: Urist McCyclorister
   abstract: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/diona.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/diona.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McPlantster
-  parent: [BaseMobProtogen, BaseSpeciesPickupableHuge]
+  parent: [BaseSpeciesPickupableHuge, BaseMobProtogen]
   id: BaseMobProtoDiona
   abstract: true
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/diona.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/diona.yml
@@ -19,7 +19,6 @@
       Male: ProtoDionaMSounds
       Female: ProtoDionaFSounds
       Unsexed: ProtoDionaMSounds
-  - type: Absorbable
   - type: Tag
     tags:
     - CanPilot

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/dwarf.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/dwarf.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McHandster The Proto-Dwarf
-  parent: [BaseMobProtogen, BaseSpeciesPickupable]
+  parent: [BaseSpeciesPickupable, BaseMobProtogen]
   id: BaseMobProtoDwarf
   abstract: true
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/dwarf.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/dwarf.yml
@@ -19,7 +19,6 @@
       0: Alive
       110: Critical
       220: Dead
-  - type: Absorbable
   - type: Icon
     sprite: _FarHorizons/Mobs/Species/Proto-Humie/parts.rsi
     state: full

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/elf.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/elf.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseMobProtogen, BaseSpeciesPickupableLarge]
+  parent: BaseMobProtogen
   id: BaseMobProtoElf
   name: Urist McElgister
   abstract: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/elf.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/elf.yml
@@ -11,9 +11,6 @@
     understands:
     - GalacticCommon
     - Machine
-  - type: Absorbable
-  - type: Hunger
-  - type: Thirst
   - type: Icon
     sprite: _FarHorizons/Mobs/Species/Proto-Humie/parts.rsi
     state: full

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/felionoid.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/felionoid.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseMobProtogen, BaseSpeciesPickupable]
+  parent: [BaseSpeciesPickupable, BaseMobProtogen]
   id: BaseMobProtoFelionoid
   name: Urist McFelinster
   abstract: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/human.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/human.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseMobProtogen, BaseSpeciesPickupableLarge]
+  parent: BaseMobProtogen
   id: BaseMobProtoHuman
   name: Urist McHandster
   abstract: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/human.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/human.yml
@@ -13,7 +13,6 @@
     - GalacticCommon
     - Machine
     - SolCommon
-  - type: Absorbable
   - type: Icon
     sprite: _FarHorizons/Mobs/Species/Proto-Humie/parts.rsi
     state: full

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/lagomorph.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/lagomorph.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseMobProtogen, BaseSpeciesPickupableLarge]
+  parent: BaseMobProtogen
   id: BaseMobProtoLagomorph
   name: Urist McLagomorphster
   abstract: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/moth.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/moth.yml
@@ -17,7 +17,6 @@
     - Mothroach
   - type: Jump
     action: JumpMoth
-  - type: Absorbable
   - type: HumanoidAppearance
     species: ProtoMoth
     hideLayersOnEquip:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/moth.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/moth.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urist McFluffster
-  parent: [BaseMobProtogen, BaseSpeciesPickupableLarge]
+  parent: BaseMobProtogen
   id: BaseMobProtoMoth
   abstract: true
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/reptilian.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/reptilian.yml
@@ -14,7 +14,6 @@
     - GalacticCommon
     - Machine
     - Draconic
-  - type: Absorbable
   - type: HumanoidAppearance
     species: ProtoReptilian
     hideLayersOnEquip:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/reptilian.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/reptilian.yml
@@ -1,7 +1,7 @@
 - type: entity
   save: false
   name: Urisst' Mztosster
-  parent: [BaseMobProtogen, BaseSpeciesPickupableLarge]
+  parent: BaseMobProtogen
   id: BaseMobProtoReptilian
   abstract: true
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/resomi.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/resomi.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: Urist McRapster
-  parent: [BaseMobProtogen, BaseColdBird, BaseSpeciesPickupable]
+  parent: [BaseSpeciesPickupable, BaseMobProtogen, BaseColdBird]
   id: BaseMobProtoResomi
   abstract: true
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/resomi.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/resomi.yml
@@ -13,7 +13,6 @@
     - GalacticCommon
     - Machine
     - Scratch
-  - type: Absorbable
   - type: Jump
     action: JumpResomi
   - type: DamageVisuals

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/slime.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/slime.yml
@@ -29,7 +29,6 @@
         type: StoreBoundUserInterface
       enum.SurgeryUIKey.Key:
         type: SurgeryBui
-  - type: Absorbable
   - type: Icon
     sprite: _FarHorizons/Mobs/Species/Proto-Slime/parts.rsi
     state: full

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/slime.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/slime.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseMobProtogen, BaseSpeciesPickupableLarge]
+  parent: BaseMobProtogen
   id: BaseMobProtoSlimePerson
   name: Urist McSlimester
   abstract: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/thaven.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/thaven.yml
@@ -1,6 +1,6 @@
 - type: entity
   save: false
-  parent: [BaseMobProtogen, BaseSpeciesPickupableLarge]
+  parent: BaseMobProtogen
   id: BaseMobProtoThaven
   name: Urist McEarster
   abstract: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/vox.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/vox.yml
@@ -13,7 +13,6 @@
     - GalacticCommon
     - Machine
     - VoxPidgin
-  - type: Absorbable
   - type: Icon
     sprite: _FarHorizons/Mobs/Species/Proto-Vox/parts.rsi
     state: full

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/vox.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/vox.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseMobProtogen, BaseSpeciesPickupableLarge]
+  parent: BaseMobProtogen
   id: BaseMobProtoVox
   name: Urist McVoxster
   abstract: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/vulpkanin.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Protogen/vulpkanin.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [BaseMobProtogen, BaseSpeciesPickupableLarge]
+  parent: BaseMobProtogen
   id: BaseMobProtoVulp
   name: Urist McVulpster
   abstract: true

--- a/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/arachnid_inventory_template.yml
+++ b/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/arachnid_inventory_template.yml
@@ -120,7 +120,7 @@
       - ProtogenCybernetics
   - name: outerClothing2
     slotTexture: suit
-    slotFlags: OUTERCLOTHING
+    slotFlags: OUTERCLOTHING2
     uiWindowPos: 1,1
     strippingWindowPos: 3,2
     displayName: Protogen Cybernetics

--- a/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/cyclorite_inventory_template.yml
+++ b/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/cyclorite_inventory_template.yml
@@ -27,7 +27,7 @@
       - ProtogenCybernetics
   - name: outerClothing2
     slotTexture: suit
-    slotFlags: OUTERCLOTHING
+    slotFlags: OUTERCLOTHING2
     uiWindowPos: 1,1
     strippingWindowPos: 0,3
     displayName: Protogen Cybernetics

--- a/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/diona_inventory_template.yml
+++ b/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/diona_inventory_template.yml
@@ -20,7 +20,7 @@
       - ProtogenCybernetics
   - name: outerClothing2
     slotTexture: suit
-    slotFlags: OUTERCLOTHING
+    slotFlags: OUTERCLOTHING2
     uiWindowPos: 1,1
     strippingWindowPos: 0,3
     displayName: Protogen Cybernetics

--- a/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/protogen_inventory_template.yml
+++ b/Resources/Prototypes/_Starlight/Inventory/InventoryTemplates/Protogen/protogen_inventory_template.yml
@@ -27,7 +27,7 @@
       - ProtogenCybernetics
   - name: outerClothing2
     slotTexture: suit
-    slotFlags: OUTERCLOTHING
+    slotFlags: OUTERCLOTHING2
     uiWindowPos: 1,1
     strippingWindowPos: 0,3
     displayName: Protogen Cybernetics


### PR DESCRIPTION
## Short description
Fixes a couple more bugs we found.

## Why we need to add this
Fixes are fixes.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: All Protogens are now properly absorbable by Changelings, regardless of frame type.
- fix: All Protogens now occupy the same bag space as their non-Proto variants.
- fix: Proto-Moths use the correct death sounds now.
