### PR TITLE
Ambuzol Recipe Tweak Again

### DIFF
--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -139,9 +139,9 @@
 
 - type: reagent #starlight start
   id: ZombieBlood
-  name: reagent-name-putrid-blood
+  name: reagent-name-mortucussus
   group: Biological
-  desc: reagent-desc-putrid-blood
+  desc: reagent-desc-mortucussus
   physicalDesc: reagent-physical-desc-necrotic
   flavor: bitter
   color: "#2b0700"

--- a/Resources/Prototypes/Recipes/Reactions/biological.yml
+++ b/Resources/Prototypes/Recipes/Reactions/biological.yml
@@ -91,7 +91,9 @@
     ZombieBlood:
       amount: 1
   products:
-    Mortucussus: 1 # starlight end
+    Mold: 2
+    Protein: 1
+    Toxin: 1 # starlight end
 
 - type: reaction
   id: CycloriteBloodBreakdown

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -213,7 +213,7 @@
       amount: 1
     Ammonia:
       amount: 1
-    Mortucussus: # starlight
+    ZombieBlood:
       amount: 2
   products:
     Ambuzol: 4

--- a/Resources/Prototypes/_Starlight/Reagents/biological.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/biological.yml
@@ -200,29 +200,6 @@
       - !type:SatiateThirst
         factor: 1
 
-# - type: reagent
-  # id: Mortucussus
-  # name: reagent-name-mortucussus
-  # group: Biological
-  # desc: reagent-desc-mortucussus
-  # physicalDesc: reagent-physical-desc-necrotic
-  # flavor: bitter
-  # color: "#2b0700"
-  # metabolisms:
-    # Drink:
-      # # Disgusting!
-      # effects:
-      # - !type:SatiateThirst
-        # factor: -0.5
-    # Poison:
-      # effects:
-      # - !type:HealthChange
-        # damage:
-          # types:
-            # Poison: 4
-      # - !type:Vomit
-        # probability: 0.25
-
 - type: reagent
   parent: Blood
   id: BloodChangeling

--- a/Resources/Prototypes/_Starlight/Reagents/biological.yml
+++ b/Resources/Prototypes/_Starlight/Reagents/biological.yml
@@ -200,28 +200,28 @@
       - !type:SatiateThirst
         factor: 1
 
-- type: reagent
-  id: Mortucussus
-  name: reagent-name-mortucussus
-  group: Biological
-  desc: reagent-desc-mortucussus
-  physicalDesc: reagent-physical-desc-necrotic
-  flavor: bitter
-  color: "#2b0700"
-  metabolisms:
-    Drink:
-      # Disgusting!
-      effects:
-      - !type:SatiateThirst
-        factor: -0.5
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 4
-      - !type:Vomit
-        probability: 0.25
+# - type: reagent
+  # id: Mortucussus
+  # name: reagent-name-mortucussus
+  # group: Biological
+  # desc: reagent-desc-mortucussus
+  # physicalDesc: reagent-physical-desc-necrotic
+  # flavor: bitter
+  # color: "#2b0700"
+  # metabolisms:
+    # Drink:
+      # # Disgusting!
+      # effects:
+      # - !type:SatiateThirst
+        # factor: -0.5
+    # Poison:
+      # effects:
+      # - !type:HealthChange
+        # damage:
+          # types:
+            # Poison: 4
+      # - !type:Vomit
+        # probability: 0.25
 
 - type: reagent
   parent: Blood


### PR DESCRIPTION
## Short description
Renamed Putrid Blood to Mortucussus and removed the Mortucussus reagent and recipe added by #4747 . Making Ambuzol now no longer requires a centrifuge.

## Why we need to add this
Players had a very hard time making Mortucussus to make Ambuzol with, harder than expected. This change simplifies the recipe back while keeping the metashield preserving alterations from #4747 .

## Media (Video/Screenshots)
No.

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Putrid Blood has been renamed to Mortucussus, which is now directly used for the Ambuzol recipe. Centrifuging the blood drawn from Zombies is no longer required. All other Metashiled changes from PR 4747 are kept.

