### PR TITLE
Fix GSO Icon

### DIFF
--- a/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/greenshield.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/greenshield.yml
@@ -110,7 +110,7 @@
   id: GreenshieldOutfit
   name: job-name-greenshield
   startingGear: GreenshieldGear
-  icon: JobIconNTNCBlueShield
+  icon: JobIconCCGreenShield
   hasMindShield: true
   job: CentralCommandGreenShield
   equipment:

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/greenshield.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/CentComm/greenshield.yml
@@ -11,7 +11,7 @@
     proto: ExtRolesReq
   setPreference: false
   startingGear: GSOGear
-  icon: JobIconNTNCBlueShield # The icon works fine, no need to change it imo
+  icon: JobIconCCGreenShield
   rules: job-rules-cc-aligned
   supervisors: job-supervisors-centcom
   canBeAntag: false

--- a/Resources/Prototypes/_Starlight/StatusIcon/job.yml
+++ b/Resources/Prototypes/_Starlight/StatusIcon/job.yml
@@ -32,6 +32,14 @@
 
 - type: jobIcon
   parent: JobIcon
+  id: JobIconCCGreenShield
+  icon:
+    sprite: /Textures/_Starlight/Interface/Misc/job_icons.rsi
+    state: CCGreenShield
+  jobName: job-name-greenshield
+
+- type: jobIcon
+  parent: JobIcon
   id: JobIconSurgeon
   icon:
     sprite: /Textures/_Starlight/Interface/Misc/job_icons.rsi


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
A new dedicated GSO icon was added in https://github.com/ss14Starlight/space-station-14/pull/4952 the new icon was not added to jobs.yml and thus does not show on hud, this fixes that
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bug Fix
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="127" height="136" alt="image" src="https://github.com/user-attachments/assets/b037b5ef-e677-412f-92a6-3474e2ecd133" />
<img width="99" height="122" alt="image" src="https://github.com/user-attachments/assets/f1486732-b8b8-4edb-ace9-81f343d70992" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Tjmaxmillion
- fix: Fixed GSO Job icon.

