### PR TITLE
Changes the name of the Spegs to Speed legs

### DIFF
--- a/Resources/Prototypes/_Starlight/Body/Parts/cyberlimbs.yml
+++ b/Resources/Prototypes/_Starlight/Body/Parts/cyberlimbs.yml
@@ -259,7 +259,7 @@
 # Speed legs
 - type: entity
   id: LeftLegCyberSpeed
-  name: "left speg"
+  name: "left speed leg"
   parent: [PartCyber, BaseLeftLeg]
   description: Gotta Go Fast!
   components:
@@ -286,7 +286,7 @@
 
 - type: entity
   id: RightLegCyberSpeed
-  name: "right speg"
+  name: "right speed leg"
   parent: [PartCyber, BaseRightLeg]
   description: Gotta Go Fast!
   components:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Changing the name of the name of the speed cyberlimb from spegs to speed legs.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Spegs should be a nickname, not the in-game name, and I see people regularly get confused on what they are because speg seems like gibberish.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="336" height="87" alt="image" src="https://github.com/user-attachments/assets/5f9dbc72-5b95-4c95-90eb-db53051b0f48" />
<img width="277" height="100" alt="image" src="https://github.com/user-attachments/assets/e8b38693-bb93-403b-aff5-e46c0cb40c8b" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Musikly

- tweak: Changed name of the speed cyberlimb from "speg" to "speed leg".
