### PR TITLE
Fix that one XenoArtifactTest that causes Shard 4 to flake so often

### DIFF
--- a/Content.IntegrationTests/Tests/XenoArtifactTest.cs
+++ b/Content.IntegrationTests/Tests/XenoArtifactTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.IntegrationTests.Fixtures;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 using Robust.Shared.GameObjects;
@@ -6,7 +7,7 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture]
-public sealed class XenoArtifactTest
+public sealed class XenoArtifactTest : GameTest
 {
     [TestPrototypes]
     private const string Prototypes = @"
@@ -90,7 +91,7 @@ public sealed class XenoArtifactTest
     [Test]
     public async Task XenoArtifactAddNodeTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -133,9 +134,6 @@ public sealed class XenoArtifactTest
             Assert.That(artifactSystem.GetDirectPredecessorNodes(artifactEnt, node3!.Value), Has.Count.EqualTo(1));
             Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node3!.Value), Has.Count.EqualTo(2));
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -144,7 +142,7 @@ public sealed class XenoArtifactTest
     [Test]
     public async Task XenoArtifactRemoveNodeTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -182,9 +180,6 @@ public sealed class XenoArtifactTest
             Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node2!.Value), Is.Empty);
             Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -193,7 +188,7 @@ public sealed class XenoArtifactTest
     [Test]
     public async Task XenoArtifactResizeTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -245,9 +240,6 @@ public sealed class XenoArtifactTest
             Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
             Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node4!.Value), Is.Empty);
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -256,7 +248,7 @@ public sealed class XenoArtifactTest
     [Test]
     public async Task XenoArtifactReplaceTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -304,9 +296,6 @@ public sealed class XenoArtifactTest
             Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
 
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 
     /// <summary>
@@ -315,7 +304,7 @@ public sealed class XenoArtifactTest
     [Test]
     public async Task XenoArtifactBuildActiveNodesTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -367,15 +356,12 @@ public sealed class XenoArtifactTest
             Assert.That(artifactEnt.Comp.CachedActiveNodes, Has.Count.EqualTo(expectedActiveNodes.Length));
 
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 
     [Test]
     public async Task XenoArtifactGenerateSegmentsTest()
     {
-        await using var pair = await PoolManager.GetServerClient();
+        var pair = Pair;
         var server = pair.Server;
 
         var entManager = server.ResolveDependency<IEntityManager>();
@@ -412,8 +398,5 @@ public sealed class XenoArtifactTest
             Assert.That(grouped[2].Count(), Is.LessThanOrEqualTo(2)); // maintain same width or, if we used 3 nodes on previous layer - we only have 1 left!
 
         });
-        await server.WaitRunTicks(1);
-
-        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/XenoArtifactTest.cs
+++ b/Content.IntegrationTests/Tests/XenoArtifactTest.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 using Robust.Shared.GameObjects;
@@ -7,12 +8,21 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests;
 
 [TestFixture]
+[TestOf(typeof(SharedXenoArtifactSystem))]
 public sealed class XenoArtifactTest : GameTest
 {
+    private const string TestArtifact = "TestArtifact";
+    private const string TestArtifactNode = "TestArtifactNode";
+    private const string TestGenArtifactFlat = "TestGenArtifactFlat";
+    private const string TestGenArtifactTall = "TestGenArtifactTall";
+    private const string TestGenArtifactFull = "TestGenArtifactFull";
+
+    [SidedDependency(Side.Server)] private SharedXenoArtifactSystem _sArtifactSystem = null!;
+
     [TestPrototypes]
-    private const string Prototypes = @"
+    private const string Prototypes = $@"
 - type: entity
-  id: TestArtifact
+  id: {TestArtifact}
   parent: BaseXenoArtifact
   name: artifact
   components:
@@ -22,7 +32,7 @@ public sealed class XenoArtifactTest : GameTest
       tableId: XenoArtifactEffectsDefaultTable
 
 - type: entity
-  id: TestGenArtifactFlat
+  id: {TestGenArtifactFlat}
   parent: BaseXenoArtifact
   name: artifact
   components:
@@ -41,7 +51,7 @@ public sealed class XenoArtifactTest : GameTest
       tableId: XenoArtifactEffectsDefaultTable
 
 - type: entity
-  id: TestGenArtifactTall
+  id: {TestGenArtifactTall}
   parent: BaseXenoArtifact
   name: artifact
   components:
@@ -60,7 +70,7 @@ public sealed class XenoArtifactTest : GameTest
       tableId: XenoArtifactEffectsDefaultTable
 
 - type: entity
-  id: TestGenArtifactFull
+  id: {TestGenArtifactFull}
   name: artifact
   components:
   - type: XenoArtifact
@@ -78,7 +88,7 @@ public sealed class XenoArtifactTest : GameTest
       tableId: XenoArtifactEffectsDefaultTable
 
 - type: entity
-  id: TestArtifactNode
+  id: {TestArtifactNode}
   name: artifact node
   components:
   - type: XenoArtifactNode
@@ -89,314 +99,268 @@ public sealed class XenoArtifactTest : GameTest
     /// Checks that adding nodes and edges properly adds them into the adjacency matrix
     /// </summary>
     [Test]
+    [Description("Checks that adding nodes and edges properly adds them into the adjacency matrix")]
+    [RunOnSide(Side.Server)]
     public async Task XenoArtifactAddNodeTest()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var artifactUid = SSpawn(TestArtifact);
+        var artifactEnt = (artifactUid, comp: SComp<XenoArtifactComponent>(artifactUid));
 
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var artifactSystem = entManager.System<SharedXenoArtifactSystem>();
+        // Create 3 nodes
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node1, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node2, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node3, false));
 
-        await server.WaitPost(() =>
-        {
-            var artifactUid = entManager.Spawn("TestArtifact");
-            var artifactEnt = (artifactUid, comp: entManager.GetComponent<XenoArtifactComponent>(artifactUid));
+        Assert.That(_sArtifactSystem.GetAllNodeIndices(artifactEnt).Count(), Is.EqualTo(3));
 
-            // Create 3 nodes
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node1, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node2, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node3, false));
+        // Add connection from 1 -> 2 and 2-> 3
+        _sArtifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node2!.Value, node3!.Value, false);
 
-            Assert.That(artifactSystem.GetAllNodeIndices(artifactEnt).Count(), Is.EqualTo(3));
+        // Assert that successors and direct successors are counted correctly for node 1.
+        Assert.That(_sArtifactSystem.GetDirectSuccessorNodes(artifactEnt, node1!.Value), Has.Count.EqualTo(1));
+        Assert.That(_sArtifactSystem.GetSuccessorNodes(artifactEnt, node1!.Value), Has.Count.EqualTo(2));
+        // Assert that we didn't somehow get predecessors on node 1.
+        Assert.That(_sArtifactSystem.GetDirectPredecessorNodes(artifactEnt, node1!.Value), Is.Empty);
+        Assert.That(_sArtifactSystem.GetPredecessorNodes(artifactEnt, node1!.Value), Is.Empty);
 
-            // Add connection from 1 -> 2 and 2-> 3
-            artifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
-            artifactSystem.AddEdge(artifactEnt, node2!.Value, node3!.Value, false);
+        // Assert that successors and direct successors are counted correctly for node 2.
+        Assert.That(_sArtifactSystem.GetDirectSuccessorNodes(artifactEnt, node2!.Value), Has.Count.EqualTo(1));
+        Assert.That(_sArtifactSystem.GetSuccessorNodes(artifactEnt, node2!.Value), Has.Count.EqualTo(1));
+        // Assert that predecessors and direct predecessors are counted correctly for node 2.
+        Assert.That(_sArtifactSystem.GetDirectPredecessorNodes(artifactEnt, node2!.Value), Has.Count.EqualTo(1));
+        Assert.That(_sArtifactSystem.GetPredecessorNodes(artifactEnt, node2!.Value), Has.Count.EqualTo(1));
 
-            // Assert that successors and direct successors are counted correctly for node 1.
-            Assert.That(artifactSystem.GetDirectSuccessorNodes(artifactEnt, node1!.Value).Count, Is.EqualTo(1));
-            Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node1!.Value).Count, Is.EqualTo(2));
-            // Assert that we didn't somehow get predecessors on node 1.
-            Assert.That(artifactSystem.GetDirectPredecessorNodes(artifactEnt, node1!.Value), Is.Empty);
-            Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node1!.Value), Is.Empty);
-
-            // Assert that successors and direct successors are counted correctly for node 2.
-            Assert.That(artifactSystem.GetDirectSuccessorNodes(artifactEnt, node2!.Value), Has.Count.EqualTo(1));
-            Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node2!.Value), Has.Count.EqualTo(1));
-            // Assert that predecessors and direct predecessors are counted correctly for node 2.
-            Assert.That(artifactSystem.GetDirectPredecessorNodes(artifactEnt, node2!.Value), Has.Count.EqualTo(1));
-            Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node2!.Value), Has.Count.EqualTo(1));
-
-            // Assert that successors and direct successors are counted correctly for node 3.
-            Assert.That(artifactSystem.GetDirectSuccessorNodes(artifactEnt, node3!.Value), Is.Empty);
-            Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node3!.Value), Is.Empty);
-            // Assert that predecessors and direct predecessors are counted correctly for node 3.
-            Assert.That(artifactSystem.GetDirectPredecessorNodes(artifactEnt, node3!.Value), Has.Count.EqualTo(1));
-            Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node3!.Value), Has.Count.EqualTo(2));
-        });
+        // Assert that successors and direct successors are counted correctly for node 3.
+        Assert.That(_sArtifactSystem.GetDirectSuccessorNodes(artifactEnt, node3!.Value), Is.Empty);
+        Assert.That(_sArtifactSystem.GetSuccessorNodes(artifactEnt, node3!.Value), Is.Empty);
+        // Assert that predecessors and direct predecessors are counted correctly for node 3.
+        Assert.That(_sArtifactSystem.GetDirectPredecessorNodes(artifactEnt, node3!.Value), Has.Count.EqualTo(1));
+        Assert.That(_sArtifactSystem.GetPredecessorNodes(artifactEnt, node3!.Value), Has.Count.EqualTo(2));
     }
 
     /// <summary>
     /// Checks to make sure that removing nodes properly cleans up all connections.
     /// </summary>
     [Test]
+    [Description("Checks to make sure that removing nodes properly cleans up all connections.")]
+    [RunOnSide(Side.Server)]
     public async Task XenoArtifactRemoveNodeTest()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var artifactUid = SSpawn(TestArtifact);
+        var artifactEnt = (artifactUid, comp: SComp<XenoArtifactComponent>(artifactUid));
 
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var artifactSystem = entManager.System<SharedXenoArtifactSystem>();
+        // Create 3 nodes
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node1, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node2, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node3, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node4, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node5, false));
 
-        await server.WaitPost(() =>
-        {
-            var artifactUid = entManager.Spawn("TestArtifact");
-            var artifactEnt = (artifactUid, comp: entManager.GetComponent<XenoArtifactComponent>(artifactUid));
+        Assert.That(_sArtifactSystem.GetAllNodeIndices(artifactEnt).Count(), Is.EqualTo(5));
 
-            // Create 3 nodes
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node1, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node2, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node3, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node4, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node5, false));
+        // Add connection: 1 -> 2 -> 3 -> 4 -> 5
+        _sArtifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node2!.Value, node3!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node3!.Value, node4!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node4!.Value, node5!.Value, false);
 
-            Assert.That(artifactSystem.GetAllNodeIndices(artifactEnt).Count(), Is.EqualTo(5));
+        // Make sure we have a continuous connection between the two ends of the graph.
+        Assert.That(_sArtifactSystem.GetSuccessorNodes(artifactEnt, node1.Value), Has.Count.EqualTo(4));
+        Assert.That(_sArtifactSystem.GetPredecessorNodes(artifactEnt, node5.Value), Has.Count.EqualTo(4));
 
-            // Add connection: 1 -> 2 -> 3 -> 4 -> 5
-            artifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
-            artifactSystem.AddEdge(artifactEnt, node2!.Value, node3!.Value, false);
-            artifactSystem.AddEdge(artifactEnt, node3!.Value, node4!.Value, false);
-            artifactSystem.AddEdge(artifactEnt, node4!.Value, node5!.Value, false);
+        // Remove the node and make sure it's no longer in the artifact.
+        Assert.That(_sArtifactSystem.RemoveNode(artifactEnt, node3!.Value, false));
+        Assert.That(_sArtifactSystem.TryGetIndex(artifactEnt, node3!.Value, out _), Is.False, "Node 3 still present in artifact.");
 
-            // Make sure we have a continuous connection between the two ends of the graph.
-            Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node1.Value), Has.Count.EqualTo(4));
-            Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node5.Value), Has.Count.EqualTo(4));
-
-            // Remove the node and make sure it's no longer in the artifact.
-            Assert.That(artifactSystem.RemoveNode(artifactEnt, node3!.Value, false));
-            Assert.That(artifactSystem.TryGetIndex(artifactEnt, node3!.Value, out _), Is.False, "Node 3 still present in artifact.");
-
-            // Check to make sure that we got rid of all the connections.
-            Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node2!.Value), Is.Empty);
-            Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
-        });
+        // Check to make sure that we got rid of all the connections.
+        Assert.That(_sArtifactSystem.GetSuccessorNodes(artifactEnt, node2!.Value), Is.Empty);
+        Assert.That(_sArtifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
     }
 
     /// <summary>
     /// Sets up series of linked nodes and ensures that resizing the adjacency matrix doesn't disturb the connections
     /// </summary>
     [Test]
+    [Description("Sets up series of linked nodes and ensures that resizing the adjacency matrix doesn't disturb the connections")]
+    [RunOnSide(Side.Server)]
     public async Task XenoArtifactResizeTest()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var artifactUid = SSpawn(TestArtifact);
+        var artifactEnt = (artifactUid, comp: SComp<XenoArtifactComponent>(artifactUid));
 
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var artifactSystem = entManager.System<SharedXenoArtifactSystem>();
+        // Create 3 nodes
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node1, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node2, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node3, false));
 
-        await server.WaitPost(() =>
-        {
-            var artifactUid = entManager.Spawn("TestArtifact");
-            var artifactEnt = (artifactUid, comp: entManager.GetComponent<XenoArtifactComponent>(artifactUid));
+        // Add connection: 1 -> 2 -> 3
+        _sArtifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node2!.Value, node3!.Value, false);
 
-            // Create 3 nodes
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node1, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node2, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node3, false));
+        // Make sure our connection is set up
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1.Value, node2.Value));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2.Value, node3.Value));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2.Value, node1.Value), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3.Value, node2.Value), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1.Value, node3.Value), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3.Value, node1.Value), Is.False);
 
-            // Add connection: 1 -> 2 -> 3
-            artifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
-            artifactSystem.AddEdge(artifactEnt, node2!.Value, node3!.Value, false);
+        Assert.That(_sArtifactSystem.GetIndex(artifactEnt, node1!.Value), Is.Zero);
+        Assert.That(_sArtifactSystem.GetIndex(artifactEnt, node2!.Value), Is.EqualTo(1));
+        Assert.That(_sArtifactSystem.GetIndex(artifactEnt, node3!.Value), Is.EqualTo(2));
 
-            // Make sure our connection is set up
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node1.Value, node2.Value));
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node2.Value, node3.Value));
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node2.Value, node1.Value), Is.False);
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node3.Value, node2.Value), Is.False);
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node1.Value, node3.Value), Is.False);
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node3.Value, node1.Value), Is.False);
+        // Add a new node, resizing the original adjacency matrix and array.
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node4));
 
-            Assert.That(artifactSystem.GetIndex(artifactEnt, node1!.Value), Is.EqualTo(0));
-            Assert.That(artifactSystem.GetIndex(artifactEnt, node2!.Value), Is.EqualTo(1));
-            Assert.That(artifactSystem.GetIndex(artifactEnt, node3!.Value), Is.EqualTo(2));
+        // Check that our connections haven't changed.
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1.Value, node2.Value));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2.Value, node3.Value));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2.Value, node1.Value), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3.Value, node2.Value), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1.Value, node3.Value), Is.False);
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node3.Value, node1.Value), Is.False);
 
-            // Add a new node, resizing the original adjacency matrix and array.
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node4));
+        // Has our array shifted any when we resized?
+        Assert.That(_sArtifactSystem.GetIndex(artifactEnt, node1!.Value), Is.Zero);
+        Assert.That(_sArtifactSystem.GetIndex(artifactEnt, node2!.Value), Is.EqualTo(1));
+        Assert.That(_sArtifactSystem.GetIndex(artifactEnt, node3!.Value), Is.EqualTo(2));
 
-            // Check that our connections haven't changed.
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node1.Value, node2.Value));
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node2.Value, node3.Value));
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node2.Value, node1.Value), Is.False);
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node3.Value, node2.Value), Is.False);
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node1.Value, node3.Value), Is.False);
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node3.Value, node1.Value), Is.False);
-
-            // Has our array shifted any when we resized?
-            Assert.That(artifactSystem.GetIndex(artifactEnt, node1!.Value), Is.EqualTo(0));
-            Assert.That(artifactSystem.GetIndex(artifactEnt, node2!.Value), Is.EqualTo(1));
-            Assert.That(artifactSystem.GetIndex(artifactEnt, node3!.Value), Is.EqualTo(2));
-
-            // Check that 4 didn't somehow end up with connections
-            Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
-            Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node4!.Value), Is.Empty);
-        });
+        // Check that 4 didn't somehow end up with connections
+        Assert.That(_sArtifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
+        Assert.That(_sArtifactSystem.GetSuccessorNodes(artifactEnt, node4!.Value), Is.Empty);
     }
 
     /// <summary>
     /// Checks if removing a node and adding a new node into its place in the adjacency matrix doesn't accidentally retain extra data.
     /// </summary>
     [Test]
+    [Description("Checks if removing a node and adding a new node into its place in the adjacency matrix doesn't accidentally retain extra data.")]
+    [RunOnSide(Side.Server)]
     public async Task XenoArtifactReplaceTest()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var artifactUid = SSpawn(TestArtifact);
+        var artifactEnt = (artifactUid, Comp: SComp<XenoArtifactComponent>(artifactUid));
 
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var artifactSystem = entManager.System<SharedXenoArtifactSystem>();
+        // Create 3 nodes
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node1, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node2, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node3, false));
 
-        await server.WaitPost(() =>
-        {
-            var artifactUid = entManager.Spawn("TestArtifact");
-            var artifactEnt = (artifactUid, comp: entManager.GetComponent<XenoArtifactComponent>(artifactUid));
+        // Add connection: 1 -> 2 -> 3
+        _sArtifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node2!.Value, node3!.Value, false);
 
-            // Create 3 nodes
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node1, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node2, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node3, false));
+        // Make sure our connection is set up
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node1.Value, node2.Value));
+        Assert.That(_sArtifactSystem.NodeHasEdge(artifactEnt, node2.Value, node3.Value));
 
-            // Add connection: 1 -> 2 -> 3
-            artifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
-            artifactSystem.AddEdge(artifactEnt, node2!.Value, node3!.Value, false);
+        // Remove middle node, severing connections
+        _sArtifactSystem.RemoveNode(artifactEnt, node2!.Value, false);
 
-            // Make sure our connection is set up
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node1.Value, node2.Value));
-            Assert.That(artifactSystem.NodeHasEdge(artifactEnt, node2.Value, node3.Value));
+        // Make sure our connection are properly severed.
+        Assert.That(_sArtifactSystem.GetSuccessorNodes(artifactEnt, node1.Value), Is.Empty);
+        Assert.That(_sArtifactSystem.GetPredecessorNodes(artifactEnt, node3.Value), Is.Empty);
 
-            // Remove middle node, severing connections
-            artifactSystem.RemoveNode(artifactEnt, node2!.Value, false);
+        // Make sure our matrix is 3x3
+        Assert.That(artifactEnt.Comp.NodeAdjacencyMatrixRows, Is.EqualTo(3));
+        Assert.That(artifactEnt.Comp.NodeAdjacencyMatrixColumns, Is.EqualTo(3));
 
-            // Make sure our connection are properly severed.
-            Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node1.Value), Is.Empty);
-            Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node3.Value), Is.Empty);
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node4, false));
 
-            // Make sure our matrix is 3x3
-            Assert.That(artifactEnt.Item2.NodeAdjacencyMatrixRows, Is.EqualTo(3));
-            Assert.That(artifactEnt.Item2.NodeAdjacencyMatrixColumns, Is.EqualTo(3));
+        // Make sure that adding in a new node didn't add a new slot but instead re-used the middle slot.
+        Assert.That(artifactEnt.Comp.NodeAdjacencyMatrixRows, Is.EqualTo(3));
+        Assert.That(artifactEnt.Comp.NodeAdjacencyMatrixColumns, Is.EqualTo(3));
 
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node4, false));
-
-            // Make sure that adding in a new node didn't add a new slot but instead re-used the middle slot.
-            Assert.That(artifactEnt.Item2.NodeAdjacencyMatrixRows, Is.EqualTo(3));
-            Assert.That(artifactEnt.Item2.NodeAdjacencyMatrixColumns, Is.EqualTo(3));
-
-            // Ensure that all connections are still severed
-            Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node1.Value), Is.Empty);
-            Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node3.Value), Is.Empty);
-            Assert.That(artifactSystem.GetSuccessorNodes(artifactEnt, node4!.Value), Is.Empty);
-            Assert.That(artifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
-
-        });
+        // Ensure that all connections are still severed
+        Assert.That(_sArtifactSystem.GetSuccessorNodes(artifactEnt, node1.Value), Is.Empty);
+        Assert.That(_sArtifactSystem.GetPredecessorNodes(artifactEnt, node3.Value), Is.Empty);
+        Assert.That(_sArtifactSystem.GetSuccessorNodes(artifactEnt, node4!.Value), Is.Empty);
+        Assert.That(_sArtifactSystem.GetPredecessorNodes(artifactEnt, node4!.Value), Is.Empty);
     }
 
     /// <summary>
     /// Checks if the active nodes are properly detected.
     /// </summary>
     [Test]
+    [Description("Checks if the active nodes are properly detected.")]
+    [RunOnSide(Side.Server)]
     public async Task XenoArtifactBuildActiveNodesTest()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var artifactUid = SSpawn(TestArtifact);
+        Entity<XenoArtifactComponent> artifactEnt = (artifactUid, SComp<XenoArtifactComponent>(artifactUid));
 
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var artifactSystem = entManager.System<SharedXenoArtifactSystem>();
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node1, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node2, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node3, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node4, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node5, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node6, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node7, false));
+        Assert.That(_sArtifactSystem.AddNode(artifactEnt, TestArtifactNode, out var node8, false));
 
-        await server.WaitPost(() =>
-        {
-            var artifactUid = entManager.Spawn("TestArtifact");
-            Entity<XenoArtifactComponent> artifactEnt = (artifactUid, entManager.GetComponent<XenoArtifactComponent>(artifactUid));
+        //                       /----( 6 )
+        //           /----[*3 ]-/----( 7 )----( 8 )
+        //          /
+        //         /           /----[*5 ]
+        // [ 1 ]--/----[ 2 ]--/----( 4 )
+        // Diagram of the example generation. Nodes in [brackets] are unlocked, nodes in (braces) are locked
+        // and nodes with an *asterisk are supposed to be active.
+        _sArtifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node1!.Value, node3!.Value, false);
 
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node1, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node2, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node3, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node4, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node5, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node6, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node7, false));
-            Assert.That(artifactSystem.AddNode(artifactEnt, "TestArtifactNode", out var node8, false));
+        _sArtifactSystem.AddEdge(artifactEnt, node2!.Value, node4!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node2!.Value, node5!.Value, false);
 
-            //                       /----( 6 )
-            //           /----[*3 ]-/----( 7 )----( 8 )
-            //          /
-            //         /           /----[*5 ]
-            // [ 1 ]--/----[ 2 ]--/----( 4 )
-            // Diagram of the example generation. Nodes in [brackets] are unlocked, nodes in (braces) are locked
-            // and nodes with an *asterisk are supposed to be active.
-            artifactSystem.AddEdge(artifactEnt, node1!.Value, node2!.Value, false);
-            artifactSystem.AddEdge(artifactEnt, node1!.Value, node3!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node3!.Value, node6!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node3!.Value, node7!.Value, false);
 
-            artifactSystem.AddEdge(artifactEnt, node2!.Value, node4!.Value, false);
-            artifactSystem.AddEdge(artifactEnt, node2!.Value, node5!.Value, false);
+        _sArtifactSystem.AddEdge(artifactEnt, node7!.Value, node8!.Value, false);
 
-            artifactSystem.AddEdge(artifactEnt, node3!.Value, node6!.Value, false);
-            artifactSystem.AddEdge(artifactEnt, node3!.Value, node7!.Value, false);
+        _sArtifactSystem.SetNodeUnlocked(node1!.Value);
+        _sArtifactSystem.SetNodeUnlocked(node2!.Value);
+        _sArtifactSystem.SetNodeUnlocked(node3!.Value);
+        _sArtifactSystem.SetNodeUnlocked(node5!.Value);
 
-            artifactSystem.AddEdge(artifactEnt, node7!.Value, node8!.Value, false);
-
-            artifactSystem.SetNodeUnlocked(node1!.Value);
-            artifactSystem.SetNodeUnlocked(node2!.Value);
-            artifactSystem.SetNodeUnlocked(node3!.Value);
-            artifactSystem.SetNodeUnlocked(node5!.Value);
-
-            NetEntity[] expectedActiveNodes =
-            [
-                entManager.GetNetEntity(node3!.Value.Owner),
-                entManager.GetNetEntity(node5!.Value.Owner)
-            ];
-            Assert.That(artifactEnt.Comp.CachedActiveNodes, Is.SupersetOf(expectedActiveNodes));
-            Assert.That(artifactEnt.Comp.CachedActiveNodes, Has.Count.EqualTo(expectedActiveNodes.Length));
-
-        });
+        NetEntity[] expectedActiveNodes =
+        [
+            SEntMan.GetNetEntity(node3!.Value.Owner),
+            SEntMan.GetNetEntity(node5!.Value.Owner)
+        ];
+        Assert.That(artifactEnt.Comp.CachedActiveNodes, Is.SupersetOf(expectedActiveNodes));
+        Assert.That(artifactEnt.Comp.CachedActiveNodes, Has.Count.EqualTo(expectedActiveNodes.Length));
     }
 
     [Test]
+    [RunOnSide(Side.Server)]
     public async Task XenoArtifactGenerateSegmentsTest()
     {
-        var pair = Pair;
-        var server = pair.Server;
+        var artifact1Uid = SSpawn(TestGenArtifactFlat);
+        Entity<XenoArtifactComponent> artifact1Ent = (artifact1Uid, SComp<XenoArtifactComponent>(artifact1Uid));
 
-        var entManager = server.ResolveDependency<IEntityManager>();
-        var artifactSystem = entManager.System<SharedXenoArtifactSystem>();
+        var segments1 = _sArtifactSystem.GetSegments(artifact1Ent);
+        Assert.That(segments1, Has.Count.EqualTo(2));
+        Assert.That(segments1[0], Has.Count.EqualTo(1));
+        Assert.That(segments1[1], Has.Count.EqualTo(1));
 
-        await server.WaitPost(() =>
-        {
-            var artifact1Uid = entManager.Spawn("TestGenArtifactFlat");
-            Entity<XenoArtifactComponent> artifact1Ent = (artifact1Uid, entManager.GetComponent<XenoArtifactComponent>(artifact1Uid));
+        var artifact2Uid = SSpawn(TestGenArtifactTall);
+        Entity<XenoArtifactComponent> artifact2Ent = (artifact2Uid, SComp<XenoArtifactComponent>(artifact2Uid));
 
-            var segments1 = artifactSystem.GetSegments(artifact1Ent);
-            Assert.That(segments1.Count, Is.EqualTo(2));
-            Assert.That(segments1[0].Count, Is.EqualTo(1));
-            Assert.That(segments1[1].Count, Is.EqualTo(1));
+        var segments2 = _sArtifactSystem.GetSegments(artifact2Ent);
+        Assert.That(segments2, Has.Count.EqualTo(1));
+        Assert.That(segments2[0], Has.Count.EqualTo(2));
 
-            var artifact2Uid = entManager.Spawn("TestGenArtifactTall");
-            Entity<XenoArtifactComponent> artifact2Ent = (artifact2Uid, entManager.GetComponent<XenoArtifactComponent>(artifact2Uid));
+        var artifact3Uid = SSpawn(TestGenArtifactFull);
+        Entity<XenoArtifactComponent> artifact3Ent = (artifact3Uid, SComp<XenoArtifactComponent>(artifact3Uid));
 
-            var segments2 = artifactSystem.GetSegments(artifact2Ent);
-            Assert.That(segments2.Count, Is.EqualTo(1));
-            Assert.That(segments2[0].Count, Is.EqualTo(2));
-
-            var artifact3Uid = entManager.Spawn("TestGenArtifactFull");
-            Entity<XenoArtifactComponent> artifact3Ent = (artifact3Uid, entManager.GetComponent<XenoArtifactComponent>(artifact3Uid));
-
-            var segments3 = artifactSystem.GetSegments(artifact3Ent);
-            Assert.That(segments3.Count, Is.EqualTo(1));
-            Assert.That(segments3.Sum(x => x.Count), Is.EqualTo(6));
-            var nodesDepths = segments3[0].Select(x => x.Comp.Depth).ToArray();
-            Assert.That(nodesDepths.Distinct().Count(), Is.EqualTo(3));
-            var grouped = nodesDepths.ToLookup(x => x);
-            Assert.That(grouped[0].Count(), Is.EqualTo(2));
-            Assert.That(grouped[1].Count(), Is.GreaterThanOrEqualTo(2)); // tree is attempting sometimes to get wider (so it will look like a tree)
-            Assert.That(grouped[2].Count(), Is.LessThanOrEqualTo(2)); // maintain same width or, if we used 3 nodes on previous layer - we only have 1 left!
-
-        });
+        var segments3 = _sArtifactSystem.GetSegments(artifact3Ent);
+        Assert.That(segments3, Has.Count.EqualTo(1));
+        Assert.That(segments3.Sum(x => x.Count), Is.EqualTo(6));
+        var nodesDepths = segments3[0].Select(x => x.Comp.Depth).ToArray();
+        Assert.That(nodesDepths.Distinct().Count(), Is.EqualTo(3));
+        var grouped = nodesDepths.ToLookup(x => x);
+        Assert.That(grouped[0].Count(), Is.EqualTo(2));
+        Assert.That(grouped[1].Count(), Is.GreaterThanOrEqualTo(2)); // tree is attempting sometimes to get wider (so it will look like a tree)
+        Assert.That(grouped[2].Count(), Is.LessThanOrEqualTo(2)); // maintain same width or, if we used 3 nodes on previous layer - we only have 1 left!
     }
 }


### PR DESCRIPTION
## Short description
Ports the XenoArtifactTest update from [GameTest Part 2](https://github.com/space-wizards/space-station-14/pull/43207), and a recent update to the test from Wizden [#43930](https://github.com/space-wizards/space-station-14/pull/43930).

## Why we need to add this
I'm tired of this test flaking.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

No changelog, nothing player facing.