### PR TITLE
Cosmic Cult and Terror Spider Evac

### DIFF
--- a/Content.Server/_Starlight/CosmicCult/Components/CosmicCultRuleComponent.cs
+++ b/Content.Server/_Starlight/CosmicCult/Components/CosmicCultRuleComponent.cs
@@ -59,7 +59,7 @@ public sealed partial class CosmicCultRuleComponent : Component
     /// Time for emergency shuttle arrival.
     /// </summary>
     [DataField]
-    public TimeSpan EvacShuttleTime = TimeSpan.FromMinutes(5);
+    public TimeSpan EvacShuttleTime = TimeSpan.FromMinutes(8);
 
     [DataField]
     public HashSet<EntityUid> Cultists = [];

--- a/Content.Server/_Starlight/GameTicking/Rules/Components/TerrorSpiderRuleComponent.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/Components/TerrorSpiderRuleComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Server._Starlight.GameTicking.Rules.Components;
 public sealed partial class TerrorSpiderRuleComponent : Component
 {
     /// <summary>
-    /// What happens if all of the cultists die.
+    /// What happens if all of the terror spiders die.
     /// </summary>
     [DataField]
     public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.ShuttleCall;

--- a/Content.Server/_Starlight/GameTicking/Rules/Components/TerrorSpiderRuleComponent.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/Components/TerrorSpiderRuleComponent.cs
@@ -1,3 +1,4 @@
+using Content.Server.RoundEnd;
 namespace Content.Server._Starlight.GameTicking.Rules.Components;
 
 /// <summary>
@@ -6,6 +7,48 @@ namespace Content.Server._Starlight.GameTicking.Rules.Components;
 [RegisterComponent, Access(typeof(TerrorSpiderRuleSystem))]
 public sealed partial class TerrorSpiderRuleComponent : Component
 {
+    /// <summary>
+    /// What happens if all of the cultists die.
+    /// </summary>
+    [DataField]
+    public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.ShuttleCall;
+
+    /// <summary>
+    /// Time for emergency shuttle arrival.
+    /// </summary>
+    [DataField]
+    public TimeSpan EvacShuttleTime = TimeSpan.FromMinutes(8);
+
+    /// <summary>
+    /// Sender for shuttle call.
+    /// </summary>
+    [DataField]
+    public LocId RoundEndTextSender = "comms-console-announcement-title-centcom";
+
+    /// <summary>
+    /// Text for shuttle call if Terror Spiders lose.
+    /// </summary>
+    [DataField]
+    public LocId RoundEndTextShuttleCallLose = "terror-spiders-crew-victory-announcement";
+
+    /// <summary>
+    /// Text for announcement if Terror Spiders are defeated while Evac is already on its way.
+    /// </summary>
+    [DataField]
+    public LocId RoundEndTextAnnouncementLose = "terror-spiders-elimination-announcement";
+
+    /// <summary>
+    /// Text for shuttle call if Terror Spiders win.
+    /// </summary>
+    [DataField]
+    public LocId RoundEndTextShuttleCallWin = "terror-spiders-spider-victory-announcement";
+
+    /// <summary>
+    /// Text for announcement if Terror Spiders are victorious while Evac is already on its way.
+    /// </summary>
+    [DataField]
+    public LocId RoundEndTextAnnouncementWin = "terror-spiders-domination-announcement";
+
     /// <summary>
     /// The amount of time between each check for players check.
     /// </summary>

--- a/Content.Server/_Starlight/GameTicking/Rules/TerrorSpiderRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/TerrorSpiderRuleSystem.cs
@@ -186,23 +186,13 @@ public sealed partial class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpider
                 // Send Central Command announcement
                 if (component.Status == TerrorSpidersWinStatus.Lose)
                 {
-                    _chatSystem.DispatchGlobalAnnouncement(
-                        Loc.GetString("central-command-terror-spiders-announcement-lose"),
-                        Loc.GetString("central-command-sender"),
-                        true,
-                        new SoundPathSpecifier("/Audio/_Starlight/Announcements/callEvac.ogg"),
-                        Color.Green
-                    );
+                    _roundEnd.DoRoundEndBehavior(component.RoundEndBehavior, component.EvacShuttleTime, component.RoundEndTextSender, component.RoundEndTextShuttleCallLose, component.RoundEndTextAnnouncementLose);
+                    component.RoundEndBehavior = RoundEndBehavior.Nothing;
                 }
                 else if (component.Status == TerrorSpidersWinStatus.Win)
                 {
-                    _chatSystem.DispatchGlobalAnnouncement(
-                        Loc.GetString("central-command-terror-spiders-announcement-win"),
-                        Loc.GetString("central-command-sender"),
-                        true,
-                        new SoundPathSpecifier("/Audio/_Starlight/Announcements/announce_broken.ogg"),
-                        Color.Red
-                    );
+                    _roundEnd.DoRoundEndBehavior(component.RoundEndBehavior, component.EvacShuttleTime, component.RoundEndTextSender, component.RoundEndTextShuttleCallWin, component.RoundEndTextAnnouncementWin);
+                    component.RoundEndBehavior = RoundEndBehavior.Nothing;
                 }
 
                 component.AlreadyAnnounced = true;
@@ -216,8 +206,7 @@ public sealed partial class TerrorSpiderRuleSystem : GameRuleSystem<TerrorSpider
 
         if (!component.RoundAlreadyEnded && component.EndRoundTime < _timing.CurTime)
         {
-            // Call Evac and end the gamemode
-            _roundEnd.RequestRoundEnd(null, false);
+            // End the gamemode
             component.RoundAlreadyEnded = true;
             _ticker.EndGameRule(uid);
         }

--- a/Resources/Locale/en-US/_Starlight/terrorspiders/terrorspiders.ftl
+++ b/Resources/Locale/en-US/_Starlight/terrorspiders/terrorspiders.ftl
@@ -1,2 +1,4 @@
-central-command-terror-spiders-announcement-lose = Long-range sensors indicate all Princesses of Terror are now dead. The emergency shuttle has been called. You may recall the shuttle to extend the shift.
-central-command-terror-spiders-announcement-win = We have detected that Terror Spiders have overtaken the station. Dispatching an emergency shuttle to collect remaining personnel.
+terror-spiders-crew-victory-announcement = Long-range sensors indicate all Princesses of Terror are now dead. The emergency shuttle has been called. ETA: {$time} {$units}. You may recall the shuttle to extend the shift.
+terror-spiders-elimination-announcement =  Long-range sensors indicate all Princesses of Terror are now dead. An emergency shuttle is already inbound.
+terror-spiders-spider-victory-announcement = We have detected that Terror Spiders have overtaken the station. Dispatching an emergency shuttle to collect remaining personnel. ETA: {$time} {$units}.
+terror-spiders-domination-announcement =  We have detected that Terror Spiders have overtaken the station. An emergency shuttle is already inbound.


### PR DESCRIPTION
## Short description
Makes Cosmic Cult and Terror Spiders do an 8 minute Evac, like Nukies, so it's recallable.

## Why we need to add this
5 minutes for Cosmic Cult is un-recallable, and 10 minutes for Terror Spiders is too much.

## Media
<img width="553" height="96" alt="image" src="https://github.com/user-attachments/assets/ac4df179-6cd4-422e-b9e6-727a33591f49" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: The Cosmic Cult and Terror Spiders now call 8 minute evac shuttles instead of 5 and 10 minutes respectively.

