### PR TITLE
The Colossus Returns

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -55,12 +55,17 @@
     - id: DragonSpawn
     - id: NinjaSpawn
     - id: ParadoxCloneSpawn
+    - id: ParadoxCrisisSpawn # Starlight
     - id: SleeperAgents
  #   - id: ZombieOutbreak starlight - no more midround zeds
     - id: LoneOpsSpawn
     - id: WizardSpawn
-    - id: AbductorsSpawn # Starlight
-    - id: TerrorSpidersSpawn # Starlight
+    - id: AbductorsSpawn # Starlight start
+    - id: SubXenoborgs
+    - id: TerrorSpidersSpawn
+    - id: RailroadingTerminator
+    - id: Brighteye
+    - id: ColossusSpawn # Starlight end
     - id: EeepEvent # imp
     - !type:NestedSelector
       tableId: DerelictBorgEventTable

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -591,7 +591,7 @@
   components:
   - type: RampingStationEventScheduler
     scheduledGameRules: !type:NestedSelector
-      tableId: BasicGameRulesTableNoRoundenders # 🌟Starlight🌟
+      tableId: BasicGameRulesTable
 
 - type: entity
   id: SpaceTrafficControlEventScheduler # iff we make a selector for EntityTables that can respect StationEventComp restrictions, or somehow impliment them otherwise in said tables,

--- a/Resources/Prototypes/_Starlight/CosmicCult/events.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/events.yml
@@ -3,7 +3,7 @@
   id: ColossusSpawn
   components:
   - type: StationEvent
-    weight: 4.5
+    weight: 3
     earliestStart: 30
     reoccurrenceDelay: 20
     minimumPlayers: 25

--- a/Resources/Prototypes/_Starlight/GameRules/events.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/events.yml
@@ -79,32 +79,6 @@
     - type: DynamicRuleCost
       cost: 125 # They're not that special.
 
-# Roundender-less events table for survival
-- type: entityTable
-  id: BasicAntagEventsTableNoRoundenders
-  table:
-    !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
-    children:
-      - id: ClosetSkeleton
-      - id: DragonSpawn
-      - id: KingRatMigration
-      - id: NinjaSpawn
-      - id: ParadoxCloneSpawn
-      - id: ParadoxCrisisSpawn # Starlight
-      - id: RevenantSpawn
-      - id: SleeperAgents
-      #    - id: ZombieOutbreak
-      - id: LoneOpsSpawn
-      - !type:NestedSelector
-        tableId: DerelictBorgEventTable
-      - id: WizardSpawn
-      - id: SubXenoborgs # Starlight, make it spawn sub instead
-      - id: EeepEvent # imp
-      # Starlight gamerules:
-      - id: AbductorsSpawn
-      - id: RailroadingTerminator
-      - id: Brighteye
-
 - type: entity
   parent: BaseGameRule
   id: DerelictBorgiSpawn

--- a/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
@@ -1,20 +1,4 @@
 # event schedulers
-
-- type: entityTable
-  id: BasicGameRulesTableNoRoundenders
-  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
-    children:
-      - !type:NestedSelector
-        tableId: BasicCalmEventsTable
-      - !type:NestedSelector
-        tableId: BasicAntagEventsTableNoRoundenders
-      - !type:NestedSelector
-        tableId: CargoGiftsTable
-      - !type:NestedSelector
-        tableId: CalmPestEventsTable
-      - !type:NestedSelector
-        tableId: SpicyPestEventsTable
-
 - type: entity
   parent: BaseGameRule
   id: SubGamemodesRuleNoChangelings

--- a/Resources/Prototypes/_Starlight/ninja_threats.yml
+++ b/Resources/Prototypes/_Starlight/ninja_threats.yml
@@ -32,3 +32,8 @@
   id: Eeeplet
   announcement: terror-eeep
   rule: EeepEvent
+
+- type: ninjaHackingThreat
+  id: Colossus
+  announcement: terror-colossus
+  rule: ColossusSpawn

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -12,6 +12,7 @@
     Wizard: 0.1
     Xenoborgs: 0.05
     Eeeplet: 0.5
+    Colossus: 0.2
     # Starlight End
 
 - type: ninjaHackingThreat


### PR DESCRIPTION
## Short description
Adds the Lone Colossus back to the event pool. Asked Crazy about it, they said they didn't know why it was removed, but weren't against it coming back in.

Also cleans up part of the event scheduler, basically just porting some of the work I did on the Antag Selection rewrite, since maintaining two schedulers was getting annoying.

## Why we need to add this
NoRoundEnders was added solely to remove zombies from the event scheduler pool in Survival, but then we removed zombies from the event scheduler pool in every other gamemode too, so this scheduler no longer has a reason to exist.

As for the colossus, it's a fun midround antag to fight, and a blessing if it happens to roll in a cosmic cult round. I lowered it's weight a little, so it's about as rare as a lone op now.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: The Lone Colossus will now spawn again occasionally.

