### PR TITLE
Labelable Air Alarms

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -30,6 +30,7 @@
           - Item
         tags:
           - Structure
+          - Labelable # Starlight
     - type: PhysicalComposition
     # Starlight-start: Vending Machines Prices
     - type: ItemPrice

--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -21,7 +21,7 @@
           type: HandLabelerBoundUserInterface
     - type: HandLabeler
     # Starlight-start
-      blacklist:1
+      blacklist:
         tags:
           - NotLabelable
     # Starlight-end

--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -21,7 +21,7 @@
           type: HandLabelerBoundUserInterface
     - type: HandLabeler
     # Starlight-start
-      blacklist:
+      blacklist:1
         tags:
           - NotLabelable
     # Starlight-end

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/air_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/air_alarm.yml
@@ -45,6 +45,7 @@
   - type: Tag
     tags:
       - AirAlarm
+      - Labelable # Starlight
   - type: AtmosDevice
   - type: AirAlarm
   - type: AtmosAlertsDevice

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -361,6 +361,9 @@
   id: L6Saw
 
 - type: Tag
+  id: Labelable
+
+- type: Tag
   id: LightRifleHeavy
 
 - type: Tag


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Allow air alarms to be labeled.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

To permit players the ability to label Air Alarms, to bring it into line with other atmospheric and power devices. A useful feature when doing large projects involving air alarms.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="788" height="403" alt="image" src="https://github.com/user-attachments/assets/0f4162a2-d152-456b-9b66-ac71e55306cd" />

<img width="1679" height="1091" alt="image" src="https://github.com/user-attachments/assets/0c373e49-021a-44f1-9f3f-01babc99d0ed" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.
-->

:cl: OMEGA
- tweak: Air alarms can now be labeled.