### PR TITLE
Faster Engineering suits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -30,11 +30,13 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.8
+        Shock: 0.8 #SL - same as engi suit
+        Heat: 0.65 #SL
+        Caustic: 0.5 #SL - same as engi suit
         Radiation: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+    walkModifier: 0.85 #SL
+    sprintModifier: 0.85 #SL
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitAtmos
@@ -72,8 +74,8 @@
         Caustic: 0.5
         Radiation: 0.2
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+    walkModifier: 0.85 #SL
+    sprintModifier: 0.85 #SL
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering
@@ -465,8 +467,8 @@
         Radiation: 0.0
         Caustic: 0.7
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.9 #SL
+    sprintModifier: 0.9 #SL
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineeringWhite

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -118,8 +118,8 @@
         Heat: 0.8
         Cold: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.9 #SL
+    sprintModifier: 0.9 #SL
   - type: HeldSpeedModifier
   - type: GroupExamine
   - type: ProtectedFromStepTriggers

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -381,8 +381,11 @@
   - type: Sprite
     sprite: Objects/Tools/rcd.rsi
     state: icon
-  - type: Item
-    size: Normal
+  - type: Item #SL
+    size: Small
+    shape:
+    - 0,0,1,1
+    - 0,0,1,1
   - type: Clothing
     sprite: Objects/Tools/rcd.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -385,7 +385,6 @@
     size: Small
     shape:
     - 0,0,1,1
-    - 0,0,1,1
   - type: Clothing
     sprite: Objects/Tools/rcd.rsi
     quickEquip: false


### PR DESCRIPTION
Technically was supposed to do this like 2 months ago with the mat bags but idk

## Short description
Makes the Engineering Hardsuits faster and not completely horrific to navigate with
Also made the RCD fit in pocket
Made Fire suit faster so it also stays a sidegrade for Atmos players
Added missing shock and caustic to Atmos hardsuit, as well as higher heat resist because, i mean, why not, that thing is THE heat resistant suit.

## Why we need to add this
Engineering Hardsuits were the slowest in the game for no justifiable reason, 30% slowdown for 10% resist and decent rad resist was not it.

## Media (Video/Screenshots)
<img width="455" height="473" alt="Screenshot 2026-07-07 204337" src="https://github.com/user-attachments/assets/3f86370c-fbed-4015-b9e1-920374d00ce8" />
<img width="470" height="438" alt="Screenshot 2026-07-07 204343" src="https://github.com/user-attachments/assets/f54179a8-d525-4990-9e2c-2af6116deec8" />
<img width="416" height="370" alt="Screenshot 2026-07-07 204348" src="https://github.com/user-attachments/assets/e27bf593-255c-4a10-8ef9-aa7b57bbd5bd" />
<img width="443" height="306" alt="Screenshot 2026-07-07 204411" src="https://github.com/user-attachments/assets/c58ac17d-c6b3-48e5-bff8-aa738053d6d4" />
<img width="1010" height="122" alt="Screenshot 2026-07-07 203405" src="https://github.com/user-attachments/assets/26053b7e-6af6-432a-ad9f-35fdce9cdb99" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.


:cl: Roro
- tweak: Engineering Hardsuit slowdown 30% -> 15%.
- tweak: Atmos Hardsuit slowdown 30% -> 15%.
- tweak: Chief Engineer Hardsuit slowdown 20% -> 10%.
- tweak: Atmos Fire suit slowdown 20% -> 10%.
- tweak: RCD now fits in pocket.
- tweak: Atmos Hardsuit now has shock and caustic resists, as well as higher heat resist 20% -> 35%.
