### PR TITLE
Fixes the permanent "seeing stars" effect over your head when you wake up from sleep

### DIFF
--- a/Content.Shared/Stunnable/SharedStunSystem.Visualizer.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Visualizer.cs
@@ -27,7 +27,7 @@ public abstract partial class SharedStunSystem
 
     private void OnSleepStateChanged(Entity<StunVisualsComponent> entity, ref SleepStateChangedEvent args)
     {
-        if (!args.FellAsleep) return; // Starlight - don't re-apply the stunned visuals when making up from sleep
+        if (!args.FellAsleep) return; // Starlight - don't re-apply the stunned visuals when waking up from sleep
 
         Appearance.SetData(entity, StunVisuals.SeeingStars, GetStarsData(entity));
     }

--- a/Content.Shared/Stunnable/SharedStunSystem.Visualizer.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Visualizer.cs
@@ -27,6 +27,8 @@ public abstract partial class SharedStunSystem
 
     private void OnSleepStateChanged(Entity<StunVisualsComponent> entity, ref SleepStateChangedEvent args)
     {
+        if (!args.FellAsleep) return; // Starlight - don't re-apply the stunned visuals when making up from sleep
+
         Appearance.SetData(entity, StunVisuals.SeeingStars, GetStarsData(entity));
     }
 
@@ -37,7 +39,7 @@ public abstract partial class SharedStunSystem
 
         // Here so server can tell the client to do things
         // Don't dirty the component if we don't need to
-        if (!Appearance.TryGetData<bool>(entity, StunVisuals.SeeingStars, out var stars, entity.Comp) && stars)
+        if (Appearance.TryGetData<bool>(entity, StunVisuals.SeeingStars, out var stars, entity.Comp) && stars)
             return;
 
         if (!Blocker.CanConsciouslyPerformAction(entity))


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
I hate this bug and no one's fixed it so I'm fixing it.

Whenever you woke up from sleeping (whether it was sleeping on a bed or due to chems like nocturine / breathing nitrious oxide), you would get the "seeing stars" effect above your head **forever**.

I ported a one line fix from https://github.com/space-wizards/space-station-14/pull/39409

This:
```csharp
        // Here so server can tell the client to do things
        // Don't dirty the component if we don't need to
        if (!Appearance.TryGetData<bool>(entity, StunVisuals.SeeingStars, out var stars, entity.Comp) && stars)
            return;
```

Was fixed to this:
```csharp
        // Here so server can tell the client to do things
        // Don't dirty the component if we don't need to
        if (Appearance.TryGetData<bool>(entity, StunVisuals.SeeingStars, out var stars, entity.Comp) && stars)
            return;
```

So I didn't put a SL comment on it.

The other line is mine. Every time you woke up from sleep, it would apply the seeing stars to you because you woke up from being asleep. Honestly this code is somewhat bewildering to me because the stunned visuals aren't applied when you go to sleep in the first place?  I kept the fix minimally invasive - just one line of code that avoids applying the 'seeing stars' effect if you are waking up.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix. People don't do a ton of sleeping on beds (unless they're purposely getting the effect), but this is a massive meta fix for vampires in particular because you would have a shitload of people with seeing stars if a vampire was sleeping a lot of people.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/6da1675c-a07e-48af-8365-93cbda34c629

fig. 1 - Demo of fix.


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: You will no longer permanently have the 'seeing stars' effect stuck on your character after waking up from being asleep.