### PR TITLE
Gave the Material Silo A magnet

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/silo.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/silo.yml
@@ -61,3 +61,25 @@
   - type: WiresPanel
   - type: StaticPrice
     price: 1500
+# Starlight Edit, Added a Magnet to material silo for easier material collection
+  - type: ItemToggle
+    onUse: false
+    onActivate: false
+    verbToggleOn: verb-toggle-magnet-activate
+    verbToggleOff: verb-toggle-magnet-deactivate
+    soundActivate:
+      collection: sparks
+      params:
+        variation: 0.250
+      soundDeactivate:
+        collection: sparks
+        params:
+          variation: 0.250
+  - type: AltUseToggle
+  - type: ComponentToggler
+    components:
+      - type: MagnetPickup
+        range: 2
+        requiresEquipping: false
+        slotFlags: 0
+# Starlight Edit End


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
It gives any Material Silo A magnet, The range of the magnet is 1 tile in each direction (Up, Down, Left, Right).
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Its a PAINNN when you have like 50 stacks of steel and 30 stacks of everything else from mining and now your just sitting there having to grab it and insert it for the next minute or two
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->


https://github.com/user-attachments/assets/05ea344f-7661-4798-8fd1-1a4bcd489ee1





## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: Forrestgod
- tweak: Gave the Material Silo An Item Magnet.
-->
