### PR TITLE
WT550g can no longer accept any ammunition.

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -387,10 +387,6 @@
           shader: unshaded
     - type: Clothing
       sprite: _Starlight/Objects/Weapons/Guns/SMGs/wt550g.rsi
-    - type: ItemSlots
-      slots:
-        gun_magazine:
-          startingItem: MagazinePistolSubMachineGunTopMounted
     - type: Contraband
       allowedDepartments: [ CentralCommand ]
       allowedJobs: []


### PR DESCRIPTION
## Short description
WT550g can currently accept any ammunition and fire it at the rate and accuracy of a regular WT550.

## Why we need to add this
Bugs need fixing.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: BornStellar
- fix: WT550g can no longer accept any ammunition.
