### PR TITLE
Thief's toolbox / satchel is no longer contraband

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/thief.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/thief.yml
@@ -41,9 +41,9 @@
 
 - type: entity
   id: ToolboxThief
-  name: undetermined thieving toolbox
-  description: This is where your favorite thief's supplies lie. Try to remember which ones.
-  parent: [ BaseItem, BaseMinorContraband ]
+  name: undetermined toolbox # Starlight
+  description: This is where your favorite tools lie. Try to remember which ones. # Starlight
+  parent: [ BaseItem ] # Starlight - no longer contraband
   components:
   - type: Sprite
     sprite: Objects/Tools/Toolboxes/toolbox_thief.rsi
@@ -67,8 +67,8 @@
 
 - type: entity
   id: SatchelThief
-  name: undetermined thieving satchel
-  description: This is where your favorite thief's supplies lie. Folded for your convenience.
+  name: undetermined tools satchel # Starlight
+  description: This is where your favorite tools lie. Folded for your convenience. # Starlight
   parent: ToolboxThief
   components:
   - type: Sprite


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
This PR removes the contraband tags from the thieving toolbox and satchel, with the idea being to make Thief a little more new-player friendly if you happen to get searched extremely early or before you've figured out what tools you want to take.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Highly upvoted suggestion: https://discord.com/channels/1272545509562777621/1524533633958940732

The idea of this suggestion is to make Thief a little friendlier to new players. It's more engaging for Security if they have a Thief actually doing Crimes instead of just getting caught on an unlucky Security Drill or Code Blue random search.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="399" height="173" alt="image" src="https://github.com/user-attachments/assets/15c53a2b-a3ea-4810-b28d-43a1d4537d58" />
<img width="435" height="167" alt="image" src="https://github.com/user-attachments/assets/098c8eeb-cd54-438b-bf51-f88e40c03d6a" />

fig. 1 - No longer contraband, names and descriptions tweaked slightly.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Thief's undetermined toolbox & thief's undetermined satchel are no longer contraband. New antags rejoice.