### PR TITLE
Disable Xenoborgs and Terror Spiders

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -61,8 +61,8 @@
     - id: LoneOpsSpawn
     - id: WizardSpawn
     - id: AbductorsSpawn # Starlight start
-    - id: SubXenoborgs
-    - id: TerrorSpidersSpawn
+    #- id: SubXenoborgs
+    #- id: TerrorSpidersSpawn
     - id: RailroadingTerminator
     - id: Brighteye
     - id: ColossusSpawn # Starlight end

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -28,8 +28,8 @@
       prob: 0.20 # Starlight
     - id: SubWizard
       prob: 0.05 # Starlight. We can go back down to 0.05, since they scale now.
-    - id: SubXenoborgs # Starlight, subgamemode replaced with SubXenoborgs
-      prob: 0.05 # Starlight start, Equalizing subgamemodes
+    #- id: SubXenoborgs # Starlight, subgamemode replaced with SubXenoborgs
+    #  prob: 0.05 # Starlight start, Equalizing subgamemodes
     - id: Brighteye
       prob: 0.05
     - id: SiliconLiberation
@@ -47,8 +47,8 @@
       prob: 0.20 #0.4 -> 0.25 to account for more subgamemodes existing now
     - id: VampireLess # Reworked
       prob: 0.20
-    - id: SubXenoborgs # Starlight, subgamemode replaced with SubXenoborgs
-      prob: 0.05 # Equalizing subgamemodes
+    #- id: SubXenoborgs # Starlight, subgamemode replaced with SubXenoborgs
+    #  prob: 0.05
     - id: Brighteye
       prob: 0.05
     - id: SiliconLiberation

--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -18,26 +18,26 @@
           max: 5 # 5 seconds, really just here to ensure it rolls roundstart and then doesn't roll again
         children:
         - id: Traitor
-          weight: 35
+          weight: 42.5
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
         - id: Nukeops
-          weight: 10
+          weight: 12.5
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 20
         - id: Revolutionary
-          weight: 10
+          weight: 12.5
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 15
         - id: CosmicCult
-          weight: 10
+          weight: 12.5
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -51,26 +51,26 @@
           - !type:PlayerCountCondition
             min: 20
         - id: WizardDuel
-          weight: 5
+          weight: 10
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 35
-        - id: Xenoborgs
-          weight: 10
-          conditions:
-          - !type:HasBudgetCondition
-          - !type:MaxRuleOccurenceCondition
-          - !type:PlayerCountCondition
-            min: 20
-        - id: TerrorSpidersSpawn
-          weight: 10
-          conditions:
-          - !type:HasBudgetCondition
-          - !type:MaxRuleOccurenceCondition
-          - !type:PlayerCountCondition
-            min: 50
+        #- id: Xenoborgs
+        #  weight: 10
+        #  conditions:
+        #  - !type:HasBudgetCondition
+        #  - !type:MaxRuleOccurenceCondition
+        #  - !type:PlayerCountCondition
+        #    min: 20
+        #- id: TerrorSpidersSpawn
+        #  weight: 10
+        #  conditions:
+        #  - !type:HasBudgetCondition
+        #  - !type:MaxRuleOccurenceCondition
+        #  - !type:PlayerCountCondition
+        #    min: 50
       # Minor Rules
       - !type:GroupSelector
         conditions:
@@ -150,22 +150,22 @@
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 35
-        - id: SubXenoborgs
-          weight: 5
-          prob: 0.50
-          conditions:
-          - !type:HasBudgetCondition
-          - !type:MaxRuleOccurenceCondition
-          - !type:PlayerCountCondition
-            min: 20
-        - id: TerrorSpidersSpawn
-          weight: 5
-          prob: 0.50
-          conditions:
-          - !type:HasBudgetCondition
-          - !type:MaxRuleOccurenceCondition
-          - !type:PlayerCountCondition
-            min: 50
+        #- id: SubXenoborgs
+        #  weight: 5
+        #  prob: 0.50
+        #  conditions:
+        #  - !type:HasBudgetCondition
+        #  - !type:MaxRuleOccurenceCondition
+        #  - !type:PlayerCountCondition
+        #    min: 20
+        #- id: TerrorSpidersSpawn
+        #  weight: 5
+        #  prob: 0.50
+        #  conditions:
+        #  - !type:HasBudgetCondition
+        #  - !type:MaxRuleOccurenceCondition
+        #  - !type:PlayerCountCondition
+        #    min: 50
         - id: ThiefLess
           weight: 8
           prob: 0.50

--- a/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
@@ -13,8 +13,8 @@
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: Devil
       prob: 0.05 # rare
-    - id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
-      prob: 0.05 # Equalizing subgamemodes.
+    #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
+    #  prob: 0.05
     - id: Brighteye
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation
@@ -34,8 +34,8 @@
       prob: 0.175
     - id: SubWizard
       prob: 0.05 # We can go back down to 0.05, since they scale now.
-    - id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
-      prob: 0.05 # Equalizing subgamemodes.
+    #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
+    #      prob: 0.05
     - id: Brighteye
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     # No SELF Agents in rev games because of the FREEmag.
@@ -55,8 +55,8 @@
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: Devil
       prob: 0.05 # rare
-    - id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
-      prob: 0.05 # Equalizing subgamemodes.
+    #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
+    #  prob: 0.05
     - id: Brighteye
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation
@@ -74,8 +74,8 @@
       prob: 0.05
     - id: Devil
       prob: 0.05
-    - id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
-      prob: 0.05 # Equalizing subgamemodes.
+    #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
+    #      prob: 0.05
     - id: Brighteye
       prob: 0.05
     - id: SiliconLiberation
@@ -95,8 +95,8 @@
       prob: 0.20
     - id: SLChangelingLess # I have managed to make changelings lose their abilities when they turn into zombies, so the concern with them is gone.
       prob: 0.20
-    - id: SubXenoborgs # I think there's interesting roleplay opportunity if Xenoborgs spawn. You could willingly choose to get borged to prevent infection. I want to see how this plays out.
-      prob: 0.05
+    #- id: SubXenoborgs # I think there's interesting roleplay opportunity if Xenoborgs spawn. You could willingly choose to get borged to prevent infection. I want to see how this plays out.
+    #  prob: 0.05
     - id: Brighteye
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation # I mean technically there's nothing inherently wrong with them showing up.
@@ -116,8 +116,8 @@
       prob: 0.15
     - id: SubWizard
       prob: 0.05
-    - id: SubXenoborgs
-      prob: 0.05
+    #- id: SubXenoborgs
+    #  prob: 0.05
     # No SELF Agents in Nukie games because of the FREEmag = free guns!!!
 
 - type: entity

--- a/Resources/Prototypes/_Starlight/game_presets.yml
+++ b/Resources/Prototypes/_Starlight/game_presets.yml
@@ -140,7 +140,7 @@
     - Traitor
     - Revolutionary
     - WizardDuel
-    - Xenoborgs
+    #- Xenoborgs
     - RampingStationEventScheduler
     - SLChangeling
     - SpaceTrafficControlEventScheduler
@@ -171,7 +171,7 @@
     - Revolutionary
     - SubWizard # Well, you did say *Aller* at once.
     - WizardDuel # Well, you did say *Aller* at once.
-    - Xenoborgs
+    #- Xenoborgs
     - BasicStationEventScheduler
     - BasicStationEventScheduler
     - ShitStationEventScheduler

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -43,7 +43,7 @@
     - Revolutionary
     - Zombie
     - WizardDuel # Starlight
-    - Xenoborgs
+    #- Xenoborgs # Starlight
     - KesslerSyndromeScheduler
     - RampingStationEventScheduler
     - SLChangeling #Starlight
@@ -56,7 +56,7 @@
     - Brighteye #Starlight
     - ThiefGamerule # Starlight, Event Light
     - CosmicCult #Starlight
-    - TerrorSpidersSpawn # Starlight
+    #- TerrorSpidersSpawn # Starlight
     - Devil # Starlight
 
 - type: gamePreset
@@ -77,7 +77,7 @@
     - Zombie
     - SubWizard # Starlight. Well, you did say *Aller* at once.
     - WizardDuel # Starlight. Well, you did say *Aller* at once.
-    - Xenoborgs
+    #- Xenoborgs # Starlight
     - BasicStationEventScheduler
     - BasicStationEventScheduler # Starlight, ShitStation
     - ShitStationEventScheduler # Starlight, ShitStation
@@ -101,7 +101,7 @@
     - RailroadingTerminator # Starlight
     - RailroadingMinor # Starlight
     - CosmicCult # Starlight
-    - TerrorSpidersSpawn # Starlight
+    #- TerrorSpidersSpawn # Starlight
     - Devil # Starlight
 
 - type: gamePreset

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,39 +3,39 @@
   id: Secret
   weights:
     Nukeops: 0.088 # SL
-    Traitor: 0.2 # SL
+    Traitor: 0.24 # SL
     Zombie: 0.078 # SL
     Zombieteors: 0.01 # SL
     Survival: 0.078 # SL
     KesslerSyndrome: 0.01 # SL
     Revolutionary: 0.088 # SL
     CosmicCult: 0.088 # SL
-    Vampire: 0.06 # SL
-    WizardDuel: 0.05 # SL + Moff Station
-    Traitorling: 0.06 #SL
-    ShitStation: 0.05 #SL
-    Xenoborgs: 0.05 #SL
+    Vampire: 0.07 # SL
+    WizardDuel: 0.07 # SL + Moff Station
+    Traitorling: 0.07 #SL
+    ShitStation: 0.07 #SL
+    #Xenoborgs: 0.05 #SL
     Vamptraitorling: 0.03 #SL
     AlmostAllAtOnce: 0.01 #SL
-    TerrorSpiders: 0.05 # SL: Should be changed if too high
+    #TerrorSpiders: 0.05 # SL: Should be changed if too high
 
 # Starlight - Beta's Secret Pool
 - type: weightedRandom
   id: SecretLP
   weights:
     Nukeops: 0.07
-    Traitor: 0.25
+    Traitor: 0.27
     Zombie: 0.07
-    Vampire: 0.07
+    Vampire: 0.09
     Zombieteors: 0.01
     Survival: 0.07
     KesslerSyndrome: 0.01
     Revolutionary: 0.06
     CosmicCult: 0.06
-    Extended: 0.15
-    WizardDuel: 0.03 # SL + Moff Station
-    Traitorling: 0.05
-    SubXenoborgs: 0.07
-    ShitStation: 0.06 #SL, ShitStation for Beta. Try it out, see if they find it fun. If they don't, easy to remove. I've heard a couple people say they wanted it, at least.
-    Vamptraitorling: 0.03 # SL, I was told to add it, so...
-    TerrorSpiders: 0.07 # SL: Should be changed if too high
+    Extended: 0.17
+    WizardDuel: 0.04 # SL + Moff Station
+    Traitorling: 0.09
+    #SubXenoborgs: 0.07
+    ShitStation: 0.08 #SL, ShitStation for Beta. Try it out, see if they find it fun. If they don't, easy to remove. I've heard a couple people say they wanted it, at least.
+    Vamptraitorling: 0.04 # SL, I was told to add it, so...
+    #TerrorSpiders: 0.07 # SL: Should be changed if too high

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -10,7 +10,7 @@
     NinjaBackup: 0.75
     Rod: 0.75
     Wizard: 0.1
-    Xenoborgs: 0.05
+    #Xenoborgs: 0.05
     Eeeplet: 0.5
     Colossus: 0.2
     # Starlight End


### PR DESCRIPTION
## Short description
Disables Xenoborgs and Terror Spiders from Secret, Dynamic, the "All" gamemodes, and Subgamemodes.

## Why we need to add this
Both of these antags are so fundamentally broken at this point, and nobody has volunteered to fix them.

### Terror Spiders
- **Still** spawn in Nullspace, requiring an active admin online to teleport them. Prior PRs to fix this have *not* fixed this.
- Still suffer from being incredibly underwhelming, as the crew has resorted to spacing and plasma firing them, ending whatever momentum they have in seconds. Even though their webs block the spacing, spiderlings still suffocate and die on them, so spacing them effectively kills princesses abilities to create more spiders. And, of course, a single mech can also just stunlock them indefinitely.
- A major fundamental flaw they have, that contributes to a lot of spider roles not being claimed, is that claiming a ghost role means you can't ever return to your original body; this leads to a lot of terror spiders being unclaimed roles. This works a little better on Alpha, given the immense number of ghosts we have, but this wouldn't work on any other server.

### Xenoborgs
- Their main issue; the lag. Nobody knows what causes it; dark brought up that it was a weird light-texture issue, Crazy brought up that it was a weird mind issue, someone else brought up that it was a weird charge issue, but nothing's been done to solve this problem. They still inconsistently lag you.
- They suffer the same "people refuse the role" problem that Terror Spiders suffer. Since being converted gibs your body, a lot of people just leave the round, since they don't want to be a borg. While terror spiders have a way around this, being ai controlled, xenoborgs have no such benefit.
- They're really... not that well designed. Every xenoborg game starts with them killing mining, then salvage, and then stranding the cargo shuttle. This disables cargo for the entire shift, which forces the round to a crawl. There's nothing you can do to stop this unless literally 1 specific security officer is online to take them down, and the round ends up stalling out until the borgs make their big laggy move on evac.

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- remove: Disabled Xenoborgs and Terror Spiders until their respective issues are fixed.
