### PR TITLE
Fixes a thruster on the NukeOps "Omen" shuttle

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/omen.yml
+++ b/Resources/Maps/_Starlight/Shuttles/omen.yml
@@ -3411,8 +3411,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 14.5,0.5
       parent: 1
-    - type: Thruster
-      enabled: False
   - uid: 476
     components:
     - type: Transform


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
A thruster was accidentally turned off on the NukeOps' Omen shuttle. This PR fixes that.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: A thruster that was stuck permanently turned off on the NukeOps "GX-86 Omen" shuttle has been fixed.