### PR TITLE
Experimental alcohol lag fix

### DIFF
--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -1,4 +1,4 @@
-using Content.Shared.CCVar; // Starlight-edit
+using Content.Shared._Starlight.CCVar;
 using Content.Shared.Drunk;
 using Content.Shared.StatusEffectNew;
 using Robust.Client.Graphics;
@@ -58,7 +58,7 @@ public sealed partial class DrunkOverlay : Overlay
         _drunkShader = _prototypeManager.Index(Shader).InstanceUnique();
         // Starlight-start: cache status effect system and register cvar listener
         _statusEffects = _sysMan.GetEntitySystem<StatusEffectsSystem>();
-        _cfg.OnValueChanged(CCVars.DrunkRenderFix, OnDrunkRenderFixChanged, invokeImmediately: true);
+        _cfg.OnValueChanged(git.DrunkRenderFix, OnDrunkRenderFixChanged, invokeImmediately: true);
         // Starlight-end
     }
 

--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -58,7 +58,7 @@ public sealed partial class DrunkOverlay : Overlay
         _drunkShader = _prototypeManager.Index(Shader).InstanceUnique();
         // Starlight-start: cache status effect system and register cvar listener
         _statusEffects = _sysMan.GetEntitySystem<StatusEffectsSystem>();
-        _cfg.OnValueChanged(git.DrunkRenderFix, OnDrunkRenderFixChanged, invokeImmediately: true);
+        _cfg.OnValueChanged(StarlightCCVars.DrunkRenderFix, OnDrunkRenderFixChanged, invokeImmediately: true);
         // Starlight-end
     }
 

--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -3,7 +3,7 @@ using Content.Shared.Drunk;
 using Content.Shared.StatusEffectNew;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
-using Robust.Shared.Configuration; // Starlight-edit
+using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;

--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -1,8 +1,9 @@
+using Content.Shared.CCVar; // Starlight-edit
 using Content.Shared.Drunk;
-using Content.Shared.StatusEffect;
 using Content.Shared.StatusEffectNew;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
+using Robust.Shared.Configuration; // Starlight-edit
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -13,15 +14,21 @@ public sealed partial class DrunkOverlay : Overlay
 {
     private static readonly ProtoId<ShaderPrototype> Shader = "Drunk";
 
+    // Starlight-start
+    private static readonly TimeSpan ScreenCaptureInterval = TimeSpan.FromSeconds(1.0 / 30.0);
+    // Starlight-end
+
     [Dependency] private IEntityManager _entityManager = default!;
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private IEntitySystemManager _sysMan = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IConfigurationManager _cfg = default!; // Starlight
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
-    public override bool RequestScreenTexture => true;
+    public override bool RequestScreenTexture { get; set; } // Starlight-edit: was `=> true`, the base class is exactly like this, override maintained for source clarity
     private readonly ShaderInstance _drunkShader;
+    private readonly StatusEffectsSystem _statusEffects; // Starlight-edit
 
     public float CurrentBoozePower = 0.0f;
 
@@ -39,11 +46,33 @@ public sealed partial class DrunkOverlay : Overlay
 
     private float _visualScale = 0;
 
+    // Starlight-start: screen texture caching
+    private bool _drunkRenderFix;
+    private TimeSpan _nextScreenCapture;
+    private Texture? _cachedScreenTexture;
+    // Starlight-end
+
     public DrunkOverlay()
     {
         IoCManager.InjectDependencies(this);
         _drunkShader = _prototypeManager.Index(Shader).InstanceUnique();
+        // Starlight-start: cache status effect system and register cvar listener
+        _statusEffects = _sysMan.GetEntitySystem<StatusEffectsSystem>();
+        _cfg.OnValueChanged(CCVars.DrunkRenderFix, OnDrunkRenderFixChanged, invokeImmediately: true);
+        // Starlight-end
     }
+
+    // Starlight-start: enable and disable render fix in real-time
+    private void OnDrunkRenderFixChanged(bool enabled)
+    {
+        _drunkRenderFix = enabled;
+        if (!enabled)
+        {
+            _cachedScreenTexture = null;
+            RequestScreenTexture = true;
+        }
+    }
+    // Starlight-end
 
     protected override void FrameUpdate(FrameEventArgs args)
     {
@@ -53,8 +82,8 @@ public sealed partial class DrunkOverlay : Overlay
         if (playerEntity == null)
             return;
 
-        var statusSys = _sysMan.GetEntitySystem<Shared.StatusEffectNew.StatusEffectsSystem>();
-        if (!statusSys.TryGetMaxTime<DrunkStatusEffectComponent>(playerEntity.Value, out var status))
+        // Starlight-edit: use cached status system
+        if (!_statusEffects.TryGetMaxTime<DrunkStatusEffectComponent>(playerEntity.Value, out var status))
             return;
 
         var time = status.Item2;
@@ -73,16 +102,44 @@ public sealed partial class DrunkOverlay : Overlay
             return false;
 
         _visualScale = BoozePowerToVisual(CurrentBoozePower);
-        return _visualScale > 0;
+        // Starlight-start: if no booze, don't grab screen texture, only grab screen texture 30 times / sec instead of every frame
+        if (_visualScale <= 0)
+        {
+            RequestScreenTexture = false;
+            return false;
+        }
+
+        if (_drunkRenderFix)
+            RequestScreenTexture = _timing.RealTime >= _nextScreenCapture;
+        else
+            RequestScreenTexture = true;
+
+        return true;
+        // Starlight-end
     }
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (ScreenTexture == null)
+        // Starlight-start: capture frame update every 30Hz if render fix on, otherwise everyframe
+        var screen = ScreenTexture;
+        if (_drunkRenderFix)
+        {
+            if (RequestScreenTexture && ScreenTexture != null)
+            {
+                _cachedScreenTexture = ScreenTexture;
+                _nextScreenCapture = _timing.RealTime + ScreenCaptureInterval;
+                RequestScreenTexture = false;
+            }
+
+            screen = _cachedScreenTexture;
+        }
+
+        if (screen == null)
             return;
 
         var handle = args.WorldHandle;
-        _drunkShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
+        _drunkShader.SetParameter("SCREEN_TEXTURE", screen);
+        // Starlight-end
         _drunkShader.SetParameter("boozePower", _visualScale);
         handle.UseShader(_drunkShader);
         handle.DrawRect(args.WorldBounds, Color.White);

--- a/Content.Shared/CCVar/CCVars.Debug.cs
+++ b/Content.Shared/CCVar/CCVars.Debug.cs
@@ -10,4 +10,12 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> DebugQuickInspect =
         CVarDef.Create("debug.quick_inspect", "", CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    #region Starlight
+    /// <summary>
+    /// Experimental fix: rate-limits drunk overlay screen-texture copies to ~30Hz instead of every render frame.
+    /// </summary>
+    public static readonly CVarDef<bool> DrunkRenderFix =
+        CVarDef.Create("debug.drunk_render_fix", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+    #endregion Starlight
 }

--- a/Content.Shared/CCVar/CCVars.Debug.cs
+++ b/Content.Shared/CCVar/CCVars.Debug.cs
@@ -10,12 +10,4 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<string> DebugQuickInspect =
         CVarDef.Create("debug.quick_inspect", "", CVar.CLIENTONLY | CVar.ARCHIVE);
-
-    #region Starlight
-    /// <summary>
-    /// Experimental fix: rate-limits drunk overlay screen-texture copies to ~30Hz instead of every render frame.
-    /// </summary>
-    public static readonly CVarDef<bool> DrunkRenderFix =
-        CVarDef.Create("debug.drunk_render_fix", false, CVar.CLIENTONLY | CVar.ARCHIVE);
-    #endregion Starlight
 }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Graphics.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Graphics.cs
@@ -5,4 +5,10 @@ public sealed partial class StarlightCCVars
 {
     public static readonly CVarDef<bool> TracesEnabled =
         CVarDef.Create("opt.traces_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Experimental fix: rate-limits drunk overlay screen-texture copies to ~30Hz instead of every render frame.
+    /// </summary>
+    public static readonly CVarDef<bool> DrunkRenderFix =
+        CVarDef.Create("opt.drunk_render_fix", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 }


### PR DESCRIPTION
## Short description
Adds an experimental fix for the alcohol lag that has been reported numerous times, disabled by default enabled by setting `opt.drunk_render_fix` to true.

## Why we need to add this
This will hopefully fix #5038, [this thread](https://discord.com/channels/1272545509562777621/1509365322757439554), [this thread](https://discord.com/channels/1272545509562777621/1523743383594467390), [this thread](https://discord.com/channels/1272545509562777621/1515343691995152474), and [this thread](https://discord.com/channels/1272545509562777621/1519592978597806162).

## Media (Video/Screenshots)
I can't really provide any for this.

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AprilCatStreams
- fix: (Experimental) Alcohol render lag.
