### PR TITLE
fix biomass divide by zero and perceived incorrect fluid scaling

### DIFF
--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -212,7 +212,9 @@ namespace Content.Server.Medical.BiomassReclaimer
             {
                 component.BloodReagents = solution.Clone();
                 // Starlight-start: fix Biomass divide by zero and presumed incorrect fluid scaling
-                component.BloodReagents.ScaleSolution(component.BloodReagents.Volume / 50);
+                component.BloodReagents.ScaleSolution(.25f);
+                if (component.BloodReagents.Volume > 50)
+                    component.BloodReagents.ScaleTo(50f);
                 // Starlight-end
             }
             if (TryComp<ButcherableComponent>(toProcess, out var butcherableComponent))

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -211,7 +211,9 @@ namespace Content.Server.Medical.BiomassReclaimer
                 _solution.ResolveSolution(toProcess, stream.BloodSolutionName, ref stream.BloodSolution, out var solution))
             {
                 component.BloodReagents = solution.Clone();
-                component.BloodReagents.ScaleSolution(50 / component.BloodReagents.Volume);
+                // Starlight-start: fix Biomass divide by zero and presumed incorrect fluid scaling
+                component.BloodReagents.ScaleSolution(component.BloodReagents.Volume / 50);
+                // Starlight-end
             }
             if (TryComp<ButcherableComponent>(toProcess, out var butcherableComponent))
             {


### PR DESCRIPTION
## Short description
Fixes a divide by zero error which prevented bodies with no blood from being put through the biomass reclaimer. It also fixes what I perceive to have been an incorrect fluid scaling algorithm.

## Why we need to add this
Allows bloodless bodies to be placed through the biomass reclaimer and makes blood spills from the reclaimer make more sense by making the reclaimer contain more blood when the body contains more blood. Fixes the issue discussed in [this thread](https://discord.com/channels/1272545509562777621/1517183459494203483).

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/396a510d-290a-4d62-a145-2083554b552a

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AprilCatStreams
- fix: Fixed divide by zero in Biomass Reclaimer allowing bloodless bodies to be processed again.