### PR TITLE
Fix borg module container unnesting to fix #5070

### DIFF
--- a/Content.Shared/Silicons/Borgs/BorgModuleItemExtractionDoAfterEvent.cs
+++ b/Content.Shared/Silicons/Borgs/BorgModuleItemExtractionDoAfterEvent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Silicons.Borgs;
+
+/// <summary>
+/// Do-after raised when finishing screwdriver extraction of items from <see cref="Components.ItemBorgModuleComponent"/>.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class BorgModuleItemExtractionDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/Silicons/Borgs/Components/ItemBorgModuleComponent.cs
+++ b/Content.Shared/Silicons/Borgs/Components/ItemBorgModuleComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared.Hands.Components;
+using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
@@ -51,6 +52,18 @@ public sealed partial class ItemBorgModuleComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<TagPrototype> ModuleItemTag = "BorgItem";
+
+    /// <summary>
+    /// How long it takes to pry stored items out of the module with a screwdriver.
+    /// </summary>
+    [DataField]
+    public float ItemExtractionDelay = 0.5f;
+
+    /// <summary>
+    /// Sound played when items are successfully pried out of the module.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier ItemExtractionSound = new SoundCollectionSpecifier("storageRustle");
     #endregion Starlight
 }
 

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
@@ -6,7 +6,6 @@ using Content.Shared.Interaction.Components;
 using Content.Shared.Localizations;
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.Storage.Components; // Starlight-edit
-using Content.Shared.Storage.EntitySystems; // Starlight-edit
 using Robust.Shared.Containers;
 #region Starlight
 using Content.Shared.Tag;
@@ -23,7 +22,6 @@ public abstract partial class SharedBorgSystem
 {
     private EntityQuery<BorgModuleComponent> _moduleQuery;
     [Dependency] private SharedToolSystem _tool = default!; //Starlight
-    [Dependency] private readonly SharedEntityStorageSystem _entityStorage = default!; // Starlight
 
     public void InitializeModule()
     {

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
@@ -5,13 +5,13 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Localizations;
 using Content.Shared.Silicons.Borgs.Components;
-using Content.Shared.Storage; // Starlight-edit
-using Content.Shared.Storage.Components; // Starlight-edit
 using Robust.Shared.Containers;
 #region Starlight
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Stacks;
+using Content.Shared.Storage;
+using Content.Shared.Storage.Components;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared._Starlight.Silicons;
@@ -580,9 +580,9 @@ public abstract partial class SharedBorgSystem
             if (nested is ContainerSlot)
                 continue;
 
-            if (TryComp<EntityStorageComponent>(item, out var es) && ReferenceEquals(nested, es.Contents))
+            if (entityStorage != null && ReferenceEquals(nested, entityStorage.Contents))
                 continue;
-            if (TryComp<StorageComponent>(item, out var st) && st.Container != null && ReferenceEquals(nested, st.Container))
+            if (storage != null && storage.Container != null && ReferenceEquals(nested, storage.Container))
                 continue;
             into.AddRange(nested.ContainedEntities);
         }
@@ -613,9 +613,9 @@ public abstract partial class SharedBorgSystem
         {
             if (nested is ContainerSlot || nested.ContainedEntities.Count == 0)
                 continue;
-            if (TryComp<EntityStorageComponent>(item, out var es) && ReferenceEquals(nested, es.Contents))
+            if (entityStorage != null && ReferenceEquals(nested, entityStorage.Contents))
                 continue;
-            if (TryComp<StorageComponent>(item, out var st) && st.Container != null && ReferenceEquals(nested, st.Container))
+            if (storage != null && storage.Container != null && ReferenceEquals(nested, storage.Container))
                 continue;
             _container.EmptyContainer(nested, force: true, destination: dest);
             emptied = true;

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
@@ -5,6 +5,8 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Localizations;
 using Content.Shared.Silicons.Borgs.Components;
+using Content.Shared.Storage.Components; // Starlight-edit
+using Content.Shared.Storage.EntitySystems; // Starlight-edit
 using Robust.Shared.Containers;
 #region Starlight
 using Content.Shared.Tag;
@@ -21,6 +23,7 @@ public abstract partial class SharedBorgSystem
 {
     private EntityQuery<BorgModuleComponent> _moduleQuery;
     [Dependency] private SharedToolSystem _tool = default!; //Starlight
+    [Dependency] private readonly SharedEntityStorageSystem _entityStorage = default!; // Starlight
 
     public void InitializeModule()
     {
@@ -408,6 +411,28 @@ public abstract partial class SharedBorgSystem
     #endregion
 
     #region Starlight
+    private void EmptyNestedStorage(EntityUid item)
+    {
+        if (TryComp<EntityStorageComponent>(item, out var storage))
+        {
+            var dest = Transform(item).Coordinates;
+            foreach (var ent in storage.Contents.ContainedEntities.ToList())
+            {
+                _container.Remove(ent, storage.Contents, force: true, destination: dest);
+            }
+        }
+
+        if (!TryComp<ContainerManagerComponent>(item, out var manager))
+            return;
+
+        foreach (var nested in _container.GetAllContainers(item, manager))
+        {
+            if (nested is ContainerSlot)
+                continue;
+            _container.EmptyContainer(nested, force: true, destination: Transform(item).Coordinates);
+        }
+    }
+
     private void OnInteractUsing(EntityUid uid, ItemBorgModuleComponent component, ref AfterInteractUsingEvent args)
     {
         if (args.Handled)
@@ -420,7 +445,12 @@ public abstract partial class SharedBorgSystem
             if (!_container.TryGetContainer(uid, component.HoldingContainer, out var container, manager)) return;
             foreach (var item in container.ContainedEntities.ToList())
             {
-                if (_tag.HasTag(item, component.ModuleItemTag)) continue;
+                if (_tag.HasTag(item, component.ModuleItemTag))
+                {
+                    EmptyNestedStorage(item);
+                    continue;
+                }
+
                 while (_container.TryGetContainingContainer(item, out var containing))
                     if (!_container.Remove(item, containing)) break;
             }

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
@@ -5,11 +5,13 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Interaction.Components;
 using Content.Shared.Localizations;
 using Content.Shared.Silicons.Borgs.Components;
+using Content.Shared.Storage; // Starlight-edit
 using Content.Shared.Storage.Components; // Starlight-edit
 using Robust.Shared.Containers;
 #region Starlight
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
+using Content.Shared.Stacks;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared._Starlight.Silicons;
@@ -21,6 +23,7 @@ public abstract partial class SharedBorgSystem
 {
     private EntityQuery<BorgModuleComponent> _moduleQuery;
     [Dependency] private SharedToolSystem _tool = default!; //Starlight
+    [Dependency] private SharedStackSystem _stacks = default!; // Starlight
 
     public void InitializeModule()
     {
@@ -419,11 +422,35 @@ public abstract partial class SharedBorgSystem
         if (items.Count == 0)
             return;
 
+        var grouped = new Dictionary<string, (string Name, int Count)>();
+        foreach (var item in items)
+        {
+            var name = Identity.Name(item, EntityManager);
+            var count = _stacks.GetCount(item);
+
+            string key;
+            if (TryComp<StackComponent>(item, out var stack))
+                key = $"stack:{stack.StackTypeId}";
+            else if (TryComp<MetaDataComponent>(item, out var meta) && meta.EntityPrototype is { } proto)
+                key = $"proto:{proto.ID}";
+            else
+                key = $"uid:{item}";
+            if (grouped.TryGetValue(key, out var existing))
+                grouped[key] = (existing.Name, existing.Count + count);
+            else
+                grouped[key] = (name, count);
+        }
+
+        var entries = grouped.Values
+            .Select(g => Loc.GetString("borg-module-item-contents-entry",
+                ("count", g.Count),
+                ("item", g.Name)))
+            .ToList();
+
         using (args.PushGroup(nameof(ItemBorgModuleComponent)))
         {
-            var names = ContentLocalizationManager.FormatList(
-                items.Select(i => Identity.Name(i, EntityManager)).ToList());
-            args.PushMarkup(Loc.GetString("borg-module-item-contents", ("items", names)));
+            args.PushMarkup(Loc.GetString("borg-module-item-contents",
+                ("items", ContentLocalizationManager.FormatList(entries))));
         }
     }
 
@@ -479,133 +506,120 @@ public abstract partial class SharedBorgSystem
 
     private void CollectExtractableItems(Entity<ItemBorgModuleComponent> module, List<EntityUid> into)
     {
-        if (_container.TryGetContainer(module, module.Comp.HoldingContainer, out var container))
+        ForEachModuleProvidedItem(module, (item, _) =>
         {
-            foreach (var item in container.ContainedEntities)
-            {
-                if (_tag.HasTag(item, module.Comp.ModuleItemTag))
-                    CollectNestedContents(item, into);
-                else
-                    into.Add(item);
-            }
-        }
-
-        if (!TryComp<BorgModuleComponent>(module, out var borgModule)
-            || borgModule.InstalledEntity is not { } chassis
-            || !TryComp<HandsComponent>(chassis, out var hands))
-            return;
-
-        for (var i = 0; i < module.Comp.Hands.Count; i++)
-        {
-            var handId = $"{GetNetEntity(module.Owner)}-hand-{i}";
-            if (!_hands.TryGetHeldItem((chassis, hands), handId, out var held))
-                continue;
-
-            if (_tag.HasTag(held.Value, module.Comp.ModuleItemTag))
-                CollectNestedContents(held.Value, into);
-            else
-                into.Add(held.Value);
-        }
-    }
-
-    private void CollectNestedContents(EntityUid item, List<EntityUid> into)
-    {
-        if (TryComp<EntityStorageComponent>(item, out var storage))
-        {
-            into.AddRange(storage.Contents.ContainedEntities);
-            return;
-        }
-
-        if (!TryComp<ContainerManagerComponent>(item, out var manager))
-            return;
-
-        foreach (var nested in _container.GetAllContainers(item, manager))
-        {
-            if (nested is ContainerSlot)
-                continue;
-
-            into.AddRange(nested.ContainedEntities);
-        }
+            var before = into.Count;
+            CollectNestedContents(item, into);
+            if (into.Count > before)
+                return;
+            if (!_tag.HasTag(item, module.Comp.ModuleItemTag))
+                into.Add(item);
+        });
     }
 
     private bool TryExtractItems(Entity<ItemBorgModuleComponent> module)
     {
         var extracted = false;
         var dropCoords = Transform(module).Coordinates;
-
-        if (_container.TryGetContainer(module, module.Comp.HoldingContainer, out var container))
+        ForEachModuleProvidedItem(module, (item, inChassisHand) =>
         {
-            foreach (var item in container.ContainedEntities.ToList())
-            {
-                if (_tag.HasTag(item, module.Comp.ModuleItemTag))
-                {
-                    if (EmptyNestedStorage(item))
-                        extracted = true;
-                    continue;
-                }
-
-                if (_container.Remove(item, container, force: true, destination: dropCoords))
-                    extracted = true;
-            }
-        }
-
-        if (!TryComp<BorgModuleComponent>(module, out var borgModule)
-            || borgModule.InstalledEntity is not { } chassis
-            || !TryComp<HandsComponent>(chassis, out var hands))
-            return extracted;
-
-        for (var i = 0; i < module.Comp.Hands.Count; i++)
-        {
-            var handId = $"{GetNetEntity(module.Owner)}-hand-{i}";
-            if (!_hands.TryGetHeldItem((chassis, hands), handId, out var held))
-                continue;
-
-            if (_tag.HasTag(held.Value, module.Comp.ModuleItemTag))
-            {
-                if (EmptyNestedStorage(held.Value))
-                    extracted = true;
-                continue;
-            }
-
-            RemComp<UnremoveableComponent>(held.Value);
-            if (_hands.TryDrop((chassis, hands), held.Value, checkActionBlocker: false))
+            if (EmptyNestedStorage(item))
                 extracted = true;
-        }
 
+            if (_tag.HasTag(item, module.Comp.ModuleItemTag))
+                return;
+            if (inChassisHand)
+            {
+                if (!TryComp<BorgModuleComponent>(module, out var borgModule)
+                    || borgModule.InstalledEntity is not { } chassis
+                    || !TryComp<HandsComponent>(chassis, out var hands))
+                    return;
+                RemComp<UnremoveableComponent>(item);
+                if (_hands.TryDrop((chassis, hands), item, checkActionBlocker: false))
+                    extracted = true;
+                return;
+            }
+            if (_container.TryGetContainingContainer(item, out var container)
+                && _container.Remove(item, container, force: true, destination: dropCoords))
+                extracted = true;
+        });
         return extracted;
     }
 
-    private bool EmptyNestedStorage(EntityUid item)
+    private void ForEachModuleProvidedItem(Entity<ItemBorgModuleComponent> module, Action<EntityUid, bool> action)
     {
-        var emptied = false;
-        var dest = Transform(item).Coordinates;
-
-        if (TryComp<EntityStorageComponent>(item, out var storage))
+        if (_container.TryGetContainer(module, module.Comp.HoldingContainer, out var container))
         {
-            foreach (var ent in storage.Contents.ContainedEntities.ToList())
-            {
-                if (_container.Remove(ent, storage.Contents, force: true, destination: dest))
-                    emptied = true;
-            }
-
-            return emptied;
+            foreach (var item in container.ContainedEntities.ToArray())
+                action(item, false);
         }
+        if (!TryComp<BorgModuleComponent>(module, out var borgModule)
+            || borgModule.InstalledEntity is not { } chassis
+            || !TryComp<HandsComponent>(chassis, out var hands))
+            return;
+        for (var i = 0; i < module.Comp.Hands.Count; i++)
+        {
+            var handId = $"{GetNetEntity(module.Owner)}-hand-{i}";
+            if (_hands.TryGetHeldItem((chassis, hands), handId, out var held))
+                action(held.Value, true);
+        }
+    }
 
+    private void CollectNestedContents(EntityUid item, List<EntityUid> into)
+    {
+        if (TryComp<EntityStorageComponent>(item, out var entityStorage))
+            into.AddRange(entityStorage.Contents.ContainedEntities);
+        if (TryComp<StorageComponent>(item, out var storage)
+            && storage.Container != null)
+            into.AddRange(storage.Container.ContainedEntities);
         if (!TryComp<ContainerManagerComponent>(item, out var manager))
-            return false;
+            return;
 
         foreach (var nested in _container.GetAllContainers(item, manager))
         {
             if (nested is ContainerSlot)
                 continue;
 
-            if (nested.ContainedEntities.Count == 0)
+            if (TryComp<EntityStorageComponent>(item, out var es) && ReferenceEquals(nested, es.Contents))
                 continue;
+            if (TryComp<StorageComponent>(item, out var st) && st.Container != null && ReferenceEquals(nested, st.Container))
+                continue;
+            into.AddRange(nested.ContainedEntities);
+        }
+    }
 
+    private bool EmptyNestedStorage(EntityUid item)
+    {
+        var emptied = false;
+        var dest = Transform(item).Coordinates;
+        if (TryComp<EntityStorageComponent>(item, out var entityStorage))
+        {
+            foreach (var ent in entityStorage.Contents.ContainedEntities.ToArray())
+            {
+                if (_container.Remove(ent, entityStorage.Contents, force: true, destination: dest))
+                    emptied = true;
+            }
+        }
+        if (TryComp<StorageComponent>(item, out var storage)
+            && storage.Container != null
+            && storage.Container.ContainedEntities.Count > 0)
+        {
+            _container.EmptyContainer(storage.Container, force: true, destination: dest);
+            emptied = true;
+        }
+        if (!TryComp<ContainerManagerComponent>(item, out var manager))
+            return emptied;
+        foreach (var nested in _container.GetAllContainers(item, manager))
+        {
+            if (nested is ContainerSlot || nested.ContainedEntities.Count == 0)
+                continue;
+            if (TryComp<EntityStorageComponent>(item, out var es) && ReferenceEquals(nested, es.Contents))
+                continue;
+            if (TryComp<StorageComponent>(item, out var st) && st.Container != null && ReferenceEquals(nested, st.Container))
+                continue;
             _container.EmptyContainer(nested, force: true, destination: dest);
             emptied = true;
         }
-
         return emptied;
     }
     #endregion Starlight

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
@@ -8,11 +8,10 @@ using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.Storage.Components; // Starlight-edit
 using Robust.Shared.Containers;
 #region Starlight
-using Content.Shared.Tag;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
-using System.Linq;
 using Content.Shared._Starlight.Silicons;
 #endregion Starlight
 
@@ -37,7 +36,11 @@ public abstract partial class SharedBorgSystem
         SubscribeLocalEvent<ItemBorgModuleComponent, ComponentStartup>(OnProvideItemStartup);
         SubscribeLocalEvent<ItemBorgModuleComponent, BorgModuleSelectedEvent>(OnItemModuleSelected);
         SubscribeLocalEvent<ItemBorgModuleComponent, BorgModuleUnselectedEvent>(OnItemModuleUnselected);
-        SubscribeLocalEvent<ItemBorgModuleComponent, AfterInteractUsingEvent>(OnInteractUsing);//Starlight
+        // Starlight begin
+        SubscribeLocalEvent<ItemBorgModuleComponent, ExaminedEvent>(OnItemModuleExamine);
+        SubscribeLocalEvent<ItemBorgModuleComponent, AfterInteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<ItemBorgModuleComponent, BorgModuleItemExtractionDoAfterEvent>(OnItemExtractionFinished);
+        // Starlight end
 
         SubscribeLocalEvent<ComponentBorgModuleComponent, BorgModuleInstalledEvent>(OnComponentModuleInstalled);
         SubscribeLocalEvent<ComponentBorgModuleComponent, BorgModuleUninstalledEvent>(OnComponentModuleUninstalled);
@@ -409,15 +412,108 @@ public abstract partial class SharedBorgSystem
     #endregion
 
     #region Starlight
-    private void EmptyNestedStorage(EntityUid item)
+    private void OnItemModuleExamine(Entity<ItemBorgModuleComponent> ent, ref ExaminedEvent args)
+    {
+        var items = new List<EntityUid>();
+        CollectExtractableItems(ent, items);
+        if (items.Count == 0)
+            return;
+
+        using (args.PushGroup(nameof(ItemBorgModuleComponent)))
+        {
+            var names = ContentLocalizationManager.FormatList(
+                items.Select(i => Identity.Name(i, EntityManager)).ToList());
+            args.PushMarkup(Loc.GetString("borg-module-item-contents", ("items", names)));
+        }
+    }
+
+    private void OnInteractUsing(Entity<ItemBorgModuleComponent> ent, ref AfterInteractUsingEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!TryComp<ToolComponent>(args.Used, out var tool)
+            || !_tool.HasQuality(args.Used, ent.Comp.ItemExtractionMethod, tool))
+            return;
+
+        args.Handled = true;
+
+        if (!args.CanReach)
+        {
+            if (_timing.IsFirstTimePredicted)
+                _popup.PopupClient(Loc.GetString("interaction-system-user-interaction-cannot-reach"), args.User, args.User);
+            return;
+        }
+
+        var extractable = new List<EntityUid>();
+        CollectExtractableItems(ent, extractable);
+        if (extractable.Count == 0)
+        {
+            _popup.PopupClient(Loc.GetString("borg-module-item-extract-empty", ("module", ent.Owner)), ent.Owner, args.User);
+            return;
+        }
+
+        _tool.UseTool(args.Used,
+            args.User,
+            ent.Owner,
+            ent.Comp.ItemExtractionDelay,
+            ent.Comp.ItemExtractionMethod,
+            new BorgModuleItemExtractionDoAfterEvent(),
+            toolComponent: tool);
+    }
+
+    private void OnItemExtractionFinished(Entity<ItemBorgModuleComponent> ent, ref BorgModuleItemExtractionDoAfterEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (!TryExtractItems(ent))
+        {
+            _popup.PopupClient(Loc.GetString("borg-module-item-extract-empty", ("module", ent.Owner)), ent.Owner, args.User);
+            return;
+        }
+
+        _popup.PopupClient(Loc.GetString("borg-module-item-extract-success", ("module", ent.Owner)), ent.Owner, args.User);
+        _audio.PlayPredicted(ent.Comp.ItemExtractionSound, ent.Owner, args.User);
+    }
+
+    private void CollectExtractableItems(Entity<ItemBorgModuleComponent> module, List<EntityUid> into)
+    {
+        if (_container.TryGetContainer(module, module.Comp.HoldingContainer, out var container))
+        {
+            foreach (var item in container.ContainedEntities)
+            {
+                if (_tag.HasTag(item, module.Comp.ModuleItemTag))
+                    CollectNestedContents(item, into);
+                else
+                    into.Add(item);
+            }
+        }
+
+        if (!TryComp<BorgModuleComponent>(module, out var borgModule)
+            || borgModule.InstalledEntity is not { } chassis
+            || !TryComp<HandsComponent>(chassis, out var hands))
+            return;
+
+        for (var i = 0; i < module.Comp.Hands.Count; i++)
+        {
+            var handId = $"{GetNetEntity(module.Owner)}-hand-{i}";
+            if (!_hands.TryGetHeldItem((chassis, hands), handId, out var held))
+                continue;
+
+            if (_tag.HasTag(held.Value, module.Comp.ModuleItemTag))
+                CollectNestedContents(held.Value, into);
+            else
+                into.Add(held.Value);
+        }
+    }
+
+    private void CollectNestedContents(EntityUid item, List<EntityUid> into)
     {
         if (TryComp<EntityStorageComponent>(item, out var storage))
         {
-            var dest = Transform(item).Coordinates;
-            foreach (var ent in storage.Contents.ContainedEntities.ToList())
-            {
-                _container.Remove(ent, storage.Contents, force: true, destination: dest);
-            }
+            into.AddRange(storage.Contents.ContainedEntities);
+            return;
         }
 
         if (!TryComp<ContainerManagerComponent>(item, out var manager))
@@ -427,32 +523,90 @@ public abstract partial class SharedBorgSystem
         {
             if (nested is ContainerSlot)
                 continue;
-            _container.EmptyContainer(nested, force: true, destination: Transform(item).Coordinates);
+
+            into.AddRange(nested.ContainedEntities);
         }
     }
 
-    private void OnInteractUsing(EntityUid uid, ItemBorgModuleComponent component, ref AfterInteractUsingEvent args)
+    private bool TryExtractItems(Entity<ItemBorgModuleComponent> module)
     {
-        if (args.Handled)
-            return;
+        var extracted = false;
+        var dropCoords = Transform(module).Coordinates;
 
-        if (TryComp<ToolComponent>(args.Used, out var tool)
-                 && _tool.HasQuality(args.Used, component.ItemExtractionMethod, tool))
+        if (_container.TryGetContainer(module, module.Comp.HoldingContainer, out var container))
         {
-            if (!TryComp<ContainerManagerComponent>(uid, out var manager)) return;
-            if (!_container.TryGetContainer(uid, component.HoldingContainer, out var container, manager)) return;
             foreach (var item in container.ContainedEntities.ToList())
             {
-                if (_tag.HasTag(item, component.ModuleItemTag))
+                if (_tag.HasTag(item, module.Comp.ModuleItemTag))
                 {
-                    EmptyNestedStorage(item);
+                    if (EmptyNestedStorage(item))
+                        extracted = true;
                     continue;
                 }
 
-                while (_container.TryGetContainingContainer(item, out var containing))
-                    if (!_container.Remove(item, containing)) break;
+                if (_container.Remove(item, container, force: true, destination: dropCoords))
+                    extracted = true;
             }
         }
+
+        if (!TryComp<BorgModuleComponent>(module, out var borgModule)
+            || borgModule.InstalledEntity is not { } chassis
+            || !TryComp<HandsComponent>(chassis, out var hands))
+            return extracted;
+
+        for (var i = 0; i < module.Comp.Hands.Count; i++)
+        {
+            var handId = $"{GetNetEntity(module.Owner)}-hand-{i}";
+            if (!_hands.TryGetHeldItem((chassis, hands), handId, out var held))
+                continue;
+
+            if (_tag.HasTag(held.Value, module.Comp.ModuleItemTag))
+            {
+                if (EmptyNestedStorage(held.Value))
+                    extracted = true;
+                continue;
+            }
+
+            RemComp<UnremoveableComponent>(held.Value);
+            if (_hands.TryDrop((chassis, hands), held.Value, checkActionBlocker: false))
+                extracted = true;
+        }
+
+        return extracted;
+    }
+
+    private bool EmptyNestedStorage(EntityUid item)
+    {
+        var emptied = false;
+        var dest = Transform(item).Coordinates;
+
+        if (TryComp<EntityStorageComponent>(item, out var storage))
+        {
+            foreach (var ent in storage.Contents.ContainedEntities.ToList())
+            {
+                if (_container.Remove(ent, storage.Contents, force: true, destination: dest))
+                    emptied = true;
+            }
+
+            return emptied;
+        }
+
+        if (!TryComp<ContainerManagerComponent>(item, out var manager))
+            return false;
+
+        foreach (var nested in _container.GetAllContainers(item, manager))
+        {
+            if (nested is ContainerSlot)
+                continue;
+
+            if (nested.ContainedEntities.Count == 0)
+                continue;
+
+            _container.EmptyContainer(nested, force: true, destination: dest);
+            emptied = true;
+        }
+
+        return emptied;
     }
     #endregion Starlight
 }

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
@@ -6,7 +6,6 @@ using Content.Shared.Interaction.Components;
 using Content.Shared.Localizations;
 using Content.Shared.Silicons.Borgs.Components;
 using Robust.Shared.Containers;
-#region Starlight
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Stacks;
@@ -15,7 +14,6 @@ using Content.Shared.Storage.Components;
 using Content.Shared.Tools.Components;
 using Content.Shared.Tools.Systems;
 using Content.Shared._Starlight.Silicons;
-#endregion Starlight
 
 namespace Content.Shared.Silicons.Borgs;
 
@@ -42,7 +40,7 @@ public abstract partial class SharedBorgSystem
         // Starlight begin
         SubscribeLocalEvent<ItemBorgModuleComponent, ExaminedEvent>(OnItemModuleExamine);
         SubscribeLocalEvent<ItemBorgModuleComponent, AfterInteractUsingEvent>(OnInteractUsing);
-        SubscribeLocalEvent<ItemBorgModuleComponent, BorgModuleItemExtractionDoAfterEvent>(OnItemExtractionFinished);
+        SubscribeLocalEvent<ItemBorgModuleComponent, _Starlight.Silicons.Borgs.BorgModuleItemExtractionDoAfterEvent>(OnItemExtractionFinished);
         // Starlight end
 
         SubscribeLocalEvent<ComponentBorgModuleComponent, BorgModuleInstalledEvent>(OnComponentModuleInstalled);
@@ -485,11 +483,11 @@ public abstract partial class SharedBorgSystem
             ent.Owner,
             ent.Comp.ItemExtractionDelay,
             ent.Comp.ItemExtractionMethod,
-            new BorgModuleItemExtractionDoAfterEvent(),
+            new _Starlight.Silicons.Borgs.BorgModuleItemExtractionDoAfterEvent(),
             toolComponent: tool);
     }
 
-    private void OnItemExtractionFinished(Entity<ItemBorgModuleComponent> ent, ref BorgModuleItemExtractionDoAfterEvent args)
+    private void OnItemExtractionFinished(Entity<ItemBorgModuleComponent> ent, ref _Starlight.Silicons.Borgs.BorgModuleItemExtractionDoAfterEvent args)
     {
         if (args.Cancelled)
             return;

--- a/Content.Shared/_Starlight/Silicons/Borgs/BorgModuleItemExtractionDoAfterEvent.cs
+++ b/Content.Shared/_Starlight/Silicons/Borgs/BorgModuleItemExtractionDoAfterEvent.cs
@@ -1,10 +1,11 @@
 using Content.Shared.DoAfter;
+using Content.Shared.Silicons.Borgs.Components;
 using Robust.Shared.Serialization;
 
-namespace Content.Shared.Silicons.Borgs;
+namespace Content.Shared._Starlight.Silicons.Borgs;
 
 /// <summary>
-/// Do-after raised when finishing screwdriver extraction of items from <see cref="Components.ItemBorgModuleComponent"/>.
+/// Do-after raised when finishing screwdriver extraction of items from <see cref="ItemBorgModuleComponent"/>.
 /// </summary>
 [Serializable, NetSerializable]
 public sealed partial class BorgModuleItemExtractionDoAfterEvent : SimpleDoAfterEvent;

--- a/Resources/Locale/en-US/_Starlight/borg/borg.ftl
+++ b/Resources/Locale/en-US/_Starlight/borg/borg.ftl
@@ -36,6 +36,7 @@ borg-type-cargo-transponder = cargo cyborg
 
 # Item module contents / screwdriver extraction
 borg-module-item-contents = Use a screwdriver on this module to retrieve: [color=yellow]{$items}[/color].
+borg-module-item-contents-entry = {$count}x {$item}
 borg-module-item-extract-empty = There is nothing to remove from {THE($module)}.
 borg-module-item-extract-success = You pry the contents out of {THE($module)}.
 

--- a/Resources/Locale/en-US/_Starlight/borg/borg.ftl
+++ b/Resources/Locale/en-US/_Starlight/borg/borg.ftl
@@ -34,6 +34,11 @@ borg-type-cargo-name = Cargo
 borg-type-cargo-desc = Haul cargo, deliver orders, and make the station rich!
 borg-type-cargo-transponder = cargo cyborg
 
+# Item module contents / screwdriver extraction
+borg-module-item-contents = Use a screwdriver on this module to retrieve: [color=yellow]{$items}[/color].
+borg-module-item-extract-empty = There is nothing to remove from {THE($module)}.
+borg-module-item-extract-success = You pry the contents out of {THE($module)}.
+
 # Module incompatibilities
 borg-module-incompatibility-xenoborg-engiweapon = Incompatible with other Engineering Xenoborg weapon modules.
 borg-module-incompatibility-xenoborg-heavyweapon = Incompatible with other Heavy Xenoborg weapon modules.


### PR DESCRIPTION
## Short description
Allows using a screwdriver on borg modules to remove items from nested containers.

## Why we need to add this
This fixes #5070 to prevent items getting stuck in modules when a borg is destroyed or a module is removed.

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/2d5e768b-1382-4a96-aa03-4fc59ae90c9e

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- fix: Items can now be removed from nested borg module containers.
