### PR TITLE
Don't upload dump when tests succeed

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -123,6 +123,7 @@ jobs:
       run: dotnet restore Content.IntegrationTests/Content.IntegrationTests.csproj
 
     - name: Run Content.IntegrationTests
+      id: run-integration-tests
       uses: nick-fields/retry@v3
       env:
         DOTNET_gcServer: "1"
@@ -150,7 +151,7 @@ jobs:
     - name: Upload crash dumps
       id: upload-dumps
       uses: actions/upload-artifact@v4
-      if: always()
+      if: ${{ always() && steps.run-integration-tests.outcome == 'failure' }}
       with:
         name: blame-dump-shard-${{ matrix.shard }}
         path: |


### PR DESCRIPTION
## Short description

build-test-debug CI job has two attempts built in, but currently takes a sweet 10 minutes uploading a dump artifact even if the second attempt succeeded and the job has a success outcome.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Saves 10mins CI time every time one attempt fails but the second attempt passes.

Example: https://github.com/ss14Starlight/space-station-14/actions/runs/29106462985/job/86409839109?pr=5073

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

N/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
