### PR TITLE
Fix job selection UI layout, resolves #3848

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1273,7 +1273,7 @@ namespace Content.Client.Lobby.UI
                     }
                     description.AddMessage(!reason.IsEmpty ? reason : FormattedMessage.FromMarkupPermissive(Loc.GetString("job-no-requirements")));
 
-                    selector.Setup(items, job.LocalizedName, 200, description, icon, job.Guides);
+                    selector.Setup(items, job.LocalizedName, 210, description, icon, job.Guides); // Starlight-edit: account for longer job names to keep alignment (NTR for example)
 
                     if (!allowed)
                     {


### PR DESCRIPTION
## Short description
Fixes the UI alignment in the character job select screen identified in #3848.

## Why we need to add this
Fixes a minor job UI layout bug, QoL/UX.

## Media (Video/Screenshots)
Before:
<img width="931" height="555" alt="image" src="https://github.com/user-attachments/assets/1dc1411a-42eb-4ffb-a30a-a2ade5fe5dee" />
After:
<img width="688" height="371" alt="image" src="https://github.com/user-attachments/assets/4b0228bf-80ab-4798-bf31-4bad7c9d620b" />

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AprilCatStreams
- fix: UI misalignment in job selection screen of character editor due to long job names.
