### PR TITLE
ID Card Computer Fixes

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml
@@ -29,6 +29,14 @@
             <Button Name="JobTitleSaveButton" Text="{Loc 'id-card-console-window-save-button'}" Disabled="True" />
         </GridContainer>
         <Control MinSize="0 8" />
+        <!-- Starlight-start -->
+        <Label Name="MissingPrivilegesWarning"
+               Text="{Loc 'id-card-console-window-missing-privileges-warning'}"
+               FontColorOverride="#FFFF00"
+               Visible="False"
+               HorizontalAlignment="Center"
+               Margin="0 0 0 4" />
+        <!-- Starlight-end -->
         <!-- Job preset selection, grant/revoke all access buttons. -->
         <BoxContainer Margin="0 8 0 4">
             <BoxContainer>

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -131,10 +131,27 @@ namespace Content.Client.Access.UI
 
         private void SetAllAccess(bool enabled)
         {
-            _pendingPressedAccessLevels.Clear(); // Starlight-edit
-            foreach (var button in _accessButtons.ButtonsList.Values)
-                if (!button.Disabled && button.Pressed != enabled)
-                    button.Pressed = enabled;
+            // Starlight-edit: Start
+            if (enabled)
+            {
+                foreach (var access in _allowedAccessLevels)
+                    _pendingPressedAccessLevels.Add(access);
+            }
+            else
+            {
+                _pendingPressedAccessLevels.RemoveWhere(a => _allowedAccessLevels.Contains(a));
+            }
+
+            foreach (var (access, button) in _accessButtons.ButtonsList)
+            {
+                if (button.Disabled)
+                    continue;
+
+                button.Pressed = _pendingPressedAccessLevels.Contains(access);
+            }
+
+            _pendingAccessOverride = true;
+            // Starlight-edit: End
         }
 
         private void SelectJobPreset(OptionButton.ItemSelectedEventArgs args)
@@ -169,7 +186,8 @@ namespace Content.Client.Access.UI
             var allowedJobAccess = allJobAccess
                 .Where(x => _allowedAccessLevels.Contains(x) && allConsoleGroupTags.Contains(x))
                 .ToHashSet();
-            _pendingPressedAccessLevels = allowedJobAccess;
+            _pendingPressedAccessLevels.RemoveWhere(a => _allowedAccessLevels.Contains(a));
+            _pendingPressedAccessLevels.UnionWith(allowedJobAccess);
 
             _pendingAccessOverride = true;
 
@@ -230,6 +248,11 @@ namespace Content.Client.Access.UI
 
             // Track allowed access for filtering on submit
             _allowedAccessLevels = allowedAccess.ToHashSet();
+
+            var targetHasUnmodifiableAccess = interfaceEnabled
+                && state.TargetIdAccessList != null
+                && state.TargetIdAccessList.Any(access => !_allowedAccessLevels.Contains(access));
+            MissingPrivilegesWarning.Visible = targetHasUnmodifiableAccess;
 
             var allPossibleAccess = _prototypeManager.EnumeratePrototypes<AccessLevelPrototype>()
                 .Where(a => a.CanAddToIdCard)

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -186,10 +186,8 @@ namespace Content.Client.Access.UI
             var allowedJobAccess = allJobAccess
                 .Where(x => _allowedAccessLevels.Contains(x) && allConsoleGroupTags.Contains(x))
                 .ToHashSet();
-            _pendingPressedAccessLevels.RemoveWhere(a => _allowedAccessLevels.Contains(a));
-            _pendingPressedAccessLevels.UnionWith(allowedJobAccess);
 
-            _pendingAccessOverride = true;
+            _pendingPressedAccessLevels.UnionWith(allowedJobAccess);
 
             // Update visible buttons to match pending pressed state
             foreach (var (access, button) in _accessButtons.ButtonsList)

--- a/Resources/Locale/en-US/access/components/id-card-console-component.ftl
+++ b/Resources/Locale/en-US/access/components/id-card-console-component.ftl
@@ -8,7 +8,9 @@ id-card-console-window-insert-button = Insert
 id-card-console-window-job-selection-label = Job preset (sets department and job icon):
 id-card-console-window-select-all-button = Grant all
 id-card-console-window-deselect-all-button = Revoke all
-
+# Starlight-start
+id-card-console-window-missing-privileges-warning = Notice: Target ID has access levels the current privileged ID cannot modify.
+# Starlight-end
 access-id-card-console-component-no-hands-error = You have no hands.
 id-card-console-privileged-id = Privileged ID
 id-card-console-target-id = Target ID

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
@@ -119,7 +119,7 @@
       - Law
       - NanoTrasen
       privilegedIdSlot:
-        name: id-card-clipboard-priviliged-id
+        name: Privileged ID # Starlight-edit: Use English String
         ejectSound: /Audio/Machines/id_swipe.ogg
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectOnBreak: true
@@ -128,7 +128,7 @@
           components:
           - IdCard
       targetIdSlot:
-        name: id-card-clipboard-target-id
+        name: Target ID # Starlight-edit: Use English String
         ejectSound: /Audio/Machines/id_swipe.ogg
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectOnBreak: true


### PR DESCRIPTION
## Short description
Fixes #3813, allowing the ID terminal to work correctly again on cards with higher privilege levels, also adds a warning when an ID is inserted with accesses that the privileged ID cannot modify.

## Why we need to add this
Improves user awareness of ID settings and allows quicker all access and job setting by HoP again.

## Media (Video/Screenshots)
<img width="1512" height="719" alt="image" src="https://github.com/user-attachments/assets/9af4f2c6-d026-412d-847f-2c319c44ea51" />

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AprilCatStreams
- fix: The ID computer's job assignment dropdown, grant all, and revoke all work correctly again.
- tweak: New UI element to inform you when you are editing an ID card with more privileges than you have.
