### PR TITLE
Prevent Bleading Caused By Holding Amputated Limbs

### DIFF
--- a/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/SurgerySystem.Steps.cs
@@ -60,7 +60,8 @@ public sealed partial class SurgerySystem : SharedSurgerySystem
 
             incision.NextUpdate = _timing.CurTime + incision.UpdateInterval;
 
-            var patient = Transform(uid).ParentUid;
+            if (!TryComp<BodyPartComponent>(uid, out var part) || part.Body is not { } patient)
+                continue;
 
             _bloodstreamSystem.TryModifyBleedAmount(patient, 0.1f);
         }


### PR DESCRIPTION
## Short description
Fix #4175, a bug in patient retrieval logic in the surgical system caused incision damage to be applied to the person holding an amputated limb.

## Why we need to add this
So surgeons don't die by treating patients.

## Media (Video/Screenshots)
<img width="1512" height="958" alt="image" src="https://github.com/user-attachments/assets/2699e65b-1123-46cc-974d-494742d6782b" />
Holding limb, no bleeding

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl:
- fix: Surgically removed limbs no longer cause the holder to bleed.
