### PR TITLE
Prevent PDA Use After Death

### DIFF
--- a/Content.Shared/_Starlight/Interaction/SharedInteractionSystem.PAI.cs
+++ b/Content.Shared/_Starlight/Interaction/SharedInteractionSystem.PAI.cs
@@ -11,6 +11,6 @@ public abstract partial class SharedInteractionSystem
                _containerSystem.TryGetContainingContainer(actor, out var container) &&
                container != null &&
                container.Owner == target &&
-               container.ID == "pai_slot";
+               (container.ID == "pai_slot" || container.ID == "PDA-pai");
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -100,7 +100,6 @@
   - type: UserInterface
     interfaces:
       enum.PdaUiKey.Key:
-        requireInputValidation: false #Starlight pAI can open PDAs, see PR #3272
         type: PdaBoundUserInterface
       enum.StoreUiKey.Key:
         type: StoreBoundUserInterface


### PR DESCRIPTION
## Short description
PR #3272 previously disable the input validation for the PDA UI to allow slotted pAIs to use it. This however also turned off the dead/crit checks. This PR re-enables input validation and instead corrects the IsSlottedPAI call to check if it's in a PDA and bypass checks that way.

## Why we need to add this
Users can currently use PDA apps while dead. Fixes #4187.

## Media (Video/Screenshots)
N/A

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl:
- fix: Users can no longer use their PDAs while dead/crit.
