### PR TITLE
Add Health Analyzer Back to Roboticist PDA

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/pda.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: BasePDA
+  parent: BaseMedicalPDA
   id: RoboticistPDA
   name: roboticist PDA
   description: Covered in dirt and oil. The screen is covered in something sticky.
@@ -16,13 +16,6 @@
     accentVColor: "#d33725"
   - type: Icon
     state: pda-roboticist
-  - type: HealthAnalyzer
-    scanningEndSound:
-      path: "/Audio/Items/Medical/healthscanner.ogg"
-    damageContainers:
-    - Silicon
-    - IPC
-    - Hybrid
 
 - type: entity
   parent: BaseMedicalPDA


### PR DESCRIPTION
## Short description
Fixes #4104, wizden used to provide medical analyzer for roboticists. Starlight brought them back but their PDA is only now being brought back in-line with the modern SS14 PDA system.

## Why we need to add this
QoL for robotics.

## Media (Video/Screenshots)
N/A

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AprilCatStreams
- fix: Brought Roboticists PDA back to the modern times with a health analyzer.