### PR TITLE
Swing your Sheathes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -31,6 +31,12 @@
           tags:
           - CaptainSabre
   - type: Appearance
+  - type: MeleeWeapon # Starlight start
+    damage:
+      types:
+        Blunt: 9
+    soundHit:
+      collection: MetalThud # Starlight end
 
 - type: entity
   parent: ClothingBeltStorageBase

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
@@ -92,6 +92,12 @@
         whitelist:
           tags:
           - CaneBlade
+  - type: MeleeWeapon # Starlight start
+    damage:
+      types:
+        Blunt: 9
+    soundHit:
+      collection: MetalThud # Starlight end
 
 - type: entity
   id: CaneSheathFilled

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Back/backpacks.yml
@@ -106,3 +106,9 @@
     - type: Storage
       grid:
       - 0,0,1,15 #its a part of the joke of the inventory being sword shaped and inconvient.
+    - type: MeleeWeapon # Technically a sheathe; it's the same damage as the mail trunk, worse than a toolbox, mainly just a gimmick so you can swing the sheathe
+      damage:
+        types:
+          Blunt: 9
+      soundHit:
+        collection: MetalThud

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Belt/vibroblade_sheaths.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Belt/vibroblade_sheaths.yml
@@ -29,6 +29,12 @@
           tags:
           - CentcommVibroblade
   - type: Appearance
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 9
+    soundHit:
+      collection: MetalThud
 
 - type: entity
   parent: CentcommVibrobladeSheath
@@ -73,6 +79,12 @@
           tags:
           - PrototypeVibroblade
   - type: Appearance
+  - type: MeleeWeapon
+    damage:
+      types:
+        Blunt: 9
+    soundHit:
+      collection: MetalThud
 
 - type: entity
   parent: PrototypeVibrobladeSheath


### PR DESCRIPTION
## Short description
You can now swing your sheathes; they deal the same damage as the mail trunks. It's not really any special damage, a toolbox does more, but swinging the sheathe looks cool.

## Why we need to add this
Looks cool, it's a popular thing to do in media, even if it's impractical. The damage isn't significant.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: You can now swing vibroblade sheathes, the captain's sheathe, the cane sheathe, and the bunny gang backpack.
