### PR TITLE
AAC Tablet colors, dept only, based on Starlight more or less

### DIFF
--- a/Content.Client/_Starlight/AACTablet/UI/AACSheetlet.cs
+++ b/Content.Client/_Starlight/AACTablet/UI/AACSheetlet.cs
@@ -1,0 +1,63 @@
+using Content.Client.Stylesheets;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using static Content.Client.Stylesheets.StylesheetHelpers;
+
+namespace Content.Client._Starlight.AACTablet.UI;
+
+[CommonSheetlet]
+public sealed class AACSheetlet<T> : Sheetlet<T> where T : PalettedStylesheet
+{
+    private static readonly (string StyleClass, Color Department)[] SubjectButtonColors =
+    [
+        ("CommandButton", Color.FromHex("#1b67a5")),
+        ("EngineeringButton", Color.FromHex("#f37700")),
+        ("EpistemicsButton", Color.FromHex("#8b308f")), // Science
+        ("JusticeButton", Color.FromHex("#326500")), // Law
+        ("LogisticsButton", Color.FromHex("#b18644")), // Cargo
+        ("MedicalButton", Color.FromHex("#417da2")),
+        ("SecurityButton", Color.FromHex("#830000")),
+        ("ServiceButton", Color.FromHex("#639137")),
+        ("CentralCommandButton", Color.FromHex("#0a5704")),
+        ("NanotrasenButton", Color.FromHex("#0d304d")),
+    ];
+
+    public override StyleRule[] GetRules(T sheet, object config)
+    {
+        var rules = new List<StyleRule>
+        {
+            E<RichTextLabel>()
+                .Class("WhiteText")
+                .FontColor(Color.White),
+            E<Label>()
+                .Class("WhiteText")
+                .FontColor(Color.White),
+        };
+
+        foreach (var (styleClass, department) in SubjectButtonColors)
+        {
+            var hover = Color.InterpolateBetween(department, Color.White, 0.2f);
+            var pressed = Color.InterpolateBetween(department, Color.Black, 0.2f);
+
+            rules.AddRange([
+                E<ContainerButton>()
+                    .Class(ContainerButton.StyleClassButton)
+                    .Class(styleClass)
+                    .PseudoNormal()
+                    .Prop(Control.StylePropertyModulateSelf, department),
+                E<ContainerButton>()
+                    .Class(ContainerButton.StyleClassButton)
+                    .Class(styleClass)
+                    .PseudoHovered()
+                    .Prop(Control.StylePropertyModulateSelf, hover),
+                E<ContainerButton>()
+                    .Class(ContainerButton.StyleClassButton)
+                    .Class(styleClass)
+                    .PseudoPressed()
+                    .Prop(Control.StylePropertyModulateSelf, pressed),
+            ]);
+        }
+
+        return rules.ToArray();
+    }
+}

--- a/Resources/Prototypes/_Starlight/QuickPhrases/base.yml
+++ b/Resources/Prototypes/_Starlight/QuickPhrases/base.yml
@@ -1,11 +1,11 @@
 - type: quickPhrase
   id: BaseCentralcommandPhrase
   group: CentralCommand
-  styleClass: CentralCommandButton #Coloring seems missing for all buttons, someone else needs to add them.
+  styleClass: CentralCommandButton
   abstract: true
 
 - type: quickPhrase
   id: BaseNanotrasenPhrase
   group: Nanotrasen
-  styleClass: NanotrasenButton #Coloring seems missing for all buttons, someone else needs to add them.
+  styleClass: NanotrasenButton
   abstract: true


### PR DESCRIPTION
## Short description
Fixes #3651, provides new colors for departments in the AAC tablet. They are more or less based on the Starlight colors as best as possible while still being readable.

## Why we need to add this
Colors are pretty.

## Media (Video/Screenshots)
<img width="560" height="313" alt="image" src="https://github.com/user-attachments/assets/27cb5837-f747-4e31-9629-61a99231fb25" />
<img width="560" height="313" alt="image" src="https://github.com/user-attachments/assets/c3b681ee-6b6a-45d3-a266-7b9794b4ae78" />
<img width="560" height="313" alt="image" src="https://github.com/user-attachments/assets/8145d0d8-537b-4e1f-8b50-6c4c1832dd83" />
<img width="560" height="313" alt="image" src="https://github.com/user-attachments/assets/f85e651b-2bd3-42a5-a11e-67a162e86eb3" />
<img width="560" height="313" alt="image" src="https://github.com/user-attachments/assets/dc7bf2f4-7647-4b25-8c3e-218b2ccc9fa6" />
<img width="560" height="313" alt="image" src="https://github.com/user-attachments/assets/2bf6f7b6-ad9a-4f68-915f-9b94b26f3ea3" />
<img width="549" height="311" alt="image" src="https://github.com/user-attachments/assets/157ddb3c-1c02-4190-ae24-26abdb679453" />
<img width="549" height="311" alt="image" src="https://github.com/user-attachments/assets/5f7a8f8a-1106-4c7e-913b-e3923d87dcaf" />
<img width="549" height="311" alt="image" src="https://github.com/user-attachments/assets/f1813e59-5aac-494f-aa1d-52418d6b8036" />
<img width="549" height="311" alt="image" src="https://github.com/user-attachments/assets/674c092a-b316-480b-a4c5-24ef82e12fec" />
<img width="549" height="311" alt="image" src="https://github.com/user-attachments/assets/bab69350-546f-4216-925d-84517a8f8b6e" />
<img width="547" height="319" alt="image" src="https://github.com/user-attachments/assets/c2e3bee8-f9e8-4ff1-afa5-b1dd57ce217e" />
<img width="547" height="319" alt="image" src="https://github.com/user-attachments/assets/291189f1-c673-47c7-bdce-42b007f057de" />
<img width="544" height="311" alt="image" src="https://github.com/user-attachments/assets/f95cfa91-5e22-43c9-8b9d-e1f6ea800062" />
<img width="544" height="311" alt="image" src="https://github.com/user-attachments/assets/a38b6e81-0dc7-42fb-8326-aa05d432d83a" />
<img width="544" height="311" alt="image" src="https://github.com/user-attachments/assets/36b0efca-092e-4313-8988-0c42cd734116" />
<img width="545" height="309" alt="image" src="https://github.com/user-attachments/assets/ce3f9d57-1a23-471b-807a-40d51f7234ca" />
<img width="556" height="318" alt="image" src="https://github.com/user-attachments/assets/fad1a5f0-83ec-4e26-8eca-8aae937aaacb" />

Sorry, that concludes image spam.

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AprilCatStreams
- add: Added colors for the AAC Tablet.