### PR TITLE
Broken Cryopods can be deconstructed

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
@@ -158,3 +158,7 @@
     materialComposition:
       Steel: 2000 # 20 sheets
       Glass: 1000 # 10 sheets
+  - type: Construction #Starlight - Makes the destroyed Cryo Pods Deconstrucable - start
+    graph: Machine
+    node: destroyedMachineFrame
+    #Starlight - End

--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
@@ -156,8 +156,8 @@
         acts: [ "Destruction" ]
   - type: PhysicalComposition
     materialComposition:
-      Steel: 2000 # 20 sheets
-      Glass: 1000 # 10 sheets
+      Steel: 500 # 5 sheets - Starlight
+      Glass: 300 # 3 sheets - Starlight
   - type: Construction #Starlight - Makes the destroyed Cryo Pods Deconstrucable - start
     graph: Machine
     node: destroyedMachineFrame


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
This PR makes Broken Cryopods de-constructable, since they aren't able to be removed like airlock assembly's or broken machine frames all you can *try* to do is unanchor it and throw it away into space, HOWEVER these Cryopods are more then 1 tile large meaning you have to put a literal hole in the wall for it to fit.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Trying to do something like wreck fixing is HORRIFIC when you try to fix these, Since you cant remove them you have to just place them..SOMEWHERE, They are able to be broken through pure brute force buuttt that takes 100 damage to do that and you don't even get any mats from that, This just drops 3 steel as the glass is literally all gone on a broken cryo pod.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Pretty simple to imagine
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: Forrestgod
- tweak: Broken Cryopods can now be deconstructed via a welder just like broken machine frames.

