### PR TITLE
Paracusia Medicine

### DIFF
--- a/Content.Client/Traits/ParacusiaSystem.cs
+++ b/Content.Client/Traits/ParacusiaSystem.cs
@@ -1,10 +1,11 @@
+using System.ComponentModel;
 using System.Numerics;
 using Content.Shared.Traits.Assorted;
-using Robust.Shared.Random;
 using Robust.Client.Player;
-using Robust.Shared.Player;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
 namespace Content.Client.Traits;
@@ -70,6 +71,13 @@ public sealed partial class ParacusiaSystem : SharedParacusiaSystem
 
         // Play the sound
         paracusia.Stream = _audio.PlayStatic(paracusia.Sounds, uid, newCoords)?.Entity;
+    }
+    private void ResetParacusiaTimer(EntityUid uid)
+    {
+        if (!TryComp<ParacusiaComponent>(uid, out var paracusia))
+            return;
+        //Set new time.
+        paracusia.NextIncidentTime = _timing.CurTime + TimeSpan.FromSeconds(_random.NextFloat(paracusia.MinTimeBetweenIncidents, paracusia.MaxTimeBetweenIncidents));
     }
 
 }

--- a/Content.Shared/EntityEffects/Effects/ResetParacusiaEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/ResetParacusiaEntityEffectSystem.cs
@@ -1,0 +1,37 @@
+using Content.Shared.Traits.Assorted;
+using Robust.Shared.Prototypes;
+
+using Content.Shared.Traits.Assorted;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.EntityEffects.Effects;
+
+/// <summary>
+/// Resets the Paracusia timer on a given entity.
+/// The new duration of the timer is modified by scale.
+/// </summary>
+/// <inheritdoc cref="EntityEffectSystem{T,TEffect}"/>
+public sealed partial class ResetParacusiaEntityEffectSystem : EntityEffectSystem<ParacusiaComponent, ResetParacusia>
+{
+	[Dependency] private SharedParacusiaSystem _paracusia = default!;
+
+	protected override void Effect(Entity<ParacusiaComponent> entity, ref EntityEffectEvent<ResetParacusia> args)
+	{
+		var timer = args.Effect.TimerReset * args.Scale;
+
+		_paracusia.ResetParacusiaTimer(entity.AsNullable(), timer);
+	}
+}
+
+/// <inheritdoc cref="EntityEffect"/>
+public sealed partial class ResetParacusia : EntityEffectBase<ResetParacusia>
+{
+    /// <summary>
+    /// The time we set our Paracusia timer to.
+    /// </summary>
+    [DataField("TimerReset")]
+    public TimeSpan TimerReset = TimeSpan.FromSeconds(600);
+
+    public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys, ILocalizationManager loc) => // Starlight
+        loc.GetString("entity-effect-guidebook-reset-narcolepsy", ("chance", Probability));
+}

--- a/Content.Shared/Traits/Assorted/SharedParacusiaSystem.cs
+++ b/Content.Shared/Traits/Assorted/SharedParacusiaSystem.cs
@@ -2,4 +2,8 @@ namespace Content.Shared.Traits.Assorted;
 
 public abstract class SharedParacusiaSystem : EntitySystem
 {
+    public void ResetParacusiaTimer(EntityUid uid, TimeSpan timer)
+    {
+        
+    }
 }


### PR DESCRIPTION
## Short description
This PR is to add the ability to have medications reset the timer for paracusia halucinations

## Why we need to add this
Given there is already medication to help with narcolepsy (ephedrine) I feel that we can continue adding effects that interact with the trait system. This would add additional RP for people suffering from paracusia.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
Adds ResetParacusia system

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
