### PR TITLE
Fix MedTak borgs not seeing client icons

### DIFF
--- a/Content.Shared/_Starlight/Implants/Components/IconImplantComponent.cs
+++ b/Content.Shared/_Starlight/Implants/Components/IconImplantComponent.cs
@@ -19,6 +19,6 @@ public sealed partial class IconImplantComponent : Component
     /// <summary>
     /// The 'type' of icon that this is - needs to match a string in <see cref="ShowImplantedIconsComponent"/>
     /// </summary>
-    [DataField(required: true)]
-    public string IconType = default!;
+    [DataField]
+    public string IconType = "default";
 }

--- a/Content.Shared/_Starlight/Overlay/Components/ShowImplantedIconsComponent.cs
+++ b/Content.Shared/_Starlight/Overlay/Components/ShowImplantedIconsComponent.cs
@@ -11,6 +11,6 @@ public sealed partial class ShowImplantedIconsComponent : Component
     /// <summary>
     /// The 'type' of icon that this can show, needs to match with <see cref="IconImplantComponent"/> to work
     /// </summary>
-    [DataField(required: true), AutoNetworkedField]
-    public List<string> ShownIcons = default!;
+    [DataField, AutoNetworkedField]
+    public List<string> ShownIcons = new List<string> {"default"};
 }

--- a/Resources/Prototypes/_Starlight/Admeme/MedTak/Entities/Mobs/medtak_chassis.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/MedTak/Entities/Mobs/medtak_chassis.yml
@@ -40,6 +40,9 @@
       - Maintenance
     - type: AccessReader
       access: [["MedTak"]]
+    - type: ShowImplantedIcons
+      shownIcons:
+      - MedTak
     - type: ShowHealthBars
       damageContainers:
       - Biological


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
I missed borgs when adding client icons, they should be visible to them now.
also fixes the `ShowImplantedIconsComponent` freaking out if added to an entity
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bug fix
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: SevenShades
- fix: MedTak silicons not seeing client icons.