### PR TITLE
Fix inconsistent animal breeding behavior

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Popups;
 using Content.Shared.Database;

--- a/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/AnimalHusbandrySystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Popups;
 using Content.Shared.Database;
@@ -72,6 +73,9 @@ public sealed partial class AnimalHusbandrySystem : EntitySystem
 
         var partners = new HashSet<Entity<ReproductivePartnerComponent>>();
         _entityLookup.GetEntitiesInRange(xform.Coordinates, component.BreedRange, partners);
+
+        // Starlight - Exclude any breeding partners that aren't breedable partners anyway
+        partners.RemoveWhere(partner => !_whitelistSystem.IsWhitelistPass(component.PartnerWhitelist, partner) || _mobState.IsIncapacitated(partner));
 
         if (partners.Count >= component.Capacity)
             return false;


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixing an oversight in the animal husbandry system that incorrectly assumed every reproductive animal in breeding range (dead or alive, valid reproductive partner or not) was valid to check against for breeding limits.
This caused a lot of invisible and strange behavior, where animals simply appeared to 'break' or stop breeding despite meeting the conditions to breed with a valid breeding partner and plenty of food and water.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Explained the issue and fix here: https://discord.com/channels/1272545509562777621/1274328216768872470/1525661156755116033

A summary is as follows:
Animal husbandry has been part of the game for a long time.  It's also been considered 'broken' in some indescribable, odd way.  At some point, the cows stop breeding.  The chickens keep doing it.  You can kill several animals and they'll still not breed.  It's been confusing behavior.
In a nutshell, the reason that animals had inconsistent breeding behavior was because they limited themselves to **all breedable animals in a radius** around them, regardless of whether or not the animal _could actually breed_ with the other animal.  Chickens have a higher population count than the rest of the livestock, so the behavior became that you had like one or two cows that wouldn't reproduce while you had ten chickens.
Confusingly, if you then killed a few chickens in the pen, no animal would breed either.  This is because dead animals counted against population limits, too.

Now animals check against valid living breeding targets when attempting to reproduce.  As it should have always been.
Tested plenty in localhost.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

In the image below, various reproducing animals have been fed and watered.  In addition,  several pigs were (at the time of the screenshot) removed from the pen to ensure more could breed.
These creatures' population counts (non-inclusive) are defined as follows:
Chickens: up to 12 within 3 tiles
Cows: up to 6 within 3 tiles
Pigs: Up to 6 within 3 tiles
Goats: Up to 6 within 3 tiles
These are **non-inclusive** figures, so you can have up to 13 chickens, 7 of the other creatures.
<img width="1243" height="848" alt="image" src="https://github.com/user-attachments/assets/0223d125-1c81-4d9f-a860-bd9051782a5c" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Sparlight
- fix: Fixed inconsistent animal husbandry behavior.  Now your chickens won't stop your cows from breeding.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

-->
