### PR TITLE
Fixes BaseAnimalKidneys missing parent for surgery

### DIFF
--- a/Resources/Prototypes/_Starlight/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Animal/animal.yml
@@ -146,7 +146,7 @@
 
 - type: entity
   id: OrganAnimalKidneys
-  parent: BaseAnimalOrgan
+  parent: [ BaseAnimalOrgan, BaseOrganKidneys ]
   name: animal kidneys
   categories: [ HideSpawnMenu ]
   components:


### PR DESCRIPTION
## Short description
BaseAnimalKidneys was missing the parenting of BaseOrganKidneys, which contains the OrganKidneys and OrganDamage components used for Surgery.

This fixes #5104

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/f667c740-0be2-463e-8a20-469988465980

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- fix: Animal Kidneys can now be used in Surgery to replace kidneys.
