### PR TITLE
Fix role time requirement showing 'unknown' for met requirements

### DIFF
--- a/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
@@ -59,7 +59,7 @@ public sealed partial class RoleTimeRequirement : JobRequirement
         var jobProto = jobSystem.GetJobPrototype(proto);
 
         // Starlight start
-        // Handle non-job role time requirements.
+        // Handle non-job role time requirements
         protoManager.TryIndex<PlayTimeTrackerPrototype>(proto, out var tracker);
         string roleName;
         if (jobProto is not null && protoManager.TryIndex<JobPrototype>(jobProto, out var indexedJobName))

--- a/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
@@ -59,10 +59,15 @@ public sealed partial class RoleTimeRequirement : JobRequirement
         var jobProto = jobSystem.GetJobPrototype(proto);
 
         // Starlight start
-        // Handle non-job role time requirements
-        var roleName = protoManager.TryIndex<PlayTimeTrackerPrototype>(proto, out var tracker)
-            ? tracker.LocalizedName
-            : Loc.GetString(proto);
+        // Handle non-job role time requirements.
+        protoManager.TryIndex<PlayTimeTrackerPrototype>(proto, out var tracker);
+        string roleName;
+        if (jobProto is not null && protoManager.TryIndex<JobPrototype>(jobProto, out var indexedJobName))
+            roleName = indexedJobName.LocalizedName;
+        else if (tracker is not null)
+            roleName = tracker.LocalizedName;
+        else
+            roleName = Loc.GetString(proto);
 
         reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
             Inverted ? "role-timer-not-too-high" : "role-timer-role-sufficient",

--- a/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
@@ -60,11 +60,11 @@ public sealed partial class RoleTimeRequirement : JobRequirement
 
         // Starlight start
         // Handle non-job role time requirements
-        protoManager.TryIndex<PlayTimeTrackerPrototype>(proto, out var tracker);
         string roleName;
+        PlayTimeTrackerPrototype? tracker = null;
         if (jobProto is not null && protoManager.TryIndex<JobPrototype>(jobProto, out var indexedJobName))
             roleName = indexedJobName.LocalizedName;
-        else if (tracker is not null)
+        else if (protoManager.TryIndex(proto, out tracker))
             roleName = tracker.LocalizedName;
         else
             roleName = Loc.GetString(proto);


### PR DESCRIPTION
## Short description
Job play-time trackers don't set a Name field, so the requirement-met message resolved the role name to generic-unknown. Prefer the job prototype's name, falling back to the tracker name then the raw id.

## Why we need to add this
https://discord.com/channels/1272545509562777621/1525410214352781334

## Media (Video/Screenshots)
<img width="909" height="221" alt="image" src="https://github.com/user-attachments/assets/fa0ecf74-291f-4908-b4fb-84764b5b6a8b" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: ku-mo
- fix: Role time requirements no longer display as "unknown" for roles you already meet the playtime for.
