### PR TITLE
ID Card Computer Fixes

### DIFF
--- a/.github/workflows/close-master-pr.yml
+++ b/.github/workflows/close-master-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
-    if: ${{github.head_ref == 'master' || github.head_ref == 'main' || github.head_ref == 'develop' || github.head_ref == 'Starlight'}}
+    if: ${{github.head_ref == 'master' || github.head_ref == 'main' || github.head_ref == 'develop' || github.head_ref == 'Sol' || github.head_ref == 'sol-dev'}}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/target-branch-validation.yml
+++ b/.github/workflows/target-branch-validation.yml
@@ -14,24 +14,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if PR targets starlight-dev
+      - name: Check if PR targets sol-dev
         run: |
           SOURCE_BRANCH="${{ github.event.pull_request.head.ref }}"
           TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
           echo "PR from: $SOURCE_BRANCH -> $TARGET_BRANCH"
 
           # Allow starlight-dev to starlight PRs in both directions
-          if [[ ("$SOURCE_BRANCH" == "starlight-dev" && "$TARGET_BRANCH" == "Starlight") ||
-                ("$SOURCE_BRANCH" == "Starlight" && "$TARGET_BRANCH" == "starlight-dev") ]]; then
+          if [[ ("$SOURCE_BRANCH" == "sol-dev" && "$TARGET_BRANCH" == "Sol") ||
+                ("$SOURCE_BRANCH" == "Sol" && "$TARGET_BRANCH" == "sol-dev") ]]; then
             echo "Allowed: PR between starlight-dev and starlight branches"
             exit 0
           fi
 
           # For all other PRs, require starlight-dev as target
-          if [ "$TARGET_BRANCH" != "starlight-dev" ]; then
-            echo "Error: PR must target 'starlight-dev' branch, but targets '$TARGET_BRANCH'"
-            echo "Please change the target branch to 'starlight-dev'"
+          if [ "$TARGET_BRANCH" != "sol-dev" ]; then
+            echo "Error: PR must target 'sol-dev' branch, but targets '$TARGET_BRANCH'"
+            echo "Please change the target branch to 'sol-dev'"
             exit 1
           else
-            echo "Success: PR correctly targets 'starlight-dev' branch"
+            echo "Success: PR correctly targets 'sol-dev' branch"
           fi

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml
@@ -29,6 +29,14 @@
             <Button Name="JobTitleSaveButton" Text="{Loc 'id-card-console-window-save-button'}" Disabled="True" />
         </GridContainer>
         <Control MinSize="0 8" />
+        <!-- Starlight-start -->
+        <Label Name="MissingPrivilegesWarning"
+               Text="{Loc 'id-card-console-window-missing-privileges-warning'}"
+               FontColorOverride="#FFFF00"
+               Visible="False"
+               HorizontalAlignment="Center"
+               Margin="0 0 0 4" />
+        <!-- Starlight-end -->
         <!-- Job preset selection, grant/revoke all access buttons. -->
         <BoxContainer Margin="0 8 0 4">
             <BoxContainer>

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -131,10 +131,27 @@ namespace Content.Client.Access.UI
 
         private void SetAllAccess(bool enabled)
         {
-            _pendingPressedAccessLevels.Clear(); // Starlight-edit
-            foreach (var button in _accessButtons.ButtonsList.Values)
-                if (!button.Disabled && button.Pressed != enabled)
-                    button.Pressed = enabled;
+            // Starlight-edit: Start
+            if (enabled)
+            {
+                foreach (var access in _allowedAccessLevels)
+                    _pendingPressedAccessLevels.Add(access);
+            }
+            else
+            {
+                _pendingPressedAccessLevels.RemoveWhere(a => _allowedAccessLevels.Contains(a));
+            }
+
+            foreach (var (access, button) in _accessButtons.ButtonsList)
+            {
+                if (button.Disabled)
+                    continue;
+
+                button.Pressed = _pendingPressedAccessLevels.Contains(access);
+            }
+
+            _pendingAccessOverride = true;
+            // Starlight-edit: End
         }
 
         private void SelectJobPreset(OptionButton.ItemSelectedEventArgs args)
@@ -169,7 +186,8 @@ namespace Content.Client.Access.UI
             var allowedJobAccess = allJobAccess
                 .Where(x => _allowedAccessLevels.Contains(x) && allConsoleGroupTags.Contains(x))
                 .ToHashSet();
-            _pendingPressedAccessLevels = allowedJobAccess;
+            _pendingPressedAccessLevels.RemoveWhere(a => _allowedAccessLevels.Contains(a));
+            _pendingPressedAccessLevels.UnionWith(allowedJobAccess);
 
             _pendingAccessOverride = true;
 
@@ -230,6 +248,11 @@ namespace Content.Client.Access.UI
 
             // Track allowed access for filtering on submit
             _allowedAccessLevels = allowedAccess.ToHashSet();
+
+            var targetHasUnmodifiableAccess = interfaceEnabled
+                && state.TargetIdAccessList != null
+                && state.TargetIdAccessList.Any(access => !_allowedAccessLevels.Contains(access));
+            MissingPrivilegesWarning.Visible = targetHasUnmodifiableAccess;
 
             var allPossibleAccess = _prototypeManager.EnumeratePrototypes<AccessLevelPrototype>()
                 .Where(a => a.CanAddToIdCard)

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -186,10 +186,8 @@ namespace Content.Client.Access.UI
             var allowedJobAccess = allJobAccess
                 .Where(x => _allowedAccessLevels.Contains(x) && allConsoleGroupTags.Contains(x))
                 .ToHashSet();
-            _pendingPressedAccessLevels.RemoveWhere(a => _allowedAccessLevels.Contains(a));
-            _pendingPressedAccessLevels.UnionWith(allowedJobAccess);
 
-            _pendingAccessOverride = true;
+            _pendingPressedAccessLevels.UnionWith(allowedJobAccess);
 
             // Update visible buttons to match pending pressed state
             foreach (var (access, button) in _accessButtons.ButtonsList)

--- a/Resources/Locale/en-US/_Starlight/access/id-card-console-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/access/id-card-console-component.ftl
@@ -1,0 +1,1 @@
+id-card-console-window-missing-privileges-warning = Notice: Target ID has access levels the current privileged ID cannot modify.

--- a/Resources/Locale/en-US/access/components/id-card-console-component.ftl
+++ b/Resources/Locale/en-US/access/components/id-card-console-component.ftl
@@ -8,9 +8,6 @@ id-card-console-window-insert-button = Insert
 id-card-console-window-job-selection-label = Job preset (sets department and job icon):
 id-card-console-window-select-all-button = Grant all
 id-card-console-window-deselect-all-button = Revoke all
-# Starlight-start
-id-card-console-window-missing-privileges-warning = Notice: Target ID has access levels the current privileged ID cannot modify.
-# Starlight-end
 access-id-card-console-component-no-hands-error = You have no hands.
 id-card-console-privileged-id = Privileged ID
 id-card-console-target-id = Target ID

--- a/Resources/Locale/en-US/access/components/id-card-console-component.ftl
+++ b/Resources/Locale/en-US/access/components/id-card-console-component.ftl
@@ -8,7 +8,9 @@ id-card-console-window-insert-button = Insert
 id-card-console-window-job-selection-label = Job preset (sets department and job icon):
 id-card-console-window-select-all-button = Grant all
 id-card-console-window-deselect-all-button = Revoke all
-
+# Starlight-start
+id-card-console-window-missing-privileges-warning = Notice: Target ID has access levels the current privileged ID cannot modify.
+# Starlight-end
 access-id-card-console-component-no-hands-error = You have no hands.
 id-card-console-privileged-id = Privileged ID
 id-card-console-target-id = Target ID

--- a/Resources/Locale/en-US/access/components/id-card-console-component.ftl
+++ b/Resources/Locale/en-US/access/components/id-card-console-component.ftl
@@ -8,6 +8,7 @@ id-card-console-window-insert-button = Insert
 id-card-console-window-job-selection-label = Job preset (sets department and job icon):
 id-card-console-window-select-all-button = Grant all
 id-card-console-window-deselect-all-button = Revoke all
+
 access-id-card-console-component-no-hands-error = You have no hands.
 id-card-console-privileged-id = Privileged ID
 id-card-console-target-id = Target ID

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
@@ -119,7 +119,7 @@
       - Law
       - NanoTrasen
       privilegedIdSlot:
-        name: Privileged ID # Starlight-edit: Use English String
+        name: id-card-console-privileged-id # Fix translation key
         ejectSound: /Audio/Machines/id_swipe.ogg
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectOnBreak: true
@@ -128,7 +128,7 @@
           components:
           - IdCard
       targetIdSlot:
-        name: Target ID # Starlight-edit: Use English String
+        name: id-card-console-target-id # Fix translation key
         ejectSound: /Audio/Machines/id_swipe.ogg
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectOnBreak: true

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
@@ -119,7 +119,7 @@
       - Law
       - NanoTrasen
       privilegedIdSlot:
-        name: id-card-clipboard-priviliged-id
+        name: Privileged ID # Starlight-edit: Use English String
         ejectSound: /Audio/Machines/id_swipe.ogg
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectOnBreak: true
@@ -128,7 +128,7 @@
           components:
           - IdCard
       targetIdSlot:
-        name: id-card-clipboard-target-id
+        name: Target ID # Starlight-edit: Use English String
         ejectSound: /Audio/Machines/id_swipe.ogg
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectOnBreak: true

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
@@ -119,7 +119,7 @@
       - Law
       - NanoTrasen
       privilegedIdSlot:
-        name: id-card-console-privileged-id # Fix translation key
+        name: id-card-console-privileged-id # Starlight-edit: Fix translation key
         ejectSound: /Audio/Machines/id_swipe.ogg
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectOnBreak: true
@@ -128,7 +128,7 @@
           components:
           - IdCard
       targetIdSlot:
-        name: id-card-console-target-id # Fix translation key
+        name: id-card-console-target-id # Starlight-edit: Fix translation key
         ejectSound: /Audio/Machines/id_swipe.ogg
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
         ejectOnBreak: true


### PR DESCRIPTION
## Short description
Fixes #3813, allowing the ID terminal to work correctly again on cards with higher privilege levels, also adds a warning when an ID is inserted with accesses that the privileged ID cannot modify.

Reopened with corrections requested (locale moved) purely because @TaserTheFox seems to really want this fix in and wasn't able to get the commit to work with needed changes themselves.

## Why we need to add this
Improves user awareness of ID settings and allows quicker all access and job setting by HoP again.

## Media (Video/Screenshots)
<img width="1512" height="719" alt="image" src="https://github.com/user-attachments/assets/e441ebae-463f-44ee-9623-85741c416670" />

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: AprilCatStreams
- fix: The ID computer's job assignment dropdown, grant all, and revoke all work correctly again.
- tweak: New UI element to inform you when you are editing an ID card with more privileges than you have.
