### PR TITLE
Reverts #857 and makes the Immovable Rod scary again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Magic/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/immovable_rod.yml
@@ -12,14 +12,6 @@
     state: icon
     noRot: false
   - type: ImmovableRod
-    minSpeed: 35
-    maxSpeed: 35
-    randomizeVelocity: false
-    shouldGib: false
-    damage:
-      types:
-        Blunt: 175 # Damage is applied twice
-        Piercing: 25
   - type: GravityAffected
   - type: Physics
     bodyType: Dynamic
@@ -43,9 +35,6 @@
   - type: WarpPoint
     follow: true
     location: immovable rod
-    blacklist:
-      tags:
-      - GhostOnlyWarp
 
 - type: entity
   parent: ImmovableRod
@@ -61,14 +50,8 @@
   suffix: Slow
   components:
   - type: ImmovableRod
-    minSpeed: 35
-    maxSpeed: 35
-    randomizeVelocity: false
-    shouldGib: false
-    damage:
-      types:
-        Blunt: 175
-        Piercing: 25
+    minSpeed: 1
+    maxSpeed: 5
 
 - type: entity
   parent: ImmovableRodDespawn
@@ -78,14 +61,6 @@
   - type: ImmovableRod
     destroyTiles: false
     hitSoundProbability: 1.0
-    minSpeed: 35
-    maxSpeed: 35
-    randomizeVelocity: false
-    shouldGib: false
-    damage:
-      types:
-        Blunt: 175
-        Piercing: 25
 
 # For Wizard Polymorph
 - type: entity
@@ -116,13 +91,12 @@
 
 - type: entity
   parent: ImmovableRodKeepTiles
-  id: ImmovableRodKeepTilesStill #for some GOD FORSAKEN REASON, the event draws from THIS one.
+  id: ImmovableRodKeepTilesStill
   suffix: Keep Tiles, Still
   components:
   - type: ImmovableRod
     randomizeVelocity: false
-    minSpeed: 35
-    maxSpeed: 35
+    maxSpeed: 0
 
 - type: entity
   parent: ImmovableRodKeepTilesStill

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -220,7 +220,7 @@
   - type: ImmovableRodRule
     rodPrototypes:
     - id: ImmovableRodKeepTilesStill
-      prob: 0.89
+      prob: 0.94
       orGroup: rodProto
     - id: ImmovableRodMop
       prob: 0.0075


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
#857 made it so that immovable rods couldn't gib you, but also made them way faster.

This PR reverts them to the Wizden behaviour, which makes them slower but restores their gib-on-impact behaviour.
- https://github.com/space-wizards/space-station-14/blob/master/Resources/Prototypes/Entities/Objects/Magic/immovable_rod.yml
- https://github.com/space-wizards/space-station-14/blob/master/Resources/Prototypes/GameRules/meteorswarms.yml

**Note**: This doesn't change the Wizard's polymorph rod spell. It doesn't gib on upstream, it doesn't gib on Starlight live, and it still doesn't gib after this PR

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
1. Popular community suggestion, surprisingly: https://discord.com/channels/1272545509562777621/1525712931004612688

2. A lot of the fun in immovable rods is the sheer horror they inflict when they hit someone. They just don't have the same shock-and-awe impact when it's just a bunch of blunt damage.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="968" height="646" alt="image" src="https://github.com/user-attachments/assets/45500616-ef6b-4c19-bf1b-0a6569082f2a" />

fig. 1 - Immovable honk greeting some ERT Engineers.

https://github.com/user-attachments/assets/ad776260-b9bd-4642-8ee3-6d7123bf2267

fig. 2 - Video of a dozen immovable rods.

<img width="971" height="626" alt="image" src="https://github.com/user-attachments/assets/eccf5231-c698-4ee3-8f93-cdd1d587cda0" />

fig. 3 - Wizzard's rod polymorph still doesn't gib.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: The (non-wizard) immovable rod will now gib you again.