### PR TITLE
Test and CI/CD updates

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,7 +11,7 @@ jobs:
     name: Run Benchmarks
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
     - name: Get Engine version

--- a/.github/workflows/build-docfx.yml
+++ b/.github/workflows/build-docfx.yml
@@ -8,7 +8,7 @@ jobs:
   docfx:
    runs-on: ubuntu-latest
    steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
     - name: Setup submodule
       run: |
         git submodule update --init --recursive

--- a/.github/workflows/build-docfx.yml
+++ b/.github/workflows/build-docfx.yml
@@ -19,7 +19,7 @@ jobs:
         cd RobustToolbox/
         git submodule update --init --recursive
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4.1.0
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout Master
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
 
       - name: Setup Submodule
         run: |

--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -39,7 +39,7 @@ jobs:
           git submodule update --init --recursive
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4.1.0
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -83,7 +83,7 @@ jobs:
       run: dotnet restore Content.Tests/Content.Tests.csproj
 
     - name: Run Content.Tests
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 15
         max_attempts: 2
@@ -124,7 +124,7 @@ jobs:
 
     - name: Run Content.IntegrationTests
       id: run-integration-tests
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       env:
         DOTNET_gcServer: "1"
       with:

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -7,7 +7,7 @@ concurrency:
 
 on:
   push:
-    branches: [ master, staging, stable, Starlight, starlight-dev, upstream-devtest, fix/tests ]
+    branches: [ master, staging, stable, Starlight, upstream-devtest, fix/tests ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -72,7 +72,7 @@ jobs:
         dotnet-version: 10.0.x
 
     - name: Download build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: build-output
 
@@ -112,7 +112,7 @@ jobs:
         dotnet-version: 10.0.x
 
     - name: Download build artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: build-output
 

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -7,7 +7,7 @@ concurrency:
 
 on:
   push:
-    branches: [ master, staging, stable, Starlight, upstream-devtest, fix/tests ]
+    branches: [ master, staging, stable, Starlight, starlight-dev, upstream-devtest, fix/tests ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -34,7 +34,7 @@ jobs:
         git submodule update --init --recursive
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4.1.0
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4.1.0
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4.1.0
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Master
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@v7
 
     - name: Setup Submodule
       run: |

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -50,13 +50,13 @@ jobs:
           python3 Tools/_Starlight/partition_tests.py generate 8 .integration-filters
 
     - name: Archive build output
-      run: tar czf /tmp/build.tar.gz --exclude='.git' .
+      run: tar --use-compress-program='zstd -T0' -cf /tmp/build.tar.zst --exclude='.git' .
 
     - name: Upload build artifact
       uses: actions/upload-artifact@v4
       with:
         name: build-output
-        path: /tmp/build.tar.gz
+        path: /tmp/build.tar.zst
         retention-days: 1
         compression-level: 0
 
@@ -77,7 +77,7 @@ jobs:
         name: build-output
 
     - name: Extract build
-      run: tar xzf build.tar.gz && rm build.tar.gz
+      run: tar --use-compress-program='zstd -d -T0' -xf build.tar.zst && rm build.tar.zst
 
     - name: Restore packages
       run: dotnet restore Content.Tests/Content.Tests.csproj
@@ -117,7 +117,7 @@ jobs:
         name: build-output
 
     - name: Extract build
-      run: tar xzf build.tar.gz && rm build.tar.gz
+      run: tar --use-compress-program='zstd -d -T0' -xf build.tar.zst && rm build.tar.zst
 
     - name: Restore packages
       run: dotnet restore Content.IntegrationTests/Content.IntegrationTests.csproj

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -15,6 +15,6 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
     - name: Check for CRLF, trailing whitespace, and missing final newlines
       run: Tools/check_crlf.py

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -34,7 +34,7 @@ jobs:
         git tag
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v4.1.0
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install -y python3-paramiko python3-lxml
 
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
       with:
         submodules: 'recursive'
         fetch-depth: 0

--- a/.github/workflows/rsi-diff.yml
+++ b/.github/workflows/rsi-diff.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
 
       - name: Get changed files
         id: files

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout Master
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
 
       - name: Setup Submodule
         run: |

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -54,7 +54,7 @@ jobs:
           git submodule update --init --recursive
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4.1.0
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/update-credits.yml
+++ b/.github/workflows/update-credits.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'space-wizards/space-station-14'
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
         with:
           ref: master
 

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.actor != 'PJBot' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
     - name: Setup Submodule
       run: git submodule update --init
     - name: Pull engine updates

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -18,7 +18,7 @@ jobs:
     name: Validate RSIs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
       - name: Setup Submodule
         run: git submodule update --init
       - name: Pull engine updates

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.actor != 'PJBot' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@v7
     - name: Setup Submodule
       run: git submodule update --init
     - name: Pull engine updates

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -30,7 +30,7 @@ jobs:
           cd RobustToolbox/
           git submodule update --init --recursive
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4.1.0
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
       - name: Install dependencies

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.actor != 'PJBot' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v7
       - name: Setup submodule
         run: |
           git submodule update --init --recursive

--- a/Content.IntegrationTests/Tests/_Starlight/Audio/StereoTest.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Audio/StereoTest.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Content.IntegrationTests.Fixtures;
 using Content.Shared.Audio;
 using Robust.Client.Audio;
@@ -73,9 +75,10 @@ public sealed class StereoTest : GameTest
 
         var audioRoot = new ResPath("/Audio/");
 
-        var badFiles = new Dictionary<string, string>();
+        var badFiles = new ConcurrentDictionary<string, string>();
+        var readErrors = new ConcurrentBag<string>();
 
-        var ambienceTracks = new List<ResPath>();
+        var ambienceTracks = new HashSet<ResPath>();
         foreach (var ambience in protoMan.EnumeratePrototypes<AmbientMusicPrototype>())
         {
             switch (ambience.Sound)
@@ -85,7 +88,7 @@ public sealed class StereoTest : GameTest
                         break;
 
                     var slothCud = protoMan.Index<SoundCollectionPrototype>(collection.Collection);
-                    ambienceTracks.AddRange(slothCud.PickFiles);
+                    ambienceTracks.UnionWith(slothCud.PickFiles);
                     break;
                 case SoundPathSpecifier path:
                     ambienceTracks.Add(path.Path);
@@ -93,19 +96,24 @@ public sealed class StereoTest : GameTest
             }
         }
 
-        foreach (var file in resMan.ContentFindFiles(audioRoot))
+        var filesToCheck = resMan.ContentFindFiles(audioRoot)
+            .Where(file =>
+            {
+                if (ambienceTracks.Contains(file))
+                    return false; // Ambience tracks can be stereo, so we skip them.
+
+                // We can ignore some files/paths if we want to, for example if they are stereo on purpose or if we just don't care about them.
+                if (IgnoredFiles.Contains(file) || IgnoredPaths.Any(p => file.ToString().StartsWith(p.ToString())))
+                    return false;
+
+                var ext = file.Extension.ToLowerInvariant();
+                return ext is "ogg" or "wav";
+            })
+            .ToList();
+
+        Parallel.ForEach(filesToCheck, file =>
         {
-            if (ambienceTracks.Contains(file))
-                continue; // Ambience tracks can be stereo, so we skip them.
-
-            // We can ignore some files/paths if we want to, for example if they are stereo on purpose or if we just don't care about them.
-            if (IgnoredFiles.Contains(file) || IgnoredPaths.Any(p => file.ToString().StartsWith(p.ToString())))
-                continue;
-
             var ext = file.Extension.ToLowerInvariant();
-            if (ext is not "ogg" and not "wav")
-                continue;
-
             try
             {
                 using var stream = resMan.ContentFileRead(file);
@@ -119,10 +127,11 @@ public sealed class StereoTest : GameTest
             }
             catch (Exception e)
             {
-                Assert.Fail($"Failed to read audio file {file}: {e}");
+                readErrors.Add($"Failed to read audio file {file}: {e}");
             }
-        }
+        });
 
+        Assert.That(readErrors, Is.Empty, string.Join('\n', readErrors));
         Assert.That(badFiles, Is.Empty, "Some audio is invalid:\n" + string.Join('\n', badFiles.Select(p => $"{p.Key}: {p.Value}"))
         );
     }

--- a/Content.IntegrationTests/Tests/_Starlight/Body/LungTest.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Body/LungTest.cs
@@ -106,7 +106,7 @@ namespace Content.IntegrationTests.Tests._Starlight.Body
 
             // --- End setup
 
-            var inhaleCycles = 100;
+            var inhaleCycles = 20;
             for (var i = 0; i < inhaleCycles; i++)
             {
                 // Breathe in

--- a/Content.IntegrationTests/Tests/_Starlight/Power/GridPowerTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Power/GridPowerTests.cs
@@ -10,11 +10,12 @@ using Robust.Shared.Utility;
 
 namespace Content.IntegrationTests.Tests._Starlight.Power;
 
+[Parallelizable(ParallelScope.All)]
 public sealed class GridPowerTests : GameTest
 {
     private const string EmptyMap = "Empty";
 
-    private static readonly ResPath[] GridPaths =
+    private static readonly ResPath[] _gridPaths =
     [
         // NT-CC
         new("/Maps/_Starlight/Shuttles/CC-NT/CBURN.yml"),
@@ -113,7 +114,7 @@ public sealed class GridPowerTests : GameTest
         new("/Maps/_Starlight/MedTak/MedTakPointAlpha.yml")
     ];
 
-    [Test, TestCaseSource(nameof(GridPaths))]
+    [Test, TestCaseSource(nameof(_gridPaths))]
     public async Task TestGridApcLoad(ResPath gridFilePath)
     {
         var pair = Pair;


### PR DESCRIPTION
## Short description
This is some general updating of CI/CD as well as some optimisations.

**Starlight Tests** (All times are from running the tests locally)
- Adds parallel testing to the GridPowerTests (Run time from 852s -> 260s) and StereoTest (183s -> 109s).
- Reduces the amount of breaths taken in the Lung Test from 100 to 20 breaths (548s -> 109s)

**Bumps github actions:** Removes node v20 warnings.
nick-fields/retry@v3 -> v4
actions/setup-dotnet@v4.1.0 -> v5 (Matches Upstream)
actions/checkout@v4.2.2 -> v7
actions/download-artifact@v4 -> v8

**Build Test Debug**
- use Zstandard compression for the build (Faster algo and we can use multiple threads) (40s~ -> 15s~)
- Remove starlight-dev from push, branch rules say everything must go through the merge queue, this should stop some merges having 19 tests and others having 32.


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
