### PR TITLE
feat(chat): enable auto-fill highlights with character info by default

### DIFF
--- a/Content.Client/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Client/CharacterInfo/CharacterInfoSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.CharacterInfo;
+using Content.Shared.CharacterInfo;
 using Content.Shared.Objectives;
 using Robust.Client.Player;
 using Robust.Client.UserInterface;
@@ -32,6 +32,10 @@ public sealed partial class CharacterInfoSystem : EntitySystem
     private void OnCharacterInfoEvent(CharacterInfoEvent msg, EntitySessionEventArgs args)
     {
         var entity = GetEntity(msg.NetEntity);
+        if (!Exists(entity))
+        {
+            return;
+        }
         var data = new CharacterData(entity, msg.JobTitle, msg.Objectives, msg.Briefing, Name(entity));
 
         OnCharacterUpdate?.Invoke(data);

--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -157,6 +157,8 @@ namespace Content.Client.Entry
             //_jobRequirements.Initialize(); //🌟Starlight🌟 - Moved to PostInit
             _playbackMan.Initialize();
             _clientsidePlaytimeManager.Initialize();
+            //🌟Starlight🌟 - Auto-fill chat highlights with character info by default (useful for high player-count rounds)
+            _configManager.OverrideDefault(Content.Shared.CCVar.CCVars.ChatAutoFillHighlights, true);
 
             //AUTOSCALING default Setup!
             _configManager.SetCVar("interface.resolutionAutoScaleUpperCutoffX", 1080);

--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client._Starlight.Managers;
+using Content.Client._Starlight.Managers;
 using Content.Client._Starlight.Achievement;
 using Content.Client._NullLink; // NullLink
 using Content.Client.Administration.Managers;
@@ -157,8 +157,6 @@ namespace Content.Client.Entry
             //_jobRequirements.Initialize(); //🌟Starlight🌟 - Moved to PostInit
             _playbackMan.Initialize();
             _clientsidePlaytimeManager.Initialize();
-            //🌟Starlight🌟 - Auto-fill chat highlights with character info by default (useful for high player-count rounds)
-            _configManager.OverrideDefault(Content.Shared.CCVar.CCVars.ChatAutoFillHighlights, true);
 
             //AUTOSCALING default Setup!
             _configManager.SetCVar("interface.resolutionAutoScaleUpperCutoffX", 1080);

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -32,6 +32,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
     private string? _highlightsColor;
 
     private bool _autoFillHighlightsEnabled;
+    private string _autoHighlights = ""; // Starlight
 
     /// <summary>
     ///     The boolean that keeps track of the 'OnCharacterUpdated' event, whenever it's a player attaching or opening the character info panel.
@@ -42,7 +43,16 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
 
     private void InitializeHighlights()
     {
-        _config.OnValueChanged(CCVars.ChatAutoFillHighlights, (value) => { _autoFillHighlightsEnabled = value; }, true);
+        // Starlight Start
+        _config.OnValueChanged(CCVars.ChatAutoFillHighlights, (value) =>
+        {
+            _autoFillHighlightsEnabled = value;
+            if (value)
+                UpdateAutoFillHighlights();
+            else
+                ReloadHighlights();
+        }, true);
+        // Starlight End
 
         _config.OnValueChanged(CCVars.ChatHighlightsColor, (value) => { _highlightsColor = value; }, true);
 
@@ -73,9 +83,10 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         // If auto highlights are enabled generate a request for new character info
         // that will be used to determine the highlights.
         _charInfoIsAttach = true;
-        _characterInfo.RequestCharacterInfo();
+        _characterInfo?.RequestCharacterInfo(); // Starlight
     }
 
+    // Starlight Start
     public void UpdateHighlights(string newHighlights, bool firstLoad = false)
     {
         // Do nothing if the provided highlights are the same as the old ones and it is not the first time.
@@ -85,11 +96,26 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         _config.SetCVar(CCVars.ChatHighlights, newHighlights);
         _config.SaveToFile();
 
+        ReloadHighlights();
+        HighlightsUpdated?.Invoke(newHighlights);
+    }
+
+    public void ReloadHighlights()
+    {
         _highlights.Clear();
+
+        var combined = _config.GetCVar(CCVars.ChatHighlights);
+        if (_autoFillHighlightsEnabled && !string.IsNullOrEmpty(_autoHighlights))
+        {
+            if (string.IsNullOrEmpty(combined))
+                combined = _autoHighlights;
+            else
+                combined += "\n" + _autoHighlights;
+        }
 
         // We first subdivide the highlights based on newlines to prevent replacing
         // a valid "\n" tag and adding it to the final regex.
-        var splittedHighlights = newHighlights.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var splittedHighlights = combined.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         for (var i = 0; i < splittedHighlights.Length; i++)
         {
@@ -127,6 +153,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         // the full word (eg. "Security") gets picked before the abbreviation (eg. "Sec").
         _highlights.Sort((x, y) => y.Length.CompareTo(x.Length));
     }
+    // Starlight End
 
     private void OnCharacterUpdated(CharacterData data)
     {
@@ -162,8 +189,10 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (_loc.TryGetString($"highlights-{jobKey}", out var jobMatches))
             newHighlights += '\n' + jobMatches.Replace(", ", "\n");
 
-        UpdateHighlights(newHighlights);
-        HighlightsUpdated?.Invoke(newHighlights);
+        // Starlight Start
+        _autoHighlights = newHighlights;
+        ReloadHighlights();
+        // Starlight End
         _charInfoIsAttach = false;
     }
 }

--- a/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Content.Client.CharacterInfo;
+using Content.Client.UserInterface.Systems.Chat;
+using Content.Shared.CCVar;
+using NUnit.Framework;
+using Robust.Client.UserInterface;
+using Robust.Shared.Configuration;
+
+namespace Content.IntegrationTests.Tests._Starlight
+{
+    [TestFixture]
+    public sealed class ChatHighlightTest
+    {
+        [Test]
+        public async Task TestCustomHighlightsPreserved()
+        {
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
+            {
+                Connected = true,
+            });
+
+            var client = pair.Client;
+            var configManager = client.ResolveDependency<IConfigurationManager>();
+            var uiManager = client.ResolveDependency<IUserInterfaceManager>();
+
+            await client.WaitPost(() =>
+            {
+                var chatController = uiManager.GetUIController<ChatUIController>();
+
+                // 1. Enable auto-fill highlights
+                configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
+
+                // 2. Set custom highlights
+                var customHighlights = "ling\nrev";
+                chatController.UpdateHighlights(customHighlights);
+
+                // Verify they are saved
+                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
+
+                // 3. Simulate character update
+                var characterData = new CharacterInfoSystem.CharacterData(
+                    default,
+                    "Captain",
+                    new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
+                    null,
+                    "John Doe"
+                );
+
+                var method = chatController.GetType().GetMethod(
+                    "OnCharacterUpdated",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+
+                Assert.That(method, Is.Not.Null);
+
+                // Set internal state to allow character update processing
+                var attachField = chatController.GetType().GetField(
+                    "_charInfoIsAttach",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+                Assert.That(attachField, Is.Not.Null);
+                attachField.SetValue(chatController, true);
+
+                // Invoke update
+                method.Invoke(chatController, new object[] { characterData });
+
+                // 4. Assertions:
+                // - Custom highlights in config must remain unchanged
+                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
+
+                // - Internal active regex highlights must contain both custom & auto-filled highlights
+                var highlightsField = chatController.GetType().GetField(
+                    "_highlights",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+                Assert.That(highlightsField, Is.Not.Null);
+                var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+
+                // Check that custom and auto highlights are loaded
+                // Custom:
+                Assert.That(activeHighlights, Contains.Item("ling"));
+                Assert.That(activeHighlights, Contains.Item("rev"));
+                // Auto:
+                Assert.That(activeHighlights, Contains.Item("Captain"));
+                Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)")); // "Cap" becomes regex-escaped and word-bounded
+
+                // 5. Disable auto-fill highlights and verify auto-filled highlights are removed
+                configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
+
+                activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+                Assert.That(activeHighlights, Contains.Item("ling"));
+                Assert.That(activeHighlights, Contains.Item("rev"));
+                Assert.That(activeHighlights, Is.Not.Contains("Captain"));
+            });
+
+            await pair.CleanReturnAsync();
+        }
+
+        [Test]
+        public async Task TestDayOneMigrationTransition()
+        {
+            await using var pair = await PoolManager.GetServerClient(new PoolSettings
+            {
+                Connected = true,
+            });
+
+            var client = pair.Client;
+            var configManager = client.ResolveDependency<IConfigurationManager>();
+            var uiManager = client.ResolveDependency<IUserInterfaceManager>();
+
+            await client.WaitPost(() =>
+            {
+                var chatController = uiManager.GetUIController<ChatUIController>();
+
+                // 1. Start with auto-fill disabled
+                configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
+
+                // 2. Set custom highlights
+                var customHighlights = "ling\nrev";
+                chatController.UpdateHighlights(customHighlights);
+
+                // Verify active matches are ONLY custom highlights
+                var highlightsField = chatController.GetType().GetField(
+                    "_highlights",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+                Assert.That(highlightsField, Is.Not.Null);
+                var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+
+                Assert.That(activeHighlights, Contains.Item("ling"));
+                Assert.That(activeHighlights, Contains.Item("rev"));
+                Assert.That(activeHighlights.Count, Is.EqualTo(2));
+
+                // 3. Simulate Day 1 merge: transition to true
+                configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
+
+                // 4. Simulate character update (spawning into round)
+                var characterData = new CharacterInfoSystem.CharacterData(
+                    default,
+                    "Captain",
+                    new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
+                    null,
+                    "John Doe"
+                );
+
+                var method = chatController.GetType().GetMethod(
+                    "OnCharacterUpdated",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+
+                Assert.That(method, Is.Not.Null);
+
+                var attachField = chatController.GetType().GetField(
+                    "_charInfoIsAttach",
+                    BindingFlags.NonPublic | BindingFlags.Instance
+                );
+                Assert.That(attachField, Is.Not.Null);
+                attachField.SetValue(chatController, true);
+
+                // Invoke character update
+                method.Invoke(chatController, new object[] { characterData });
+
+                // 5. Assertions:
+                // - Config highlights MUST NOT be wiped and remain as custom highlights
+                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
+
+                // - Active highlights list must now merge both custom and auto-filled ones
+                activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+                Assert.That(activeHighlights, Contains.Item("ling"));
+                Assert.That(activeHighlights, Contains.Item("rev"));
+                Assert.That(activeHighlights, Contains.Item("Captain"));
+                Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)"));
+            });
+
+            await pair.CleanReturnAsync();
+        }
+    }
+}

--- a/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
@@ -24,6 +24,9 @@ public sealed class ChatHighlightTest : GameTest
     {
         var chatController = _uiManager.GetUIController<ChatUIController>();
 
+        // Assert that the CVar defaults to true on Starlight
+        Assert.That(_configManager.GetCVar(CCVars.ChatAutoFillHighlights), Is.True);
+
         // 1. Enable auto-fill highlights
         _configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
 
@@ -95,6 +98,9 @@ public sealed class ChatHighlightTest : GameTest
     public async Task TestEnablingAutoFillPreservesCustomHighlights()
     {
         var chatController = _uiManager.GetUIController<ChatUIController>();
+
+        // Assert that the CVar defaults to true on Starlight
+        Assert.That(_configManager.GetCVar(CCVars.ChatAutoFillHighlights), Is.True);
 
         // 1. Start with auto-fill disabled
         _configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);

--- a/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
@@ -18,6 +18,27 @@ public sealed class ChatHighlightTest : GameTest
     [SidedDependency(Side.Client)] private readonly IConfigurationManager _configManager = null!;
     [SidedDependency(Side.Client)] private readonly IUserInterfaceManager _uiManager = null!;
 
+    private void InvokeOnCharacterUpdated(ChatUIController chatController, CharacterInfoSystem.CharacterData characterData)
+    {
+        var method = chatController.GetType().GetMethod(
+            "OnCharacterUpdated",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+
+        Assert.That(method, Is.Not.Null);
+
+        // Set internal state to allow character update processing
+        var attachField = chatController.GetType().GetField(
+            "_charInfoIsAttach",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        Assert.That(attachField, Is.Not.Null);
+        attachField.SetValue(chatController, true);
+
+        // Invoke update
+        method.Invoke(chatController, new object[] { characterData });
+    }
+
     [Test]
     [RunOnSide(Side.Client)]
     public async Task TestCustomHighlightsPreserved()
@@ -46,23 +67,7 @@ public sealed class ChatHighlightTest : GameTest
             "John Doe"
         );
 
-        var method = chatController.GetType().GetMethod(
-            "OnCharacterUpdated",
-            BindingFlags.NonPublic | BindingFlags.Instance
-        );
-
-        Assert.That(method, Is.Not.Null);
-
-        // Set internal state to allow character update processing
-        var attachField = chatController.GetType().GetField(
-            "_charInfoIsAttach",
-            BindingFlags.NonPublic | BindingFlags.Instance
-        );
-        Assert.That(attachField, Is.Not.Null);
-        attachField.SetValue(chatController, true);
-
-        // Invoke update
-        method.Invoke(chatController, new object[] { characterData });
+        InvokeOnCharacterUpdated(chatController, characterData);
 
         // 4. Assertions:
         // - Custom highlights in config must remain unchanged
@@ -91,6 +96,7 @@ public sealed class ChatHighlightTest : GameTest
         Assert.That(activeHighlights, Contains.Item("ling"));
         Assert.That(activeHighlights, Contains.Item("rev"));
         Assert.That(activeHighlights, Is.Not.Contains("Captain"));
+        Assert.That(activeHighlights, Is.Not.Contains("(?<!\\w)Cap(?!\\w)"));
     }
 
     [Test]
@@ -133,22 +139,7 @@ public sealed class ChatHighlightTest : GameTest
             "John Doe"
         );
 
-        var method = chatController.GetType().GetMethod(
-            "OnCharacterUpdated",
-            BindingFlags.NonPublic | BindingFlags.Instance
-        );
-
-        Assert.That(method, Is.Not.Null);
-
-        var attachField = chatController.GetType().GetField(
-            "_charInfoIsAttach",
-            BindingFlags.NonPublic | BindingFlags.Instance
-        );
-        Assert.That(attachField, Is.Not.Null);
-        attachField.SetValue(chatController, true);
-
-        // Invoke character update
-        method.Invoke(chatController, new object[] { characterData });
+        InvokeOnCharacterUpdated(chatController, characterData);
 
         // 5. Assertions:
         // - Config highlights MUST NOT be wiped and remain as custom highlights

--- a/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
@@ -1,181 +1,158 @@
-using System;
+#nullable enable
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using Content.Client.CharacterInfo;
 using Content.Client.UserInterface.Systems.Chat;
+using Content.IntegrationTests.Fixtures;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Shared.CCVar;
 using NUnit.Framework;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
 
-namespace Content.IntegrationTests.Tests._Starlight
+namespace Content.IntegrationTests.Tests._Starlight;
+
+public sealed class ChatHighlightTest : GameTest
 {
-    [TestFixture]
-    public sealed class ChatHighlightTest
+    [SidedDependency(Side.Client)] private readonly IConfigurationManager _configManager = null!;
+    [SidedDependency(Side.Client)] private readonly IUserInterfaceManager _uiManager = null!;
+
+    [Test]
+    [RunOnSide(Side.Client)]
+    public async Task TestCustomHighlightsPreserved()
     {
-        [Test]
-        public async Task TestCustomHighlightsPreserved()
-        {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                Connected = true,
-            });
+        var chatController = _uiManager.GetUIController<ChatUIController>();
 
-            var client = pair.Client;
-            var configManager = client.ResolveDependency<IConfigurationManager>();
-            var uiManager = client.ResolveDependency<IUserInterfaceManager>();
+        // 1. Enable auto-fill highlights
+        _configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
 
-            await client.WaitPost(() =>
-            {
-                var chatController = uiManager.GetUIController<ChatUIController>();
+        // 2. Set custom highlights
+        var customHighlights = "ling\nrev";
+        chatController.UpdateHighlights(customHighlights);
 
-                // 1. Enable auto-fill highlights
-                configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
+        // Verify they are saved
+        Assert.That(_configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
 
-                // 2. Set custom highlights
-                var customHighlights = "ling\nrev";
-                chatController.UpdateHighlights(customHighlights);
+        // 3. Simulate character update
+        var characterData = new CharacterInfoSystem.CharacterData(
+            default,
+            "Captain",
+            new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
+            null,
+            "John Doe"
+        );
 
-                // Verify they are saved
-                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
+        var method = chatController.GetType().GetMethod(
+            "OnCharacterUpdated",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
 
-                // 3. Simulate character update
-                var characterData = new CharacterInfoSystem.CharacterData(
-                    default,
-                    "Captain",
-                    new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
-                    null,
-                    "John Doe"
-                );
+        Assert.That(method, Is.Not.Null);
 
-                var method = chatController.GetType().GetMethod(
-                    "OnCharacterUpdated",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
+        // Set internal state to allow character update processing
+        var attachField = chatController.GetType().GetField(
+            "_charInfoIsAttach",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        Assert.That(attachField, Is.Not.Null);
+        attachField.SetValue(chatController, true);
 
-                Assert.That(method, Is.Not.Null);
+        // Invoke update
+        method.Invoke(chatController, new object[] { characterData });
 
-                // Set internal state to allow character update processing
-                var attachField = chatController.GetType().GetField(
-                    "_charInfoIsAttach",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-                Assert.That(attachField, Is.Not.Null);
-                attachField.SetValue(chatController, true);
+        // 4. Assertions:
+        // - Custom highlights in config must remain unchanged
+        Assert.That(_configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
 
-                // Invoke update
-                method.Invoke(chatController, new object[] { characterData });
+        // - Internal active regex highlights must contain both custom & auto-filled highlights
+        var highlightsField = chatController.GetType().GetField(
+            "_highlights",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        Assert.That(highlightsField, Is.Not.Null);
+        var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
 
-                // 4. Assertions:
-                // - Custom highlights in config must remain unchanged
-                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
+        // Check that custom and auto highlights are loaded
+        // Custom:
+        Assert.That(activeHighlights, Contains.Item("ling"));
+        Assert.That(activeHighlights, Contains.Item("rev"));
+        // Auto:
+        Assert.That(activeHighlights, Contains.Item("Captain"));
+        Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)")); // "Cap" becomes regex-escaped and word-bounded
 
-                // - Internal active regex highlights must contain both custom & auto-filled highlights
-                var highlightsField = chatController.GetType().GetField(
-                    "_highlights",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-                Assert.That(highlightsField, Is.Not.Null);
-                var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+        // 5. Disable auto-fill highlights and verify auto-filled highlights are removed
+        _configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
 
-                // Check that custom and auto highlights are loaded
-                // Custom:
-                Assert.That(activeHighlights, Contains.Item("ling"));
-                Assert.That(activeHighlights, Contains.Item("rev"));
-                // Auto:
-                Assert.That(activeHighlights, Contains.Item("Captain"));
-                Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)")); // "Cap" becomes regex-escaped and word-bounded
+        activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+        Assert.That(activeHighlights, Contains.Item("ling"));
+        Assert.That(activeHighlights, Contains.Item("rev"));
+        Assert.That(activeHighlights, Is.Not.Contains("Captain"));
+    }
 
-                // 5. Disable auto-fill highlights and verify auto-filled highlights are removed
-                configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
+    [Test]
+    [RunOnSide(Side.Client)]
+    public async Task TestEnablingAutoFillPreservesCustomHighlights()
+    {
+        var chatController = _uiManager.GetUIController<ChatUIController>();
 
-                activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
-                Assert.That(activeHighlights, Contains.Item("ling"));
-                Assert.That(activeHighlights, Contains.Item("rev"));
-                Assert.That(activeHighlights, Is.Not.Contains("Captain"));
-            });
+        // 1. Start with auto-fill disabled
+        _configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
 
-            await pair.CleanReturnAsync();
-        }
+        // 2. Set custom highlights
+        var customHighlights = "ling\nrev";
+        chatController.UpdateHighlights(customHighlights);
 
-        [Test]
-        public async Task TestDayOneMigrationTransition()
-        {
-            await using var pair = await PoolManager.GetServerClient(new PoolSettings
-            {
-                Connected = true,
-            });
+        // Verify active matches are ONLY custom highlights
+        var highlightsField = chatController.GetType().GetField(
+            "_highlights",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        Assert.That(highlightsField, Is.Not.Null);
+        var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
 
-            var client = pair.Client;
-            var configManager = client.ResolveDependency<IConfigurationManager>();
-            var uiManager = client.ResolveDependency<IUserInterfaceManager>();
+        Assert.That(activeHighlights, Contains.Item("ling"));
+        Assert.That(activeHighlights, Contains.Item("rev"));
+        Assert.That(activeHighlights.Count, Is.EqualTo(2));
 
-            await client.WaitPost(() =>
-            {
-                var chatController = uiManager.GetUIController<ChatUIController>();
+        // 3. Enable auto-fill highlights
+        _configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
 
-                // 1. Start with auto-fill disabled
-                configManager.SetCVar(CCVars.ChatAutoFillHighlights, false);
+        // 4. Simulate character update (spawning into round)
+        var characterData = new CharacterInfoSystem.CharacterData(
+            default,
+            "Captain",
+            new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
+            null,
+            "John Doe"
+        );
 
-                // 2. Set custom highlights
-                var customHighlights = "ling\nrev";
-                chatController.UpdateHighlights(customHighlights);
+        var method = chatController.GetType().GetMethod(
+            "OnCharacterUpdated",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
 
-                // Verify active matches are ONLY custom highlights
-                var highlightsField = chatController.GetType().GetField(
-                    "_highlights",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-                Assert.That(highlightsField, Is.Not.Null);
-                var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+        Assert.That(method, Is.Not.Null);
 
-                Assert.That(activeHighlights, Contains.Item("ling"));
-                Assert.That(activeHighlights, Contains.Item("rev"));
-                Assert.That(activeHighlights.Count, Is.EqualTo(2));
+        var attachField = chatController.GetType().GetField(
+            "_charInfoIsAttach",
+            BindingFlags.NonPublic | BindingFlags.Instance
+        );
+        Assert.That(attachField, Is.Not.Null);
+        attachField.SetValue(chatController, true);
 
-                // 3. Simulate Day 1 merge: transition to true
-                configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
+        // Invoke character update
+        method.Invoke(chatController, new object[] { characterData });
 
-                // 4. Simulate character update (spawning into round)
-                var characterData = new CharacterInfoSystem.CharacterData(
-                    default,
-                    "Captain",
-                    new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
-                    null,
-                    "John Doe"
-                );
+        // 5. Assertions:
+        // - Config highlights MUST NOT be wiped and remain as custom highlights
+        Assert.That(_configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
 
-                var method = chatController.GetType().GetMethod(
-                    "OnCharacterUpdated",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-
-                Assert.That(method, Is.Not.Null);
-
-                var attachField = chatController.GetType().GetField(
-                    "_charInfoIsAttach",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-                Assert.That(attachField, Is.Not.Null);
-                attachField.SetValue(chatController, true);
-
-                // Invoke character update
-                method.Invoke(chatController, new object[] { characterData });
-
-                // 5. Assertions:
-                // - Config highlights MUST NOT be wiped and remain as custom highlights
-                Assert.That(configManager.GetCVar(CCVars.ChatHighlights), Is.EqualTo(customHighlights));
-
-                // - Active highlights list must now merge both custom and auto-filled ones
-                activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
-                Assert.That(activeHighlights, Contains.Item("ling"));
-                Assert.That(activeHighlights, Contains.Item("rev"));
-                Assert.That(activeHighlights, Contains.Item("Captain"));
-                Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)"));
-            });
-
-            await pair.CleanReturnAsync();
-        }
+        // - Active highlights list must now merge both custom and auto-filled ones
+        activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+        Assert.That(activeHighlights, Contains.Item("ling"));
+        Assert.That(activeHighlights, Contains.Item("rev"));
+        Assert.That(activeHighlights, Contains.Item("Captain"));
+        Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)"));
     }
 }

--- a/Content.Shared/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/CCVar/CCVars.Chat.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Configuration;
+using Robust.Shared.Configuration;
 
 namespace Content.Shared.CCVar;
 
@@ -76,7 +76,7 @@ public sealed partial class CCVars
     /// An option to toggle the automatic filling of the highlights with the character's info, if available.
     /// </summary>
     public static readonly CVarDef<bool> ChatAutoFillHighlights =
-        CVarDef.Create("chat.auto_fill_highlights", false, CVar.CLIENTONLY | CVar.ARCHIVE, "Toggles automatically filling the highlights with the character's information.");
+        CVarDef.Create("chat.auto_fill_highlights", true, CVar.CLIENTONLY | CVar.ARCHIVE, "Toggles automatically filling the highlights with the character's information.");
 
     /// <summary>
     /// The color in which the highlights will be displayed.

--- a/Content.Shared/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/CCVar/CCVars.Chat.cs
@@ -76,7 +76,7 @@ public sealed partial class CCVars
     /// An option to toggle the automatic filling of the highlights with the character's info, if available.
     /// </summary>
     public static readonly CVarDef<bool> ChatAutoFillHighlights =
-        CVarDef.Create("chat.auto_fill_highlights", true, CVar.CLIENTONLY | CVar.ARCHIVE, "Toggles automatically filling the highlights with the character's information.");
+        CVarDef.Create("chat.auto_fill_highlights", true, CVar.CLIENTONLY | CVar.ARCHIVE, "Toggles automatically filling the highlights with the character's information."); // Starlight-edit: changed default to true
 
     /// <summary>
     /// The color in which the highlights will be displayed.


### PR DESCRIPTION
## Short description
Enables the smart chat highlights for role and name automatically. This already exists under Options > Accessibility, tick "Auto-fill the highlights with the character's information" but this makes it default on.

Per: https://discord.com/channels/1272545509562777621/1525803155076550687/1525803155076550687

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

While this feature already exists in Accessibility settings, most players (including myself, given I suggested adding this feature 😅) will not find it.

I believe it's a massive help for new and existing players alike, especially given the main server has 200+ players most rounds, making the radio very chaotic and hard to follow.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="522" height="401" alt="image" src="https://github.com/user-attachments/assets/109abf9e-abe3-4c10-ab16-e300c3e8bb4f" />
<img width="730" height="146" alt="image" src="https://github.com/user-attachments/assets/fa8280a3-3afd-405c-b2d5-78b96d1c8aae" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
tweak: Enable department and character name as chat highlights by default (can be disabled via Accessibility options).
