### PR TITLE
Fix Xenoartifact test becoming a 50/50 chance at failure

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Materials/misc.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Materials/misc.yml
@@ -7,8 +7,8 @@
     - type: XenoArtifact
       priceMultiplier: 1.5
       nodeCount:
-        min: 24
-        max: 25
+        min: 23
+        max: 24
     - type: Sprite
       sprite: _Starlight/Objects/Materials/abyss.rsi
       state: abyss_core


### PR DESCRIPTION
## Short description
[This PR](https://github.com/ss14Starlight/space-station-14/pull/5022) removed a trigger from artifacts, but didn't decrease the abyssium core's max number of nodes, leading to it becoming possible to roll 25 nodes, even though only 24 possible ones exist.

## Why we need to add this
A 50% chance of failing tests is really bad.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

No cl no player facing.