### PR TITLE
Fix ammunition not showing damage values

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Cartridges.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Cartridges.cs
@@ -3,8 +3,10 @@ using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Examine;
 using Content.Shared.Projectiles;
+using Content.Shared.Weapons.Hitscan.Components;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
 
@@ -26,27 +28,50 @@ public abstract partial class SharedGunSystem
             : Loc.GetString("gun-cartridge-unspent"));
     }
 
+    #region Starlight
+    // starlight - support hitscan projectiles for damage detail viewing
+
     private void OnCartridgeDamageExamine(Entity<CartridgeAmmoComponent> ent, ref DamageExamineEvent args)
     {
-        var damageSpec = GetProjectileDamage(ent.Comp.Prototype);
-
-        if (damageSpec == null)
+        if(GetProjectileDamage(ent.Comp.Prototype) is not (DamageSpecifier, float) damageSpec)
             return;
 
-        _damageExamine.AddDamageExamine(args.Message, Damageable.ApplyUniversalAllModifiers(damageSpec), Loc.GetString("damage-projectile"));
+        _damageExamine.AddDamageExamine(args.Message, Damageable.ApplyUniversalAllModifiers(damageSpec.Item1), Loc.GetString("damage-projectile"));
+
+        // show armor penetration for hitscan, but only if its actually nonzero
+        if (damageSpec.Item2 != 0f)
+        {
+            var msg = new FormattedMessage();
+            var loc = damageSpec.Item2 < 0 ? "damage-examine-penetration-negative" : "damage-examine-penetration-positive";
+            var pen = Math.Abs(Math.Round(damageSpec.Item2 * 100f));
+            if (msg.TryAddMarkup(Loc.GetString(loc, ("penetration", pen)), out _))
+            {
+                args.Message.PushNewline();
+                args.Message.AddMessage(msg);
+            }
+        }
     }
 
-    private DamageSpecifier? GetProjectileDamage(EntProtoId proto)
+    private (DamageSpecifier, float)? GetProjectileDamage(EntProtoId proto)
     {
         if (!ProtoManager.TryIndex(proto, out var entityProto))
             return null;
 
-        if (!entityProto.TryGetComponent<ProjectileComponent>(out var projectile, Factory))
-            return null;
-
-        if (!projectile.Damage.Empty)
-            return projectile.Damage * Damageable.UniversalProjectileDamageModifier;
+        if (entityProto.TryGetComponent<ProjectileComponent>(out var projectile, Factory))
+        {
+            if (!projectile.Damage.Empty)
+                return (projectile.Damage * Damageable.UniversalProjectileDamageModifier, 0f);
+        }
+        else if (entityProto.TryGetComponent<HitscanBasicDamageComponent>(out var hitscan, Factory))
+        {
+            if (!hitscan.Damage.Empty)
+            {
+                float hitscanPenetration = hitscan.IgnoreResistances ? 1f : hitscan.ArmorPenetration;
+                return (hitscan.Damage * Damageable.UniversalHitscanDamageModifier, hitscanPenetration);
+            }
+        }
 
         return null;
     }
+    #endregion
 }

--- a/Resources/Locale/en-US/_Starlight/damage/damage-examine.ftl
+++ b/Resources/Locale/en-US/_Starlight/damage/damage-examine.ftl
@@ -1,3 +1,3 @@
 # Damage examines
-damage-examine-penetration-positive = This ammo type ignores [color=red]{$penetration}[/color]% of armor
-damage-examine-penetration-negative = This ammo type causes armor to be [color=red]{$penetration}[/color]% more effective
+damage-examine-penetration-positive = This ammo type [color=red]ignores {$penetration}%[/color] of armor
+damage-examine-penetration-negative = This ammo type [color=red]increases effectiveness[/color] of armor by [color=red]{$penetration}%[/color]


### PR DESCRIPTION
## Short description
There was once a time, long long ago, when ammunition cartridges displayed their damage values

Hitscan does damage differently so it wasn't showing on popup
Fixed that, and added an additional line if the cartridge as armour penetration, to display it's effectiveness against armour. There was already loc strings for this functionality, but it was never implemented as they remain unused.

## Why we need to add this
bugfix, epic meta

## Media (Video/Screenshots)
<img width="387" height="139" alt="Screenshot_20260714_225936" src="https://github.com/user-attachments/assets/7e3058f6-4733-413d-ad03-e7fc551dc3cd" />
<img width="387" height="139" alt="Screenshot_20260714_225956" src="https://github.com/user-attachments/assets/8c4e19ab-ee2b-4be0-aead-e158435b6f5f" />



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- fix: Ammunition now shows how much damage it deals again.
- add: Ammunition that has armour penetration characteristics now shows what percentage of armor it ignores or is reduced by.