### PR TITLE
Fix patchmaking weirdness, add container label entry field

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterBoundUserInterface.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterBoundUserInterface.cs
@@ -42,11 +42,15 @@ namespace Content.Client.Chemistry.UI
                 new ChemMasterSetModeMessage(ChemMasterMode.Discard));
             _window.CreatePillButton.OnPressed += _ => SendMessage(
                 new ChemMasterCreatePillsMessage(
-                    (uint) _window.PillDosage.Value, (uint) _window.PillNumber.Value, _window.LabelLine));
+                    (uint) _window.PillDosage.Value, (uint) _window.PillNumber.Value, _window.LabelLine,
+                     _window.ContainerLabelLine)); // Starlight - added arg for containerLabel
             // Starlight-start
             _window.CreatePatchButton.OnPressed += _ => SendMessage(
                 new ChemMasterCreatePatchesMessage(
-                    (uint) _window.PatchDosage.Value, (uint) _window.PatchNumber.Value, _window.LabelLine));
+                    (uint) _window.PatchDosage.Value,
+                    (uint) _window.PatchNumber.Value,
+                    _window.LabelLine,
+                    _window.ContainerLabelLine));
             // Starlight-end
             _window.CreateBottleButton.OnPressed += _ => SendMessage(
                 new ChemMasterOutputToBottleMessage(

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -100,6 +100,14 @@
                 <!-- Packaging Info -->
                 <BoxContainer Orientation="Vertical" Margin="4" HorizontalExpand="True" VerticalExpand="True" SeparationOverride="5">
                     <!-- Label for output -->
+					<!-- Starlight Container Label start-->
+					<BoxContainer Orientation="Horizontal">
+						<Label Text="{Loc 'chem-master-containerlabel-text-label'}" />
+						<Control HorizontalExpand="True" MinSize="50 0"/>
+						<LineEdit Name="ContainerLabelLineEdit" SetWidth="455"/>
+					</BoxContainer>
+					<!-- Starlight Container Label end-->
+					
                     <BoxContainer Orientation="Horizontal">
                         <Label Text="{Loc 'chem-master-current-text-label'}" />
                         <Control HorizontalExpand="True" MinSize="50 0"/>

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -109,7 +109,7 @@
 					<!-- Starlight Container Label end-->
 					
                     <BoxContainer Orientation="Horizontal">
-                        <Label Text="{Loc 'chem-master-current-text-label'}" />
+                        <Label Text="{Loc 'chem-master-pillpatch-text-label'}" />
                         <Control HorizontalExpand="True" MinSize="50 0"/>
                         <LineEdit Name="LabelLineEdit" SetWidth="455"/>
                     </BoxContainer>

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -107,7 +107,7 @@
 						<LineEdit Name="ContainerLabelLineEdit" SetWidth="455"/>
 					</BoxContainer>
 					<!-- Starlight Container Label end-->
-					
+
                     <BoxContainer Orientation="Horizontal">
                         <Label Text="{Loc 'chem-master-pillpatch-text-label'}" />
                         <Control HorizontalExpand="True" MinSize="50 0"/>

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -25,6 +25,9 @@ namespace Content.Client.Chemistry.UI
     {
         [Dependency] private IPrototypeManager _prototypeManager = default!;
         [Dependency] private IEntityManager _entityManager = default!;
+        private NetEntity? _lastOutputContainer; // Starlight
+        private bool _containerLabelManuallySet; // Starlight
+        private bool _settingContainerLabelProgrammatically; // Starlight
 
         private readonly SpriteSystem _sprite;
 
@@ -94,8 +97,15 @@ namespace Content.Client.Chemistry.UI
             BottleDosage.InitDefaultButtons();
 
             // Ensure label length is within the character limit.
-            ContainerLabelLineEdit.IsValid = s => s.Length <= SharedChemMaster.LabelMaxLength; // Starlight
             LabelLineEdit.IsValid = s => s.Length <= SharedChemMaster.LabelMaxLength;
+            // Starlight-start
+            ContainerLabelLineEdit.IsValid = s => s.Length <= SharedChemMaster.LabelMaxLength; // Starlight
+            ContainerLabelLineEdit.OnTextChanged += _ =>
+            {
+                if (!_settingContainerLabelProgrammatically)
+                    _containerLabelManuallySet = true;
+            };
+            // Starlight-end
 
             Tabs.SetTabTitle(0, Loc.GetString("chem-master-window-input-tab"));
             Tabs.SetTabTitle(1, Loc.GetString("chem-master-window-output-tab"));
@@ -158,8 +168,19 @@ namespace Content.Client.Chemistry.UI
                 LabelLine = GenerateLabel(castState);
 
             // Starlight-start
-            if (string.IsNullOrEmpty(ContainerLabelLine))
-                ContainerLabelLine = castState.OutputContainerInfo?.ContainerLabel ?? "";
+            var currentContainer = castState.OutputContainerInfo?.Uid;
+            if (currentContainer != _lastOutputContainer)
+            {
+                _lastOutputContainer = currentContainer;
+                _containerLabelManuallySet = false;
+                ContainerLabelLine = "";
+            }
+
+            if (castState.OutputContainerInfo is not null && !_containerLabelManuallySet)
+            {
+                var existingLabel = castState.OutputContainerInfo?.ContainerLabel;
+                ContainerLabelLine = !string.IsNullOrEmpty(existingLabel) ? existingLabel : LabelLine;
+            }
             // Starlight-end
 
             // Ensure the Panel Info is updated, including UI elements for Buffer Volume, Output Container and so on
@@ -488,7 +509,12 @@ namespace Content.Client.Chemistry.UI
         public string ContainerLabelLine
         {
             get => ContainerLabelLineEdit.Text;
-            set => ContainerLabelLineEdit.Text = value;
+            set
+            {
+                _settingContainerLabelProgrammatically = true;
+                ContainerLabelLineEdit.Text = value;
+                _settingContainerLabelProgrammatically = false;
+            }
         }
         // Starlight end
 

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -94,6 +94,7 @@ namespace Content.Client.Chemistry.UI
             BottleDosage.InitDefaultButtons();
 
             // Ensure label length is within the character limit.
+            ContainerLabelLineEdit.IsValid = s => s.Length <= SharedChemMaster.LabelMaxLength; // Starlight
             LabelLineEdit.IsValid = s => s.Length <= SharedChemMaster.LabelMaxLength;
 
             Tabs.SetTabTitle(0, Loc.GetString("chem-master-window-input-tab"));
@@ -155,6 +156,11 @@ namespace Content.Client.Chemistry.UI
 
             if (castState.UpdateLabel)
                 LabelLine = GenerateLabel(castState);
+
+            // Starlight-start
+            if (string.IsNullOrEmpty(ContainerLabelLine))
+                ContainerLabelLine = castState.OutputContainerInfo?.ContainerLabel ?? "";
+            // Starlight-end
 
             // Ensure the Panel Info is updated, including UI elements for Buffer Volume, Output Container and so on
             UpdatePanelInfo(castState);
@@ -478,6 +484,13 @@ namespace Content.Client.Chemistry.UI
             get => LabelLineEdit.Text;
             set => LabelLineEdit.Text = value;
         }
+        // Starlight Start
+        public string ContainerLabelLine
+        {
+            get => ContainerLabelLineEdit.Text;
+            set => ContainerLabelLineEdit.Text = value;
+        }
+        // Starlight end
 
         private void SetBufferText(FixedPoint2? volume, string text)
         {

--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Server.Chemistry.Components;
 using Content.Server.Popups;
 using Content.Server.Storage.EntitySystems;
@@ -10,6 +12,7 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
+using Content.Shared.Labels.Components;
 using Content.Shared.Labels.EntitySystems;
 using Content.Shared.Storage;
 using Content.Shared.Tag; //Starlight-edit
@@ -19,8 +22,6 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Content.Server.Chemistry.EntitySystems
 {
@@ -233,7 +234,14 @@ namespace Content.Server.Chemistry.EntitySystems
 
             if (!WithdrawFromSource(chemMaster, needed, user, out var withdrawal))
                 return;
-            _labelSystem.Label(container, message.Label);
+
+            // Starlight-start
+            var containerLabel = string.IsNullOrWhiteSpace(message.ContainerLabel)
+                ? message.Label
+                : message.ContainerLabel;
+            // Starlight-end
+
+            _labelSystem.Label(container, containerLabel); // Starlight: message.Label -> containerLabel
 
             for (var i = 0; i < message.Number; i++)
             {
@@ -287,7 +295,13 @@ namespace Content.Server.Chemistry.EntitySystems
             if (!WithdrawFromSource(chemMaster, needed, user, out var withdrawal))
                 return;
 
-            _labelSystem.Label(container, message.Label);
+            // Starlight-start
+            var containerLabel = string.IsNullOrWhiteSpace(message.ContainerLabel)
+                ? message.Label
+                : message.ContainerLabel;
+            // Starlight-end
+
+            _labelSystem.Label(container, containerLabel); // Starlight: message.Label -> containerLabel
 
             for (var i = 0; i < message.Number; i++)
             {
@@ -450,6 +464,9 @@ namespace Content.Server.Chemistry.EntitySystems
                 return null;
 
             //Starlight-start
+            TryComp<LabelComponent>(container.Value, out var labelComp);
+            var existingLabel = labelComp?.CurrentLabel;
+
             var items = storage.Container.ContainedEntities.Select((Func<EntityUid, (string, FixedPoint2 quantity)>) (pill =>
             {
                 if (_solutionContainerSystem.TryGetSolution(pill, SharedChemMaster.PillSolutionName, out _, out var solution))
@@ -470,15 +487,17 @@ namespace Content.Server.Chemistry.EntitySystems
 
             if (_tag.HasTag(container.Value, PatchPackTag))
             {
-                return new ContainerInfo(name, _storageSystem.GetCumulativeItemAreas((container.Value, storage)) / 2, storage.Grid.GetArea() / 2)
+                return new ContainerInfo(name, _storageSystem.GetCumulativeItemAreas((container.Value, storage)), storage.Grid.GetArea())
                 {
-                    PatchEntities = items
+                    PatchEntities = items,
+                    ContainerLabel = existingLabel
                 };
             }
 
             return new ContainerInfo(name, _storageSystem.GetCumulativeItemAreas((container.Value, storage)), storage.Grid.GetArea())
             {
-                PillEntities = items
+                PillEntities = items,
+                ContainerLabel = existingLabel
             };
             //Starlight-end
         }

--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -490,14 +490,16 @@ namespace Content.Server.Chemistry.EntitySystems
                 return new ContainerInfo(name, _storageSystem.GetCumulativeItemAreas((container.Value, storage)), storage.Grid.GetArea())
                 {
                     PatchEntities = items,
-                    ContainerLabel = existingLabel
+                    ContainerLabel = existingLabel,
+                    Uid = GetNetEntity(container.Value)
                 };
             }
 
             return new ContainerInfo(name, _storageSystem.GetCumulativeItemAreas((container.Value, storage)), storage.Grid.GetArea())
             {
                 PillEntities = items,
-                ContainerLabel = existingLabel
+                ContainerLabel = existingLabel,
+                Uid = GetNetEntity(container.Value)
             };
             //Starlight-end
         }

--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -1,7 +1,7 @@
 using Content.Server.Chemistry.Components;
 using Content.Server.Popups;
 using Content.Server.Storage.EntitySystems;
-using Content.Shared._Starlight.Plumbing.Components; // Starlight-edit: Plumbing valve
+using Content.Shared._Starlight.Plumbing.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
@@ -10,10 +10,10 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
-using Content.Shared.Labels.Components; // Starlight-edit
+using Content.Shared.Labels.Components;
 using Content.Shared.Labels.EntitySystems;
 using Content.Shared.Storage;
-using Content.Shared.Tag; //Starlight-edit
+using Content.Shared.Tag;
 using JetBrains.Annotations;
 using Robust.Server.Audio;
 using Robust.Server.GameObjects;

--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Content.Server.Chemistry.Components;
 using Content.Server.Popups;
 using Content.Server.Storage.EntitySystems;
@@ -12,7 +10,7 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
-using Content.Shared.Labels.Components;
+using Content.Shared.Labels.Components; // Starlight-edit
 using Content.Shared.Labels.EntitySystems;
 using Content.Shared.Storage;
 using Content.Shared.Tag; //Starlight-edit
@@ -22,6 +20,8 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Content.Server.Chemistry.EntitySystems
 {

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
-using JetBrains.Annotations;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Chemistry

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
+using JetBrains.Annotations;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Chemistry
@@ -62,12 +63,14 @@ namespace Content.Shared.Chemistry
         public readonly uint Dosage;
         public readonly uint Number;
         public readonly string Label;
+        public readonly string? ContainerLabel; // Starlight
 
-        public ChemMasterCreatePillsMessage(uint dosage, uint number, string label)
+        public ChemMasterCreatePillsMessage(uint dosage, uint number, string label, string containerLabel) // Starlight - add containerLabel
         {
             Dosage = dosage;
             Number = number;
             Label = label;
+            ContainerLabel = containerLabel; // Starlight
         }
     }
 
@@ -78,12 +81,14 @@ namespace Content.Shared.Chemistry
         public readonly uint Dosage;
         public readonly uint Number;
         public readonly string Label;
+        public readonly string? ContainerLabel;
 
-        public ChemMasterCreatePatchesMessage(uint dosage, uint number, string label)
+        public ChemMasterCreatePatchesMessage(uint dosage, uint number, string label, string containerLabel)
         {
             Dosage = dosage;
             Number = number;
             Label = label;
+            ContainerLabel = containerLabel;
         }
     }
     //Starlight-end
@@ -194,7 +199,13 @@ namespace Content.Shared.Chemistry
         /// A list of the patch entities and their sizes within the container
         /// STARLIGHT: Added specifically for patches
         /// </summary>
-        public List<(string Id, FixedPoint2 Quantity)>? PatchEntities { get; init; }
+        public List<(string Id, FixedPoint2 Quantity)>? PatchEntities { get; init; } // Starlight
+
+        /// <summary>
+        /// The label of the container, if one exists at all, to allow us to change the label of the container separate from the pills/patches.
+        /// STARLIGHT:  Affects both pills and patches.
+        /// </summary>
+        public string? ContainerLabel { get; init;  } // Starlight
 
         public List<ReagentQuantity>? Reagents { get; init; }
 

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -207,6 +207,8 @@ namespace Content.Shared.Chemistry
         /// </summary>
         public string? ContainerLabel { get; init;  } // Starlight
 
+        public NetEntity? Uid; // Starlight
+
         public List<ReagentQuantity>? Reagents { get; init; }
 
         public ContainerInfo(string displayName, FixedPoint2 currentVolume, FixedPoint2 maxVolume)

--- a/Resources/Locale/en-US/_Starlight/chemistry/components/chem-master-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/chemistry/components/chem-master-component.ftl
@@ -1,5 +1,6 @@
 chem-master-window-patches-label = Patches:
 chem-master-window-patches-number-label = Count:
+chem-master-containerlabel-text-label = Container Label:
 
 # Plumbing valve
 chem-master-window-valve-open = Valve: Open

--- a/Resources/Locale/en-US/_Starlight/chemistry/components/chem-master-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/chemistry/components/chem-master-component.ftl
@@ -1,6 +1,7 @@
 chem-master-window-patches-label = Patches:
 chem-master-window-patches-number-label = Count:
 chem-master-containerlabel-text-label = Container Label:
+chem-master-pillpatch-text-label = Pill/Patch Label:
 
 # Plumbing valve
 chem-master-window-valve-open = Valve: Open


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Ever since #4970, patch pack size has remained unchanged (5x2 grid), while patches have been moved to 1x1 size.  The chemmaster systems for making patches weren't updated to compensate for this, resulting in odd behavior, described in the next section.
Additionally, I've added the functionality to name the patch pack / pill canister separately from the contents.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
After #4970, making 5 patches in the chemmaster resulted in 5 patches being made, but the UI showed 2/5 in the pack.  Trying to make 5 more patches on top of the existing 5 patches added 3 patches to the pack and updated the UI to 4/5 or something.
I've fixed this to be accurate, now showing 0-10/10.
Additionally, while I was in this, I added functionality to allow the container name to be changed separately from the contents.  Since patch packs can contain 10 things, I figured people might like to mix/match.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/b9e3001f-0ad1-4c76-a680-8120dc27307f



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- add: Patch packs and pills can now be named separately from their contents in the chemmaster UI.
- fix: Patch packs now show the correct number of patches in them in the chemmaster UI.
- fix: Patch packs now make the correct number of patches when patches are already in the pack.
