### PR TITLE
Removed ulnitranium from default scrubber list

### DIFF
--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -38,7 +38,6 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             // Funkystation End: Funky atmos - /tg/ gases
             #region Starlight
             // Starlight gases
-            Gas.Ulnitranium,
             Gas.ZXA,
             #endregion
         };


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Ulnitranium is set to not be scrubbed by default by scrubbers

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This would make it more on par with pluoxium which is already not scrubbed by scrubbers by default. Ulnitranium has zero side effects just like pluoxium and is the equivalent for nitrogen breathers.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="673" height="676" alt="image" src="https://github.com/user-attachments/assets/7435a8ec-8c9f-4223-a3fb-45ba79878a6d" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: joshujo
- tweak: Ulnitranium is no longer scrubbed by scrubbers by default.

