### PR TITLE
Eeep blood recovery

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/eeep.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/eeep.yml
@@ -113,6 +113,8 @@
       reagents:
       - ReagentId: ChloralHydrate
         Quantity: 200
+    bleedReductionAmount: 1
+    bloodRefreshAmount: 2
   - type: Sprite
     sprite: _Impstation/Mobs/Aliens/eeeplet.rsi
     noRot: true
@@ -194,7 +196,9 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: ChloralHydrate
-        Quantity: 200
+        Quantity: 400
+    bleedReductionAmount: 1
+    bloodRefreshAmount: 4
   - type: Electrified
     requirePower: false
     shockDamage: 4


### PR DESCRIPTION
## Short description
At the request of redmushie, add some blodo recovery to the eeep

Currently the eeep has nothing, meaning it will bleed out pretty badly and suffer from bloodloss
With this PR the eep can recover from its bleeding fairly fast, if it gets to safety and doesnt receive new wounds.

I didnt change how the eeep recovered from bloodloss damage itself, meaning an eeep betetr disengage fast once it starts bleeding.

## Why we need to add this
Makes the eeeps better to play, instead of havign to hide for extensive periods of time to recover.

## Media (Video/Screenshots)
video of the eeep having received 1/3 of his health in slash and at max bleedstack, the bleeding stops quickly enough for the eeep to not receive significant damage and is quickly healed at above 90%
https://streamable.com/ill2f7

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Littlemen/Romero
- add: The Eeep now recovers blood quickly.
