### PR TITLE
Derelict Salvage Chassis Mining Module

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -456,6 +456,7 @@
       tags:
       - BorgModuleGeneric
       - BorgModuleCargo
+      - BorgModuleMining #Starlight
     hasMindState: borg_e #Starlight ;-;
     noMindState: borg_e_r #Starlight ;-;
 # Starlight Start


### PR DESCRIPTION
## Short description
Whitelists derelict salvage chassis for mining modules that they already start with

## Why we need to add this
allows derelict salvage borgs to upgrade their existing modules

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Swonki
- fix: derelict salvage cyborg is now whitelisted for its mining module.
