### PR TITLE
critical: fix disposals deleting people

### DIFF
--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Climbing.Systems;
 using Content.Shared.Containers;
 using Content.Shared.Database;
+using Content.Shared.Destructible;
 using Content.Shared.Disposal.Components;
 using Content.Shared.Disposal.Holder;
 using Content.Shared.Disposal.Tube;
@@ -84,6 +85,10 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
 
         // See SharedDisposalUnitSystem.Visuals
         SubscribeLocalEvent<DisposalUnitComponent, DisposalUnitUiButtonPressedMessage>(OnUiButtonPressed);
+
+        #region Starlight
+        SubscribeLocalEvent<DisposalUnitComponent, DestructionEventArgs>(OnDestruction);
+        #endregion
     }
 
     #region: Event handling
@@ -148,6 +153,13 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
         }
     }
 
+    #endregion
+
+    #region Starlight
+    /// <summary>
+    /// stop destruction from deleting people inside
+    /// </summary>
+    private void OnDestruction(Entity<DisposalUnitComponent> ent, ref DestructionEventArgs args) => EjectContents(ent);
     #endregion
 
     /// <summary>


### PR DESCRIPTION
## Short description
Fixes issue #5160 
Destroying a disposal unit deletes all contents, including players inside
Eject players on destruction

## Why we need to add this
free rr 1234

## Media (Video/Screenshots)
<img width="106" height="94" alt="image" src="https://github.com/user-attachments/assets/4b1b8054-1f07-476d-b6a9-643a6431bafb" />


## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- fix: Fix disposals deleting people.
