### PR TITLE
Allow avali, lizards, and moths to eat ice cream, and supply changes.

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -22,7 +22,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockChefvendFilled
-  cost: 1300 # Starlight-edit
+  cost: 1400 # Starlight-edit
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefvend.yml
@@ -25,6 +25,9 @@
     KitchenOvenFlatpack: 1
     KitchenStoveFlatpack: 1
     SlopDispenserFlatpack: 1
+    JugIceCream: 2
+    JugCocoaPowder: 1
+    DrinkCreamCarton: 1
     # Starlight-end
   contrabandInventory:
     EggBoxBroken: 1

--- a/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
@@ -13,6 +13,7 @@
       - Crayon
       - Paper
       - AvianFood
+      - IceCream
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_Starlight/Body/Organs/moth.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/moth.yml
@@ -23,6 +23,7 @@
       - ClothMade
       - Paper
       - Pill
+      - IceCream
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_Starlight/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/reptilian.yml
@@ -13,6 +13,7 @@
       - Pill
       - Crayon
       - Paper
+      - IceCream
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_Starlight/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Fills/Crates/service.yml
@@ -29,7 +29,7 @@
         - id: FoodSnackPistachios
           amount: 5
         - id: FoodBerries
-          amount: 3
+          amount: 9
         - id: IceCreamMakerFlatpack
           amount: 1
         - id: DrinkGlass

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Consumable/Food/icecream.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Consumable/Food/icecream.yml
@@ -48,6 +48,9 @@
     solutionName: food
     maxFillLevels: 5
     fillBaseName: fill-
+  - type: Tag
+    tags:
+      - IceCream
 
 - type: entity
   name: vanilla ice cream

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -318,6 +318,9 @@
   id: HuntedTraitBackground
 
 - type: Tag
+  id: IceCream
+
+- type: Tag
   id: ImprovisedAmmoBox
 
 - type: Tag


### PR DESCRIPTION
## Short description
This PR will allow Avali, lizards, and moths to be able to eat ice creams from the ice cream expansion.
It will also tweak the supply amount of berries in the starter kit, two jugs of ice cream in the chef vend, and one cocoa powder jug in the chef vend as well.

## Why we need to add this
All species should be able to enjoy the ice cream expansion.
I initially intended all species to be able to eat ice cream, similar to a drink. Due to an oversight with how EdibleComponent works with unique stomachs, this unfortunately left out Avali, lizards, and moths unable to eat ice cream.

## Contents
Added an IceCream tag to be used in the ice cream prototype.
Added the IceCream tag in the avali, lizard, and moth stomachs.
Made the ice cream starter crate have 9 berries instead of 3.
Added 2 jugs of ice cream, and one jug of cocoa powder to the chef vend machine.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/594e980b-3418-4afe-9ba4-82c3d35a9205

https://github.com/user-attachments/assets/bac70cc8-aa7b-4d4b-83ca-4dfe9412b357

https://github.com/user-attachments/assets/a6a2a4e7-ccd9-414a-9261-6dd303d17895

<img width="600" height="405" alt="chefvend-resupply" src="https://github.com/user-attachments/assets/b69c9176-b2e0-4a2b-a527-caffad5e6d79" />

<img width="753" height="528" alt="extra_berries" src="https://github.com/user-attachments/assets/fc5f74bf-77dd-4ae5-9f9d-b7162f20416d" />


## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: DreadfulTaco
- fix: Fixed Avali, Lizards, and Moths to be able to eat ice cream.
- tweak: Added more ice cream supplies to ChefVends, and to the ice cream starter crate.
