### PR TITLE
Knockback staminia multiplier clean up

### DIFF
--- a/Content.Shared/_Starlight/Knockback/KnockbackByUserTagComponent.cs
+++ b/Content.Shared/_Starlight/Knockback/KnockbackByUserTagComponent.cs
@@ -20,5 +20,5 @@ public sealed partial class KnockbackData
     [DataField]
     public float Knockback = 0;
     [DataField]
-    public float StaminaMultiplier = 1;
+    public float StaminaMultiplier = 0;
 }

--- a/Content.Shared/_Starlight/Knockback/KnockbackByUserTagComponent.cs
+++ b/Content.Shared/_Starlight/Knockback/KnockbackByUserTagComponent.cs
@@ -20,5 +20,5 @@ public sealed partial class KnockbackData
     [DataField]
     public float Knockback = 0;
     [DataField]
-    public float StaminaMultiplier = 10;
+    public float StaminaMultiplier = 1;
 }

--- a/Content.Shared/_Starlight/Knockback/SharedKnockbackSystem.cs
+++ b/Content.Shared/_Starlight/Knockback/SharedKnockbackSystem.cs
@@ -113,7 +113,7 @@ public abstract partial class SharedKnockbackSystem : EntitySystem
             {
                 var tagdata = ent.Comp.DoestContain[tag];
                 totalData.Knockback += tagdata.Knockback;
-                totalData.StaminaMultiplier = tagdata.StaminaMultiplier;
+                totalData.StaminaMultiplier += tagdata.StaminaMultiplier;
                 hadAnyMatches = true;
             }
         }

--- a/Content.Shared/_Starlight/Knockback/SharedKnockbackSystem.cs
+++ b/Content.Shared/_Starlight/Knockback/SharedKnockbackSystem.cs
@@ -113,7 +113,7 @@ public abstract partial class SharedKnockbackSystem : EntitySystem
             {
                 var tagdata = ent.Comp.DoestContain[tag];
                 totalData.Knockback += tagdata.Knockback;
-                totalData.StaminaMultiplier += tagdata.StaminaMultiplier;
+                totalData.StaminaMultiplier = tagdata.StaminaMultiplier;
                 hadAnyMatches = true;
             }
         }

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -14,16 +14,16 @@
     doestContain:
       Skating:
         knockback: 0.5
-        staminaMultiplier: 100
+        staminaMultiplier: 110
       Rodentia:
         knockback: 0.01
-        staminaMultiplier: 100
+        staminaMultiplier: 110
       Resomi:
         knockback: 0.01
-        staminaMultiplier: 100
+        staminaMultiplier: 110
       Felionoid:
         knockback: 0.005 # half of what resomi take
-        staminaMultiplier: 100
+        staminaMultiplier: 110
   - type: Sprite
   - type: Item
     size: Ginormous

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -14,7 +14,7 @@
     doestContain:
       Skating:
         knockback: 0.5
-        staminaMultiplier: 110
+        staminaMultiplier: 100
       Rodentia:
         knockback: 0.01
         staminaMultiplier: 110

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -14,7 +14,7 @@
     doestContain:
       Skating:
         knockback: 0.5
-        staminaMultiplier: 110
+        staminaMultiplier: 100
       Rodentia:
         knockback: 0.02
         staminaMultiplier: 110

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -14,16 +14,16 @@
     doestContain:
       Skating:
         knockback: 0.5
-        staminaMultiplier: 100
+        staminaMultiplier: 110
       Rodentia:
         knockback: 0.02
-        staminaMultiplier: 100
+        staminaMultiplier: 110
       Resomi:
         knockback: 0.02
-        staminaMultiplier: 100
+        staminaMultiplier: 110
       Felionoid:
         knockback: 0.01 #half of what resomi take
-        staminaMultiplier: 100
+        staminaMultiplier: 110
     # starlight start
   - type: MeleeWeapon
     wideAnimationRotation: 90

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -14,16 +14,16 @@
     doestContain:
       Skating:
         knockback: 5
-        staminaMultiplier: 20
+        staminaMultiplier: 30
       Rodentia:
         knockback: 10
-        staminaMultiplier: 8
+        staminaMultiplier: 18
       Resomi:
         knockback: 10
-        staminaMultiplier: 8
+        staminaMultiplier: 18
       Felionoid:
         knockback: 5 # half of what resomi take
-        staminaMultiplier: 8
+        staminaMultiplier: 18
   - type: Sprite
   - type: Clothing
     sprite: Objects/Weapons/Guns/Launchers/china_lake.rsi
@@ -140,12 +140,16 @@
     doestContain:
       Skating:
         knockback: -2.5
+        staminaMultiplier: 20
       Rodentia:
         knockback: -10
+        staminaMultiplier: 20
       Resomi:
         knockback: -5
+        staminaMultiplier: 20
       Felionoid:
         knockback: -2.5 # half of what resomi take
+        staminaMultiplier: 20
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/rocket.rsi
     layers:
@@ -183,13 +187,13 @@
     doestContain:
       Resomi:
         knockback: 10
-        staminaMultiplier: 8
+        staminaMultiplier: 18
       Rodentia:
         knockback: 10
-        staminaMultiplier: 8
+        staminaMultiplier: 18
       Felionoid:
         knockback: 5 # half of what resomi take
-        staminaMultiplier: 8
+        staminaMultiplier: 18
   - type: Sprite
     sprite: Objects/Weapons/Guns/Launchers/rocket.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -14,7 +14,7 @@
     doestContain:
       Skating:
         knockback: 5
-        staminaMultiplier: 30
+        staminaMultiplier: 20
       Rodentia:
         knockback: 10
         staminaMultiplier: 18
@@ -140,7 +140,7 @@
     doestContain:
       Skating:
         knockback: -2.5
-        staminaMultiplier: 20
+        staminaMultiplier: 10
       Rodentia:
         knockback: -10
         staminaMultiplier: 20

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -14,13 +14,16 @@
     doestContain:
       Skating:
         knockback: 1.0
-        staminaMultiplier: 100
+        staminaMultiplier: 110
       Rodentia:
         knockback: 0.1
+        staminaMultiplier: 20
       Resomi:
         knockback: 0.1
+        staminaMultiplier: 20
       Felionoid:
         knockback: 0.05 #half of what resomi take
+        staminaMultiplier: 20
   - type: Sprite
   - type: Item
     size: Huge

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -14,7 +14,7 @@
     doestContain:
       Skating:
         knockback: 1.0
-        staminaMultiplier: 110
+        staminaMultiplier: 100
       Rodentia:
         knockback: 0.1
         staminaMultiplier: 20

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -14,7 +14,7 @@
     doestContain:
       Skating:
         knockback: 2
-        staminaMultiplier: 60
+        staminaMultiplier: 50
       Rodentia:
         knockback: 3
         staminaMultiplier: 30

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -14,16 +14,16 @@
     doestContain:
       Skating:
         knockback: 2
-        staminaMultiplier: 50
+        staminaMultiplier: 60
       Rodentia:
         knockback: 3
-        staminaMultiplier: 20
+        staminaMultiplier: 30
       Resomi:
         knockback: 3
-        staminaMultiplier: 20
+        staminaMultiplier: 30
       Felionoid:
         knockback: 1.5 #half of what resomi take
-        staminaMultiplier: 20
+        staminaMultiplier: 30
   - type: Sprite
     layers:
     - state: icon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -13,17 +13,17 @@
   - type: KnockbackByUserTag # Starlight
     doestContain:
       Skating:
-        knockback: 2.0
-        staminaMultiplier: 50
+        knockback: 2
+        staminaMultiplier: 60
       Rodentia:
         knockback: 4
-        staminaMultiplier: 15
+        staminaMultiplier: 25
       Resomi:
         knockback: 4
-        staminaMultiplier: 15
+        staminaMultiplier: 25
       Felionoid:
         knockback: 2 #half of what resomi take
-        staminaMultiplier: 15
+        staminaMultiplier: 25
     # starlight start
   - type: MeleeWeapon
     wideAnimationRotation: 90
@@ -90,10 +90,13 @@
     doestContain:
       Rodentia:
         knockback: 3
+        staminaMultiplier: 20
       Resomi:
         knockback: 2
+        staminaMultiplier: 20
       Felionoid:
         knockback: 1 # half of what resomi take
+        staminaMultiplier: 20
   - type: BallisticAmmoProvider # Starlight
     capacity: 10
     proto: CartridgeMagnumSP

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -14,7 +14,7 @@
     doestContain:
       Skating:
         knockback: 2
-        staminaMultiplier: 60
+        staminaMultiplier: 50
       Rodentia:
         knockback: 4
         staminaMultiplier: 25

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -23,7 +23,7 @@
     doestContain:
       Skating:
         knockback: 1.0
-        staminaMultiplier: 110
+        staminaMultiplier: 100
       Rodentia:
         knockback: 1.5
         staminaMultiplier: 20

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -23,13 +23,16 @@
     doestContain:
       Skating:
         knockback: 1.0
-        staminaMultiplier: 100
+        staminaMultiplier: 110
       Rodentia:
         knockback: 1.5
+        staminaMultiplier: 20
       Resomi:
         knockback: 1.5
+        staminaMultiplier: 20
       Felionoid:
         knockback: 0.75 # half of what resomi take
+        staminaMultiplier: 20
   - type: BallisticAmmoProvider
     whitelist:
       tags:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
This PR does not contain balance changes. All gun-based knockback and stamina damage is intended to be the same in normal circumstances.

There's some nuances with skating stamina damage - see next section for details. In short: stamina damage when skating is _technically_ different, but not meaningfully difference (i.e. you're still going to stamina crit shooting a double barrel on skates no matter who you are)

This PR modifies `SharedKnockbackSystem` and `KnockbackByUserTagComponent` to make `StaminaMultiplier` work as expected.

- The default value for `StaminaMultiplier` has been changed from 10 $$\rightarrow$$ 0
- All weapons have had their `StaminaMultiplier`s updated to reflect what they are on live
- If the weapon didn't have a `StaminaMultiplier`, it's been set to 20 (see next section for _why_ this is 20 instead of 10)
- If the weapon did have a `StaminaMultiplier`, it's been increased by +10
- `Skating` did not have its `StaminaMultiplier` increased, but shooting on skates still has the same end effect

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
### tl;dr
- This PR makes the `StaminaMultiplier` work how you think it'd work
- If `StaminaMultiplier` zero, it makes the stamina damage zero
- If `StaminaMultiplier` is 30, it deals $$\text{knockback}\times30$$ stamina damage

### The Long Version
While testing some stuff related to weapon knockback, I wanted to set a gun's `StaminaMultiplier` to zero. I was then surprised to see that the gun was still doing stamina damage.

Looking at the function `GetKnockbackData()` reveals that `StaminaMultiplier` has its value set additively:
```csharp
            if (_tagSystem.HasTag(user, tag))
            {
                var tagdata = ent.Comp.DoestContain[tag];
                totalData.Knockback += tagdata.Knockback;
                totalData.StaminaMultiplier += tagdata.StaminaMultiplier;
                hadAnyMatches = true;
            }
```

Which wouldn't be an issue if the value started at zero, but it actually defaults to 10:
```csharp
public sealed partial class KnockbackData
{
    public KnockbackData() { }

    [DataField]
    public float Knockback = 0;
    [DataField]
    public float StaminaMultiplier = 10;
}
```

This has some interesting quirks:
- Not defining a `staminaMultiplier` in the `yml` of a gun sets its `StaminaMultiplier` to 20 (it adds the default value twice!)
- Setting `staminaMultiplier` to 0 in the `yml` is "adding zero", so you get a `StaminaMultiplier` of 10.
- Setting `staminaMultiplier` to -10 in the `yml` makes `StaminaMultiplier` zero.

I think this is unintuitive. You'd expect the following line:
```yml
      Resomi:
        knockback: 3
        staminaMultiplier: 20
```

Would result in a `StaminaMultiplier` of 20 and deal $$3\times20=60$$ stamina damage
...but it actually does $$3\times(10+20)=90$$ stamina damage.

Similarly, this setup:
```yml
      Resomi:
        knockback: 3
        staminaMultiplier: 0
```

Still does $$3\times(10+0)=30$$ stamina damage.

### Skating
Skating stamina damage has a unique issue with how the `StaminaMultiplier` is calculated. It's clearly written with the intention that any regular (non-small) person should stamina crit.

From `shotguns.yml`:
```yml
  - type: KnockbackByUserTag # Starlight
    doestContain:
      Skating:
        knockback: 2
        staminaMultiplier: 50
```
$$ 2 \times 50 = 100$$ stamina damage, meaning shooting once should stamina crit you. However, as mentioned previously, they actually take $$2 \times (10+50) = 120$$ stamina damage. This still stamina crits you, just by more than the intended amount.

This nuance doesn't end up mattering -- both situations result in a stamina crit for the human-on-rollerskates, but it _is_ slightly different so I'm going to mention it.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
I used the following test on Live to confirm that this changes in this PR do not change the amount of stamina damage in normal circumstances.
<img width="1062" height="976" alt="image" src="https://github.com/user-attachments/assets/a013bf68-c388-43a3-8e0e-12ddae12af2a" />

Testing before these changes on the default `starlight-dev` branch:
```
LIVE - Using a Resomi with no stamina modifying equipment

WeaponShotgunDoubleBarreled
[INFO] system.knockback: KNOCKBACK:          3
[INFO] system.knockback: STAMINA MULTIPLIER: 30
[INFO] system.knockback: STAMINA DAMAGE:     90

WeaponRifleLecter
[INFO] system.knockback: KNOCKBACK:          0.1
[INFO] system.knockback: STAMINA MULTIPLIER: 20
[INFO] system.knockback: STAMINA DAMAGE:     2

WeaponSniperMosin
[INFO] system.knockback: KNOCKBACK:          2
[INFO] system.knockback: STAMINA MULTIPLIER: 20
[INFO] system.knockback: STAMINA DAMAGE:     40

WeaponSniperHristov
[INFO] system.knockback: KNOCKBACK:          4
[INFO] system.knockback: STAMINA MULTIPLIER: 25
[INFO] system.knockback: STAMINA DAMAGE:     100

WeaponLightMachineGunL6
[INFO] system.knockback: KNOCKBACK:          0.02
[INFO] system.knockback: STAMINA MULTIPLIER: 110
[INFO] system.knockback: STAMINA DAMAGE:     2.2

WeaponLauncherChinaLake
[INFO] system.knockback: KNOCKBACK:          10
[INFO] system.knockback: STAMINA MULTIPLIER: 18
[INFO] system.knockback: STAMINA DAMAGE:     180

WeaponShotgunDoubleBarreled 
*edited to staminaMultiplier: 0 for demonstration
[INFO] system.knockback: KNOCKBACK:          3
[INFO] system.knockback: STAMINA MULTIPLIER: 10
[INFO] system.knockback: STAMINA DAMAGE:     30

LIVE - RESOMI ON ROLLERSKATES
ClothingShoesSkates + WeaponShotgunDoubleBarreled
[INFO] system.knockback: KNOCKBACK:          5
[INFO] system.knockback: STAMINA MULTIPLIER: 80
[INFO] system.knockback: STAMINA DAMAGE:     400

LIVE - HUMAN ON ROLLERSKATES
ClothingShoesSkates + WeaponShotgunDoubleBarreled
[INFO] system.knockback: KNOCKBACK:          2
[INFO] system.knockback: STAMINA MULTIPLIER: 60
[INFO] system.knockback: STAMINA DAMAGE:     120
```

My testing after applying the changes:
```
MODIFIED - Using a Resomi with no stamina modifying equipment

WeaponShotgunDoubleBarreled
[INFO] system.knockback: KNOCKBACK:          3
[INFO] system.knockback: STAMINA MULTIPLIER: 30
[INFO] system.knockback: STAMINA DAMAGE:     90

WeaponRifleLecter
[INFO] system.knockback: KNOCKBACK:          0.1
[INFO] system.knockback: STAMINA MULTIPLIER: 20
[INFO] system.knockback: STAMINA DAMAGE:     2

WeaponSniperMosin
[INFO] system.knockback: KNOCKBACK:          2
[INFO] system.knockback: STAMINA MULTIPLIER: 20
[INFO] system.knockback: STAMINA DAMAGE:     40

WeaponSniperHristov
[INFO] system.knockback: KNOCKBACK:          4
[INFO] system.knockback: STAMINA MULTIPLIER: 25
[INFO] system.knockback: STAMINA DAMAGE:     100

WeaponLightMachineGunL6
[INFO] system.knockback: KNOCKBACK:          0.02
[INFO] system.knockback: STAMINA MULTIPLIER: 110
[INFO] system.knockback: STAMINA DAMAGE:     2.2

WeaponLauncherChinaLake
[INFO] system.knockback: KNOCKBACK:          10
[INFO] system.knockback: STAMINA MULTIPLIER: 18
[INFO] system.knockback: STAMINA DAMAGE:     180

WeaponShotgunDoubleBarreled 
*edited to staminaMultiplier: 0 for demonstration
[INFO] system.knockback: KNOCKBACK:          3
[INFO] system.knockback: STAMINA MULTIPLIER: 0
[INFO] system.knockback: STAMINA DAMAGE:     0

MODIFIED - RESOMI ON ROLLERSKATES
ClothingShoesSkates + WeaponShotgunDoubleBarreled
[INFO] system.knockback: KNOCKBACK:          5
[INFO] system.knockback: STAMINA MULTIPLIER: 80
[INFO] system.knockback: STAMINA DAMAGE:     400

MODIFIED - HUMAN ON ROLLERSKATES
ClothingShoesSkates + WeaponShotgunDoubleBarreled
[INFO] system.knockback: KNOCKBACK:          2
[INFO] system.knockback: STAMINA MULTIPLIER: 50
[INFO] system.knockback: STAMINA DAMAGE:     100
```

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

