### PR TITLE
Make IngestionBlocker networked.

### DIFF
--- a/Content.Shared/Nutrition/Components/IngestionBlockerComponent.cs
+++ b/Content.Shared/Nutrition/Components/IngestionBlockerComponent.cs
@@ -10,12 +10,12 @@ namespace Content.Shared.Nutrition.Components;
 ///     In the event that more head-wear & mask functionality is added (like identity systems, or raising/lowering of
 ///     masks), then this component might become redundant.
 /// </remarks>
-[RegisterComponent, Access(typeof(IngestionSystem)), NetworkedComponent, AutoGenerateComponentState] // Starlight edit: I'm lazy and this is the easiest way to fix the bug.
+[RegisterComponent, Access(typeof(IngestionSystem)), NetworkedComponent, AutoGenerateComponentState] // Starlight edit
 public sealed partial class IngestionBlockerComponent : Component
 {
     /// <summary>
     ///     Is this component currently blocking consumption.
     /// </summary>
-    [DataField, AutoNetworkedField] // Starlight edit: I'm lazy and this is the easiest way to fix the bug.
+    [DataField, AutoNetworkedField] // Starlight edit
     public bool Enabled { get; set; } = true;
 }

--- a/Content.Shared/Nutrition/Components/IngestionBlockerComponent.cs
+++ b/Content.Shared/Nutrition/Components/IngestionBlockerComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Nutrition.EntitySystems;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Nutrition.Components;
 
@@ -9,12 +10,12 @@ namespace Content.Shared.Nutrition.Components;
 ///     In the event that more head-wear & mask functionality is added (like identity systems, or raising/lowering of
 ///     masks), then this component might become redundant.
 /// </remarks>
-[RegisterComponent, Access(typeof(IngestionSystem))]
+[RegisterComponent, Access(typeof(IngestionSystem)), NetworkedComponent, AutoGenerateComponentState] // Starlight edit: I'm lazy and this is the easiest way to fix the bug.
 public sealed partial class IngestionBlockerComponent : Component
 {
     /// <summary>
     ///     Is this component currently blocking consumption.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField] // Starlight edit: I'm lazy and this is the easiest way to fix the bug.
     public bool Enabled { get; set; } = true;
 }

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -46,6 +46,7 @@ public sealed partial class IngestionSystem
     private void OnBlockerMaskToggled(Entity<IngestionBlockerComponent> ent, ref ItemMaskToggledEvent args)
     {
         ent.Comp.Enabled = !args.Mask.Comp.IsToggled;
+        Dirty(ent); // Starlight
     }
 
     private void OnIngestionBlockerAttempt(Entity<IngestionBlockerComponent> entity, ref IngestionAttemptEvent args)


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Does what it says on the tin.
Fixes a small bug regarding eating/drinking with a pulled down mask after relogging.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Fix a small bug where upon relogging with a pulled-down mask, a popup would show up saying you need to pull it down when trying to eat/drink despite it already being down.