### PR TITLE
Subgamerule metagaming

### DIFF
--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -215,15 +215,16 @@ public sealed partial class GameTicker
             return false;
 
         CurrentPreset = Preset;
-        foreach (var rule in Preset.Rules)
-        {
-            AddGameRule(rule);
-        }
 
         // Starlight begin - Notify admins of preset now that it is locked in.
         if (Preset.ID != "Secret") _chatManager.SendAdminAnnouncement($"Round preset selected: {Preset.ID}.");
         _adminLogger.Add(LogType.RoundstartRulesAdded, LogImpact.High, $"Round preset selected: {Preset.ID}.");
         // Starlight end
+
+        foreach (var rule in Preset.Rules)
+        {
+            AddGameRule(rule);
+        }
 
         return true;
     }

--- a/Content.Server/GameTicking/Rules/SubGamemodesSystem.cs
+++ b/Content.Server/GameTicking/Rules/SubGamemodesSystem.cs
@@ -1,11 +1,15 @@
+using Content.Server.Chat.Managers;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Storage;
 
 namespace Content.Server.GameTicking.Rules;
 
-public sealed class SubGamemodesSystem : GameRuleSystem<SubGamemodesComponent>
+public sealed partial class SubGamemodesSystem : GameRuleSystem<SubGamemodesComponent> // Starlight edit: Editing this anyway may as well fix it not being partial.
 {
+    [Dependency] private IChatManager _chat = default!; // Starlight
+    [Dependency] private GameTicker _ticker = default!; // Starlight
+
     protected override void Added(EntityUid uid, SubGamemodesComponent comp, GameRuleComponent rule, GameRuleAddedEvent args)
     {
         var picked = EntitySpawnCollection.GetSpawns(comp.Rules, RobustRandom);
@@ -13,6 +17,10 @@ public sealed class SubGamemodesSystem : GameRuleSystem<SubGamemodesComponent>
         {
             Log.Info($"Starting gamerule {id} as a subgamemode of {ToPrettyString(uid):rule}");
             GameTicker.AddGameRule(id);
+            // Starlight begin
+            if (_ticker is { RunLevel: GameRunLevel.PreRoundLobby, CurrentPreset: not null })
+                _chat.SendAdminAnnouncement($"Preset {_ticker.CurrentPreset.ID}/{MetaData(uid).EntityPrototype!.ID} added {id} as a subgamemode.");
+            // Starlight end
         }
     }
 }

--- a/Content.Server/GameTicking/Rules/SubGamemodesSystem.cs
+++ b/Content.Server/GameTicking/Rules/SubGamemodesSystem.cs
@@ -5,7 +5,7 @@ using Content.Shared.Storage;
 
 namespace Content.Server.GameTicking.Rules;
 
-public sealed partial class SubGamemodesSystem : GameRuleSystem<SubGamemodesComponent> // Starlight edit: Editing this anyway may as well fix it not being partial.
+public sealed partial class SubGamemodesSystem : GameRuleSystem<SubGamemodesComponent> // Starlight edit
 {
     [Dependency] private IChatManager _chat = default!; // Starlight
     [Dependency] private GameTicker _ticker = default!; // Starlight


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Like the last PR I did that made it show the selected gamerule for admins, but now it broadcasts when a subgamerule is added too so that admins know exactly what antags to expect.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Admin convenience.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.