### PR TITLE
Making the crew pay a lot less odd.

### DIFF
--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -2,62 +2,64 @@
   id: standart
   jobs:
     Captain: 150
-    HeadOfPersonnel: 130
+    HeadOfPersonnel: 145
     HeadOfSecurity: 145
     ChiefEngineer: 140
-    ResearchDirector: 130
-    ChiefMedicalOfficer: 135
-    Quartermaster: 120
+    ResearchDirector: 140
+    ChiefMedicalOfficer: 140
+    Quartermaster: 140
 
-    BlueShield: 110
+    BlueShield: 160
     NanoTrasenRepresentative: 165
     Magistrate: 176
     NanotrasenCareerTrainer: 150
-    IAA: 76
+    IAA: 80
 
     Chemist: 90
-    Paramedic: 50
-    MedicalDoctor: 58
-    MedicalIntern: 23
+    Paramedic: 85
+    MedicalDoctor: 59
+    MedicalIntern: 30
     Surgeon: 90
+    Psychologist: 84
 
-    AtmosphericTechnician: 90
-    StationEngineer: 54
-    TechnicalAssistant: 23
+    AtmosphericTechnician: 95
+    StationEngineer: 60
+    TechnicalAssistant: 30
 
-    Warden: 90
+    Warden: 110
     Detective: 80
-    Brigmedic: 73
+    Brigmedic: 82
     DutyOfficer: 70
     SecurityOfficer: 64
-    SecurityCadet: 23
+    SecurityCadet: 30
 
     StationAi: 155
     Borg: 85
 
     Chaplain: 50
     Chef: 50
-    Janitor: 30
+    Janitor: 45
     Botanist: 50
     Lawyer: 55
     Librarian: 50
     Musician: 40
     Bartender: 50
-    Mime: 30
-    Clown: 30
-    ServiceWorker: 23
-    Performer: 23
+    Mime: 40
+    Clown: 40
+    ServiceWorker: 30
+    Performer: 30
     Assistant: 15
+    Reporter: 50
 
-    Scientist: 65
-    Roboticist: 56
-    ResearchAssistant: 23
+    Scientist: 60
+    Roboticist: 85
+    ResearchAssistant: 30
 
-    SalvageLead: 75
-    SalvageSpecialist: 60
-    MiningSpecialist: 60
-    CargoTechnician: 45
-    MailTech: 55
+    SalvageLead: 110
+    SalvageSpecialist: 85
+    MiningSpecialist: 85
+    CargoTechnician: 60
+    MailTech: 70
 
     Visitor: 0
 

--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -17,7 +17,7 @@
 
     Chemist: 90
     Paramedic: 85
-    MedicalDoctor: 59
+    MedicalDoctor: 60
     MedicalIntern: 30
     Surgeon: 90
     Psychologist: 84
@@ -28,7 +28,7 @@
 
     Warden: 110
     Detective: 80
-    Brigmedic: 82
+    Brigmedic: 85
     DutyOfficer: 70
     SecurityOfficer: 64
     SecurityCadet: 30


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Standardized the pay for a lot of roles to be less weird and unique. (Cargo roles got paid less for **no** reason???)

 Changes:
  ### Command
    Hop, 130 -> 145 (matching with Hos as a "second in command")
    RD, CMO, QM, -> 140 (matching the CE)
  ### NT
    BSO, 110 -> 160 (They protect command, they should get paid well)
    IAA, 76 -> 80 
  ### Med
    Paramedic, 50 -> 85 (They used to get paid less than doctors??? Increased to match other subdepartment roles better)
    Doctor, 58 -> 60 (All departmental main roles ~60)
    MedIntern, 23 -> 30 (All training roles standardized to 30)
    +++Psychologist, 0 -> 84 (Psych doesn't get paid, now they do)
  ### Sec
    Warden 90, -> 110 (Warden is one of the most intensive non command roles, they should get paid better than most)
    Brigmedic, 73 -> 85 (To match the subdepartment pay of ~85)
    SecCadet, 23 -> 30 (All training roles standardized to 30)
  ### Engi
    Atmostech, 90 -> 95 (They keep the air on, they can be paid well)
    Engineer, 54 -> 60 (All departmental main roles ~60)
    TechAssistant, 23 -> 30 (All training roles standardized to 30)
  ### Sci
    Scientist, 65 -> 60 (They got paid more than sec??? Standardized to ~60)
    Roboticist, 56 -> 85 (Got paid less than scientists for some reason?? Standardized to subdepartment of ~85)
    ResearchAssistant, 23 -> 30 (All training roles standardized to 30)
  ### Cargo
     SalvageLead, 75 -> 110 (A unique role like warden, standardized equal to warden)
     Salvage, 60 -> 85 (Standardized to subdepartment of ~85)
     Mining, 60 -> 85 (Standardized to subdepartment of ~85)
     CargoTech, 45 -> 60 (Got paid less than service roles for some reason?  Standardized all departmental main roles ~60)
     MailTech, 55 -> 70 (Bit less than the other subdepartments due to being easier)
  ### Service
     Janitor, 30 -> 45 (The hardest workers on station, they deserve to be paid a bit better)
     ServiceWorker, 23 -> 30 (Not officially a training role, but a lot like one, so its getting standardized)
     Performer, 23 -> 30 (Same as Service Workers)
     Clown, 30 -> 40 (Just so they earn more than training roles)
     Mime, 30 -> 40 (Same reason as clown)
     +++ Reporter 0 -> 50 (Also doesn't get paid, has been standardized to the same as most of service at 50)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

1. Standardizing numbers is good.
2. A lot of these numbers felt weird and biased toward certain departments, they have been changed so pay feels a lot more accurate to the level of expected work and skill.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Musiklie
- tweak: After an incident where a station refused to work for unknowable reasons, NT & CC have agreed to increase/standardize the pay of many roles across station to more reasonable levels. 

