### PR TITLE
Destructible Water Tiles

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -144,6 +144,12 @@
       sprite: Objects/Tools/Hydroponics/spade.rsi
   - type: Shovel
     speedModifier: 0.75 # slower at digging than a full-sized shovel
+  # 🌟Starlight-start🌟
+  - type: Tool
+    qualities:
+      - Digging
+    speedModifier: 0.75 # see above
+  # 🌟Starlight-end🌟
   - type: PhysicalComposition
     materialComposition:
       Steel: 100

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -550,7 +550,11 @@
   - type: StaticPrice
     price: 25
   - type: Shovel
-
+  # 🌟Starlight-start🌟
+  - type: Tool
+    qualities:
+      - Digging
+  # 🌟Starlight-end🌟
 - type: entity
   parent: BaseItem
   id: RollingPin

--- a/Resources/Prototypes/_Starlight/Entities/Tiles/water.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Tiles/water.yml
@@ -9,3 +9,36 @@
     drawdepth: BelowFloor
     layers:
       - state: shoreline_azure_water
+
+- type: entity
+  parent: FloorWaterEntity
+  id: FloorWaterDestructibleEntity
+  suffix: Destructible
+  name: water
+  components:
+  - type: Construction
+    graph: Water
+    node: water
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 500 #Relatively high, so it doesn't accidentally break unless you're really trying to do so.
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+
+- type: entity
+  parent: FloorWaterDestructibleEntity
+  id: FloorAzureWaterDestructibleEntity
+  name: azure water
+  description: A real thirst quencher. Corals are not included!
+  components:
+  - type: Sprite
+    sprite: _Starlight/Tiles/Planet/azure_water.rsi
+    drawdepth: BelowFloor
+    layers:
+      - state: shoreline_azure_water

--- a/Resources/Prototypes/_Starlight/Recipes/Construction/Graphs/Structures/water.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Construction/Graphs/Structures/water.yml
@@ -1,0 +1,20 @@
+- type: constructionGraph
+  id: Water
+  start: start
+  graph:
+    - node: start
+      actions:
+        - !type:DeleteEntity
+
+    - node: water
+      entity: FloorWaterDestructibleEntity
+      edges:
+        - to: start
+          completed:
+          - !type:EmptyAllContainers {}
+          - !type:PlaySound
+            sound: /Audio/Effects/Fluids/watersplash.ogg
+          - !type:DeleteEntity {}
+          steps:
+            - tool: Digging
+              doAfter: 5

--- a/Resources/Prototypes/tool_qualities.yml
+++ b/Resources/Prototypes/tool_qualities.yml
@@ -67,7 +67,14 @@
   toolName: tool-quality-rolling-tool-name
   spawn: RollingPin
   icon: { sprite: Objects/Tools/rolling_pin.rsi, state: icon }
-
+  # 🌟Starlight-start🌟
+- type: tool
+  id: Digging
+  name: tool-quality-digging-name
+  toolName: tool-quality-digging-tool-name
+  spawn: Shovel
+  icon: { sprite: Objects/Tools/shovel.rsi, state: icon }
+  # 🌟Starlight-end🌟
 - type: tool
   id: Brushing
   name: tool-quality-brushing-name


### PR DESCRIPTION
## Short description
Adds water tiles that can be both destroyed via damage, and deconstructed using a shovel.
<!-- What do you propose to change with your PR? -->

## Why we need to add this
Mainly mapping for mapping use, as currently you're unable to remove the water tiles to replace them with something else during a round. This can be an issue when using a large volume of water tiles within the interior of a station.
Additionally, adding "Digging" as a tool type can allow additional shovel uses in the future.
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)

<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/fd1822b6-4755-4aec-b0d0-51a44c580285
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Makeshift
- add: Added destructible water tiles for mapping use. 
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
