### PR TITLE
Mald PR: Make Makeshift ID Cards Microwaveable

### DIFF
--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Popups;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Server.Kitchen.EntitySystems;
+using Content.Shared._Starlight.Access;
 
 namespace Content.Server.Access.Systems;
 
@@ -29,11 +30,43 @@ public sealed partial class IdCardSystem : SharedIdCardSystem
         base.Initialize();
 
         SubscribeLocalEvent<IdCardComponent, BeingMicrowavedEvent>(OnMicrowaved);
+        SubscribeLocalEvent<MakeshiftIdCardComponent, BeingMicrowavedEvent>(OnMakeshiftMicrowaved); // Starlight
     }
 
     private void OnMicrowaved(EntityUid uid, IdCardComponent component, BeingMicrowavedEvent args)
     {
-        if (!component.CanMicrowave || !TryComp<CookingDeviceComponent>(args.Microwave, out var micro) || micro.Broken) // Starlight-edit
+        if (!component.CanMicrowave) // Starlight-edit-edit - Moved to the other function
+            return;
+
+        DoMicrowave(uid, args); // Starlight - Move to separate function to avoid reusing code.
+    }
+
+    public override void ExpireId(Entity<ExpireIdCardComponent> ent)
+    {
+        if (ent.Comp.Expired)
+            return;
+
+        base.ExpireId(ent);
+
+        if (ent.Comp.ExpireMessage != null)
+        {
+            _chat.TrySendInGameICMessage(
+                ent,
+                Loc.GetString(ent.Comp.ExpireMessage),
+                InGameICChatType.Speak,
+                ChatTransmitRange.Normal,
+                true);
+        }
+    }
+
+    #region Starlight
+
+    public void OnMakeshiftMicrowaved(Entity<MakeshiftIdCardComponent> ent, ref BeingMicrowavedEvent args)
+        => DoMicrowave(ent, args);
+
+    private void DoMicrowave(EntityUid uid, BeingMicrowavedEvent args)
+    {
+        if (!TryComp<CookingDeviceComponent>(args.Microwave, out var micro) || micro.Broken)
             return;
 
         if (TryComp<AccessComponent>(uid, out var access))
@@ -93,25 +126,8 @@ public sealed partial class IdCardSystem : SharedIdCardSystem
 
             _adminLogger.Add(LogType.Action, LogImpact.High,
                     $"{ToPrettyString(args.Microwave)} added {random.ID} access to {ToPrettyString(uid):entity}");
-
         }
     }
 
-    public override void ExpireId(Entity<ExpireIdCardComponent> ent)
-    {
-        if (ent.Comp.Expired)
-            return;
-
-        base.ExpireId(ent);
-
-        if (ent.Comp.ExpireMessage != null)
-        {
-            _chat.TrySendInGameICMessage(
-                ent,
-                Loc.GetString(ent.Comp.ExpireMessage),
-                InGameICChatType.Speak,
-                ChatTransmitRange.Normal,
-                true);
-        }
-    }
+    #endregion
 }

--- a/Content.Shared/_Starlight/Access/MakeshiftIdCardComponent.cs
+++ b/Content.Shared/_Starlight/Access/MakeshiftIdCardComponent.cs
@@ -1,0 +1,5 @@
+namespace Content.Shared._Starlight.Access;
+
+/// Maybe used for more later but for now just to make so it can be fucking microwaved.
+[RegisterComponent]
+public sealed partial class MakeshiftIdCardComponent : Component;

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -338,6 +338,7 @@
       - id: LidSalami
         weight: 0.05
       - id: MakeshiftID # Starlight
+        weight: 0.2 # Starlight
       - id: Flash3Use # Starlight
         weight: 0.3 # Starlight
       - id: Flash4Use # Starlight

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/identification_cards.yml
@@ -663,6 +663,7 @@
   name: makeshift ID card
   description: A set of door electronics rewired to act as an ID card.
   components: # Noteably absent is the ID card component and nanochat component - so borgs will treat you as non crew. It also can't be used in a PDA, and cannot be reprogrammed by an ID card computer.
+  - type: MakeshiftIdCard
   - type: Sprite
     sprite: _Starlight/Objects/Misc/id_cards.rsi
     state: makeshift

--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/tider_anvil.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/tider_anvil.yml
@@ -185,9 +185,9 @@
   result: MakeshiftID
   completetime: 120
   materials:
-     Steel: 1000
-     Plastic: 400
-     Plasteel: 350
+     Steel: 1200
+     Plastic: 600
+     Plasteel: 950
 
 # AMMO
 - type: latheRecipe


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
They literally do fucking nothing right now as far as I can tell, its just maintenance access and thats IT!! They can't copy access, they can't be modified since they can't be inserted into ID card computers, the ONLY thing they're good for is basic maints access which basically nobody benefits from unless you're like a ling and want to avoid door logs but that's it. This gives them at least some use to the average antag/tider.
To compensate and to make so the tiders can't just get an endless amount for effectively free, the cost in materials to print one has been increased.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Makes the item actually useful for more than like one niche scenario.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- add: Makeshift ID cards can now be microwaved for random accesses.
- tweak: Makeshift ID cards now cost more materials to print at the tider anvil.
- tweak: Makeshift ID cards are now much less common as maints loot.