### PR TITLE
Sound marker

### DIFF
--- a/Resources/Prototypes/Entities/Markers/soundmakers.yml
+++ b/Resources/Prototypes/Entities/Markers/soundmakers.yml
@@ -1,0 +1,18 @@
+- type: entity
+  id: SoundMakerMaintsAmbience
+  parent: MarkerBase
+  name: sound maker
+  description: Marker that emits maintenance sounds in a 10 meter radius.
+  suffix: Sounds, Maintenance
+  components:
+  - type: SpamEmitSound
+    minInterval: 30
+    maxInterval: 60
+    sound:
+      collection: MaintsAmbience
+      params:
+        volume: -10
+        maxDistance: 10
+        variation: 0.01
+  - type: Sprite
+    state: pink

--- a/Resources/Prototypes/_Starlight/SoundCollections/sound_marker.yml
+++ b/Resources/Prototypes/_Starlight/SoundCollections/sound_marker.yml
@@ -1,0 +1,15 @@
+- type: soundCollection
+  id: MaintsAmbience
+  files:
+    - /Audio/Ambience/ambimaint1.ogg
+    - /Audio/Ambience/ambimaint2.ogg
+    - /Audio/Ambience/ambimaint3.ogg
+    - /Audio/Ambience/ambimaint4.ogg
+    - /Audio/Ambience/ambimaint5.ogg
+    - /Audio/Ambience/maintambience.ogg
+    - /Audio/Ambience/ambitrain2.ogg
+    - /Audio/Ambience/ambigen4.ogg
+    - /Audio/Ambience/ambigen5.ogg
+    - /Audio/Ambience/ambigen10.ogg
+    - /Audio/Ambience/ambigen15.ogg
+    - /Audio/Ambience/ambimystery.ogg


### PR DESCRIPTION
## Short description
Im planning on adding one simple lil sound marker prototype entity thing.

## Why we need to add this
It can serve as a easy to spawn baseline entity for mappers to use for ambience in their maps and such.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- add: Added a sound marker for mappers to use.
