### PR TITLE
Update remote department shuttle consoles name to include "remote"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -322,8 +322,8 @@
 - type: entity
   parent: BaseComputerCircuitboard
   id: CargoShuttleConsoleCircuitboard
-  name: cargo shuttle console board
-  description: A computer printed circuit board for a cargo shuttle console.
+  name: remote cargo shuttle console board # Starlight begin
+  description: A computer printed circuit board for a remote cargo shuttle console. # Starlight end
   components:
   - type: Sprite
     state: cpu_supply

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -251,9 +251,9 @@
 - type: entity
   parent: BaseComputerShuttle
   id: ComputerShuttleCargo
-  categories: [ ShouldMapStation ] # Starlight
-  name: cargo shuttle console
-  description: Used to pilot the cargo shuttle.
+  categories: [ ShouldMapStation ] # Starlight begin
+  name: remote cargo shuttle console
+  description: Used to pilot the cargo shuttle remotely. # Starlight end
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/computers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/computers.yml
@@ -17,8 +17,8 @@
 - type: entity
   parent: BaseComputerCircuitboard
   id: SalvageShuttleConsoleCircuitboard
-  name: salvage shuttle console board
-  description: A computer printed circuit board for a salvage shuttle console.
+  name: remote salvage shuttle console board
+  description: A computer printed circuit board for a remote salvage shuttle console.
   components:
   - type: Sprite
     state: cpu_supply
@@ -59,8 +59,8 @@
 - type: entity
   parent: BaseComputerCircuitboard
   id: MiningShuttleConsoleCircuitboard
-  name: mining shuttle console board
-  description: A computer printed circuit board for a mining shuttle console.
+  name: remote mining shuttle console board
+  description: A computer printed circuit board for a remote mining shuttle console.
   components:
     - type: Sprite
       state: cpu_supply
@@ -72,8 +72,8 @@
 - type: entity
   parent: BaseComputerCircuitboard
   id: SecurityShuttleConsoleCircuitboard
-  name: security shuttle console board
-  description: A computer printed circuit board for a security shuttle console.
+  name: remote security shuttle console board
+  description: A computer printed circuit board for a remote security shuttle console.
   components:
     - type: Sprite
       state: cpu_supply

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
@@ -223,7 +223,8 @@
   parent: BaseComputerShuttle
   id: CompuerShuttleSalvage
   categories: [ ShouldMapStation ]
-  name: salvage shuttle console
+  name: remote salvage shuttle console
+  description: Used to pilot the salvage shuttle remotely.
   components:
   - type: Sprite
     layers:
@@ -399,7 +400,8 @@
   parent: BaseComputerShuttle
   id: ComputerShuttleMining
   categories: [ ShouldMapStation ]
-  name: mining shuttle console
+  name: remote mining shuttle console
+  description: Used to pilot the mining shuttle remotely.
   components:
     - type: Sprite
       layers:
@@ -435,7 +437,8 @@
 - type: entity
   parent: BaseComputerShuttle
   id: ComputerShuttleSecurity
-  name: security shuttle console
+  name: remote security shuttle console
+  description: Used to pilot the security shuttle remotely.
   components:
     - type: Sprite
       layers:


### PR DESCRIPTION
## Short description
these consoles are only used for remote access, name change makes this more clear

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: mikeysaurus
- tweak: Department remote shuttle consoles have been renamed to explicitly identify them as remote shuttle consoles.
