### PR TITLE
Gave reporters tools to manage their cameras

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -30,6 +30,8 @@
     - CassetteTape
     - RubberStampReporter
     - ClothingOuterPressArmor
+    - Wrench
+    - NetworkConfigurator
   # Starlight End
 
 - type: chameleonOutfit


### PR DESCRIPTION
## Short description
Added tools to the reporter's backback

## Why we need to add this
Added a wrench to allow reporters to anchor and unanchor their camera's
Added a networking tool to allow them to link and unlink their camera's to their servers

## Media (Video/Screenshots)
N/A

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RedSpeeds
- add: Added Wrench and Network Configurator to reporters.
