### PR TITLE
Corrections to missing and illogical salaries

### DIFF
--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -17,7 +17,7 @@
 
     Chemist: 90
     Psychologist: 80
-    Paramedic: 70
+    Paramedic: 50
     MedicalDoctor: 60
     MedicalIntern: 23
     Surgeon: 90

--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -54,7 +54,7 @@
     Zookeeper: 34
 
     Scientist: 65
-    Roboticist: 70
+    Roboticist: 58
     ResearchAssistant: 23
 
     SalvageLead: 75

--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -51,7 +51,7 @@
     Reporter: 50
     Assistant: 15
     Boxer: 23
-    Zookeeper: 40
+    Zookeeper: 34
 
     Scientist: 65
     Roboticist: 70

--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -48,7 +48,7 @@
     Clown: 30
     ServiceWorker: 23
     Performer: 23
-    Reporter: 50
+    Reporter: 46
     Assistant: 15
     Boxer: 23
     Zookeeper: 34

--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -50,7 +50,7 @@
     Performer: 23
     Reporter: 50
     Assistant: 15
-    Boxer: 30
+    Boxer: 23
     Zookeeper: 40
 
     Scientist: 65

--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -16,7 +16,7 @@
     IAA: 76
 
     Chemist: 90
-    Psychologist: 80
+    Psychologist: 76
     Paramedic: 50
     MedicalDoctor: 58
     MedicalIntern: 23

--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -18,7 +18,7 @@
     Chemist: 90
     Psychologist: 80
     Paramedic: 50
-    MedicalDoctor: 60
+    MedicalDoctor: 58
     MedicalIntern: 23
     Surgeon: 90
 

--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -16,8 +16,9 @@
     IAA: 76
 
     Chemist: 90
-    Paramedic: 50
-    MedicalDoctor: 58
+    Psychologist: 80
+    Paramedic: 70
+    MedicalDoctor: 60
     MedicalIntern: 23
     Surgeon: 90
 
@@ -32,7 +33,7 @@
     SecurityOfficer: 64
     SecurityCadet: 23
 
-    StationAi: 155
+    StationAi: 149
     Borg: 85
 
     Chaplain: 50
@@ -47,10 +48,13 @@
     Clown: 30
     ServiceWorker: 23
     Performer: 23
+    Reporter: 50
     Assistant: 15
+    Boxer: 30
+    Zookeeper: 40
 
     Scientist: 65
-    Roboticist: 56
+    Roboticist: 70
     ResearchAssistant: 23
 
     SalvageLead: 75


### PR DESCRIPTION
## Short description
Adds salaries for jobs that literally weren't getting paid (Psychologist, Reporter, Boxer, Zookeeper) and rationalizes a few other salary numbers.

## Why we need to add this
A reporter main said she literally had never been paid. 😭

## Media (Video/Screenshots)
n/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Rhetorica
- add: Reporter salary now 46 credits (previously 0).
- add: Psychologist salary now 76 credits (previously 0).
- add: Boxer salary now 23 credits, like Performer (previously 0).
- add: Zookeeper salary now 34 credits (previously 0).
- tweak: Station AI salary now 149 credits, 1 credit lower than Captain, so SELF has something to whine about (previously 155).
