### PR TITLE
SpawnAndDirtyAllEntities Batching

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -22,14 +22,14 @@ namespace Content.IntegrationTests.Tests
     public sealed class EntityTest : GameTest
     {
         private static readonly ProtoId<EntityCategoryPrototype> SpawnerCategory = "Spawner";
-#region Starlight
+        // Starlight Start
         /// <summary>
         ///     How many prototypes <see cref="SpawnAndDirtyAllEntities"/> spawns before syncing, asserting and
         ///     deleting. Peak memory scales with this, not with the total prototype count. Raising it makes the test
         ///     faster and hungrier; lowering it does the reverse.
         /// </summary>
         private const int DirtyBatchSize = 2000;
-#endregion
+        // Starlight End
 
         public override PoolSettings PoolSettings => new()
         {
@@ -181,13 +181,13 @@ namespace Content.IntegrationTests.Tests
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                 .Select(p => p.ID)
                 .ToList();
-#region starlight
+            // Starlight Start
             var cEntMan = client.ResolveDependency<IEntityManager>();
 
             for (var i = 0; i < protoIds.Count; i += DirtyBatchSize)
             {
                 var batch = protoIds.GetRange(i, Math.Min(DirtyBatchSize, protoIds.Count - i));
-#endregion
+            // Starlight End
                 await server.WaitPost(() =>
                 {
                     foreach (var protoId in batch) // Starlight
@@ -203,7 +203,7 @@ namespace Content.IntegrationTests.Tests
                 });
 
                 await pair.RunUntilSynced();
-#region Starlight
+                // Starlight Start
                 // Make sure the client actually received the entities.
                 // 500 is completely arbitrary and inherited from when this ran as a single pass; a short final batch
                 // scales it down. Note that the client & sever entity counts aren't expected to match.
@@ -242,7 +242,7 @@ namespace Content.IntegrationTests.Tests
 
                 GC.Collect();
             }
-#endregion
+            // Starlight End
         }
 
         /// <summary>

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -22,8 +22,14 @@ namespace Content.IntegrationTests.Tests
     public sealed class EntityTest : GameTest
     {
         private static readonly ProtoId<EntityCategoryPrototype> SpawnerCategory = "Spawner";
-
-        private const int DirtyBatchSize = 2000; // Starlight
+#region Starlight
+        /// <summary>
+        ///     How many prototypes <see cref="SpawnAndDirtyAllEntities"/> spawns before syncing, asserting and
+        ///     deleting. Peak memory scales with this, not with the total prototype count. Raising it makes the test
+        ///     faster and hungrier; lowering it does the reverse.
+        /// </summary>
+        private const int DirtyBatchSize = 2000;
+#endregion
 
         public override PoolSettings PoolSettings => new()
         {

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -21,6 +22,8 @@ namespace Content.IntegrationTests.Tests
     public sealed class EntityTest : GameTest
     {
         private static readonly ProtoId<EntityCategoryPrototype> SpawnerCategory = "Spawner";
+
+        private const int DirtyBatchSize = 2000; // Starlight
 
         public override PoolSettings PoolSettings => new()
         {
@@ -172,48 +175,68 @@ namespace Content.IntegrationTests.Tests
                 .Where(p => !p.Components.ContainsKey("MapGrid")) // This will smash stuff otherwise.
                 .Select(p => p.ID)
                 .ToList();
+#region starlight
+            var cEntMan = client.ResolveDependency<IEntityManager>();
 
-            await server.WaitPost(() =>
+            for (var i = 0; i < protoIds.Count; i += DirtyBatchSize)
             {
-                foreach (var protoId in protoIds)
+                var batch = protoIds.GetRange(i, Math.Min(DirtyBatchSize, protoIds.Count - i));
+#endregion
+                await server.WaitPost(() =>
                 {
-                    mapSys.CreateMap(out var mapId);
-                    var grid = mapManager.CreateGridEntity(mapId);
-                    var ent = sEntMan.SpawnEntity(protoId, new EntityCoordinates(grid.Owner, 0.5f, 0.5f));
-                    foreach (var (_, component) in sEntMan.GetNetComponents(ent))
+                    foreach (var protoId in batch) // Starlight
                     {
-                        sEntMan.Dirty(ent, component);
+                        mapSys.CreateMap(out var mapId);
+                        var grid = mapManager.CreateGridEntity(mapId);
+                        var ent = sEntMan.SpawnEntity(protoId, new EntityCoordinates(grid.Owner, 0.5f, 0.5f));
+                        foreach (var (_, component) in sEntMan.GetNetComponents(ent))
+                        {
+                            sEntMan.Dirty(ent, component);
+                        }
                     }
-                }
-            });
+                });
 
-            await pair.RunUntilSynced();
+                await pair.RunUntilSynced();
+#region Starlight
+                // Make sure the client actually received the entities.
+                // 500 is completely arbitrary and inherited from when this ran as a single pass; a short final batch
+                // scales it down. Note that the client & sever entity counts aren't expected to match.
+                Assert.That(cEntMan.EntityCount, Is.GreaterThan(Math.Min(500, batch.Count / 2)),
+                    $"Client received too few entities for the batch of {batch.Count} starting at index {i}.");
 
-            // Make sure the client actually received the entities
-            // 500 is completely arbitrary. Note that the client & sever entity counts aren't expected to match.
-            Assert.That(client.ResolveDependency<IEntityManager>().EntityCount, Is.GreaterThan(500));
-
-            await server.WaitPost(() =>
-            {
-                static IEnumerable<(EntityUid, TComp)> Query<TComp>(IEntityManager entityMan)
-                    where TComp : Component
+                await server.WaitPost(() =>
                 {
-                    var query = entityMan.AllEntityQueryEnumerator<TComp>();
+                    var toDelete = new List<EntityUid>();
+                    var query = sEntMan.AllEntityQueryEnumerator<MetaDataComponent>();
                     while (query.MoveNext(out var uid, out var meta))
                     {
-                        yield return (uid, meta);
+                        if (!meta.EntityDeleted)
+                            toDelete.Add(uid);
                     }
-                }
 
-                var entityMetas = Query<MetaDataComponent>(sEntMan).ToList();
-                foreach (var (uid, meta) in entityMetas)
-                {
-                    if (!meta.EntityDeleted)
+                    foreach (var uid in toDelete)
+                    {
                         sEntMan.DeleteEntity(uid);
-                }
+                    }
 
-                Assert.That(sEntMan.EntityCount, Is.Zero);
-            });
+                    Assert.Multiple(() =>
+                    {
+                        var leftover = sEntMan.AllEntityQueryEnumerator<MetaDataComponent>();
+                        while (leftover.MoveNext(out _, out var meta))
+                        {
+                            Assert.Fail($"Failed to delete {meta.EntityPrototype}, NAME: {meta.EntityName}");
+                        }
+
+                        Assert.That(sEntMan.EntityCount, Is.Zero,
+                            $"One of these prototypes is to blame: {string.Join(",", batch)}");
+                    });
+                });
+
+                await pair.RunUntilSynced();
+
+                GC.Collect();
+            }
+#endregion
         }
 
         /// <summary>


### PR DESCRIPTION
## Short description
This fixes SpawnAndDirtyAllEntities using up all of the runners memory, causing the runner to crash, By batching the test.

## Why we need this
After much testing I found that this test is using a megaton of ram, causing the VM to freeze and just fail.
```
[04:02:13] === probe: spawndirty ===
[04:06:16] spawndirty exit=0 PEAK_KB=16047648 PEAK_GB=15.30
SERVER: 50.040s [WARN] system.paradox_clone_rule: Exhausted all alive players while searching for a valid target. Failed to create paradox clone.
SERVER: 50.053s [WARN] system.paradox_clone_rule: Exhausted all alive players while searching for a valid target. Failed to create paradox clone.
  Passed SpawnAndDirtyAllEntities [2 m 57 s]
Total tests: 1
 Total time: 4.0272 Minutes
[04:06:16] DONE
```
Curve:
```
  t(s)   RSS(GiB)
     0     0.31
    66     3.04
   132     6.33
   181    11.08
   197    15.17
   240    15.28  <- end
```
Peak of 15.28gb on a local VM, and Githubs runners have a max memory of 16gb
Considering that there are 2 concurrent tests running at once you are coinflipping if this passes

This makes the test handle this in batches (Something that RMC, Goob, etc) Already figured out and fixed, I only figured out they figured it out after I figured it out (sad)

but this fixes it, and makes the run faster, more test PR's to follow.

Now:
6.17 GiB Peak,  2m 19s runtime

The batchsize may need to be updated in future depending on prototype numbers, we have it at 2000 but like, at 500 it is only 20 seconds slower, also removing the garbage collector makes it faster but use more ram.

Fuck it heres a table

version | batch | peak RSS | duration
-- | -- | -- | --
original single-pass | - | 15.30 GiB | 2m 57s
batched only | 8000 | 15.07 GiB | 2m 33s
batched only | 2000 | 8.81 GiB | 2m 14s
batched only | 500 | 6.55 GiB | 2m 11s
batched + GC | 100 | 5.74 GiB | 4m 36s
batched + GC| 500 | 5.85 GiB | 2m 42s
batched + GC | 2000 | 6.17 GiB | 2m 19s


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.