### PR TITLE
Traitors are a little less common in dynamic

### DIFF
--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -50,9 +50,9 @@
         - !type:RoundDurationCondition
           max: 5 # 5 seconds, really just here to ensure it rolls roundstart and then doesn't roll again
         children:
-        - id: Traitor
+        - id: TraitorLess # We'll use TraitorLess instead of Traitor, at least on Alpha, since they tend to lump in with a lot of other things.
           weight: 42.5
-          prob: 0.85 # Give traitor a chance to fail, since it's so common. In essence, this means we have a chance at getting Extended.
+          prob: 0.80 # Give traitor a chance to fail, since it's so common. In essence, this means we have a chance at getting Extended.
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -140,16 +140,13 @@
         children:
         - id: TraitorLess
           weight: 20
-          prob: 0.50 # Have a 50% chance to fail to add the gamemode, even if it wins the roll. Mostly a failsafe so the actual midrounds can trigger, but also to stop them from always rolling even if cost rolls high. We don't want things to be predictable, no?
+          prob: 0.40 # Traitor gets a lower rate compared to other dynamic multiantags.
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
-          - !type:MutuallyExclusiveRuleCondition
-            rules:
-            - Traitor # This is the most likely scenario; we don't want 24 traitors.
         - id: NukeopsLate
           weight: 9
-          prob: 0.50
+          prob: 0.50 # Have a 50% chance to fail to add the gamemode, even if it wins the roll. Mostly a failsafe so the actual midrounds can trigger, but also to stop them from always rolling even if cost rolls high. We don't want things to be predictable, no?
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -469,7 +466,7 @@
         children:
         - id: TraitorLess
           weight: 25
-          prob: 0.50 # Have a 50% chance to fail to add the gamemode, even if it wins the roll. Mostly a failsafe so the actual midrounds can trigger, but also to stop them from always rolling even if cost rolls high. We don't want things to be predictable, no?
+          prob: 0.40
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition


### PR DESCRIPTION
## Short description
Title.

## Why we need to add this
They're a bit too common.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Traitors are a little less common in dynamic.
