### PR TITLE
Move station combat mech electronics to security techfab

### DIFF
--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/Packs/security.yml
@@ -154,6 +154,12 @@
   - ShuttleGunPerforatorCircuitboard
   - ShuttleGunSvalinnMachineGunCircuitboard
   - ScanGateMachineCircuitboard
+  - GygaxCentralElectronics
+  - GygaxPeripheralsElectronics
+  - GygaxTargetingElectronics
+  - DurandCentralElectronics
+  - DurandPeripheralsElectronics
+  - DurandTargetingElectronics
 
 - type: latheRecipePack
   parent:
@@ -292,9 +298,6 @@
   - GygaxLLeg
   - GygaxRArm
   - GygaxRLeg
-  - GygaxCentralElectronics
-  - GygaxPeripheralsElectronics
-  - GygaxTargetingElectronics
 
   - DurandHarness
   - DurandArmor
@@ -303,9 +306,6 @@
   - DurandLLeg
   - DurandRArm
   - DurandRLeg
-  - DurandCentralElectronics
-  - DurandPeripheralsElectronics
-  - DurandTargetingElectronics
 
 - type: latheRecipePack
   id: SecurityCyberLimbs


### PR DESCRIPTION
## Short description
Move combat mech electronics to the security techfab. The chassis can still be made in the exosuit fabricator

## Why we need to add this
Limits robotocist powergaming of preparing combat mechs without security permission.

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Swonki
- tweak: Durand and Gygax Electronics moved to security techfab.
