### PR TITLE
Pyroq Los Prospera Debug Outfits

### DIFF
--- a/Resources/Prototypes/_Starlight/Admeme/Pyroq_Los_Prospera/cartel.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/Pyroq_Los_Prospera/cartel.yml
@@ -1,0 +1,133 @@
+- type: startingGear
+  id: PoroqBoss
+  equipment:
+     jumpsuit: CamoUniformSuit
+     back: ClothingBackpackDuffel
+     shoes: ClothingShoesBootsCombatFilled
+     outClothing: ClothingOuterArmorBasic
+     id: PiratePDA
+     eyes: ClothingEyesGlassesSunglasses
+     ears: ClothingHeadsetFreelance
+     mask: ClothingMaskNeckGaiterRed
+     belt: ClothingBeltMilitaryWebbing
+     gloves: ClothingHandsMercGloveCombat
+     head: ClothingHeadHatBeret
+     suitstorage: WeaponRifleARG
+     pocket1: SmokeGrenade
+     pocket2: Flashbang
+  storage:
+     back:
+       -BoxZiptie
+       -StunProd
+     belt:
+       -WeaponPistolDeagle
+       -MagazineLightRifleFMJ
+       -MagazineLightRifleFMJ
+       -MagazineLightRifleFMJ
+       -MagazineLightRifleFMJ
+       -MagazineMagnum
+       -MagazineMagnum
+       -WeaponDisabler
+
+
+- type: StartingGear
+  id: PoroqMedic
+  equipment:
+        jumpsuit: CamoUniformSuit
+        back: ClothingBackpackDuffel
+        shoes: ClothingShoesBootsCombatFilled
+        outClothing: ClothingOuterArmorBasic
+        id: PiratePDA
+        ears: ClothingHeadsetFreelance
+        mask: ClothingMaskNeckGaiter
+        belt: ClothingBeltMilitaryWebbingMed
+        gloves: ClothingHandsMercGloveCombat
+        head: ClothingHeadHatBeretFrench
+        suitstorage: WeaponSubMachineGunUzi
+        pocket1: SmokeGrenade
+        pocket2: Flashbang
+    storage:
+        back:
+          -DefibrillatorSyndicate
+          -MedkitCombatFilled
+          -MedkitCombatFilled
+          -MedkitCombatFilled
+          -MedkitCombatFilled
+        belt:
+          -WeaponPistolDeagle
+          =MagazinePistolSubMachineGunUzi
+          -MagazinePistolSubMachineGunUzi
+          -MagazinePistolSubMachineGunUzi
+          -MagazineMagnum
+          -MagazineMagnum
+          -MedkitCombatFilled
+          -CombatMedipen
+          -CombatMedipen
+
+- type: StartingGear
+  id: PoroqFighterARG
+  equipment:
+    jumpsuit: CamoUniformSuit
+    back: ClothingBackpackDuffel
+    shoes: ClothingShoesBootsCombatFilled
+    outClothing: ClothingOuterArmorBasic
+    id: PiratePDA
+    ears: ClothingHeadsetFreelance
+    mask: ClothingMaskNeckGaiter
+    belt: ClothingBeltMilitaryWebbing
+    gloves: ClothingHandsMercGloveCombat
+    head: ClothingHeadHatBeretFrench
+    suitstorage: WeaponRifleARG
+    pocket1: ExGrenade
+    pocket2: ExGrenade
+
+  storage:
+    back:
+      -MagazineBoxLightRifleFMJ
+      -MagazineBoxLightRifleFMJ
+      -MagazineBoxLightRifleFMJ
+      -MagazineBoxLightRifleFMJ
+    belt:
+      -WeaponPistolDeagle
+      -MagazineLightRifleFMJ
+      -MagazineLightRifleFMJ
+      -MagazineLightRifleFMJ
+      -MagazineLightRifleFMJ
+      -MagazineLightRifleFMJ
+      -MagazineLightRifleFMJ
+      -MagazineMagnum
+      -MagazineMagnum
+
+- type: StartingGear
+  id: PoroqFighterShotgun
+  equipment:
+  jumpsuit: CamoUniformSuit
+  back: ClothingBackpackDuffel
+  shoes: ClothingShoesBootsCombatFilled
+  outClothing: ClothingOuterArmorBasic
+  id: PiratePDA
+  ears: ClothingHeadsetFreelance
+  mask: ClothingMaskNeckGaiter
+  belt: ClothingBeltMilitaryWebbing
+  gloves: ClothingHandsMercGloveCombat
+  head: ClothingHeadHatBeretFrench
+  suitstorage: WeaponShotgunCombat
+  pocket1: ExGrenade
+  pocket2: ExGrenade
+
+  storage:
+    back:
+      -BoxLethalShot
+      -BoxLethalShot
+      -BoxLethalShot
+      -BoxLethalShot
+    belt:
+      -WeaponPistolDeagle
+      -SpeedLoaderMagnumBasic
+      -SpeedLoaderMagnumBasic
+      -SpeedLoaderMagnumBasic
+      -SpeedLoaderMagnumBasic
+      -SpeedLoaderMagnumBasic
+      -SpeedLoaderMagnumBasic
+      -MagazineMagnum
+      -MagazineMagnum


### PR DESCRIPTION


## Short description
Quick spawn outfits that come with gear and items necessary for the antags to work.

## Why we need to add this
Speed up the spawning process of event antags for MedTak and other similar events that need a specialized antag. The outfits utilize items that are already in-game and see little to no use currently.


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x ] I do not require assistance to complete the PR.
- [x ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ ✓] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
