### PR TITLE
Fixes Performers not having Service Access

### DIFF
--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Civilian/performer.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Civilian/performer.yml
@@ -13,8 +13,8 @@
   access:
   - Theatre
   - Maintenance
-  extendedAccess:
   - Service
+  extendedAccess:
   - Bar
   - Kitchen
   - Hydroponics


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
#4927 gave all Service employees Service access, but forgot Performers.

This PR gives Performers Service access.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Popular suggestion in Discord: https://discord.com/channels/1272545509562777621/1529092768440258622

Same reason as #4927 - Perfomers are part of Service and employees of Service should have Service access. They need it to be able to use the Service Request Console, access doors related to their work, and open orders that are covered with Service tamper seals. I think Performer not getting Service access in #4927 was likely an oversight.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Performers now have service access just like other theatre staff.
