### PR TITLE
Fix flakey AgeRequirementsTest

### DIFF
--- a/Content.IntegrationTests/Tests/Round/JobRequirementsTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobRequirementsTest.cs
@@ -138,13 +138,11 @@ public sealed class JobRequirementsTest
 
         await pair.Client.WaitAssertion(() =>
         {
-            // Starlight Begin
             cPref.UpdateCharacter(humanoidZero
                 .WithSpecies(SharedHumanoidAppearanceSystem.DefaultSpecies)
                 .WithAge(age)
                 .WithJobPreferences(priorities.Keys), 0);
             cPref.UpdateJobPriorities(priorities);
-            // Starlight End
         });
 
         await pair.ReallyBeIdle();
@@ -202,11 +200,9 @@ public sealed class JobRequirementsTest
 
         await pair.Client.WaitAssertion(() =>
         {
-            // Starlight Begin
             humanoidZero = humanoidZero
                 .WithSpecies(SharedHumanoidAppearanceSystem.DefaultSpecies)
                 .WithJobPreferences(priorities.Keys);
-            // Starlight End
             cPref.UpdateCharacter(humanoidZero.WithAge(75), 0);
             var maxSlots = cPref.Settings?.MaxCharacterSlots ?? 30;
             for (var i = 1; i < maxSlots; i++)

--- a/Content.IntegrationTests/Tests/Round/JobRequirementsTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobRequirementsTest.cs
@@ -138,8 +138,13 @@ public sealed class JobRequirementsTest
 
         await pair.Client.WaitAssertion(() =>
         {
-            cPref.UpdateCharacter(humanoidZero.WithAge(age).WithJobPreferences(priorities.Keys), 0);
+            // Starlight Begin
+            cPref.UpdateCharacter(humanoidZero
+                .WithSpecies(SharedHumanoidAppearanceSystem.DefaultSpecies)
+                .WithAge(age)
+                .WithJobPreferences(priorities.Keys), 0);
             cPref.UpdateJobPriorities(priorities);
+            // Starlight End
         });
 
         await pair.ReallyBeIdle();
@@ -197,7 +202,11 @@ public sealed class JobRequirementsTest
 
         await pair.Client.WaitAssertion(() =>
         {
-            humanoidZero = humanoidZero.WithJobPreferences(priorities.Keys);
+            // Starlight Begin
+            humanoidZero = humanoidZero
+                .WithSpecies(SharedHumanoidAppearanceSystem.DefaultSpecies)
+                .WithJobPreferences(priorities.Keys);
+            // Starlight End
             cPref.UpdateCharacter(humanoidZero.WithAge(75), 0);
             var maxSlots = cPref.Settings?.MaxCharacterSlots ?? 30;
             for (var i = 1; i < maxSlots; i++)


### PR DESCRIPTION
## Short description
AgeRequirementsTest picked a random species, Diona, Dwarf and Aielith all have a min age of 30, causing testfail.
This forces human, since we know their age, god forbid it changes.
This test isn't even upstream, I think maybe we need to like rebase our tests atp.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
