### PR TITLE
Stir Stir Cleanup

### DIFF
--- a/Resources/Locale/en-US/_Starlight/job/job-desc.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job-desc.ftl
@@ -17,3 +17,4 @@ job-description-salvagelead = Lead your salvage team and keep them safe. Remembe
 job-description-surgeon = Heal people, cripple enemies, and replace limbs and organs!
 job-description-zookeeper = Put on a joyful display of cute animals and space carps for all the crew to see.
 job-description-nct = Your job is to try to assist as many crew members as possible regardless of department. You are NOT permitted to give command staff advice on any command SOP questions or aid in legal advice.
+job-description-stirstir = A disreputable monkey who should not be trusted. A real cell stuffer.

--- a/Resources/Locale/en-US/_Starlight/job/job-desc.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job-desc.ftl
@@ -18,3 +18,4 @@ job-description-surgeon = Heal people, cripple enemies, and replace limbs and or
 job-description-zookeeper = Put on a joyful display of cute animals and space carps for all the crew to see.
 job-description-nct = Your job is to try to assist as many crew members as possible regardless of department. You are NOT permitted to give command staff advice on any command SOP questions or aid in legal advice.
 job-description-stirstir = A disreputable monkey who should not be trusted. A real cell stuffer.
+job-description-prisoner = You are a corporate owned prisoner serving out a sentence in a hard labor colony.

--- a/Resources/Locale/en-US/_Starlight/job/job-names.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job-names.ftl
@@ -1,4 +1,5 @@
 job-name-assistant = Assistant
+job-name-stirstir = Stir Stir
 
 # Role timers - Apparently someone from upstream will cut us if these aren't alphabetical?
 JobBlueShield = BlueShield Officer
@@ -15,4 +16,3 @@ JobRoboticist = Roboticist
 JobSalvageLead = Salvage Lead
 JobSurgeon = Surgeon
 JobZookeeper = Zookeeper
-job-name-stirstir = Stir Stir

--- a/Resources/Locale/en-US/_Starlight/job/job-names.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job-names.ftl
@@ -15,3 +15,4 @@ JobRoboticist = Roboticist
 JobSalvageLead = Salvage Lead
 JobSurgeon = Surgeon
 JobZookeeper = Zookeeper
+job-name-stirstir = Stir Stir

--- a/Resources/Locale/en-US/_Starlight/job/job-supervisors.ftl
+++ b/Resources/Locale/en-US/_Starlight/job/job-supervisors.ftl
@@ -6,3 +6,4 @@ job-supervisors-station-ai = the Station AI
 job-supervisors-warden = the Warden
 job-supervisors-none = Nobody
 job-supervisors-solgov = Trans-Solar Federation
+job-supervisors-prisoner = the Prison Officers, Deputy Governor, and Governor

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
@@ -102,7 +102,7 @@
     name: ghost-role-information-stirstir-name
     description: ghost-role-information-stirstir-description
     rules: ghost-role-information-nonantagonist-rules
-    job: Prisoner
+    job: StirStir
   - type: GhostTakeoverAvailable
   - type: Butcherable
     butcheringType: Spike

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Fun/prisoner.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Fun/prisoner.yml
@@ -3,13 +3,26 @@
   name: job-name-prisoner
   description: job-description-prisoner
   playTimeTracker: JobPrisoner
+  startingGear: PrisonerGear
+  setPreference: false
+  icon: "JobIconPrisoner"
+  supervisors: job-supervisors-prisoner
+  access:
+  - GenpopEnter
+
+- type: job
+  id: StirStir
+  name: job-name-stirstir
+  description: job-description-stirstir
+  playTimeTracker: JobStirStir
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
       time: 0.25h
   startingGear: PrisonerGear
+  setPreference: false
   icon: "JobIconPrisoner"
-  supervisors: job-supervisors-hop
+  supervisors: job-supervisors-security
   access:
   - GenpopEnter
 

--- a/Resources/Prototypes/_Starlight/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/_Starlight/Roles/play_time_trackers.yml
@@ -76,6 +76,9 @@
 - type: playTimeTracker
   id: JobPrisoner
 
+- type: playTimeTracker
+  id: JobStirStir
+
 # Other ghosts
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_Starlight/Roles/salaries.yml
+++ b/Resources/Prototypes/_Starlight/Roles/salaries.yml
@@ -65,6 +65,7 @@
 
     Visitor: 0
     Prisoner: 0
+    StirStir: 0
 
 - type: SalaryRoleBonus
   id: BlackOpsBonus


### PR DESCRIPTION
## Short description
Splits Stir Stir and Prisoner into 2 roles. Prisoner is now set up for future use in Prison Colony and has no time req. Both are hidden from the job selection menu, and have loc files.

## Why we need to add this
Cleanup

## Media (Video/Screenshots)
n/a

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Fixed Prisoner appearing as a job in the job menu. Split Stir Stir into a new job. Cleaned up loc files. Prepped Prisoner role for use in Prison Colony.
