### PR TITLE
Structural damage to mechs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -77,7 +77,7 @@
       mech-battery-slot: !type:ContainerSlot
       mech-gas-tank-slot: !type:ContainerSlot
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic #🌟STARLIGHT Inorganic -> StructuralInorganic
     damageModifierSet: LightArmor
   - type: FootstepModifier
     footstepSoundCollection:

--- a/Resources/Prototypes/_Starlight/Damage/mech_modifier_sets.yml
+++ b/Resources/Prototypes/_Starlight/Damage/mech_modifier_sets.yml
@@ -8,6 +8,7 @@
     Piercing: 0.65
     Shock: 1.2
     Heat: 0.8
+    Structural: 0.8
   flatReductions:
     Blunt: 3
     Heat: 3
@@ -20,6 +21,7 @@
     Piercing: 0.55
     Shock: 1.4
     Heat: 0.7
+    Structural: 0.8
   flatReductions:
     Blunt: 10
     Heat: 8
@@ -32,6 +34,7 @@
     Piercing: 0.45
     Shock: 0.8
     Heat: 0.65
+    Structural: 0.6
   flatReductions:
     Blunt: 12
     Heat: 10

--- a/Resources/Prototypes/_Starlight/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Starlight/Damage/modifier_sets.yml
@@ -222,6 +222,7 @@
     Piercing: 0.35
     Shock: 1.8
     Heat: 0.6
+    Structural: 0.4
   flatReductions:
     Blunt: 15
     Heat: 15


### PR DESCRIPTION
## Short description
Makes mechs inorganicstructural, letting them sustain structural damage

## Why we need to add this
There have been a multitude of mech nerf posts, each popular, with a recent one hitting 23-3 approval. A conclusion I came to based on feedback was that many nerfs would make mechs far too bothersome to work with (such as pilot damage), while other changes would not be worthwhile or make meaningful differences to balance. Adding this change makes a large pool of (currently underused) weapons that become significant, logical counters to mechs, including other mechs, anti-material rifles, and breaching weapons/ammunition. all of which both crew and antagonists have access to.

As it stands, it creates a logical flow for the mech power order, and makes dealing with them an effort of using the right equipment.

Paddy - Clarke - Gygax - Durand - Mauler, with the mauler being able to 1 / 2 shot most other mechs in melee combat, and being 4/5 shot by others. The clarke becomes very weak to other mechs, even with its high DPS.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Swonki
- add: Mechs now take structural damage, with a slight resistance.
