### PR TITLE
Fix verb ordering on handheld crew monitors

### DIFF
--- a/Content.Shared/_Starlight/Medical/CrewMonitoring/CrewMonitorAlertsSystem.cs
+++ b/Content.Shared/_Starlight/Medical/CrewMonitoring/CrewMonitorAlertsSystem.cs
@@ -28,7 +28,7 @@ public sealed class CrewMonitorAlertsSystem : EntitySystem
                 ent.Comp.Enabled = !ent.Comp.Enabled;
                 Dirty(ent);
             },
-            Priority = 1,
+            Priority = -1,
         });
     }
 }


### PR DESCRIPTION
## Short description
Fix verb ordering on crew monitors so that when a user alt clicks it removes the battery rather than toggling alerts

## Why we need to add this
When a user alt clicks something with a battery they expect the battery to be removed.
https://discord.com/channels/1272545509562777621/1529606514648547389

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Mack
- fix: Handheld crew monitors will once again eject the battery on alt-click.
