### PR TITLE
Added accesses to borg and improved the purrfuss borg 

### DIFF
--- a/Resources/Locale/en-US/_Starlight/borg/borg_modules.ftl
+++ b/Resources/Locale/en-US/_Starlight/borg/borg_modules.ftl
@@ -1,4 +1,4 @@
-borg-slot-papers-empty = Documents and Stamps
+borg-slot-papers-empty = Documents, Stamps, Ids
 borg-slot-ore-empty = Ore
 borg-slot-fuel-empty = Fuel tanks
 borg-slot-seeds-empty = Seeds

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -370,6 +370,8 @@
           - Document
           components:
           - Stamp
+          - IdCard
+          - Pda
   - type: BorgModuleIcon
     icon: { sprite: _Starlight/Interface/Actions/actions_borg.rsi, state: paperwork-module }
 

--- a/Resources/Prototypes/_Starlight/borg_types.yml
+++ b/Resources/Prototypes/_Starlight/borg_types.yml
@@ -41,6 +41,7 @@
       groups:
         - CyborgAllAccess
       tags:
+        - HeadOfSecurity
         - Borg
         - BorgSecurity
 
@@ -177,6 +178,7 @@
     tags:
     - Borg
     - Debrief
+    - HeadOfPersonnel
 
   # Visual
   inventoryTemplateId: borgTall
@@ -228,3 +230,4 @@
       tags:
         - Borg
         - BorgCargo
+        - Quartermaster

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -37,6 +37,7 @@
       tags:
         - Borg
         - BorgResearch
+        - ResearchDirector
   # Starlight END
 
 # Engineering borg
@@ -79,6 +80,7 @@
     tags:
       - Borg
       - BorgEngineering
+      - ChiefEngineer
   # Starlight end
 
   # Visual
@@ -146,6 +148,7 @@
     tags:
       - Borg
       - BorgCargo
+      - Quartermaster
   # Starlight-end
 
 
@@ -233,7 +236,9 @@
       - CyborgAllAccess
     tags:
       - Borg
-      - BorgMedical # Starlight END
+      - BorgMedical
+      - ChiefMedicalOfficer
+      # Starlight END
 
   # Visual
   inventoryTemplateId: borgDutch


### PR DESCRIPTION
## Short description
Allowed the purrfuss borg to interact with PDA's and access cards as well as adding the head office accesses to borg types

## Why we need to add this
Outcome of a poll as well as changed requested to make the purrfuss borg be able to more effectively do their job

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- add: Added head office accesses to borg types of their department.
- tweak: Allowed purrfuss borg to interact with more items.

