### PR TITLE
Pipe crawling Meta error fix

### DIFF
--- a/Content.Shared/_Starlight/VentCrawl/EntitySystems/SharedVentCrawlSystem.Tube.cs
+++ b/Content.Shared/_Starlight/VentCrawl/EntitySystems/SharedVentCrawlSystem.Tube.cs
@@ -161,7 +161,7 @@ public sealed partial class SharedVentCrawlSystem
 
         tube.Connected = false;
 
-        foreach (var holder in tube.ContainedHolders)
+        foreach (var holder in tube.ContainedHolders.ToArray())
             ExitVentCrawl(holder);
     }
 

--- a/Content.Shared/_Starlight/VentCrawl/EntitySystems/SharedVentCrawlSystem.cs
+++ b/Content.Shared/_Starlight/VentCrawl/EntitySystems/SharedVentCrawlSystem.cs
@@ -128,6 +128,13 @@ public sealed partial class SharedVentCrawlSystem : EntitySystem
 
         holder.IsExitingVentCrawls = true;
 
+        if (holder.CurrentTube is { } currentTube &&
+            TryComp<VentCrawlTubeComponent>(currentTube, out var tube) &&
+            tube.ContainedHolders.Remove(uid))
+        {
+            Dirty(currentTube, tube);
+        }
+
         UpdateExitAction(holder);
 
         var container = GetOrEnsureContainer(uid);


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes this error
```
[ERRO] resolve: Can't resolve "Robust.Shared.GameObjects.MetaDataComponent" on entity 23442/n0D!
   at System.Environment.get_StackTrace()
   at Robust.Shared.GameObjects.EntityManager.GetNetEntity(EntityUid uid, MetaDataComponent metadata) in C:\Users\CrazyPhantom\Documents\Github\Starlight\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Network.cs:line 186
   at Robust.Shared.GameObjects.EntityManager.GetNetEntityList(List`1 entities) in C:\Users\CrazyPhantom\Documents\Github\Starlight\RobustToolbox\Robust.Shared\GameObjects\EntityManager.Network.cs:line 525
   at Content.Shared._Starlight.VentCrawl.Components.VentCrawlTubeComponent.VentCrawlTubeComponent_AutoNetworkSystem.OnGetState(EntityUid uid, VentCrawlTubeComponent component, ComponentGetState& args) in C:\Users\CrazyPhantom\Documents\Github\Starlight\Content.Shared\obj\Debug\Robust.Shared.CompNetworkGenerator\Robust.Shared.CompNetworkGenerator.ComponentNetworkGenerator\VentCrawlTubeComponent_CompNetwork.g.cs:line 45
```

Replicable by crawling in a pipe, un-anchoring that pipe and re-anchoring it
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Its a bugfix :godo:
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

Not player facing
