### PR TITLE
(Novo Lobster) Adds warm light tubes

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
@@ -26,6 +26,7 @@
   - DimLightBulb
   - WarmLightBulb
   - BlackLightTube # Starlight
+  - LightTubeWarm # Starlight
 
 - type: latheRecipePack
   id: PowerCellsStatic

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Power/lights.yml
@@ -13,3 +13,16 @@
     PowerUse: 25
     dimmable: false
   - type: DarkLight
+
+- type: entity
+  parent: BaseLightTube
+  name: warm light tube
+  description: A warm light tube conducive to slowly bleeding out in the snow. Definitely contains sodium.
+  id: LightTubeWarm
+  components:
+  - type: LightBulb
+    color: "#ff9833" # 2200k color temp
+    lightEnergy: 0.8
+    lightRadius: 10
+    lightSoftness: 3
+    dimmable: false

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Lighting/base_lighting.yml
@@ -29,3 +29,28 @@
     softness: 1
     color: "#5D0CED"
   - type: DarkLight
+
+- type: entity
+  id: PoweredlightWarm
+  suffix: Warm
+  parent: Poweredlight
+  components:
+  - type: PoweredLight
+    hasLampOnSpawn: LightTubeWarm
+  - type: PointLight
+    enabled: true
+    radius: 10
+    energy: 0.8
+    softness: 3
+    color: "#ff9833"
+
+- type: entity
+  parent: AlwaysPoweredWallLight
+  id: AlwaysPoweredLightWarm
+  suffix: Always Powered, Warm
+  components:
+  - type: PointLight
+    radius: 10
+    energy: 0.8
+    softness: 3
+    color: "#ff9833"

--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/misc.yml
@@ -572,6 +572,11 @@
   result: BlackLightTube
 
 - type: latheRecipe
+  parent: BaseLightRecipe
+  id: LightTubeWarm
+  result: LightTubeWarm
+
+- type: latheRecipe
   id: CassetteTape
   result: CassetteTape
   completetime: 2


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds the 'warm' light tube. These have the same colour as `PoweredWarmSmallLight` but are a tiny bit brighter and have a bit more range.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Used extensively for #5111 and by gosh do we need more light variety on maps.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1224" height="802" alt="image" src="https://github.com/user-attachments/assets/27fc6f74-bf2c-4710-9ade-889fba8c769c" />

fig. 1 - Warm light tubes.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- add: Added warm light tubes. Less harsh than sodium light tubes, but still very orange. Printable at autolathes.