### PR TITLE
(Novo Lobster) Enables weather on snowed plating

### DIFF
--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -59,6 +59,7 @@
     collection: FootstepPlating
   friction: 0.75 #a little less then actual snow
   heatCapacity: 10000
+  weather: true # Starlight - it's got snow on it, so it's outside
 
 - type: tile
   id: PlatingIronsand


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Sets `weather: true` on snowed plating `PlatingSnow`.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It's got snow on it, so it should be outside.

More seriously:
- Cork already uses this as if it were an outdoor tile.
- Starboard already uses this as if it were an outdoor tile.
- Lagan only accidentally uses this tile (someone misclicked 2 snowed platings under the walls of Engineering).
- Plasma _does_ use this as if it's indoors. I've asked for #5276 to fix that. It's a total of like 8 tiles though.

I need this tile to be outdoors for #5111, which will be the most extensive use of this tile (more than all of the above maps **combined**). This change affects currently maps minimally.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

<!--
**Changelog**
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
