### PR TITLE
Nanochat spam

### DIFF
--- a/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleComponent.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleComponent.cs
@@ -14,7 +14,4 @@ public sealed partial class NanoChatSpamRuleComponent : Component
     /// </summary>
     [DataField]
     public float RecipientChance = 0.3f;
-
-    [DataField]
-    public int? MaxPlayers;
 }

--- a/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleComponent.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleComponent.cs
@@ -4,24 +4,6 @@ namespace Content.Server._Starlight.GameTicking.Rules;
 public sealed partial class NanoChatSpamRuleComponent : Component
 {
     /// <summary>
-    /// Minimum delay between spam messages (in seconds).
-    /// </summary>
-    [DataField]
-    public float MinDelay = 120f;
-
-    /// <summary>
-    /// Maximum delay between spam messages (in seconds).
-    /// </summary>
-    [DataField]
-    public float MaxDelay = 300f;
-
-    /// <summary>
-    /// Time until next spam message.
-    /// </summary>
-    [DataField]
-    public float NextSpamTime;
-
-    /// <summary>
     /// Maximum number of recipients per spam message.
     /// </summary>
     [DataField]
@@ -32,4 +14,7 @@ public sealed partial class NanoChatSpamRuleComponent : Component
     /// </summary>
     [DataField]
     public float RecipientChance = 0.3f;
+
+    [DataField]
+    public int? MaxPlayers;
 }

--- a/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleSystem.cs
@@ -43,7 +43,7 @@ public sealed partial class NanoChatSpamRuleSystem : StationEventSystem<NanoChat
     [Dependency] private SharedTimeSystem _timeSystem = default!;
     [Dependency] private ContainerSystem _container = default!;
 
-    private static readonly Regex _randomNumberPattern = new(@"\[\[randomnumber:(\d+):(\d+)\]\]", RegexOptions.Compiled);
+    private static readonly Regex _randomNumberPattern = MyRegex();
 
     protected override void Started(EntityUid uid, NanoChatSpamRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
@@ -370,4 +370,7 @@ public sealed partial class NanoChatSpamRuleSystem : StationEventSystem<NanoChat
 
         return allNames.Count > 0 ? _random.Pick(allNames) : "John Doe";
     }
+
+    [GeneratedRegex(@"\[\[randomnumber:(\d+):(\d+)\]\]", RegexOptions.Compiled)]
+    private static partial Regex MyRegex();
 }

--- a/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared._CD.CartridgeLoader.Cartridges;
 using Content.Shared._Starlight.Time;
 using Robust.Server.Containers;
 using Content.Server.StationEvents.Events;
+using Content.Server.StationEvents.Components;
 
 namespace Content.Server._Starlight.GameTicking.Rules;
 
@@ -43,17 +44,20 @@ public sealed partial class NanoChatSpamRuleSystem : StationEventSystem<NanoChat
     [Dependency] private SharedTimeSystem _timeSystem = default!;
     [Dependency] private ContainerSystem _container = default!;
 
-    private static readonly Regex _randomNumberPattern = MyRegex();
+    private static readonly Regex _randomNumberPattern = RandomNumberPatternRegex();
 
     protected override void Started(EntityUid uid, NanoChatSpamRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, component, gameRule, args);
 
         // Fire once, auto ended by StationEventSystem
-        SendSpamMessage(component);
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent))
+            return;
+
+        SendSpamMessage(component, stationEvent.TargetStation);
     }
 
-    private void SendSpamMessage(NanoChatSpamRuleComponent component)
+    private void SendSpamMessage(NanoChatSpamRuleComponent component, EntityUid? targetStation)
     {
         // Get all advertisement prototypes
         var adPrototypes = _prototype.EnumeratePrototypes<NanoChatAdvertisementPrototype>().ToList();
@@ -68,6 +72,10 @@ public sealed partial class NanoChatSpamRuleSystem : StationEventSystem<NanoChat
         {
             // Skip if no number assigned
             if (card.Number == null)
+                continue;
+
+            // Only include NanoChat cards belonging to the event's target station.
+            if (targetStation == null || _station.GetOwningStation(cardUid) != targetStation)
                 continue;
 
             // Check if card is in a PDA that belongs to a player
@@ -372,5 +380,5 @@ public sealed partial class NanoChatSpamRuleSystem : StationEventSystem<NanoChat
     }
 
     [GeneratedRegex(@"\[\[randomnumber:(\d+):(\d+)\]\]", RegexOptions.Compiled)]
-    private static partial Regex MyRegex();
+    private static partial Regex RandomNumberPatternRegex();
 }

--- a/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleSystem.cs
@@ -27,7 +27,7 @@ using Content.Server.StationEvents.Components;
 namespace Content.Server._Starlight.GameTicking.Rules;
 
 /// <summary>
-/// Game rule that periodically sends spam advertisements via NanoChat.
+/// Game rule that sends spam advertisements via NanoChat.
 /// </summary>
 public sealed partial class NanoChatSpamRuleSystem : StationEventSystem<NanoChatSpamRuleComponent>
 {

--- a/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/NanoChatSpamRuleSystem.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Content.Server.CartridgeLoader;
 using Content.Server._CD.CartridgeLoader.Cartridges;
-using Content.Server.GameTicking.Rules;
 using Content.Server.Station.Systems;
 using Robust.Server.Player;
 using Content.Shared._CD.NanoChat;
@@ -22,13 +21,14 @@ using Content.Server.Mind;
 using Content.Shared._CD.CartridgeLoader.Cartridges;
 using Content.Shared._Starlight.Time;
 using Robust.Server.Containers;
+using Content.Server.StationEvents.Events;
 
 namespace Content.Server._Starlight.GameTicking.Rules;
 
 /// <summary>
 /// Game rule that periodically sends spam advertisements via NanoChat.
 /// </summary>
-public sealed partial class NanoChatSpamRuleSystem : GameRuleSystem<NanoChatSpamRuleComponent>
+public sealed partial class NanoChatSpamRuleSystem : StationEventSystem<NanoChatSpamRuleComponent>
 {
     [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IRobustRandom _random = default!;
@@ -49,23 +49,7 @@ public sealed partial class NanoChatSpamRuleSystem : GameRuleSystem<NanoChatSpam
     {
         base.Started(uid, component, gameRule, args);
 
-        // Schedule first spam
-        component.NextSpamTime = _random.NextFloat(component.MinDelay, component.MaxDelay);
-    }
-
-    protected override void ActiveTick(EntityUid uid, NanoChatSpamRuleComponent component, GameRuleComponent gameRule, float frameTime)
-    {
-        base.ActiveTick(uid, component, gameRule, frameTime);
-
-        component.NextSpamTime -= frameTime;
-
-        if (component.NextSpamTime > 0)
-            return;
-
-        // Reset timer
-        component.NextSpamTime += _random.NextFloat(component.MinDelay, component.MaxDelay);
-
-        // Send spam
+        // Fire once, auto ended by StationEventSystem
         SendSpamMessage(component);
     }
 

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -34,6 +34,11 @@
     - id: CommunicationBlackout
     - id: NightShift
     - id: SyndicateDeadDrop
+    - id: NanoChatSpamTiny
+    - id: NanoChatSpamLowPop
+    - id: NanoChatSpamMidPop
+    - id: NanoChatSpamHighPop
+    - id: NanoChatSpamUltraPop
     # Starlight End
     - id: MalignRiftSpawn # Funky
 

--- a/Resources/Prototypes/_Starlight/GameRules/nanochat_spam.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/nanochat_spam.yml
@@ -1,10 +1,102 @@
 - type: entity
-  id: NanoChatSpam
+  id: NanoChatSpamBase
   parent: BaseGameRule
+  abstract: true
   components:
   - type: GameRule
+  - type: StationEvent
+    weight: 6
+    earliestStart: 10
+    duration: 1
+
+- type: entity
+  parent: NanoChatSpamBase
+  id: NanoChatSpamTiny
+  components:
+  - type: StationEvent
+    minimumPlayers: 5
   - type: NanoChatSpamRule
-    minDelay: 5  # 2m
-    maxDelay: 10  # 5m
-    maxRecipientsPerMessage: 3  # Up to 3 people get each spam
-    recipientChance: 0.3  # 30% of eligible players get spam
+    maxRecipientsPerMessage: 1
+    recipientChance: 0.3
+
+- type: entity
+  parent: NanoChatSpamBase
+  id: NanoChatSpamLowPop
+  components:
+  - type: StationEvent
+    minimumPlayers: 20
+  - type: NanoChatSpamRule
+    maxRecipientsPerMessage: 2
+    recipientChance: 0.3
+
+- type: entity
+  parent: NanoChatSpamBase
+  id: NanoChatSpamMidPop
+  components:
+  - type: StationEvent
+    minimumPlayers: 40
+  - type: NanoChatSpamRule
+    maxRecipientsPerMessage: 3
+    recipientChance: 0.3
+
+- type: entity
+  parent: NanoChatSpamBase
+  id: NanoChatSpamHighPop
+  components:
+  - type: StationEvent
+    minimumPlayers: 80
+  - type: NanoChatSpamRule
+    maxRecipientsPerMessage: 5
+    recipientChance: 0.3
+
+- type: entity
+  parent: NanoChatSpamBase
+  id: NanoChatSpamUltraPop
+  components:
+  - type: StationEvent
+    minimumPlayers: 150
+  - type: NanoChatSpamRule
+    maxRecipientsPerMessage: 8
+    recipientChance: 0.3
+
+# Admin variants
+- type: entity
+  id: NanoChatSpamAdminBase
+  parent: BaseGameRule
+  abstract: true
+  components:
+  - type: GameRule
+  - type: StationEvent
+    duration: 1
+
+- type: entity
+  parent: NanoChatSpamAdminBase
+  id: NanoChatSpam1
+  components:
+  - type: NanoChatSpamRule
+    maxRecipientsPerMessage: 1
+    recipientChance: 1.0
+
+- type: entity
+  parent: NanoChatSpamAdminBase
+  id: NanoChatSpam2
+  components:
+  - type: NanoChatSpamRule
+    maxRecipientsPerMessage: 2
+    recipientChance: 1.0
+
+- type: entity
+  parent: NanoChatSpamAdminBase
+  id: NanoChatSpam5
+  components:
+  - type: NanoChatSpamRule
+    maxRecipientsPerMessage: 5
+    recipientChance: 1.0
+
+- type: entity
+  parent: NanoChatSpamAdminBase
+  id: NanoChatSpam10
+  components:
+  - type: NanoChatSpamRule
+    maxRecipientsPerMessage: 10
+    recipientChance: 1.0


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes Nanochat spam to function like meteor events (Triggered once then thrown out) and also puts it into the pool and adds more events than 1 based on populations
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Nanochat spam has been sitting unused for months
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- add: Nanochat spam is no longer Admin only and is based on population.