### PR TITLE
tweak: Improved chat filters and highlights UI.

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -40,6 +40,10 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
     private bool _charInfoIsAttach = false;
 
     public event Action<string>? HighlightsUpdated;
+    // Starlight Start
+    public event Action<string>? AutoHighlightsUpdated;
+    public string AutoHighlights => _autoFillHighlightsEnabled ? _autoHighlights : string.Empty;
+    // Starlight End
 
     private void InitializeHighlights()
     {
@@ -51,6 +55,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
                 UpdateAutoFillHighlights();
             else
                 ReloadHighlights();
+            AutoHighlightsUpdated?.Invoke(AutoHighlights);
         }, true);
         // Starlight End
 
@@ -192,6 +197,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         // Starlight Start
         _autoHighlights = newHighlights;
         ReloadHighlights();
+        AutoHighlightsUpdated?.Invoke(AutoHighlights);
         // Starlight End
         _charInfoIsAttach = false;
     }

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -34,6 +34,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
 
     private bool _autoFillHighlightsEnabled;
     private string _autoHighlights = ""; // Starlight
+    private CharacterData? _cachedCharacterData; // Starlight
 
     /// <summary>
     ///     The boolean that keeps track of the 'OnCharacterUpdated' event, whenever it's a player attaching or opening the character info panel.
@@ -99,12 +100,20 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         _autoHighlights = string.Empty;
         ReloadHighlights();
         AutoHighlightsUpdated?.Invoke(AutoHighlights);
-        // Starlight end
 
-        // If auto highlights are enabled generate a request for new character info
-        // that will be used to determine the highlights.
-        _charInfoIsAttach = true;
-        _characterInfo?.RequestCharacterInfo(); // Starlight
+        if (_cachedCharacterData != null && _cachedCharacterData.Value.Entity == _player.LocalEntity)
+        {
+            _charInfoIsAttach = true;
+            OnCharacterUpdated(_cachedCharacterData.Value);
+        }
+        else
+        {
+            // If auto highlights are enabled generate a request for new character info
+            // that will be used to determine the highlights.
+            _charInfoIsAttach = true;
+            _characterInfo?.RequestCharacterInfo();
+        }
+        // Starlight end
     }
 
     // Starlight Start
@@ -178,6 +187,8 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
 
     private void OnCharacterUpdated(CharacterData data)
     {
+        _cachedCharacterData = data; // Starlight
+
         // If _charInfoIsAttach is false then the opening of the character panel was the one
         // to generate the event, dismiss it.
         if (!_charInfoIsAttach)
@@ -210,7 +221,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (_loc.TryGetString($"highlights-{jobKey}", out var jobMatches))
             newHighlights += '\n' + jobMatches.Replace(", ", "\n");
 
-// Starlight Start
+        // Starlight Start
         _autoHighlights = newHighlights;
         ReloadHighlights();
         AutoHighlightsUpdated?.Invoke(AutoHighlights);

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -4,6 +4,7 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controllers;
 using Content.Shared.CCVar;
 using Content.Client.CharacterInfo;
+using Content.Client._Starlight.TextToSpeech;
 using static Content.Client.CharacterInfo.CharacterInfoSystem;
 
 namespace Content.Client.UserInterface.Systems.Chat;
@@ -41,7 +42,14 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
 
     public event Action<string>? HighlightsUpdated;
     // Starlight Start
+    /// <summary>
+    ///     Event triggered when the auto-fill highlights list is updated.
+    /// </summary>
     public event Action<string>? AutoHighlightsUpdated;
+
+    /// <summary>
+    ///     The current active auto-fill highlights list, or empty if disabled.
+    /// </summary>
     public string AutoHighlights => _autoFillHighlightsEnabled ? _autoHighlights : string.Empty;
     // Starlight End
 
@@ -54,8 +62,10 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
             if (value)
                 UpdateAutoFillHighlights();
             else
+            {
                 ReloadHighlights();
-            AutoHighlightsUpdated?.Invoke(AutoHighlights);
+                AutoHighlightsUpdated?.Invoke(AutoHighlights);
+            }
         }, true);
         // Starlight End
 
@@ -84,6 +94,12 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
     {
         if (!_autoFillHighlightsEnabled)
             return;
+
+        // Starlight start
+        _autoHighlights = string.Empty;
+        ReloadHighlights();
+        AutoHighlightsUpdated?.Invoke(AutoHighlights);
+        // Starlight end
 
         // If auto highlights are enabled generate a request for new character info
         // that will be used to determine the highlights.
@@ -194,11 +210,31 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (_loc.TryGetString($"highlights-{jobKey}", out var jobMatches))
             newHighlights += '\n' + jobMatches.Replace(", ", "\n");
 
-        // Starlight Start
+// Starlight Start
         _autoHighlights = newHighlights;
         ReloadHighlights();
         AutoHighlightsUpdated?.Invoke(AutoHighlights);
         // Starlight End
         _charInfoIsAttach = false;
     }
+
+    // Starlight start
+    /// <summary>
+    ///     Clears the active TTS speech queue.
+    /// </summary>
+    public void ClearTTSQueue()
+    {
+        if (_ent.TrySystem<TextToSpeechSystem>(out var tts))
+            tts.ClearQueue();
+    }
+
+    /// <summary>
+    ///     Sets the mute state of a TTS radio channel.
+    /// </summary>
+    public void SetTTSChannelMuted(Robust.Shared.Prototypes.ProtoId<Content.Shared.Radio.RadioChannelPrototype> channelId, bool muted)
+    {
+        if (_ent.TrySystem<TextToSpeechStreamSystem>(out var ttsStream))
+            ttsStream.SetChannelMuted(channelId, muted);
+    }
+    // Starlight end
 }

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml
@@ -16,6 +16,7 @@
                     <TextEdit Name="HighlightEdit" MinHeight="150" Margin="5 5"/>
                 </PanelContainer>
                 <Button Name="HighlightButton" Text="{Loc 'hud-chatbox-highlights-button'}" ToolTip="{Loc 'hud-chatbox-highlights-tooltip'}"/>
+                <RichTextLabel Name="AutoHighlightsLabel" Access="Public" Visible="False" Margin="2 5" SetWidth="120"/>
             </BoxContainer>
             <!-- Starlight start -->
             <BoxContainer Name="TTSMuteVBox" MinWidth="120" Margin="0 10" Orientation="Vertical" SeparationOverride="4">

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml
@@ -1,11 +1,19 @@
 <controls:ChannelFilterPopup
     xmlns="https://spacestation14.io"
     xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
+    xmlns:cc="clr-namespace:Content.Client.Administration.UI.CustomControls"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Systems.Chat.Controls">
     <PanelContainer Name="FilterPopupPanel" StyleClasses="BorderedWindowPanel">
         <BoxContainer Orientation="Horizontal" SeparationOverride="8" Margin="10 0">
-            <BoxContainer Name="FilterVBox" MinWidth="105" Margin="0 10" Orientation="Vertical" SeparationOverride="4"/>
-            <BoxContainer Name="HighlightsVBox" MinWidth="120" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
+            <BoxContainer Name="FilterVBox" MinWidth="105" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
+                <!-- Starlight start -->
+                <Label Text="{Loc 'hud-chatbox-channel-filter'}"/>
+                <!-- Starlight end -->
+            </BoxContainer>
+            <!-- Starlight start -->
+            <cc:VSeparator Margin="2 10" />
+            <!-- Starlight end -->
+            <BoxContainer Name="HighlightsVBox" MinWidth="160" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
                 <Label Text="{Loc 'hud-chatbox-highlights'}"/>
                 <PanelContainer>
                     <!-- Begin custom background for TextEdit -->
@@ -13,12 +21,20 @@
                         <gfx:StyleBoxFlat BackgroundColor="#323446"/>
                     </PanelContainer.PanelOverride>
                     <!-- End custom background -->
-                    <TextEdit Name="HighlightEdit" MinHeight="150" Margin="5 5"/>
+                    <!-- Starlight start -->
+                    <TextEdit Name="HighlightEdit" MinHeight="75" Margin="5 5"/>
+                    <!-- Starlight end -->
                 </PanelContainer>
                 <Button Name="HighlightButton" Text="{Loc 'hud-chatbox-highlights-button'}" ToolTip="{Loc 'hud-chatbox-highlights-tooltip'}"/>
-                <RichTextLabel Name="AutoHighlightsLabel" Access="Public" Visible="False" Margin="2 5" SetWidth="120"/>
+                <!-- Starlight start -->
+                <CheckBox Name="AutoFillCheckBox" Text="{Loc 'hud-chatbox-auto-fill-toggle'}" Margin="0 4 0 0"/>
+                <ScrollContainer VerticalExpand="True" HScrollEnabled="False">
+                    <RichTextLabel Name="AutoHighlightsLabel" Visible="False" Margin="2 0" VerticalAlignment="Top"/>
+                </ScrollContainer>
+                <!-- Starlight end -->
             </BoxContainer>
             <!-- Starlight start -->
+            <cc:VSeparator Margin="2 10" />
             <BoxContainer Name="TTSMuteVBox" MinWidth="120" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
                 <Label Text="{Loc 'hud-chatbox-tts-mute'}"/>
                 <ScrollContainer VerticalExpand="True" HScrollEnabled="False" MinHeight="150">

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml
@@ -5,15 +5,13 @@
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Systems.Chat.Controls">
     <PanelContainer Name="FilterPopupPanel" StyleClasses="BorderedWindowPanel">
         <BoxContainer Orientation="Horizontal" SeparationOverride="8" Margin="10 0">
-            <BoxContainer Name="FilterVBox" MinWidth="105" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
-                <!-- Starlight start -->
-                <Label Text="{Loc 'hud-chatbox-channel-filter'}"/>
-                <!-- Starlight end -->
-            </BoxContainer>
             <!-- Starlight start -->
+            <BoxContainer Name="FilterVBox" MinWidth="105" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
+                <Label Text="{Loc 'hud-chatbox-channel-filter'}"/>
+            </BoxContainer>
             <cc:VSeparator Margin="2 10" />
-            <!-- Starlight end -->
             <BoxContainer Name="HighlightsVBox" MinWidth="160" Margin="0 10" Orientation="Vertical" SeparationOverride="4">
+                <!-- Starlight end -->
                 <Label Text="{Loc 'hud-chatbox-highlights'}"/>
                 <PanelContainer>
                     <!-- Begin custom background for TextEdit -->

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Content.Shared.Chat;
 using Content.Shared.CCVar;
@@ -20,7 +21,6 @@ public sealed partial class ChannelFilterPopup : Popup
 {
     // Starlight begin
     [Dependency] private readonly IConfigurationManager _cfg = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     // Starlight end
     // order in which the available channel filters show up when available
@@ -47,8 +47,16 @@ public sealed partial class ChannelFilterPopup : Popup
 
     // Starlight start
     private readonly Dictionary<ProtoId<RadioChannelPrototype>, CheckBox> _ttsMuteStates = new();
-    private TextToSpeechStreamSystem? _ttsStream;
-    private TextToSpeechSystem? _tts;
+
+    /// <summary>
+    ///     Event triggered when the clear TTS queue button is pressed.
+    /// </summary>
+    public event Action? OnClearTTSQueue;
+
+    /// <summary>
+    ///     Event triggered when a TTS channel's mute state is toggled.
+    /// </summary>
+    public event Action<ProtoId<RadioChannelPrototype>, bool>? OnTTSMuteStateChanged;
     // Starlight end
 
     public ChannelFilterPopup()
@@ -68,24 +76,37 @@ public sealed partial class ChannelFilterPopup : Popup
             UpdateHighlights(highlights);
         }
 
+        // Starlight start - auto-fill toggle
+        AutoFillCheckBox.Pressed = _cfg.GetCVar(CCVars.ChatAutoFillHighlights);
+        AutoFillCheckBox.OnToggled += OnAutoFillToggled;
+        _cfg.OnValueChanged(CCVars.ChatAutoFillHighlights, OnAutoFillCVarChanged);
+        // Starlight end
+
         // Starlight start
         InitializeTTSMuteChannels();
-        TTSClearQueueButton.OnPressed += _ => ClearQueue();
+        TTSClearQueueButton.OnPressed += _ => OnClearTTSQueue?.Invoke();
         TTSToggleAllButton.OnPressed += _ => ToggleAllTTSMuteCheckboxes();
         // Starlight end
     }
+
+    // Starlight start
+    /// <summary>
+    ///     Cleans up event listeners and configuration subscriptions to avoid memory leaks.
+    /// </summary>
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (!disposing) return;
+
+        _cfg.UnsubValueChanged(CCVars.ChatAutoFillHighlights, OnAutoFillCVarChanged);
+    }
+    // Starlight end
     // Starlight start
 
-    private void ClearQueue()
-    {
-        if (_tts == null)
-        {
-            _tts = _entityManager.System<TextToSpeechSystem>();
-        }
-        _tts?.ClearQueue();
-    }
-
-    // Creates checkbox toggle mute buttons for each defined Radio channel prototype
+    /// <summary>
+    ///     Creates checkbox toggle mute buttons for each defined Radio channel prototype.
+    /// </summary>
     private void InitializeTTSMuteChannels()
     {
         foreach (var channel in _protoManager.EnumeratePrototypes<RadioChannelPrototype>()
@@ -98,14 +119,16 @@ public sealed partial class ChannelFilterPopup : Popup
             };
 
             var channelId = channel.ID;
-            checkbox.OnToggled += args => SetChannelMuteState(channelId, args.Pressed);
+            checkbox.OnToggled += args => OnTTSMuteStateChanged?.Invoke(channelId, args.Pressed);
 
             _ttsMuteStates[channel.ID] = checkbox;
             TTSChannelsVBox.AddChild(checkbox);
         }
     }
 
-    // Toggles all mute buttons on, then off, and so on
+    /// <summary>
+    ///     Toggles all mute buttons on, then off, and so on.
+    /// </summary>
     private void ToggleAllTTSMuteCheckboxes()
     {
         bool allChecked = _ttsMuteStates.Values.All(checkbox => checkbox.Pressed);
@@ -114,15 +137,8 @@ public sealed partial class ChannelFilterPopup : Popup
         foreach (var (channelId, checkbox) in _ttsMuteStates)
         {
             checkbox.Pressed = newState;
-            SetChannelMuteState(channelId, newState);
+            OnTTSMuteStateChanged?.Invoke(channelId, newState);
         }
-    }
-
-    // Function to apply the mute state from the UI to the TTS system for a specific channel
-    private void SetChannelMuteState(ProtoId<RadioChannelPrototype> channelId, bool muted)
-    {
-        _ttsStream ??= _entityManager.System<TextToSpeechStreamSystem>();
-        _ttsStream.SetChannelMuted(channelId, muted);
     }
 
     // Starlight end
@@ -200,6 +216,27 @@ public sealed partial class ChannelFilterPopup : Popup
         OnNewHighlights?.Invoke(Rope.Collapse(HighlightEdit.TextRope));
     }
 
+    // Starlight start
+    /// <summary>
+    ///     Event handler triggered when the auto-fill highlights checkbox is toggled.
+    /// </summary>
+    private void OnAutoFillToggled(ButtonToggledEventArgs args)
+    {
+        _cfg.SetCVar(CCVars.ChatAutoFillHighlights, args.Pressed);
+        _cfg.SaveToFile();
+    }
+
+    /// <summary>
+    ///     Event handler triggered when the auto-fill highlights CVar value changes.
+    /// </summary>
+    private void OnAutoFillCVarChanged(bool value)
+    {
+        AutoFillCheckBox.Pressed = value;
+    }
+
+    /// <summary>
+    ///     Updates and renders the list of active auto-generated highlights in the UI.
+    /// </summary>
     public void UpdateAutoHighlights(string autoHighlights)
     {
         if (string.IsNullOrEmpty(autoHighlights))
@@ -211,15 +248,16 @@ public sealed partial class ChannelFilterPopup : Popup
         var list = autoHighlights
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(h => h.TrimStart('@'))
-            .Distinct();
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(FormattedMessage.EscapeText);
 
-        var joined = string.Join(", ", list);
-        var header = Loc.GetString("hud-chatbox-auto-highlights");
-        var markup = $"{header} [color=#8a8a8a][i]{joined}[/i][/color]";
+        var bullets = string.Join("\n", list.Select(h => $"•\u00A0{h}"));
+        var markup = $"[color=#8a8a8a][i]{bullets}[/i][/color]";
 
         AutoHighlightsLabel.SetMessage(Robust.Shared.Utility.FormattedMessage.FromMarkupOrThrow(markup));
         AutoHighlightsLabel.Visible = true;
     }
+    // Starlight end
 
     public void UpdateUnread(ChatChannel channel, int? unread)
     {

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -101,8 +101,6 @@ public sealed partial class ChannelFilterPopup : Popup
 
         _cfg.UnsubValueChanged(CCVars.ChatAutoFillHighlights, OnAutoFillCVarChanged);
     }
-    // Starlight end
-    // Starlight start
 
     /// <summary>
     ///     Creates checkbox toggle mute buttons for each defined Radio channel prototype.
@@ -249,12 +247,13 @@ public sealed partial class ChannelFilterPopup : Popup
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(h => h.TrimStart('@'))
             .Distinct(StringComparer.OrdinalIgnoreCase)
-            .Select(FormattedMessage.EscapeText);
+            .Select(FormattedMessage.EscapeText)
+            .Select(h => Loc.GetString("hud-chatbox-auto-highlights-bullet", ("item", h)));
 
-        var bullets = string.Join("\n", list.Select(h => $"•\u00A0{h}"));
-        var markup = $"[color=#8a8a8a][i]{bullets}[/i][/color]";
+        var bullets = string.Join("\n", list);
+        var markup = Loc.GetString("hud-chatbox-auto-highlights-wrapper", ("bullets", bullets));
 
-        AutoHighlightsLabel.SetMessage(Robust.Shared.Utility.FormattedMessage.FromMarkupOrThrow(markup));
+        AutoHighlightsLabel.SetMessage(FormattedMessage.FromMarkupOrThrow(markup));
         AutoHighlightsLabel.Visible = true;
     }
     // Starlight end

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -200,6 +200,27 @@ public sealed partial class ChannelFilterPopup : Popup
         OnNewHighlights?.Invoke(Rope.Collapse(HighlightEdit.TextRope));
     }
 
+    public void UpdateAutoHighlights(string autoHighlights)
+    {
+        if (string.IsNullOrEmpty(autoHighlights))
+        {
+            AutoHighlightsLabel.Visible = false;
+            return;
+        }
+
+        var list = autoHighlights
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(h => h.TrimStart('@'))
+            .Distinct();
+
+        var joined = string.Join(", ", list);
+        var header = Loc.GetString("hud-chatbox-auto-highlights");
+        var markup = $"{header} [color=#8a8a8a][i]{joined}[/i][/color]";
+
+        AutoHighlightsLabel.SetMessage(Robust.Shared.Utility.FormattedMessage.FromMarkupOrThrow(markup));
+        AutoHighlightsLabel.Visible = true;
+    }
+
     public void UpdateUnread(ChatChannel channel, int? unread)
     {
         if (_filterStates.TryGetValue(channel, out var checkbox))

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -48,7 +48,9 @@ public partial class ChatBox : UIWidget
         _controller = UserInterfaceManager.GetUIController<ChatUIController>();
         _controller.MessageAdded += OnMessageAdded;
         _controller.HighlightsUpdated += OnHighlightsUpdated;
+        _controller.AutoHighlightsUpdated += OnAutoHighlightsUpdated;
         _controller.RegisterChat(this);
+        ChatInput.FilterButton.Popup.UpdateAutoHighlights(_controller.AutoHighlights);
     }
 
     private void OnTextEntered(LineEditEventArgs args)
@@ -77,6 +79,11 @@ public partial class ChatBox : UIWidget
     private void OnHighlightsUpdated(string highlights)
     {
         ChatInput.FilterButton.Popup.UpdateHighlights(highlights);
+    }
+
+    private void OnAutoHighlightsUpdated(string autoHighlights)
+    {
+        ChatInput.FilterButton.Popup.UpdateAutoHighlights(autoHighlights);
     }
 
     private void OnChannelSelect(ChatSelectChannel channel)
@@ -229,6 +236,8 @@ public partial class ChatBox : UIWidget
 
         if (!disposing) return;
         _controller.UnregisterChat(this);
+        _controller.HighlightsUpdated -= OnHighlightsUpdated;
+        _controller.AutoHighlightsUpdated -= OnAutoHighlightsUpdated;
         ChatInput.Input.OnTextEntered -= OnTextEntered;
         ChatInput.Input.OnKeyBindDown -= OnInputKeyBindDown;
         ChatInput.Input.OnTextChanged -= OnTextChanged;

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Content.Client.UserInterface.Systems.Chat.Controls;
 using Content.Shared.Chat;
@@ -20,6 +21,8 @@ namespace Content.Client.UserInterface.Systems.Chat.Widgets;
 [Virtual]
 public partial class ChatBox : UIWidget
 {
+    private const int FormattedMessageDefaultCapacity = 3;
+
     [Dependency] private IEntityManager _entManager = default!;
     [Dependency] private ILogManager _log = default!;
 
@@ -45,12 +48,20 @@ public partial class ChatBox : UIWidget
         ChatInput.ChannelSelector.OnChannelSelect += OnChannelSelect;
         ChatInput.FilterButton.Popup.OnChannelFilter += OnChannelFilter;
         ChatInput.FilterButton.Popup.OnNewHighlights += OnNewHighlights;
+        // Starlight start
+        ChatInput.FilterButton.Popup.OnClearTTSQueue += OnClearTTSQueue;
+        ChatInput.FilterButton.Popup.OnTTSMuteStateChanged += OnTTSMuteStateChanged;
+        // Starlight end
         _controller = UserInterfaceManager.GetUIController<ChatUIController>();
         _controller.MessageAdded += OnMessageAdded;
         _controller.HighlightsUpdated += OnHighlightsUpdated;
+        // Starlight start
         _controller.AutoHighlightsUpdated += OnAutoHighlightsUpdated;
+        // Starlight end
         _controller.RegisterChat(this);
+        // Starlight start
         ChatInput.FilterButton.Popup.UpdateAutoHighlights(_controller.AutoHighlights);
+        // Starlight end
     }
 
     private void OnTextEntered(LineEditEventArgs args)
@@ -81,10 +92,15 @@ public partial class ChatBox : UIWidget
         ChatInput.FilterButton.Popup.UpdateHighlights(highlights);
     }
 
+    // Starlight start
+    /// <summary>
+    ///     Event handler triggered when the auto-fill highlights list is updated in the controller.
+    /// </summary>
     private void OnAutoHighlightsUpdated(string autoHighlights)
     {
         ChatInput.FilterButton.Popup.UpdateAutoHighlights(autoHighlights);
     }
+    // Starlight end
 
     private void OnChannelSelect(ChatSelectChannel channel)
     {
@@ -139,7 +155,7 @@ public partial class ChatBox : UIWidget
 
     public void AddLine(string message, Color color)
     {
-        var formatted = new FormattedMessage(3);
+        var formatted = new FormattedMessage(FormattedMessageDefaultCapacity);
         formatted.PushColor(color);
         formatted.AddMarkupPermissive(message);
         formatted.Pop();
@@ -236,11 +252,36 @@ public partial class ChatBox : UIWidget
 
         if (!disposing) return;
         _controller.UnregisterChat(this);
+        // Starlight start
+        _controller.MessageAdded -= OnMessageAdded;
         _controller.HighlightsUpdated -= OnHighlightsUpdated;
         _controller.AutoHighlightsUpdated -= OnAutoHighlightsUpdated;
+        // Starlight end
         ChatInput.Input.OnTextEntered -= OnTextEntered;
         ChatInput.Input.OnKeyBindDown -= OnInputKeyBindDown;
         ChatInput.Input.OnTextChanged -= OnTextChanged;
         ChatInput.ChannelSelector.OnChannelSelect -= OnChannelSelect;
+        // Starlight start
+        ChatInput.FilterButton.Popup.OnClearTTSQueue -= OnClearTTSQueue;
+        ChatInput.FilterButton.Popup.OnTTSMuteStateChanged -= OnTTSMuteStateChanged;
+        // Starlight end
     }
+
+    // Starlight start
+    /// <summary>
+    ///     Event handler triggered when the clear TTS queue button is pressed.
+    /// </summary>
+    private void OnClearTTSQueue()
+    {
+        _controller.ClearTTSQueue();
+    }
+
+    /// <summary>
+    ///     Event handler triggered when a TTS channel's mute state is toggled.
+    /// </summary>
+    private void OnTTSMuteStateChanged(Robust.Shared.Prototypes.ProtoId<Content.Shared.Radio.RadioChannelPrototype> channelId, bool muted)
+    {
+        _controller.SetTTSChannelMuted(channelId, muted);
+    }
+    // Starlight end
 }

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -21,7 +21,7 @@ namespace Content.Client.UserInterface.Systems.Chat.Widgets;
 [Virtual]
 public partial class ChatBox : UIWidget
 {
-    private const int FormattedMessageDefaultCapacity = 3;
+    private const int FormattedMessageDefaultCapacity = 3; // Starlight
 
     [Dependency] private IEntityManager _entManager = default!;
     [Dependency] private ILogManager _log = default!;
@@ -55,13 +55,9 @@ public partial class ChatBox : UIWidget
         _controller = UserInterfaceManager.GetUIController<ChatUIController>();
         _controller.MessageAdded += OnMessageAdded;
         _controller.HighlightsUpdated += OnHighlightsUpdated;
-        // Starlight start
-        _controller.AutoHighlightsUpdated += OnAutoHighlightsUpdated;
-        // Starlight end
+        _controller.AutoHighlightsUpdated += OnAutoHighlightsUpdated; // Starlight
         _controller.RegisterChat(this);
-        // Starlight start
-        ChatInput.FilterButton.Popup.UpdateAutoHighlights(_controller.AutoHighlights);
-        // Starlight end
+        ChatInput.FilterButton.Popup.UpdateAutoHighlights(_controller.AutoHighlights); // Starlight
     }
 
     private void OnTextEntered(LineEditEventArgs args)

--- a/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
@@ -10,6 +10,8 @@ using Content.Shared.CCVar;
 using NUnit.Framework;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
+using Content.Client.UserInterface.Systems.Chat.Widgets;
+using Content.Client.UserInterface.Systems.Chat.Controls;
 
 namespace Content.IntegrationTests.Tests._Starlight;
 
@@ -152,4 +154,69 @@ public sealed class ChatHighlightTest : GameTest
         Assert.That(activeHighlights, Contains.Item("Captain"));
         Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)"));
     }
+
+    [Test]
+    [RunOnSide(Side.Client)]
+    public async Task TestAutoHighlightsVisibleInUI()
+    {
+        var chatController = _uiManager.GetUIController<ChatUIController>();
+        
+        // 1. Enable auto-fill highlights
+        _configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
+
+        // 2. Set custom highlights
+        var customHighlights = "ling\nrev";
+        chatController.UpdateHighlights(customHighlights);
+
+        // 3. Create a ChatBox widget
+        var chatBox = new ChatBox();
+
+        // 4. Simulate character update
+        var characterData = new CharacterInfoSystem.CharacterData(
+            default,
+            "Captain",
+            new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
+            null,
+            "John Doe"
+        );
+
+        InvokeOnCharacterUpdated(chatController, characterData);
+
+        // 5. Get the text currently displayed in the filter popup's textbox and auto-highlights label
+        var highlightEdit = chatBox.ChatInput.FilterButton.Popup.FindControl<Robust.Client.UserInterface.Controls.TextEdit>("HighlightEdit");
+        var uiHighlightsText = Robust.Shared.Utility.Rope.Collapse(highlightEdit.TextRope);
+        var autoHighlightsLabel = chatBox.ChatInput.FilterButton.Popup.FindControl<Robust.Client.UserInterface.Controls.RichTextLabel>("AutoHighlightsLabel");
+
+        try
+        {
+            // Assert that the UI textbox ONLY contains custom highlights (doesn't pollute/show auto highlights)
+            Assert.That(uiHighlightsText, Contains.Substring("ling"));
+            Assert.That(uiHighlightsText, Contains.Substring("rev"));
+            Assert.That(uiHighlightsText, Is.Not.Contains("Captain"));
+
+            // Assert that the read-only AutoHighlightsLabel is visible and displays the active auto highlights
+            Assert.That(autoHighlightsLabel.Visible, Is.True);
+            Assert.That(autoHighlightsLabel.Text, Is.Not.Null);
+            Assert.That(autoHighlightsLabel.Text, Contains.Substring("Captain"));
+            Assert.That(autoHighlightsLabel.Text, Contains.Substring("John"));
+            Assert.That(autoHighlightsLabel.Text, Contains.Substring("Doe"));
+
+            // Assert that internally they are indeed active in memory
+            var highlightsField = chatController.GetType().GetField(
+                "_highlights",
+                BindingFlags.NonPublic | BindingFlags.Instance
+            );
+            Assert.That(highlightsField, Is.Not.Null);
+            var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
+            
+            Assert.That(activeHighlights, Contains.Item("ling"));
+            Assert.That(activeHighlights, Contains.Item("rev"));
+            Assert.That(activeHighlights, Contains.Item("Captain"));
+        }
+        finally
+        {
+            chatBox.Dispose();
+        }
+    }
 }
+

--- a/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/ChatHighlightTest.cs
@@ -10,8 +10,6 @@ using Content.Shared.CCVar;
 using NUnit.Framework;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
-using Content.Client.UserInterface.Systems.Chat.Widgets;
-using Content.Client.UserInterface.Systems.Chat.Controls;
 
 namespace Content.IntegrationTests.Tests._Starlight;
 
@@ -154,69 +152,4 @@ public sealed class ChatHighlightTest : GameTest
         Assert.That(activeHighlights, Contains.Item("Captain"));
         Assert.That(activeHighlights, Contains.Item("(?<!\\w)Cap(?!\\w)"));
     }
-
-    [Test]
-    [RunOnSide(Side.Client)]
-    public async Task TestAutoHighlightsVisibleInUI()
-    {
-        var chatController = _uiManager.GetUIController<ChatUIController>();
-        
-        // 1. Enable auto-fill highlights
-        _configManager.SetCVar(CCVars.ChatAutoFillHighlights, true);
-
-        // 2. Set custom highlights
-        var customHighlights = "ling\nrev";
-        chatController.UpdateHighlights(customHighlights);
-
-        // 3. Create a ChatBox widget
-        var chatBox = new ChatBox();
-
-        // 4. Simulate character update
-        var characterData = new CharacterInfoSystem.CharacterData(
-            default,
-            "Captain",
-            new Dictionary<string, List<Shared.Objectives.ObjectiveInfo>>(),
-            null,
-            "John Doe"
-        );
-
-        InvokeOnCharacterUpdated(chatController, characterData);
-
-        // 5. Get the text currently displayed in the filter popup's textbox and auto-highlights label
-        var highlightEdit = chatBox.ChatInput.FilterButton.Popup.FindControl<Robust.Client.UserInterface.Controls.TextEdit>("HighlightEdit");
-        var uiHighlightsText = Robust.Shared.Utility.Rope.Collapse(highlightEdit.TextRope);
-        var autoHighlightsLabel = chatBox.ChatInput.FilterButton.Popup.FindControl<Robust.Client.UserInterface.Controls.RichTextLabel>("AutoHighlightsLabel");
-
-        try
-        {
-            // Assert that the UI textbox ONLY contains custom highlights (doesn't pollute/show auto highlights)
-            Assert.That(uiHighlightsText, Contains.Substring("ling"));
-            Assert.That(uiHighlightsText, Contains.Substring("rev"));
-            Assert.That(uiHighlightsText, Is.Not.Contains("Captain"));
-
-            // Assert that the read-only AutoHighlightsLabel is visible and displays the active auto highlights
-            Assert.That(autoHighlightsLabel.Visible, Is.True);
-            Assert.That(autoHighlightsLabel.Text, Is.Not.Null);
-            Assert.That(autoHighlightsLabel.Text, Contains.Substring("Captain"));
-            Assert.That(autoHighlightsLabel.Text, Contains.Substring("John"));
-            Assert.That(autoHighlightsLabel.Text, Contains.Substring("Doe"));
-
-            // Assert that internally they are indeed active in memory
-            var highlightsField = chatController.GetType().GetField(
-                "_highlights",
-                BindingFlags.NonPublic | BindingFlags.Instance
-            );
-            Assert.That(highlightsField, Is.Not.Null);
-            var activeHighlights = (List<string>)highlightsField.GetValue(chatController)!;
-            
-            Assert.That(activeHighlights, Contains.Item("ling"));
-            Assert.That(activeHighlights, Contains.Item("rev"));
-            Assert.That(activeHighlights, Contains.Item("Captain"));
-        }
-        finally
-        {
-            chatBox.Dispose();
-        }
-    }
 }
-

--- a/Resources/Locale/en-US/_Starlight/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/_Starlight/chat/ui/chat-box.ftl
@@ -1,3 +1,7 @@
 hud-chatbox-tts-mute = Mute TTS Channels
 hud-chatbox-tts-clear-queue = Clear TTS Queue
 hud-chatbox-tts-toggle-all = Toggle All
+hud-chatbox-channel-filter = Channels
+hud-chatbox-auto-fill-toggle = Name & Job
+hud-chatbox-auto-highlights-bullet = • {$item}
+hud-chatbox-auto-highlights-wrapper = [color=#8a8a8a][i]{$bullets}[/i][/color]

--- a/Resources/Locale/en-US/_Starlight/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/_Starlight/chat/ui/chat-box.ftl
@@ -1,3 +1,3 @@
-hud-chatbox-tts-mute = Mute TTS Channels:
+hud-chatbox-tts-mute = Mute TTS Channels
 hud-chatbox-tts-clear-queue = Clear TTS Queue
 hud-chatbox-tts-toggle-all = Toggle All

--- a/Resources/Locale/en-US/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/chat/ui/chat-box.ftl
@@ -40,3 +40,4 @@ hud-chatbox-highlights-tooltip = The words need to be separated by a newline,
 hud-chatbox-highlights-placeholder = @McHands
                                      "Judge"
                                      Medical
+hud-chatbox-auto-highlights = Auto Highlights:

--- a/Resources/Locale/en-US/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/chat/ui/chat-box.ftl
@@ -32,8 +32,9 @@ hud-chatbox-channel-Visual = Actions
 hud-chatbox-channel-Damage = Damage
 hud-chatbox-channel-Unspecified = Unspecified
 
-hud-chatbox-channel-filter = Channels
+# Starlight start
 hud-chatbox-highlights = Chat Highlights
+# Starlight end
 hud-chatbox-highlights-button = Submit
 hud-chatbox-highlights-tooltip = The words need to be separated by a newline,
                                  if wrapped around " they will be highlighted
@@ -41,4 +42,3 @@ hud-chatbox-highlights-tooltip = The words need to be separated by a newline,
 hud-chatbox-highlights-placeholder = @McHands
                                      "Judge"
                                      Medical
-hud-chatbox-auto-fill-toggle = Name & Job

--- a/Resources/Locale/en-US/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/chat/ui/chat-box.ftl
@@ -32,7 +32,8 @@ hud-chatbox-channel-Visual = Actions
 hud-chatbox-channel-Damage = Damage
 hud-chatbox-channel-Unspecified = Unspecified
 
-hud-chatbox-highlights = Highlights:
+hud-chatbox-channel-filter = Channels
+hud-chatbox-highlights = Chat Highlights
 hud-chatbox-highlights-button = Submit
 hud-chatbox-highlights-tooltip = The words need to be separated by a newline,
                                  if wrapped around " they will be highlighted
@@ -40,4 +41,4 @@ hud-chatbox-highlights-tooltip = The words need to be separated by a newline,
 hud-chatbox-highlights-placeholder = @McHands
                                      "Judge"
                                      Medical
-hud-chatbox-auto-highlights = Auto Highlights:
+hud-chatbox-auto-fill-toggle = Name & Job


### PR DESCRIPTION
## Short description
With my previous PR, the auto-highlights were set to default on, and be stored in memory rather than in-file https://github.com/ss14Starlight/space-station-14/pull/5125

However a bug was raised to my attention post-merge where the auto-highlight values don't show up in the chat filter popup UI.

Rather than include them back in the editable list (which has weird edge cases (people editing auto-generated values, then submitting: what does that do?) I decided to make them read-only and separated out in the UI.

Alongside this, I made a few UX improvements like separating the columns of this popup and bringing the auto-highlight settings toggle forward into this filters menu where it's much more intuitive to turn on and off.

## Why we need to add this
This fixes an issue where the auto-highlights aren't obvious and visible to players, and not easy to understand how to toggle on and off

## Media (Video/Screenshots)
| Before| After|
| -------- | ------- |
|<img width="550" height="432" alt="Screenshot 2026-07-24 222209" src="https://github.com/user-attachments/assets/2c919102-9950-41cf-80e0-706518bcb11b" /> | <img width="617" height="457" alt="Screenshot 2026-07-24 225146" src="https://github.com/user-attachments/assets/dc6570b4-d12e-48c2-864d-809516356f83" /> |


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- tweak: Improved chat filters and highlights UI.
