### PR TITLE
Observer typing indicators

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -74,6 +74,7 @@
     castShadows: false
     enabled: false
   - type: ActiveInputMover # Starlight
+  - type: Speech # Starlight, only adds speech bubble while typing
 
 # proto for player ghosts specifically
 - type: entity


### PR DESCRIPTION
## Short description

Adds typing indicators to observers.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

No longer will we stare at one another, expecting the other to say something, when they weren't typing at all.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="313" height="189" alt="image" src="https://github.com/user-attachments/assets/8b687acb-68c6-4366-a7f3-c187b4cbd25c" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Observer ghosts now have typing indicators.

