### PR TITLE
Revert atmos device pressure limits to upstream levels

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -465,7 +465,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     The default pressure at which pumps and powered equipment max out at, in kPa.
         /// </summary>
-        public const float MaxOutputPressure = 9000; ///Starlight edit
+        public const float MaxOutputPressure = 4500;
 
         /// <summary>
         ///     The default maximum speed powered equipment can work at, in L/s.


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Reverts https://github.com/ss14Starlight/space-station-14/pull/3115, returning gas pressure levels to upstream levels.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

I've been spending a lot of time the past couple of days looking into improving Engineering and Atmos, and this is one change I cannot justify.

All gases and reactions (upstream and Funky alike) and even the TEG are balanced around the upstream level of maximum pressure. Things are just broken in terms of balance as a result of this increase.

Just to illustrate my point, two examples.

The first is metal hydrogen. It's a metal ingot (item) used for crafting e.g. armor (nothing to write home about), but requiring a gas reaction between BZ and Hydrogen at a minimum of 10,000 kPa pressure to form. This is meant to be a challenge in the sense that the pump limit is 9,000 kPa, meaning you need a way of bringing it to that pressure while also keeping it somewhat cool as the reaction is more efficient the colder it is. However, post-doubling, that challenge is entirely nullified as volume pumps and injectors go to 18,000 kPa.

Second example being the TEG. Due to the higher pressure limits, these can be pushed way beyond what was intended. The TEG already isn't balanced towards the high end, but this just exacerbates the problem:

Here's a personal attempt at a so-called HyperTEG, facilitated by higher pump limits:

<img width="1660" height="1087" alt="image" src="https://github.com/user-attachments/assets/3dc2a819-611b-41b7-a1ed-52bd3a62e993" />

I don't think I need to explain that 45MW (or more) is excessive when the average station uses 300-500 kW.

These examples aren't meant to be exhaustive, but I think you get the gist that nothing else was designed around this.

After revering we have a more sane baseline that we can balance actual changes off of, which is my leading motivator for wanting to revert this.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

N/a

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- tweak: Maximum atmospheric device output pressures have been reverted to their non-doubled levels.
