### PR TITLE
Give cyborgs access to their own department head's office

### DIFF
--- a/Resources/Prototypes/_Starlight/borg_types.yml
+++ b/Resources/Prototypes/_Starlight/borg_types.yml
@@ -177,6 +177,7 @@
     tags:
     - Borg
     - Debrief
+    - HeadOfPersonnel
 
   # Visual
   inventoryTemplateId: borgTall
@@ -228,3 +229,4 @@
       tags:
         - Borg
         - BorgCargo
+        - Quartermaster

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -37,6 +37,7 @@
       tags:
         - Borg
         - BorgResearch
+        - ResearchDirector
   # Starlight END
 
 # Engineering borg
@@ -79,6 +80,7 @@
     tags:
       - Borg
       - BorgEngineering
+      - ChiefEngineer
   # Starlight end
 
   # Visual
@@ -146,6 +148,7 @@
     tags:
       - Borg
       - BorgCargo
+      - Quartermaster
   # Starlight-end
 
 
@@ -233,7 +236,8 @@
       - CyborgAllAccess
     tags:
       - Borg
-      - BorgMedical # Starlight END
+      - BorgMedical
+      - ChiefMedicalOfficer # Starlight END
 
   # Visual
   inventoryTemplateId: borgDutch


### PR DESCRIPTION
## Short description
Following the community poll, each chassis now gets access to the office of the head it actually works under: generic to the RD, engineering to the CE, medical to the CMO, mining and cargo to the QM, and purrfus to the HoP. The janitor and service chassis are deliberately left unchanged, as neither has a reason to enter the HoP's office.

Captain, Armory, Debrief, Magistrate, Ntrep and BlueShield remain ungranted to every chassis. CyborgAllAccess itself is untouched, so CyborgAllAccessParityTest continues to hold.

## Why we need to add this
Increase the RP potential, and as requested in [this poll](https://discord.com/channels/1272545509562777621/1322283126285668382/1516924359846138067) (208 "all access" / 347 "some access by chassis" / 121 "no access").

Note that borgs currently have no head office access at all, so this adds access rather than restricting it.

## Media (Video/Screenshots)
-

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Glaud
- add: Some cyborgs can now enter the office of their own department's Head of Staff. 