### PR TITLE
Fix evil antag railroading cards not spawning

### DIFF
--- a/Content.Server/_Starlight/Railroading/RailroadRuleSystem.cs
+++ b/Content.Server/_Starlight/Railroading/RailroadRuleSystem.cs
@@ -231,10 +231,10 @@ public sealed partial class RailroadRuleSystem : GameRuleSystem<RailroadRuleComp
                 else
                     ruleEnt.Comp.PoolByObjective.Add(objectiveProtoId, [(card.Owner, card.Comp, ruleOwner)]);
             }
-            else
-            {
-                ruleEnt.Comp.Pool.Add((card.Owner, card.Comp, ruleOwner));
-            }
+        }
+        else
+        {
+            ruleEnt.Comp.Pool.Add((card.Owner, card.Comp, ruleOwner));
         }
     }
 


### PR DESCRIPTION
## Short description
Fix the multi month old issue where terminator, criminal, etc cards just stopped spawning entirely

code was shifted in #4318 that handled the case where cards without complex spawn requirements are added, making it impossible for cards without RailroadSpawnFlow to appear at all

I presume author just thought it was a duplicate of the above section or didn't fully understand what the code block was doing, as is it also would have caused a bunch of weird behaviour when cards that don't have any candidates get added to the pool, imagine john mctider getting offered brighteye cards

either way, fixed now

## Why we need to add this
distinct lack of criminal captains griefing entire rounds recently

## Media (Video/Screenshots)
<img width="548" height="483" alt="image" src="https://github.com/user-attachments/assets/3383fe1c-2fc7-47cb-af45-c14cbc7181ed" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Arkanic
- fix: Fixed criminal, terminator, etc railroading cards not appearing.
