### PR TITLE
Disable brighteye from rolling

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -69,7 +69,7 @@
     #- id: SubXenoborgs
     #- id: TerrorSpidersSpawn
     - id: RailroadingTerminator
-    - id: Brighteye
+    #- id: Brighteye # Brighteye is disabled until more work is put in.
     - id: ColossusSpawn # Starlight end
     - id: EeepEvent # imp
     - !type:NestedSelector

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -30,8 +30,8 @@
       prob: 0.05 # Starlight. We can go back down to 0.05, since they scale now.
     #- id: SubXenoborgs # Starlight, subgamemode replaced with SubXenoborgs
     #  prob: 0.05 # Starlight start, Equalizing subgamemodes
-    - id: Brighteye
-      prob: 0.05
+    #- id: Brighteye # Brighteye is disabled until more work is put in.
+    #  prob: 0.05
     - id: SiliconLiberation
       prob: 0.20 #Starlight end
 
@@ -49,8 +49,8 @@
       prob: 0.20
     #- id: SubXenoborgs # Starlight, subgamemode replaced with SubXenoborgs
     #  prob: 0.05
-    - id: Brighteye
-      prob: 0.05
+    #- id: Brighteye # Starlight - disabled from rolling
+    #  prob: 0.05
     - id: SiliconLiberation
       prob: 0.20 #Starlight end
 
@@ -68,8 +68,8 @@
       prob: 0.20 # Starlight, Xenoborgs need a little bit of a distraction
     - id: SubWizard
       prob: 0.05 # Starlight Space is dangerous, yo.
-    - id: Brighteye # Starlight
-      prob: 0.05
+    #- id: Brighteye # Starlight - disabled from rolling
+    #  prob: 0.05
     - id: SiliconLiberation #Starlight
       prob: 0.20 #Starlight
 
@@ -85,8 +85,8 @@
       prob: 0.15
     - id: VampireLess # Reworked
       prob: 0.15
-    - id: Brighteye
-      prob: 0.05
+    #- id: Brighteye # Starlight - disabled from rolling
+    #  prob: 0.05
     - id: SiliconLiberation
       prob: 0.2 #Starlight end
 

--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -298,14 +298,14 @@
             min: 10
           - !type:RoundDurationCondition
             min: 1200 # 20 minutes
-        - id: Brighteye
-          weight: 1
-          conditions:
-          - !type:HasBudgetCondition
-          - !type:PlayerCountCondition
-            min: 20
-          - !type:RoundDurationCondition
-            min: 1200 # 20 minutes
+        #- id: Brighteye # Brighteye is disabled until more work is put in.
+        #  weight: 1
+        #  conditions:
+        #  - !type:HasBudgetCondition
+        #  - !type:PlayerCountCondition
+        #    min: 20
+        #  - !type:RoundDurationCondition
+        #    min: 1200 # 20 minutes
         - id: EeepEvent
           weight: 1
           conditions:
@@ -630,14 +630,14 @@
             min: 10
           - !type:RoundDurationCondition
             min: 1200 # 20 minutes
-        - id: Brighteye
-          weight: 1
-          conditions:
-          - !type:HasBudgetCondition
-          - !type:PlayerCountCondition
-            min: 20
-          - !type:RoundDurationCondition
-            min: 1200 # 20 minutes
+        #- id: Brighteye # Starlight - disabled from rolling
+        #  weight: 1
+        #  conditions:
+        #  - !type:HasBudgetCondition
+        #  - !type:PlayerCountCondition
+        #    min: 20
+        #  - !type:RoundDurationCondition
+        #    min: 1200 # 20 minutes
         - id: EeepEvent
           weight: 1
           conditions:

--- a/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
@@ -15,8 +15,8 @@
       prob: 0.05 # rare
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #  prob: 0.05
-    - id: Brighteye
-      prob: 0.05 # We can go back down to 0.05, since they scale now.
+    #- id: Brighteye # Brighteye is disabled until more work is put in.
+    #  prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation
       prob: 0.17
 
@@ -36,8 +36,8 @@
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #      prob: 0.05
-    - id: Brighteye
-      prob: 0.05 # We can go back down to 0.05, since they scale now.
+    #- id: Brighteye # Starlight - disabled from rolling
+    #  prob: 0.05 # We can go back down to 0.05, since they scale now.
     # No SELF Agents in rev games because of the FREEmag.
     # no devil because this is the secret set used for conversion antags i guess? either way dont want revs spamming devil
 
@@ -57,8 +57,8 @@
       prob: 0.05 # rare
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #  prob: 0.05
-    - id: Brighteye
-      prob: 0.05 # We can go back down to 0.05, since they scale now.
+    #- id: Brighteye # Starlight - disabled from rolling
+    #  prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation
       prob: 0.20
 
@@ -76,8 +76,8 @@
       prob: 0.05
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #      prob: 0.05
-    - id: Brighteye
-      prob: 0.05
+    #- id: Brighteye # Starlight - disabled from rolling
+    #  prob: 0.05
     - id: SiliconLiberation
       prob: 0.12
 
@@ -97,8 +97,8 @@
       prob: 0.20
     #- id: SubXenoborgs # I think there's interesting roleplay opportunity if Xenoborgs spawn. You could willingly choose to get borged to prevent infection. I want to see how this plays out.
     #  prob: 0.05
-    - id: Brighteye
-      prob: 0.05 # We can go back down to 0.05, since they scale now.
+    #- id: Brighteye # Starlight - disabled from rolling
+    #  prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation # I mean technically there's nothing inherently wrong with them showing up.
       prob: 0.15
 


### PR DESCRIPTION
## Short description
The brighteye antag is not finished and shouldn't be rolled until completed.

## Why we need to add this
People just don't really enjoy playing against the brighteye, personally I didn't enjoy playing as it, you can very easily softlock yourself and there is no real goal, I also don't really think an antag thats as OP as it is should have a race preference with goals to protect certain crew members.

https://discord.com/channels/1272545509562777621/1504451169848918150

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Mack
- remove: Disabled the Bright-Eye antag from rolling.