### PR TITLE
Fix whispering with language prefix

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -816,7 +816,7 @@ public sealed partial class ChatUIController : UIController
                 chatChannel = ChatSelectChannel.Dead;
         }
 
-        return (chatChannel, text[1..].TrimStart(), null, null, language); //Starlight edit
+        return (chatChannel, text, null, null, language); //Starlight edit - Whispering is weird just parse out the comma later...
     }
 
     public void SendMessage(ChatBox box, ChatSelectChannel channel)

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -222,8 +222,11 @@ public sealed partial class ChatSystem : SharedChatSystem
             language = _language.GetLanguageFromPrefix(source, ref message.Text, out _, true);
         else language = languageOverride ?? _language.GetLanguage(source);
 
-        // Parse out the whisper prefix here instead of before whisper cmd to fix language prefix bullshittery
-        if (message.Text.StartsWith(WhisperPrefix))
+        // Parse out the whisper and emote prefix here instead of before whisper cmd to fix language prefix bullshittery
+        if (message.Text.StartsWith(WhisperPrefix) && desiredType == InGameICChatType.Whisper)
+            message.Text = message.Text[1..];
+        else if ((message.Text.StartsWith(EmotesPrefix) || message.Text.StartsWith(EmotesAltPrefix)) &&
+                 desiredType == InGameICChatType.Emote)
             message.Text = message.Text[1..];
         // Starlight end
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -221,6 +221,10 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (message.Text.StartsWith(SharedLanguageSystem.ChatPrefixChar))
             language = _language.GetLanguageFromPrefix(source, ref message.Text, out _, true);
         else language = languageOverride ?? _language.GetLanguage(source);
+
+        // Parse out the whisper prefix here instead of before whisper cmd to fix language prefix bullshittery
+        if (message.Text.StartsWith(WhisperPrefix))
+            message.Text = message.Text[1..];
         // Starlight end
 
         bool shouldCapitalize = (desiredType != InGameICChatType.Emote);


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Does what it says on the tin, makes so sending a message like `+mof,hello` will properly whisper the word "Hello" in moffic instead of whispering "Mof,hello" in galcom or whatever your current language is.
This was accomplished by moving the parsing out of the whisper prefix to the serverside message handling instead of attempting to do so clientside before sending the whisper command to server.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Objective chat improvement
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Fix whisper messages that start with a language prefix (e.g. "+mof,hello" now whispers "Hello" in Moffic instead of "Mof,hello" in your currently selected language).