### PR TITLE
Changes "cap gun [Fake]" to "cap gun [Lethal]" in the spawn panel

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/weapons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/weapons.yml
@@ -173,7 +173,7 @@
 - type: entity
   parent: RevolverCapGun
   id: RevolverCapGunFake
-  suffix: Fake
+  suffix: Lethal # Starlight - Fake -> Lethal to make it obvious to mappers which one shoots actual bullets
   components:
   - type: RevolverAmmoProvider
     whitelist:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Changes the `suffix` on `RevolverCapGunFake` to be "Lethal" instead of "Fake".

Not a player-facing change, this suffix only shows up in the spawn menu.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
English double-negatives make it hard to rationalize which one is the toy and which one is the one that shoots actual live munitions.

<img width="241" height="89" alt="image" src="https://github.com/user-attachments/assets/31e4cb19-103d-43a3-a7b1-b09a27a1d990" />

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="349" height="398" alt="image" src="https://github.com/user-attachments/assets/9d1dfe9e-7004-4687-9d35-2d3ddeecc78c" />

fig. 1 - It's now very obvious which gun is the scary lethal one.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

