### PR TITLE
Revert "Change smoke/foam/explosion chemistry reaction order & energy…

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -108,7 +108,6 @@
   id: PotassiumExplosion
   impact: High
   priority: 20
-  conserveEnergy: false
   reactants:
     Water:
       amount: 1
@@ -124,9 +123,8 @@
 
 - type: reaction
   id: Smoke
-  priority: -10
+  priority: 10
   impact: High
-  conserveEnergy: false
   reactants:
     Phosphorus:
       amount: 1
@@ -143,9 +141,8 @@
 
 - type: reaction
   id: Foam
-  priority: -10
+  priority: 10
   impact: High
-  conserveEnergy: false
   reactants:
     Fluorosurfactant:
       amount: 1
@@ -161,8 +158,7 @@
 - type: reaction
   id: IronMetalFoam
   impact: High
-  priority: -10
-  conserveEnergy: false
+  priority: 10
   reactants:
     Iron:
       amount: 3
@@ -180,8 +176,7 @@
 - type: reaction
   id: AluminiumMetalFoam
   impact: High
-  priority: -10
-  conserveEnergy: false
+  priority: 10
   reactants:
     Aluminium:
       amount: 3
@@ -200,7 +195,6 @@
   id: UraniumEmpExplosion
   impact: High
   priority: 20
-  conserveEnergy: false
   reactants:
     Iron:
       amount: 1
@@ -219,7 +213,6 @@
   id: Flash
   impact: High
   priority: 20
-  conserveEnergy: false
   reactants:
     Aluminium:
       amount: 1


### PR DESCRIPTION
… transfer (#37915)"

This reverts commit d3cdae5a9271f1de3355e2e22b0aa423502c5230.

## Short description
add chemical explosion energy transfer back . now you can properly heat up chemical on floor using explosion or other heat sources

## Why we need to add this
it allow antags in medbay using more tools to deal with their targed and get creative with chemical and chem bomb instead of what we have which is 10 toxin mixed togather or just napalm phlog that prob RR their teach lesson targed

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/1cb72d37-ea5c-4d31-9d41-82ebbf0ff6a6

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Jack
- tweak: Reverted PR #37915.
- tweak: Chemicals now retain heat when thrown or spilled.


