### PR TITLE
Revert "Disable brighteye from rolling (#5320)"

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -69,7 +69,7 @@
     #- id: SubXenoborgs
     #- id: TerrorSpidersSpawn
     - id: RailroadingTerminator
-    #- id: Brighteye # Brighteye is disabled until more work is put in.
+    - id: Brighteye
     - id: ColossusSpawn # Starlight end
     - id: EeepEvent # imp
     - !type:NestedSelector

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -30,8 +30,8 @@
       prob: 0.05 # Starlight. We can go back down to 0.05, since they scale now.
     #- id: SubXenoborgs # Starlight, subgamemode replaced with SubXenoborgs
     #  prob: 0.05 # Starlight start, Equalizing subgamemodes
-    #- id: Brighteye # Brighteye is disabled until more work is put in.
-    #  prob: 0.05
+    - id: Brighteye
+      prob: 0.05
     - id: SiliconLiberation
       prob: 0.20 #Starlight end
 
@@ -49,8 +49,8 @@
       prob: 0.20
     #- id: SubXenoborgs # Starlight, subgamemode replaced with SubXenoborgs
     #  prob: 0.05
-    #- id: Brighteye # Starlight - disabled from rolling
-    #  prob: 0.05
+    - id: Brighteye
+      prob: 0.05
     - id: SiliconLiberation
       prob: 0.20 #Starlight end
 
@@ -68,8 +68,8 @@
       prob: 0.20 # Starlight, Xenoborgs need a little bit of a distraction
     - id: SubWizard
       prob: 0.05 # Starlight Space is dangerous, yo.
-    #- id: Brighteye # Starlight - disabled from rolling
-    #  prob: 0.05
+    - id: Brighteye # Starlight
+      prob: 0.05
     - id: SiliconLiberation #Starlight
       prob: 0.20 #Starlight
 
@@ -85,8 +85,8 @@
       prob: 0.15
     - id: VampireLess # Reworked
       prob: 0.15
-    #- id: Brighteye # Starlight - disabled from rolling
-    #  prob: 0.05
+    - id: Brighteye
+      prob: 0.05
     - id: SiliconLiberation
       prob: 0.2 #Starlight end
 

--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -298,14 +298,14 @@
             min: 10
           - !type:RoundDurationCondition
             min: 1200 # 20 minutes
-        #- id: Brighteye # Brighteye is disabled until more work is put in.
-        #  weight: 1
-        #  conditions:
-        #  - !type:HasBudgetCondition
-        #  - !type:PlayerCountCondition
-        #    min: 20
-        #  - !type:RoundDurationCondition
-        #    min: 1200 # 20 minutes
+        - id: Brighteye
+          weight: 1
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:PlayerCountCondition
+            min: 20
+          - !type:RoundDurationCondition
+            min: 1200 # 20 minutes
         - id: EeepEvent
           weight: 1
           conditions:
@@ -630,14 +630,14 @@
             min: 10
           - !type:RoundDurationCondition
             min: 1200 # 20 minutes
-        #- id: Brighteye # Starlight - disabled from rolling
-        #  weight: 1
-        #  conditions:
-        #  - !type:HasBudgetCondition
-        #  - !type:PlayerCountCondition
-        #    min: 20
-        #  - !type:RoundDurationCondition
-        #    min: 1200 # 20 minutes
+        - id: Brighteye
+          weight: 1
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:PlayerCountCondition
+            min: 20
+          - !type:RoundDurationCondition
+            min: 1200 # 20 minutes
         - id: EeepEvent
           weight: 1
           conditions:

--- a/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
@@ -15,8 +15,8 @@
       prob: 0.05 # rare
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #  prob: 0.05
-    #- id: Brighteye # Brighteye is disabled until more work is put in.
-    #  prob: 0.05 # We can go back down to 0.05, since they scale now.
+    - id: Brighteye
+      prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation
       prob: 0.17
 
@@ -36,8 +36,8 @@
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #      prob: 0.05
-    #- id: Brighteye # Starlight - disabled from rolling
-    #  prob: 0.05 # We can go back down to 0.05, since they scale now.
+    - id: Brighteye
+      prob: 0.05 # We can go back down to 0.05, since they scale now.
     # No SELF Agents in rev games because of the FREEmag.
     # no devil because this is the secret set used for conversion antags i guess? either way dont want revs spamming devil
 
@@ -57,8 +57,8 @@
       prob: 0.05 # rare
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #  prob: 0.05
-    #- id: Brighteye # Starlight - disabled from rolling
-    #  prob: 0.05 # We can go back down to 0.05, since they scale now.
+    - id: Brighteye
+      prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation
       prob: 0.20
 
@@ -76,8 +76,8 @@
       prob: 0.05
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #      prob: 0.05
-    #- id: Brighteye # Starlight - disabled from rolling
-    #  prob: 0.05
+    - id: Brighteye
+      prob: 0.05
     - id: SiliconLiberation
       prob: 0.12
 
@@ -97,8 +97,8 @@
       prob: 0.20
     #- id: SubXenoborgs # I think there's interesting roleplay opportunity if Xenoborgs spawn. You could willingly choose to get borged to prevent infection. I want to see how this plays out.
     #  prob: 0.05
-    #- id: Brighteye # Starlight - disabled from rolling
-    #  prob: 0.05 # We can go back down to 0.05, since they scale now.
+    - id: Brighteye
+      prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation # I mean technically there's nothing inherently wrong with them showing up.
       prob: 0.15
 


### PR DESCRIPTION
This reverts commit ec60708f49b923d109f3df270593215c180bba72.

## Short description
Reenables brighteyes antag until there was an actual community vote about it.

## Why we need to add this
No idea *why* this was seen as necessary to do. There are plenty of people who *do* enjoy the RP antag nature of it, and this came entirely out of nowhere.
While the sentiment isn't unfounded, maybe we should just... Ask people first?

## Media (Video/Screenshots)
No images, clean revert

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
(Don't really want to take credit for just... pressing revert :sweat_smile: )

:cl: STARLIGHT TEAM
- add: Reenabled Brighteyes for now.
