### PR TITLE
Rip and Tear

### DIFF
--- a/Resources/Locale/en-US/_Starlight/tools/tool-qualities.ftl
+++ b/Resources/Locale/en-US/_Starlight/tools/tool-qualities.ftl
@@ -1,2 +1,5 @@
 tool-quality-censer-name = Censer
 tool-quality-censer-tool-name = Censer
+
+tool-quality-tearing-name = Tearing
+tool-quality-tearing-tool-name = Fireaxe

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -40,7 +40,9 @@
   - type: Tool
     qualities:
       - Prying
+      - Tearing # Starlight
   - type: ToolTileCompatible
+    delay: 6 # Starlight
   - type: Prying
     useSoundOnDoafter: /Audio/_Starlight/Machines/airlock_pry.ogg #SL
     playSoundOnDoafter: true #SL
@@ -80,3 +82,6 @@
     slots:
     - back
     - suitStorage
+  - type: Tool # Ronstation start
+    qualities:
+      - Prying # Ronstation end

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -82,6 +82,3 @@
     slots:
     - back
     - suitStorage
-  - type: Tool # Ronstation start
-    qualities:
-      - Prying # Ronstation end

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -4,6 +4,7 @@
   sprite: /Textures/Tiles/plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Tearing ] # Starlight
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -19,7 +20,7 @@
   - 1.0
   - 1.0
   baseTurf: Plating # Starlight-edit - swap baseTurf to Plating, so when we weld it, we revert to that.
-  deconstructTools: [ Welding ] # Starlight - add welding as a deconstruct interaction, so we have an easy way to mend it.
+  deconstructTools: [ Welding, Tearing ] # Starlight - add welding as a deconstruct interaction, so we have an easy way to mend it.
   itemDrop: NothingEntity # Starlight - remove drop
   isSubfloor: true
   footstepSounds:
@@ -33,6 +34,7 @@
   sprite: /Textures/Tiles/Asteroid/asteroid_plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Tearing ] # Starlight
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -44,6 +46,7 @@
   sprite: /Textures/Tiles/Misc/clockwork/clockwork_floor.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Tearing ] # Starlight
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -55,6 +58,7 @@
   sprite: /Textures/Tiles/snow_plating.png #Not in the snow planet RSI because it doesn't have any metadata. Should probably be moved to its own folder later.
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Tearing ] # Starlight
   footstepSounds:
     collection: FootstepPlating
   friction: 0.75 #a little less then actual snow

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Weapons/Melee/h2_fireaxe.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Weapons/Melee/h2_fireaxe.yml
@@ -23,6 +23,7 @@
   - type: Tool
     qualities:
       - Prying
+      - Tearing # Starlight
   - type: Construction
     graph: MetalHydrogenAxeConstruct
     node: icon

--- a/Resources/Prototypes/_Starlight/tool_qualities.yml
+++ b/Resources/Prototypes/_Starlight/tool_qualities.yml
@@ -1,0 +1,6 @@
+- type: tool
+  id: Tearing
+  name: tool-quality-tearing-name
+  toolName: tool-quality-tearing-tool-name
+  spawn: FireAxe
+  icon: { sprite: Objects/Weapons/Melee/fireaxe.rsi, state: icon }


### PR DESCRIPTION
## Short description
Allows the Atmos Fireaxe/Metal Hydrogen Axe to tear plating. The antag axe cannot do this.

Somewhat a port of [this pr](https://github.com/RonRonstation/ronstation/pull/184) from Ronstation; it's in Wizden files, which they cite as dual licensed to MIT.

## Why we need to add this
Mostly to go along with https://github.com/ss14Starlight/space-station-14/pull/5338, to give a way to tear tiles that doesn't create sparks.

## Media (Video/Screenshots)
[Content.Client_mX7Mze7mDE.webm](https://github.com/user-attachments/assets/7305f9e9-05e0-41d3-9408-7e0df869d531)


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld, Merrokitsune
- add: The fire axes can now tear plating.

