### PR TITLE
Fix AI warp showing Monument

### DIFF
--- a/Content.Server/Silicons/StationAi/StationAiSystem.cs
+++ b/Content.Server/Silicons/StationAi/StationAiSystem.cs
@@ -53,6 +53,7 @@ using Robust.Shared.Log;
 using Robust.Shared.Map;
 using System.Collections.Generic;
 using Content.Shared._Starlight.StationAi;
+using Content.Shared.Tag;
 #endregion Starlight
 
 namespace Content.Server.Silicons.StationAi;
@@ -79,6 +80,7 @@ public sealed partial class StationAiSystem : SharedStationAiSystem
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     // Starlight Start
     [Dependency] private IMapManager _map = default!;
+    [Dependency] private TagSystem _tags = default!;
     [Dependency] private SuitSensorSystem _suitSensors = default!;
     [Dependency] private FollowerSystem _followerSystem = default!;
     [Dependency] private StationAiVisionSystem _aiVision = default!;
@@ -87,6 +89,7 @@ public sealed partial class StationAiSystem : SharedStationAiSystem
     private readonly HashSet<Entity<StationAiCoreComponent>> _stationAiCores = new();
 
     // Starlight-start
+    private readonly ProtoId<TagPrototype> _ignoreWarpTag = new("GhostOnlyWarp");
     private readonly Dictionary<EntityUid, EntityUid> _activeFollowTargets = new();
     private readonly List<EntityUid> _followTargetsToRemove = new();
     private readonly ISawmill _warpSawmill = Logger.GetSawmill("stationai.warp");
@@ -272,6 +275,11 @@ public sealed partial class StationAiSystem : SharedStationAiSystem
 
             if (string.IsNullOrWhiteSpace(warp.Location))
                 continue;
+
+            // Starlight Start
+            if (_tags.HasTag(uid, _ignoreWarpTag))
+                continue;
+            // Starlight End
 
             if (aiStation is { } station)
             {

--- a/Resources/Prototypes/_Starlight/CosmicCult/Tileset/monument.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Tileset/monument.yml
@@ -97,7 +97,6 @@
   - type: GuideHelp
     guides:
     - CosmicCult
-    location: The Monument
   - type: CosmicCultExamine
     cultistText: cosmic-examine-text-forthecult
   - type: CosmicCorrupting

--- a/Resources/Prototypes/_Starlight/CosmicCult/Tileset/monument.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Tileset/monument.yml
@@ -97,6 +97,15 @@
   - type: GuideHelp
     guides:
     - CosmicCult
+  - type: WarpPoint
+    follow: false
+    location: The Monument
+    blacklist:
+      tags:
+        - GhostOnlyWarp
+  - type: Tag
+    tags:
+      - GhostOnlyWarp
   - type: CosmicCultExamine
     cultistText: cosmic-examine-text-forthecult
   - type: CosmicCorrupting

--- a/Resources/Prototypes/_Starlight/CosmicCult/Tileset/monument.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Tileset/monument.yml
@@ -97,7 +97,6 @@
   - type: GuideHelp
     guides:
     - CosmicCult
-  - type: WarpPoint
     location: The Monument
   - type: CosmicCultExamine
     cultistText: cosmic-examine-text-forthecult


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Makes the CosCult monument warp point ghost only and makes the AI core warps not show ghost warps.
Done by Red, Applied by me
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Fixes an issue where AI could warp to the monument
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: redmushie
- fix: Issue where AI could teleport to the Monument.