### PR TITLE
The Fire (space) Axe can no longer tear

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -84,5 +84,4 @@
     - suitStorage
   - type: Tool # Ronstation start
     qualities:
-      - Prying
-      - Tearing # Ronstation end
+      - Prying # Ronstation end

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -82,3 +82,7 @@
     slots:
     - back
     - suitStorage
+  - type: Tool # Ronstation start
+    qualities:
+      - Prying
+      - Tearing # Ronstation end


### PR DESCRIPTION
## Short description
I was convinced to change this at 1 in the morning but after getting a good 8 hours of sleep I have realized my folly.

## Why we need to add this
The antag one shouldn't be able to tear, it's too useful for being a weapon.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: The syndicate fire axe can no longer tear plating.
