### PR TITLE
Unpredict Throwing™

### DIFF
--- a/Content.Client/_Starlight/Throwing/PredictedThrownItemSystem.cs
+++ b/Content.Client/_Starlight/Throwing/PredictedThrownItemSystem.cs
@@ -1,5 +1,7 @@
 using Content.Shared._Starlight.Throwing;
+using Content.Shared.Throwing;
 using Robust.Client.Physics;
+using Robust.Client.Player;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 
@@ -8,6 +10,7 @@ namespace Content.Client._Starlight.Throwing;
 public sealed partial class PredictedThrownItemSystem : EntitySystem
 {
     [Dependency] private SharedPhysicsSystem _phys = default!;
+    [Dependency] private IPlayerManager _plr = default!;
 
     public override void Initialize()
     {
@@ -18,8 +21,13 @@ public sealed partial class PredictedThrownItemSystem : EntitySystem
         SubscribeLocalEvent<PredictedThrownItemComponent, UpdateIsPredictedEvent>(OnUpdatePredicted);
     }
 
-    private void OnStartup(Entity<PredictedThrownItemComponent> ent, ref ComponentStartup args) =>
+    private void OnStartup(Entity<PredictedThrownItemComponent> ent, ref ComponentStartup args)
+    {
+        if (!TryComp<ThrownItemComponent>(ent, out var thrown)) return;
+        if (_plr.LocalEntity is null) return;
+        if (thrown.Thrower != _plr.LocalEntity.Value) return; // This always ends up being 0 on other clients and 0 on the last frame of prediction... SURELY NOT AN ISSUE...
         _phys.UpdateIsPredicted(ent.Owner);
+    }
 
     private void OnShutdown(Entity<PredictedThrownItemComponent> ent, ref ComponentShutdown args) =>
         Timer.Spawn(3000, () =>
@@ -27,6 +35,11 @@ public sealed partial class PredictedThrownItemSystem : EntitySystem
             _phys.UpdateIsPredicted(ent.Owner);
         });
 
-    private void OnUpdatePredicted(Entity<PredictedThrownItemComponent> ent, ref UpdateIsPredictedEvent args) =>
+    private void OnUpdatePredicted(Entity<PredictedThrownItemComponent> ent, ref UpdateIsPredictedEvent args)
+    {
+        if (!TryComp<ThrownItemComponent>(ent, out var thrown)) return;
+        if (_plr.LocalEntity is null) return;
+        if (thrown.Thrower != _plr.LocalEntity.Value) return;
         args.IsPredicted = true;
+    }
 }

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared._Starlight.Abstract.Extensions;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Camera;
 using Content.Shared.CCVar;
@@ -15,7 +16,8 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Content.Shared._Starlight.Throwing; // Starlight
-using Robust.Shared.Network; // Starlight
+using Robust.Shared.Network;
+using Robust.Shared.Random; // Starlight
 
 namespace Content.Shared.Throwing;
 
@@ -40,14 +42,25 @@ public sealed partial class ThrowingSystem : EntitySystem
     [Dependency] private ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private IConfigurationManager _configManager = default!;
     [Dependency] private INetManager _net = default!; // Starlight
+    [Dependency] private IRobustRandom _random = default!; // Starlight
 
     private EntityQuery<AnchorableComponent> _anchorableQuery;
+    // Starlight begin
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+    /// <summary>
+    /// Items dropped when the holder falls down will be launched in
+    /// a direction offset by up to this many degrees from the holder's
+    /// movement direction.
+    /// </summary>
+    private const float DropHeldItemsSpread = 45;
+    // Starlight end
 
     public override void Initialize()
     {
         base.Initialize();
 
         _anchorableQuery = GetEntityQuery<AnchorableComponent>();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>(); // Starlight
 
         Subs.CVar(_configManager, CCVars.TileFrictionModifier, value => _frictionModifier = value, true);
         Subs.CVar(_configManager, CCVars.AirFriction, value => _airDamping = value, true);
@@ -65,7 +78,7 @@ public sealed partial class ThrowingSystem : EntitySystem
         bool animated = true,
         bool playSound = true,
         bool doSpin = true,
-        bool predicted = true, // Starlight
+        bool predicted = false, // Starlight
         ThrowingUnanchorStrength unanchor = ThrowingUnanchorStrength.None)
     {
         var thrownPos = _transform.GetMapCoordinates(uid);
@@ -99,7 +112,7 @@ public sealed partial class ThrowingSystem : EntitySystem
         bool animated = true,
         bool playSound = true,
         bool doSpin = true,
-        bool predicted = true, // Starlight
+        bool predicted = false, // Starlight
         ThrowingUnanchorStrength unanchor = ThrowingUnanchorStrength.None)
     {
         var physicsQuery = GetEntityQuery<PhysicsComponent>();
@@ -145,7 +158,7 @@ public sealed partial class ThrowingSystem : EntitySystem
         bool animated = true,
         bool playSound = true,
         bool doSpin = true,
-        bool predicted = true, // Starlight
+        bool predicted = false, // Starlight
         ThrowingUnanchorStrength unanchor = ThrowingUnanchorStrength.None)
     {
         if (baseThrowSpeed <= 0 || direction == Vector2Helpers.Infinity || direction == Vector2Helpers.NaN || direction == Vector2.Zero || friction < 0)
@@ -235,8 +248,10 @@ public sealed partial class ThrowingSystem : EntitySystem
             _physics.SetBodyStatus(uid, physics, BodyStatus.InAir);
         }
 
+        // Starlight begin
         if (predicted)
-            EnsureComp<PredictedThrownItemComponent>(uid); // Starlight
+            EnsureComp<PredictedThrownItemComponent>(uid);
+        // Starlight end
 
         if (user == null)
             return;
@@ -263,7 +278,38 @@ public sealed partial class ThrowingSystem : EntitySystem
             _physics.ApplyLinearImpulse(user.Value, -impulseVector / physics.Mass * pushbackRatio * MathF.Min(massLimit, physics.Mass), body: userPhysics);
     }
 
+    #region Starlight
 
+    public void PredictedFallThrowItem(EntityUid holder, EntityUid item, float baseThrowSpeed)
+    {
+        // If the holder doesn't have a physics component, they ain't moving
+        var holderVelocity = _physicsQuery.TryComp(holder, out var physics) ? physics.LinearVelocity : Vector2.Zero;
+        var spreadMaxAngle = Angle.FromDegrees(DropHeldItemsSpread);
+
+        // Rotate the item's throw vector a bit for each item
+        var angleOffset = _random.NextAnglePredicted(_gameTiming, -spreadMaxAngle, spreadMaxAngle);
+        // Rotate the holder's velocity vector by the angle offset to get the item's velocity vector
+        var itemVelocity = angleOffset.RotateVec(holderVelocity);
+        // Decrease the distance of the throw by a random amount
+        itemVelocity *= _random.NextFloatPredicted(_gameTiming, 1f);
+        // Heavier objects don't get thrown as far
+        // If the item doesn't have a physics component, it isn't going to get thrown anyway, but we'll assume infinite mass
+        itemVelocity *= _physicsQuery.TryComp(item, out var heldPhysics) ? heldPhysics.InvMass : 0;
+        // Throw at half the holder's intentional throw speed and
+        // vary the speed a little to make it look more interesting
+        var throwSpeed = baseThrowSpeed * _random.NextFloatPredicted(_gameTiming, 0.45f, 0.55f);
+
+        TryThrow(item,
+            itemVelocity,
+            throwSpeed,
+            holder,
+            pushbackRatio: 0,
+            compensateFriction: false,
+            predicted: true
+        );
+    }
+
+    #endregion
 }
 
 /// <summary>

--- a/Content.Shared/Weapons/Melee/MeleeThrowOnHitSystem.cs
+++ b/Content.Shared/Weapons/Melee/MeleeThrowOnHitSystem.cs
@@ -102,6 +102,6 @@ public sealed partial class MeleeThrowOnHitSystem : EntitySystem
         if (direction == Vector2.Zero)
             return;
 
-        _throwing.TryThrow(target, direction.Normalized() * ent.Comp.Distance, ent.Comp.Speed, user, unanchor: ent.Comp.UnanchorOnHit);
+        _throwing.TryThrow(target, direction.Normalized() * ent.Comp.Distance, ent.Comp.Speed, user, unanchor: ent.Comp.UnanchorOnHit, predicted: true); // Starlight edit
     }
 }

--- a/Content.Shared/_Starlight/Hands/PredictedHandsSystem.cs
+++ b/Content.Shared/_Starlight/Hands/PredictedHandsSystem.cs
@@ -35,15 +35,6 @@ public sealed partial class PredictedHandsSystem : EntitySystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IRobustRandom _random = default!;
 
-    private EntityQuery<PhysicsComponent> _physicsQuery;
-
-    /// <summary>
-    /// Items dropped when the holder falls down will be launched in
-    /// a direction offset by up to this many degrees from the holder's
-    /// movement direction.
-    /// </summary>
-    private const float DropHeldItemsSpread = 45;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -54,8 +45,6 @@ public sealed partial class PredictedHandsSystem : EntitySystem
         CommandBinds.Builder
             .Bind(ContentKeyFunctions.ThrowItemInHand, new PointerInputCmdHandler(HandleThrowItem))
             .Register<PredictedHandsSystem>();
-
-        _physicsQuery = GetEntityQuery<PhysicsComponent>();
     }
 
     public override void Shutdown() => CommandBinds.Unregister<PredictedHandsSystem>();
@@ -138,17 +127,13 @@ public sealed partial class PredictedHandsSystem : EntitySystem
         if (_hands.IsHolding((player, hands), throwEnt, out _) && !_hands.TryDrop(player, throwEnt.Value))
             return false;
 
-        _throwing.TryThrow(ev.ItemUid, ev.Direction, ev.ThrowSpeed, ev.PlayerUid, compensateFriction: !HasComp<LandAtCursorComponent>(ev.ItemUid));
+        _throwing.TryThrow(ev.ItemUid, ev.Direction, ev.ThrowSpeed, ev.PlayerUid, compensateFriction: !HasComp<LandAtCursorComponent>(ev.ItemUid), predicted: true);
 
         return true;
     }
 
     private void OnDropHandItems(Entity<HandsComponent> entity, ref DropHandItemsEvent args)
     {
-        // If the holder doesn't have a physics component, they ain't moving
-        var holderVelocity = _physicsQuery.TryComp(entity, out var physics) ? physics.LinearVelocity : Vector2.Zero;
-        var spreadMaxAngle = Angle.FromDegrees(DropHeldItemsSpread);
-
         foreach (var hand in entity.Comp.Hands.Keys)
         {
             if (!_hands.TryGetHeldItem(entity.AsNullable(), hand, out var heldEntity))
@@ -163,26 +148,9 @@ public sealed partial class PredictedHandsSystem : EntitySystem
             if (!_hands.TryDrop(entity.AsNullable(), hand, checkActionBlocker: false))
                 continue;
 
-            // Rotate the item's throw vector a bit for each item
-            var angleOffset = _random.NextAnglePredicted(_timing, -spreadMaxAngle, spreadMaxAngle);
-            // Rotate the holder's velocity vector by the angle offset to get the item's velocity vector
-            var itemVelocity = angleOffset.RotateVec(holderVelocity);
-            // Decrease the distance of the throw by a random amount
-            itemVelocity *= _random.NextFloatPredicted(_timing, 1f);
-            // Heavier objects don't get thrown as far
-            // If the item doesn't have a physics component, it isn't going to get thrown anyway, but we'll assume infinite mass
-            itemVelocity *= _physicsQuery.TryComp(heldEntity, out var heldPhysics) ? heldPhysics.InvMass : 0;
-            // Throw at half the holder's intentional throw speed and
-            // vary the speed a little to make it look more interesting
-            var throwSpeed = entity.Comp.BaseThrowspeed * _random.NextFloatPredicted(_timing, 0.45f, 0.55f);
-
-            _throwing.TryThrow(heldEntity.Value,
-                itemVelocity,
-                throwSpeed,
-                entity,
-                pushbackRatio: 0,
-                compensateFriction: false
-            );
+            _throwing.PredictedFallThrowItem(entity, heldEntity.Value, entity.Comp.BaseThrowspeed);
         }
     }
+
+
 }

--- a/Content.Shared/_Starlight/Storage/MouthStorageComponent.cs
+++ b/Content.Shared/_Starlight/Storage/MouthStorageComponent.cs
@@ -23,4 +23,6 @@ public sealed partial class MouthStorageComponent : Component
 
     // Mimimum inflicted damage on hit to spit out items
     [DataField] public FixedPoint2 SpitDamageThreshold = FixedPoint2.New(2);
+
+    [DataField] public float BaseThrowSpeed = 11f;
 }

--- a/Content.Shared/_Starlight/Storage/SharedMouthStorageSystem.cs
+++ b/Content.Shared/_Starlight/Storage/SharedMouthStorageSystem.cs
@@ -95,6 +95,9 @@ public abstract partial class SharedMouthStorageSystem : EntitySystem
             var ev = new FellDownThrowAttemptEvent(entity);
             RaiseLocalEvent(entity, ref ev);
 
+            if (ev.Cancelled)
+                return;
+
             _throwing.PredictedFallThrowItem(uid, entity, component.BaseThrowSpeed);
         }
     }

--- a/Content.Shared/_Starlight/Storage/SharedMouthStorageSystem.cs
+++ b/Content.Shared/_Starlight/Storage/SharedMouthStorageSystem.cs
@@ -92,7 +92,10 @@ public abstract partial class SharedMouthStorageSystem : EntitySystem
             var angle = rand.NextAngle().RotateVec(new Vector2(rand.NextFloat(), 0));
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            _throwing.TryThrow(entity, angle);
+            var ev = new FellDownThrowAttemptEvent(entity);
+            RaiseLocalEvent(entity, ref ev);
+
+            _throwing.PredictedFallThrowItem(uid, entity, component.BaseThrowSpeed);
         }
     }
 }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Makes prediction for throwing not occur for most sources of `ThrowSystem.TryThrow()`, and make so the ones that do require a thrower to predict for. Other players will not predict the thrown item but the thrower will.
Also makes rodentia spitting out items predicted properly since it's capable of doing that pretty easily.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Eliminates the erroneous visual of items teleporting ahead when thrown by other players due to the fact that we can't predict the throw itself from other players.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- add: Rodentias spitting out items is now predicted.
- fix: The Great Un-Predictening of Throwing has been implemented. (Still predicted for you, but fixes items teleporting in the air when other players and some other things cause an item to be thrown).