### PR TITLE
Add back the magic Crayon

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -699,7 +699,7 @@
     - id: FoamBlade
     - id: ClothingHeadHatBunny
     - id: PersonalAI
-    #- id: CrayonMagic # Starlight-edit commented out due to lag for now - 31-05-2026
+    #- id: CrayonMagic # Starlight-edit commented out, loadout only for now
     - id: ToySword
     - id: RevolverCapGun
     - id: ToyRubberDuck

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -115,7 +115,7 @@
   - DaBling
   - CrapPlushie ##not a typo
   - LighterGatcha
-  #- MagicCrayon starlight edit commented out for now due to lag - 31-05-2026
+  - MagicCrayon
   - HappyHonk
   - LeftRipperArm
   - RightMechwrightArm

--- a/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
@@ -471,16 +471,16 @@
     - MysteryLighterBox
   groupBy: "smokeables"
 
-#- type: loadout
-#  id: MagicCrayon
-#  effects:
-#    - !type:JobRequirementLoadoutEffect
-#      requirement:
-#        !type:OverallPlaytimeRequirement
-#        time: 360000 # 100hr
-#  storage:
-#    back:
-#      - CrayonMagic
+- type: loadout
+  id: MagicCrayon
+  effects:
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:OverallPlaytimeRequirement
+        time: 360000 # 100 hours
+  storage:
+    back:
+      - CrayonMagic
 
 - type: loadout
   id: HappyHonk


### PR DESCRIPTION
## Short description
Adds the magic crayon back to loadouts.

## Why we need to add this
Crazy has redone the decal system and as such we can attempt to add back the magic crayon.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: DocMoth
- tweak: Adds the Magic Crayon back to loadouts.

