### PR TITLE
Cap DAGD to 1

### DIFF
--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -73,7 +73,7 @@
       - StealCondition
   - type: DieCondition
   - type: ObjectiveLimit #Starlight edit
-    limit: 3 # Starlight
+    limit: 1 # Starlight | Anything above 1 is way too fucking many.
 
 #- type: entity
 #  parent: [BaseTraitorObjective, BaseLivingObjective]


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
After seeing a shift where 3 DAGDs rolled, yeah no that was actual hell crew stood zero chance, all of command and almost all of security was wiped within minutes. Genuinely no way to even play around it, 3 is too many.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Balancing.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- tweak: The limit of how many DAGD's can appear in a round has been lowered from 3 to 1.