### PR TITLE
Add Funky and Starlight gas miners for testing convenience

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/miners.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/miners.yml
@@ -1,0 +1,149 @@
+# Funky gases START
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerBZ
+  name: BZ gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: BZ
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerHealium
+  name: healium gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: Healium
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerNitrium
+  name: nitrium gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: Nitrium
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerPluoxium
+  name: pluoxium gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: Pluoxium
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerHydrogen
+  name: hydrogen gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: Hydrogen
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerHyperNoblium
+  name: hyper-noblium gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: HyperNoblium
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerProtoNitrate
+  name: proto-nitrate gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: ProtoNitrate
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerZauker
+  name: zauker gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: Zauker
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerHalon
+  name: halon gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: Halon
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerHelium
+  name: helium gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: Helium
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerAntiNoblium
+  name: anti-noblium gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: AntiNoblium
+      maxExternalPressure: 4500
+
+# Funky gases END
+# Starlight gases START
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerUlnitranium
+  name: ulnitranium gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: Ulnitranium
+      maxExternalPressure: 4500
+
+- type: entity
+  parent: GasMinerBase
+  id: GasMinerZXA
+  name: ZXA gas miner
+  categories: [ DoNotMap ]
+  suffix: 4500kPa, DO NOT MAP
+  components:
+    - type: GasMiner
+      spawnGas: ZXA
+      maxExternalPressure: 4500
+
+# Starlight gases END


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Adds DO NOT MAP gas miner prototypes for all Funky and Starlight unique gases.

The "DO NOT MAP" suffix didn't seem to auto apply this time so I added it manually. _shrugs_

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Trying to test gas changes like #5359 using cans is miserable.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/5787496b-c116-47f7-b442-b6502bd170c1

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

Not user facing, no CL