### PR TITLE
Disposals whacks you

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -79,7 +79,7 @@
     # Starlight Start
     damageOnTurn:
       types:
-        Blunt: 5
+        Blunt: 4
     maxAllowedDamage: 100
     # Starlight End
     container:

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -76,6 +76,12 @@
     traversalSpeed: 10
     exitDistanceMultiplier: 1.5
     exitSpeedMultiplier: 1
+    # Starlight Start
+    damageOnTurn:
+      types:
+        Blunt: 5
+    maxAllowedDamage: 100
+    # Starlight End
     container:
       occludes: true
       showEnts: false


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Essentially a port of https://github.com/funky-station/forky-station/pull/248 - Disposals Hurt (MIT)
But with different, far toned down damage.
5 blunt per corner, which is pretty fair imo for most maps, and capping at 100 damage
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
People escaping into dispos 100 times a shift is very tiring
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://cdn.discordapp.com/attachments/1356838103670849710/1531245987631464458/2026-07-27_20-22-42.mp4?ex=6a688374&is=6a6731f4&hm=fdef4dbc6f7583e5fb4950b117e76a1f51cff5fba1bb7584a694d6da8cadaf58&
(I couldnt find a better way to get the media to fit)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- add: Hitting a corner in disposals now deals 4 blunt, maxing at 100.