### PR TITLE
Fix chat prefixes + more langprefix fixes

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -782,7 +782,7 @@ public sealed partial class ChatUIController : UIController
         {
             language = foundLanguage;
             if (foundLanguage.ChatPrefix is null)
-                throw new Exception("how the genuine fuck did you trigger this without there being a prefix");
+                throw new Exception("Chat prefix is null? This should be impossible");
             var pfxLength = foundLanguage.ChatPrefix.Length + 1;
             if (text.Length < pfxLength + 1) return (ChatSelectChannel.None, text, null, null, foundLanguage);
             modText = text[pfxLength..];

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -781,8 +781,11 @@ public sealed partial class ChatUIController : UIController
         if (TryGetLanguage(ref text, out var foundLanguage))
         {
             language = foundLanguage;
-            if(text.Length<5) return (ChatSelectChannel.None, text, null, null, foundLanguage);
-            modText = text[4..];
+            if (foundLanguage.ChatPrefix is null)
+                throw new Exception("how the genuine fuck did you trigger this without there being a prefix");
+            var pfxLength = foundLanguage.ChatPrefix.Length + 1;
+            if (text.Length < pfxLength + 1) return (ChatSelectChannel.None, text, null, null, foundLanguage);
+            modText = text[pfxLength..];
         }
         //Starlight end
 
@@ -816,7 +819,16 @@ public sealed partial class ChatUIController : UIController
                 chatChannel = ChatSelectChannel.Dead;
         }
 
-        return (chatChannel, text, null, null, language); //Starlight edit - Whispering is weird just parse out the comma later...
+        // Starlight begin
+        if (chatChannel == ChatSelectChannel.Whisper && text.StartsWith('+')) // TRIM AHEAD
+        {
+            var idx = text.IndexOf(',');
+            text = text.Remove(idx, 1);
+            return (chatChannel, text, null, null, language);
+        }
+        // Starlight end
+
+        return (chatChannel, text[1..].TrimStart(), null, null, language); //Starlight edit
     }
 
     public void SendMessage(ChatBox box, ChatSelectChannel channel)
@@ -832,7 +844,7 @@ public sealed partial class ChatUIController : UIController
         if (string.IsNullOrWhiteSpace(text))
             return;
 
-        (var prefixChannel, text, var _, var _, _) = SplitInputContents(text); // Starlight edit
+        (var prefixChannel, text, var _, var _, var language) = SplitInputContents(text); // Starlight edit
 
         // Check if message is longer than the character limit
         if (text.Length > MaxMessageLength)
@@ -847,8 +859,14 @@ public sealed partial class ChatUIController : UIController
             channel = prefixChannel;
         else if (channel == ChatSelectChannel.Radio)
         {
-            // radio must have prefix as it goes through the say command.
-            text = $";{text}";
+            // Starlight begin
+            if (language?.ChatPrefix is not null)
+            {
+                var pfxLength = language.ChatPrefix.Length + 1;
+                text = text.Insert(pfxLength, ";");
+            }
+            else text = $";{text}";
+            // Starlight end
         }
 
         _manager.SendMessage(text, prefixChannel == 0 ? channel : prefixChannel);

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -219,15 +219,12 @@ public sealed partial class ChatSystem : SharedChatSystem
         LanguagePrototype language;
 
         if (message.Text.StartsWith(SharedLanguageSystem.ChatPrefixChar))
+        {
             language = _language.GetLanguageFromPrefix(source, ref message.Text, out _, true);
+            // tts is stupid, remove prefix from tts property. luckily this is being done before anything else so i get to just set it directly, yay me!
+            message.Tts = message.Text;
+        }
         else language = languageOverride ?? _language.GetLanguage(source);
-
-        // Parse out the whisper and emote prefix here instead of before whisper cmd to fix language prefix bullshittery
-        if (message.Text.StartsWith(WhisperPrefix) && desiredType == InGameICChatType.Whisper)
-            message.Text = message.Text[1..];
-        else if ((message.Text.StartsWith(EmotesPrefix) || message.Text.StartsWith(EmotesAltPrefix)) &&
-                 desiredType == InGameICChatType.Emote)
-            message.Text = message.Text[1..];
         // Starlight end
 
         bool shouldCapitalize = (desiredType != InGameICChatType.Emote);

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -221,7 +221,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (message.Text.StartsWith(SharedLanguageSystem.ChatPrefixChar))
         {
             language = _language.GetLanguageFromPrefix(source, ref message.Text, out _, true);
-            // tts is stupid, remove prefix from tts property. luckily this is being done before anything else so i get to just set it directly, yay me!
+            // remove prefix from tts property. luckily this is being done before anything else so i get to just set it directly, yay me!
             message.Tts = message.Text;
         }
         else language = languageOverride ?? _language.GetLanguage(source);


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Moves parsing back to client because chat code is buns.
Keeps the whisper fix for language prefixes.
Fixes trying to use language prefix while tabbed to radio chat.
Fixes TTS vocalizing the language prefix.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Fix chat prefixes showing up in some message types.
- fix: Fix language prefix not being parsed out of the message when tabbed into the radio chat.
- fix: Fix TTS vocalizing language prefixes.