### PR TITLE
(POC) SMES Priority System

### DIFF
--- a/Content.Server/_Starlight/Power/Pow3r/PowerNetworkBatteryPriorityComponent.cs
+++ b/Content.Server/_Starlight/Power/Pow3r/PowerNetworkBatteryPriorityComponent.cs
@@ -1,0 +1,73 @@
+using Content.Server.Power.Components;
+
+namespace Content.Server._Starlight.Power.Pow3r
+{
+    /// <summary>
+    ///     Optional companion to <see cref="PowerNetworkBatteryComponent"/>.
+    ///     Batteries with a higher <see cref="Priority"/> value will only be
+    ///     allowed to discharge once all batteries sharing the same output
+    ///     network with a lower Priority are already close to their supply
+    ///     cap (i.e. can't meet demand on their own).
+    /// </summary>
+    /// <remarks>
+    ///     Entities without this component are treated as Priority 0
+    ///     ("always eligible" / primary tier) by
+    ///     <see cref="PowerNetworkBatteryPrioritySystem"/>.
+    ///     This does not modify the pow3r solver at all - it only toggles
+    ///     <see cref="PowerNetworkBatteryComponent.CanDischarge"/> on/off
+    ///     from the outside based on how saturated lower-priority tiers are.
+    /// </remarks>
+    [RegisterComponent]
+    public sealed partial class PowerNetworkBatteryPriorityComponent : Component
+    {
+        /// <summary>
+        ///     Lower values discharge first. Must be greater than 0 to have
+        ///     any effect (0 is the implicit "always eligible" tier).
+        /// </summary>
+        [DataField("priority")]
+        public int Priority = 1;
+
+        /// <summary>
+        ///     Fraction (0-1) of the combined MaxSupply that lower-priority
+        ///     tiers must reach/exceed before this battery is allowed to
+        ///     start discharging.
+        /// </summary>
+        [DataField("engageThreshold")]
+        public float EngageThreshold = 0.98f;
+
+        /// <summary>
+        ///     Fraction (0-1) of the combined MaxSupply that lower-priority
+        ///     tiers must drop back below before this battery disengages
+        ///     again. Should be lower than EngageThreshold to give hysteresis
+        ///     and avoid rapid on/off flapping.
+        /// </summary>
+        [DataField("disengageThreshold")]
+        public float DisengageThreshold = 0.90f;
+
+        /// <summary>
+        ///     Fraction (0-1) of combined stored charge (CurrentStorage /
+        ///     Capacity) that lower-priority tiers must drop AT OR BELOW
+        ///     before this battery engages, regardless of rate saturation.
+        ///     Catches a primary that is running dry even though it is not
+        ///     currently rate-capped.
+        /// </summary>
+        [DataField("chargeEngageThreshold")]
+        public float ChargeEngageThreshold = 0.20f;
+
+        /// <summary>
+        ///     Fraction (0-1) of combined stored charge that lower-priority
+        ///     tiers must climb back above before this battery is allowed to
+        ///     disengage on the charge signal. Should be higher than
+        ///     ChargeEngageThreshold to give hysteresis.
+        /// </summary>
+        [DataField("chargeDisengageThreshold")]
+        public float ChargeDisengageThreshold = 0.40f;
+
+        /// <summary>
+        ///     Whether this battery is currently permitted to discharge.
+        ///     Runtime-only, not saved/loaded.
+        /// </summary>
+        [ViewVariables]
+        public bool Engaged;
+    }
+}

--- a/Content.Server/_Starlight/Power/Pow3r/PowerNetworkBatteryPrioritySystem.cs
+++ b/Content.Server/_Starlight/Power/Pow3r/PowerNetworkBatteryPrioritySystem.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
+using Content.Server.Power.Pow3r;
+using Content.Shared.Power.Components;
+using Content.Shared.Power.EntitySystems;
+using JetBrains.Annotations;
+
+namespace Content.Server._Starlight.Power.Pow3r
+{
+    /// <summary>
+    ///     Implements "backup battery" behaviour: a battery tagged with
+    ///     <see cref="PowerNetworkBatteryPriorityComponent"/> only discharges
+    ///     once lower-priority batteries on the same network are saturated
+    ///     and can no longer meet demand on their own.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately does not touch <see cref="PowerNetSystem"/>, the
+    ///     pow3r solver, <see cref="PowerNetworkBatteryComponent"/>, or
+    ///     <see cref="BatteryComponent"/>. It only reads public runtime
+    ///     state/methods already exposed on those components (including
+    ///     <see cref="SharedBatterySystem.GetCharge"/> for current charge)
+    ///     after the solver has run, and flips
+    ///     <see cref="PowerNetworkBatteryComponent.CanDischarge"/> accordingly,
+    ///     which the solver will respect on the next tick.
+    /// </remarks>
+    [UsedImplicitly]
+    public sealed class PowerNetworkBatteryPrioritySystem : EntitySystem
+    {
+        // Starlight Start
+        // BatteryComponent deliberately doesn't store a continuously-updated
+        // "current charge" field (to avoid re-networking every SMES every
+        // tick) - current charge has to be computed via GetCharge instead.
+        [Dependency] private readonly SharedBatterySystem _battery = default!;
+        // Starlight End
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            // Run after the power net has solved for this tick so we're
+            // reacting to fresh CurrentSupply/MaxSupply numbers.
+            UpdatesAfter.Add(typeof(PowerNetSystem));
+        }
+
+        public override void Update(float frameTime)
+        {
+            base.Update(frameTime);
+
+            // Group every battery on the map by the network it discharges into.
+            // Starlight Start
+            var byNetwork = new Dictionary<PowerState.NodeId, List<(EntityUid Uid, PowerNetworkBatteryComponent Comp)>>();
+            // Starlight End
+
+            var enumerator = EntityQueryEnumerator<PowerNetworkBatteryComponent>();
+            while (enumerator.MoveNext(out var uid, out var comp))
+            {
+                var netId = comp.NetworkBattery.LinkedNetworkDischarging;
+                if (netId == default)
+                    continue; // not wired up to a discharge network right now
+
+                if (!byNetwork.TryGetValue(netId, out var list))
+                {
+                    list = new List<(EntityUid, PowerNetworkBatteryComponent)>();
+                    byNetwork[netId] = list;
+                }
+
+                list.Add((uid, comp));
+            }
+
+            var priorityQuery = GetEntityQuery<PowerNetworkBatteryPriorityComponent>();
+            // Starlight Start
+            // Read charge from the entity's existing BatteryComponent rather
+            // than adding new fields to PowerNetworkBatteryComponent - it's
+            // already public and already holds this exact data (the same
+            // CurrentCharge/MaxCharge configured via `battery:` in YAML), so
+            // no core file needs to change at all.
+            var batteryQuery = GetEntityQuery<BatteryComponent>();
+            // Starlight End
+
+            foreach (var (_, batteries) in byNetwork)
+            {
+                // Bucket this network's batteries by priority tier.
+                // Untagged batteries are implicit tier 0.
+                var tiers = new SortedDictionary<int, List<(EntityUid Uid, PowerNetworkBatteryComponent Comp, PowerNetworkBatteryPriorityComponent? Prio)>>();
+
+                foreach (var (uid, comp) in batteries)
+                {
+                    priorityQuery.TryGetComponent(uid, out var prio);
+                    var tier = prio?.Priority ?? 0;
+
+                    if (!tiers.TryGetValue(tier, out var list))
+                    {
+                        list = new List<(EntityUid, PowerNetworkBatteryComponent, PowerNetworkBatteryPriorityComponent?)>();
+                        tiers[tier] = list;
+                    }
+
+                    list.Add((uid, comp, prio));
+                }
+
+                // Starlight Start
+                // Do NOT early-out on a single tier. A network can end up
+                // containing only tagged batteries (e.g. two backups wired
+                // together with no untagged primary at all) - in that case
+                // the lowest priority actually present still needs to be
+                // forced eligible below, since nothing else will ever flip
+                // it on from CanDischarge: false.
+                // Starlight End
+
+                // The solver already computes exactly the number we want:
+                // PowerNetworkBatteryComponent.LoadingNetworkDemand is set by
+                // BatteryRampPegSolver to the network's unmet demand (after
+                // ordinary generators, before battery help), identically on
+                // every discharging battery in the network, and reset to 0
+                // when there's no shortfall. Read it from tier 0 specifically
+                // - a currently-disengaged higher tier has a stale/zeroed
+                // copy of this value, since the solver skips batteries with
+                // CanDischarge == false when assigning it.
+                var tier0 = tiers[tiers.Keys.Min()];
+                float totalDemand = 0f;
+                foreach (var (_, comp, _) in tier0)
+                    totalDemand = Math.Max(totalDemand, comp.LoadingNetworkDemand);
+
+                // Walk tiers from lowest (primary) to highest (backup-most),
+                // tracking the combined MAX CAPACITY and combined stored
+                // charge of everything strictly below the current tier.
+                float cumulativeMaxBelow = 0f;
+                float cumulativeStorageBelow = 0f;
+                float cumulativeCapacityBelow = 0f;
+                var first = true;
+
+                foreach (var (_, entries) in tiers)
+                {
+                    if (!first)
+                    {
+                        // Rate signal: is demand outrunning what the lower
+                        // tiers are physically able to output right now?
+                        var rateSaturation = cumulativeMaxBelow > 0f ? totalDemand / cumulativeMaxBelow : 0f;
+
+                        // Charge signal: are the lower tiers running dry,
+                        // independent of whether they're currently rate-capped?
+                        var chargeFraction = cumulativeCapacityBelow > 0f
+                            ? cumulativeStorageBelow / cumulativeCapacityBelow
+                            : 0f;
+
+                        foreach (var (uid, comp, prio) in entries)
+                        {
+                            if (prio == null)
+                                continue; // shouldn't happen for tier > 0, but be safe
+
+                            var overloaded = prio.Engaged
+                                ? rateSaturation > prio.DisengageThreshold
+                                : rateSaturation >= prio.EngageThreshold;
+
+                            var depleted = prio.Engaged
+                                ? chargeFraction < prio.ChargeDisengageThreshold
+                                : chargeFraction <= prio.ChargeEngageThreshold;
+
+                            // Engage on either condition; only disengage once
+                            // BOTH have cleared, so a lower tier that's either
+                            // overloaded OR running dry keeps the backup on.
+                            var shouldEngage = overloaded || depleted;
+
+                            // Starlight Start
+                            // Always assign CanDischarge, not just on an
+                            // Engaged transition - otherwise a later external
+                            // write to CanDischarge (or a component that only
+                            // just started being tracked) is never corrected
+                            // back to the state this system actually wants.
+                            comp.CanDischarge = shouldEngage;
+                            if (shouldEngage != prio.Engaged)
+                                prio.Engaged = shouldEngage;
+                            // Starlight End
+                        }
+                    }
+                    // Starlight Start
+                    else
+                    {
+                        // This is the lowest priority tier actually present
+                        // on this network. There's nothing below it to defer
+                        // to, so it must always be eligible to discharge -
+                        // otherwise a network made up entirely of tagged
+                        // batteries (no untagged primary) would leave this
+                        // tier stuck at its initial CanDischarge: false
+                        // forever, since only non-lowest tiers are gated
+                        // above. Untagged (Prio == null) entries are left
+                        // alone - they were never ours to manage.
+                        foreach (var (_, comp, prio) in entries)
+                        {
+                            if (prio == null)
+                                continue;
+
+                            comp.CanDischarge = true;
+                            if (!prio.Engaged)
+                                prio.Engaged = true;
+                        }
+                    }
+                    // Starlight End
+
+                    // Starlight Start
+                    // Fold this tier's max supply into the cumulative rate
+                    // total, and its charge into the cumulative charge total.
+                    // MaxCharge is a plain public field, safe to read directly.
+                    // Current charge is NOT a stored field on BatteryComponent
+                    // (this fork computes it on demand to avoid networking
+                    // every battery every tick) - GetCharge derives it from
+                    // LastCharge/ChargeRate/LastUpdate.
+                    foreach (var (uid, comp, _) in entries)
+                    {
+                        cumulativeMaxBelow += comp.MaxSupply;
+
+                        if (batteryQuery.TryGetComponent(uid, out var battery))
+                        {
+                            Entity<BatteryComponent> batteryEnt = (uid, battery);
+                            cumulativeStorageBelow += _battery.GetCharge(batteryEnt.AsNullable());
+                            cumulativeCapacityBelow += battery.MaxCharge;
+                        }
+                    }
+                    // Starlight End
+
+                    first = false;
+                }
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Power/smes.yml
@@ -43,3 +43,54 @@
   components:
   - type: Battery
     startingCharge: 0
+
+- type: entity
+  parent: SMESBasic
+  id: SMESBasicBackup
+  suffix: Basic, 8MJ, Backup
+  name: backup SMES
+  description: A SMES unit that only discharges power when the primary supply on its network can't keep up with demand.
+  components:
+    - type: PowerNetworkBatteryPriority
+      priority: 1
+      engageThreshold: 0.98          # engage once demand hits 98% of combined lower-tier max supply (rate-capped)
+      disengageThreshold: 0.90       # disengage (rate signal) once demand drops back below 90% of lower-tier max supply
+      chargeEngageThreshold: 0.20    # engage once lower tiers' combined charge drops to 20% or below (running dry)
+      chargeDisengageThreshold: 0.40 # disengage (charge signal) once lower tiers climb back above 40% charge
+      # Engages if EITHER signal trips; only disengages once BOTH clear.
+    - type: PowerNetworkBattery
+      canDischarge: false            # starts disengaged; PowerNetworkBatteryPrioritySystem manages this at runtime
+
+- type: entity
+  parent: SMESAdvanced
+  id: SMESAdvancedBackup
+  suffix: Advanced, 16MJ, Backup
+  name: advanced backup SMES
+  description: An advanced SMES unit that only discharges power when the primary supply on its network can't keep up with demand.
+  components:
+    - type: PowerNetworkBatteryPriority
+      priority: 1
+      engageThreshold: 0.98         # engage once demand hits 98% of combined lower-tier max supply (rate-capped)
+      disengageThreshold: 0.90       # disengage (rate signal) once demand drops back below 90% of lower-tier max supply
+      chargeEngageThreshold: 0.20    # engage once lower tiers' combined charge drops to 20% or below (running dry)
+      chargeDisengageThreshold: 0.40 # disengage (charge signal) once lower tiers climb back above 40% charge
+      # Engages if EITHER signal trips; only disengages once BOTH clear.
+    - type: PowerNetworkBattery
+      canDischarge: false            # starts disengaged; PowerNetworkBatteryPrioritySystem manages this at runtime
+
+- type: entity
+  parent: SMESBlue
+  id: SMESBlueBackup
+  suffix: Hyper Advanced, 64MJ, Backup
+  name: hyper advanced backup SMES
+  description: A hyper advanced SMES unit that only discharges power when the primary supply on its network can't keep up with demand.
+  components:
+    - type: PowerNetworkBatteryPriority
+      priority: 1
+      engageThreshold: 0.98         # engage once demand hits 98% of combined lower-tier max supply (rate-capped)
+      disengageThreshold: 0.90       # disengage (rate signal) once demand drops back below 90% of lower-tier max supply
+      chargeEngageThreshold: 0.20    # engage once lower tiers' combined charge drops to 20% or below (running dry)
+      chargeDisengageThreshold: 0.40 # disengage (charge signal) once lower tiers climb back above 40% charge
+      # Engages if EITHER signal trips; only disengages once BOTH clear.
+    - type: PowerNetworkBattery
+      canDischarge: false            # starts disengaged; PowerNetworkBatteryPrioritySystem manages this at runtime


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Proof of concept - Code is AI generated and should not be merged:

Introduction of a SMES priority system. In which the current SMES would remain unchanged, and their lack of a priority label places them as Priority 0. New prototypes called backup SMES would be introduced with a Priority of 1.

Priority 0 SMES will discharge as per normal. While allowing backup SMES to store their power, until the main P0 SMES are unable to meet demand, in which case the backup SMES will begin supplying the network.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Currently, all power is drawn as equally as possible from all available SMES connected to the station's main HV network. This translates to the SMES attached to solar arrays never being able to fill due to having all that they make demanded from them at time of generation, or for them to lose what little charge they accrue when the solar panels they are attached to lose line of sight to the sun.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->



https://github.com/user-attachments/assets/d31200fb-4da4-4d74-a749-ad5f96743c26


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: OMEGA
- add: SMES priority system, which enables SMES of a higher priority to only discharge when the network needs it.
- add: backup SMES with a higher priority, for usage on secondary power sources like Solars.
