### PR TITLE
Lighting Clean Up

### DIFF
--- a/Content.Client/_CP14/Overlays/BasePostProcessOverlay.cs
+++ b/Content.Client/_CP14/Overlays/BasePostProcessOverlay.cs
@@ -41,7 +41,7 @@ public sealed class CP14BasePostProcessOverlay : Overlay
         if (args.Viewport.Eye != eyeComp.Eye)
             return false;
 
-        if (!_lightManager.Enabled || !eyeComp.Eye.DrawLight || !eyeComp.Eye.DrawFov)
+        if (!_lightManager.Enabled || !eyeComp.Eye.DrawLight)
             return false;
 
         var playerEntity = _playerManager.LocalSession?.AttachedEntity;

--- a/Content.Client/_CP14/Overlays/BasePostProcessOverlay.cs
+++ b/Content.Client/_CP14/Overlays/BasePostProcessOverlay.cs
@@ -41,7 +41,7 @@ public sealed class CP14BasePostProcessOverlay : Overlay
         if (args.Viewport.Eye != eyeComp.Eye)
             return false;
 
-        if (!_lightManager.Enabled || !eyeComp.Eye.DrawLight)
+        if (!_lightManager.Enabled || !eyeComp.Eye.DrawLight) // SL Edit made visible to ghosts
             return false;
 
         var playerEntity = _playerManager.LocalSession?.AttachedEntity;

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -228,7 +228,8 @@
   - type: PointLight
     enabled: false
     radius: 8
-    energy: 5
+    energy: 2 #SL Edits
+    softness: 0.9 #SL Edits
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -273,7 +273,7 @@
   - type: LightBulb
     color: "#EEEEFF"
     lightEnergy: 1
-    lightRadius: 15
+    lightRadius: 13 #SL Edit
     lightSoftness: 0.9
     BurningTemperature: 350
     PowerUse: 12

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -286,9 +286,9 @@
   components:
   - type: LightBulb
     color: "#B4FCF0"
-    lightEnergy: 4.5
+    lightEnergy: 4 #SL 4.5 -> 4
     lightRadius: 12
-    lightSoftness: 0.5
+    lightSoftness: 0.8 #SL 0.5 -> 0.8
     BurningTemperature: 350
     PowerUse: 100
 
@@ -326,7 +326,7 @@
   id: LightTubeCrystalCyan
   components:
   - type: LightBulb
-    color: "#47f8ff"
+    color: "#5ae8ed" #SL Edit
   - type: Construction
     graph: CyanLight
     node: icon
@@ -341,7 +341,7 @@
   id: LightTubeCrystalBlue
   components:
   - type: LightBulb
-    color: "#39a1ff"
+    color: "#4ca1eb" #SL Edit
   - type: Construction
     graph: BlueLight
     node: icon
@@ -356,7 +356,7 @@
   id: LightTubeCrystalYellow
   components:
   - type: LightBulb
-    color: "#ffde46"
+    color: "#edd25a" #SL Edit
   - type: Construction
     graph: YellowLight
     node: icon
@@ -371,7 +371,7 @@
   id: LightTubeCrystalPink
   components:
   - type: LightBulb
-    color: "#ff66cc"
+    color: "#f075c7" #SL Edit
   - type: Construction
     graph: PinkLight
     node: icon
@@ -386,7 +386,7 @@
   id: LightTubeCrystalOrange
   components:
   - type: LightBulb
-    color: "#ff8227"
+    color: "#ea863e" #SL Edit
   - type: Construction
     graph: OrangeLight
     node: icon
@@ -402,7 +402,7 @@
   id: LightTubeCrystalBlack
   components:
   - type: LightBulb
-    color: "#363636"
+    color: "#4d4d4d" #SL Edit
     lightEnergy: 1
     lightRadius: 8
   - type: DarkLight # Starlight
@@ -420,7 +420,7 @@
   id: LightTubeCrystalRed
   components:
   - type: LightBulb
-    color: "#fb4747"
+    color: "#ec5555" #SL Edit
   - type: Construction
     graph: RedLight
     node: icon
@@ -435,7 +435,7 @@
   id: LightTubeCrystalGreen
   components:
   - type: LightBulb
-    color: "#52ff39"
+    color: "#7eeb4c" #SL Edit
   - type: Construction
     graph: GreenLight
     node: icon
@@ -467,7 +467,7 @@
   id: LightBulbCrystalCyan
   components:
   - type: LightBulb
-    color: "#47f8ff"
+    color: "#5ae8ed" #SL Edit
   - type: Construction
     graph: CyanLightBulb
     node: icon
@@ -482,7 +482,7 @@
   id: LightBulbCrystalBlue
   components:
   - type: LightBulb
-    color: "#39a1ff"
+    color: "#4ca1eb" #SL Edit
   - type: Construction
     graph: BlueLightBulb
     node: icon
@@ -497,7 +497,7 @@
   id: LightBulbCrystalYellow
   components:
   - type: LightBulb
-    color: "#ffde46"
+    color: "#edd25a" #SL Edit
   - type: Construction
     graph: YellowLightBulb
     node: icon
@@ -512,7 +512,7 @@
   id: LightBulbCrystalPink
   components:
   - type: LightBulb
-    color: "#ff66cc"
+    color: "#f075c7" #SL Edit
   - type: Construction
     graph: PinkLightBulb
     node: icon
@@ -527,7 +527,7 @@
   id: LightBulbCrystalOrange
   components:
   - type: LightBulb
-    color: "#ff8227"
+    color: "#ea863e" #SL Edit
   - type: Construction
     graph: OrangeLightBulb
     node: icon
@@ -543,7 +543,7 @@
   id: LightBulbCrystalBlack
   components:
   - type: LightBulb
-    color: "#363636"
+    color: "#4d4d4d" #SL Edit
     lightEnergy: 1
     lightRadius: 8
   - type: DarkLight # Starlight
@@ -561,7 +561,7 @@
   id: LightBulbCrystalRed
   components:
   - type: LightBulb
-    color: "#fb4747"
+    color: "#ec5555" #SL Edit
   - type: Construction
     graph: RedLightBulb
     node: icon
@@ -576,7 +576,7 @@
   id: LightBulbCrystalGreen
   components:
   - type: LightBulb
-    color: "#52ff39"
+    color: "#7eeb4c" #SL Edit
   - type: Construction
     graph: GreenLightBulb
     node: icon

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -74,8 +74,8 @@
         interpolate: Nearest
         minDuration: 0.001
         maxDuration: 0.001
-        startValue: 4.0
-        endValue: 8.0
+        startValue: 1.0 #SL
+        endValue: 2.0 #SL 
         property: Energy
         isLooped: true
       - !type:FadeBehaviour # fade out radius as it burns out

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -48,8 +48,8 @@
   - type: PointLight
     enabled: false
     color: "#FF8080"
-    radius: 1.0
-    energy: 9.0
+    radius: 3.0 #SL Edit 1.0 -> 3.0
+    energy: 2.0 #SL Edit 9.0 -> 2.0
     netsync: false
   - type: IgnitionSource
     temperature: 1000

--- a/Resources/Prototypes/Entities/Objects/Tools/flare.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flare.yml
@@ -75,7 +75,7 @@
         minDuration: 0.001
         maxDuration: 0.001
         startValue: 1.0 #SL
-        endValue: 2.0 #SL 
+        endValue: 2.0 #SL
         property: Energy
         isLooped: true
       - !type:FadeBehaviour # fade out radius as it burns out

--- a/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lantern.yml
@@ -39,8 +39,8 @@
       delay: 1
     - type: PointLight
       enabled: false
-      radius: 3
-      energy: 2.5
+      radius: 4 #SL Edit 3 -> 4
+      energy: 1.5 #SL Edit 2.5 -> 1.5
       color: "#FFC458"
       netsync: false
     - type: Appearance

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -215,8 +215,8 @@
   components:
   - type: PointLight
     radius: 12
-    energy: 4.5
-    softness: 0.5
+    energy: 4 #SL 4.5 -> 4
+    softness: 0.8 #SL 0.5 -> 0.8
     color: "#B4FCF0"
 
 #Sodium lights
@@ -527,7 +527,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#47f8ff"
+    color: "#5ae8ed" #SL Edit
   - type: DamageOnInteract
     damage:
       types:
@@ -543,7 +543,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#47f8ff"
+    color: "#5ae8ed" #SL Edit
 
 - type: entity
   id: PoweredlightBlue
@@ -556,7 +556,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#39a1ff"
+    color: "#4ca1eb" #SL Edit
   - type: DamageOnInteract
     damage:
       types:
@@ -572,7 +572,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#39a1ff"
+    color: "#4ca1eb" #SL Edit
 
 - type: entity
   id: PoweredlightYellow
@@ -585,7 +585,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#ffde46"
+    color: "#edd25a" #SL Edit
   - type: DamageOnInteract
     damage:
       types:
@@ -601,7 +601,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#ffde46"
+    color: "#edd25a" #SL Edit
 
 - type: entity
   id: PoweredlightPink
@@ -614,7 +614,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#ff66cc"
+    color: "#f075c7" #SL Edit
   - type: DamageOnInteract
     damage:
       types:
@@ -630,7 +630,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#ff66cc"
+    color: "#f075c7" #SL Edit
 
 - type: entity
   id: PoweredlightOrange
@@ -643,7 +643,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#ff8227"
+    color: "#ea863e" #SL Edit
   - type: DamageOnInteract
     damage:
       types:
@@ -659,7 +659,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#ff8227"
+    color: "#ea863e" #SL Edit
 
 - type: entity
   id: PoweredlightBlack
@@ -673,7 +673,7 @@
     radius: 8
     energy: 1
     softness: 0.5
-    color: "#363636"
+    color: "#4d4d4d" #SL Edit
   - type: DamageOnInteract
     damage:
       types:
@@ -689,7 +689,7 @@
     radius: 8
     energy: 1
     softness: 0.5
-    color: "#363636"
+    color: "#4d4d4d" #SL Edit
 
 - type: entity
   id: PoweredlightRed
@@ -702,7 +702,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#fb4747"
+    color: "#ec5555" #SL Edit
   - type: DamageOnInteract
     damage:
       types:
@@ -718,7 +718,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#fb4747"
+    color: "#ec5555" #SL Edit
 
 - type: entity
   id: PoweredlightGreen
@@ -731,7 +731,7 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#52ff39"
+    color: "#7eeb4c" #SL Edit
   - type: DamageOnInteract
     damage:
       types:
@@ -747,4 +747,4 @@
     radius: 8
     energy: 3
     softness: 0.5
-    color: "#52ff39"
+    color: "#7eeb4c" #SL Edit

--- a/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/ground_lighting.yml
@@ -32,7 +32,7 @@
         - BulletImpassable
   - type: PointLight
     radius: 10
-    energy: 2.5
+    energy: 2 # SL Edit 2.5 -> 2
     softness: 0.9
     color: "#EEEEFF"
   - type: Anchorable
@@ -151,7 +151,7 @@
     state: base
   - type: PointLight
     enabled: true
-    radius: 15
+    radius: 13 #SL Edit 15 -> 13
     energy: 1
     softness: 0.9
     color: "#EEEEFF"

--- a/Resources/Prototypes/_CP14/Shaders/shaders.yml
+++ b/Resources/Prototypes/_CP14/Shaders/shaders.yml
@@ -5,11 +5,11 @@
   params:
     CircleRadius: 420.0
     CircleMinDist: 0.0
-    CirclePow: 0.20
+    CirclePow: 0.20 #SL Edit
     CircleMax: 4.0
-    CircleMult: 0.2
+    CircleMult: 0.2 #SL Edit
     FalloffClampMin: 0.075
     FalloffClampMax: 1.0
-    FalloffStrength: 0.8
+    FalloffStrength: 0.8 #SL Edit
     FalloffPow: 3.0
     HDR: 1.5

--- a/Resources/Prototypes/_CP14/Shaders/shaders.yml
+++ b/Resources/Prototypes/_CP14/Shaders/shaders.yml
@@ -5,11 +5,11 @@
   params:
     CircleRadius: 420.0
     CircleMinDist: 0.0
-    CirclePow: 1.0
+    CirclePow: 0.20
     CircleMax: 4.0
-    CircleMult: 0.25
+    CircleMult: 0.2
     FalloffClampMin: 0.075
     FalloffClampMax: 1.0
-    FalloffStrength: 0.75
+    FalloffStrength: 0.8
     FalloffPow: 3.0
     HDR: 1.5

--- a/Resources/Prototypes/_ES/Entities/Effects/sparks.yml
+++ b/Resources/Prototypes/_ES/Entities/Effects/sparks.yml
@@ -40,8 +40,8 @@
     fadeTime: 0.5
   - type: AnimationPlayer
   - type: PointLight
-    radius: 1.5
-    energy: 3
+    radius: 1.0 #SL Edit 1.5 -> 1
+    energy: 1 #SL Edit 3 -> 1
     falloff: 6
     color: "#FAA019"
     netsync: false

--- a/Resources/Prototypes/_Moffstation/Entities/Effects/sparks.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Effects/sparks.yml
@@ -40,8 +40,8 @@
   - type: IgnitionSource
     ignited: false
   - type: PointLight
-    radius: 8
-    energy: 4
+    radius: 4 #SL Edit
+    energy: 1 #SL Edit
     color: "#18abf5"
   # story time
   # the bluespace effect is added to portals
@@ -71,5 +71,5 @@
     ignited: false
   - type: PointLight
     radius: 8
-    energy: 4
+    energy: 3 #SL Edit
     color: "#960202"

--- a/Resources/Textures/_CP14/Shaders/base_postprocess.swsl
+++ b/Resources/Textures/_CP14/Shaders/base_postprocess.swsl
@@ -7,12 +7,12 @@ uniform highp float Zoom;
 //Variables for controlling the falloff of the additive lighting effect.
 uniform highp float CircleRadius; //= 420.0;
 uniform highp float CircleMinDist; //= 0.0;
-uniform highp float CirclePow; //= 1.0;
+uniform highp float CirclePow; //= 0.20;
 uniform highp float CircleMax; //= 4.0;
-uniform highp float CircleMult; //= 0.25;
+uniform highp float CircleMult; //= 0.2;
 uniform highp float FalloffClampMin; //= 0.075;
 uniform highp float FalloffClampMax; //= 1.0;
-uniform highp float FalloffStrength; //= 0.75;
+uniform highp float FalloffStrength; //= 0.8;
 uniform highp float FalloffPow; //= 3.0;
 uniform highp float HDR; //= 1.5;
 

--- a/Resources/Textures/_CP14/Shaders/base_postprocess.swsl
+++ b/Resources/Textures/_CP14/Shaders/base_postprocess.swsl
@@ -7,12 +7,12 @@ uniform highp float Zoom;
 //Variables for controlling the falloff of the additive lighting effect.
 uniform highp float CircleRadius; //= 420.0;
 uniform highp float CircleMinDist; //= 0.0;
-uniform highp float CirclePow; //= 0.20;
+uniform highp float CirclePow; //= 0.20; // Starlight
 uniform highp float CircleMax; //= 4.0;
-uniform highp float CircleMult; //= 0.2;
+uniform highp float CircleMult; //= 0.2; // Starlight
 uniform highp float FalloffClampMin; //= 0.075;
 uniform highp float FalloffClampMax; //= 1.0;
-uniform highp float FalloffStrength; //= 0.8;
+uniform highp float FalloffStrength; //= 0.8; // Starlight
 uniform highp float FalloffPow; //= 3.0;
 uniform highp float HDR; //= 1.5;
 


### PR DESCRIPTION
## Short description
Tweaked values on multiple light sources in the game as well as the Additive Lighting Post Processing effect to reduce 'spotlight' effects on some items like Floodlights, Flares, and Exterior Lights.

The cause: Wizden has some light sources set to energy of 5-10, which creates the spotlight. Nothing needs more than 3 imo. So I lowered some light sources' energy to 2-3 and then upped their radius slightly to compensate.

Also made it so the new additive lighting is rendered to ghosts. I don't know why it wasn't but now it is.

## Why we need to add this
Fixing some visual scuff from light sources using additive lighting.

## Media (Video/Screenshots)
<img width="871" height="627" alt="image" src="https://github.com/user-attachments/assets/d85e804f-bb3a-42f4-82ea-d45d2dfe6fce" />
<img width="373" height="415" alt="image" src="https://github.com/user-attachments/assets/288cbd9f-0191-4e3d-8d5d-f25b4d921932" />


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed saturation of colored light tubes and bulbs to be 20% less saturated. Barely noticeable, but it blows out colors a bit less and is less painful to look at.
- fix: Fixed 'spotlights' over some light sources like Exterior Lights, Floodlights, and Flares. Exterior Lights still have a spotlight, but it is smaller. Floodlights only have a spotlight in a fully lit room, and it is very small. Any light can have a spotlight if light stacking happens, but this reduces their occurrence in normal gameplay.
- fix: Fixed ghosts not being able to see the new additive lighting effects.
- tweak: Lighting from sparks are less bright, so they should in theory not hurt Shadekin- or if they do, they will hurt less than before.

