### PR TITLE
Sparking Clean Up

### DIFF
--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -489,5 +489,6 @@ public enum LogType
     Railroading = 1000,
     BugReport = 1001,
     RoundstartRulesAdded = 1002,
+    Sparks = 1003,
     #endregion
 }

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -137,7 +137,7 @@ public sealed partial class RCDSystem : EntitySystem
 
         // Set the current RCD prototype to the one supplied
         component.ProtoId = args.ProtoId;
-        _esSparks.DoSparks(uid, 1, user: args.Actor); // ES
+        //_esSparks.DoSparks(uid, 1, user: args.Actor); // ES - Starlight, we don't need sparks on RCD construct selection
         UpdateCachedPrototype(uid, component); // Starlight: RPD
 
         _adminLogger.Add(LogType.RCD, LogImpact.Low, $"{args.Actor} set RCD mode to: {prototype.Mode} : {prototype.Prototype}");

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -364,6 +364,7 @@ public sealed partial class RCDSystem : EntitySystem
 
         // Try to start the do after
         var effect = Spawn(effectPrototype, location);
+        _adminLogger.Add(LogType.RCD, LogImpact.Low, $"{ToPrettyString(user):user} spawned {ToPrettyString(effect):effect} with {ToPrettyString(uid):rcd/rpd/rpld} at {location}"); // Starlight, effect logging
         var ev = new RCDDoAfterEvent(GetNetCoordinates(location), component.ConstructionDirection, placementLayer, component.ProtoId, cost, GetNetEntity(effect));      // Starlight Edit: Include layer as well in snapshot at start so finalize uses consistent placement state.
 
         var doAfterArgs = new DoAfterArgs(EntityManager, user, delay, ev, uid, target: args.Target, used: uid)
@@ -785,7 +786,7 @@ public sealed partial class RCDSystem : EntitySystem
         {
             case RcdMode.ConstructTile:
                 _mapSystem.SetTile(gridUid, mapGrid, position, new Tile(_tileDefMan[prototype.Prototype].TileId));
-                _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used RCD to set grid: {gridUid} {position} to {prototype.Prototype}");
+                _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used {ToPrettyString(uid):rcd} to set grid: {gridUid} {position} to {prototype.Prototype}"); // Starlight, RCD uid
                 break;
 
             case RcdMode.ConstructObject:
@@ -830,7 +831,7 @@ public sealed partial class RCDSystem : EntitySystem
                                 if (Exists(conflict) && HasComp<RCDDeconstructableComponent>(conflict))
                                 {
                                     _adminLogger.Add(LogType.RCD, LogImpact.Medium,
-                                        $"{ToPrettyString(user):user} RPD/RPLD replaced {ToPrettyString(conflict.Value)} at {position}");
+                                        $"{ToPrettyString(user):user} used {ToPrettyString(uid):rpd/rpld} to replace {ToPrettyString(conflict.Value)} at {position}");
                                     Del(conflict.Value);
                                     _audio.PlayPvs(component.SuccessSound, uid);
                                 }
@@ -867,7 +868,7 @@ public sealed partial class RCDSystem : EntitySystem
                         _transform.AnchorEntity(ent, entXformPost);
                 }
 
-                _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used RCD to spawn {ToPrettyString(ent)} at {position} on grid {gridUid}");
+                _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used {ToPrettyString(uid):rcd} to spawn {ToPrettyString(ent)} at {position} on grid {gridUid}"); // Starlight, RCD uid
                 break;
 
             case RcdMode.Deconstruct:
@@ -877,12 +878,12 @@ public sealed partial class RCDSystem : EntitySystem
                     // Deconstruct tile (either converts the tile to lattice, or removes lattice)
                     var tileDef = (_turf.GetContentTileDefinition(tile).ID != "Lattice") ? new Tile(_tileDefMan["Lattice"].TileId) : Tile.Empty;
                     _mapSystem.SetTile(gridUid, mapGrid, position, tileDef);
-                    _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used RCD to set grid: {gridUid} tile: {position} open to space");
+                    _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used {ToPrettyString(uid):rcd} to set grid: {gridUid} tile: {position} open to space"); // Starlight, RCD uid
                 }
                 else
                 {
                     // Deconstruct object
-                    _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used RCD to delete {ToPrettyString(target):target}");
+                    _adminLogger.Add(LogType.RCD, LogImpact.High, $"{ToPrettyString(user):user} used {ToPrettyString(uid):rcd} to delete {ToPrettyString(target):target}"); // Starlight, RCD uid
                     QueueDel(target);
                 }
 

--- a/Content.Shared/_ES/Sparks/ESSparksSystem.cs
+++ b/Content.Shared/_ES/Sparks/ESSparksSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
 using Content.Shared._ES.Physics.PreventCollide;
 using Content.Shared._ES.Sparks.Components;
 using Content.Shared.Power.Components;
@@ -24,6 +26,7 @@ public sealed partial class ESSparksSystem : EntitySystem
     [Dependency] private SharedTransformSystem _transform = default!;
 
     [Dependency] private EntityQuery<TransformComponent> _transformQuery; // Moff
+    [Dependency] private ISharedAdminLogManager _adminLogger = default!; // Starlight
 
     public static readonly EntProtoId DefaultSparks = "ESEffectSparks";
 
@@ -81,6 +84,7 @@ public sealed partial class ESSparksSystem : EntitySystem
         comp.LastSparkTime = _timing.CurTime;
 
         var coords = Transform(source).Coordinates;
+        _adminLogger.Add(LogType.Sparks, LogImpact.Low, $"{ToPrettyString(source)} spawned {number} sparks at {coords}"); // Starlight
         DoSparks(coords, number, sparksPrototype, user, source, tileFireChance);
     }
 

--- a/Content.Shared/_ES/Sparks/ESSparksSystem.cs
+++ b/Content.Shared/_ES/Sparks/ESSparksSystem.cs
@@ -84,7 +84,8 @@ public sealed partial class ESSparksSystem : EntitySystem
         comp.LastSparkTime = _timing.CurTime;
 
         var coords = Transform(source).Coordinates;
-        _adminLogger.Add(LogType.Sparks, LogImpact.Low, $"{ToPrettyString(source)} spawned {number} sparks at {coords}"); // Starlight
+        var sparkLabel = number == 1 ? "spark" : "sparks"; // Starlight
+        _adminLogger.Add(LogType.Sparks, LogImpact.Low, $"{ToPrettyString(source)} spawned {number} {sparkLabel} at {coords}"); // Starlight
         DoSparks(coords, number, sparksPrototype, user, source, tileFireChance);
     }
 

--- a/Resources/Prototypes/Entities/Effects/rcd.yml
+++ b/Resources/Prototypes/Entities/Effects/rcd.yml
@@ -17,9 +17,10 @@
   - type: AnimationPlayer
   # Moffstation - Start - More sparks
   - type: ESSparkOnTrigger
-    sparkPrototype: MoffEffectSparksWelding
-  - type: RepeatingTrigger
-    delay: 1
+    count: 2 # Starlight, less sparks
+    sparkPrototype: SLEffectSparksRCD # Starlight, a little smaller
+  #- type: RepeatingTrigger # Starlight, we only need this once, no doublespark
+  #  delay: 1 # Starlight
   - type: TriggerOnSpawn
   # Moffstation - End
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -90,6 +90,7 @@
   # ES START
   - type: ESSparkOnItemToggle
     count: 1
+    sparkPrototype: SLEffectSparksBaton # Starlight, smaller sparks
   # ES END
   - type: StaminaDamageOnHit
     damage: 35

--- a/Resources/Prototypes/_Moffstation/Entities/Effects/sparks.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Effects/sparks.yml
@@ -73,3 +73,4 @@
     radius: 8
     energy: 4
     color: "#960202"
+  - type: PortalBlacklist # Starlight

--- a/Resources/Prototypes/_Starlight/Entities/Effects/sparks.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Effects/sparks.yml
@@ -1,0 +1,30 @@
+- type: entity
+  parent: ESEffectSparks
+  id: SLEffectSparksBaton
+  name: sparks
+  components:
+  - type: Sprite
+    sprite: _ES/Effects/sparks.rsi
+    scale: 0.5, 0.5
+    layers:
+    - state: sparks
+      shader: unshaded
+    drawdepth: Effects
+    noRot: true
+    loop: false
+
+- type: entity
+  parent: MoffEffectSparksWelding
+  id: SLEffectSparksRCD
+  name: sparks
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    sprite: _ES/Effects/sparks.rsi
+    scale: 0.75, 0.75
+    layers:
+    - state: sparks
+      shader: unshaded
+    drawdepth: Effects
+    noRot: true
+    loop: false


### PR DESCRIPTION
## Short description
Tweaks sparks to make them a little less overwhelming + also adds logging.

## Why we need to add this
Graphical improvement.

## Media (Video/Screenshots)
[Content.Client_BAniZ053NE.webm](https://github.com/user-attachments/assets/d752a561-b049-4cdb-9e0e-6645b34cc8cc)

[Content.Client_i2o254CHmJ.webm](https://github.com/user-attachments/assets/1fa847c3-ea20-463c-acd4-767e68ef9c68)

<img width="1097" height="671" alt="image" src="https://github.com/user-attachments/assets/bda0f2d5-448f-4eee-8c46-d19deefed42f" />

Bonus with the stun baton is that you can see the entity id of the person holding the baton too. (image slightly out of date, see second image for the better rcd logging)

<img width="685" height="333" alt="image" src="https://github.com/user-attachments/assets/8d648823-dad0-462f-a6ba-48621f987edb" />

You can now actually trace the spark to the rcd/rpd/rpld by following the sprak effect.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: Sparks are now logged.
- tweak: RCD/RPD/RPLDs now only spark once, when creating an object.
- tweak: Stun Baton sparks are smaller now.

