### PR TITLE
Less Lethal Disposals

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -79,7 +79,7 @@
     # Starlight Start
     damageOnTurn:
       types:
-        Blunt: 4
+        Blunt: 1
     maxAllowedDamage: 100
     # Starlight End
     container:


### PR DESCRIPTION
## Short description
Lowers blunt damage done taking turns in disposals from 4 to 1. Max damage is still 100.

## Why we need to add this
After testing multiple maps, it was found that using AI chutes, or most disposal units, would deal between 50-100 damage (likely more if there wasn't the cap). This was far more lethal than intended, and made AI chutes useless.

After discussion with mappers, and the original PR maker @CrazyPhantom779 , lowering the damage to still discourage reckless disposal flushing while making it significantly less likely to halve someone's health or outright crit them, was seen as a good idea.

## Media (Video/Screenshots)
No.

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Made disposals 25% as lethal as before. 

